### PR TITLE
Fix 'mkdir' in python processing tools

### DIFF
--- a/python/plugins/processing/tools/system.py
+++ b/python/plugins/processing/tools/system.py
@@ -94,15 +94,7 @@ def getNumExportedLayers():
 
 
 def mkdir(newdir):
-    newdir = newdir.strip('\n\r ')
-    if os.path.isdir(newdir):
-        pass
-    else:
-        (head, tail) = os.path.split(newdir)
-        if head and not os.path.isdir(head):
-            mkdir(head)
-        if tail:
-            os.mkdir(newdir)
+    os.makedirs(newdir.strip('\n\r '), exist_ok=True)
 
 
 def tempHelpFolder():


### PR DESCRIPTION
## Description

Replace recusive creation function by library recursive directory creation function
[`os.makedirs`](https://docs.python.org/3.8/library/os.html). 

This will not throw exception
in case the directory already exists because it has been created atfer the existence test.

This fix the raising of exception in  concurrency situation when initializing processing in a multi processing environment.

## Affected files

`/usr/share/qgis/python/plugins/processing/tools/system.py`

