### PR TITLE
Add the first "out of the box" label style to the default style database 

### DIFF
--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5854,4 +5854,20 @@
       <prop k="stops" v="0.25;254,204,92,255:0.5;253,141,60,255:0.75;240,59,32,255"/>
     </colorramp>
   </colorramps>
+  <labelsettings>
+    <labelsetting favorite="1" name="Watercourse Label" addedVersion="32000">
+      <settings calloutType="simple">
+        <text-style fontSize="10" fieldName="" fontLetterSpacing="0.65625" fontSizeUnit="Point" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" useSubstitutions="0" fontKerning="1" fontWordSpacing="0.21875" fontFamily="Cambria" textOpacity="1" fontStrikeout="0" allowHtml="0" fontItalic="1" capitalization="0" textColor="0,145,202,255" previewBkgrdColor="243,243,238,255" namedStyle="Italic" textOrientation="horizontal" isExpression="1" fontUnderline="0" blendMode="0" fontWeight="50">
+        <families>
+          <family name="Cambria"/>        
+          <family name="Georgia"/>
+          <family name="Serif"/>
+        </families>
+        </text-style>
+        <text-format formatNumbers="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" plussign="0" decimals="3" wrapChar="" autoWrapLength="0" multilineAlign="0" useMaxLineLengthForAutoWrap="1"/>
+        <placement centroidInside="0" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorType="0" xOffset="0" quadOffset="4" maxCurvedCharAngleOut="-35" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" placementFlags="14" repeatDistanceUnits="MM" overrunDistanceUnit="MM" offsetUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" fitInPolygonOnly="0" dist="0" distUnits="MM" repeatDistance="300" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" centroidWhole="0" maxCurvedCharAngleIn="29" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placement="3" overrunDistance="4" layerType="LineGeometry" yOffset="0" rotationAngle="0" polygonPlacementFlags="2" geometryGeneratorEnabled="0"/>
+        <rendering minFeatureSize="0" zIndex="0" obstacleType="1" scaleMax="0" drawLabels="1" obstacle="1" mergeLines="1" labelPerPart="0" displayAll="0" fontMinPixelSize="3" limitNumLabels="0" scaleMin="0" maxNumLabels="2000" fontMaxPixelSize="10000" obstacleFactor="1" fontLimitPixelSize="0" scaleVisibility="0" upsidedownLabels="0"/>
+      </settings>
+    </labelsetting>
+  </labelsettings> 
 </qgis_style>

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5855,11 +5855,11 @@
     </colorramp>
   </colorramps>
   <labelsettings>
-    <labelsetting favorite="1" name="Watercourse Label" addedVersion="32000">
+    <labelsetting favorite="1" name="Watercourses" addedVersion="32000">
       <settings calloutType="simple">
         <text-style fontSize="10" fieldName="" fontLetterSpacing="0.65625" fontSizeUnit="Point" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" useSubstitutions="0" fontKerning="1" fontWordSpacing="0.21875" fontFamily="Cambria" textOpacity="1" fontStrikeout="0" allowHtml="0" fontItalic="1" capitalization="0" textColor="0,145,202,255" previewBkgrdColor="243,243,238,255" namedStyle="Italic" textOrientation="horizontal" isExpression="1" fontUnderline="0" blendMode="0" fontWeight="50">
         <families>
-          <family name="Cambria"/>        
+          <family name="Cambria"/>
           <family name="Georgia"/>
           <family name="Serif"/>
         </families>

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -3004,7 +3004,10 @@ void QgsPalLayerSettings::parseTextStyle( QFont &labelFont,
     if ( !ddFontFamily.isEmpty() )
     {
       // both family and style are different, build font from database
-      QFont styledfont = mFontDB.font( ddFontFamily, ddFontStyle, appFont.pointSize() );
+      if ( !mFontDB )
+        mFontDB = std::make_unique< QFontDatabase >();
+
+      QFont styledfont = mFontDB->font( ddFontFamily, ddFontStyle, appFont.pointSize() );
       if ( appFont != styledfont )
       {
         newFont = styledfont;
@@ -3020,7 +3023,9 @@ void QgsPalLayerSettings::parseTextStyle( QFont &labelFont,
     if ( ddFontStyle.compare( QLatin1String( "Ignore" ), Qt::CaseInsensitive ) != 0 )
     {
       // just family is different, build font from database
-      QFont styledfont = mFontDB.font( ddFontFamily, mFormat.namedStyle(), appFont.pointSize() );
+      if ( !mFontDB )
+        mFontDB = std::make_unique< QFontDatabase >();
+      QFont styledfont = mFontDB->font( ddFontFamily, mFormat.namedStyle(), appFont.pointSize() );
       if ( appFont != styledfont )
       {
         newFont = styledfont;

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -1064,7 +1064,7 @@ class CORE_EXPORT QgsPalLayerSettings
 
     QgsExpression *expression = nullptr;
 
-    QFontDatabase mFontDB;
+    std::unique_ptr< QFontDatabase > mFontDB;
 
     QgsTextFormat mFormat;
 

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -2837,92 +2837,97 @@ bool QgsStyle::importXml( const QString &filename, int sinceVersion )
   }
 
   // load text formats
-  if ( version == STYLE_CURRENT_VERSION )
+
+  // this is ONLY safe to do if we have a QGuiApplication-- it requires QFontDatabase, which is not available otherwise!
+  if ( dynamic_cast< QGuiApplication * >( QCoreApplication::instance() ) )
   {
-    const QDomElement textFormatElement = docEl.firstChildElement( QStringLiteral( "textformats" ) );
-    e = textFormatElement.firstChildElement();
-    while ( !e.isNull() )
+    if ( version == STYLE_CURRENT_VERSION )
     {
-      const int entityAddedVersion = e.attribute( QStringLiteral( "addedVersion" ) ).toInt();
-      if ( entityAddedVersion != 0 && sinceVersion != -1 && entityAddedVersion <= sinceVersion )
+      const QDomElement textFormatElement = docEl.firstChildElement( QStringLiteral( "textformats" ) );
+      e = textFormatElement.firstChildElement();
+      while ( !e.isNull() )
       {
-        // skip the format, should already be present
-        continue;
-      }
-
-      if ( e.tagName() == QLatin1String( "textformat" ) )
-      {
-        QString name = e.attribute( QStringLiteral( "name" ) );
-        QStringList tags;
-        if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+        const int entityAddedVersion = e.attribute( QStringLiteral( "addedVersion" ) ).toInt();
+        if ( entityAddedVersion != 0 && sinceVersion != -1 && entityAddedVersion <= sinceVersion )
         {
-          tags = e.attribute( QStringLiteral( "tags" ) ).split( ',' );
-        }
-        bool favorite = false;
-        if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == QLatin1String( "1" ) )
-        {
-          favorite = true;
+          // skip the format, should already be present
+          continue;
         }
 
-        QgsTextFormat format;
-        const QDomElement styleElem = e.firstChildElement();
-        format.readXml( styleElem, QgsReadWriteContext() );
-        addTextFormat( name, format );
-        if ( mCurrentDB )
+        if ( e.tagName() == QLatin1String( "textformat" ) )
         {
-          saveTextFormat( name, format, favorite, tags );
+          QString name = e.attribute( QStringLiteral( "name" ) );
+          QStringList tags;
+          if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+          {
+            tags = e.attribute( QStringLiteral( "tags" ) ).split( ',' );
+          }
+          bool favorite = false;
+          if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == QLatin1String( "1" ) )
+          {
+            favorite = true;
+          }
+
+          QgsTextFormat format;
+          const QDomElement styleElem = e.firstChildElement();
+          format.readXml( styleElem, QgsReadWriteContext() );
+          addTextFormat( name, format );
+          if ( mCurrentDB )
+          {
+            saveTextFormat( name, format, favorite, tags );
+          }
         }
+        else
+        {
+          QgsDebugMsg( "unknown tag: " + e.tagName() );
+        }
+        e = e.nextSiblingElement();
       }
-      else
-      {
-        QgsDebugMsg( "unknown tag: " + e.tagName() );
-      }
-      e = e.nextSiblingElement();
     }
-  }
 
-  // load label settings
-  if ( version == STYLE_CURRENT_VERSION )
-  {
-    const QDomElement labelSettingsElement = docEl.firstChildElement( QStringLiteral( "labelsettings" ) );
-    e = labelSettingsElement.firstChildElement();
-    while ( !e.isNull() )
+    // load label settings
+    if ( version == STYLE_CURRENT_VERSION )
     {
-      const int entityAddedVersion = e.attribute( QStringLiteral( "addedVersion" ) ).toInt();
-      if ( entityAddedVersion != 0 && sinceVersion != -1 && entityAddedVersion <= sinceVersion )
+      const QDomElement labelSettingsElement = docEl.firstChildElement( QStringLiteral( "labelsettings" ) );
+      e = labelSettingsElement.firstChildElement();
+      while ( !e.isNull() )
       {
-        // skip the settings, should already be present
-        continue;
-      }
-
-      if ( e.tagName() == QLatin1String( "labelsetting" ) )
-      {
-        QString name = e.attribute( QStringLiteral( "name" ) );
-        QStringList tags;
-        if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+        const int entityAddedVersion = e.attribute( QStringLiteral( "addedVersion" ) ).toInt();
+        if ( entityAddedVersion != 0 && sinceVersion != -1 && entityAddedVersion <= sinceVersion )
         {
-          tags = e.attribute( QStringLiteral( "tags" ) ).split( ',' );
-        }
-        bool favorite = false;
-        if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == QLatin1String( "1" ) )
-        {
-          favorite = true;
+          // skip the settings, should already be present
+          continue;
         }
 
-        QgsPalLayerSettings settings;
-        const QDomElement styleElem = e.firstChildElement();
-        settings.readXml( styleElem, QgsReadWriteContext() );
-        addLabelSettings( name, settings );
-        if ( mCurrentDB )
+        if ( e.tagName() == QLatin1String( "labelsetting" ) )
         {
-          saveLabelSettings( name, settings, favorite, tags );
+          QString name = e.attribute( QStringLiteral( "name" ) );
+          QStringList tags;
+          if ( e.hasAttribute( QStringLiteral( "tags" ) ) )
+          {
+            tags = e.attribute( QStringLiteral( "tags" ) ).split( ',' );
+          }
+          bool favorite = false;
+          if ( e.hasAttribute( QStringLiteral( "favorite" ) ) && e.attribute( QStringLiteral( "favorite" ) ) == QLatin1String( "1" ) )
+          {
+            favorite = true;
+          }
+
+          QgsPalLayerSettings settings;
+          const QDomElement styleElem = e.firstChildElement();
+          settings.readXml( styleElem, QgsReadWriteContext() );
+          addLabelSettings( name, settings );
+          if ( mCurrentDB )
+          {
+            saveLabelSettings( name, settings, favorite, tags );
+          }
         }
+        else
+        {
+          QgsDebugMsg( "unknown tag: " + e.tagName() );
+        }
+        e = e.nextSiblingElement();
       }
-      else
-      {
-        QgsDebugMsg( "unknown tag: " + e.tagName() );
-      }
-      e = e.nextSiblingElement();
     }
   }
 

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -2839,7 +2839,7 @@ bool QgsStyle::importXml( const QString &filename, int sinceVersion )
   // load text formats
 
   // this is ONLY safe to do if we have a QGuiApplication-- it requires QFontDatabase, which is not available otherwise!
-  if ( dynamic_cast< QGuiApplication * >( QCoreApplication::instance() ) )
+  if ( qobject_cast< QGuiApplication * >( QCoreApplication::instance() ) )
   {
     if ( version == STYLE_CURRENT_VERSION )
     {


### PR DESCRIPTION
For WAY too long we've shipped QGIS without any out-of-the-box label or text styles. Time for that to change!

This adds the first label style to the default style, a label style for water line features

![image](https://user-images.githubusercontent.com/1829991/115673107-9a575e80-a38f-11eb-9c9a-541e430b2ed2.png)

Seen in action here:

![image](https://user-images.githubusercontent.com/1829991/115673269-ca9efd00-a38f-11eb-8659-25172d9c47fa.png)


