### PR TITLE
Provide a mechanism to specify a list of fallback font families for QgsTextFormat

### DIFF
--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -218,6 +218,38 @@ Sets the named style for the font used for rendering text.
 .. seealso:: :py:func:`setFont`
 %End
 
+    QStringList families() const;
+%Docstring
+Returns the list of font families to use when restoring the text format, in order of precedence.
+
+.. warning::
+
+   The list of families returned by this method is ONLY used when restoring the text format
+   from serialized versions, and will not affect the current :py:func:`~QgsTextFormat.font` familily used by the format.
+
+.. seealso:: :py:func:`setFamilies`
+
+.. versionadded:: 3.20
+%End
+
+    void setFamilies( const QStringList &families );
+%Docstring
+Sets a list of font ``families`` to use for the text format, in order of precedence.
+
+When restoring serialized versions of the text format then the first matching font family
+from this list will be used for the text format. This provides a way to specify a list of possible
+font families which are used as fallbacks if a family isn't available on a particular QGIS install (CSS style).
+
+.. warning::
+
+   The list of families set by calling this method is ONLY used when restoring the text format
+   from serialized versions, and will not affect the current :py:func:`~QgsTextFormat.font` familily used by the format.
+
+.. seealso:: :py:func:`families`
+
+.. versionadded:: 3.20
+%End
+
     double size() const;
 %Docstring
 Returns the size for rendered text. Units are retrieved using :py:func:`~QgsTextFormat.sizeUnit`.

--- a/src/core/textrenderer/qgstextformat.h
+++ b/src/core/textrenderer/qgstextformat.h
@@ -222,6 +222,32 @@ class CORE_EXPORT QgsTextFormat
     void setNamedStyle( const QString &style );
 
     /**
+     * Returns the list of font families to use when restoring the text format, in order of precedence.
+     *
+     * \warning The list of families returned by this method is ONLY used when restoring the text format
+     * from serialized versions, and will not affect the current font() familily used by the format.
+     *
+     * \see setFamilies()
+     * \since QGIS 3.20
+     */
+    QStringList families() const;
+
+    /**
+     * Sets a list of font \a families to use for the text format, in order of precedence.
+     *
+     * When restoring serialized versions of the text format then the first matching font family
+     * from this list will be used for the text format. This provides a way to specify a list of possible
+     * font families which are used as fallbacks if a family isn't available on a particular QGIS install (CSS style).
+     *
+     * \warning The list of families set by calling this method is ONLY used when restoring the text format
+     * from serialized versions, and will not affect the current font() familily used by the format.
+     *
+     * \see families()
+     * \since QGIS 3.20
+     */
+    void setFamilies( const QStringList &families );
+
+    /**
      * Returns the size for rendered text. Units are retrieved using sizeUnit().
      * \see setSize()
      * \see sizeUnit()

--- a/src/core/textrenderer/qgstextrenderer_p.h
+++ b/src/core/textrenderer/qgstextrenderer_p.h
@@ -262,6 +262,7 @@ class QgsTextSettingsPrivate : public QSharedData
       : QSharedData( other )
       , isValid( other.isValid )
       , textFont( other.textFont )
+      , families( other.families )
       , textNamedStyle( other.textNamedStyle )
       , fontSizeUnits( other.fontSizeUnits )
       , fontSizeMapUnitScale( other.fontSizeMapUnitScale )
@@ -280,6 +281,7 @@ class QgsTextSettingsPrivate : public QSharedData
 
     bool isValid = false;
     QFont textFont;
+    QStringList families;
     QString textNamedStyle;
     QgsUnitTypes::RenderUnit fontSizeUnits = QgsUnitTypes::RenderPoints;
     QgsMapUnitScale fontSizeMapUnitScale;

--- a/tests/src/python/test_qgstextrenderer.py
+++ b/tests/src/python/test_qgstextrenderer.py
@@ -10,9 +10,13 @@ __author__ = 'Nyall Dawson'
 __date__ = '2016-09'
 __copyright__ = 'Copyright 2016, The QGIS Project'
 
-import qgis  # NOQA
 import os
 
+import qgis  # NOQA
+from PyQt5.QtSvg import QSvgGenerator
+from qgis.PyQt.QtCore import (Qt, QSizeF, QPointF, QRectF, QDir, QSize)
+from qgis.PyQt.QtGui import (QColor, QPainter, QFont, QImage, QBrush, QPen)
+from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (QgsTextBufferSettings,
                        QgsTextMaskSettings,
                        QgsTextBackgroundSettings,
@@ -35,11 +39,8 @@ from qgis.core import (QgsTextBufferSettings,
                        QgsSymbolLayerId,
                        QgsSymbolLayerReference,
                        QgsStringUtils)
-from qgis.PyQt.QtGui import (QColor, QPainter, QFont, QImage, QBrush, QPen, QFontMetricsF)
-from qgis.PyQt.QtCore import (Qt, QSizeF, QPointF, QRectF, QDir, QSize)
-from qgis.PyQt.QtXml import QDomDocument
-from PyQt5.QtSvg import QSvgGenerator
 from qgis.testing import unittest, start_app
+
 from utilities import getTestFont, svgSymbolsPath
 
 start_app()
@@ -152,6 +153,10 @@ class PyQgsTextRenderer(unittest.TestCase):
 
         t = QgsTextFormat()
         t.setPreviewBackgroundColor(QColor(255, 0, 0))
+        self.assertTrue(t.isValid())
+
+        t = QgsTextFormat()
+        t.setFamilies(['Arial', 'Comic Sans'])
         self.assertTrue(t.isValid())
 
         t = QgsTextFormat()
@@ -688,6 +693,7 @@ class PyQgsTextRenderer(unittest.TestCase):
         s.setFont(font)
         s.setCapitalization(QgsStringUtils.TitleCase)
         s.setNamedStyle('Italic')
+        s.setFamilies(['Arial', 'Comic Sans'])
         s.setSize(5)
         s.setSizeUnit(QgsUnitTypes.RenderPoints)
         s.setSizeMapUnitScale(QgsMapUnitScale(1, 2))
@@ -795,6 +801,10 @@ class PyQgsTextRenderer(unittest.TestCase):
         s.dataDefinedProperties().setProperty(QgsPalLayerSettings.Bold, QgsProperty.fromExpression('1>3'))
         self.assertNotEqual(s, s2)
 
+        s = self.createFormatSettings()
+        s.setFamilies(['Times New Roman'])
+        self.assertNotEqual(s, s2)
+
     def checkTextFormat(self, s):
         """ test QgsTextFormat """
         self.assertTrue(s.buffer().enabled())
@@ -806,6 +816,7 @@ class PyQgsTextRenderer(unittest.TestCase):
         self.assertTrue(s.shadow().enabled())
         self.assertEqual(s.shadow().offsetAngle(), 223)
         self.assertEqual(s.font().family(), 'QGIS Vera Sans')
+        self.assertEqual(s.families(), ['Arial', 'Comic Sans'])
         self.assertFalse(s.font().kerning())
         self.assertEqual(s.namedStyle(), 'Italic')
         self.assertEqual(s.size(), 5)
@@ -852,6 +863,48 @@ class PyQgsTextRenderer(unittest.TestCase):
         from_mime, ok = QgsTextFormat.fromMimeData(md)
         self.assertTrue(ok)
         self.checkTextFormat(from_mime)
+
+    def testRestoreUsingFamilyList(self):
+        format = QgsTextFormat()
+
+        doc = QDomDocument("testdoc")
+        elem = format.writeXml(doc, QgsReadWriteContext())
+        parent = doc.createElement("settings")
+        parent.appendChild(elem)
+        doc.appendChild(parent)
+
+        # swap out font name in xml to one which doesn't exist on system
+        xml = doc.toString()
+        xml = xml.replace(QFont().family(), 'NOT A REAL FONT')
+        doc = QDomDocument("testdoc")
+        doc.setContent(xml)
+        parent = doc.firstChildElement('settings')
+
+        t = QgsTextFormat()
+        t.readXml(parent, QgsReadWriteContext())
+        # should be default font
+        self.assertEqual(t.font().family(), QFont().family())
+
+        format.setFamilies(['not real', 'still not real', getTestFont().family()])
+
+        doc = QDomDocument("testdoc")
+        elem = format.writeXml(doc, QgsReadWriteContext())
+        parent = doc.createElement("settings")
+        parent.appendChild(elem)
+        doc.appendChild(parent)
+
+        # swap out font name in xml to one which doesn't exist on system
+        xml = doc.toString()
+        xml = xml.replace(QFont().family(), 'NOT A REAL FONT')
+        doc = QDomDocument("testdoc")
+        doc.setContent(xml)
+        parent = doc.firstChildElement('settings')
+
+        t = QgsTextFormat()
+        t.readXml(parent, QgsReadWriteContext())
+        self.assertEqual(t.families(), ['not real', 'still not real', getTestFont().family()])
+        # should have skipped the missing fonts and fallen back to the test font family entry, NOT the default application font!
+        self.assertEqual(t.font().family(), getTestFont().family())
 
     def containsAdvancedEffects(self):
         t = QgsTextFormat()
@@ -2573,7 +2626,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.buffer().setEnabled(True)
         format.buffer().setSize(4)
         format.buffer().setSizeUnit(QgsUnitTypes.RenderMillimeters)
-        assert self.checkRender(format, 'text_rect_multiline_justify_aligned', text=['a t est', 'off', 'justification', 'align'],
+        assert self.checkRender(format, 'text_rect_multiline_justify_aligned',
+                                text=['a t est', 'off', 'justification', 'align'],
                                 alignment=QgsTextRenderer.AlignJustify, rect=QRectF(100, 100, 200, 100))
 
     def testDrawTextRectJustifyAlign(self):
@@ -2591,7 +2645,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
 
         assert self.checkRender(format, 'text_rect_multiline_bottom_aligned', text=['test', 'bottom', 'aligned'],
-                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100), vAlignment=QgsTextRenderer.AlignBottom)
+                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100),
+                                vAlignment=QgsTextRenderer.AlignBottom)
 
     def testDrawTextRectBottomAlign(self):
         format = QgsTextFormat()
@@ -2600,7 +2655,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
 
         assert self.checkRender(format, 'text_rect_bottom_aligned', text=['bottom aligned'],
-                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100), vAlignment=QgsTextRenderer.AlignBottom)
+                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100),
+                                vAlignment=QgsTextRenderer.AlignBottom)
 
     def testDrawTextRectMultilineVCenterAlign(self):
         format = QgsTextFormat()
@@ -2609,7 +2665,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
 
         assert self.checkRender(format, 'text_rect_multiline_vcenter_aligned', text=['test', 'center', 'aligned'],
-                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100), vAlignment=QgsTextRenderer.AlignVCenter)
+                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100),
+                                vAlignment=QgsTextRenderer.AlignVCenter)
 
     def testDrawTextRectVCenterAlign(self):
         format = QgsTextFormat()
@@ -2618,7 +2675,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
 
         assert self.checkRender(format, 'text_rect_vcenter_aligned', text=['center aligned'],
-                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100), vAlignment=QgsTextRenderer.AlignVCenter)
+                                alignment=QgsTextRenderer.AlignLeft, rect=QRectF(100, 100, 200, 100),
+                                vAlignment=QgsTextRenderer.AlignVCenter)
 
     def testDrawTextRectMultilineCenterAlign(self):
         format = QgsTextFormat()
@@ -2674,7 +2732,8 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setFont(getTestFont('bold'))
         format.setSize(30)
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
-        assert self.checkRenderPoint(format, 'text_point_justify_multiline_aligned', text=['a t est', 'off', 'justification', 'align'],
+        assert self.checkRenderPoint(format, 'text_point_justify_multiline_aligned',
+                                     text=['a t est', 'off', 'justification', 'align'],
                                      alignment=QgsTextRenderer.AlignJustify, point=QPointF(100, 200))
 
     def testDrawTextPointCenterAlign(self):
@@ -2723,7 +2782,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setSizeUnit(QgsUnitTypes.RenderPoints)
         format.setColor(QColor(0, 255, 0))
         format.setAllowHtmlFormatting(True)
-        assert self.checkRenderPoint(format, 'text_html_formatting', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testHtmlFormattingBuffer(self):
         format = QgsTextFormat()
@@ -2735,7 +2796,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.buffer().setEnabled(True)
         format.buffer().setSize(5)
         format.buffer().setColor(QColor(50, 150, 200))
-        assert self.checkRenderPoint(format, 'text_html_formatting_buffer', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting_buffer', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testHtmlFormattingShadow(self):
         format = QgsTextFormat()
@@ -2748,7 +2811,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.shadow().setOffsetDistance(5)
         format.shadow().setBlurRadius(0)
         format.shadow().setColor(QColor(50, 150, 200))
-        assert self.checkRenderPoint(format, 'text_html_formatting_shadow', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting_shadow', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testHtmlFormattingBufferShadow(self):
         format = QgsTextFormat()
@@ -2764,7 +2829,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.shadow().setOffsetDistance(5)
         format.shadow().setBlurRadius(0)
         format.shadow().setColor(QColor(50, 150, 200))
-        assert self.checkRenderPoint(format, 'text_html_formatting_buffer_shadow', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting_buffer_shadow', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testHtmlFormattingVertical(self):
         format = QgsTextFormat()
@@ -2774,7 +2841,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.setColor(QColor(0, 255, 0))
         format.setAllowHtmlFormatting(True)
         format.setOrientation(QgsTextFormat.VerticalOrientation)
-        assert self.checkRenderPoint(format, 'text_html_formatting_vertical', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting_vertical', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testHtmlFormattingBufferVertical(self):
         format = QgsTextFormat()
@@ -2787,7 +2856,9 @@ class PyQgsTextRenderer(unittest.TestCase):
         format.buffer().setSize(5)
         format.buffer().setColor(QColor(50, 150, 200))
         format.setOrientation(QgsTextFormat.VerticalOrientation)
-        assert self.checkRenderPoint(format, 'text_html_formatting_buffer_vertical', None, text=['<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'], point=QPointF(50, 200))
+        assert self.checkRenderPoint(format, 'text_html_formatting_buffer_vertical', None, text=[
+            '<s>t</s><span style="text-decoration: overline">e</span><span style="color: red">s<span style="text-decoration: underline">t</span></span>'],
+            point=QPointF(50, 200))
 
     def testTextRenderFormat(self):
         format = QgsTextFormat()


### PR DESCRIPTION
Just like in CSS, these families will be used as an ordered list of fonts to fallback on if the actual text format font isn't available
on a particular QGIS install.

This is API only, and isn't designed to be shown anywhere in QGIS. Instead the intended use is for creators of QGIS styles to either use the raw api to specify the list of fallback fonts OR hand edit the style xml to add the fallback fonts, e.g by adding a block like:

    <families>
      <family name="Arial"/>
      <family name="Helvetica"/>
      <family name="Sans"/>
    </families>

To the "text-style" parent element.
