### PR TITLE
Transfer first z or m value to point

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -810,6 +810,7 @@ already contains a M value.
 .. versionadded:: 3.20
 %End
 
+
     static bool transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 %Docstring
 A Z or M dimension is added to ``point`` if one of the points in the list
@@ -818,30 +819,7 @@ A Z or M dimension is added to ``point`` if one of the points in the list
 This method is equivalent to successively calling Z and M but avoiding
 looping twice over the set of points.
 
-:param points: List of points in which a Z or M point is searched.
-:param point: The point to update with Z or M dimension and value.
-
-:return: ``True`` if the point is updated, ``False`` otherwise
-
-.. warning::
-
-   This method does not copy the z or m value of the coordinate from the
-   points whose z or m value is closest to the original x/y point, but only the first one found.
-
-
-.. versionadded:: 3.20
-%End
-
-
-    static bool transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point );
-%Docstring
-A Z or M dimension is added to ``point`` if one of the points in the list
-``points`` contains Z or M value.
-
-This method is equivalent to successively calling Z and M but avoiding
-looping twice over the set of points.
-
-:param geom: :py:class:`QgsGeometry` in which a Z or M point is searched.
+:param points: List of points in which a M point is searched.
 :param point: The point to update with Z or M dimension and value.
 
 :return: ``True`` if the point is updated, ``False`` otherwise

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -833,6 +833,28 @@ looping twice over the set of points.
 .. versionadded:: 3.20
 %End
 
+    static bool transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point );
+%Docstring
+A Z or M dimension is added to ``point`` if one of the points in the list
+``points`` contains Z or M value.
+
+This method is equivalent to successively calling Z and M but avoiding
+looping twice over the set of points.
+
+:param geom: geometry in which a M point is searched.
+:param point: The point to update with Z or M dimension and value.
+
+:return: ``True`` if the point is updated, ``False`` otherwise
+
+.. warning::
+
+   This method does not copy the z or m value of the coordinate from the
+   points whose z or m value is closest to the original x/y point, but only the first one found.
+
+
+.. versionadded:: 3.20
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -832,6 +832,28 @@ looping twice over the set of points.
 .. versionadded:: 3.20
 %End
 
+    static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point );
+%Docstring
+A Z or M dimension is added to ``point`` if one of the points in the list
+``points`` contains Z or M value.
+
+This method is equivalent to successively calling Z and M but avoiding
+looping twice over the set of points.
+
+:param points: List of points in which a Z or M point is searched.
+:param point: The point to update with Z or M dimension and value.
+
+:return: ``True`` if the point is updated, ``False`` otherwise
+
+.. warning::
+
+   This method does not copy the z or m value of the coordinate from the
+   points whose z or m value is closest to the original x/y point, but only the first one found.
+
+
+.. versionadded:: 3.20
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -810,6 +810,28 @@ already contains a M value.
 .. versionadded:: 3.20
 %End
 
+    static bool transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
+%Docstring
+A Z or M dimension is added to ``point`` if one of the points in the list
+``points`` contains Z or M value.
+
+This method is equivalent to successively calling Z and M but avoiding
+looping twice over the set of points.
+
+:param points: List of points in which a Z or M point is searched.
+:param point: The point to update with Z or M dimension and value.
+
+:return: ``True`` if the point is updated, ``False`` otherwise
+
+.. warning::
+
+   This method does not copy the z or m value of the coordinate from the
+   points whose z or m value is closest to the original x/y point, but only the first one found.
+
+
+.. versionadded:: 3.20
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -832,7 +832,8 @@ looping twice over the set of points.
 .. versionadded:: 3.20
 %End
 
-    static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point );
+
+    static bool transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point );
 %Docstring
 A Z or M dimension is added to ``point`` if one of the points in the list
 ``points`` contains Z or M value.
@@ -840,7 +841,7 @@ A Z or M dimension is added to ``point`` if one of the points in the list
 This method is equivalent to successively calling Z and M but avoiding
 looping twice over the set of points.
 
-:param points: List of points in which a Z or M point is searched.
+:param geom: :py:class:`QgsGeometry` in which a Z or M point is searched.
 :param point: The point to update with Z or M dimension and value.
 
 :return: ``True`` if the point is updated, ``False`` otherwise

--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -40,7 +40,7 @@ QgsCircle QgsCircle::from2Points( const QgsPoint &pt1, const QgsPoint &pt2 )
   double azimuth = QgsGeometryUtils::lineAngle( pt1.x(), pt1.y(), pt2.x(), pt2.y() ) * 180.0 / M_PI;
   double radius = pt1.distance( pt2 ) / 2.0;
 
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsCircle( center, radius, azimuth );
 }
@@ -141,7 +141,7 @@ QgsCircle QgsCircle::from3Points( const QgsPoint &pt1, const QgsPoint &pt2, cons
   double bSlope = yDelta_b / xDelta_b;
 
   // set z coordinate for center
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << p1 << p2 << p3, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << p1 << p2 << p3, center );
 
   if ( ( std::fabs( xDelta_a ) <= epsilon ) && ( std::fabs( yDelta_b ) <= epsilon ) )
   {
@@ -183,7 +183,7 @@ QgsCircle QgsCircle::fromCenterPoint( const QgsPoint &center, const QgsPoint &pt
   double azimuth = QgsGeometryUtils::lineAngle( center.x(), center.y(), pt1.x(), pt1.y() ) * 180.0 / M_PI;
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1, centerPt );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1, centerPt );
 
   return QgsCircle( centerPt, centerPt.distance( pt1 ), azimuth );
 }
@@ -388,7 +388,7 @@ QgsCircle QgsCircle::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 )
   }
 
   QgsPoint center = QgsGeometryUtils::midpoint( pt1, pt2 );
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsCircle( center, delta_x / 2.0, 0 );
 }

--- a/src/core/geometry/qgsellipse.cpp
+++ b/src/core/geometry/qgsellipse.cpp
@@ -57,7 +57,7 @@ QgsEllipse QgsEllipse::fromFoci( const QgsPoint &pt1, const QgsPoint &pt2, const
   double axis_a = dist / 2.0;
   double axis_b = std::sqrt( std::pow( axis_a, 2.0 ) - std::pow( dist_p1p2 / 2.0, 2.0 ) );
 
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2 << pt3, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << pt1 << pt2 << pt3, center );
 
   return QgsEllipse( center, axis_a, axis_b, azimuth );
 }
@@ -69,7 +69,7 @@ QgsEllipse QgsEllipse::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 )
   double axis_b = std::fabs( pt2.y() - pt1.y() ) / 2.0;
   double azimuth = 90.0;
 
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << pt1 << pt2, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << pt1 << pt2, center );
 
   return QgsEllipse( center, axis_a, axis_b, azimuth );
 }
@@ -81,7 +81,7 @@ QgsEllipse QgsEllipse::fromCenterPoint( const QgsPoint &center, const QgsPoint &
   double azimuth = 90.0;
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1, centerPt );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1, centerPt );
 
   return QgsEllipse( centerPt, axis_a, axis_b, azimuth );
 }
@@ -96,7 +96,7 @@ QgsEllipse QgsEllipse::fromCenter2Points( const QgsPoint &center, const QgsPoint
   double axis_b = center.distance( pp );
 
   QgsPoint centerPt( center );
-  QgsGeometryUtils::transferFirstZValueToPoint( QgsPointSequence() << center << pt1 << pt2, centerPt );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1 << pt2, centerPt );
 
   return QgsEllipse( centerPt, axis_a, axis_b, azimuth );
 }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1808,8 +1808,8 @@ void QgsGeometryUtils::weightedPointInTriangle( const double aX, const double aY
 
 bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point )
 {
-  bool z_passed = false;
-  bool m_passed = false;
+  bool zFound = false;
+  bool mFound = false;
 
   for ( const QgsPoint &pt : points )
   {
@@ -1817,19 +1817,19 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &po
     {
       point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
       point.setM( pt.m() );
-      m_passed = true;
+      mFound = true;
     }
     if ( !z_passed && pt.is3D() )
     {
       point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
       point.setZ( pt.z() );
-      z_passed = true;
+      zFound = true;
     }
-    if ( z_passed && m_passed )
+    if ( zFound && mFound )
       break;
   }
 
-  return z_passed || m_passed;
+  return zFound || mFound;
 }
 
 bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1815,14 +1815,12 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &po
   {
     if ( !m_passed && pt.isMeasure() )
     {
-      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
-      point.setM( pt.m() );
+      point.addMValue( pt.m() );
       mFound = true;
     }
     if ( !z_passed && pt.is3D() )
     {
-      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
-      point.setZ( pt.z() );
+      point.addZValue( pt.z() );
       zFound = true;
     }
     if ( zFound && mFound )
@@ -1840,8 +1838,7 @@ bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &point
   {
     if ( pt.isMeasure() )
     {
-      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
-      point.setM( pt.m() );
+      point.addMValue( pt.m() );
       rc = true;
       break;
     }
@@ -1858,8 +1855,7 @@ bool QgsGeometryUtils::transferFirstZValueToPoint( const QgsPointSequence &point
   {
     if ( pt.is3D() )
     {
-      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
-      point.setZ( pt.z() );
+      point.addZValue( pt.z() );
       rc = true;
       break;
     }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1815,12 +1815,14 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &po
   {
     if ( !mFound && pt.isMeasure() )
     {
-      point.addMValue( pt.m() );
+      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
+      point.setM( pt.m() );
       mFound = true;
     }
     if ( !zFound && pt.is3D() )
     {
-      point.addZValue( pt.z() );
+      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
+      point.setZ( pt.z() );
       zFound = true;
     }
     if ( zFound && mFound )
@@ -1862,7 +1864,8 @@ bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &point
   {
     if ( pt.isMeasure() )
     {
-      point.addMValue( pt.m() );
+      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
+      point.setM( pt.m() );
       rc = true;
       break;
     }
@@ -1879,7 +1882,8 @@ bool QgsGeometryUtils::transferFirstZValueToPoint( const QgsPointSequence &point
   {
     if ( pt.is3D() )
     {
-      point.addZValue( pt.z() );
+      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
+      point.setZ( pt.z() );
       rc = true;
       break;
     }

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1842,7 +1842,7 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsAbstractGeometry:
   bool zFound = false;
   bool mFound = false;
 
-  for ( QgsAbstractGeometry::vertex_iterator it = verticesBegin ; it != verticesEnd ; it++ )
+  for ( QgsAbstractGeometry::vertex_iterator it = verticesBegin ; it != verticesEnd ; ++it )
   {
     if ( !mFound && ( *it ).isMeasure() )
     {

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1813,14 +1813,38 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &po
 
   for ( const QgsPoint &pt : points )
   {
-    if ( !m_passed && pt.isMeasure() )
+    if ( !mFound && pt.isMeasure() )
     {
       point.addMValue( pt.m() );
       mFound = true;
     }
-    if ( !z_passed && pt.is3D() )
+    if ( !zFound && pt.is3D() )
     {
       point.addZValue( pt.z() );
+      zFound = true;
+    }
+    if ( zFound && mFound )
+      break;
+  }
+
+  return zFound || mFound;
+}
+
+bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point )
+{
+  bool zFound = false;
+  bool mFound = false;
+
+  for ( QgsAbstractGeometry::vertex_iterator it = verticesBegin ; it != verticesEnd ; it++ )
+  {
+    if ( !mFound && ( *it ).isMeasure() )
+    {
+      point.addMValue( ( *it ).m() );
+      mFound = true;
+    }
+    if ( !zFound && ( *it ).is3D() )
+    {
+      point.addZValue( ( *it ).z() );
       zFound = true;
     }
     if ( zFound && mFound )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1806,63 +1806,6 @@ void QgsGeometryUtils::weightedPointInTriangle( const double aX, const double aY
   pointY = rBy + rCy + aY;
 }
 
-bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point )
-{
-  bool zFound = false;
-  bool mFound = false;
-
-  for ( const QgsPoint &pt : points )
-  {
-    if ( !mFound && pt.isMeasure() )
-    {
-      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
-      point.setM( pt.m() );
-      mFound = true;
-    }
-    if ( !zFound && pt.is3D() )
-    {
-      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
-      point.setZ( pt.z() );
-      zFound = true;
-    }
-    if ( zFound && mFound )
-      break;
-  }
-
-  return zFound || mFound;
-}
-
-bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point )
-{
-  return QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
-}
-
-bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point )
-{
-  bool zFound = false;
-  bool mFound = false;
-
-  for ( QgsAbstractGeometry::vertex_iterator it = verticesBegin ; it != verticesEnd ; ++it )
-  {
-    if ( !mFound && ( *it ).isMeasure() )
-    {
-      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
-      point.setM( ( *it ).m() );
-      mFound = true;
-    }
-    if ( !zFound && ( *it ).is3D() )
-    {
-      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
-      point.setZ( ( *it ).z() );
-      zFound = true;
-    }
-    if ( zFound && mFound )
-      break;
-  }
-
-  return zFound || mFound;
-}
-
 bool QgsGeometryUtils::transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point )
 {
   bool rc = false;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1832,6 +1832,11 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsPointSequence &po
   return zFound || mFound;
 }
 
+bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point )
+{
+  return QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+}
+
 bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point )
 {
   bool zFound = false;
@@ -1841,12 +1846,14 @@ bool QgsGeometryUtils::transferFirstZOrMValueToPoint( const QgsAbstractGeometry:
   {
     if ( !mFound && ( *it ).isMeasure() )
     {
-      point.addMValue( ( *it ).m() );
+      point.convertTo( QgsWkbTypes::addM( point.wkbType() ) );
+      point.setM( ( *it ).m() );
       mFound = true;
     }
     if ( !zFound && ( *it ).is3D() )
     {
-      point.addZValue( ( *it ).z() );
+      point.convertTo( QgsWkbTypes::addZ( point.wkbType() ) );
+      point.setZ( ( *it ).z() );
       zFound = true;
     }
     if ( zFound && mFound )

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -22,6 +22,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgis_sip.h"
 #include "qgspoint.h"
 #include "qgsabstractgeometry.h"
+#include "qgsgeometry.h"
 #include "qgsvector3d.h"
 
 #include <QJsonArray>
@@ -848,7 +849,27 @@ class CORE_EXPORT QgsGeometryUtils
      * This method is equivalent to successively calling Z and M but avoiding
      * looping twice over the set of points.
      *
-     * \param points List of points in which a Z or M point is searched.
+     * \param verticesBegin begin vertex which a Z or M point is searched.
+     * \param verticesEnd end vertex which a Z or M point is searched.
+     * \param point The point to update with Z or M dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the z or m value of the coordinate from the
+     * points whose z or m value is closest to the original x/y point, but only the first one found.
+     *
+     * \since QGIS 3.20
+     * \note Not available in Python bindings
+     */
+    static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point ) SIP_SKIP;
+
+    /**
+     * A Z or M dimension is added to \a point if one of the points in the list
+     * \a points contains Z or M value.
+     *
+     * This method is equivalent to successively calling Z and M but avoiding
+     * looping twice over the set of points.
+     *
+     * \param geom QgsGeometry in which a Z or M point is searched.
      * \param point The point to update with Z or M dimension and value.
      * \returns TRUE if the point is updated, FALSE otherwise
      *
@@ -857,7 +878,7 @@ class CORE_EXPORT QgsGeometryUtils
      *
      * \since QGIS 3.20
      */
-    static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point );
+    static bool transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point );
 
     /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -842,6 +842,24 @@ class CORE_EXPORT QgsGeometryUtils
     static bool transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 
     /**
+     * A Z or M dimension is added to \a point if one of the points in the list
+     * \a points contains Z or M value.
+     *
+     * This method is equivalent to successively calling Z and M but avoiding
+     * looping twice over the set of points.
+     *
+     * \param points List of points in which a Z or M point is searched.
+     * \param point The point to update with Z or M dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the z or m value of the coordinate from the
+     * points whose z or m value is closest to the original x/y point, but only the first one found.
+     *
+     * \since QGIS 3.20
+     */
+    static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point );
+
+    /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)
      * and segment (\a bX, \a bY) (\a dX, \a dY).
      * The bisector segment of AB-CD is (point, projection of point by \a angle)

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -857,8 +857,8 @@ class CORE_EXPORT QgsGeometryUtils
      * \warning This method does not copy the z or m value of the coordinate from the
      * points whose z or m value is closest to the original x/y point, but only the first one found.
      *
-     * \since QGIS 3.20
      * \note Not available in Python bindings
+     * \since QGIS 3.20
      */
     static bool transferFirstZOrMValueToPoint( const QgsAbstractGeometry::vertex_iterator &verticesBegin, const QgsAbstractGeometry::vertex_iterator &verticesEnd, QgsPoint &point ) SIP_SKIP;
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -823,7 +823,7 @@ class CORE_EXPORT QgsGeometryUtils
      */
     static bool transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 
-    /*
+    /**
      * A Z or M dimension is added to \a point if one of the points in the list
      * \a points contains Z or M value.
      *

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -823,6 +823,24 @@ class CORE_EXPORT QgsGeometryUtils
      */
     static bool transferFirstMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
 
+    /*
+     * A Z or M dimension is added to \a point if one of the points in the list
+     * \a points contains Z or M value.
+     *
+     * This method is equivalent to successively calling Z and M but avoiding
+     * looping twice over the set of points.
+     *
+     * \param points List of points in which a Z or M point is searched.
+     * \param point The point to update with Z or M dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the z or m value of the coordinate from the
+     * points whose z or m value is closest to the original x/y point, but only the first one found.
+     *
+     * \since QGIS 3.20
+     */
+    static bool transferFirstZOrMValueToPoint( const QgsPointSequence &points, QgsPoint &point );
+
     /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)
      * and segment (\a bX, \a bY) (\a dX, \a dY).

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -890,6 +890,27 @@ class CORE_EXPORT QgsGeometryUtils
     }
 
     /**
+     * A Z or M dimension is added to \a point if one of the points in the list
+     * \a points contains Z or M value.
+     *
+     * This method is equivalent to successively calling Z and M but avoiding
+     * looping twice over the set of points.
+     *
+     * \param geom geometry in which a M point is searched.
+     * \param point The point to update with Z or M dimension and value.
+     * \returns TRUE if the point is updated, FALSE otherwise
+     *
+     * \warning This method does not copy the z or m value of the coordinate from the
+     * points whose z or m value is closest to the original x/y point, but only the first one found.
+     *
+     * \since QGIS 3.20
+     */
+    static bool transferFirstZOrMValueToPoint( const QgsGeometry &geom, QgsPoint &point )
+    {
+      return QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+    }
+
+    /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)
      * and segment (\a bX, \a bY) (\a dX, \a dY).
      * The bisector segment of AB-CD is (point, projection of point by \a angle)

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -588,7 +588,7 @@ QgsPoint QgsTriangle::inscribedCenter() const
 
   QgsPointSequence points;
   points << vertexAt( 0 ) << vertexAt( 1 ) << vertexAt( 2 );
-  QgsGeometryUtils::transferFirstZValueToPoint( points, center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( points, center );
 
   return center;
 }

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -87,6 +87,7 @@ class TestQgsGeometryUtils: public QObject
     void testClosestSideOfRectangle();
     void transferFirstZValueToPoint();
     void transferFirstMValueToPoint();
+    void transferFirstZOrMValueToPoint();
 };
 
 
@@ -1668,6 +1669,52 @@ void TestQgsGeometryUtils::transferFirstMValueToPoint()
   QCOMPARE( ret, true );
   QCOMPARE( pointZ.wkbType(), QgsWkbTypes::PointZM );
   QCOMPARE( pointZ.m(), 5.0 );
+}
+
+void TestQgsGeometryUtils::transferFirstZOrMValueToPoint()
+{
+  QgsPoint point( 1, 2 );
+
+  // Type: Point
+  bool ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( 0, 2 ), point );
+  QCOMPARE( ret, false );
+
+  // Type: PointZ
+  point = QgsPoint( 1, 2 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( 0, 2, 4 ), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.wkbType(), QgsWkbTypes::PointZ );
+  QCOMPARE( point.z(), 4.0 );
+
+  // Type: PointM
+  point = QgsPoint( 1, 2 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 4 ), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.wkbType(), QgsWkbTypes::PointM );
+  QCOMPARE( point.m(), 4.0 );
+
+  // Type: PointM
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.wkbType(), QgsWkbTypes::PointM );
+  QCOMPARE( point.m(), 5.0 ); // now point.m == 5
+
+  // Add M to a PointZ
+  point = QgsPoint( 1, 2, 4 );
+  // Type: PointM
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.wkbType(), QgsWkbTypes::PointZM );
+  QCOMPARE( point.m(), 5.0 );
+
+  // Add Z from point1 and M from point2
+  point = QgsPoint( 1, 2 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << QgsPoint( 7, 8, 9 ) << QgsPoint( QgsWkbTypes::PointM, 0, 2, 0, 5 ), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.wkbType(), QgsWkbTypes::PointZM );
+  QCOMPARE( point.z(), 9.0 );
+  QCOMPARE( point.m(), 5.0 );
+
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtils )

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -1720,56 +1720,105 @@ void TestQgsGeometryUtils::transferFirstZOrMValueToPoint()
 
 void TestQgsGeometryUtils::transferFirstZOrMValueToPoint_iterator()
 {
-
   QgsPoint point( 1, 2 );
   QgsGeometry geom;
 
   geom = QgsGeometry::fromWkt( "LineString( 0 2, 2 3)" );
+  // iterator
   bool ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, false );
+  // QgsGeometry
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
   QCOMPARE( ret, false );
 
   // Z
-  point = QgsPoint( 1, 2 );
   geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3, 2 3 4)" );
+  // iterator
+  point = QgsPoint( 1, 2 );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
 
-  // M
+  // QgsGeometry
   point = QgsPoint( 1, 2 );
-  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3, 2 3 4)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+
+  // M
+  geom = QgsGeometry::fromWkt( "LineStringM( 0 2 3, 2 3 4)" );
+  // iterator
+  point = QgsPoint( 1, 2 );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.m(), 3.0 );
 
-  // ZM
+  // QgsGeometry
   point = QgsPoint( 1, 2 );
-  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.m(), 3.0 );
+
+  // ZM
+  geom = QgsGeometry::fromWkt( "LineStringZM( 0 2 3 5, 2 3 4 6)" );
+  // iterator
+  point = QgsPoint( 1, 2 );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // QgsGeometry
+  point = QgsPoint( 1, 2 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
   QCOMPARE( point.m(), 5.0 );
 
   // point is Z and linestring ZM
+  geom = QgsGeometry::fromWkt( "LineStringZM( 0 2 3 5, 2 3 4 6)" );
+  // iterator
   point = QgsPoint( 1, 2, 4 );
-  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // QgsGeometry
+  point = QgsPoint( 1, 2, 4 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
   QCOMPARE( point.m(), 5.0 );
 
   // point is M and linestring ZM
+  geom = QgsGeometry::fromWkt( "LineStringZM( 0 2 3 5, 2 3 4 6)" );
+  // iterator
   point = QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 );
-  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
   QCOMPARE( point.m(), 5.0 );
 
+  // QgsGeometry
+  point = QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
   // point is ZM and linestring ZM
+  geom = QgsGeometry::fromWkt( "LineStringZM( 0 2 3 5, 2 3 4 6)" );
+  // iterator
   point = QgsPoint( 1, 2, 5, 4 );
-  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
   ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // QgsGeometry
+  point = QgsPoint( 1, 2, 5, 4 );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom, point );
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
   QCOMPARE( point.m(), 5.0 );

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -17,6 +17,7 @@
 
 #include "qgstest.h"
 #include <QObject>
+#include "qgsgeometry.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
 #include "qgspolygon.h"
@@ -88,6 +89,7 @@ class TestQgsGeometryUtils: public QObject
     void transferFirstZValueToPoint();
     void transferFirstMValueToPoint();
     void transferFirstZOrMValueToPoint();
+    void transferFirstZOrMValueToPoint_iterator();
 };
 
 
@@ -1714,7 +1716,63 @@ void TestQgsGeometryUtils::transferFirstZOrMValueToPoint()
   QCOMPARE( point.wkbType(), QgsWkbTypes::PointZM );
   QCOMPARE( point.z(), 9.0 );
   QCOMPARE( point.m(), 5.0 );
+}
 
+void TestQgsGeometryUtils::transferFirstZOrMValueToPoint_iterator()
+{
+
+  QgsPoint point( 1, 2 );
+  QgsGeometry geom;
+
+  geom = QgsGeometry::fromWkt( "LineString( 0 2, 2 3)" );
+  bool ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, false );
+
+  // Z
+  point = QgsPoint( 1, 2 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3, 2 3 4)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+
+  // M
+  point = QgsPoint( 1, 2 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3, 2 3 4)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.m(), 3.0 );
+
+  // ZM
+  point = QgsPoint( 1, 2 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // point is Z and linestring ZM
+  point = QgsPoint( 1, 2, 4 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // point is M and linestring ZM
+  point = QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
+
+  // point is ZM and linestring ZM
+  point = QgsPoint( 1, 2, 5, 4 );
+  geom = QgsGeometry::fromWkt( "LineStringZ( 0 2 3 5, 2 3 4 6)" );
+  ret = QgsGeometryUtils::transferFirstZOrMValueToPoint( geom.vertices_begin(), geom.vertices_end(), point );
+  QCOMPARE( ret, true );
+  QCOMPARE( point.z(), 3.0 );
+  QCOMPARE( point.m(), 5.0 );
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtils )


### PR DESCRIPTION
## Description

This PR is the continuation of the https://github.com/qgis/QGIS/pull/42812#discussion_r615314067. It adds a method for adding the Z and the M from a `QgsPointSequence`. It is equivalent to using the `transferFirstZValueToPoint` and `transferFirstMValueToPoint` methods but avoid looping twice. 

It is used in the QgsCircle, QgsEllipse, QgsTriangle classes. Three other dedicated PR will complete and add tests on these classes using this method.

Sponsored by: Métropole Européenne de Lille @Jean-Roc