### PR TITLE
Expose more geos methods via QgsGeometry

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -564,6 +564,50 @@ In case of error -1 will be returned.
 .. versionadded:: 3.0
 %End
 
+    double frechetDistance( const QgsGeometry &geom ) const throw( QgsNotSupportedException );
+%Docstring
+Returns the Fréchet distance this geometry and ``geom``, restricted to discrete points for both geometries.
+
+The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
+Therefore it is often better than the Hausdorff distance.
+
+In case of error -1 will be returned.
+
+This method requires QGIS builds based on GEOS 3.7 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
+
+.. seealso:: :py:func:`frechetDistanceDensify`
+
+.. versionadded:: 3.20
+%End
+
+    double frechetDistanceDensify( const QgsGeometry &geom, double densifyFraction ) const throw( QgsNotSupportedException );
+%Docstring
+Returns the Fréchet distance this geometry and ``geom``, restricted to discrete points for both geometries.
+
+The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
+Therefore it is often better than the Hausdorff distance.
+
+This function accepts a ``densifyFraction`` argument. The function performs a segment
+densification before computing the discrete Fréchet distance. The ``densifyFraction`` parameter
+sets the fraction by which to densify each segment. Each segment will be split into a
+number of equal-length subsegments, whose fraction of the total length is
+closest to the given fraction.
+
+This method can be used when the default approximation provided by :py:func:`~QgsGeometry.frechetDistance`
+is not sufficient. Decreasing the ``densifyFraction`` parameter will make the
+distance returned approach the true Fréchet distance for the geometries.
+
+This method requires QGIS builds based on GEOS 3.7 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
+
+.. seealso:: :py:func:`frechetDistance`
+
+.. versionadded:: 3.20
+%End
+
     QgsPointXY closestVertex( const QgsPointXY &point, int &closestVertexIndex /Out/, int &previousVertexIndex /Out/, int &nextVertexIndex /Out/, double &sqrDist /Out/ ) const;
 %Docstring
 Returns the vertex closest to the given point, the corresponding vertex index, squared distance snap point / target point
@@ -1347,6 +1391,81 @@ Optionally, the distance to the polygon boundary from the pole can be stored.
 .. versionadded:: 3.0
 %End
 
+    QgsGeometry largestEmptyCircle( double tolerance, const QgsGeometry &boundary = QgsGeometry() ) const throw( QgsNotSupportedException );
+%Docstring
+Constructs the Largest Empty Circle for a set of obstacle geometries, up to a
+specified tolerance.
+
+The Largest Empty Circle is the largest circle which has its center in the convex hull of the
+obstacles (the boundary), and whose interior does not intersect with any obstacle.
+The circle center is the point in the interior of the boundary which has the farthest distance from
+the obstacles (up to tolerance). The circle is determined by the center point and a point lying on an
+obstacle indicating the circle radius.
+The implementation uses a successive-approximation technique over a grid of square cells covering the obstacles and boundary.
+The grid is refined using a branch-and-bound algorithm.  Point containment and distance are computed in a performant
+way by using spatial indexes.
+Returns a two-point linestring, with one point at the center of the inscribed circle and the other
+on the boundary of the inscribed circle.
+
+This method requires QGIS builds based on GEOS 3.9 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.8 or earlier.
+
+.. versionadded:: 3.20
+%End
+
+    QgsGeometry minimumWidth() const throw( QgsNotSupportedException );
+%Docstring
+Returns a linestring geometry which represents the minimum diameter of the geometry.
+
+The minimum diameter is defined to be the width of the smallest band that
+contains the geometry, where a band is a strip of the plane defined
+by two parallel lines. This can be thought of as the smallest hole that the geometry
+can be moved through, with a single rotation.
+
+This method requires QGIS builds based on GEOS 3.6 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+
+.. versionadded:: 3.20
+%End
+
+    double minimumClearance() const throw( QgsNotSupportedException );
+%Docstring
+Computes the minimum clearance of a geometry.
+
+The minimum clearance is the smallest amount by which
+a vertex could be move to produce an invalid polygon, a non-simple linestring, or a multipoint with
+repeated points.  If a geometry has a minimum clearance of 'eps', it can be said that:
+
+- No two distinct vertices in the geometry are separated by less than 'eps'
+- No vertex is closer than 'eps' to a line segment of which it is not an endpoint.
+
+If the minimum clearance cannot be defined for a geometry (such as with a single point, or a multipoint
+whose points are identical, a value of Infinity will be calculated.
+
+If an error occurs while calculating the clearance NaN will be returned.
+
+This method requires QGIS builds based on GEOS 3.6 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+
+.. versionadded:: 3.20
+%End
+
+    QgsGeometry minimumClearanceLine() const throw( QgsNotSupportedException );
+%Docstring
+Returns a LineString whose endpoints define the minimum clearance of a geometry.
+
+If the geometry has no minimum clearance, an empty LineString will be returned.
+
+This method requires QGIS builds based on GEOS 3.6 or later.
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+
+.. versionadded:: 3.20
+%End
+
     QgsGeometry convexHull() const;
 %Docstring
 Returns the smallest convex polygon that contains all the points in the geometry.
@@ -1385,6 +1504,34 @@ instead of polygons.
 An empty geometry will be returned if the diagram could not be calculated.
 
 .. versionadded:: 3.0
+%End
+
+    QgsGeometry node() const;
+%Docstring
+Returns a (Multi)LineString representing the fully noded version of a collection of linestrings.
+
+The noding preserves all of the input nodes, and introduces the least possible number of new nodes.
+The resulting linework is dissolved (duplicate lines are removed).
+
+The input geometry type should be a (Multi)LineString.
+
+.. versionadded:: 3.20
+%End
+
+    QgsGeometry sharedPaths( const QgsGeometry &other ) const;
+%Docstring
+Find paths shared between the two given lineal geometries (this and ``other``).
+
+Returns a GeometryCollection having two elements:
+
+- first element is a MultiLineString containing shared paths
+  having the same direction on both inputs
+- second element is a MultiLineString containing shared paths
+  having the opposite direction on the two inputs
+
+Returns a null geometry on exception.
+
+.. versionadded:: 3.20
 %End
 
     QgsGeometry subdivide( int maxNodes = 256 ) const;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -566,14 +566,14 @@ In case of error -1 will be returned.
 
     double frechetDistance( const QgsGeometry &geom ) const throw( QgsNotSupportedException );
 %Docstring
-Returns the Fréchet distance this geometry and ``geom``, restricted to discrete points for both geometries.
+Returns the Fréchet distance between this geometry and ``geom``, restricted to discrete points for both geometries.
 
 The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
 Therefore it is often better than the Hausdorff distance.
 
 In case of error -1 will be returned.
 
-This method requires QGIS builds based on GEOS 3.7 or later.
+This method requires a QGIS build based on GEOS 3.7 or later.
 
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
 
@@ -584,7 +584,7 @@ This method requires QGIS builds based on GEOS 3.7 or later.
 
     double frechetDistanceDensify( const QgsGeometry &geom, double densifyFraction ) const throw( QgsNotSupportedException );
 %Docstring
-Returns the Fréchet distance this geometry and ``geom``, restricted to discrete points for both geometries.
+Returns the Fréchet distance between this geometry and ``geom``, restricted to discrete points for both geometries.
 
 The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
 Therefore it is often better than the Hausdorff distance.
@@ -599,7 +599,7 @@ This method can be used when the default approximation provided by :py:func:`~Qg
 is not sufficient. Decreasing the ``densifyFraction`` parameter will make the
 distance returned approach the true Fréchet distance for the geometries.
 
-This method requires QGIS builds based on GEOS 3.7 or later.
+This method requires a QGIS build based on GEOS 3.7 or later.
 
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
 
@@ -1423,7 +1423,7 @@ contains the geometry, where a band is a strip of the plane defined
 by two parallel lines. This can be thought of as the smallest hole that the geometry
 can be moved through, with a single rotation.
 
-This method requires QGIS builds based on GEOS 3.6 or later.
+This method requires a QGIS build based on GEOS 3.6 or later.
 
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 
@@ -1435,18 +1435,18 @@ This method requires QGIS builds based on GEOS 3.6 or later.
 Computes the minimum clearance of a geometry.
 
 The minimum clearance is the smallest amount by which
-a vertex could be move to produce an invalid polygon, a non-simple linestring, or a multipoint with
+a vertex could be moved to produce an invalid polygon, a non-simple linestring, or a multipoint with
 repeated points.  If a geometry has a minimum clearance of 'eps', it can be said that:
 
 - No two distinct vertices in the geometry are separated by less than 'eps'
 - No vertex is closer than 'eps' to a line segment of which it is not an endpoint.
 
 If the minimum clearance cannot be defined for a geometry (such as with a single point, or a multipoint
-whose points are identical, a value of Infinity will be calculated.
+whose points are identical) a value of infinity will be returned.
 
 If an error occurs while calculating the clearance NaN will be returned.
 
-This method requires QGIS builds based on GEOS 3.6 or later.
+This method requires a QGIS build based on GEOS 3.6 or later.
 
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 
@@ -1459,7 +1459,7 @@ Returns a LineString whose endpoints define the minimum clearance of a geometry.
 
 If the geometry has no minimum clearance, an empty LineString will be returned.
 
-This method requires QGIS builds based on GEOS 3.6 or later.
+This method requires a QGIS build based on GEOS 3.6 or later.
 
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1409,7 +1409,12 @@ on the boundary of the inscribed circle.
 
 This method requires QGIS builds based on GEOS 3.9 or later.
 
+.. warning::
+
+   the ``tolerance`` value must be a value greater than 0, or the algorithm may never converge on a solution
+
 :raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.8 or earlier.
+
 
 .. versionadded:: 3.20
 %End

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2252,8 +2252,7 @@ double QgsGeometry::minimumClearance() const
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  double result( geos.minimumClearance( &mLastError ) );
-  return result;
+  return geos.minimumClearance( &mLastError );
 }
 
 QgsGeometry QgsGeometry::minimumClearanceLine() const

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1839,6 +1839,31 @@ double QgsGeometry::hausdorffDistanceDensify( const QgsGeometry &geom, double de
   return g.hausdorffDistanceDensify( geom.d->geometry.get(), densifyFraction, &mLastError );
 }
 
+
+double QgsGeometry::frechetDistance( const QgsGeometry &geom ) const
+{
+  if ( !d->geometry || !geom.d->geometry )
+  {
+    return -1.0;
+  }
+
+  QgsGeos g( d->geometry.get() );
+  mLastError.clear();
+  return g.frechetDistance( geom.d->geometry.get(), &mLastError );
+}
+
+double QgsGeometry::frechetDistanceDensify( const QgsGeometry &geom, double densifyFraction ) const
+{
+  if ( !d->geometry || !geom.d->geometry )
+  {
+    return -1.0;
+  }
+
+  QgsGeos g( d->geometry.get() );
+  mLastError.clear();
+  return g.frechetDistanceDensify( geom.d->geometry.get(), densifyFraction, &mLastError );
+}
+
 QgsAbstractGeometry::vertex_iterator QgsGeometry::vertices_begin() const
 {
   if ( !d->geometry || d->geometry.get()->isEmpty() )
@@ -2187,6 +2212,65 @@ QgsGeometry QgsGeometry::poleOfInaccessibility( double precision, double *distan
   return engine.poleOfInaccessibility( precision, distanceToBoundary );
 }
 
+QgsGeometry QgsGeometry::largestEmptyCircle( double tolerance,  const QgsGeometry &boundary ) const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+
+  mLastError.clear();
+  QgsGeometry result( geos.largestEmptyCircle( tolerance, boundary.constGet(), &mLastError ) );
+  result.mLastError = mLastError;
+  return result;
+}
+
+QgsGeometry QgsGeometry::minimumWidth() const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+
+  mLastError.clear();
+  QgsGeometry result( geos.minimumWidth( &mLastError ) );
+  result.mLastError = mLastError;
+  return result;
+}
+
+double QgsGeometry::minimumClearance() const
+{
+  if ( !d->geometry )
+  {
+    return std::numeric_limits< double >::quiet_NaN();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+
+  mLastError.clear();
+  double result( geos.minimumClearance( &mLastError ) );
+  return result;
+}
+
+QgsGeometry QgsGeometry::minimumClearanceLine() const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+
+  mLastError.clear();
+  QgsGeometry result( geos.minimumClearanceLine( &mLastError ) );
+  result.mLastError = mLastError;
+  return result;
+}
+
 QgsGeometry QgsGeometry::convexHull() const
 {
   if ( !d->geometry )
@@ -2229,6 +2313,34 @@ QgsGeometry QgsGeometry::delaunayTriangulation( double tolerance, bool edgesOnly
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
   QgsGeometry result = geos.delaunayTriangulation( tolerance, edgesOnly );
+  result.mLastError = mLastError;
+  return result;
+}
+
+QgsGeometry QgsGeometry::node() const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+  mLastError.clear();
+  QgsGeometry result( geos.node( &mLastError ) );
+  result.mLastError = mLastError;
+  return result;
+}
+
+QgsGeometry QgsGeometry::sharedPaths( const QgsGeometry &other ) const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  QgsGeos geos( d->geometry.get() );
+  mLastError.clear();
+  QgsGeometry result( geos.sharedPaths( other.constGet(), &mLastError ) );
   result.mLastError = mLastError;
   return result;
 }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1411,6 +1411,8 @@ class CORE_EXPORT QgsGeometry
      *
      * This method requires QGIS builds based on GEOS 3.9 or later.
      *
+     * \warning the \a tolerance value must be a value greater than 0, or the algorithm may never converge on a solution
+     *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
      *
      * \since QGIS 3.20

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -640,14 +640,14 @@ class CORE_EXPORT QgsGeometry
     double hausdorffDistanceDensify( const QgsGeometry &geom, double densifyFraction ) const;
 
     /**
-     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     * Returns the Fréchet distance between this geometry and \a geom, restricted to discrete points for both geometries.
      *
      * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
      * Therefore it is often better than the Hausdorff distance.
      *
      * In case of error -1 will be returned.
      *
-     * This method requires QGIS builds based on GEOS 3.7 or later.
+     * This method requires a QGIS build based on GEOS 3.7 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
      * \see frechetDistanceDensify()
@@ -656,7 +656,7 @@ class CORE_EXPORT QgsGeometry
     double frechetDistance( const QgsGeometry &geom ) const SIP_THROW( QgsNotSupportedException );
 
     /**
-     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     * Returns the Fréchet distance between this geometry and \a geom, restricted to discrete points for both geometries.
      *
      * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
      * Therefore it is often better than the Hausdorff distance.
@@ -671,7 +671,7 @@ class CORE_EXPORT QgsGeometry
      * is not sufficient. Decreasing the \a densifyFraction parameter will make the
      * distance returned approach the true Fréchet distance for the geometries.
      *
-     * This method requires QGIS builds based on GEOS 3.7 or later.
+     * This method requires a QGIS build based on GEOS 3.7 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
      * \see frechetDistance()
@@ -1425,7 +1425,7 @@ class CORE_EXPORT QgsGeometry
      * by two parallel lines. This can be thought of as the smallest hole that the geometry
      * can be moved through, with a single rotation.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *
@@ -1437,18 +1437,18 @@ class CORE_EXPORT QgsGeometry
      * Computes the minimum clearance of a geometry.
      *
      * The minimum clearance is the smallest amount by which
-     * a vertex could be move to produce an invalid polygon, a non-simple linestring, or a multipoint with
+     * a vertex could be moved to produce an invalid polygon, a non-simple linestring, or a multipoint with
      * repeated points.  If a geometry has a minimum clearance of 'eps', it can be said that:
      *
      * - No two distinct vertices in the geometry are separated by less than 'eps'
      * - No vertex is closer than 'eps' to a line segment of which it is not an endpoint.
      *
      * If the minimum clearance cannot be defined for a geometry (such as with a single point, or a multipoint
-     * whose points are identical, a value of Infinity will be calculated.
+     * whose points are identical) a value of infinity will be returned.
      *
      * If an error occurs while calculating the clearance NaN will be returned.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *
@@ -1461,7 +1461,7 @@ class CORE_EXPORT QgsGeometry
      *
      * If the geometry has no minimum clearance, an empty LineString will be returned.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -512,6 +512,60 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
   return distance;
 }
 
+double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistance requires a QGIS build based on GEOS 3.9 or later" ) );
+#else
+  double distance = -1.0;
+  if ( !mGeos )
+  {
+    return distance;
+  }
+
+  geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
+  if ( !otherGeosGeom )
+  {
+    return distance;
+  }
+
+  try
+  {
+    GEOSFrechetDistance_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), &distance );
+  }
+  CATCH_GEOS_WITH_ERRMSG( -1.0 )
+
+  return distance;
+#endif
+}
+
+double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistanceDensify requires a QGIS build based on GEOS 3.9 or later" ) );
+#else
+  double distance = -1.0;
+  if ( !mGeos )
+  {
+    return distance;
+  }
+
+  geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
+  if ( !otherGeosGeom )
+  {
+    return distance;
+  }
+
+  try
+  {
+    GEOSFrechetDistanceDensify_r( geosinit()->ctxt, mGeos.get(), otherGeosGeom.get(), densifyFraction, &distance );
+  }
+  CATCH_GEOS_WITH_ERRMSG( -1.0 )
+
+  return distance;
+#endif
+}
+
 bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
   return relation( geom, RelationIntersects, errorMsg );
@@ -2103,6 +2157,148 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance
       distance = -distance;
     }
     geos.reset( GEOSBufferWithParams_r( geosinit()->ctxt, mGeos.get(), bp.get(), distance ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tolerance, QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  throw QgsNotSupportedException( QStringLiteral( "Calculating maximumInscribedCircle requires a QGIS build based on GEOS 3.9 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos.reset( GEOSMaximumInscribedCircle_r( geosinit()->ctxt, mGeos.get(), tolerance ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+#endif
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary, QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  throw QgsNotSupportedException( QStringLiteral( "Calculating largestEmptyCircle requires a QGIS build based on GEOS 3.9 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos::unique_ptr boundaryGeos;
+    if ( boundary )
+      boundaryGeos = asGeos( boundary );
+
+    geos.reset( GEOSLargestEmptyCircle_r( geosinit()->ctxt, mGeos.get(), boundaryGeos.get(), tolerance ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+#endif
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  throw QgsNotSupportedException( QStringLiteral( "Calculating minimumWidth requires a QGIS build based on GEOS 3.6 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos.reset( GEOSMinimumWidth_r( geosinit()->ctxt, mGeos.get() ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+#endif
+}
+
+double QgsGeos::minimumClearance( QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  throw QgsNotSupportedException( QStringLiteral( "Calculating minimumClearance requires a QGIS build based on GEOS 3.6 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return std::numeric_limits< double >::quiet_NaN();
+  }
+
+  geos::unique_ptr geos;
+  double res = 0;
+  try
+  {
+    if ( GEOSMinimumClearance_r( geosinit()->ctxt, mGeos.get(), &res ) != 0 )
+      return std::numeric_limits< double >::quiet_NaN();
+  }
+  CATCH_GEOS_WITH_ERRMSG( std::numeric_limits< double >::quiet_NaN() )
+  return res;
+#endif
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *errorMsg ) const
+{
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  throw QgsNotSupportedException( QStringLiteral( "Calculating minimumClearanceLine requires a QGIS build based on GEOS 3.6 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos.reset( GEOSMinimumClearanceLine_r( geosinit()->ctxt, mGeos.get() ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+#endif
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::node( QString *errorMsg ) const
+{
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos.reset( GEOSNode_r( geosinit()->ctxt, mGeos.get() ) );
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+  return fromGeos( geos.get() );
+}
+
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg ) const
+{
+  if ( !mGeos || !other )
+  {
+    return nullptr;
+  }
+
+  geos::unique_ptr geos;
+  try
+  {
+    geos::unique_ptr otherGeos = asGeos( other );
+    if ( !otherGeos )
+      return nullptr;
+
+    geos.reset( GEOSSharedPaths_r( geosinit()->ctxt, mGeos.get(), otherGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -515,6 +515,8 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
 double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  ( void )geom;
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistance requires a QGIS build based on GEOS 3.9 or later" ) );
 #else
   double distance = -1.0;
@@ -542,6 +544,9 @@ double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *error
 double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  ( void )geom;
+  ( void )densifyFraction;
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistanceDensify requires a QGIS build based on GEOS 3.9 or later" ) );
 #else
   double distance = -1.0;
@@ -2165,6 +2170,8 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance
 std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tolerance, QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  ( void )tolerance;
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating maximumInscribedCircle requires a QGIS build based on GEOS 3.9 or later" ) );
 #else
   if ( !mGeos )
@@ -2185,6 +2192,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tol
 std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary, QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+  ( void )tolerance;
+  ( void )boundary;
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating largestEmptyCircle requires a QGIS build based on GEOS 3.9 or later" ) );
 #else
   if ( !mGeos )
@@ -2209,6 +2219,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double toleran
 std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating minimumWidth requires a QGIS build based on GEOS 3.6 or later" ) );
 #else
   if ( !mGeos )
@@ -2229,6 +2240,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) 
 double QgsGeos::minimumClearance( QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating minimumClearance requires a QGIS build based on GEOS 3.6 or later" ) );
 #else
   if ( !mGeos )
@@ -2251,6 +2263,7 @@ double QgsGeos::minimumClearance( QString *errorMsg ) const
 std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *errorMsg ) const
 {
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<6
+  ( void )errorMsg;
   throw QgsNotSupportedException( QStringLiteral( "Calculating minimumClearanceLine requires a QGIS build based on GEOS 3.6 or later" ) );
 #else
   if ( !mGeos )

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -514,10 +514,10 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
 
 double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
 {
-#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<7
   ( void )geom;
   ( void )errorMsg;
-  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistance requires a QGIS build based on GEOS 3.9 or later" ) );
+  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistance requires a QGIS build based on GEOS 3.7 or later" ) );
 #else
   double distance = -1.0;
   if ( !mGeos )
@@ -543,11 +543,11 @@ double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *error
 
 double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg ) const
 {
-#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<7
   ( void )geom;
   ( void )densifyFraction;
   ( void )errorMsg;
-  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistanceDensify requires a QGIS build based on GEOS 3.9 or later" ) );
+  throw QgsNotSupportedException( QStringLiteral( "Calculating frechetDistanceDensify requires a QGIS build based on GEOS 3.7 or later" ) );
 #else
   double distance = -1.0;
   if ( !mGeos )

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -217,12 +217,12 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     double hausdorffDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg = nullptr ) const;
 
     /**
-     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     * Returns the Fréchet distance between this geometry and \a geom, restricted to discrete points for both geometries.
      *
      * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
      * Therefore it is often better than the Hausdorff distance.
      *
-     * This method requires QGIS builds based on GEOS 3.7 or later.
+     * This method requires a QGIS build based on GEOS 3.7 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
      * \see frechetDistanceDensify()
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     double frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const;
 
     /**
-     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     * Returns the Fréchet distance between this geometry and \a geom, restricted to discrete points for both geometries.
      *
      * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
      * Therefore it is often better than the Hausdorff distance.
@@ -246,7 +246,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * is not sufficient. Decreasing the \a densifyFraction parameter will make the
      * distance returned approach the true Fréchet distance for the geometries.
      *
-     * This method requires QGIS builds based on GEOS 3.7 or later.
+     * This method requires a QGIS build based on GEOS 3.7 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
      * \see frechetDistance()
@@ -313,7 +313,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Returns a two-point linestring, with one point at the center of the inscribed circle and the other
      * on the boundary of the inscribed circle.
      *
-     * This method requires QGIS builds based on GEOS 3.9 or later.
+     * This method requires a QGIS build based on GEOS 3.9 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
      *
@@ -336,7 +336,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Returns a two-point linestring, with one point at the center of the inscribed circle and the other
      * on the boundary of the inscribed circle.
      *
-     * This method requires QGIS builds based on GEOS 3.9 or later.
+     * This method requires a QGIS build based on GEOS 3.9 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
      *
@@ -352,7 +352,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * by two parallel lines. This can be thought of as the smallest hole that the geometry
      * can be moved through, with a single rotation.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *
@@ -364,18 +364,18 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * Computes the minimum clearance of a geometry.
      *
      * The minimum clearance is the smallest amount by which
-     * a vertex could be move to produce an invalid polygon, a non-simple linestring, or a multipoint with
+     * a vertex could be moved to produce an invalid polygon, a non-simple linestring, or a multipoint with
      * repeated points.  If a geometry has a minimum clearance of 'eps', it can be said that:
      *
      * - No two distinct vertices in the geometry are separated by less than 'eps'
      * - No vertex is closer than 'eps' to a line segment of which it is not an endpoint.
      *
      * If the minimum clearance cannot be defined for a geometry (such as with a single point, or a multipoint
-     * whose points are identical, a value of Infinity will be calculated.
+     * whose points are identical) a value of infinity will be returned.
      *
      * If an error occurs while calculating the clearance NaN will be returned.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *
@@ -388,7 +388,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      *
      * If the geometry has no minimum clearance, an empty LineString will be returned.
      *
-     * This method requires QGIS builds based on GEOS 3.6 or later.
+     * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
      *

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -338,6 +338,8 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      *
      * This method requires a QGIS build based on GEOS 3.9 or later.
      *
+     * \warning the \a tolerance value must be a value greater than 0, or the algorithm may never converge on a solution
+     *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
      *
      * \since QGIS 3.20

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -216,6 +216,44 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      */
     double hausdorffDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg = nullptr ) const;
 
+    /**
+     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     *
+     * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
+     * Therefore it is often better than the Hausdorff distance.
+     *
+     * This method requires QGIS builds based on GEOS 3.7 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
+     * \see frechetDistanceDensify()
+     * \since QGIS 3.20
+     */
+    double frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns the Fréchet distance this geometry and \a geom, restricted to discrete points for both geometries.
+     *
+     * The Fréchet distance is a measure of similarity between curves that takes into account the location and ordering of the points along the curves.
+     * Therefore it is often better than the Hausdorff distance.
+     *
+     * This function accepts a \a densifyFraction argument. The function performs a segment
+     * densification before computing the discrete Fréchet distance. The \a densifyFraction parameter
+     * sets the fraction by which to densify each segment. Each segment will be split into a
+     * number of equal-length subsegments, whose fraction of the total length is
+     * closest to the given fraction.
+     *
+     * This method can be used when the default approximation provided by frechetDistance()
+     * is not sufficient. Decreasing the \a densifyFraction parameter will make the
+     * distance returned approach the true Fréchet distance for the geometries.
+     *
+     * This method requires QGIS builds based on GEOS 3.7 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.6 or earlier.
+     * \see frechetDistance()
+     * \since QGIS 3.20
+     */
+    double frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg = nullptr ) const;
+
     bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
     bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
@@ -256,6 +294,135 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer( double distance, int segments, int side,
         int joinStyle, double miterLimit,
         QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns the maximum inscribed circle.
+     *
+     * Constructs the Maximum Inscribed Circle for a  polygonal geometry, up to a specified tolerance.
+     * The Maximum Inscribed Circle is determined by a point in the interior of the area
+     * which has the farthest distance from the area boundary, along with a boundary point at that distance.
+     * In the context of geography the center of the Maximum Inscribed Circle is known as the
+     * Pole of Inaccessibility. A cartographic use case is to determine a suitable point
+     * to place a map label within a polygon.
+     * The radius length of the Maximum Inscribed Circle is a  measure of how "narrow" a polygon is. It is the
+     * distance at which the negative buffer becomes empty.
+     * The class supports polygons with holes and multipolygons.
+     * The implementation uses a successive-approximation technique over a grid of square cells covering the area geometry.
+     * The grid is refined using a branch-and-bound algorithm. Point containment and distance are computed in a performant
+     * way by using spatial indexes.
+     * Returns a two-point linestring, with one point at the center of the inscribed circle and the other
+     * on the boundary of the inscribed circle.
+     *
+     * This method requires QGIS builds based on GEOS 3.9 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > maximumInscribedCircle( double tolerance, QString *errorMsg = nullptr ) const;
+
+    /**
+     * Constructs the Largest Empty Circle for a set of obstacle geometries, up to a
+     * specified tolerance.
+     *
+     * The Largest Empty Circle is the largest circle which has its center in the convex hull of the
+     * obstacles (the boundary), and whose interior does not intersect with any obstacle.
+     * The circle center is the point in the interior of the boundary which has the farthest distance from
+     * the obstacles (up to tolerance). The circle is determined by the center point and a point lying on an
+     * obstacle indicating the circle radius.
+     * The implementation uses a successive-approximation technique over a grid of square cells covering the obstacles and boundary.
+     * The grid is refined using a branch-and-bound algorithm.  Point containment and distance are computed in a performant
+     * way by using spatial indexes.
+     * Returns a two-point linestring, with one point at the center of the inscribed circle and the other
+     * on the boundary of the inscribed circle.
+     *
+     * This method requires QGIS builds based on GEOS 3.9 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.8 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary = nullptr, QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns a linestring geometry which represents the minimum diameter of the geometry.
+     *
+     * The minimum diameter is defined to be the width of the smallest band that
+     * contains the geometry, where a band is a strip of the plane defined
+     * by two parallel lines. This can be thought of as the smallest hole that the geometry
+     * can be moved through, with a single rotation.
+     *
+     * This method requires QGIS builds based on GEOS 3.6 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > minimumWidth( QString *errorMsg = nullptr ) const;
+
+    /**
+     * Computes the minimum clearance of a geometry.
+     *
+     * The minimum clearance is the smallest amount by which
+     * a vertex could be move to produce an invalid polygon, a non-simple linestring, or a multipoint with
+     * repeated points.  If a geometry has a minimum clearance of 'eps', it can be said that:
+     *
+     * - No two distinct vertices in the geometry are separated by less than 'eps'
+     * - No vertex is closer than 'eps' to a line segment of which it is not an endpoint.
+     *
+     * If the minimum clearance cannot be defined for a geometry (such as with a single point, or a multipoint
+     * whose points are identical, a value of Infinity will be calculated.
+     *
+     * If an error occurs while calculating the clearance NaN will be returned.
+     *
+     * This method requires QGIS builds based on GEOS 3.6 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    double minimumClearance( QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns a LineString whose endpoints define the minimum clearance of a geometry.
+     *
+     * If the geometry has no minimum clearance, an empty LineString will be returned.
+     *
+     * This method requires QGIS builds based on GEOS 3.6 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.5 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > minimumClearanceLine( QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns a (Multi)LineString representing the fully noded version of a collection of linestrings.
+     *
+     * The noding preserves all of the input nodes, and introduces the least possible number of new nodes.
+     * The resulting linework is dissolved (duplicate lines are removed).
+     *
+     * The input geometry type should be a (Multi)LineString.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > node( QString *errorMsg = nullptr ) const;
+
+    /**
+     * Find paths shared between the two given lineal geometries (this and \a other).
+     *
+     * Returns a GeometryCollection having two elements:
+     *
+     * - first element is a MultiLineString containing shared paths
+     *   having the same direction on both inputs
+     * - second element is a MultiLineString containing shared paths
+     *   having the opposite direction on the two inputs
+     *
+     * Returns NULLPTR on exception.
+     *
+     * \since QGIS 3.20
+     */
+    std::unique_ptr< QgsAbstractGeometry > sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg = nullptr ) const;
 
     /**
      * Reshapes the geometry using a line

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -2607,7 +2607,8 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(g.reshapeGeometry(QgsLineString([QgsPoint(0, 0), QgsPoint(0.5, 0.5), QgsPoint(0, 1)])),
                          QgsGeometry.Success)
         expWkt = 'Polygon ((0 0, 1 0, 1 1, 0 1, 0.5 0.5, 0 0))'
-        self.assertTrue(compareWkt(g.asWkt(), expWkt),
+        wkt = g.asWkt()
+        self.assertTrue(compareWkt(wkt, expWkt),
                         "testReshape failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt))
 
         # Test reshape a line from first/last vertex
@@ -6064,6 +6065,81 @@ class TestQgsGeometry(unittest.TestCase):
         g = QgsGeometry.fromWkt('LineString(0 0, 10 0, 10 10)')
         self.assertTrue(g.get().transform(transformer))
         self.assertEqual(g.asWkt(0), 'LineString (0 1, 20 1, 20 11)')
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30900, "GEOS 3.9 required")
+    def testFrechetDistance(self):
+        """
+        Test QgsGeometry.frechetDistance
+        """
+        l1 = QgsGeometry.fromWkt('LINESTRING (0 0, 100 0)')
+        l2 = QgsGeometry.fromWkt('LINESTRING (0 0, 50 50, 100 0)')
+        self.assertAlmostEqual(l1.frechetDistance(l2), 70.711, 3)
+        self.assertAlmostEqual(l2.frechetDistance(l1), 70.711, 3)
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30900, "GEOS 3.9 required")
+    def testFrechetDistanceDensify(self):
+        """
+        Test QgsGeometry.frechetDistanceDensify
+        """
+        l1 = QgsGeometry.fromWkt('LINESTRING (0 0, 100 0)')
+        l2 = QgsGeometry.fromWkt('LINESTRING (0 0, 50 50, 100 0)')
+        self.assertAlmostEqual(l1.frechetDistanceDensify(l2, 0.5), 50.000, 3)
+        self.assertAlmostEqual(l2.frechetDistanceDensify(l1, 0.5), 50.000, 3)
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30900, "GEOS 3.9 required")
+    def testLargestEmptyCircle(self):
+        """
+        Test QgsGeometry.largestEmptyCircle
+        """
+        g1 = QgsGeometry.fromWkt('POLYGON ((50 50, 150 50, 150 150, 50 150, 50 50))')
+        self.assertEqual(g1.largestEmptyCircle(1).asWkt(), 'LineString (100 100, 100 50)')
+        self.assertEqual(g1.largestEmptyCircle(0.1).asWkt(), 'LineString (100 100, 100 50)')
+        g2 = QgsGeometry.fromWkt('MultiPolygon (((95.03667481662591854 163.45354523227382515, 95.03667481662591854 122.0354523227383936, 34.10757946210270575 122.0354523227383936, 34.10757946210270575 163.45354523227382515, 95.03667481662591854 163.45354523227382515)),((35.64792176039119198 76.3386308068459698, 94.52322738386308743 76.3386308068459698, 94.52322738386308743 41.25305623471882654, 35.64792176039119198 41.25305623471882654, 35.64792176039119198 76.3386308068459698)),((185.23227383863081741 108.34352078239608375, 185.23227383863081741 78.56356968215158076, 118.99755501222495013 78.56356968215158076, 118.99755501222495013 108.34352078239608375, 185.23227383863081741 108.34352078239608375)))')
+        self.assertEqual(g2.largestEmptyCircle(0.1).asWkt(1), 'LineString (129.3 142.5, 129.3 108.3)')
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30600, "GEOS 3.6 required")
+    def testMinimumClearance(self):
+        """
+        Test QgsGeometry.minimumClearance
+        """
+        l1 = QgsGeometry.fromWkt('POLYGON ((0 0, 1 0, 1 1, 0.5 3.2e-4, 0 0))')
+        self.assertAlmostEqual(l1.minimumClearance(), 0.00032, 5)
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30600, "GEOS 3.6 required")
+    def testMinimumClearanceLine(self):
+        """
+        Test QgsGeometry.minimumClearanceLine
+        """
+        l1 = QgsGeometry.fromWkt('POLYGON ((0 0, 1 0, 1 1, 0.5 3.2e-4, 0 0))')
+        self.assertEqual(l1.minimumClearanceLine().asWkt(6), 'LineString (0.5 0.00032, 0.5 0)')
+
+    @unittest.skipIf(Qgis.geosVersionInt() < 30600, "GEOS 3.6 required")
+    def testMinimumWidth(self):
+        """
+        Test QgsGeometry.minimumWidth
+        """
+        l1 = QgsGeometry.fromWkt('POLYGON ((0 0, 1 0, 1 1, 0.5 3.2e-4, 0 0))')
+        self.assertEqual(l1.minimumWidth().asWkt(6), 'LineString (0.5 0.5, 1 0)')
+
+    def testNode(self):
+        """
+        Test QgsGeometry.node
+        """
+        l1 = QgsGeometry.fromWkt('LINESTRINGZ(0 0 0, 10 10 10, 0 10 5, 10 0 3)')
+        self.assertEqual(l1.node().asWkt(6), 'MultiLineStringZ ((0 0 0, 5 5 4.5),(5 5 4.5, 10 10 10, 0 10 5, 5 5 4.5),(5 5 4.5, 10 0 3))')
+        l1 = QgsGeometry.fromWkt('MULTILINESTRING ((2 5, 2 1, 7 1), (6 1, 4 1, 2 3, 2 5))')
+        self.assertEqual(l1.node().asWkt(6), 'MultiLineString ((2 5, 2 3),(2 3, 2 1, 4 1),(4 1, 6 1),(6 1, 7 1),(4 1, 2 3))')
+
+    def testSharedPaths(self):
+        """
+        Test QgsGeometry.sharedPaths
+        """
+        l1 = QgsGeometry.fromWkt('MULTILINESTRING((26 125,26 200,126 200,126 125,26 125),(51 150,101 150,76 175,51 150))')
+        l2 = QgsGeometry.fromWkt('LINESTRING(151 100,126 156.25,126 125,90 161, 76 175)')
+        self.assertEqual(l1.sharedPaths(l2).asWkt(6), 'GeometryCollection (MultiLineString ((126 156.25, 126 125),(101 150, 90 161),(90 161, 76 175)),MultiLineString EMPTY)')
+        l1 = QgsGeometry.fromWkt('LINESTRING(76 175,90 161,126 125,126 156.25,151 100)')
+        l2 = QgsGeometry.fromWkt('MULTILINESTRING((26 125,26 200,126 200,126 125,26 125),(51 150,101 150,76 175,51 150))')
+        self.assertEqual(l1.sharedPaths(l2).asWkt(6), 'GeometryCollection (MultiLineString EMPTY,MultiLineString ((76 175, 90 161),(90 161, 101 150),(126 125, 126 156.25)))')
 
     def renderGeometry(self, geom, use_pen, as_polygon=False, as_painter_path=False):
         image = QImage(200, 200, QImage.Format_RGB32)


### PR DESCRIPTION
This PR exposes more of GEOS functionality through QgsGeometry, so that these methods can be easily called on QGIS geometries.

Included are:

- frechetDistance/frechetDistanceDensify
- largestEmptyCircle
- minimumWidth
- minimumClearance
- minimumClearanceLine
- node
- sharedPaths

(see commit for full documentation on the newly exposed methods)

Some of these methods require GEOS versions > QGIS minimum (which is a current an **extremely** conservative 3.0.0 min!). In order to gracefully handle situations where the QGIS build may be using an older GEOS then the method is added in I've added a new "QgsNotSupportedException" exception which is raised whenever one of the new methods is called yet is unavailable on the current install. This should allow us to track newer GEOS versions and functionality closely without being held back by ancient distro GEOS packaging.

This is an API only change. We should consider exposing these functions via QGIS expressions and processing at some stage.