### PR TITLE
Add QgsGeometry::isAxisParallelRectangle for checking whether a geometry is a axis-parallel rectangle

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -355,6 +355,21 @@ Uses GEOS library for the test.
 .. versionadded:: 3.0
 %End
 
+    bool isAxisParallelRectangle( double maximumDeviation, bool simpleRectanglesOnly = false ) const;
+%Docstring
+Returns ``True`` if the geometry is a polygon that is almost an axis-parallel rectangle.
+
+The ``maximumDeviation`` argument specifes the maximum angle (in degrees) that the polygon edges
+are allowed to deviate from axis parallel lines.
+
+By default the check will permit polygons with more than 4 edges, so long as the overall shape of
+the polygon is an axis-parallel rectangle (i.e. it is tolerant to rectangles with additional vertices
+added along the rectangle sides). If ``simpleRectanglesOnly`` is set to ``True`` then the method will
+only return ``True`` if the geometry is a simple rectangle consisting of 4 edges.
+
+.. versionadded:: 3.20
+%End
+
     double area() const;
 %Docstring
 Returns the planar, 2-dimensional area of the geometry.

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2737,6 +2737,15 @@ bool QgsGeometry::isSimple() const
   return geos.isSimple( &mLastError );
 }
 
+bool QgsGeometry::isAxisParallelRectangle( double maximumDeviation, bool simpleRectanglesOnly ) const
+{
+  if ( !d->geometry )
+    return false;
+
+  QgsInternalGeometryEngine engine( *this );
+  return engine.isAxisParallelRectangle( maximumDeviation, simpleRectanglesOnly );
+}
+
 bool QgsGeometry::isGeosEqual( const QgsGeometry &g ) const
 {
   if ( !d->geometry || !g.d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -390,6 +390,21 @@ class CORE_EXPORT QgsGeometry
     bool isSimple() const;
 
     /**
+     * Returns TRUE if the geometry is a polygon that is almost an axis-parallel rectangle.
+     *
+     * The \a maximumDeviation argument specifes the maximum angle (in degrees) that the polygon edges
+     * are allowed to deviate from axis parallel lines.
+     *
+     * By default the check will permit polygons with more than 4 edges, so long as the overall shape of
+     * the polygon is an axis-parallel rectangle (i.e. it is tolerant to rectangles with additional vertices
+     * added along the rectangle sides). If \a simpleRectanglesOnly is set to TRUE then the method will
+     * only return TRUE if the geometry is a simple rectangle consisting of 4 edges.
+     *
+     * \since QGIS 3.20
+     */
+    bool isAxisParallelRectangle( double maximumDeviation, bool simpleRectanglesOnly = false ) const;
+
+    /**
      * Returns the planar, 2-dimensional area of the geometry.
      *
      * \warning QgsGeometry objects are inherently Cartesian/planar geometries, and the area

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -57,6 +57,21 @@ class QgsInternalGeometryEngine
     QString lastError() const;
 
     /**
+     * Returns TRUE if the geometry is a polygon that is almost an axis-parallel rectangle.
+     *
+     * The \a maximumDeviation argument specifes the maximum angle (in degrees) that the polygon edges
+     * are allowed to deviate from axis parallel lines.
+     *
+     * By default the check will permit polygons with more than 4 edges, so long as the overall shape of
+     * the polygon is an axis-parallel rectangle (i.e. it is tolerant to rectangles with additional vertices
+     * added along the rectangle sides). If \a simpleRectanglesOnly is set to TRUE then the method will
+     * only return TRUE if the geometry is a simple rectangle consisting of 4 edges.
+     *
+     * \since QGIS 3.20
+     */
+    bool isAxisParallelRectangle( double maximumDeviation, bool simpleRectanglesOnly = false ) const;
+
+    /**
      * Will extrude a line or (segmentized) curve by a given offset and return a polygon
      * representation of it.
      *


### PR DESCRIPTION
Taken from the closed PR https://github.com/qgis/QGIS/pull/41172, so full credit to @stefanuhrig for the implementation here!
