### PR TITLE
Fix Oracle crashing when piecewise field reading takes place

### DIFF
--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -1549,6 +1549,7 @@ int QOCISpatialCols::readPiecewise( QVector<QVariant> &values, int index )
   int            r = 0;
   bool           nullField;
 
+  bool firstPiece = true;
   do
   {
     r = OCIStmtGetPieceInfo( d->sql, d->err, reinterpret_cast<void **>( &dfn ), &typep,
@@ -1589,20 +1590,21 @@ int QOCISpatialCols::readPiecewise( QVector<QVariant> &values, int index )
     {
       if ( isStringField )
       {
-        QString str = values.at( fieldNum + index ).toString();
+        QString str = firstPiece ? QString() : values.at( fieldNum + index ).toString();
         str += QString( reinterpret_cast<const QChar *>( col ), chunkSize / 2 );
         values[fieldNum + index] = str;
         fieldInf[fieldNum].ind = 0;
       }
       else
       {
-        QByteArray ba = values.at( fieldNum + index ).toByteArray();
+        QByteArray ba = firstPiece ? QByteArray() : values.at( fieldNum + index ).toByteArray();
         int sz = ba.size();
         ba.resize( sz + chunkSize );
         memcpy( ba.data() + sz, reinterpret_cast<char *>( col ), chunkSize );
         values[fieldNum + index] = ba;
         fieldInf[fieldNum].ind = 0;
       }
+      firstPiece = false;
     }
   }
   while ( status == OCI_SUCCESS_WITH_INFO || status == OCI_NEED_DATA );
@@ -3413,7 +3415,6 @@ bool QOCISpatialResult::gotoNext( QSqlCachedResult::ValueCache &values, int inde
   // need to read piecewise before assigning values
   if ( r == OCI_SUCCESS && piecewise )
   {
-    values.clear();
     r = d->cols->readPiecewise( values, index );
   }
 


### PR DESCRIPTION
## Description
This is a different take on #36769. To avoiding hitting #42857 and crashing, instead of clearing `values`, we just ignore its contents when reading the first piece in piecewise field reading.

Fixes #42857

What do you think @troopa81 @SebastienPeillet ?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
