### PR TITLE
Try to use provider native method for saving default metadata before resorting to .qmd sidecar files

### DIFF
--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -426,7 +426,7 @@ Loads a layer style defined by ``uri``
 .. versionadded:: 3.10
 %End
 
-    virtual bool saveLayerMetadata( const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage /Out/ );
+    virtual bool saveLayerMetadata( const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage /Out/ ) throw( QgsNotSupportedException );
 %Docstring
 Saves ``metadata`` to the layer corresponding to the specified ``uri``.
 
@@ -435,6 +435,10 @@ Saves ``metadata`` to the layer corresponding to the specified ``uri``.
 
 :return: - ``True`` if the metadata was successfully saved.
          - errorMessage: descriptive string of error if encountered
+
+
+:raises :: py:class:`QgsNotSupportedException` if the provider does not support saving layer metadata for the
+   specified ``uri``.
 
 
 .. versionadded:: 3.20

--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -118,6 +118,7 @@ library object.
     enum ProviderCapability
     {
       FileBasedUris,
+      SaveLayerMetadata,
     };
     typedef QFlags<QgsProviderMetadata::ProviderCapability> ProviderCapabilities;
 
@@ -591,6 +592,7 @@ relating to the connection have been updated.
 
 QFlags<QgsProviderMetadata::ProviderMetadataCapability> operator|(QgsProviderMetadata::ProviderMetadataCapability f1, QFlags<QgsProviderMetadata::ProviderMetadataCapability> f2);
 
+QFlags<QgsProviderMetadata::ProviderCapability> operator|(QgsProviderMetadata::ProviderCapability f1, QFlags<QgsProviderMetadata::ProviderCapability> f2);
 
 
 /************************************************************************

--- a/python/core/auto_generated/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/qgsproviderregistry.sip.in
@@ -233,7 +233,7 @@ Loads a layer style defined by ``uri``
 .. versionadded:: 3.10
 %End
 
-    bool saveLayerMetadata( const QString &providerKey, const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage /Out/ );
+    bool saveLayerMetadata( const QString &providerKey, const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage /Out/ ) throw( QgsNotSupportedException );
 %Docstring
 Saves ``metadata`` to the layer corresponding to the specified ``uri``.
 
@@ -243,6 +243,10 @@ Saves ``metadata`` to the layer corresponding to the specified ``uri``.
 
 :return: - ``True`` if the metadata was successfully saved.
          - errorMessage: descriptive string of error if encountered
+
+
+:raises :: py:class:`QgsNotSupportedException` if the provider does not support saving layer metadata for the
+   specified ``uri``.
 
 
 .. versionadded:: 3.20

--- a/python/core/qgsexception.sip
+++ b/python/core/qgsexception.sip
@@ -46,3 +46,15 @@
   SIP_UNBLOCK_THREADS
 %End
 };
+
+%Exception QgsNotSupportedException(SIP_Exception) /PyName=QgsNotSupportedException/
+{
+%TypeHeaderCode
+#include <qgsexception.h>
+%End
+%RaiseCode
+  SIP_BLOCK_THREADS
+  PyErr_SetString(sipException_QgsNotSupportedException, sipExceptionRef.what().toUtf8().constData() );
+  SIP_UNBLOCK_THREADS
+%End
+};

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -7652,6 +7652,6 @@ void QgsOgrProviderMetadata::saveConnection( const QgsAbstractProviderConnection
 
 QgsProviderMetadata::ProviderCapabilities QgsOgrProviderMetadata::providerCapabilities() const
 {
-  return FileBasedUris;
+  return FileBasedUris | SaveLayerMetadata;
 }
 ///@endcond

--- a/src/core/qgsexception.h
+++ b/src/core/qgsexception.h
@@ -108,5 +108,21 @@ class CORE_EXPORT QgsProviderConnectionException: public QgsException
 
 };
 
+/**
+ * \class QgsNotSupportedException
+ * \ingroup core
+ * \brief Custom exception class which is raised when an operation is not supported.
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsNotSupportedException : public QgsException
+{
+  public:
+
+    /**
+     * Constructor for QgsNotSupportedException, with the specified error \a message.
+     */
+    QgsNotSupportedException( const QString &message ) : QgsException( message ) {}
+
+};
 
 #endif

--- a/src/core/qgsprovidermetadata.cpp
+++ b/src/core/qgsprovidermetadata.cpp
@@ -232,10 +232,9 @@ QString QgsProviderMetadata::loadStyle( const QString &, QString &errCause )
   return QString();
 }
 
-bool QgsProviderMetadata::saveLayerMetadata( const QString &, const QgsLayerMetadata &, QString &errorMessage )
+bool QgsProviderMetadata::saveLayerMetadata( const QString &, const QgsLayerMetadata &, QString & )
 {
-  errorMessage = QObject::tr( "Provider %1 does not support writing layer metadata" ).arg( key() );
-  return false;
+  throw QgsNotSupportedException( QObject::tr( "Provider %1 does not support writing layer metadata" ).arg( key() ) );
 }
 
 bool QgsProviderMetadata::createDb( const QString &, QString &errCause )

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -483,9 +483,12 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
      *
      * \returns TRUE if the metadata was successfully saved.
      *
+     * \throws QgsNotSupportedException if the provider does not support saving layer metadata for the
+     * specified \a uri.
+     *
      * \since QGIS 3.20
      */
-    virtual bool saveLayerMetadata( const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage SIP_OUT );
+    virtual bool saveLayerMetadata( const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage SIP_OUT ) SIP_THROW( QgsNotSupportedException );
 
     /**
      * Creates database by the provider on the path

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -162,6 +162,7 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     enum ProviderCapability
     {
       FileBasedUris = 1 << 0, //!< Indicates that the provider can utilize URIs which are based on paths to files (as opposed to database or internet paths)
+      SaveLayerMetadata = 1 << 1, //!< Indicates that the provider supports saving native layer metadata (since QGIS 3.20)
     };
     Q_DECLARE_FLAGS( ProviderCapabilities, ProviderCapability )
 
@@ -673,6 +674,6 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProviderMetadata::ProviderMetadataCapabilities )
-
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProviderMetadata::ProviderCapabilities )
 
 #endif //QGSPROVIDERMETADATA_H

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -668,8 +668,7 @@ bool QgsProviderRegistry::saveLayerMetadata( const QString &providerKey, const Q
     return meta->saveLayerMetadata( uri, metadata, errorMessage );
   else
   {
-    errorMessage = QObject::tr( "Unable to load %1 provider" ).arg( providerKey );
-    return false;
+    throw QgsNotSupportedException( QObject::tr( "Unable to load %1 provider" ).arg( providerKey ) );
   }
 }
 

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -271,9 +271,12 @@ class CORE_EXPORT QgsProviderRegistry
      *
      * \returns TRUE if the metadata was successfully saved.
      *
+     * \throws QgsNotSupportedException if the provider does not support saving layer metadata for the
+     * specified \a uri.
+     *
      * \since QGIS 3.20
      */
-    bool saveLayerMetadata( const QString &providerKey, const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage SIP_OUT );
+    bool saveLayerMetadata( const QString &providerKey, const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage SIP_OUT ) SIP_THROW( QgsNotSupportedException );
 
     /**
      * Creates database by the provider on the path

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -1271,6 +1271,22 @@ class PyQgsOGRProvider(unittest.TestCase):
         with self.assertRaises(QgsNotSupportedException):
             QgsProviderRegistry.instance().saveLayerMetadata('ogr', 'WFS:http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap', metadata)
 
+    def testSaveDefaultMetadataUnsupported(self):
+        """
+        Test saving default metadata to an unsupported layer
+        """
+        layer = QgsVectorLayer('WFS:http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap', 'test')
+        # now save some metadata
+        metadata = QgsLayerMetadata()
+        metadata.setAbstract('my abstract')
+        metadata.setIdentifier('my identifier')
+        metadata.setLicenses(['l1', 'l2'])
+        layer.setMetadata(metadata)
+        # save as default
+        msg, res = layer.saveDefaultMetadata()
+        self.assertFalse(res)
+        self.assertEqual(msg, 'Storing metadata for the specified uri is not supported')
+
     def testEmbeddedSymbolsKml(self):
         """
         Test retrieving embedded symbols from a KML file


### PR DESCRIPTION
This ensures we correctly store metadata in the gpkg_metadata table, linked to the associated table, for GPKG files instead of as sidecar files.

Fixes #31161, fixes #25119