### PR TITLE
Calls to qgis::make_unique and qgis::as_const to namespace std

### DIFF
--- a/src/quickgui/qgsquickhighlightsgnode.cpp
+++ b/src/quickgui/qgsquickhighlightsgnode.cpp
@@ -86,8 +86,8 @@ QSGGeometryNode *QgsQuickHighlightSGNode::createLineGeometry( const QgsLineStrin
 {
   Q_ASSERT( line );
 
-  std::unique_ptr<QSGGeometryNode> node = qgis::make_unique< QSGGeometryNode>();
-  std::unique_ptr<QSGGeometry> sgGeom = qgis::make_unique< QSGGeometry>( QSGGeometry::defaultAttributes_Point2D(), line->numPoints() );
+  std::unique_ptr<QSGGeometryNode> node = std::make_unique< QSGGeometryNode>();
+  std::unique_ptr<QSGGeometry> sgGeom = std::make_unique< QSGGeometry>( QSGGeometry::defaultAttributes_Point2D(), line->numPoints() );
   QSGGeometry::Point2D *vertices = sgGeom->vertexDataAsPoint2D();
 
   const double *x = line->xData();
@@ -114,8 +114,8 @@ QSGGeometryNode *QgsQuickHighlightSGNode::createPointGeometry( const QgsPoint *p
 {
   Q_ASSERT( point );
 
-  std::unique_ptr<QSGGeometryNode> node = qgis::make_unique< QSGGeometryNode>();
-  std::unique_ptr<QSGGeometry> sgGeom = qgis::make_unique<QSGGeometry>( QSGGeometry::defaultAttributes_Point2D(), 1 );
+  std::unique_ptr<QSGGeometryNode> node = std::make_unique< QSGGeometryNode>();
+  std::unique_ptr<QSGGeometry> sgGeom = std::make_unique<QSGGeometry>( QSGGeometry::defaultAttributes_Point2D(), 1 );
 
   QSGGeometry::Point2D *vertices = sgGeom->vertexDataAsPoint2D();
   vertices[0].set(

--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -335,7 +335,7 @@ void QgsQuickMapCanvasMap::onLayersChanged()
   if ( mMapSettings->extent().isEmpty() )
     zoomToFullExtent();
 
-  for ( const QMetaObject::Connection &conn : qgis::as_const( mLayerConnections ) )
+  for ( const QMetaObject::Connection &conn : std::as_const( mLayerConnections ) )
   {
     disconnect( conn );
   }

--- a/src/quickgui/qgsquicksimulatedpositionsource.cpp
+++ b/src/quickgui/qgsquicksimulatedpositionsource.cpp
@@ -21,7 +21,7 @@
 
 QgsQuickSimulatedPositionSource::QgsQuickSimulatedPositionSource( QObject *parent, double longitude, double latitude, double flightRadius )
   : QGeoPositionInfoSource( parent )
-  , mTimer( qgis::make_unique< QTimer >() )
+  , mTimer( std::make_unique< QTimer >() )
   , mFlightRadius( flightRadius )
   , mLongitude( longitude )
   , mLatitude( latitude )

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -369,7 +369,7 @@ QVariantMap QgsQuickUtils::createValueRelationCache( const QVariantMap &config, 
   QVariantMap valueMap;
   QgsValueRelationFieldFormatter::ValueRelationCache cache = QgsValueRelationFieldFormatter::createCache( config, formFeature );
 
-  for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgis::as_const( cache ) )
+  for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : std::as_const( cache ) )
   {
     valueMap.insert( item.key.toString(), item.value );
   }


### PR DESCRIPTION
A few calls to qgis::make_unique and qgis::as_const remain in qgisquickgui, even after 6869826898070d11b62129d22d457f875445b955, which prevents the latest master from building in Gentoo (GCC 9.3.0). This patch moves those calls to namespace std.