### PR TITLE
[Backport release-3_16] backport #41362 fix mesh layer legend

### DIFF
--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -63,9 +63,9 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
     ok = setDataProvider( providerKey, providerOptions, flags );
   }
 
+  setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
   if ( ok )
   {
-    setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
     setDefaultRendererSettings( mDatasetGroupStore->datasetGroupIndexes() );
 
     if ( mDataProvider )


### PR DESCRIPTION
This backport was initially for 3.16.5 (https://github.com/qgis/QGIS/pull/41369). But it seems something went wrong and it was not merged ...
If it could be merged for 3.16.7 