### PR TITLE
Drop build testing on 20.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,8 +38,6 @@ jobs:
         include:
           - ubuntu-base: '20.04'
             run-tests: true
-          - ubuntu-base: '20.10'
-            run-tests: false
           - ubuntu-base: '21.04'
             run-tests: false
       fail-fast: false


### PR DESCRIPTION
keep 20.04 (unit test) and 21.04.

Caching is limited to 5gb on github.
Trying to tackle this by limiting number of builds.

any opinion @nyalldawson @elpaso @troopa81 

