### PR TITLE
Create QgsRichTextEditor widget

### DIFF
--- a/python/gui/auto_generated/qgsrichtexteditor.sip.in
+++ b/python/gui/auto_generated/qgsrichtexteditor.sip.in
@@ -13,68 +13,75 @@
 class QgsRichTextEditor : QWidget, protected Ui::QgsRichTextEditorBase
 {
 %Docstring(signature="appended")
-Originally ported from https://github.com/Anchakor/MRichTextEditor, courtesy of Hobrasoft.
+A widget for editing rich text documents, with support for user controlled formatting of text
+and insertion of hyperlinks and images.
+
+:py:class:`QgsRichTextEditor` provides a reusable widget for allowing users to edit rich text documents,
+and retrieving and setting the documents via HTML formatted strings.
+
+.. versionadded:: 3.20
 %End
 
 %TypeHeaderCode
 #include "qgsrichtexteditor.h"
 %End
   public:
+
     QgsRichTextEditor( QWidget *parent = 0 );
+%Docstring
+Constructor for QgsRichTextEditor, with the specified ``parent`` widget.
+%End
 
     QString toPlainText() const;
+%Docstring
+Returns the widget's content as a plain text string.
+
+.. seealso:: :py:func:`toHtml`
+%End
+
     QString toHtml() const;
+%Docstring
+Returns the widget's content as a HTML string.
+
+.. seealso:: :py:func:`toPlainText`
+%End
+
     QTextDocument *document();
+%Docstring
+Returns a reference to the QTextDocument shown in the widget.
+%End
+
     QTextCursor textCursor() const;
+%Docstring
+Returns a reference to the text cursor.
+
+.. seealso:: :py:func:`setTextCursor`
+%End
+
     void setTextCursor( const QTextCursor &cursor );
+%Docstring
+Sets the current text ``cursor``.
+
+.. seealso:: :py:func:`textCursor`
+%End
 
   public slots:
-    void setText( const QString &text );
-    void clearSource();
 
-  protected slots:
-    void setPlainText( const QString &text );
-    void setHtml( const QString &text );
-    void textRemoveFormat();
-    void textRemoveAllFormat();
-    void textBold();
-    void textUnderline();
-    void textStrikeout();
-    void textItalic();
-    void textSize( const QString &p );
-    void textLink( bool checked );
-    void textStyle( int index );
-    void textFgColor();
-    void textBgColor();
-    void listBullet( bool checked );
-    void listOrdered( bool checked );
-    void slotCurrentCharFormatChanged( const QTextCharFormat &format );
-    void slotCursorPositionChanged();
-    void slotClipboardDataChanged();
-    void increaseIndentation();
-    void decreaseIndentation();
-    void insertImage();
-    void textSource();
+    void setText( const QString &text );
+%Docstring
+Sets the ``text`` to show in the widget.
+
+The ``text`` can either be a plain text string or a HTML document.
+%End
+
+    void clearSource();
+%Docstring
+Clears the current text from the widget.
+%End
 
   protected:
-    void mergeFormatOnWordOrSelection( const QTextCharFormat &format );
-    void fontChanged( const QFont &f );
-    void fgColorChanged( const QColor &c );
-    void bgColorChanged( const QColor &c );
-    void list( bool checked, QTextListFormat::Style style );
-    void indent( int delta );
-    void focusInEvent( QFocusEvent *event );
+    virtual void focusInEvent( QFocusEvent *event );
 
-
-    enum ParagraphItems
-    {
-      ParagraphStandard,
-      ParagraphHeading1,
-      ParagraphHeading2,
-      ParagraphHeading3,
-      ParagraphHeading4,
-      ParagraphMonospace
-    };
 
 };
 

--- a/python/gui/auto_generated/qgsrichtexteditor.sip.in
+++ b/python/gui/auto_generated/qgsrichtexteditor.sip.in
@@ -1,0 +1,89 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrichtexteditor.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsRichTextEditor : QWidget, protected Ui::QgsRichTextEditorBase
+{
+%Docstring(signature="appended")
+Originally ported from https://github.com/Anchakor/MRichTextEditor, courtesy of Hobrasoft.
+%End
+
+%TypeHeaderCode
+#include "qgsrichtexteditor.h"
+%End
+  public:
+    QgsRichTextEditor( QWidget *parent = 0 );
+
+    QString toPlainText() const;
+    QString toHtml() const;
+    QTextDocument *document();
+    QTextCursor textCursor() const;
+    void setTextCursor( const QTextCursor &cursor );
+
+  public slots:
+    void setText( const QString &text );
+    void clearSource();
+
+  protected slots:
+    void setPlainText( const QString &text );
+    void setHtml( const QString &text );
+    void textRemoveFormat();
+    void textRemoveAllFormat();
+    void textBold();
+    void textUnderline();
+    void textStrikeout();
+    void textItalic();
+    void textSize( const QString &p );
+    void textLink( bool checked );
+    void textStyle( int index );
+    void textFgColor();
+    void textBgColor();
+    void listBullet( bool checked );
+    void listOrdered( bool checked );
+    void slotCurrentCharFormatChanged( const QTextCharFormat &format );
+    void slotCursorPositionChanged();
+    void slotClipboardDataChanged();
+    void increaseIndentation();
+    void decreaseIndentation();
+    void insertImage();
+    void textSource();
+
+  protected:
+    void mergeFormatOnWordOrSelection( const QTextCharFormat &format );
+    void fontChanged( const QFont &f );
+    void fgColorChanged( const QColor &c );
+    void bgColorChanged( const QColor &c );
+    void list( bool checked, QTextListFormat::Style style );
+    void indent( int delta );
+    void focusInEvent( QFocusEvent *event );
+
+
+    enum ParagraphItems
+    {
+      ParagraphStandard,
+      ParagraphHeading1,
+      ParagraphHeading2,
+      ParagraphHeading3,
+      ParagraphHeading4,
+      ParagraphMonospace
+    };
+
+};
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsrichtexteditor.h                                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -183,6 +183,7 @@
 %Include auto_generated/qgsrelationeditorwidget.sip
 %Include auto_generated/qgsabstractrelationeditorwidget.sip
 %Include auto_generated/qgsrelationwidgetregistry.sip
+%Include auto_generated/qgsrichtexteditor.sip
 %Include auto_generated/qgsrubberband.sip
 %Include auto_generated/qgsscalecombobox.sip
 %Include auto_generated/qgsscalerangewidget.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -477,6 +477,7 @@ set(QGIS_GUI_SRCS
   qgshistogramwidget.cpp
   qgshelp.cpp
   qgsidentifymenu.cpp
+  qgsimagedroptextedit.cpp
   qgsinstallgridshiftdialog.cpp
   qgskeyvaluewidget.cpp
   qgslistwidget.cpp
@@ -570,6 +571,7 @@ set(QGIS_GUI_SRCS
   qgsrelationeditorwidget.cpp
   qgsabstractrelationeditorwidget.cpp
   qgsrelationwidgetregistry.cpp
+  qgsrichtexteditor.cpp
   qgsrubberband.cpp
   qgsscalecombobox.cpp
   qgsscalerangewidget.cpp
@@ -722,6 +724,7 @@ set(QGIS_GUI_HDRS
   qgshighlightablelineedit.h
   qgshistogramwidget.h
   qgsidentifymenu.h
+  qgsimagedroptextedit.h
   qgsinstallgridshiftdialog.h
   qgskeyvaluewidget.h
   qgslegendfilterbutton.h
@@ -818,6 +821,7 @@ set(QGIS_GUI_HDRS
   qgsrelationeditorwidget.h
   qgsabstractrelationeditorwidget.h
   qgsrelationwidgetregistry.h
+  qgsrichtexteditor.h
   qgsrubberband.h
   qgsscalecombobox.h
   qgsscalerangewidget.h

--- a/src/gui/qgsimagedroptextedit.cpp
+++ b/src/gui/qgsimagedroptextedit.cpp
@@ -1,9 +1,15 @@
-/*
+/****************************************************************************
+**
 ** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
 ** Contact: http://www.hobrasoft.cz/
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
 ** Contact: http://www.qt-project.org/legal
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** GNU Lesser General Public License Usage
@@ -19,7 +25,8 @@
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$
-*/
+**
+****************************************************************************/
 
 #include "qgsimagedroptextedit.h"
 #include <QMimeData>

--- a/src/gui/qgsimagedroptextedit.h
+++ b/src/gui/qgsimagedroptextedit.h
@@ -1,0 +1,57 @@
+/*
+** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
+** Contact: http://www.hobrasoft.cz/
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** GNU Lesser General Public License Usage
+** This file is under the terms of the GNU Lesser General Public License
+** version 2.1 as published by the Free Software Foundation and appearing
+** in the file LICENSE.LGPL included in the packaging of this file.
+** Please review the following information to ensure the
+** GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+*/
+
+#ifndef QGSIMAGEDROPTEXTEDIT_H
+#define QGSIMAGEDROPTEXTEDIT_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include <QTextEdit>
+
+#define SIP_NO_FILE
+
+class QImage;
+
+/*
+ * Originally ported from https://github.com/Anchakor/MRichTextEditor, courtesy of Hobrasoft.
+ */
+
+///@cond PRIVATE
+class GUI_EXPORT QgsImageDropTextEdit : public QTextEdit
+{
+    Q_OBJECT
+
+  public:
+    QgsImageDropTextEdit( QWidget *parent = nullptr );
+
+    void dropImage( const QImage &image, const QString &format );
+
+  protected:
+    bool canInsertFromMimeData( const QMimeData *source ) const override;
+    void insertFromMimeData( const QMimeData *source ) override;
+
+};
+///@endcond
+
+
+#endif // QGSIMAGEDROPTEXTEDIT_H

--- a/src/gui/qgsimagedroptextedit.h
+++ b/src/gui/qgsimagedroptextedit.h
@@ -1,9 +1,15 @@
-/*
+/****************************************************************************
+**
 ** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
 ** Contact: http://www.hobrasoft.cz/
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
 ** Contact: http://www.qt-project.org/legal
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** GNU Lesser General Public License Usage
@@ -19,8 +25,8 @@
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$
-*/
-
+**
+****************************************************************************/
 #ifndef QGSIMAGEDROPTEXTEDIT_H
 #define QGSIMAGEDROPTEXTEDIT_H
 

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -1,9 +1,15 @@
-/*
+/****************************************************************************
+**
 ** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
 ** Contact: http://www.hobrasoft.cz/
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
 ** Contact: http://www.qt-project.org/legal
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** GNU Lesser General Public License Usage
@@ -19,7 +25,8 @@
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$
-*/
+**
+****************************************************************************/
 
 #include "qgsrichtexteditor.h"
 #include "qgsguiutils.h"

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -63,7 +63,7 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   mParagraphStyleCombo->addItem( tr( "Heading 4" ), ParagraphHeading4 );
   mParagraphStyleCombo->addItem( tr( "Monospace" ), ParagraphMonospace );
 
-  connect( mParagraphStyleCombo, qOverload< int >( &QComboBox::activated ), this, &QgsRichTextEditor::textStyle );
+  connect( mParagraphStyleCombo, qOverload< int >( &QComboBox::currentIndexChanged ), this, &QgsRichTextEditor::textStyle );
   mToolBar->insertWidget( mToolBar->actions().at( 0 ), mParagraphStyleCombo );
 
   mFontSizeCombo = new QComboBox();
@@ -168,7 +168,7 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   for ( int size : sizes )
     mFontSizeCombo->addItem( QString::number( size ), size );
 
-  connect( mFontSizeCombo, &QComboBox::textActivated, this, &QgsRichTextEditor::textSize );
+  connect( mFontSizeCombo, &QComboBox::currentTextChanged, this, &QgsRichTextEditor::textSize );
   mFontSizeCombo->setCurrentIndex( mFontSizeCombo->findData( QApplication::font().pointSize() ) );
 
   // text foreground color
@@ -342,7 +342,7 @@ void QgsRichTextEditor::textLink( bool checked )
   mergeFormatOnWordOrSelection( fmt );
 }
 
-void QgsRichTextEditor::textStyle( int index )
+void QgsRichTextEditor::textStyle( int )
 {
   QTextCursor cursor = mTextEdit->textCursor();
   cursor.beginEditBlock();
@@ -356,35 +356,36 @@ void QgsRichTextEditor::textStyle( int index )
   cursor.setCharFormat( fmt );
   mTextEdit->setCurrentCharFormat( fmt );
 
-  if ( index == ParagraphHeading1
-       || index == ParagraphHeading2
-       || index == ParagraphHeading3
-       || index == ParagraphHeading4 )
+  ParagraphItems style = static_cast< ParagraphItems >( mParagraphStyleCombo->currentData().toInt() );
+  if ( style == ParagraphHeading1
+       || style == ParagraphHeading2
+       || style == ParagraphHeading3
+       || style == ParagraphHeading4 )
   {
-    if ( index == ParagraphHeading1 )
+    if ( style == ParagraphHeading1 )
     {
       fmt.setFontPointSize( mFontSizeH1 );
     }
-    if ( index == ParagraphHeading2 )
+    if ( style == ParagraphHeading2 )
     {
       fmt.setFontPointSize( mFontSizeH2 );
     }
-    if ( index == ParagraphHeading3 )
+    if ( style == ParagraphHeading3 )
     {
       fmt.setFontPointSize( mFontSizeH3 );
     }
-    if ( index == ParagraphHeading4 )
+    if ( style == ParagraphHeading4 )
     {
       fmt.setFontPointSize( mFontSizeH4 );
     }
-    if ( index == ParagraphHeading2 || index == ParagraphHeading4 )
+    if ( style == ParagraphHeading2 || style == ParagraphHeading4 )
     {
       fmt.setFontItalic( true );
     }
 
     fmt.setFontWeight( QFont::Bold );
   }
-  if ( index == ParagraphMonospace )
+  if ( style == ParagraphMonospace )
   {
     fmt = cursor.charFormat();
     fmt.setFontFamily( QStringLiteral( "Monospace" ) );

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -57,6 +57,8 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
 {
   setupUi( this );
 
+  mMonospaceFontFamily = QgsCodeEditor::getMonospaceFont().family();
+
   mToolBar->setIconSize( QgsGuiUtils::iconSize( false ) );
 
   connect( mTextEdit, &QTextEdit::currentCharFormatChanged, this, &QgsRichTextEditor::slotCurrentCharFormatChanged );
@@ -394,7 +396,7 @@ void QgsRichTextEditor::textStyle( int )
     case QgsRichTextEditor::ParagraphMonospace:
     {
       format = cursor.charFormat();
-      format.setFontFamily( QgsCodeEditor::getMonospaceFont().family() );
+      format.setFontFamily( mMonospaceFontFamily );
       format.setFontStyleHint( QFont::Monospace );
       format.setFontFixedPitch( true );
       break;
@@ -543,7 +545,7 @@ void QgsRichTextEditor::fontChanged( const QFont &f )
   }
   else
   {
-    if ( f.fixedPitch() && f.family() == QLatin1String( "Monospace" ) )
+    if ( f.fixedPitch() && f.family() == mMonospaceFontFamily )
     {
       mParagraphStyleCombo->setCurrentIndex( ParagraphMonospace );
     }

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -207,7 +207,7 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   // images
   connect( mActionInsertImage, &QAction::triggered, this, &QgsRichTextEditor::insertImage );
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-  connect( mFontSizeCombo, qOverload< QString >( &QComboBox::activated ), this, &QgsRichTextEditor::textSize );
+  connect( mFontSizeCombo, qOverload< const QString &>( &QComboBox::activated ), this, &QgsRichTextEditor::textSize );
 #else
   connect( mFontSizeCombo, &QComboBox::textActivated, this, &QgsRichTextEditor::textSize );
 #endif

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -175,7 +175,6 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   for ( int size : sizes )
     mFontSizeCombo->addItem( QString::number( size ), size );
 
-  connect( mFontSizeCombo, &QComboBox::currentTextChanged, this, &QgsRichTextEditor::textSize );
   mFontSizeCombo->setCurrentIndex( mFontSizeCombo->findData( QApplication::font().pointSize() ) );
 
   // text foreground color
@@ -207,6 +206,8 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
 
   // images
   connect( mActionInsertImage, &QAction::triggered, this, &QgsRichTextEditor::insertImage );
+
+  connect( mFontSizeCombo, &QComboBox::currentTextChanged, this, &QgsRichTextEditor::textSize );
 
   fontChanged( mTextEdit->font() );
 }

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -31,6 +31,7 @@
 #include "qgsrichtexteditor.h"
 #include "qgsguiutils.h"
 #include "qgscolorbutton.h"
+#include "qgscodeeditor.h"
 
 #include <QMimeData>
 #include <QApplication>
@@ -362,41 +363,44 @@ void QgsRichTextEditor::textStyle( int )
   mTextEdit->setCurrentCharFormat( format );
 
   ParagraphItems style = static_cast< ParagraphItems >( mParagraphStyleCombo->currentData().toInt() );
-  if ( style == ParagraphHeading1
-       || style == ParagraphHeading2
-       || style == ParagraphHeading3
-       || style == ParagraphHeading4 )
-  {
-    if ( style == ParagraphHeading1 )
-    {
-      format.setFontPointSize( mFontSizeH1 );
-    }
-    if ( style == ParagraphHeading2 )
-    {
-      format.setFontPointSize( mFontSizeH2 );
-    }
-    if ( style == ParagraphHeading3 )
-    {
-      format.setFontPointSize( mFontSizeH3 );
-    }
-    if ( style == ParagraphHeading4 )
-    {
-      format.setFontPointSize( mFontSizeH4 );
-    }
-    if ( style == ParagraphHeading2 || style == ParagraphHeading4 )
-    {
-      format.setFontItalic( true );
-    }
 
-    format.setFontWeight( QFont::Bold );
-  }
-  if ( style == ParagraphMonospace )
+  switch ( style )
   {
-    format = cursor.charFormat();
-    format.setFontFamily( QStringLiteral( "Monospace" ) );
-    format.setFontStyleHint( QFont::Monospace );
-    format.setFontFixedPitch( true );
+    case QgsRichTextEditor::ParagraphStandard:
+      break;
+
+    case QgsRichTextEditor::ParagraphHeading1:
+      format.setFontPointSize( mFontSizeH1 );
+      format.setFontWeight( QFont::Bold );
+      break;
+
+    case QgsRichTextEditor::ParagraphHeading2:
+      format.setFontPointSize( mFontSizeH2 );
+      format.setFontWeight( QFont::Bold );
+      format.setFontItalic( true );
+      break;
+
+    case QgsRichTextEditor::ParagraphHeading3:
+      format.setFontPointSize( mFontSizeH3 );
+      format.setFontWeight( QFont::Bold );
+      break;
+
+    case QgsRichTextEditor::ParagraphHeading4:
+      format.setFontPointSize( mFontSizeH4 );
+      format.setFontWeight( QFont::Bold );
+      format.setFontItalic( true );
+      break;
+
+    case QgsRichTextEditor::ParagraphMonospace:
+    {
+      format = cursor.charFormat();
+      format.setFontFamily( QgsCodeEditor::getMonospaceFont().family() );
+      format.setFontStyleHint( QFont::Monospace );
+      format.setFontFixedPitch( true );
+      break;
+    }
   }
+
   cursor.setCharFormat( format );
   mTextEdit->setCurrentCharFormat( format );
 

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -1,0 +1,694 @@
+/*
+** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
+** Contact: http://www.hobrasoft.cz/
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** GNU Lesser General Public License Usage
+** This file is under the terms of the GNU Lesser General Public License
+** version 2.1 as published by the Free Software Foundation and appearing
+** in the file LICENSE.LGPL included in the packaging of this file.
+** Please review the following information to ensure the
+** GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+*/
+
+#include "qgsrichtexteditor.h"
+#include <QMimeData>
+#include <QApplication>
+#include <QClipboard>
+#include <QFontDatabase>
+#include <QInputDialog>
+#include <QColorDialog>
+#include <QTextList>
+#include <QtDebug>
+#include <QFileDialog>
+#include <QImageReader>
+#include <QSettings>
+#include <QBuffer>
+#include <QUrl>
+#include <QPlainTextEdit>
+#include <QMenu>
+#include <QDialog>
+
+QgsRichTextEditor::QgsRichTextEditor( QWidget *parent ) : QWidget( parent )
+{
+  setupUi( this );
+  m_lastBlockList = nullptr;
+
+  connect( mTextEdit, &QTextEdit::currentCharFormatChanged, this, &QgsRichTextEditor::slotCurrentCharFormatChanged );
+  connect( mTextEdit, &QTextEdit::cursorPositionChanged, this, &QgsRichTextEditor::slotCursorPositionChanged );
+
+  m_fontsize_h1 = 18;
+  m_fontsize_h2 = 16;
+  m_fontsize_h3 = 14;
+  m_fontsize_h4 = 12;
+
+  fontChanged( mTextEdit->font() );
+  bgColorChanged( mTextEdit->textColor() );
+
+  // paragraph formatting
+
+  m_paragraphItems << tr( "Standard" )
+                   << tr( "Heading 1" )
+                   << tr( "Heading 2" )
+                   << tr( "Heading 3" )
+                   << tr( "Heading 4" )
+                   << tr( "Monospace" );
+  f_paragraph->addItems( m_paragraphItems );
+
+  connect( f_paragraph, qOverload< int >( &QComboBox::activated ), this, &QgsRichTextEditor::textStyle );
+
+  // undo & redo
+
+  f_undo->setShortcut( QKeySequence::Undo );
+  f_redo->setShortcut( QKeySequence::Redo );
+
+  connect( mTextEdit->document(), &QTextDocument::undoAvailable, f_undo, &QWidget::setEnabled );
+  connect( mTextEdit->document(), &QTextDocument::redoAvailable, f_redo, &QWidget::setEnabled );
+
+  f_undo->setEnabled( mTextEdit->document()->isUndoAvailable() );
+  f_redo->setEnabled( mTextEdit->document()->isRedoAvailable() );
+
+  connect( f_undo, &QAbstractButton::clicked, mTextEdit, &QTextEdit::undo );
+  connect( f_redo, &QAbstractButton::clicked, mTextEdit, &QTextEdit::redo );
+
+  // cut, copy & paste
+
+  f_cut->setShortcut( QKeySequence::Cut );
+  f_copy->setShortcut( QKeySequence::Copy );
+  f_paste->setShortcut( QKeySequence::Paste );
+
+  f_cut->setEnabled( false );
+  f_copy->setEnabled( false );
+
+  connect( f_cut, &QAbstractButton::clicked, mTextEdit, &QTextEdit::cut );
+  connect( f_copy, &QAbstractButton::clicked, mTextEdit, &QTextEdit::copy );
+  connect( f_paste, &QAbstractButton::clicked, mTextEdit, &QTextEdit::paste );
+
+  connect( mTextEdit, &QTextEdit::copyAvailable, f_cut, &QWidget::setEnabled );
+  connect( mTextEdit, &QTextEdit::copyAvailable, f_copy, &QWidget::setEnabled );
+
+#ifndef QT_NO_CLIPBOARD
+  connect( QApplication::clipboard(), &QClipboard::dataChanged, this, &QgsRichTextEditor::slotClipboardDataChanged );
+#endif
+
+  // link
+
+  f_link->setShortcut( QKeySequence( QStringLiteral( "CTRL+L" ) ) );
+
+  connect( f_link, &QAbstractButton::clicked, this, &QgsRichTextEditor::textLink );
+
+  // bold, italic & underline
+
+  f_bold->setShortcut( QKeySequence( QStringLiteral( "CTRL+B" ) ) );
+  f_italic->setShortcut( QKeySequence( QStringLiteral( "CTRL+I" ) ) );
+  f_underline->setShortcut( QKeySequence( QStringLiteral( "CTRL+U" ) ) );
+
+  connect( f_bold, &QAbstractButton::clicked, this, &QgsRichTextEditor::textBold );
+  connect( f_italic, &QAbstractButton::clicked, this, &QgsRichTextEditor::textItalic );
+  connect( f_underline, &QAbstractButton::clicked, this, &QgsRichTextEditor::textUnderline );
+  connect( f_strikeout, &QAbstractButton::clicked, this, &QgsRichTextEditor::textStrikeout );
+
+  QAction *removeFormat = new QAction( tr( "Remove Character Formatting" ), this );
+  removeFormat->setShortcut( QKeySequence( QStringLiteral( "CTRL+M" ) ) );
+  connect( removeFormat, &QAction::triggered, this, &QgsRichTextEditor::textRemoveFormat );
+  mTextEdit->addAction( removeFormat );
+
+  QAction *removeAllFormat = new QAction( tr( "Remove all Formatting" ), this );
+  connect( removeAllFormat, &QAction::triggered, this, &QgsRichTextEditor::textRemoveAllFormat );
+  mTextEdit->addAction( removeAllFormat );
+
+  QAction *textsource = new QAction( tr( "Edit Document Source" ), this );
+  textsource->setShortcut( QKeySequence( QStringLiteral( "CTRL+O" ) ) );
+  connect( textsource, &QAction::triggered, this, &QgsRichTextEditor::textSource );
+  mTextEdit->addAction( textsource );
+
+  QAction *clearText = new QAction( tr( "Clear all Content" ), this );
+  connect( clearText, &QAction::triggered, this, &QgsRichTextEditor::clearSource );
+  mTextEdit->addAction( clearText );
+
+  QMenu *menu = new QMenu( this );
+  menu->addAction( removeAllFormat );
+  menu->addAction( removeFormat );
+  menu->addAction( textsource );
+  menu->addAction( clearText );
+  f_menu->setMenu( menu );
+  f_menu->setPopupMode( QToolButton::InstantPopup );
+
+  // lists
+
+  f_list_bullet->setShortcut( QKeySequence( QStringLiteral( "CTRL+-" ) ) );
+  f_list_ordered->setShortcut( QKeySequence( QStringLiteral( "CTRL+=" ) ) );
+
+  connect( f_list_bullet, &QAbstractButton::clicked, this, &QgsRichTextEditor::listBullet );
+  connect( f_list_ordered, &QAbstractButton::clicked, this, &QgsRichTextEditor::listOrdered );
+
+  // indentation
+
+  f_indent_dec->setShortcut( QKeySequence( QStringLiteral( "CTRL+," ) ) );
+  f_indent_inc->setShortcut( QKeySequence( QStringLiteral( "CTRL+." ) ) );
+
+  connect( f_indent_inc, &QAbstractButton::clicked, this, &QgsRichTextEditor::increaseIndentation );
+  connect( f_indent_dec, &QAbstractButton::clicked, this, &QgsRichTextEditor::decreaseIndentation );
+
+  // font size
+
+  QFontDatabase db;
+  const QList< int > sizes = db.standardSizes();
+  for ( int size : sizes )
+    f_fontsize->addItem( QString::number( size ) );
+
+  connect( f_fontsize, &QComboBox::textActivated, this, &QgsRichTextEditor::textSize );
+  f_fontsize->setCurrentIndex( f_fontsize->findText( QString::number( QApplication::font()
+                               .pointSize() ) ) );
+
+  // text foreground color
+
+  QPixmap pix( 16, 16 );
+  pix.fill( QApplication::palette().windowText().color() );
+  f_fgcolor->setIcon( pix );
+
+  connect( f_fgcolor, &QAbstractButton::clicked, this, &QgsRichTextEditor::textFgColor );
+
+  // text background color
+
+  pix.fill( QApplication::palette().window().color() );
+  f_bgcolor->setIcon( pix );
+
+  connect( f_bgcolor, &QAbstractButton::clicked, this, &QgsRichTextEditor::textBgColor );
+
+  // images
+  connect( f_image, &QAbstractButton::clicked, this, &QgsRichTextEditor::insertImage );
+}
+
+
+void QgsRichTextEditor::textSource()
+{
+  QDialog *dialog = new QDialog( this );
+  QPlainTextEdit *pte = new QPlainTextEdit( dialog );
+  pte->setPlainText( mTextEdit->toHtml() );
+  QGridLayout *gl = new QGridLayout( dialog );
+  gl->addWidget( pte, 0, 0, 1, 1 );
+  dialog->setWindowTitle( tr( "Document Source" ) );
+  dialog->setMinimumWidth( 400 );
+  dialog->setMinimumHeight( 600 );
+  dialog->exec();
+
+  mTextEdit->setHtml( pte->toPlainText() );
+
+  delete dialog;
+}
+
+void QgsRichTextEditor::clearSource()
+{
+  mTextEdit->clear();
+}
+
+
+void QgsRichTextEditor::textRemoveFormat()
+{
+  QTextCharFormat fmt;
+  fmt.setFontWeight( QFont::Normal );
+  fmt.setFontUnderline( false );
+  fmt.setFontStrikeOut( false );
+  fmt.setFontItalic( false );
+  fmt.setFontPointSize( 9 );
+//  fmt.setFontFamily     ("Helvetica");
+//  fmt.setFontStyleHint  (QFont::SansSerif);
+//  fmt.setFontFixedPitch (true);
+
+  f_bold      ->setChecked( false );
+  f_underline ->setChecked( false );
+  f_italic    ->setChecked( false );
+  f_strikeout ->setChecked( false );
+  f_fontsize  ->setCurrentIndex( f_fontsize->findText( QStringLiteral( "9" ) ) );
+
+//  QTextBlockFormat bfmt = cursor.blockFormat();
+//  bfmt->setIndent(0);
+
+  fmt.clearBackground();
+
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+
+void QgsRichTextEditor::textRemoveAllFormat()
+{
+  f_bold      ->setChecked( false );
+  f_underline ->setChecked( false );
+  f_italic    ->setChecked( false );
+  f_strikeout ->setChecked( false );
+  f_fontsize  ->setCurrentIndex( f_fontsize->findText( QStringLiteral( "9" ) ) );
+  QString text = mTextEdit->toPlainText();
+  mTextEdit->setPlainText( text );
+}
+
+
+void QgsRichTextEditor::textBold()
+{
+  QTextCharFormat fmt;
+  fmt.setFontWeight( f_bold->isChecked() ? QFont::Bold : QFont::Normal );
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+
+void QgsRichTextEditor::focusInEvent( QFocusEvent * )
+{
+  mTextEdit->setFocus( Qt::TabFocusReason );
+}
+
+
+void QgsRichTextEditor::textUnderline()
+{
+  QTextCharFormat fmt;
+  fmt.setFontUnderline( f_underline->isChecked() );
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+void QgsRichTextEditor::textItalic()
+{
+  QTextCharFormat fmt;
+  fmt.setFontItalic( f_italic->isChecked() );
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+void QgsRichTextEditor::textStrikeout()
+{
+  QTextCharFormat fmt;
+  fmt.setFontStrikeOut( f_strikeout->isChecked() );
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+void QgsRichTextEditor::textSize( const QString &p )
+{
+  qreal pointSize = p.toDouble();
+  if ( p.toFloat() > 0 )
+  {
+    QTextCharFormat fmt;
+    fmt.setFontPointSize( pointSize );
+    mergeFormatOnWordOrSelection( fmt );
+  }
+}
+
+void QgsRichTextEditor::textLink( bool checked )
+{
+  bool unlink = false;
+  QTextCharFormat fmt;
+  if ( checked )
+  {
+    QString url = mTextEdit->currentCharFormat().anchorHref();
+    bool ok;
+    QString newUrl = QInputDialog::getText( this, tr( "Create a Link" ),
+                                            tr( "Link URL:" ), QLineEdit::Normal,
+                                            url,
+                                            &ok );
+    if ( ok )
+    {
+      fmt.setAnchor( true );
+      fmt.setAnchorHref( newUrl );
+      fmt.setForeground( QApplication::palette().color( QPalette::Link ) );
+      fmt.setFontUnderline( true );
+    }
+    else
+    {
+      unlink = true;
+    }
+  }
+  else
+  {
+    unlink = true;
+  }
+  if ( unlink )
+  {
+    fmt.setAnchor( false );
+    fmt.setForeground( QApplication::palette().color( QPalette::Text ) );
+    fmt.setFontUnderline( false );
+  }
+  mergeFormatOnWordOrSelection( fmt );
+}
+
+void QgsRichTextEditor::textStyle( int index )
+{
+  QTextCursor cursor = mTextEdit->textCursor();
+  cursor.beginEditBlock();
+
+  // standard
+  if ( !cursor.hasSelection() )
+  {
+    cursor.select( QTextCursor::BlockUnderCursor );
+  }
+  QTextCharFormat fmt;
+  cursor.setCharFormat( fmt );
+  mTextEdit->setCurrentCharFormat( fmt );
+
+  if ( index == ParagraphHeading1
+       || index == ParagraphHeading2
+       || index == ParagraphHeading3
+       || index == ParagraphHeading4 )
+  {
+    if ( index == ParagraphHeading1 )
+    {
+      fmt.setFontPointSize( m_fontsize_h1 );
+    }
+    if ( index == ParagraphHeading2 )
+    {
+      fmt.setFontPointSize( m_fontsize_h2 );
+    }
+    if ( index == ParagraphHeading3 )
+    {
+      fmt.setFontPointSize( m_fontsize_h3 );
+    }
+    if ( index == ParagraphHeading4 )
+    {
+      fmt.setFontPointSize( m_fontsize_h4 );
+    }
+    if ( index == ParagraphHeading2 || index == ParagraphHeading4 )
+    {
+      fmt.setFontItalic( true );
+    }
+
+    fmt.setFontWeight( QFont::Bold );
+  }
+  if ( index == ParagraphMonospace )
+  {
+    fmt = cursor.charFormat();
+    fmt.setFontFamily( QStringLiteral( "Monospace" ) );
+    fmt.setFontStyleHint( QFont::Monospace );
+    fmt.setFontFixedPitch( true );
+  }
+  cursor.setCharFormat( fmt );
+  mTextEdit->setCurrentCharFormat( fmt );
+
+  cursor.endEditBlock();
+}
+
+void QgsRichTextEditor::textFgColor()
+{
+  QColor col = QColorDialog::getColor( mTextEdit->textColor(), this );
+  QTextCursor cursor = mTextEdit->textCursor();
+  if ( !cursor.hasSelection() )
+  {
+    cursor.select( QTextCursor::WordUnderCursor );
+  }
+  QTextCharFormat fmt = cursor.charFormat();
+  if ( col.isValid() )
+  {
+    fmt.setForeground( col );
+  }
+  else
+  {
+    fmt.clearForeground();
+  }
+  cursor.setCharFormat( fmt );
+  mTextEdit->setCurrentCharFormat( fmt );
+  fgColorChanged( col );
+}
+
+void QgsRichTextEditor::textBgColor()
+{
+  QColor col = QColorDialog::getColor( mTextEdit->textBackgroundColor(), this );
+  QTextCursor cursor = mTextEdit->textCursor();
+  if ( !cursor.hasSelection() )
+  {
+    cursor.select( QTextCursor::WordUnderCursor );
+  }
+  QTextCharFormat fmt = cursor.charFormat();
+  if ( col.isValid() )
+  {
+    fmt.setBackground( col );
+  }
+  else
+  {
+    fmt.clearBackground();
+  }
+  cursor.setCharFormat( fmt );
+  mTextEdit->setCurrentCharFormat( fmt );
+  bgColorChanged( col );
+}
+
+void QgsRichTextEditor::listBullet( bool checked )
+{
+  if ( checked )
+  {
+    f_list_ordered->setChecked( false );
+  }
+  list( checked, QTextListFormat::ListDisc );
+}
+
+void QgsRichTextEditor::listOrdered( bool checked )
+{
+  if ( checked )
+  {
+    f_list_bullet->setChecked( false );
+  }
+  list( checked, QTextListFormat::ListDecimal );
+}
+
+void QgsRichTextEditor::list( bool checked, QTextListFormat::Style style )
+{
+  QTextCursor cursor = mTextEdit->textCursor();
+  cursor.beginEditBlock();
+  if ( !checked )
+  {
+    QTextBlockFormat obfmt = cursor.blockFormat();
+    QTextBlockFormat bfmt;
+    bfmt.setIndent( obfmt.indent() );
+    cursor.setBlockFormat( bfmt );
+  }
+  else
+  {
+    QTextListFormat listFmt;
+    if ( cursor.currentList() )
+    {
+      listFmt = cursor.currentList()->format();
+    }
+    listFmt.setStyle( style );
+    cursor.createList( listFmt );
+  }
+  cursor.endEditBlock();
+}
+
+void QgsRichTextEditor::mergeFormatOnWordOrSelection( const QTextCharFormat &format )
+{
+  QTextCursor cursor = mTextEdit->textCursor();
+  if ( !cursor.hasSelection() )
+  {
+    cursor.select( QTextCursor::WordUnderCursor );
+  }
+  cursor.mergeCharFormat( format );
+  mTextEdit->mergeCurrentCharFormat( format );
+  mTextEdit->setFocus( Qt::TabFocusReason );
+}
+
+void QgsRichTextEditor::slotCursorPositionChanged()
+{
+  QTextList *l = mTextEdit->textCursor().currentList();
+  if ( m_lastBlockList && ( l == m_lastBlockList || ( l != nullptr && m_lastBlockList != nullptr
+                            && l->format().style() == m_lastBlockList->format().style() ) ) )
+  {
+    return;
+  }
+  m_lastBlockList = l;
+  if ( l )
+  {
+    QTextListFormat lfmt = l->format();
+    if ( lfmt.style() == QTextListFormat::ListDisc )
+    {
+      f_list_bullet->setChecked( true );
+      f_list_ordered->setChecked( false );
+    }
+    else if ( lfmt.style() == QTextListFormat::ListDecimal )
+    {
+      f_list_bullet->setChecked( false );
+      f_list_ordered->setChecked( true );
+    }
+    else
+    {
+      f_list_bullet->setChecked( false );
+      f_list_ordered->setChecked( false );
+    }
+  }
+  else
+  {
+    f_list_bullet->setChecked( false );
+    f_list_ordered->setChecked( false );
+  }
+}
+
+void QgsRichTextEditor::fontChanged( const QFont &f )
+{
+  f_fontsize->setCurrentIndex( f_fontsize->findText( QString::number( f.pointSize() ) ) );
+  f_bold->setChecked( f.bold() );
+  f_italic->setChecked( f.italic() );
+  f_underline->setChecked( f.underline() );
+  f_strikeout->setChecked( f.strikeOut() );
+  if ( f.pointSize() == m_fontsize_h1 )
+  {
+    f_paragraph->setCurrentIndex( ParagraphHeading1 );
+  }
+  else if ( f.pointSize() == m_fontsize_h2 )
+  {
+    f_paragraph->setCurrentIndex( ParagraphHeading2 );
+  }
+  else if ( f.pointSize() == m_fontsize_h3 )
+  {
+    f_paragraph->setCurrentIndex( ParagraphHeading3 );
+  }
+  else if ( f.pointSize() == m_fontsize_h4 )
+  {
+    f_paragraph->setCurrentIndex( ParagraphHeading4 );
+  }
+  else
+  {
+    if ( f.fixedPitch() && f.family() == QLatin1String( "Monospace" ) )
+    {
+      f_paragraph->setCurrentIndex( ParagraphMonospace );
+    }
+    else
+    {
+      f_paragraph->setCurrentIndex( ParagraphStandard );
+    }
+  }
+  if ( mTextEdit->textCursor().currentList() )
+  {
+    QTextListFormat lfmt = mTextEdit->textCursor().currentList()->format();
+    if ( lfmt.style() == QTextListFormat::ListDisc )
+    {
+      f_list_bullet->setChecked( true );
+      f_list_ordered->setChecked( false );
+    }
+    else if ( lfmt.style() == QTextListFormat::ListDecimal )
+    {
+      f_list_bullet->setChecked( false );
+      f_list_ordered->setChecked( true );
+    }
+    else
+    {
+      f_list_bullet->setChecked( false );
+      f_list_ordered->setChecked( false );
+    }
+  }
+  else
+  {
+    f_list_bullet->setChecked( false );
+    f_list_ordered->setChecked( false );
+  }
+}
+
+void QgsRichTextEditor::fgColorChanged( const QColor &c )
+{
+  QPixmap pix( 16, 16 );
+  if ( c.isValid() )
+  {
+    pix.fill( c );
+  }
+  else
+  {
+    pix.fill( QApplication::palette().windowText().color() );
+  }
+  f_fgcolor->setIcon( pix );
+}
+
+void QgsRichTextEditor::bgColorChanged( const QColor &c )
+{
+  QPixmap pix( 16, 16 );
+  if ( c.isValid() )
+  {
+    pix.fill( c );
+  }
+  else
+  {
+    pix.fill( QApplication::palette().window().color() );
+  }
+  f_bgcolor->setIcon( pix );
+}
+
+void QgsRichTextEditor::slotCurrentCharFormatChanged( const QTextCharFormat &format )
+{
+  fontChanged( format.font() );
+  bgColorChanged( ( format.background().isOpaque() ) ? format.background().color() : QColor() );
+  fgColorChanged( ( format.foreground().isOpaque() ) ? format.foreground().color() : QColor() );
+  f_link->setChecked( format.isAnchor() );
+}
+
+void QgsRichTextEditor::slotClipboardDataChanged()
+{
+#ifndef QT_NO_CLIPBOARD
+  if ( const QMimeData *md = QApplication::clipboard()->mimeData() )
+    f_paste->setEnabled( md->hasText() );
+#endif
+}
+
+QString QgsRichTextEditor::toHtml() const
+{
+  QString s = mTextEdit->toHtml();
+  // convert emails to links
+  s = s.replace( QRegularExpression( QStringLiteral( "(<[^a][^>]+>(?:<span[^>]+>)?|\\s)([a-zA-Z\\d]+@[a-zA-Z\\d]+\\.[a-zA-Z]+)" ) ), "\\1<a href=\"mailto:\\2\">\\2</a>" );
+  // convert links
+  s = s.replace( QRegularExpression( QStringLiteral( "(<[^a][^>]+>(?:<span[^>]+>)?|\\s)((?:https?|ftp|file)://[^\\s'\"<>]+)" ) ), "\\1<a href=\"\\2\">\\2</a>" );
+  // see also: Utils::linkify()
+  return s;
+}
+
+void QgsRichTextEditor::increaseIndentation()
+{
+  indent( +1 );
+}
+
+void QgsRichTextEditor::decreaseIndentation()
+{
+  indent( -1 );
+}
+
+void QgsRichTextEditor::indent( int delta )
+{
+  QTextCursor cursor = mTextEdit->textCursor();
+  cursor.beginEditBlock();
+  QTextBlockFormat bfmt = cursor.blockFormat();
+  int ind = bfmt.indent();
+  if ( ind + delta >= 0 )
+  {
+    bfmt.setIndent( ind + delta );
+  }
+  cursor.setBlockFormat( bfmt );
+  cursor.endEditBlock();
+}
+
+void QgsRichTextEditor::setText( const QString &text )
+{
+  if ( text.isEmpty() )
+  {
+    setPlainText( text );
+    return;
+  }
+  if ( text[0] == '<' )
+  {
+    setHtml( text );
+  }
+  else
+  {
+    setPlainText( text );
+  }
+}
+
+void QgsRichTextEditor::insertImage()
+{
+  QSettings s;
+  QString attdir = s.value( QStringLiteral( "general/filedialog-path" ) ).toString();
+  QString file = QFileDialog::getOpenFileName( this,
+                 tr( "Select an image" ),
+                 attdir,
+                 tr( "JPEG (*.jpg);; GIF (*.gif);; PNG (*.png);; BMP (*.bmp);; All (*)" ) );
+  QImage image = QImageReader( file ).read();
+
+  mTextEdit->dropImage( image, QFileInfo( file ).suffix().toUpper().toLocal8Bit().data() );
+}

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -181,7 +181,7 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   mForeColorButton = new QgsColorButton();
   mForeColorButton->setAllowOpacity( false );
   mForeColorButton->setColorDialogTitle( tr( "Foreground Color" ) );
-  mForeColorButton->setColor( QApplication::palette().windowText().color() );
+  mForeColorButton->setColor( palette().windowText().color() );
   mForeColorButton->setShowNoColor( false );
   mForeColorButton->setToolTip( tr( "Foreground color" ) );
   mForeColorButton->setMinimumWidth( QFontMetrics( font() ).horizontalAdvance( QStringLiteral( "x" ) ) * 10 );
@@ -326,7 +326,7 @@ void QgsRichTextEditor::textLink( bool checked )
     {
       format.setAnchor( true );
       format.setAnchorHref( newUrl );
-      format.setForeground( QApplication::palette().color( QPalette::Link ) );
+      format.setForeground( palette().color( QPalette::Link ) );
       format.setFontUnderline( true );
     }
     else
@@ -341,7 +341,7 @@ void QgsRichTextEditor::textLink( bool checked )
   if ( unlink )
   {
     format.setAnchor( false );
-    format.setForeground( QApplication::palette().color( QPalette::Text ) );
+    format.setForeground( palette().color( QPalette::Text ) );
     format.setFontUnderline( false );
   }
   mergeFormatOnWordOrSelection( format );
@@ -591,7 +591,7 @@ void QgsRichTextEditor::slotCurrentCharFormatChanged( const QTextCharFormat &for
 {
   fontChanged( format.font() );
   bgColorChanged( ( format.background().isOpaque() ) ? format.background().color() : QColor() );
-  fgColorChanged( ( format.foreground().isOpaque() ) ? format.foreground().color() : QApplication::palette().windowText().color() );
+  fgColorChanged( ( format.foreground().isOpaque() ) ? format.foreground().color() : palette().windowText().color() );
   mActionInsertLink->setChecked( format.isAnchor() );
 }
 

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -237,15 +237,12 @@ void QgsRichTextEditor::clearSource()
 
 void QgsRichTextEditor::textRemoveFormat()
 {
-  QTextCharFormat fmt;
-  fmt.setFontWeight( QFont::Normal );
-  fmt.setFontUnderline( false );
-  fmt.setFontStrikeOut( false );
-  fmt.setFontItalic( false );
-  fmt.setFontPointSize( 9 );
-//  fmt.setFontFamily     ("Helvetica");
-//  fmt.setFontStyleHint  (QFont::SansSerif);
-//  fmt.setFontFixedPitch (true);
+  QTextCharFormat format;
+  format.setFontWeight( QFont::Normal );
+  format.setFontUnderline( false );
+  format.setFontStrikeOut( false );
+  format.setFontItalic( false );
+  format.setFontPointSize( 9 );
 
   mActionBold->setChecked( false );
   mActionUnderline->setChecked( false );
@@ -253,12 +250,9 @@ void QgsRichTextEditor::textRemoveFormat()
   mActionStrikeOut->setChecked( false );
   mFontSizeCombo->setCurrentIndex( mFontSizeCombo->findData( 9 ) );
 
-//  QTextBlockFormat bfmt = cursor.blockFormat();
-//  bfmt->setIndent(0);
+  format.clearBackground();
 
-  fmt.clearBackground();
-
-  mergeFormatOnWordOrSelection( fmt );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textRemoveAllFormat()
@@ -274,9 +268,9 @@ void QgsRichTextEditor::textRemoveAllFormat()
 
 void QgsRichTextEditor::textBold()
 {
-  QTextCharFormat fmt;
-  fmt.setFontWeight( mActionBold->isChecked() ? QFont::Bold : QFont::Normal );
-  mergeFormatOnWordOrSelection( fmt );
+  QTextCharFormat format;
+  format.setFontWeight( mActionBold->isChecked() ? QFont::Bold : QFont::Normal );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::focusInEvent( QFocusEvent * )
@@ -286,23 +280,23 @@ void QgsRichTextEditor::focusInEvent( QFocusEvent * )
 
 void QgsRichTextEditor::textUnderline()
 {
-  QTextCharFormat fmt;
-  fmt.setFontUnderline( mActionUnderline->isChecked() );
-  mergeFormatOnWordOrSelection( fmt );
+  QTextCharFormat format;
+  format.setFontUnderline( mActionUnderline->isChecked() );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textItalic()
 {
-  QTextCharFormat fmt;
-  fmt.setFontItalic( mActionItalic->isChecked() );
-  mergeFormatOnWordOrSelection( fmt );
+  QTextCharFormat format;
+  format.setFontItalic( mActionItalic->isChecked() );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textStrikeout()
 {
-  QTextCharFormat fmt;
-  fmt.setFontStrikeOut( mActionStrikeOut->isChecked() );
-  mergeFormatOnWordOrSelection( fmt );
+  QTextCharFormat format;
+  format.setFontStrikeOut( mActionStrikeOut->isChecked() );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textSize( const QString &p )
@@ -310,16 +304,16 @@ void QgsRichTextEditor::textSize( const QString &p )
   qreal pointSize = p.toDouble();
   if ( p.toFloat() > 0 )
   {
-    QTextCharFormat fmt;
-    fmt.setFontPointSize( pointSize );
-    mergeFormatOnWordOrSelection( fmt );
+    QTextCharFormat format;
+    format.setFontPointSize( pointSize );
+    mergeFormatOnWordOrSelection( format );
   }
 }
 
 void QgsRichTextEditor::textLink( bool checked )
 {
   bool unlink = false;
-  QTextCharFormat fmt;
+  QTextCharFormat format;
   if ( checked )
   {
     QString url = mTextEdit->currentCharFormat().anchorHref();
@@ -330,10 +324,10 @@ void QgsRichTextEditor::textLink( bool checked )
                                             &ok );
     if ( ok )
     {
-      fmt.setAnchor( true );
-      fmt.setAnchorHref( newUrl );
-      fmt.setForeground( QApplication::palette().color( QPalette::Link ) );
-      fmt.setFontUnderline( true );
+      format.setAnchor( true );
+      format.setAnchorHref( newUrl );
+      format.setForeground( QApplication::palette().color( QPalette::Link ) );
+      format.setFontUnderline( true );
     }
     else
     {
@@ -346,11 +340,11 @@ void QgsRichTextEditor::textLink( bool checked )
   }
   if ( unlink )
   {
-    fmt.setAnchor( false );
-    fmt.setForeground( QApplication::palette().color( QPalette::Text ) );
-    fmt.setFontUnderline( false );
+    format.setAnchor( false );
+    format.setForeground( QApplication::palette().color( QPalette::Text ) );
+    format.setFontUnderline( false );
   }
-  mergeFormatOnWordOrSelection( fmt );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textStyle( int )
@@ -363,9 +357,9 @@ void QgsRichTextEditor::textStyle( int )
   {
     cursor.select( QTextCursor::BlockUnderCursor );
   }
-  QTextCharFormat fmt;
-  cursor.setCharFormat( fmt );
-  mTextEdit->setCurrentCharFormat( fmt );
+  QTextCharFormat format;
+  cursor.setCharFormat( format );
+  mTextEdit->setCurrentCharFormat( format );
 
   ParagraphItems style = static_cast< ParagraphItems >( mParagraphStyleCombo->currentData().toInt() );
   if ( style == ParagraphHeading1
@@ -375,60 +369,60 @@ void QgsRichTextEditor::textStyle( int )
   {
     if ( style == ParagraphHeading1 )
     {
-      fmt.setFontPointSize( mFontSizeH1 );
+      format.setFontPointSize( mFontSizeH1 );
     }
     if ( style == ParagraphHeading2 )
     {
-      fmt.setFontPointSize( mFontSizeH2 );
+      format.setFontPointSize( mFontSizeH2 );
     }
     if ( style == ParagraphHeading3 )
     {
-      fmt.setFontPointSize( mFontSizeH3 );
+      format.setFontPointSize( mFontSizeH3 );
     }
     if ( style == ParagraphHeading4 )
     {
-      fmt.setFontPointSize( mFontSizeH4 );
+      format.setFontPointSize( mFontSizeH4 );
     }
     if ( style == ParagraphHeading2 || style == ParagraphHeading4 )
     {
-      fmt.setFontItalic( true );
+      format.setFontItalic( true );
     }
 
-    fmt.setFontWeight( QFont::Bold );
+    format.setFontWeight( QFont::Bold );
   }
   if ( style == ParagraphMonospace )
   {
-    fmt = cursor.charFormat();
-    fmt.setFontFamily( QStringLiteral( "Monospace" ) );
-    fmt.setFontStyleHint( QFont::Monospace );
-    fmt.setFontFixedPitch( true );
+    format = cursor.charFormat();
+    format.setFontFamily( QStringLiteral( "Monospace" ) );
+    format.setFontStyleHint( QFont::Monospace );
+    format.setFontFixedPitch( true );
   }
-  cursor.setCharFormat( fmt );
-  mTextEdit->setCurrentCharFormat( fmt );
+  cursor.setCharFormat( format );
+  mTextEdit->setCurrentCharFormat( format );
 
   cursor.endEditBlock();
 }
 
 void QgsRichTextEditor::textFgColor()
 {
-  QTextCharFormat fmt;
-  fmt.setForeground( mForeColorButton->color() );
-  mergeFormatOnWordOrSelection( fmt );
+  QTextCharFormat format;
+  format.setForeground( mForeColorButton->color() );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::textBgColor()
 {
-  QTextCharFormat fmt;
+  QTextCharFormat format;
   QColor col = mBackColorButton->color();
   if ( col.isValid() )
   {
-    fmt.setBackground( col );
+    format.setBackground( col );
   }
   else
   {
-    fmt.clearBackground();
+    format.clearBackground();
   }
-  mergeFormatOnWordOrSelection( fmt );
+  mergeFormatOnWordOrSelection( format );
 }
 
 void QgsRichTextEditor::listBullet( bool checked )
@@ -455,20 +449,20 @@ void QgsRichTextEditor::list( bool checked, QTextListFormat::Style style )
   cursor.beginEditBlock();
   if ( !checked )
   {
-    QTextBlockFormat obfmt = cursor.blockFormat();
-    QTextBlockFormat bfmt;
-    bfmt.setIndent( obfmt.indent() );
-    cursor.setBlockFormat( bfmt );
+    const QTextBlockFormat originalFormat = cursor.blockFormat();
+    QTextBlockFormat format;
+    format.setIndent( originalFormat.indent() );
+    cursor.setBlockFormat( format );
   }
   else
   {
-    QTextListFormat listFmt;
+    QTextListFormat listFormat;
     if ( cursor.currentList() )
     {
-      listFmt = cursor.currentList()->format();
+      listFormat = cursor.currentList()->format();
     }
-    listFmt.setStyle( style );
-    cursor.createList( listFmt );
+    listFormat.setStyle( style );
+    cursor.createList( listFormat );
   }
   cursor.endEditBlock();
 }
@@ -496,13 +490,13 @@ void QgsRichTextEditor::slotCursorPositionChanged()
   mLastBlockList = l;
   if ( l )
   {
-    QTextListFormat lfmt = l->format();
-    if ( lfmt.style() == QTextListFormat::ListDisc )
+    QTextListFormat listFormat = l->format();
+    if ( listFormat.style() == QTextListFormat::ListDisc )
     {
       mActionBulletList->setChecked( true );
       mActionOrderedList->setChecked( false );
     }
-    else if ( lfmt.style() == QTextListFormat::ListDecimal )
+    else if ( listFormat.style() == QTextListFormat::ListDecimal )
     {
       mActionBulletList->setChecked( false );
       mActionOrderedList->setChecked( true );
@@ -556,13 +550,13 @@ void QgsRichTextEditor::fontChanged( const QFont &f )
   }
   if ( mTextEdit->textCursor().currentList() )
   {
-    QTextListFormat lfmt = mTextEdit->textCursor().currentList()->format();
-    if ( lfmt.style() == QTextListFormat::ListDisc )
+    QTextListFormat listFormat = mTextEdit->textCursor().currentList()->format();
+    if ( listFormat.style() == QTextListFormat::ListDisc )
     {
       mActionBulletList->setChecked( true );
       mActionOrderedList->setChecked( false );
     }
-    else if ( lfmt.style() == QTextListFormat::ListDecimal )
+    else if ( listFormat.style() == QTextListFormat::ListDecimal )
     {
       mActionBulletList->setChecked( false );
       mActionOrderedList->setChecked( true );
@@ -634,13 +628,13 @@ void QgsRichTextEditor::indent( int delta )
 {
   QTextCursor cursor = mTextEdit->textCursor();
   cursor.beginEditBlock();
-  QTextBlockFormat bfmt = cursor.blockFormat();
-  int ind = bfmt.indent();
-  if ( ind + delta >= 0 )
+  QTextBlockFormat format = cursor.blockFormat();
+  int indent = format.indent();
+  if ( indent + delta >= 0 )
   {
-    bfmt.setIndent( ind + delta );
+    format.setIndent( indent + delta );
   }
-  cursor.setBlockFormat( bfmt );
+  cursor.setBlockFormat( format );
   cursor.endEditBlock();
 }
 

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -1,9 +1,15 @@
-/*
+/****************************************************************************
+**
 ** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
 ** Contact: http://www.hobrasoft.cz/
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
 ** Contact: http://www.qt-project.org/legal
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** GNU Lesser General Public License Usage
@@ -19,7 +25,8 @@
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$
-*/
+**
+****************************************************************************/
 
 #ifndef QGSRICHTEXTEDITOR_H
 #define QGSRICHTEXTEDITOR_H

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -1,0 +1,108 @@
+/*
+** Copyright (C) 2013 Jiří Procházka (Hobrasoft)
+** Contact: http://www.hobrasoft.cz/
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** GNU Lesser General Public License Usage
+** This file is under the terms of the GNU Lesser General Public License
+** version 2.1 as published by the Free Software Foundation and appearing
+** in the file LICENSE.LGPL included in the packaging of this file.
+** Please review the following information to ensure the
+** GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+*/
+
+#ifndef QGSRICHTEXTEDITOR_H
+#define QGSRICHTEXTEDITOR_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "ui_qgsrichtexteditorbase.h"
+#include <QPointer>
+
+class QImage;
+
+/*
+ * Originally ported from https://github.com/Anchakor/MRichTextEditor, courtesy of Hobrasoft.
+ */
+
+class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEditorBase
+{
+    Q_OBJECT
+  public:
+    QgsRichTextEditor( QWidget *parent = nullptr );
+
+    QString toPlainText() const { return mTextEdit->toPlainText(); }
+    QString toHtml() const;
+    QTextDocument *document() { return mTextEdit->document(); }
+    QTextCursor textCursor() const { return mTextEdit->textCursor(); }
+    void setTextCursor( const QTextCursor &cursor ) { mTextEdit->setTextCursor( cursor ); }
+
+  public slots:
+    void setText( const QString &text );
+    void clearSource();
+
+  protected slots:
+    void setPlainText( const QString &text ) { mTextEdit->setPlainText( text ); }
+    void setHtml( const QString &text ) { mTextEdit->setHtml( text ); }
+    void textRemoveFormat();
+    void textRemoveAllFormat();
+    void textBold();
+    void textUnderline();
+    void textStrikeout();
+    void textItalic();
+    void textSize( const QString &p );
+    void textLink( bool checked );
+    void textStyle( int index );
+    void textFgColor();
+    void textBgColor();
+    void listBullet( bool checked );
+    void listOrdered( bool checked );
+    void slotCurrentCharFormatChanged( const QTextCharFormat &format );
+    void slotCursorPositionChanged();
+    void slotClipboardDataChanged();
+    void increaseIndentation();
+    void decreaseIndentation();
+    void insertImage();
+    void textSource();
+
+  protected:
+    void mergeFormatOnWordOrSelection( const QTextCharFormat &format );
+    void fontChanged( const QFont &f );
+    void fgColorChanged( const QColor &c );
+    void bgColorChanged( const QColor &c );
+    void list( bool checked, QTextListFormat::Style style );
+    void indent( int delta );
+    void focusInEvent( QFocusEvent *event );
+
+    QStringList m_paragraphItems;
+    int m_fontsize_h1;
+    int m_fontsize_h2;
+    int m_fontsize_h3;
+    int m_fontsize_h4;
+
+    enum ParagraphItems
+    {
+      ParagraphStandard = 0,
+      ParagraphHeading1,
+      ParagraphHeading2,
+      ParagraphHeading3,
+      ParagraphHeading4,
+      ParagraphMonospace
+    };
+
+    QPointer<QTextList> m_lastBlockList;
+};
+
+
+
+#endif // QGSRICHTEXTEDITOR_H

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -30,28 +30,84 @@
 #include <QPointer>
 
 class QImage;
+class QComboBox;
+class QgsColorButton;
 
 /*
  * Originally ported from https://github.com/Anchakor/MRichTextEditor, courtesy of Hobrasoft.
  */
 
+/**
+ * \ingroup gui
+ * \brief A widget for editing rich text documents, with support for user controlled formatting of text
+ * and insertion of hyperlinks and images.
+ *
+ * QgsRichTextEditor provides a reusable widget for allowing users to edit rich text documents,
+ * and retrieving and setting the documents via HTML formatted strings.
+ *
+ * \since QGIS 3.20
+ */
 class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEditorBase
 {
     Q_OBJECT
   public:
+
+    /**
+     * Constructor for QgsRichTextEditor, with the specified \a parent widget.
+     */
     QgsRichTextEditor( QWidget *parent = nullptr );
 
+    /**
+     * Returns the widget's content as a plain text string.
+     *
+     * \see toHtml()
+     */
     QString toPlainText() const { return mTextEdit->toPlainText(); }
+
+    /**
+     * Returns the widget's content as a HTML string.
+     *
+     * \see toPlainText()
+     */
     QString toHtml() const;
+
+    /**
+     * Returns a reference to the QTextDocument shown in the widget.
+     */
     QTextDocument *document() { return mTextEdit->document(); }
+
+    /**
+     * Returns a reference to the text cursor.
+     *
+     * \see setTextCursor()
+     */
     QTextCursor textCursor() const { return mTextEdit->textCursor(); }
+
+    /**
+     * Sets the current text \a cursor.
+     *
+     * \see textCursor()
+     */
     void setTextCursor( const QTextCursor &cursor ) { mTextEdit->setTextCursor( cursor ); }
 
   public slots:
+
+    /**
+     * Sets the \a text to show in the widget.
+     *
+     * The \a text can either be a plain text string or a HTML document.
+     */
     void setText( const QString &text );
+
+    /**
+     * Clears the current text from the widget.
+     */
     void clearSource();
 
-  protected slots:
+  protected:
+    void focusInEvent( QFocusEvent *event ) override;
+
+  private slots:
     void setPlainText( const QString &text ) { mTextEdit->setPlainText( text ); }
     void setHtml( const QString &text ) { mTextEdit->setHtml( text ); }
     void textRemoveFormat();
@@ -75,20 +131,18 @@ class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEd
     void insertImage();
     void textSource();
 
-  protected:
+  private:
     void mergeFormatOnWordOrSelection( const QTextCharFormat &format );
     void fontChanged( const QFont &f );
     void fgColorChanged( const QColor &c );
     void bgColorChanged( const QColor &c );
     void list( bool checked, QTextListFormat::Style style );
     void indent( int delta );
-    void focusInEvent( QFocusEvent *event );
 
-    QStringList m_paragraphItems;
-    int m_fontsize_h1;
-    int m_fontsize_h2;
-    int m_fontsize_h3;
-    int m_fontsize_h4;
+    int mFontSizeH1 = 18;
+    int mFontSizeH2 = 16;
+    int mFontSizeH3 = 14;
+    int mFontSizeH4 = 12;
 
     enum ParagraphItems
     {
@@ -100,7 +154,13 @@ class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEd
       ParagraphMonospace
     };
 
-    QPointer<QTextList> m_lastBlockList;
+    QComboBox *mParagraphStyleCombo = nullptr;
+    QComboBox *mFontSizeCombo = nullptr;
+
+    QgsColorButton *mForeColorButton = nullptr;
+    QgsColorButton *mBackColorButton = nullptr;
+
+    QPointer<QTextList> mLastBlockList;
 };
 
 

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -168,6 +168,7 @@ class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEd
     QgsColorButton *mBackColorButton = nullptr;
 
     QPointer<QTextList> mLastBlockList;
+    QString mMonospaceFontFamily;
 };
 
 

--- a/src/ui/qgsrichtexteditorbase.ui
+++ b/src/ui/qgsrichtexteditorbase.ui
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsRichTextEditorBase</class>
+ <widget class="QWidget" name="QgsRichTextEditorBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>846</width>
+    <height>312</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>1</number>
+   </property>
+   <property name="leftMargin">
+    <number>1</number>
+   </property>
+   <property name="topMargin">
+    <number>1</number>
+   </property>
+   <property name="rightMargin">
+    <number>1</number>
+   </property>
+   <property name="bottomMargin">
+    <number>1</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="mToolbar" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QComboBox" name="f_paragraph">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Paragraph formatting</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_4">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_undo">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Undo (CTRL+Z)</string>
+        </property>
+        <property name="text">
+         <string>Undo</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-undo">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_redo">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Redo</string>
+        </property>
+        <property name="text">
+         <string>Redo</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-redo">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_cut">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Cut (CTRL+X)</string>
+        </property>
+        <property name="text">
+         <string>Cut</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-cut">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_copy">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Copy (CTRL+C)</string>
+        </property>
+        <property name="text">
+         <string>Copy</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-copy">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_paste">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Paste (CTRL+V)</string>
+        </property>
+        <property name="text">
+         <string>Paste</string>
+        </property>
+        <property name="icon">
+         <iconset theme="edit-paste">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_link">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Link (CTRL+L)</string>
+        </property>
+        <property name="text">
+         <string>Link</string>
+        </property>
+        <property name="icon">
+         <iconset theme="applications-internet">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_bold">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string notr="true">Bold (CTRL+B)</string>
+        </property>
+        <property name="text">
+         <string>Bold</string>
+        </property>
+        <property name="icon">
+         <iconset theme="format-text-bold">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_italic">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Italic (CTRL+I)</string>
+        </property>
+        <property name="text">
+         <string>Italic</string>
+        </property>
+        <property name="icon">
+         <iconset theme="format-text-italic">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_underline">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Underline (CTRL+U)</string>
+        </property>
+        <property name="text">
+         <string>Underline</string>
+        </property>
+        <property name="icon">
+         <iconset theme="format-text-underline">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_strikeout">
+        <property name="text">
+         <string>Strike Out</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_list_bullet">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Bullet list (CTRL+-)</string>
+        </property>
+        <property name="text">
+         <string>Bullet list</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_list_ordered">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Ordered list (CTRL+=)</string>
+        </property>
+        <property name="text">
+         <string>Ordered list</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_indent_dec">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Decrease indentation (CTRL+,)</string>
+        </property>
+        <property name="text">
+         <string>Decrease indentation</string>
+        </property>
+        <property name="icon">
+         <iconset theme="format-indent-less">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_indent_inc">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Increase indentation (CTRL+.)</string>
+        </property>
+        <property name="text">
+         <string>Increase indentation</string>
+        </property>
+        <property name="icon">
+         <iconset theme="format-indent-more">
+          <normaloff>.</normaloff>.</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_fgcolor">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Text foreground color</string>
+        </property>
+        <property name="text">
+         <string>.</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_bgcolor">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Text background color</string>
+        </property>
+        <property name="text">
+         <string>.</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="f_fontsize">
+        <property name="focusPolicy">
+         <enum>Qt::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Font size</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line_6">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_image">
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QToolButton" name="f_menu">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+     <zorder>f_paragraph</zorder>
+     <zorder>line_4</zorder>
+     <zorder>f_undo</zorder>
+     <zorder>f_redo</zorder>
+     <zorder>f_cut</zorder>
+     <zorder>f_copy</zorder>
+     <zorder>f_paste</zorder>
+     <zorder>line</zorder>
+     <zorder>f_link</zorder>
+     <zorder>line_3</zorder>
+     <zorder>f_italic</zorder>
+     <zorder>f_underline</zorder>
+     <zorder>line_2</zorder>
+     <zorder>f_fontsize</zorder>
+     <zorder>line_5</zorder>
+     <zorder>f_list_bullet</zorder>
+     <zorder>f_list_ordered</zorder>
+     <zorder>f_indent_dec</zorder>
+     <zorder>f_indent_inc</zorder>
+     <zorder>f_bold</zorder>
+     <zorder>f_bgcolor</zorder>
+     <zorder>f_strikeout</zorder>
+     <zorder>f_image</zorder>
+     <zorder>line_6</zorder>
+     <zorder>f_menu</zorder>
+     <zorder>f_fgcolor</zorder>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsImageDropTextEdit" name="mTextEdit">
+     <property name="autoFormatting">
+      <set>QTextEdit::AutoNone</set>
+     </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsImageDropTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>qgsimagedroptextedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mTextEdit</tabstop>
+  <tabstop>f_strikeout</tabstop>
+  <tabstop>f_image</tabstop>
+  <tabstop>f_menu</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsrichtexteditorbase.ui
+++ b/src/ui/qgsrichtexteditorbase.ui
@@ -15,547 +15,39 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>1</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>1</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>1</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>1</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>1</number>
+    <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="mToolbar" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>2</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QComboBox" name="f_paragraph">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Paragraph formatting</string>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line_4">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_undo">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Undo (CTRL+Z)</string>
-        </property>
-        <property name="text">
-         <string>Undo</string>
-        </property>
-        <property name="icon">
-         <iconset theme="edit-undo">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_redo">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Redo</string>
-        </property>
-        <property name="text">
-         <string>Redo</string>
-        </property>
-        <property name="icon">
-         <iconset theme="edit-redo">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_cut">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Cut (CTRL+X)</string>
-        </property>
-        <property name="text">
-         <string>Cut</string>
-        </property>
-        <property name="icon">
-         <iconset theme="edit-cut">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_copy">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Copy (CTRL+C)</string>
-        </property>
-        <property name="text">
-         <string>Copy</string>
-        </property>
-        <property name="icon">
-         <iconset theme="edit-copy">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_paste">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Paste (CTRL+V)</string>
-        </property>
-        <property name="text">
-         <string>Paste</string>
-        </property>
-        <property name="icon">
-         <iconset theme="edit-paste">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_link">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Link (CTRL+L)</string>
-        </property>
-        <property name="text">
-         <string>Link</string>
-        </property>
-        <property name="icon">
-         <iconset theme="applications-internet">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_bold">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string notr="true">Bold (CTRL+B)</string>
-        </property>
-        <property name="text">
-         <string>Bold</string>
-        </property>
-        <property name="icon">
-         <iconset theme="format-text-bold">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_italic">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Italic (CTRL+I)</string>
-        </property>
-        <property name="text">
-         <string>Italic</string>
-        </property>
-        <property name="icon">
-         <iconset theme="format-text-italic">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_underline">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Underline (CTRL+U)</string>
-        </property>
-        <property name="text">
-         <string>Underline</string>
-        </property>
-        <property name="icon">
-         <iconset theme="format-text-underline">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_strikeout">
-        <property name="text">
-         <string>Strike Out</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line_5">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_list_bullet">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Bullet list (CTRL+-)</string>
-        </property>
-        <property name="text">
-         <string>Bullet list</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_list_ordered">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Ordered list (CTRL+=)</string>
-        </property>
-        <property name="text">
-         <string>Ordered list</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_indent_dec">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Decrease indentation (CTRL+,)</string>
-        </property>
-        <property name="text">
-         <string>Decrease indentation</string>
-        </property>
-        <property name="icon">
-         <iconset theme="format-indent-less">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_indent_inc">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Increase indentation (CTRL+.)</string>
-        </property>
-        <property name="text">
-         <string>Increase indentation</string>
-        </property>
-        <property name="icon">
-         <iconset theme="format-indent-more">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_fgcolor">
-        <property name="minimumSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Text foreground color</string>
-        </property>
-        <property name="text">
-         <string>.</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_bgcolor">
-        <property name="minimumSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Text background color</string>
-        </property>
-        <property name="text">
-         <string>.</string>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="f_fontsize">
-        <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Font size</string>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line_6">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_image">
-        <property name="text">
-         <string notr="true">...</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QToolButton" name="f_menu">
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-     <zorder>f_paragraph</zorder>
-     <zorder>line_4</zorder>
-     <zorder>f_undo</zorder>
-     <zorder>f_redo</zorder>
-     <zorder>f_cut</zorder>
-     <zorder>f_copy</zorder>
-     <zorder>f_paste</zorder>
-     <zorder>line</zorder>
-     <zorder>f_link</zorder>
-     <zorder>line_3</zorder>
-     <zorder>f_italic</zorder>
-     <zorder>f_underline</zorder>
-     <zorder>line_2</zorder>
-     <zorder>f_fontsize</zorder>
-     <zorder>line_5</zorder>
-     <zorder>f_list_bullet</zorder>
-     <zorder>f_list_ordered</zorder>
-     <zorder>f_indent_dec</zorder>
-     <zorder>f_indent_inc</zorder>
-     <zorder>f_bold</zorder>
-     <zorder>f_bgcolor</zorder>
-     <zorder>f_strikeout</zorder>
-     <zorder>f_image</zorder>
-     <zorder>line_6</zorder>
-     <zorder>f_menu</zorder>
-     <zorder>f_fgcolor</zorder>
+    <widget class="QToolBar" name="mToolBar">
+     <addaction name="mActionUndo"/>
+     <addaction name="mActionRedo"/>
+     <addaction name="mActionCut"/>
+     <addaction name="mActionCopy"/>
+     <addaction name="mActionPaste"/>
+     <addaction name="separator"/>
+     <addaction name="mActionBold"/>
+     <addaction name="mActionItalic"/>
+     <addaction name="mActionUnderline"/>
+     <addaction name="mActionStrikeOut"/>
+     <addaction name="mActionBulletList"/>
+     <addaction name="mActionOrderedList"/>
+     <addaction name="mActionDecreaseIndent"/>
+     <addaction name="mActionIncreaseIndent"/>
+     <addaction name="separator"/>
+     <addaction name="mActionInsertLink"/>
+     <addaction name="mActionInsertImage"/>
     </widget>
    </item>
    <item>
@@ -569,6 +61,193 @@
     </widget>
    </item>
   </layout>
+  <action name="mActionUndo">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Undo</string>
+   </property>
+   <property name="toolTip">
+    <string>Undo</string>
+   </property>
+  </action>
+  <action name="mActionRedo">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionRedo.svg</normaloff>:/images/themes/default/mActionRedo.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Redo</string>
+   </property>
+   <property name="toolTip">
+    <string>Redo</string>
+   </property>
+  </action>
+  <action name="mActionCut">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCut.svg</normaloff>:/images/themes/default/mActionEditCut.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Cut</string>
+   </property>
+   <property name="toolTip">
+    <string>Cut</string>
+   </property>
+  </action>
+  <action name="mActionCopy">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Copy</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy</string>
+   </property>
+  </action>
+  <action name="mActionPaste">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Past</string>
+   </property>
+   <property name="toolTip">
+    <string>Paste</string>
+   </property>
+  </action>
+  <action name="mActionInsertLink">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="insert-link"/>
+   </property>
+   <property name="text">
+    <string>Insert Link</string>
+   </property>
+   <property name="toolTip">
+    <string>Insert link</string>
+   </property>
+  </action>
+  <action name="mActionBold">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="format-text-bold"/>
+   </property>
+   <property name="text">
+    <string>Bold</string>
+   </property>
+  </action>
+  <action name="mActionItalic">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="format-text-italic">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Italic</string>
+   </property>
+   <property name="toolTip">
+    <string>Italic</string>
+   </property>
+  </action>
+  <action name="mActionUnderline">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="format-text-underline">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Underline</string>
+   </property>
+   <property name="toolTip">
+    <string>Underline</string>
+   </property>
+  </action>
+  <action name="mActionStrikeOut">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="format-text-strikethrough">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Strike Out</string>
+   </property>
+   <property name="toolTip">
+    <string>Strike Out</string>
+   </property>
+  </action>
+  <action name="mActionBulletList">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Bullet List</string>
+   </property>
+   <property name="toolTip">
+    <string>Create a bullet list</string>
+   </property>
+  </action>
+  <action name="mActionOrderedList">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Ordered List</string>
+   </property>
+   <property name="toolTip">
+    <string>Create an ordered list</string>
+   </property>
+  </action>
+  <action name="mActionDecreaseIndent">
+   <property name="icon">
+    <iconset theme="format-indent-less"/>
+   </property>
+   <property name="text">
+    <string>Decrease Indentation</string>
+   </property>
+   <property name="toolTip">
+    <string>Decrease indentation</string>
+   </property>
+  </action>
+  <action name="mActionIncreaseIndent">
+   <property name="icon">
+    <iconset theme="format-indent-more">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Increase Indentation</string>
+   </property>
+   <property name="toolTip">
+    <string>Increase indentation</string>
+   </property>
+  </action>
+  <action name="mActionInsertImage">
+   <property name="icon">
+    <iconset theme="insert-image">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Insert Image</string>
+   </property>
+   <property name="toolTip">
+    <string>Insert image</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -579,10 +258,9 @@
  </customwidgets>
  <tabstops>
   <tabstop>mTextEdit</tabstop>
-  <tabstop>f_strikeout</tabstop>
-  <tabstop>f_image</tabstop>
-  <tabstop>f_menu</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Based on a port of https://github.com/Anchakor/MRichTextEditor, but made to fit with standard QGIS coding styles and reuse of custom QGIS widgets.

Supports text formatting, editing the HTML source, drag and drop insertion of images, and other nice stuff


https://user-images.githubusercontent.com/1829991/115334594-05adfe80-a1df-11eb-844b-250d5fd29947.mp4

