### PR TITLE
[point cloud] fix WITH_EPT flag usage

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1719,6 +1719,8 @@ if (WITH_EPT)
       pointcloud/qgseptpointcloudindex.h
       pointcloud/qgsremoteeptpointcloudindex.h
   )
+
+  add_definitions( -DWITH_EPT )
 endif()
 
 if (APPLE)

--- a/src/core/pointcloud/qgspointcloudblockrequest.cpp
+++ b/src/core/pointcloud/qgspointcloudblockrequest.cpp
@@ -56,6 +56,7 @@ void QgsPointCloudBlockRequest::blockFinishedLoading()
     try
     {
       mBlock = nullptr;
+#ifdef WITH_EPT
       if ( mDataType == QLatin1String( "binary" ) )
       {
         mBlock = QgsEptDecoder::decompressBinary( mTileDownloadManagetReply->data(), mAttributes, mRequestedAttributes );
@@ -73,6 +74,7 @@ void QgsPointCloudBlockRequest::blockFinishedLoading()
         mErrorStr = QStringLiteral( "unknown data type %1;" ).arg( mDataType );
         invalidDataType = true;
       }
+#endif
     }
     catch ( std::exception &e )
     {

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -32,7 +32,6 @@
 #include "qgsmaplayerlegend.h"
 #include "qgsmaplayerfactory.h"
 #include <QUrl>
-#include "qgseptprovider.h"
 
 QgsPointCloudLayer::QgsPointCloudLayer( const QString &uri,
                                         const QString &baseName,


### PR DESCRIPTION
## Description
Currently if the build doesn't use WITH_EPT flag in cmake, compilation will break. This PR fixes the issue.
Sorry for the late fix.
