### PR TITLE
Move currentFrame increment to the end of the loop

### DIFF
--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -116,7 +116,6 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
       }
       feedback->setProgress( currentFrame / static_cast<double>( totalFrames ) * 100 );
     }
-    ++currentFrame;
 
     navigator.setCurrentFrameNumber( currentFrame );
 
@@ -155,6 +154,8 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
     p.end();
 
     img.save( path );
+
+    ++currentFrame;
   }
 
   return true;


### PR DESCRIPTION
## Description

This PR is a fix for #42932. The main loop doing the exporting (as it is now in master) skips the first frame of an animation as it increments the frame number at the beginning of the loop rather than the end. This PR moves the increment to the end so that the exported frames match what is seen in the main UI. 
