### PR TITLE
[attribute form] Fix drag n drop spacing issue with container-less setup

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1447,6 +1447,7 @@ void QgsAttributeForm::init()
     int row = 0;
     int column = 0;
     int columnCount = 1;
+    bool hasRootFields = false;
 
     const QList<QgsAttributeEditorElement *> tabs = mLayer->editFormConfig().tabs();
 
@@ -1495,6 +1496,7 @@ void QgsAttributeForm::init()
       }
       else
       {
+        hasRootFields = true;
         tabWidget = nullptr;
         WidgetInfo widgetInfo = createWidgetFromDef( widgDef, container, mLayer, mContext );
         QLabel *label = new QLabel( widgetInfo.labelText );
@@ -1555,6 +1557,14 @@ void QgsAttributeForm::init()
         row += 1;
       }
     }
+
+    if ( hasRootFields )
+    {
+      QSpacerItem *spacerItem = new QSpacerItem( 20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding );
+      layout->addItem( spacerItem, row, 0 );
+      layout->setRowStretch( row, 1 );
+    }
+
     formWidget = container;
   }
 


### PR DESCRIPTION
## Description

While working on #42880 , I was reminded of a bad UI issue with drag n drop attribute forms:
![image](https://user-images.githubusercontent.com/1728657/115543677-d6c18680-a2cb-11eb-9cb0-478ad22ed994.png)

This bad spacing in between field widgets for container-less forms. This PR fixes that. 