### PR TITLE
Don't sync to layer on cancel

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -864,7 +864,6 @@ void QgsVectorLayerProperties::onCancel()
     int errorLine, errorColumn;
     doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
     mLayer->importNamedStyle( doc, myMessage );
-    syncToLayer();
   }
 }
 


### PR DESCRIPTION
If the dialog is being canceled and destroyed then there's no need to force it to update and reflect the layer's current state...