### PR TITLE
typo(fix): corrects common typos in project README files

### DIFF
--- a/external/o2/README.md
+++ b/external/o2/README.md
@@ -180,7 +180,7 @@ That's it. Tweets using the O2 library!
 
 ### Storing OAuth Tokens
 
-O2 provides simple storage classes for writing OAuth tokens in a peristent location. Currently, a QSettings based backing store **O2SettingsStore** is provided in O2. O2SettingsStore keeps all token values in an encrypted form. You have to specify the encryption key to use while constructing the object:
+O2 provides simple storage classes for writing OAuth tokens in a persistent location. Currently, a QSettings based backing store **O2SettingsStore** is provided in O2. O2SettingsStore keeps all token values in an encrypted form. You have to specify the encryption key to use while constructing the object:
 
     O0SettingsStore settings = new O0SettingsStore("myencryptionkey");
     // Set the store before starting OAuth, i.e before calling link()

--- a/external/wintoast/README.md
+++ b/external/wintoast/README.md
@@ -148,8 +148,8 @@ A common example of usage is to check while initializing the library or showing 
 
 ```cpp
 WinToast::WinToastError error;
-const bool succedded = WinToast::instance()->initialize(&error);
-if (!succedded) {  
+const bool succeeded = WinToast::instance()->initialize(&error);
+if (!succeeded) {  
     std::wcout << L"Error, could not initialize the lib. Error number: " 
     << error << std::endl;
 }


### PR DESCRIPTION
## Description

Scope of changes is restricted to markdown docs only. Changes are in agreement with Standard American English.
------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
