### PR TITLE
If a text format with the name "Default" is found in the style database, use this as the text format for newly created layer labels

### DIFF
--- a/python/core/auto_additions/qgsstyle.py
+++ b/python/core/auto_additions/qgsstyle.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/symbology/qgsstyle.h
+# monkey patching scoped based enum
+QgsStyle.TextFormatContext.Labeling.__doc__ = "Text format used in labeling"
+QgsStyle.TextFormatContext.__doc__ = 'Text format context.\n\n.. versionadded:: 3.20\n\n' + '* ``Labeling``: ' + QgsStyle.TextFormatContext.Labeling.__doc__
+# --

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -703,6 +703,18 @@ Returns the default patch geometry for the given symbol ``type`` and ``size`` as
 .. versionadded:: 3.14
 %End
 
+    enum class TextFormatContext
+    {
+      Labeling,
+    };
+
+    QgsTextFormat defaultTextFormat( QgsStyle::TextFormatContext context = QgsStyle::TextFormatContext::Labeling ) const;
+%Docstring
+Returns the default text format to use for new text based objects in the specified ``context``.
+
+.. versionadded:: 3.20
+%End
+
     bool saveSymbol3D( const QString &name, QgsAbstract3DSymbol *symbol /Transfer/, bool favorite, const QStringList &tags );
 %Docstring
 Adds a 3d ``symbol`` to the database.

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -20,6 +20,7 @@
 #include "qgsunittypes.h"
 #include "qgsexception.h"
 #include "qgsapplication.h"
+#include "qgsstyle.h"
 
 #include <list>
 
@@ -272,6 +273,8 @@ QgsPalLayerSettings::QgsPalLayerSettings()
   , mCallout( QgsApplication::calloutRegistry()->defaultCallout() )
 {
   initPropertyDefinitions();
+
+  mFormat = QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling );
 }
 Q_NOWARN_DEPRECATED_POP
 

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -1222,6 +1222,11 @@ QList<QList<QPolygonF> > QgsStyle::defaultPatchAsQPolygonF( QgsSymbol::SymbolTyp
   return res;
 }
 
+QgsTextFormat QgsStyle::defaultTextFormat( QgsStyle::TextFormatContext ) const
+{
+  return textFormat( QStringLiteral( "Default" ) );
+}
+
 bool QgsStyle::saveSymbol3D( const QString &name, QgsAbstract3DSymbol *symbol, bool favorite, const QStringList &tags )
 {
   // insert it into the database

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -723,6 +723,23 @@ class CORE_EXPORT QgsStyle : public QObject
     QList< QList< QPolygonF > > defaultPatchAsQPolygonF( QgsSymbol::SymbolType type, QSizeF size ) const;
 
     /**
+     * Text format context.
+     *
+     * \since QGIS 3.20
+     */
+    enum class TextFormatContext : int
+    {
+      Labeling, //!< Text format used in labeling
+    };
+
+    /**
+     * Returns the default text format to use for new text based objects in the specified \a context.
+     *
+     * \since QGIS 3.20
+     */
+    QgsTextFormat defaultTextFormat( QgsStyle::TextFormatContext context = QgsStyle::TextFormatContext::Labeling ) const;
+
+    /**
      * Adds a 3d \a symbol to the database.
      *
      * \param name is the name of the 3d symbol
@@ -1139,6 +1156,7 @@ class CORE_EXPORT QgsStyle : public QObject
     static QString tagmapEntityIdFieldName( StyleEntity type );
 
     friend class Qgs3D;
+    friend class TestStyle;
 
     Q_DISABLE_COPY( QgsStyle )
 };

--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -332,7 +332,7 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
     mGeometryGeneratorGroupBox->setCollapsed( true );
   mGeometryGeneratorType->setCurrentIndex( mGeometryGeneratorType->findData( mSettings.geometryGeneratorType ) );
 
-  updateWidgetForFormat( mSettings.format() );
+  updateWidgetForFormat( mSettings.format().isValid() ? mSettings.format() : QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling ) );
 
   mFieldExpressionWidget->setRow( -1 );
   mFieldExpressionWidget->setField( mSettings.fieldName );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -48,7 +48,7 @@ QgsTextFormatWidget::QgsTextFormatWidget( const QgsTextFormat &format, QgsMapCan
   initWidget();
   setWidgetMode( Text );
   populateDataDefinedButtons();
-  updateWidgetForFormat( format );
+  updateWidgetForFormat( format.isValid() ? format : QgsStyle::defaultStyle()->defaultTextFormat() );
 }
 
 QgsTextFormatWidget::QgsTextFormatWidget( QgsMapCanvas *mapCanvas, QWidget *parent, Mode mode, QgsVectorLayer *layer )


### PR DESCRIPTION
Instead of defaulting to a random font, this gives us a mechanism to supply a better default label font to users via the default
style database. And users can always modify this "default" text format if they'd like to change the default font!

For now this is the underlying code logic changes only -- we don't yet include a 'Default' text format in the default style database
to take advantage of this functionality.
