### PR TITLE
Use QgsDoubleSpinBoxes for range widget wrapper for longlong field types

### DIFF
--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -51,7 +51,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
 
   QString text;
 
-  QVariant::Type fieldType( vl->fields().at( fieldIdx ).type() );
+  const QVariant::Type fieldType( vl->fields().at( fieldIdx ).type() );
 
   switch ( fieldType )
   {
@@ -59,7 +59,15 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
     case QVariant::LongLong:
     case QVariant::Double:
     {
-      rangeStackedWidget->setCurrentIndex( vl->fields().at( fieldIdx ).type() == QVariant::Double ? 1 : 0 );
+      // we use the double spin boxes for double OR long long field types, as QSpinBox does not have sufficient
+      // available range for long long values
+      rangeStackedWidget->setCurrentIndex( fieldType == QVariant::Int ? 0 : 1 );
+      if ( fieldType == QVariant::LongLong )
+      {
+        minimumDoubleSpinBox->setDecimals( 0 );
+        maximumDoubleSpinBox->setDecimals( 0 );
+        stepDoubleSpinBox->setDecimals( 0 );
+      }
 
       rangeWidget->clear();
       rangeWidget->addItem( tr( "Editable" ), QStringLiteral( "SpinBox" ) );
@@ -107,13 +115,15 @@ QVariantMap QgsRangeConfigDlg::config()
   switch ( layer()->fields().at( field() ).type() )
   {
     case QVariant::Int:
-    case QVariant::LongLong:
       cfg.insert( QStringLiteral( "Min" ), minimumSpinBox->value() );
       cfg.insert( QStringLiteral( "Max" ), maximumSpinBox->value() );
       cfg.insert( QStringLiteral( "Step" ), stepSpinBox->value() );
       break;
 
+    // we use the double spin boxes for double OR long long field types, as QSpinBox does not have sufficient
+    // available range for long long values
     case QVariant::Double:
+    case QVariant::LongLong:
       cfg.insert( QStringLiteral( "Min" ), minimumDoubleSpinBox->value() );
       cfg.insert( QStringLiteral( "Max" ), maximumDoubleSpinBox->value() );
       cfg.insert( QStringLiteral( "Step" ), stepDoubleSpinBox->value() );

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -55,6 +55,7 @@ class TestQgsRangeWidgetWrapper : public QObject
     void test_nulls();
     void test_negativeIntegers(); // see GH issue #32149
     void test_focus();
+    void testLongLong();
 
   private:
     std::unique_ptr<QgsRangeWidgetWrapper> widget0; // For field 0
@@ -98,6 +99,7 @@ void TestQgsRangeWidgetWrapper::init()
   fields.append( dfield2 );
   // simple int
   fields.append( QgsField( "simplenumber", QVariant::Int ) );
+  fields.append( QgsField( "longlong", QVariant::LongLong ) );
   vl->dataProvider()->addAttributes( fields );
   vl->updateFields();
   QVERIFY( vl.get() );
@@ -465,6 +467,29 @@ void TestQgsRangeWidgetWrapper::test_focus()
   QCOMPARE( editor2->mLineEdit->text(), QString() );
   QCOMPARE( editor3->mLineEdit->text(), QStringLiteral( "nope" ) );
 
+}
+
+void TestQgsRangeWidgetWrapper::testLongLong()
+{
+  // test range widget with a long long field type
+  std::unique_ptr< QgsRangeWidgetWrapper >wrapper = std::make_unique<QgsRangeWidgetWrapper>( vl.get(), 4, nullptr, nullptr );
+
+  // should use a double spin box, as a integer spin box does not have sufficient range
+  QgsDoubleSpinBox *editor = qobject_cast<QgsDoubleSpinBox *>( wrapper->createWidget( nullptr ) );
+  QVERIFY( editor );
+  wrapper->initWidget( editor );
+  // no decimals, it's for long long value editing!
+  QCOMPARE( editor->decimals(), 0 );
+  QCOMPARE( editor->minimum( ), std::numeric_limits<double>::lowest() );
+  QCOMPARE( editor->maximum( ), std::numeric_limits<double>::max() );
+
+  wrapper->setValue( 1234567890123LL );
+
+  // double spin box value should be lossless
+  QCOMPARE( editor->value(), 1234567890123.0 );
+
+  // wrapper value must be a long long type, not double
+  QCOMPARE( wrapper->value(), 1234567890123LL );
 }
 
 QGSTEST_MAIN( TestQgsRangeWidgetWrapper )


### PR DESCRIPTION
We can't use QSpinBox for long long field types, as the range of
values allowed by QSpinBox isn't sufficient to store long long
values. While a double spin box isn't a perfect fit, it does
avoid value truncation in a lot more cases.
