### PR TITLE
fixes for compiling with PDAL/untwine with MSVC/Windows

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -513,7 +513,7 @@ target_link_libraries(qgis_app
   libdxfrw
 )
 
-target_compile_definitions(qgis_app PRIVATE "-DQT_NO_FOREACH")
+target_compile_definitions(qgis_app PRIVATE "-DQT_NO_FOREACH -DWIN32_LEAN_AND_MEAN")
 
 if (WITH_BINDINGS)
   target_link_libraries(qgis_app qgispython)

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -181,6 +181,8 @@ class QgsNetworkLoggerWidgetFactory;
 
 #ifdef Q_OS_WIN
 #include <windows.h>
+// because of WIN32_LEAN_AND_MEAN we need to include this explicitly
+#include <shellapi.h>
 #endif
 
 class QgsLegendFilterButton;

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -111,6 +111,8 @@ set_target_properties(untwine PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_LIBEXEC_SUBDIR}
 )
 
+target_compile_definitions(untwine PRIVATE WIN32_LEAN_AND_MEAN)
+
 target_link_libraries (untwine
   ${PDAL_LIBRARIES}
   Threads::Threads


### PR DESCRIPTION
## Description

Currently there are some problems compiling PDAL and untwine etc on Windows. Firstly, PDAL pulls in `winsock2.h` and parts of untwine and QGIS pull in `windows.h` before including PDAL (which by default includes `winsock.h`). This leads to compile errors due to the differently defined symbols in `winsock.h` and `winsock2.h` (see https://stackoverflow.com/questions/9153911/is-there-a-difference-between-winsock-h-and-winsock2-h/9168850). 

One solution is to always ensure that `winsock2.h` is included before `windows.h`. The other (less invasive) solution is to define the `WIN32_LEAN_AND_MEAN` symbol during the compile which stops `windows.h` including `winsock.h` (and a few other optional headers). This is what standalone untwine does (https://github.com/hobu/untwine/blob/main/cmake/win32_compiler_options.cmake#L9) and this is what I've gone for here.

Only problem was that qgisapp.cpp uses `ShellExecute()` from `shellapi.h` which isn't included with `windows.h` due to `WIN32_LEAN_AND_MEAN` so I've had to add this include in. 

There have also been a few recent (source) fixes to untwine for windows (https://github.com/hobu/untwine/commit/c7f94c1593badf27fb5ef91742fd470fe1c5ab69 https://github.com/hobu/untwine/pull/59 https://github.com/hobu/untwine/pull/57). Are changes to untwine pulled in automatically, or should these changes be added to this PR?

xref: https://github.com/conda-forge/qgis-feedstock/pull/178
cc: @SrNetoChan @hobu

