### PR TITLE
[remote EPT] [point cloud] fix UI freeze bug

### DIFF
--- a/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsPointCloudLayer3DRenderer : QgsAbstract3DRenderer
 {
 %Docstring(signature="appended")

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -45,8 +45,9 @@ class Qgs3DMapSettings;
  *
  * \note Not available in Python bindings
  */
-class Qgs3DRenderContext
+class Qgs3DRenderContext : public QObject
 {
+    Q_OBJECT
   public:
     Qgs3DRenderContext( const Qgs3DMapSettings &map ) : mMap( map ) {}
 

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -45,9 +45,8 @@ class Qgs3DMapSettings;
  *
  * \note Not available in Python bindings
  */
-class Qgs3DRenderContext : public QObject
+class Qgs3DRenderContext
 {
-    Q_OBJECT
   public:
     Qgs3DRenderContext( const Qgs3DMapSettings &map ) : mMap( map ) {}
 

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -71,6 +71,15 @@ void QgsPointCloud3DRenderContext::setCoordinateTransform( const QgsCoordinateTr
   mCoordinateTransform = coordinateTransform;
 }
 
+void QgsPointCloud3DRenderContext::cancelRendering()
+{
+  emit renderingCancelled();
+}
+
+
+// ---------
+
+
 QgsPointCloudLayer3DRendererMetadata::QgsPointCloudLayer3DRendererMetadata()
   : Qgs3DRendererAbstractMetadata( QStringLiteral( "pointcloud" ) )
 {

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -73,7 +73,7 @@ void QgsPointCloud3DRenderContext::setCoordinateTransform( const QgsCoordinateTr
 
 void QgsPointCloud3DRenderContext::cancelRendering()
 {
-  emit renderingCancelled();
+  emit renderingCanceled();
 }
 
 

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -27,20 +27,14 @@
 #include "qgspointcloud3dsymbol.h"
 #include "qgspointcloudlayerelevationproperties.h"
 
-#include "qgis.h"
-
 QgsPointCloud3DRenderContext::QgsPointCloud3DRenderContext( const Qgs3DMapSettings &map, const QgsCoordinateTransform &coordinateTransform, std::unique_ptr<QgsPointCloud3DSymbol> symbol, double zValueScale, double zValueFixedOffset )
   : Qgs3DRenderContext( map )
   , mSymbol( std::move( symbol ) )
   , mZValueScale( zValueScale )
   , mZValueFixedOffset( zValueFixedOffset )
   , mCoordinateTransform( coordinateTransform )
+  , mFeedback( new QgsFeedback )
 {
-  auto callback = []()->bool
-  {
-    return false;
-  };
-  mIsCanceledCallback = callback;
 }
 
 void QgsPointCloud3DRenderContext::setAttributes( const QgsPointCloudAttributeCollection &attributes )
@@ -71,12 +65,15 @@ void QgsPointCloud3DRenderContext::setCoordinateTransform( const QgsCoordinateTr
   mCoordinateTransform = coordinateTransform;
 }
 
-void QgsPointCloud3DRenderContext::cancelRendering()
+bool QgsPointCloud3DRenderContext::isCanceled() const
 {
-  emit renderingCanceled();
+  return mFeedback->isCanceled();
 }
 
-
+void QgsPointCloud3DRenderContext::cancelRendering() const
+{
+  mFeedback->cancel();
+}
 // ---------
 
 

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -22,7 +22,7 @@
 #include "qgs3drendererregistry.h"
 #include "qgsabstract3drenderer.h"
 #include "qgsmaplayerref.h"
-
+#include "qgsfeedback.h"
 #include <QObject>
 
 class QgsPointCloudLayer;
@@ -152,14 +152,15 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
     double zValueFixedOffset() const { return mZValueFixedOffset; }
 
     /**
-     * Sets the function to call to test if the rendering is canceled.
-     */
-    void setIsCanceledCallback( const std::function< bool() > &callback ) { mIsCanceledCallback = callback; }
-
-    /**
      * Returns TRUE if the rendering is canceled.
      */
-    bool isCanceled() const { return mIsCanceledCallback(); }
+    bool isCanceled() const;
+
+    /**
+     * Cancels rendering.
+     * \see isCanceled()
+     */
+    void cancelRendering() const;
 
     /**
      * Sets the coordinate transform used to transform points from layer CRS to the map CRS
@@ -172,19 +173,9 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
     QgsCoordinateTransform coordinateTransform() const { return mCoordinateTransform; }
 
     /**
-     * Cancels rendering by emitting renderingCanceled signal
-     * \since QGIS 3.20
+     * Returns the feedback object used to cancel rendering and check if rendering was canceled.
      */
-    void cancelRendering();
-
-  signals:
-
-    /**
-     * Emitted when the rendering is canceled
-     * \since QGIS 3.20
-     */
-    void renderingCanceled();
-
+    QgsFeedback *feedback() const { return mFeedback.get(); }
   private:
 #ifdef SIP_RUN
     QgsPointCloudRenderContext( const QgsPointCloudRenderContext &rh );
@@ -195,9 +186,7 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
     double mZValueScale = 1.0;
     double mZValueFixedOffset = 0;
     QgsCoordinateTransform mCoordinateTransform;
-
-    std::function< bool() > mIsCanceledCallback;
-
+    std::unique_ptr<QgsFeedback> mFeedback;
 };
 
 

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -180,7 +180,7 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
   signals:
 
     /**
-     * Emitted when the rendering is cancelled
+     * Emitted when the rendering is canceled
      * \since QGIS 3.20
      */
     void renderingCanceled();

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -41,6 +41,7 @@ class QgsPointCloudLayer;
  */
 class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
 {
+    Q_OBJECT
   public:
 
     /**
@@ -169,6 +170,20 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
      * Returns the coordinate transform used to transform points from layer CRS to the map CRS
      */
     QgsCoordinateTransform coordinateTransform() const { return mCoordinateTransform; }
+
+    /**
+     * Cancels rendering by emitting renderingCancelled signal
+     * \since QGIS 3.20
+     */
+    void cancelRendering();
+
+  signals:
+
+    /**
+     * Emitted when the rendering is cancelled
+     * \since QGIS 3.20
+     */
+    void renderingCancelled();
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -41,7 +41,6 @@ class QgsPointCloudLayer;
  */
 class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
 {
-    Q_OBJECT
   public:
 
     /**

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -172,7 +172,7 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
     QgsCoordinateTransform coordinateTransform() const { return mCoordinateTransform; }
 
     /**
-     * Cancels rendering by emitting renderingCancelled signal
+     * Cancels rendering by emitting renderingCanceled signal
      * \since QGIS 3.20
      */
     void cancelRendering();
@@ -183,7 +183,7 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
      * Emitted when the rendering is cancelled
      * \since QGIS 3.20
      */
-    void renderingCancelled();
+    void renderingCanceled();
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -52,7 +52,6 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   , mFactory( factory )
   , mContext( factory->mMap, coordinateTransform, std::move( symbol ), zValueScale, zValueOffset )
 {
-  mContext.setIsCanceledCallback( [this] { return mCanceled; } );
 
   QgsPointCloudIndex *pc = mFactory->mPointCloudIndex;
   mContext.setAttributes( pc->attributes() );
@@ -84,7 +83,7 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   {
     QgsEventTracing::ScopedEvent e( QStringLiteral( "3D" ), QStringLiteral( "PC chunk load" ) );
 
-    if ( mCanceled )
+    if ( mContext.isCanceled() )
     {
       QgsDebugMsgLevel( QStringLiteral( "canceled" ), 2 );
       return;
@@ -104,7 +103,6 @@ QgsPointCloudLayerChunkLoader::~QgsPointCloudLayerChunkLoader()
   if ( mFutureWatcher && !mFutureWatcher->isFinished() )
   {
     disconnect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
-    mCanceled = true;
     mContext.cancelRendering();
     mFutureWatcher->waitForFinished();
   }
@@ -112,7 +110,7 @@ QgsPointCloudLayerChunkLoader::~QgsPointCloudLayerChunkLoader()
 
 void QgsPointCloudLayerChunkLoader::cancel()
 {
-  mCanceled = true;
+  mContext.cancelRendering();
 }
 
 Qt3DCore::QEntity *QgsPointCloudLayerChunkLoader::createEntity( Qt3DCore::QEntity *parent )

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -104,6 +104,8 @@ QgsPointCloudLayerChunkLoader::~QgsPointCloudLayerChunkLoader()
   if ( mFutureWatcher && !mFutureWatcher->isFinished() )
   {
     disconnect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
+    mCanceled = true;
+    mContext.cancelRendering();
     mFutureWatcher->waitForFinished();
   }
 }

--- a/src/3d/qgspointcloudlayerchunkloader_p.h
+++ b/src/3d/qgspointcloudlayerchunkloader_p.h
@@ -104,7 +104,6 @@ class QgsPointCloudLayerChunkLoader : public QgsChunkLoader
     const QgsPointCloudLayerChunkLoaderFactory *mFactory;
     std::unique_ptr<QgsPointCloud3DSymbolHandler> mHandler;
     QgsPointCloud3DRenderContext mContext;
-    bool mCanceled = false;
     QFutureWatcher<void> *mFutureWatcher = nullptr;
 };
 

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -26,6 +26,7 @@
 #include "qgs3dmapsettings.h"
 #include "qgspointcloudindex.h"
 #include "qgspointcloudblockrequest.h"
+#include "qgsfeedback.h"
 
 #include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DRender/QAttribute>
@@ -240,7 +241,7 @@ QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::pointCloudBlock( QgsPointCloud
     QgsPointCloudBlockRequest *req = pc->asyncNodeData( n, request );
     QObject::connect( req, &QgsPointCloudBlockRequest::finished, &loop, &QEventLoop::quit );
 
-    QMetaObject::Connection connection = QObject::connect( &context, &QgsPointCloud3DRenderContext::renderingCanceled, [ & ]()
+    QMetaObject::Connection connection = QObject::connect( context.feedback(), &QgsFeedback::canceled, [ & ]()
     {
       loopAborted = true;
       loop.quit();

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -240,14 +240,12 @@ QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::pointCloudBlock( QgsPointCloud
     QEventLoop loop;
     QgsPointCloudBlockRequest *req = pc->asyncNodeData( n, request );
     QObject::connect( req, &QgsPointCloudBlockRequest::finished, &loop, &QEventLoop::quit );
-
-    QMetaObject::Connection connection = QObject::connect( context.feedback(), &QgsFeedback::canceled, [ & ]()
+    QObject::connect( context.feedback(), &QgsFeedback::canceled, &loop, [ & ]()
     {
       loopAborted = true;
       loop.quit();
     } );
     loop.exec();
-    QObject::disconnect( connection );
 
     if ( !loopAborted )
       block = req->block();

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -226,7 +226,7 @@ void QgsPointCloud3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const 
   // cppcheck-suppress memleak
 }
 
-QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::getPointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context )
+QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::pointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context )
 {
   QgsPointCloudBlock *block = nullptr;
   if ( pc->accessType() == QgsPointCloudIndex::AccessType::Local )
@@ -277,7 +277,7 @@ void QgsSingleColorPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *p
 
   QgsPointCloudRequest request;
   request.setAttributes( attributes );
-  std::unique_ptr<QgsPointCloudBlock> block( getPointCloudBlock( pc, n, request, context ) );
+  std::unique_ptr<QgsPointCloudBlock> block( pointCloudBlock( pc, n, request, context ) );
   if ( !block )
     return;
 
@@ -401,7 +401,7 @@ void QgsColorRampPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *pc,
 
   QgsPointCloudRequest request;
   request.setAttributes( attributes );
-  std::unique_ptr<QgsPointCloudBlock> block( getPointCloudBlock( pc, n, request, context ) );
+  std::unique_ptr<QgsPointCloudBlock> block( pointCloudBlock( pc, n, request, context ) );
   if ( !block )
     return;
 
@@ -506,7 +506,7 @@ void QgsRGBPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex *pc, const
 
   QgsPointCloudRequest request;
   request.setAttributes( attributes );
-  std::unique_ptr<QgsPointCloudBlock> block( getPointCloudBlock( pc, n, request, context ) );
+  std::unique_ptr<QgsPointCloudBlock> block( pointCloudBlock( pc, n, request, context ) );
   if ( !block )
     return;
 
@@ -669,7 +669,7 @@ void QgsClassificationPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex
 
   QgsPointCloudRequest request;
   request.setAttributes( attributes );
-  std::unique_ptr<QgsPointCloudBlock> block( getPointCloudBlock( pc, n, request, context ) );
+  std::unique_ptr<QgsPointCloudBlock> block( pointCloudBlock( pc, n, request, context ) );
   if ( !block )
     return;
 

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -240,15 +240,13 @@ QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::getPointCloudBlock( QgsPointCl
     QgsPointCloudBlockRequest *req = pc->asyncNodeData( n, request );
     QObject::connect( req, &QgsPointCloudBlockRequest::finished, &loop, &QEventLoop::quit );
 
-    QMetaObject::Connection *const connection = new QMetaObject::Connection;
-    *connection = QObject::connect( &context, &QgsPointCloud3DRenderContext::renderingCanceled, [ & ]()
+    QMetaObject::Connection connection = QObject::connect( &context, &QgsPointCloud3DRenderContext::renderingCanceled, [ & ]()
     {
       loopAborted = true;
       loop.quit();
     } );
     loop.exec();
-    QObject::disconnect( *connection );
-    delete connection;
+    QObject::disconnect( connection );
 
     if ( !loopAborted )
       block = req->block();

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -241,7 +241,7 @@ QgsPointCloudBlock *QgsPointCloud3DSymbolHandler::getPointCloudBlock( QgsPointCl
     QObject::connect( req, &QgsPointCloudBlockRequest::finished, &loop, &QEventLoop::quit );
 
     QMetaObject::Connection *const connection = new QMetaObject::Connection;
-    *connection = QObject::connect( &context, &QgsPointCloud3DRenderContext::renderingCancelled, [ & ]()
+    *connection = QObject::connect( &context, &QgsPointCloud3DRenderContext::renderingCanceled, [ & ]()
     {
       loopAborted = true;
       loop.quit();

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.h
@@ -64,7 +64,7 @@ class QgsPointCloud3DSymbolHandler // : public QgsFeature3DHandler
 
     void makeEntity( Qt3DCore::QEntity *parent, const QgsPointCloud3DRenderContext &context, PointData &out, bool selected );
     virtual Qt3DRender::QGeometry *makeGeometry( Qt3DCore::QNode *parent, const QgsPointCloud3DSymbolHandler::PointData &data, unsigned int byteStride ) = 0;
-    QgsPointCloudBlock *getPointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context );
+    QgsPointCloudBlock *pointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context );
 
     // outputs
     PointData outNormal;  //!< Features that are not selected

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.h
@@ -64,6 +64,7 @@ class QgsPointCloud3DSymbolHandler // : public QgsFeature3DHandler
 
     void makeEntity( Qt3DCore::QEntity *parent, const QgsPointCloud3DRenderContext &context, PointData &out, bool selected );
     virtual Qt3DRender::QGeometry *makeGeometry( Qt3DCore::QNode *parent, const QgsPointCloud3DSymbolHandler::PointData &data, unsigned int byteStride ) = 0;
+    QgsPointCloudBlock *getPointCloudBlock( QgsPointCloudIndex *pc, const IndexedPointCloudNode &node, const QgsPointCloudRequest &request, const QgsPointCloud3DRenderContext &context );
 
     // outputs
     PointData outNormal;  //!< Features that are not selected


### PR DESCRIPTION
## Description
Previously, when the user switches between rendering modes in 3D the UI freezes. The same blocking happens when you try to close the application when some remote ept tiles are being loaded in the background, Basically the point cloud blocks requests were not cancelled properly before and this PR fixes the issue.