### PR TITLE
[BUGFIX] Fixes QgsPostgresProviderConnection::createSpatialIndex.

### DIFF
--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -453,7 +453,7 @@ void QgsPostgresProviderConnection::createSpatialIndex( const QString &schema, c
 
   const QString indexName = QStringLiteral( "sidx_%1_%2" ).arg( name, geometryColumnName );
   executeSql( QStringLiteral( "CREATE INDEX %1 ON %2.%3 USING GIST (%4);" )
-              .arg( indexName,
+              .arg( QgsPostgresConn::quotedIdentifier( indexName ),
                     QgsPostgresConn::quotedIdentifier( schema ),
                     QgsPostgresConn::quotedIdentifier( name ),
                     QgsPostgresConn::quotedIdentifier( geometryColumnName ) ) );


### PR DESCRIPTION
## Description

Error when using 'invalid' characters (I ran into this with the `-` character) in a table name: the spatial index is not quoted raising a postgres error.

## Fix 

Add `quotedIdentifier` to avoid failure when `indexName` contains 'invalid' characters.

## Test

Tested manually on my usecase: works with the fix, does not work without the fix.
