### PR TITLE
Add scroll area to fix resizing in layer properties window

### DIFF
--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
-    <height>462</height>
+    <width>585</width>
+    <height>476</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -215,7 +215,7 @@
             <x>0</x>
             <y>0</y>
             <width>591</width>
-            <height>221</height>
+            <height>235</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_8">
@@ -228,6 +228,9 @@
            </item>
            <item row="0" column="1">
             <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
            </item>
            <item row="1" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,0">
@@ -285,9 +288,6 @@
               </widget>
              </item>
             </layout>
-           </item>
-           <item row="2" column="0" colspan="2">
-            <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
            </item>
           </layout>
          </widget>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>581</width>
-    <height>491</height>
+    <width>573</width>
+    <height>462</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -138,7 +138,7 @@
    <item row="2" column="0" colspan="3">
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="noRendererPage"/>
      <widget class="QWidget" name="singleColorRendererPage">
@@ -191,7 +191,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="colorRampRendererPage">
-      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0,1" columnstretch="0,0">
+      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0" columnstretch="0">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -205,74 +205,93 @@
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Attribute</string>
+        <widget class="QScrollArea" name="scrollArea_2">
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents_2">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>591</width>
+            <height>221</height>
+           </rect>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_8">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Attribute</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
+           </item>
+           <item row="1" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,0">
+             <item>
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsDoubleSpinBox" name="mColorRampShaderMinEdit">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-9999999999.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>9999999999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsDoubleSpinBox" name="mColorRampShaderMaxEdit">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-9999999999.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>9999999999.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="mScalarRecalculateMinMaxButton">
+               <property name="text">
+                <string>Load</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
+           </item>
+          </layout>
+         </widget>
         </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QgsPointCloudAttributeComboBox" name="mRenderingParameterComboBox"/>
-       </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true"/>
-       </item>
-       <item row="1" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,0">
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Min</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QgsDoubleSpinBox" name="mColorRampShaderMinEdit">
-           <property name="decimals">
-            <number>6</number>
-           </property>
-           <property name="minimum">
-            <double>-9999999999.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>9999999999.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Max</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QgsDoubleSpinBox" name="mColorRampShaderMaxEdit">
-           <property name="decimals">
-            <number>6</number>
-           </property>
-           <property name="minimum">
-            <double>-9999999999.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>9999999999.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="mScalarRecalculateMinMaxButton">
-           <property name="text">
-            <string>Load</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
       </layout>
      </widget>
@@ -518,7 +537,30 @@ enhancement</string>
         <number>0</number>
        </property>
        <item row="0" column="0">
-        <layout class="QGridLayout" name="mClassifiedRenderingLayout"/>
+        <layout class="QGridLayout" name="_2">
+         <item row="0" column="0">
+          <widget class="QScrollArea" name="scrollArea">
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="scrollAreaWidgetContents">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>569</width>
+              <height>233</height>
+             </rect>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_9">
+             <item row="0" column="0">
+              <layout class="QGridLayout" name="mClassifiedRenderingLayout"/>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -531,15 +573,14 @@ enhancement</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsPointCloudAttributeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgspointcloudattributecombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsColorRampShaderWidget</class>
@@ -548,9 +589,10 @@ enhancement</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsPointCloudAttributeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgspointcloudattributecombobox.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -560,7 +602,6 @@ enhancement</string>
   <tabstop>mMaxScreenErrorSpinBox</tabstop>
   <tabstop>mPointBudgetSpinBox</tabstop>
   <tabstop>mShowBoundingBoxesCheckBox</tabstop>
-  <tabstop>mRenderingParameterComboBox</tabstop>
   <tabstop>mColorRampShaderMinEdit</tabstop>
   <tabstop>mColorRampShaderMaxEdit</tabstop>
   <tabstop>mScalarRecalculateMinMaxButton</tabstop>

--- a/src/ui/qgscolorrampshaderwidgetbase.ui
+++ b/src/ui/qgscolorrampshaderwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>397</width>
-    <height>605</height>
+    <height>292</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,7 +37,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>250</height>
+       <height>0</height>
       </size>
      </property>
      <attribute name="headerMinimumSectionSize">


### PR DESCRIPTION
## Description
The layer properties window sometimes annoys user by being unable to resize to small size properly and for some smaller screen resolution that might end up occupying an unwanted part of the screen.
For example here is the smallest shrinking I could get before:
![layer_properties](https://user-images.githubusercontent.com/29183781/116352905-c9d1f500-a7ed-11eb-8588-bd8868253a55.png)
I added a scroll area around to make a scroll bar show up instead of refusing to shring further:
![Screenshot from 2021-04-28 06-54-35](https://user-images.githubusercontent.com/29183781/116353502-ca1ec000-a7ee-11eb-98a6-08d60025c59d.png)
Each widget inside a tab in the layer properties window might have different size requirements which will make it difficult to try to fix the resizing issue for them one by one, I think the better solution is to just have a scroll area around the layer properties window content like I'm doing in this PR.