### PR TITLE
Add QgsGeometry::normalize()

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -179,6 +179,17 @@ For instance, a polygon geometry will have a boundary consisting of the linestri
 .. versionadded:: 3.0
 %End
 
+    virtual void normalize() = 0;
+%Docstring
+Reorganizes the geometry into a normalized form (or "canonical" form).
+
+Polygon rings will be rearranged so that their starting vertex is the lower left and ring orientation follows the
+right hand rule, collections are ordered by geometry type, and other normalization techniques are applied. The
+resultant geometry will be geometrically equivalent to the original geometry.
+
+.. versionadded:: 3.20
+%End
+
 
     virtual bool fromWkb( QgsConstWkbPtr &wkb ) = 0;
 %Docstring

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -222,6 +222,7 @@ Appends the contents of another circular ``string`` to the end of this circular 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
+    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -203,6 +203,7 @@ Appends the contents of another circular ``string`` to the end of this circular 
 
     virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
 
+    void scroll( int firstVertexIndex ) final;
 
 
     virtual QgsCircularString *createEmptyWithSameType() const /Factory/;
@@ -222,7 +223,6 @@ Appends the contents of another circular ``string`` to the end of this circular 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
-    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -187,6 +187,7 @@ Appends first point if not already closed.
 
     virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
 
+    void scroll( int firstVertexIndex ) final;
 
 
     virtual QgsCompoundCurve *createEmptyWithSameType() const /Factory/;
@@ -206,7 +207,6 @@ Appends first point if not already closed.
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
-    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -206,6 +206,7 @@ Appends first point if not already closed.
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
+    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -296,6 +296,24 @@ Returns the curve's orientation, e.g. clockwise or counter-clockwise.
     virtual QgsPoint childPoint( int index ) const;
 
 
+    virtual void scroll( int firstVertexIndex ) = 0;
+%Docstring
+Scrolls the curve vertices so that they start with the vertex at the given index.
+
+.. warning::
+
+   This should only be called on closed curves, or the shape of the curve will be altered and
+   the result is undefined.
+
+.. warning::
+
+   The ``firstVertexIndex`` must correspond to a segment vertex and not a curve point or the result
+   is undefined.
+
+
+.. versionadded:: 3.20
+%End
+
 
 
 };

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -191,6 +191,7 @@ Returns a geometry without curves. Caller takes ownership
 
     virtual QgsCurve *toCurveType() const /Factory/;
 
+    void normalize() final /HoldGIL/;
 
     virtual QgsRectangle boundingBox() const;
 
@@ -284,18 +285,6 @@ Returns the curve's orientation, e.g. clockwise or counter-clockwise.
 .. versionadded:: 3.6
 %End
 
-
-
-  protected:
-
-    virtual void clearCache() const;
-
-
-    virtual int childCount() const;
-
-    virtual QgsPoint childPoint( int index ) const;
-
-
     virtual void scroll( int firstVertexIndex ) = 0;
 %Docstring
 Scrolls the curve vertices so that they start with the vertex at the given index.
@@ -313,6 +302,17 @@ Scrolls the curve vertices so that they start with the vertex at the given index
 
 .. versionadded:: 3.20
 %End
+
+
+
+  protected:
+
+    virtual void clearCache() const;
+
+
+    virtual int childCount() const;
+
+    virtual QgsPoint childPoint( int index ) const;
 
 
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -58,6 +58,7 @@ Curve polygon geometry type
 
     virtual QString asKml( int precision = 17 ) const;
 
+    void normalize() final /HoldGIL/;
 
     virtual double area() const /HoldGIL/;
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2029,6 +2029,17 @@ The ``flags`` parameter indicates optional flags which control the type of valid
 .. versionadded:: 1.5
 %End
 
+    void normalize();
+%Docstring
+Reorganizes the geometry into a normalized form (or "canonical" form).
+
+Polygon rings will be rearranged so that their starting vertex is the lower left and ring orientation follows the
+right hand rule, collections are ordered by geometry type, and other normalization techniques are applied. The
+resultant geometry will be geometrically equivalent to the original geometry.
+
+.. versionadded:: 3.20
+%End
+
     static QgsGeometry unaryUnion( const QVector<QgsGeometry> &geometries );
 %Docstring
 Compute the unary union on a list of ``geometries``. May be faster than an iterative union on a set of geometries.

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -150,6 +150,7 @@ An IndexError will be raised if no geometry with the specified index exists.
     }
 %End
 
+    void normalize() final /HoldGIL/;
     virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -553,6 +553,7 @@ of the curve.
 
     virtual bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = 0 );
 
+    void scroll( int firstVertexIndex ) final;
 
 
     virtual QgsLineString *createEmptyWithSameType() const /Factory/;
@@ -652,7 +653,6 @@ corresponds to the last point in the line.
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
-    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -652,6 +652,7 @@ corresponds to the last point in the line.
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     virtual QgsRectangle calculateBoundingBox() const;
 
+    void scroll( int firstVertexIndex ) final;
 
 };
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -349,6 +349,7 @@ Example
 
     QgsPoint operator-( QgsVector v ) const /HoldGIL/;
 
+    void normalize() final /HoldGIL/;
     virtual bool isEmpty() const /HoldGIL/;
 
     virtual QgsRectangle boundingBox() const /HoldGIL/;

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -235,6 +235,17 @@ class CORE_EXPORT QgsAbstractGeometry
      */
     virtual QgsAbstractGeometry *boundary() const = 0 SIP_FACTORY;
 
+    /**
+     * Reorganizes the geometry into a normalized form (or "canonical" form).
+     *
+     * Polygon rings will be rearranged so that their starting vertex is the lower left and ring orientation follows the
+     * right hand rule, collections are ordered by geometry type, and other normalization techniques are applied. The
+     * resultant geometry will be geometrically equivalent to the original geometry.
+     *
+     * \since QGIS 3.20
+     */
+    virtual void normalize() = 0;
+
     //import
 
     /**

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -297,6 +297,44 @@ QgsRectangle QgsCircularString::calculateBoundingBox() const
   return bbox;
 }
 
+void QgsCircularString::scroll( int index )
+{
+  const int size = mX.size();
+  if ( index < 1 || index >= size - 1 )
+    return;
+
+  const bool useZ = is3D();
+  const bool useM = isMeasure();
+
+  QVector<double> newX( size );
+  QVector<double> newY( size );
+  QVector<double> newZ( useZ ? size : 0 );
+  QVector<double> newM( useM ? size : 0 );
+  auto it = std::copy( mX.constBegin() + index, mX.constEnd() - 1, newX.begin() );
+  it = std::copy( mX.constBegin(), mX.constBegin() + index, it );
+  *it = *newX.constBegin();
+  mX = std::move( newX );
+
+  it = std::copy( mY.constBegin() + index, mY.constEnd() - 1, newY.begin() );
+  it = std::copy( mY.constBegin(), mY.constBegin() + index, it );
+  *it = *newY.constBegin();
+  mY = std::move( newY );
+  if ( useZ )
+  {
+    it = std::copy( mZ.constBegin() + index, mZ.constEnd() - 1, newZ.begin() );
+    it = std::copy( mZ.constBegin(), mZ.constBegin() + index, it );
+    *it = *newZ.constBegin();
+    mZ = std::move( newZ );
+  }
+  if ( useM )
+  {
+    it = std::copy( mM.constBegin() + index, mM.constEnd() - 1, newM.begin() );
+    it = std::copy( mM.constBegin(), mM.constBegin() + index, it );
+    *it = *newM.constBegin();
+    mM = std::move( newM );
+  }
+}
+
 QgsRectangle QgsCircularString::segmentBoundingBox( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3 )
 {
   double centerX, centerY, radius;

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -201,6 +201,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
+    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector<double> mX;

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -163,6 +163,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     double yAt( int index ) const override SIP_HOLDGIL;
 
     bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+    void scroll( int firstVertexIndex ) final;
 
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
@@ -201,7 +202,6 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
-    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector<double> mX;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -161,6 +161,28 @@ QgsRectangle QgsCompoundCurve::calculateBoundingBox() const
   return bbox;
 }
 
+void QgsCompoundCurve::scroll( int index )
+{
+  const int size = numPoints();
+  if ( index < 1 || index >= size - 1 )
+    return;
+
+  auto [p1, p2 ] = splitCurveAtVertex( index );
+
+  mCurves.clear();
+  if ( QgsCompoundCurve *curve2 = qgsgeometry_cast< QgsCompoundCurve *>( p2.get() ) )
+  {
+    // take the curves from the second part and make them our first lot of curves
+    mCurves = std::move( curve2->mCurves );
+  }
+  if ( QgsCompoundCurve *curve1 = qgsgeometry_cast< QgsCompoundCurve *>( p1.get() ) )
+  {
+    // take the curves from the first part and append them to our curves
+    mCurves.append( curve1->mCurves );
+    curve1->mCurves.clear();
+  }
+}
+
 bool QgsCompoundCurve::fromWkb( QgsConstWkbPtr &wkbPtr )
 {
   clear();

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -186,6 +186,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
+    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector< QgsCurve * > mCurves;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -148,6 +148,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     double yAt( int index ) const override SIP_HOLDGIL;
 
     bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+    void scroll( int firstVertexIndex ) final;
 
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
@@ -186,7 +187,6 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
-    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector< QgsCurve * > mCurves;

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -199,6 +199,33 @@ QgsCurve *QgsCurve::toCurveType() const
   return clone();
 }
 
+void QgsCurve::normalize()
+{
+  if ( isEmpty() )
+    return;
+
+  if ( !isClosed() )
+  {
+    return;
+  }
+
+  int minCoordinateIndex = 0;
+  QgsPoint minCoord;
+  int i = 0;
+  for ( auto it = vertices_begin(); it != vertices_end(); ++it )
+  {
+    const QgsPoint vertex = *it;
+    if ( minCoord.isEmpty() || minCoord.compareTo( &vertex ) > 0 )
+    {
+      minCoord = vertex;
+      minCoordinateIndex = i;
+    }
+    i++;
+  }
+
+  scroll( minCoordinateIndex );
+}
+
 QgsRectangle QgsCurve::boundingBox() const
 {
   if ( mBoundingBox.isNull() )

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -306,6 +306,19 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     int childCount() const override;
     QgsPoint childPoint( int index ) const override;
 
+    /**
+     * Scrolls the curve vertices so that they start with the vertex at the given index.
+     *
+     * \warning This should only be called on closed curves, or the shape of the curve will be altered and
+     * the result is undefined.
+     *
+     * \warning The \a firstVertexIndex must correspond to a segment vertex and not a curve point or the result
+     * is undefined.
+     *
+     * \since QGIS 3.20
+     */
+    virtual void scroll( int firstVertexIndex ) = 0;
+
 #ifndef SIP_RUN
 
     /**
@@ -326,6 +339,8 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
 
     mutable bool mHasCachedValidity = false;
     mutable QString mValidityFailureReason;
+
+    friend class TestQgsGeometry;
 };
 
 #endif // QGSCURVE_H

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -176,6 +176,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     int partCount() const override;
     QgsPoint vertexAt( QgsVertexId id ) const override;
     QgsCurve *toCurveType() const override SIP_FACTORY;
+    void normalize() final SIP_HOLDGIL;
 
     QgsRectangle boundingBox() const override;
     bool isValid( QString &error SIP_OUT, int flags = 0 ) const override;
@@ -262,6 +263,19 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
      */
     Orientation orientation() const;
 
+    /**
+     * Scrolls the curve vertices so that they start with the vertex at the given index.
+     *
+     * \warning This should only be called on closed curves, or the shape of the curve will be altered and
+     * the result is undefined.
+     *
+     * \warning The \a firstVertexIndex must correspond to a segment vertex and not a curve point or the result
+     * is undefined.
+     *
+     * \since QGIS 3.20
+     */
+    virtual void scroll( int firstVertexIndex ) = 0;
+
 #ifndef SIP_RUN
 
     /**
@@ -305,20 +319,6 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
 
     int childCount() const override;
     QgsPoint childPoint( int index ) const override;
-
-    /**
-     * Scrolls the curve vertices so that they start with the vertex at the given index.
-     *
-     * \warning This should only be called on closed curves, or the shape of the curve will be altered and
-     * the result is undefined.
-     *
-     * \warning The \a firstVertexIndex must correspond to a segment vertex and not a curve point or the result
-     * is undefined.
-     *
-     * \since QGIS 3.20
-     */
-    virtual void scroll( int firstVertexIndex ) = 0;
-
 #ifndef SIP_RUN
 
     /**

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -464,6 +464,27 @@ QString QgsCurvePolygon::asKml( int precision ) const
   return kml;
 }
 
+void QgsCurvePolygon::normalize()
+{
+  // normalize rings
+  if ( mExteriorRing )
+    mExteriorRing->normalize();
+
+  for ( QgsCurve *ring : std::as_const( mInteriorRings ) )
+  {
+    ring->normalize();
+  }
+
+  // sort rings
+  std::sort( mInteriorRings.begin(), mInteriorRings.end(), []( const QgsCurve * a, const QgsCurve * b )
+  {
+    return a->compareTo( b ) > 0;
+  } );
+
+  // normalize ring orientation
+  forceRHR();
+}
+
 double QgsCurvePolygon::area() const
 {
   if ( !mExteriorRing )

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -58,6 +58,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     json asJsonObject( int precision = 17 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
+    void normalize() final SIP_HOLDGIL;
 
     //surface interface
     double area() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2717,6 +2717,17 @@ void QgsGeometry::validateGeometry( QVector<QgsGeometry::Error> &errors, const V
   }
 }
 
+void QgsGeometry::normalize()
+{
+  if ( !d->geometry )
+  {
+    return;
+  }
+
+  detach();
+  d->geometry->normalize();
+}
+
 bool QgsGeometry::isGeosValid( const QgsGeometry::ValidityFlags flags ) const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2141,6 +2141,17 @@ class CORE_EXPORT QgsGeometry
     void validateGeometry( QVector<QgsGeometry::Error> &errors SIP_OUT, ValidationMethod method = ValidatorQgisInternal, QgsGeometry::ValidityFlags flags = QgsGeometry::ValidityFlags() ) const;
 
     /**
+     * Reorganizes the geometry into a normalized form (or "canonical" form).
+     *
+     * Polygon rings will be rearranged so that their starting vertex is the lower left and ring orientation follows the
+     * right hand rule, collections are ordered by geometry type, and other normalization techniques are applied. The
+     * resultant geometry will be geometrically equivalent to the original geometry.
+     *
+     * \since QGIS 3.20
+     */
+    void normalize();
+
+    /**
      * Compute the unary union on a list of \a geometries. May be faster than an iterative union on a set of geometries.
      * The returned geometry will be fully noded, i.e. a node will be created at every common intersection of the
      * input geometries. An empty geometry will be returned in the case of errors.

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -291,6 +291,18 @@ bool QgsGeometryCollection::removeGeometry( int nr )
   return true;
 }
 
+void QgsGeometryCollection::normalize()
+{
+  for ( QgsAbstractGeometry *geometry : std::as_const( mGeometries ) )
+  {
+    geometry->normalize();
+  }
+  std::sort( mGeometries.begin(), mGeometries.end(), []( const QgsAbstractGeometry * a, const QgsAbstractGeometry * b )
+  {
+    return a->compareTo( b ) > 0;
+  } );
+}
+
 int QgsGeometryCollection::dimension() const
 {
   int maxDim = 0;

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -179,6 +179,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     % End
 #endif
 
+    void normalize() final SIP_HOLDGIL;
     void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -581,6 +581,44 @@ QgsRectangle QgsLineString::calculateBoundingBox() const
   return QgsRectangle( xmin, ymin, xmax, ymax, false );
 }
 
+void QgsLineString::scroll( int index )
+{
+  const int size = mX.size();
+  if ( index < 1 || index >= size - 1 )
+    return;
+
+  const bool useZ = is3D();
+  const bool useM = isMeasure();
+
+  QVector<double> newX( size );
+  QVector<double> newY( size );
+  QVector<double> newZ( useZ ? size : 0 );
+  QVector<double> newM( useM ? size : 0 );
+  auto it = std::copy( mX.constBegin() + index, mX.constEnd() - 1, newX.begin() );
+  it = std::copy( mX.constBegin(), mX.constBegin() + index, it );
+  *it = *newX.constBegin();
+  mX = std::move( newX );
+
+  it = std::copy( mY.constBegin() + index, mY.constEnd() - 1, newY.begin() );
+  it = std::copy( mY.constBegin(), mY.constBegin() + index, it );
+  *it = *newY.constBegin();
+  mY = std::move( newY );
+  if ( useZ )
+  {
+    it = std::copy( mZ.constBegin() + index, mZ.constEnd() - 1, newZ.begin() );
+    it = std::copy( mZ.constBegin(), mZ.constBegin() + index, it );
+    *it = *newZ.constBegin();
+    mZ = std::move( newZ );
+  }
+  if ( useM )
+  {
+    it = std::copy( mM.constBegin() + index, mM.constEnd() - 1, newM.begin() );
+    it = std::copy( mM.constBegin(), mM.constBegin() + index, it );
+    *it = *newM.constBegin();
+    mM = std::move( newM );
+  }
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -681,6 +681,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool convertTo( QgsWkbTypes::Type type ) override;
 
     bool transform( QgsAbstractGeometryTransformer *transformer, QgsFeedback *feedback = nullptr ) override;
+    void scroll( int firstVertexIndex ) final;
 
 #ifndef SIP_RUN
     void filterVertices( const std::function< bool( const QgsPoint & ) > &filter ) override;
@@ -798,7 +799,6 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
-    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector<double> mX;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -798,6 +798,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;
     QgsRectangle calculateBoundingBox() const override;
+    void scroll( int firstVertexIndex ) final;
 
   private:
     QVector<double> mX;
@@ -820,6 +821,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     friend class QgsPolygon;
     friend class QgsTriangle;
+    friend class TestQgsGeometry;
 
 };
 

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -759,6 +759,11 @@ QgsPoint QgsPoint::project( double distance, double azimuth, double inclination 
   return QgsPoint( mX + dx, mY + dy, mZ + dz, mM, pType );
 }
 
+void QgsPoint::normalize()
+{
+  // nothing to do
+}
+
 bool QgsPoint::isEmpty() const
 {
   return std::isnan( mX ) || std::isnan( mY );

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -480,6 +480,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     QgsPoint operator-( QgsVector v ) const SIP_HOLDGIL { QgsPoint r = *this; r.rx() -= v.x(); r.ry() -= v.y(); return r; }
 
     //implementation of inherited methods
+    void normalize() final SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;
     QgsRectangle boundingBox() const override SIP_HOLDGIL;
     QString geometryType() const override SIP_HOLDGIL;

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -166,6 +166,9 @@ class TestQgsGeometry : public QObject
     void compareTo_data();
     void compareTo();
 
+    void scroll_data();
+    void scroll();
+
     // MK, Disabled 14.11.2014
     // Too unclear what exactly should be tested and which variations are allowed for the line
 #if 0
@@ -17781,6 +17784,61 @@ void TestQgsGeometry::compareTo()
   QFETCH( int, expected );
 
   QCOMPARE( QgsGeometry::fromWkt( geom1 ).get()->compareTo( QgsGeometry::fromWkt( geom2 ).get() ), expected );
+}
+
+void TestQgsGeometry::scroll_data()
+{
+  QTest::addColumn<QString>( "curve" );
+  QTest::addColumn<int>( "vertex" );
+  QTest::addColumn<QString>( "expected" );
+
+  QTest::newRow( "linestring empty" ) << QStringLiteral( "LINESTRING()" ) << 2 << QStringLiteral( "LineString EMPTY" );
+  QTest::newRow( "linestring no matching point" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3)" ) << 4 << QStringLiteral( "LineString (1 1, 1 2, 1 3)" );
+  QTest::newRow( "linestring one vertex" ) << QStringLiteral( "LINESTRING( 1 1)" ) << 0 << QStringLiteral( "LineString (1 1)" );
+  QTest::newRow( "linestring match first" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3, 1 4, 1 1)" ) << 0 << QStringLiteral( "LineString (1 1, 1 2, 1 3, 1 4, 1 1)" );
+  QTest::newRow( "linestring match second" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3, 1 4, 1 1)" ) << 1 << QStringLiteral( "LineString (1 2, 1 3, 1 4, 1 1, 1 2)" );
+  QTest::newRow( "linestring match third" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3, 1 4, 1 1)" ) << 2 << QStringLiteral( "LineString (1 3, 1 4, 1 1, 1 2, 1 3)" );
+  QTest::newRow( "linestring match forth" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3, 1 4, 1 1)" ) << 3 << QStringLiteral( "LineString (1 4, 1 1, 1 2, 1 3, 1 4)" );
+  QTest::newRow( "linestring match last" ) << QStringLiteral( "LINESTRING( 1 1, 1 2, 1 3, 1 4, 1 1)" ) << 4 << QStringLiteral( "LineString (1 1, 1 2, 1 3, 1 4, 1 1)" );
+  QTest::newRow( "linestringz" ) << QStringLiteral( "LINESTRINGZ( 1 1 3 , 1 2 4, 1 3 5 , 1 4 6, 1 1 3)" ) << 2 << QStringLiteral( "LineStringZ (1 3 5, 1 4 6, 1 1 3, 1 2 4, 1 3 5)" );
+  QTest::newRow( "linestringm" ) << QStringLiteral( "LINESTRINGM( 1 1 3 , 1 2 4, 1 3 5 , 1 4 6, 1 1 3)" ) << 2 << QStringLiteral( "LineStringM (1 3 5, 1 4 6, 1 1 3, 1 2 4, 1 3 5)" );
+  QTest::newRow( "linestringzm" ) << QStringLiteral( "LINESTRINGZM( 1 1 3 5, 1 2 4 6, 1 3 5 7, 1 4 6 8, 1 1 3 5)" ) << 2 << QStringLiteral( "LineStringZM (1 3 5 7, 1 4 6 8, 1 1 3 5, 1 2 4 6, 1 3 5 7)" );
+
+  QTest::newRow( "circularstring empty" ) << QStringLiteral( "CIRCULARSTRING()" ) << 2 << QStringLiteral( "CircularString EMPTY" );
+  QTest::newRow( "circularstring no matching point" ) << QStringLiteral( "CIRCULARSTRING( 1 1, 1 2, 1 3)" ) << 4 << QStringLiteral( "CircularString (1 1, 1 2, 1 3)" );
+  // technically not valid, but we don't want a crash
+  QTest::newRow( "circularstring one vertex" ) << QStringLiteral( "CIRCULARSTRING( 1 1)" ) << 0 << QStringLiteral( "CircularString (1 1)" );
+  QTest::newRow( "circularstring match first" ) << QStringLiteral( "CIRCULARSTRING( 1 1, 2 1, 2 2, 1 4, 1 1)" ) << 0 << QStringLiteral( "CircularString (1 1, 2 1, 2 2, 1 4, 1 1)" );
+  QTest::newRow( "circularstring match third" ) << QStringLiteral( "CIRCULARSTRING( 1 1, 2 1, 2 2, 1 4, 1 1)" ) << 2 << QStringLiteral( "CircularString (2 2, 1 4, 1 1, 2 1, 2 2)" );
+  QTest::newRow( "circularstring match 5th" ) << QStringLiteral( "CIRCULARSTRING( 1 1, 2 1, 2 2, 3 4, 2 4, 1 4, 1 1)" ) << 4 << QStringLiteral( "CircularString (2 4, 1 4, 1 1, 2 1, 2 2, 3 4, 2 4)" );
+  QTest::newRow( "circularstring match last" ) << QStringLiteral( "CIRCULARSTRING( 1 1, 2 1, 2 2, 3 4, 2 4, 1 4, 1 1)" ) << 6 << QStringLiteral( "CircularString (1 1, 2 1, 2 2, 3 4, 2 4, 1 4, 1 1)" );
+  QTest::newRow( "circularstringz" ) << QStringLiteral( "CIRCULARSTRINGZ( 1 1 3 , 2 1 4, 2 2 5 , 1 4 6, 1 1 3)" ) << 2 << QStringLiteral( "CircularStringZ (2 2 5, 1 4 6, 1 1 3, 2 1 4, 2 2 5)" );
+  QTest::newRow( "circularstringm" ) << QStringLiteral( "CIRCULARSTRINGM( 1 1 3 , 2 1 4, 2 2 5 , 1 4 6, 1 1 3)" ) << 2 << QStringLiteral( "CircularStringM (2 2 5, 1 4 6, 1 1 3, 2 1 4, 2 2 5)" );
+  QTest::newRow( "circularstringzm" ) << QStringLiteral( "CIRCULARSTRINGZM( 1 1 3 5, 2 1 4 6, 2 2 5 7, 1 4 6 8, 1 1 3 5)" ) << 2 << QStringLiteral( "CircularStringZM (2 2 5 7, 1 4 6 8, 1 1 3 5, 2 1 4 6, 2 2 5 7)" );
+
+  QTest::newRow( "compoundcurve empty" ) << QStringLiteral( "COMPOUNDCURVE()" ) << 2 << QStringLiteral( "CompoundCurve EMPTY" );
+  QTest::newRow( "compoundcurve no matching point" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2, 1 3))" ) << 4 << QStringLiteral( "CompoundCurve ((1 1, 1 2, 1 3))" );
+  QTest::newRow( "compoundcurve one vertex" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1))" ) << 0 << QStringLiteral( "CompoundCurve ((1 1))" );
+  QTest::newRow( "compoundcurve match first" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2),( 1 2, 1 3, 1 4, 1 1))" ) << 0 << QStringLiteral( "CompoundCurve ((1 1, 1 2),(1 2, 1 3, 1 4, 1 1))" );
+  QTest::newRow( "compoundcurve match second" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2),( 1 2, 1 3, 1 4, 1 1))" ) << 1 << QStringLiteral( "CompoundCurve ((1 2, 1 3, 1 4, 1 1),(1 1, 1 2))" );
+  QTest::newRow( "compoundcurve match third" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2),( 1 2, 1 3, 1 4, 1 1))" ) << 2 << QStringLiteral( "CompoundCurve ((1 3, 1 4, 1 1),(1 1, 1 2),(1 2, 1 3))" );
+  QTest::newRow( "compoundcurve match forth" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2),( 1 2, 1 3, 1 4, 1 1))" ) << 3 << QStringLiteral( "CompoundCurve ((1 4, 1 1),(1 1, 1 2),(1 2, 1 3, 1 4))" );
+  QTest::newRow( "compoundcurve match last" ) << QStringLiteral( "COMPOUNDCURVE(( 1 1, 1 2),( 1 2, 1 3, 1 4, 1 1))" ) << 4 << QStringLiteral( "CompoundCurve ((1 1, 1 2),(1 2, 1 3, 1 4, 1 1))" );
+  QTest::newRow( "compoundcurvez" ) << QStringLiteral( "COMPOUNDCURVEZ(( 1 1 3 , 1 2 4, 1 3 5 , 1 4 6, 1 1 3))" ) << 2 << QStringLiteral( "CompoundCurveZ ((1 3 5, 1 4 6, 1 1 3),(1 1 3, 1 2 4, 1 3 5))" );
+  QTest::newRow( "compoundcurvem" ) << QStringLiteral( "COMPOUNDCURVEM(( 1 1 3 , 1 2 4, 1 3 5 , 1 4 6, 1 1 3))" ) << 2 << QStringLiteral( "CompoundCurveM ((1 3 5, 1 4 6, 1 1 3),(1 1 3, 1 2 4, 1 3 5))" );
+  QTest::newRow( "compoundcurvezm" ) << QStringLiteral( "COMPOUNDCURVEZM(( 1 1 3 5, 1 2 4 6, 1 3 5 7, 1 4 6 8, 1 1 3 5))" ) << 2 << QStringLiteral( "CompoundCurveZM ((1 3 5 7, 1 4 6 8, 1 1 3 5),(1 1 3 5, 1 2 4 6, 1 3 5 7))" );
+}
+
+void TestQgsGeometry::scroll()
+{
+  QFETCH( QString, curve );
+  QFETCH( int, vertex );
+  QFETCH( QString, expected );
+
+  QgsGeometry geom = QgsGeometry::fromWkt( curve );
+  qgsgeometry_cast< QgsCurve * >( geom.get() )->scroll( vertex );
+
+  QCOMPARE( geom.get()->asWkt(), expected );
 }
 
 // MK, Disabled 14.11.2014


### PR DESCRIPTION
A port of the equivalent method from GEOS, but with added support
for curved geometries and M values

Reorganizes the geometry into a normalized form (or "canonical" form).

Polygon rings will be rearranged so that their starting vertex is
the lower left and ring orientation follows the right hand rule, collections
are ordered by geometry type, and other normalization techniques are applied.
The resultant geometry will be geometrically equivalent to the original geometry.