### PR TITLE
Don't show rasterization warnings for layout exports if only invisible items require rasterization

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -381,6 +381,27 @@ Computes the world file parameters for a specified ``region`` of the layout.
 The ``dpi`` argument can be set to the actual DPI of exported file, or left as -1 to use the layout's default DPI.
 %End
 
+    static bool requiresRasterization( const QgsLayout *layout );
+%Docstring
+Returns ``True`` if the specified ``layout`` contains visible items which have settings
+that require rasterization of the entire export layout in order to reproduce the desired
+appearance.
+
+.. seealso:: :py:func:`containsAdvancedEffects`
+
+.. versionadded:: 3.20
+%End
+
+    static bool containsAdvancedEffects( const QgsLayout *layout );
+%Docstring
+Returns ``True`` if the specified ``layout`` contains visible items which have settings
+such as opacity which will prevent these individual items from being exported as vector artwork.
+
+.. seealso:: :py:func:`requiresRasterization`
+
+.. versionadded:: 3.20
+%End
+
   protected:
 
     virtual QString generateFileName( const PageExportDetails &details ) const;

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2056,7 +2056,7 @@ void QgsLayoutDesignerDialog::print()
     showWmsPrintingWarning();
   }
 
-  if ( requiresRasterization() )
+  if ( QgsLayoutExporter::requiresRasterization( mLayout ) )
   {
     showRasterizationWarning();
   }
@@ -2260,12 +2260,12 @@ void QgsLayoutDesignerDialog::exportToPdf()
     showWmsPrintingWarning();
   }
 
-  if ( requiresRasterization() )
+  if ( QgsLayoutExporter::requiresRasterization( mLayout ) )
   {
     showRasterizationWarning();
   }
 
-  if ( containsAdvancedEffects() && ( mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool() ) )
+  if ( QgsLayoutExporter::containsAdvancedEffects( mLayout ) && ( mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool() ) )
   {
     showForceVectorWarning();
   }
@@ -2644,7 +2644,7 @@ void QgsLayoutDesignerDialog::printAtlas()
     showWmsPrintingWarning();
   }
 
-  if ( requiresRasterization() )
+  if ( QgsLayoutExporter::requiresRasterization( mLayout ) )
   {
     showRasterizationWarning();
   }
@@ -3158,12 +3158,12 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
     showWmsPrintingWarning();
   }
 
-  if ( requiresRasterization() )
+  if ( QgsLayoutExporter::requiresRasterization( mLayout ) )
   {
     showRasterizationWarning();
   }
 
-  if ( containsAdvancedEffects() && ( mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool() ) )
+  if ( QgsLayoutExporter::containsAdvancedEffects( mLayout ) && ( mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool() ) )
   {
     showForceVectorWarning();
   }
@@ -4075,7 +4075,6 @@ void QgsLayoutDesignerDialog::initializeRegistry()
   } );
 
   QgsGui::layoutItemGuiRegistry()->addLayoutItemGuiMetadata( new QgsLayoutItemGuiMetadata( QgsLayoutItemRegistry::LayoutPage, QObject::tr( "Page" ), QIcon(), createPageWidget, nullptr, QString(), false, QgsLayoutItemAbstractGuiMetadata::FlagNoCreationTools ) );
-
 }
 
 bool QgsLayoutDesignerDialog::containsWmsLayers() const
@@ -4135,35 +4134,8 @@ void QgsLayoutDesignerDialog::showSvgExportWarning()
   }
 }
 
-bool QgsLayoutDesignerDialog::requiresRasterization() const
-{
-  QList< QgsLayoutItem *> items;
-  mLayout->layoutItems( items );
-
-  for ( QgsLayoutItem *currentItem : std::as_const( items ) )
-  {
-    if ( currentItem->requiresRasterization() )
-      return true;
-  }
-  return false;
-}
-
-bool QgsLayoutDesignerDialog::containsAdvancedEffects() const
-{
-  QList< QgsLayoutItem *> items;
-  mLayout->layoutItems( items );
-
-  for ( QgsLayoutItem *currentItem : std::as_const( items ) )
-  {
-    if ( currentItem->containsAdvancedEffects() )
-      return true;
-  }
-  return false;
-}
-
 void QgsLayoutDesignerDialog::showRasterizationWarning()
 {
-
   if ( mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool() ||
        mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool() )
     return;

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -515,11 +515,6 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
 
     void showSvgExportWarning();
 
-    //! True if the layout contains advanced effects, such as blend modes
-    bool requiresRasterization() const;
-
-    bool containsAdvancedEffects() const;
-
     //! Displays a warning because of incompatibility between blend modes and QPrinter
     void showRasterizationWarning();
     void showForceVectorWarning();

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1926,7 +1926,8 @@ bool QgsLayoutExporter::requiresRasterization( const QgsLayout *layout )
 
   for ( QgsLayoutItem *currentItem : std::as_const( items ) )
   {
-    if ( currentItem->requiresRasterization() )
+    // ignore invisible items, they won't affect the output in any way...
+    if ( currentItem->isVisible() && currentItem->requiresRasterization() )
       return true;
   }
   return false;
@@ -1942,7 +1943,8 @@ bool QgsLayoutExporter::containsAdvancedEffects( const QgsLayout *layout )
 
   for ( QgsLayoutItem *currentItem : std::as_const( items ) )
   {
-    if ( currentItem->containsAdvancedEffects() )
+    // ignore invisible items, they won't affect the output in any way...
+    if ( currentItem->isVisible() && currentItem->containsAdvancedEffects() )
       return true;
   }
   return false;

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1916,6 +1916,38 @@ void QgsLayoutExporter::computeWorldFileParameters( const QRectF &exportRegion, 
   f = r[3] * s[2] + r[4] * s[5] + r[5];
 }
 
+bool QgsLayoutExporter::requiresRasterization( const QgsLayout *layout )
+{
+  if ( !layout )
+    return false;
+
+  QList< QgsLayoutItem *> items;
+  layout->layoutItems( items );
+
+  for ( QgsLayoutItem *currentItem : std::as_const( items ) )
+  {
+    if ( currentItem->requiresRasterization() )
+      return true;
+  }
+  return false;
+}
+
+bool QgsLayoutExporter::containsAdvancedEffects( const QgsLayout *layout )
+{
+  if ( !layout )
+    return false;
+
+  QList< QgsLayoutItem *> items;
+  layout->layoutItems( items );
+
+  for ( QgsLayoutItem *currentItem : std::as_const( items ) )
+  {
+    if ( currentItem->containsAdvancedEffects() )
+      return true;
+  }
+  return false;
+}
+
 QImage QgsLayoutExporter::createImage( const QgsLayoutExporter::ImageExportSettings &settings, int page, QRectF &bounds, bool &skipPage ) const
 {
   bounds = QRectF();

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -625,6 +625,25 @@ class CORE_EXPORT QgsLayoutExporter
      */
     void computeWorldFileParameters( const QRectF &region, double &a, double &b, double &c, double &d, double &e, double &f, double dpi = -1 ) const;
 
+    /**
+     * Returns TRUE if the specified \a layout contains visible items which have settings
+     * that require rasterization of the entire export layout in order to reproduce the desired
+     * appearance.
+     *
+     * \see containsAdvancedEffects()
+     * \since QGIS 3.20
+     */
+    static bool requiresRasterization( const QgsLayout *layout );
+
+    /**
+     * Returns TRUE if the specified \a layout contains visible items which have settings
+     * such as opacity which will prevent these individual items from being exported as vector artwork.
+     *
+     * \see requiresRasterization()
+     * \since QGIS 3.20
+     */
+    static bool containsAdvancedEffects( const QgsLayout *layout );
+
   protected:
 
     /**

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -1128,6 +1128,10 @@ class TestQgsLayoutExporter(unittest.TestCase):
         label.setBlendMode(QPainter.CompositionMode_Overlay)
         self.assertTrue(QgsLayoutExporter.requiresRasterization(l))
 
+        # but if the item is NOT visible, it won't affect the output in any way..
+        label.setVisibility(False)
+        self.assertFalse(QgsLayoutExporter.requiresRasterization(l))
+
     def testContainsAdvancedEffects(self):
         """
         Test QgsLayoutExporter.containsAdvancedEffects
@@ -1145,6 +1149,10 @@ class TestQgsLayoutExporter(unittest.TestCase):
         # an item with transparency will force it to be individually rasterized
         label.setItemOpacity(0.5)
         self.assertTrue(QgsLayoutExporter.containsAdvancedEffects(l))
+
+        # but if the item is NOT visible, it won't affect the output in any way..
+        label.setVisibility(False)
+        self.assertFalse(QgsLayoutExporter.containsAdvancedEffects(l))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -25,6 +25,7 @@ from qgis.core import (QgsMultiRenderChecker,
                        QgsProject,
                        QgsMargins,
                        QgsLayoutItemShape,
+                       QgsLayoutItemLabel,
                        QgsLayoutGuide,
                        QgsRectangle,
                        QgsLayoutItemPage,
@@ -1108,6 +1109,42 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.assertTrue(self.checkImage('report_page1', 'report_page1', page1_path))
         page2_path = os.path.join(self.basetestpath, 'test_report_0002.png')
         self.assertTrue(self.checkImage('report_page2', 'report_page2', page2_path))
+
+    def testRequiresRasterization(self):
+        """
+        Test QgsLayoutExporter.requiresRasterization
+        """
+        l = QgsLayout(QgsProject.instance())
+        l.initializeDefaults()
+
+        # add an item
+        label = QgsLayoutItemLabel(l)
+        label.attemptSetSceneRect(QRectF(30, 60, 200, 100))
+        l.addLayoutItem(label)
+
+        self.assertFalse(QgsLayoutExporter.requiresRasterization(l))
+
+        # an item with a blend mode will force the whole layout to be rasterized
+        label.setBlendMode(QPainter.CompositionMode_Overlay)
+        self.assertTrue(QgsLayoutExporter.requiresRasterization(l))
+
+    def testContainsAdvancedEffects(self):
+        """
+        Test QgsLayoutExporter.containsAdvancedEffects
+        """
+        l = QgsLayout(QgsProject.instance())
+        l.initializeDefaults()
+
+        # add an item
+        label = QgsLayoutItemLabel(l)
+        label.attemptSetSceneRect(QRectF(30, 60, 200, 100))
+        l.addLayoutItem(label)
+
+        self.assertFalse(QgsLayoutExporter.containsAdvancedEffects(l))
+
+        # an item with transparency will force it to be individually rasterized
+        label.setItemOpacity(0.5)
+        self.assertTrue(QgsLayoutExporter.containsAdvancedEffects(l))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When determining whether a layout requires rasterization in order to export correctly, skip over any items which aren't visible. 
These don't affect the output in any way, so showing warnings about forced rasterization is misleading