### PR TITLE
disable file line edit when property is active

### DIFF
--- a/src/gui/qgsfilecontentsourcelineedit.cpp
+++ b/src/gui/qgsfilecontentsourcelineedit.cpp
@@ -82,7 +82,8 @@ QgsAbstractFileContentSourceLineEdit::QgsAbstractFileContentSourceLineEdit( QWid
   } );
 
   mPropertyOverrideButton->setVisible( mPropertyOverrideButtonVisible );
-
+  mPropertyOverrideButton->registerEnabledWidget( mFileLineEdit, false );
+  mPropertyOverrideButton->registerEnabledWidget( mFileToolButton, false );
 }
 
 QString QgsAbstractFileContentSourceLineEdit::source() const


### PR DESCRIPTION
for instance, in SVG config, the line edit and button for the file will be disabled if the property is active

![image](https://user-images.githubusercontent.com/127259/117139642-c66dd900-adac-11eb-909e-38866724c02c.png)
