### PR TITLE
Add QgsAbstractGeometry::compareTo( QgsAbstractGeometry*)

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -829,6 +829,12 @@ geometries of different types.
 Compares to an ``other`` geometry of the same class, and returns a integer
 for sorting of the two geometries.
 
+.. note::
+
+   The actual logic for the sorting is an internal detail only and is subject to change
+   between QGIS versions. The result should only be used for direct comparison of geometries
+   and not stored for later use.
+
 .. versionadded:: 3.20
 %End
 

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -104,6 +104,13 @@ Constructor for QgsAbstractGeometry.
 Clones the geometry by performing a deep copy
 %End
 
+    virtual int compareTo( const QgsAbstractGeometry *other ) const;
+%Docstring
+Comparator for sorting of geometry.
+
+.. versionadded:: 3.20
+%End
+
     virtual void clear() = 0;
 %Docstring
 Clears the geometry, ie reset it to a null geometry
@@ -808,6 +815,22 @@ To create it, the geometry is default constructed and then the WKB is changed.
 %End
 
   protected:
+
+    int sortIndex() const;
+%Docstring
+Returns the sort index for the geometry, used in the :py:func:`~QgsAbstractGeometry.compareTo` method to compare
+geometries of different types.
+
+.. versionadded:: 3.20
+%End
+
+    virtual int compareToSameClass( const QgsAbstractGeometry *other ) const = 0;
+%Docstring
+Compares to an ``other`` geometry of the same class, and returns a integer
+for sorting of the two geometries.
+
+.. versionadded:: 3.20
+%End
 
     virtual bool hasChildGeometries() const;
 %Docstring

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -181,6 +181,7 @@ Sets the circular string's points
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -194,6 +194,7 @@ Appends first point if not already closed.
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -296,6 +296,7 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
 
     virtual QgsAbstractGeometry *childGeometry( int index ) const;
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
 
   protected:
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -317,6 +317,7 @@ Iterates through all geometries in the collection.
 
     virtual QgsAbstractGeometry *childGeometry( int index ) const;
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
 
   protected:
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -405,7 +405,6 @@ segment in the line.
 %End
 
 
-
     virtual QString geometryType() const /HoldGIL/;
 
     virtual int dimension() const /HoldGIL/;
@@ -645,6 +644,7 @@ corresponds to the last point in the line.
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -467,6 +467,7 @@ Angle undefined. Always returns 0.0
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual int childCount() const;
 
     virtual QgsPoint childPoint( int index ) const;

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -40,6 +40,39 @@ QgsAbstractGeometry &QgsAbstractGeometry::operator=( const QgsAbstractGeometry &
   return *this;
 }
 
+int QgsAbstractGeometry::compareTo( const QgsAbstractGeometry *other ) const
+{
+  // compare to self
+  if ( this == other )
+  {
+    return 0;
+  }
+
+  if ( sortIndex() != other->sortIndex() )
+  {
+    //different geometry types
+    int diff = sortIndex() - other->sortIndex();
+    return ( diff > 0 ) - ( diff < 0 );
+  }
+
+  // same types
+  if ( isEmpty() && other->isEmpty() )
+  {
+    return 0;
+  }
+
+  if ( isEmpty() )
+  {
+    return -1;
+  }
+  if ( other->isEmpty() )
+  {
+    return 1;
+  }
+
+  return compareToSameClass( other );
+}
+
 void QgsAbstractGeometry::setZMTypeFromSubGeometry( const QgsAbstractGeometry *subgeom, QgsWkbTypes::Type baseGeomType )
 {
   if ( !subgeom )
@@ -282,6 +315,44 @@ QgsAbstractGeometry::const_part_iterator QgsAbstractGeometry::const_parts_end() 
 QgsVertexIterator QgsAbstractGeometry::vertices() const
 {
   return QgsVertexIterator( this );
+}
+
+int QgsAbstractGeometry::sortIndex() const
+{
+  switch ( QgsWkbTypes::flatType( mWkbType ) )
+  {
+    case QgsWkbTypes::Point:
+      return 0;
+    case QgsWkbTypes::MultiPoint:
+      return 1;
+    case QgsWkbTypes::LineString:
+      return 2;
+    case QgsWkbTypes::CircularString:
+      return 3;
+    case QgsWkbTypes::CompoundCurve:
+      return 4;
+    case QgsWkbTypes::MultiLineString:
+      return 5;
+    case QgsWkbTypes::MultiCurve:
+      return 6;
+    case QgsWkbTypes::Polygon:
+    case QgsWkbTypes::Triangle:
+      return 7;
+    case QgsWkbTypes::CurvePolygon:
+      return 8;
+    case QgsWkbTypes::MultiPolygon:
+      return 9;
+    case QgsWkbTypes::MultiSurface:
+      return 10;
+    case QgsWkbTypes::GeometryCollection:
+      return 11;
+    case QgsWkbTypes::Unknown:
+      return 12;
+    case QgsWkbTypes::NoGeometry:
+    default:
+      break;
+  }
+  return 13;
 }
 
 bool QgsAbstractGeometry::hasChildGeometries() const

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -51,7 +51,7 @@ int QgsAbstractGeometry::compareTo( const QgsAbstractGeometry *other ) const
   if ( sortIndex() != other->sortIndex() )
   {
     //different geometry types
-    int diff = sortIndex() - other->sortIndex();
+    const int diff = sortIndex() - other->sortIndex();
     return ( diff > 0 ) - ( diff < 0 );
   }
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -164,6 +164,13 @@ class CORE_EXPORT QgsAbstractGeometry
     virtual QgsAbstractGeometry *clone() const = 0 SIP_FACTORY;
 
     /**
+     * Comparator for sorting of geometry.
+     *
+     * \since QGIS 3.20
+     */
+    virtual int compareTo( const QgsAbstractGeometry *other ) const;
+
+    /**
      * Clears the geometry, ie reset it to a null geometry
      */
     virtual void clear() = 0;
@@ -1025,6 +1032,22 @@ class CORE_EXPORT QgsAbstractGeometry
     virtual QgsAbstractGeometry *createEmptyWithSameType() const = 0 SIP_FACTORY;
 
   protected:
+
+    /**
+     * Returns the sort index for the geometry, used in the compareTo() method to compare
+     * geometries of different types.
+     *
+     * \since QGIS 3.20
+     */
+    int sortIndex() const;
+
+    /**
+     * Compares to an \a other geometry of the same class, and returns a integer
+     * for sorting of the two geometries.
+     *
+     * \since QGIS 3.20
+     */
+    virtual int compareToSameClass( const QgsAbstractGeometry *other ) const = 0;
 
     /**
      * Returns whether the geometry has any child geometries (FALSE for point / curve, TRUE otherwise)

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -1045,6 +1045,10 @@ class CORE_EXPORT QgsAbstractGeometry
      * Compares to an \a other geometry of the same class, and returns a integer
      * for sorting of the two geometries.
      *
+     * \note The actual logic for the sorting is an internal detail only and is subject to change
+     * between QGIS versions. The result should only be used for direct comparison of geometries
+     * and not stored for later use.
+     *
      * \since QGIS 3.20
      */
     virtual int compareToSameClass( const QgsAbstractGeometry *other ) const = 0;

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -112,6 +112,92 @@ QgsCircularString *QgsCircularString::createEmptyWithSameType() const
   return result.release();
 }
 
+int QgsCircularString::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsCircularString *otherLine = qgsgeometry_cast<const QgsCircularString *>( other );
+  if ( !otherLine )
+    return -1;
+
+  const int size = mX.size();
+  const int otherSize = otherLine->mX.size();
+  if ( size > otherSize )
+  {
+    return 1;
+  }
+  else if ( size < otherSize )
+  {
+    return -1;
+  }
+
+  if ( is3D() && !otherLine->is3D() )
+    return 1;
+  else if ( !is3D() && otherLine->is3D() )
+    return -1;
+  const bool considerZ = is3D();
+
+  if ( isMeasure() && !otherLine->isMeasure() )
+    return 1;
+  else if ( !isMeasure() && otherLine->isMeasure() )
+    return -1;
+  const bool considerM = isMeasure();
+
+  for ( int i = 0; i < size; i++ )
+  {
+    const double x = mX[i];
+    const double otherX = otherLine->mX[i];
+    if ( x < otherX )
+    {
+      return -1;
+    }
+    else if ( x > otherX )
+    {
+      return 1;
+    }
+
+    const double y = mY[i];
+    const double otherY = otherLine->mY[i];
+    if ( y < otherY )
+    {
+      return -1;
+    }
+    else if ( y > otherY )
+    {
+      return 1;
+    }
+
+    if ( considerZ )
+    {
+      const double z = mZ[i];
+      const double otherZ = otherLine->mZ[i];
+
+      if ( z < otherZ )
+      {
+        return -1;
+      }
+      else if ( z > otherZ )
+      {
+        return 1;
+      }
+    }
+
+    if ( considerM )
+    {
+      const double m = mM[i];
+      const double otherM = otherLine->mM[i];
+
+      if ( m < otherM )
+      {
+        return -1;
+      }
+      else if ( m > otherM )
+      {
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
 QString QgsCircularString::geometryType() const
 {
   return QStringLiteral( "CircularString" );

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -165,6 +165,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
 
   private:

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -79,7 +79,7 @@ int QgsCompoundCurve::compareToSameClass( const QgsAbstractGeometry *other ) con
   {
     const QgsAbstractGeometry *aGeom = mCurves[i];
     const QgsAbstractGeometry *bGeom = otherCurve->mCurves[j];
-    int comparison = aGeom->compareTo( bGeom );
+    const int comparison = aGeom->compareTo( bGeom );
     if ( comparison != 0 )
     {
       return comparison;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -67,6 +67,37 @@ QgsCompoundCurve *QgsCompoundCurve::createEmptyWithSameType() const
   return result.release();
 }
 
+int QgsCompoundCurve::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsCompoundCurve *otherCurve = qgsgeometry_cast<const QgsCompoundCurve *>( other );
+  if ( !otherCurve )
+    return -1;
+
+  int i = 0;
+  int j = 0;
+  while ( i < mCurves.size() && j < otherCurve->mCurves.size() )
+  {
+    const QgsAbstractGeometry *aGeom = mCurves[i];
+    const QgsAbstractGeometry *bGeom = otherCurve->mCurves[j];
+    int comparison = aGeom->compareTo( bGeom );
+    if ( comparison != 0 )
+    {
+      return comparison;
+    }
+    i++;
+    j++;
+  }
+  if ( i < mCurves.size() )
+  {
+    return 1;
+  }
+  if ( j < otherCurve->mCurves.size() )
+  {
+    return -1;
+  }
+  return 0;
+}
+
 QString QgsCompoundCurve::geometryType() const
 {
   return QStringLiteral( "CompoundCurve" );

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -174,6 +174,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
 
   private:

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -1363,3 +1363,45 @@ QgsAbstractGeometry *QgsCurvePolygon::childGeometry( int index ) const
   else
     return mInteriorRings.at( index - 1 );
 }
+
+int QgsCurvePolygon::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsCurvePolygon *otherPolygon = qgsgeometry_cast<const QgsCurvePolygon *>( other );
+  if ( !otherPolygon )
+    return -1;
+
+  if ( mExteriorRing && !otherPolygon->mExteriorRing )
+    return 1;
+  else if ( !mExteriorRing && otherPolygon->mExteriorRing )
+    return -1;
+  else if ( mExteriorRing && otherPolygon->mExteriorRing )
+  {
+    int shellComp = mExteriorRing->compareTo( otherPolygon->mExteriorRing.get() );
+    if ( shellComp != 0 )
+    {
+      return shellComp;
+    }
+  }
+
+  const int nHole1 = mInteriorRings.size();
+  const int nHole2 = otherPolygon->mInteriorRings.size();
+  if ( nHole1 < nHole2 )
+  {
+    return -1;
+  }
+  if ( nHole1 > nHole2 )
+  {
+    return 1;
+  }
+
+  for ( int i = 0; i < nHole1; i++ )
+  {
+    const int holeComp = mInteriorRings.at( i )->compareTo( otherPolygon->mInteriorRings.at( i ) );
+    if ( holeComp != 0 )
+    {
+      return holeComp;
+    }
+  }
+
+  return 0;
+}

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -306,6 +306,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
 
     int childCount() const override;
     QgsAbstractGeometry *childGeometry( int index ) const override;
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
 
   protected:
 

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -1058,7 +1058,7 @@ int QgsGeometryCollection::compareToSameClass( const QgsAbstractGeometry *other 
   {
     const QgsAbstractGeometry *aGeom = mGeometries[i];
     const QgsAbstractGeometry *bGeom = otherCollection->mGeometries[j];
-    int comparison = aGeom->compareTo( bGeom );
+    const int comparison = aGeom->compareTo( bGeom );
     if ( comparison != 0 )
     {
       return comparison;

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -1045,3 +1045,34 @@ QgsAbstractGeometry *QgsGeometryCollection::childGeometry( int index ) const
     return nullptr;
   return mGeometries.at( index );
 }
+
+int QgsGeometryCollection::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsGeometryCollection *otherCollection = qgsgeometry_cast<const QgsGeometryCollection *>( other );
+  if ( !otherCollection )
+    return -1;
+
+  int i = 0;
+  int j = 0;
+  while ( i < mGeometries.size() && j < otherCollection->mGeometries.size() )
+  {
+    const QgsAbstractGeometry *aGeom = mGeometries[i];
+    const QgsAbstractGeometry *bGeom = otherCollection->mGeometries[j];
+    int comparison = aGeom->compareTo( bGeom );
+    if ( comparison != 0 )
+    {
+      return comparison;
+    }
+    i++;
+    j++;
+  }
+  if ( i < mGeometries.size() )
+  {
+    return 1;
+  }
+  if ( j < otherCollection->mGeometries.size() )
+  {
+    return -1;
+  }
+  return 0;
+}

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -325,6 +325,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
   protected:
     int childCount() const override;
     QgsAbstractGeometry *childGeometry( int index ) const override;
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
 
   protected:
     QVector< QgsAbstractGeometry * > mGeometries;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1310,6 +1310,92 @@ QgsLineString *QgsLineString::createEmptyWithSameType() const
   return result.release();
 }
 
+int QgsLineString::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsLineString *otherLine = qgsgeometry_cast<const QgsLineString *>( other );
+  if ( !otherLine )
+    return -1;
+
+  const int size = mX.size();
+  const int otherSize = otherLine->mX.size();
+  if ( size > otherSize )
+  {
+    return 1;
+  }
+  else if ( size < otherSize )
+  {
+    return -1;
+  }
+
+  if ( is3D() && !otherLine->is3D() )
+    return 1;
+  else if ( !is3D() && otherLine->is3D() )
+    return -1;
+  const bool considerZ = is3D();
+
+  if ( isMeasure() && !otherLine->isMeasure() )
+    return 1;
+  else if ( !isMeasure() && otherLine->isMeasure() )
+    return -1;
+  const bool considerM = isMeasure();
+
+  for ( int i = 0; i < size; i++ )
+  {
+    const double x = mX[i];
+    const double otherX = otherLine->mX[i];
+    if ( x < otherX )
+    {
+      return -1;
+    }
+    else if ( x > otherX )
+    {
+      return 1;
+    }
+
+    const double y = mY[i];
+    const double otherY = otherLine->mY[i];
+    if ( y < otherY )
+    {
+      return -1;
+    }
+    else if ( y > otherY )
+    {
+      return 1;
+    }
+
+    if ( considerZ )
+    {
+      const double z = mZ[i];
+      const double otherZ = otherLine->mZ[i];
+
+      if ( z < otherZ )
+      {
+        return -1;
+      }
+      else if ( z > otherZ )
+      {
+        return 1;
+      }
+    }
+
+    if ( considerM )
+    {
+      const double m = mM[i];
+      const double otherM = otherLine->mM[i];
+
+      if ( m < otherM )
+      {
+        return -1;
+      }
+      else if ( m > otherM )
+      {
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
 QString QgsLineString::geometryType() const
 {
   return QStringLiteral( "LineString" );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -581,7 +581,6 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #endif
 
     //reimplemented methods
-
     QString geometryType() const override SIP_HOLDGIL;
     int dimension() const override SIP_HOLDGIL;
     QgsLineString *clone() const override SIP_FACTORY;
@@ -789,6 +788,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
 
   private:

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -795,3 +795,62 @@ QgsPoint *QgsPoint::createEmptyWithSameType() const
   double nan = std::numeric_limits<double>::quiet_NaN();
   return new QgsPoint( nan, nan, nan, nan, mWkbType );
 }
+
+int QgsPoint::compareToSameClass( const QgsAbstractGeometry *other ) const
+{
+  const QgsPoint *otherPoint = qgsgeometry_cast< const QgsPoint * >( other );
+  if ( !otherPoint )
+    return -1;
+
+  if ( mX < otherPoint->mX )
+  {
+    return -1;
+  }
+  else if ( mX > otherPoint->mX )
+  {
+    return 1;
+  }
+
+  if ( mY < otherPoint->mY )
+  {
+    return -1;
+  }
+  else if ( mY > otherPoint->mY )
+  {
+    return 1;
+  }
+
+  if ( is3D() && !otherPoint->is3D() )
+    return 1;
+  else if ( !is3D() && otherPoint->is3D() )
+    return -1;
+  else if ( is3D() && otherPoint->is3D() )
+  {
+    if ( mZ < otherPoint->mZ )
+    {
+      return -1;
+    }
+    else if ( mZ > otherPoint->mZ )
+    {
+      return 1;
+    }
+  }
+
+  if ( isMeasure() && !otherPoint->isMeasure() )
+    return 1;
+  else if ( !isMeasure() && otherPoint->isMeasure() )
+    return -1;
+  else if ( isMeasure() && otherPoint->isMeasure() )
+  {
+    if ( mM < otherPoint->mM )
+    {
+      return -1;
+    }
+    else if ( mM > otherPoint->mM )
+    {
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -572,6 +572,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
 
   protected:
 
+    int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     int childCount() const override;
     QgsPoint childPoint( int index ) const override;
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -17191,6 +17191,9 @@ void TestQgsGeometry::compareTo_data()
 
   QTest::newRow( "point vs multipoint" ) << QStringLiteral( "POINT( 1 2 )" ) << QStringLiteral( "MULTIPOINT((1 2))" ) << -1;
   QTest::newRow( "multipoint vs point" ) << QStringLiteral( "MULTIPOINT((1 2))" ) << QStringLiteral( "POINT( 1 2 )" ) << 1;
+  QTest::newRow( "empty point vs empty point" ) << QStringLiteral( "POINT EMPTY" ) << QStringLiteral( "POINT EMPTY" ) << 0;
+  QTest::newRow( "empty point vs non-empty point" ) << QStringLiteral( "POINT EMPTY" ) << QStringLiteral( "POINT (1 2)" ) << -1;
+  QTest::newRow( "non-empty point vs empty point" ) << QStringLiteral( "POINT (1 2)" ) << QStringLiteral( "POINT EMPTY" ) << 1;
   QTest::newRow( "point vs point" ) << QStringLiteral( "POINT( 1 2 )" ) << QStringLiteral( "POINT(1 2)" ) << 0;
   QTest::newRow( "point vs point greater x" ) << QStringLiteral( "POINT( 2 2 )" ) << QStringLiteral( "POINT(1 2)" ) << 1;
   QTest::newRow( "point vs point lesser x" ) << QStringLiteral( "POINT( 0 2 )" ) << QStringLiteral( "POINT(1 2)" ) << -1;


### PR DESCRIPTION
Allows for comparison of geometry objects, e.g. to allow for stable
sorting of them.

Ported from the GEOS equivalent method, but with addition of support
for M values and curved geometry types
