### PR TITLE
Add "persist layer metadata" checkbox to export vector file dialog

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -135,6 +135,7 @@ Constructor for MetaData
       ErrProjection,
       ErrFeatureWriteFailed,
       ErrInvalidLayer,
+      ErrSavingMetadata,
       Canceled,
     };
 
@@ -393,6 +394,10 @@ Constructor
         QgsFeedback *feedback;
 
         FieldNameSource fieldNameSource;
+
+        bool saveMetadata;
+
+        QgsLayerMetadata layerMetadata;
     };
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8908,7 +8908,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
     }
   };
 
-  saveAsVectorFileGeneral( layer, true, false, true, onSuccess, onFailure, 0, tr( "Save Scratch Layer" ) );
+  saveAsVectorFileGeneral( layer, true, false, true, onSuccess, onFailure, QgsVectorLayerSaveAsDialog::Options(), tr( "Save Scratch Layer" ) );
 }
 
 void QgisApp::saveAsLayerDefinition()
@@ -9143,7 +9143,7 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
   return saveAsVectorFileGeneral( vlayer, symbologyOption, onlySelected, defaultToAddToMap, onSuccess, onFailure );
 }
 
-QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected, bool defaultToAddToMap, const std::function<void( const QString &, bool, const QString &, const QString &, const QString & )> &onSuccess, const std::function<void ( int, const QString & )> &onFailure, int options, const QString &dialogTitle )
+QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected, bool defaultToAddToMap, const std::function<void( const QString &, bool, const QString &, const QString &, const QString & )> &onSuccess, const std::function<void ( int, const QString & )> &onFailure, QgsVectorLayerSaveAsDialog::Options options, const QString &dialogTitle )
 {
   QgsCoordinateReferenceSystem destCRS;
 
@@ -9206,6 +9206,8 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
     options.includeZ = dialog->includeZ();
     options.attributes = dialog->selectedAttributes();
     options.fieldValueConverter = converterPtr;
+    options.saveMetadata = dialog->persistMetadata();
+    options.layerMetadata = vlayer->metadata();
 
     bool addToCanvas = dialog->addToCanvas();
     QgsVectorFileWriterTask *writerTask = new QgsVectorFileWriterTask( vlayer, vectorFilename, options );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2200,7 +2200,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                          const QString &layerName,
                                          const QString &encoding,
                                          const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure,
-                                     int dialogOptions = QgsVectorLayerSaveAsDialog::AllOptions,
+                                     QgsVectorLayerSaveAsDialog::Options dialogOptions = QgsVectorLayerSaveAsDialog::AllOptions,
                                      const QString &dialogTitle = QString() );
 
     //! Sets project properties, including map untis

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1524,10 +1524,10 @@ void QgsOgrProvider::loadMetadata()
           }
           file.close();
         }
-      }
-      else
-      {
-        QgsDebugMsg( QStringLiteral( "Error reading %1 - could not open file for read" ).arg( sidecarPath ) );
+        else
+        {
+          QgsDebugMsg( QStringLiteral( "Error reading %1 - could not open file for read" ).arg( sidecarPath ) );
+        }
       }
     }
   }

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -177,6 +177,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
       ErrProjection,
       ErrFeatureWriteFailed,
       ErrInvalidLayer,
+      ErrSavingMetadata, //!< Metadata saving failed
       Canceled, //!< Writing was interrupted by manual cancellation
     };
 
@@ -533,6 +534,22 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
          * \since QGIS 3.18
          */
         FieldNameSource fieldNameSource = Original;
+
+        /**
+         * Set to TRUE to save layer metadata for the exported vector file.
+         *
+         * \see layerMetadata
+         * \since QGIS 3.20
+         */
+        bool saveMetadata = false;
+
+        /**
+         * Layer metadata to save for the exported vector file. This will only be used if saveMetadata is TRUE.
+         *
+         * \see saveMetadata
+         * \since QGIS 3.20
+         */
+        QgsLayerMetadata layerMetadata;
     };
 
 #ifndef SIP_RUN

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -49,13 +49,13 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget *par
   setup();
 }
 
-QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, int options, QWidget *parent, Qt::WindowFlags fl )
+QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, Options options, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
   , mLayer( layer )
   , mAttributeTableItemChangedSlotEnabled( true )
   , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
   , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
-  , mOptions( static_cast< Options >( options ) )
+  , mOptions( options )
 {
   if ( layer )
   {
@@ -91,6 +91,12 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
 
   if ( !( mOptions & Extent ) )
     mExtentGroupBox->hide();
+
+  if ( !( mOptions & Metadata ) )
+  {
+    mCheckPersistMetadata->setChecked( false );
+    mCheckPersistMetadata->hide();
+  }
 
   mSelectedOnly->setEnabled( layer && layer->selectedFeatureCount() != 0 );
   mButtonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
@@ -971,6 +977,11 @@ void QgsVectorLayerSaveAsDialog::setOnlySelected( bool onlySelected )
 bool QgsVectorLayerSaveAsDialog::onlySelected() const
 {
   return mSelectedOnly->isChecked();
+}
+
+bool QgsVectorLayerSaveAsDialog::persistMetadata() const
+{
+  return mCheckPersistMetadata->isChecked();
 }
 
 QgsWkbTypes::Type QgsVectorLayerSaveAsDialog::geometryType() const

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -42,7 +42,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
   public:
 
     //! Bitmask of options to be shown
-    enum Options
+    enum Option
     {
       Symbology = 1, //!< Show symbology options
       DestinationCrs = 1 << 2, //!< Show destination CRS (reprojection) option
@@ -51,8 +51,10 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
       SelectedOnly = 1 << 5, //!< Show selected features only option
       GeometryType = 1 << 6, //!< Show geometry group
       Extent = 1 << 7, //!< Show extent group
+      Metadata = 1 << 8, //!< Show metadata options
       AllOptions = ~0 //!< Show all options
     };
+    Q_DECLARE_FLAGS( Options, Option )
 
     /**
      * Construct a new QgsVectorLayerSaveAsDialog
@@ -64,7 +66,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     /**
      * Construct a new QgsVectorLayerSaveAsDialog
      */
-    QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, int options = AllOptions, QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
+    QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, Options options = AllOptions, QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
 
     /**
      * The format in which the export should be written.
@@ -176,6 +178,13 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     bool onlySelected() const;
 
     /**
+     * Returns TRUE if the persist metadata (copy source metadata to destination layer) option is checked.
+     *
+     * \since QGIS 3.20
+     */
+    bool persistMetadata() const;
+
+    /**
      * Returns the selected flat geometry type for the export.
      * \see automaticGeometryType()
      * \see forceMulti()
@@ -242,5 +251,8 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
     Options mOptions = AllOptions;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorLayerSaveAsDialog::Options )
+
 
 #endif // QGSVECTORLAYERSAVEASDIALOG_H

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -31,7 +31,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QgsFileWidget" name="mFilename">
+       <widget class="QgsFileWidget" name="mFilename" native="true">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -96,9 +96,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-303</y>
+        <y>0</y>
         <width>557</width>
-        <height>1004</height>
+        <height>987</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -189,6 +189,19 @@
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="mCheckPersistMetadata">
+         <property name="toolTip">
+          <string>If checked, any metadata present in the source layer will be copied to the output layer.</string>
+         </property>
+         <property name="text">
+          <string>Persist layer metadata</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -503,6 +516,7 @@
   <tabstop>mSelectAllAttributes</tabstop>
   <tabstop>mDeselectAllAttributes</tabstop>
   <tabstop>mReplaceRawFieldValues</tabstop>
+  <tabstop>mCheckPersistMetadata</tabstop>
   <tabstop>mSymbologyExportComboBox</tabstop>
   <tabstop>mScaleWidget</tabstop>
   <tabstop>mGeometryTypeComboBox</tabstop>


### PR DESCRIPTION
When checked (as it is by default), any layer metadata present in the
source layer will be copied and stored in the newly created destination
file.

So e.g. when right clicking a layer a project (or browser) with metadata
attached and exporting to a new format, this option will ensure that
the metadata is nicely transferred over to the newly created gpkg.