### PR TITLE
Show a warning when CRSes based on a datum ensemble are selected

### DIFF
--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -83,30 +83,22 @@ passed, the message will be a generic
 %End
 
 
-    bool showDatumEnsembleWarnings() const;
+    bool showAccuracyWarnings() const;
 %Docstring
-Returns ``True`` if the widget will show a warning to users when they select a CRS which uses
-a datum ensemble.
+Returns ``True`` if the widget will show a warning to users when they select a CRS which has
+low accuracy.
 
-.. warning::
-
-   Determining datum ensembles requires PROJ 8.0 or later.
-
-.. seealso:: :py:func:`setShowDatumEnsembleWarnings`
+.. seealso:: :py:func:`showAccuracyWarnings`
 
 .. versionadded:: 3.20
 %End
 
-    void setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings );
+    void showAccuracyWarnings( bool show );
 %Docstring
-Sets whether the widget will show a warning to users when they select a CRS which uses
-a datum ensemble.
+Sets whether the widget will ``show`` warnings to users when they select a CRS which has
+low accuracy.
 
-.. warning::
-
-   Determining datum ensembles requires PROJ 8.0 or later.
-
-.. seealso:: :py:func:`showDatumEnsembleWarnings`
+.. seealso:: :py:func:`showAccuracyWarnings`
 
 .. versionadded:: 3.20
 %End

--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -83,6 +83,34 @@ passed, the message will be a generic
 %End
 
 
+    bool showDatumEnsembleWarnings() const;
+%Docstring
+Returns ``True`` if the widget will show a warning to users when they select a CRS which uses
+a datum ensemble.
+
+.. warning::
+
+   Determining datum ensembles requires PROJ 8.0 or later.
+
+.. seealso:: :py:func:`setShowDatumEnsembleWarnings`
+
+.. versionadded:: 3.20
+%End
+
+    void setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings );
+%Docstring
+Sets whether the widget will show a warning to users when they select a CRS which uses
+a datum ensemble.
+
+.. warning::
+
+   Determining datum ensembles requires PROJ 8.0 or later.
+
+.. seealso:: :py:func:`showDatumEnsembleWarnings`
+
+.. versionadded:: 3.20
+%End
+
   signals:
 
     void crsChanged( const QgsCoordinateReferenceSystem & );

--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -88,12 +88,12 @@ passed, the message will be a generic
 Returns ``True`` if the widget will show a warning to users when they select a CRS which has
 low accuracy.
 
-.. seealso:: :py:func:`showAccuracyWarnings`
+.. seealso:: :py:func:`setShowAccuracyWarnings`
 
 .. versionadded:: 3.20
 %End
 
-    void showAccuracyWarnings( bool show );
+    void setShowAccuracyWarnings( bool show );
 %Docstring
 Sets whether the widget will ``show`` warnings to users when they select a CRS which has
 low accuracy.

--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -103,6 +103,30 @@ low accuracy.
 .. versionadded:: 3.20
 %End
 
+    void setSourceEnsemble( const QString &ensemble );
+%Docstring
+Sets the original source ``ensemble`` datum name.
+
+If set, CRS accuracy warnings will not be shown when the selected CRS in the widget has a matching
+ensemble datum, regardless of the ensemble's accuracy.
+
+.. seealso:: :py:func:`sourceEnsemble`
+
+.. versionadded:: 3.20
+%End
+
+    QString sourceEnsemble() const;
+%Docstring
+Returns the original source ensemble datum name.
+
+If set, CRS accuracy warnings will not be shown when the selected CRS in the widget has a matching
+ensemble datum, regardless of the ensemble's accuracy.
+
+.. seealso:: :py:func:`setSourceEnsemble`
+
+.. versionadded:: 3.20
+%End
+
   signals:
 
     void crsChanged( const QgsCoordinateReferenceSystem & );

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -86,6 +86,11 @@ projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
 # "UseDefaultCrs" - use the default layer CRS set via QGIS options
 projections\unknownCrsBehavior=NoAction
 
+# If the inherent inaccuracy in a selected CRS exceeds this threshold value (in meters),
+# a warning message will be shown to the user advising them to select an alternative
+# CRS if higher positional accuracy is required
+projections\crsAccuracyWarningThreshold=0.0
+
 # Specifies a manual bearing correction to apply to bearings reported by a GPS
 # device, for use when a map canvas is set to match rotation to the GPS bearing
 # or when showing the GPS bearing line

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -81,7 +81,7 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
 
   int crsid = s.value( QStringLiteral( "/DwgImport/lastCrs" ), QString::number( QgsProject::instance()->crs().srsid() ) ).toInt();
 
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
   QgsCoordinateReferenceSystem crs;
   crs.createFromSrsId( crsid );
   mCrsSelector->setCrs( crs );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -81,7 +81,7 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
 
   int crsid = s.value( QStringLiteral( "/DwgImport/lastCrs" ), QString::number( QgsProject::instance()->crs().srsid() ) ).toInt();
 
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
   QgsCoordinateReferenceSystem crs;
   crs.createFromSrsId( crsid );
   mCrsSelector->setCrs( crs );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -81,6 +81,7 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
 
   int crsid = s.value( QStringLiteral( "/DwgImport/lastCrs" ), QString::number( QgsProject::instance()->crs().srsid() ) ).toInt();
 
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
   QgsCoordinateReferenceSystem crs;
   crs.createFromSrsId( crsid );
   mCrsSelector->setCrs( crs );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -522,6 +522,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
       break;
   }
 
+  const double crsAccuracyWarningThreshold = mSettings->value( QStringLiteral( "/projections/crsAccuracyWarningThreshold" ), 0.0, QgsSettings::App ).toDouble();
+  mCrsAccuracySpin->setMinimumWidth( QFontMetrics( font() ).horizontalAdvance( '0' ) * 20 );
+  mCrsAccuracySpin->setClearValue( 0.0, tr( "Always show" ) );
+  mCrsAccuracySpin->setValue( crsAccuracyWarningThreshold );
+
   mShowDatumTransformDialogCheckBox->setChecked( mSettings->value( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App ).toBool() );
 
   // Datum transforms
@@ -1700,6 +1705,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/projections/defaultProjectCrs" ), leProjectGlobalCrs->crs().authid(), QgsSettings::App );
   mSettings->setEnumValue( QStringLiteral( "/projections/newProjectCrsBehavior" ), radProjectUseCrsOfFirstLayer->isChecked() ? QgsGui::UseCrsOfFirstLayerAdded : QgsGui::UsePresetCrs, QgsSettings::App );
   mSettings->setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );
+  mSettings->setValue( QStringLiteral( "/projections/crsAccuracyWarningThreshold" ), mCrsAccuracySpin->value(), QgsSettings::App );
 
   //measurement settings
   mSettings->setValue( QStringLiteral( "measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked(), QgsSettings::Core );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -84,7 +84,7 @@ QgsAlignRasterDialog::QgsAlignRasterDialog( QWidget *parent )
   mAlign = new QgsAlignRaster;
   mAlign->setProgressHandler( new QgsAlignRasterDialogProgress( mProgress ) );
 
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   connect( mBtnAdd, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::addLayer );
   connect( mBtnRemove, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::removeLayer );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -84,6 +84,8 @@ QgsAlignRasterDialog::QgsAlignRasterDialog( QWidget *parent )
   mAlign = new QgsAlignRaster;
   mAlign->setProgressHandler( new QgsAlignRasterDialogProgress( mProgress ) );
 
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
+
   connect( mBtnAdd, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::addLayer );
   connect( mBtnRemove, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::removeLayer );
   connect( mBtnEdit, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::editLayer );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -84,7 +84,7 @@ QgsAlignRasterDialog::QgsAlignRasterDialog( QWidget *parent )
   mAlign = new QgsAlignRaster;
   mAlign->setProgressHandler( new QgsAlignRasterDialogProgress( mProgress ) );
 
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   connect( mBtnAdd, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::addLayer );
   connect( mBtnRemove, &QAbstractButton::clicked, this, &QgsAlignRasterDialog::removeLayer );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -491,7 +491,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mCRS = QgsCoordinateReferenceSystem::fromSrsId( crsid );
   mCrsSelector->setCrs( mCRS );
   mCrsSelector->setLayerCrs( mCRS );
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
   mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -491,7 +491,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mCRS = QgsCoordinateReferenceSystem::fromSrsId( crsid );
   mCrsSelector->setCrs( mCRS );
   mCrsSelector->setLayerCrs( mCRS );
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
   mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -491,6 +491,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mCRS = QgsCoordinateReferenceSystem::fromSrsId( crsid );
   mCrsSelector->setCrs( mCRS );
   mCrsSelector->setLayerCrs( mCRS );
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
   mCrsSelector->setMessage( tr( "Select the coordinate reference system for the dxf file. "
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -80,7 +80,7 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QgsRasterLayer *rasterLayer, QWidget *
     setExtentSize( rasterLayer->width(), rasterLayer->height(), rasterLayer->extent() );
     mCrsSelector->setCrs( rasterLayer->crs() );
   }
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -80,6 +80,7 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QgsRasterLayer *rasterLayer, QWidget *
     setExtentSize( rasterLayer->width(), rasterLayer->height(), rasterLayer->extent() );
     mCrsSelector->setCrs( rasterLayer->crs() );
   }
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
 
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -80,7 +80,7 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QgsRasterLayer *rasterLayer, QWidget *
     setExtentSize( rasterLayer->width(), rasterLayer->height(), rasterLayer->extent() );
     mCrsSelector->setCrs( rasterLayer->crs() );
   }
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -34,6 +34,7 @@
 #include <QSpinBox>
 #include <QRegularExpression>
 #include "gdal.h"
+#include "qgsdatums.h"
 
 static const int COLUMN_IDX_NAME = 0;
 static const int COLUMN_IDX_TYPE = 1;
@@ -201,7 +202,19 @@ void QgsVectorLayerSaveAsDialog::setup()
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !filePath.isEmpty() );
   } );
 
-  mCrsSelector->showAccuracyWarnings( true );
+  try
+  {
+    const QgsDatumEnsemble ensemble = mSelectedCrs.datumEnsemble();
+    if ( ensemble.isValid() )
+    {
+      mCrsSelector->setSourceEnsemble( ensemble.name() );
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+  }
+
+  mCrsSelector->setShowAccuracyWarnings( true );
 }
 
 QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( const QMap<QString, QgsVectorFileWriter::Option *> &options )

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -201,7 +201,7 @@ void QgsVectorLayerSaveAsDialog::setup()
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !filePath.isEmpty() );
   } );
 
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 }
 
 QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( const QMap<QString, QgsVectorFileWriter::Option *> &options )

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -200,6 +200,8 @@ void QgsVectorLayerSaveAsDialog::setup()
     }
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !filePath.isEmpty() );
   } );
+
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
 }
 
 QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( const QMap<QString, QgsVectorFileWriter::Option *> &options )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -254,7 +254,7 @@ QgsProcessingCrsParameterDefinitionWidget::QgsProcessingCrsParameterDefinitionWi
   mCrsSelector = new QgsProjectionSelectionWidget();
 
   // possibly we should expose this for parameter by parameter control
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   if ( const QgsProcessingParameterCrs *crsParam = dynamic_cast<const QgsProcessingParameterCrs *>( definition ) )
     mCrsSelector->setCrs( QgsProcessingParameters::parameterAsCrs( crsParam, crsParam->defaultValueForGui(), context ) );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -254,7 +254,7 @@ QgsProcessingCrsParameterDefinitionWidget::QgsProcessingCrsParameterDefinitionWi
   mCrsSelector = new QgsProjectionSelectionWidget();
 
   // possibly we should expose this for parameter by parameter control
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   if ( const QgsProcessingParameterCrs *crsParam = dynamic_cast<const QgsProcessingParameterCrs *>( definition ) )
     mCrsSelector->setCrs( QgsProcessingParameters::parameterAsCrs( crsParam, crsParam->defaultValueForGui(), context ) );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -252,6 +252,10 @@ QgsProcessingCrsParameterDefinitionWidget::QgsProcessingCrsParameterDefinitionWi
   vlayout->addWidget( new QLabel( tr( "Default value" ) ) );
 
   mCrsSelector = new QgsProjectionSelectionWidget();
+
+  // possibly we should expose this for parameter by parameter control
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
+
   if ( const QgsProcessingParameterCrs *crsParam = dynamic_cast<const QgsProcessingParameterCrs *>( definition ) )
     mCrsSelector->setCrs( QgsProcessingParameters::parameterAsCrs( crsParam, crsParam->defaultValueForGui(), context ) );
   else

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -100,7 +100,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mFeatureIdColumnEdit->setPlaceholderText( QStringLiteral( DEFAULT_OGR_FID_COLUMN_TITLE ) );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text Data" ), "text" );
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number (integer)" ), "integer" );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -100,7 +100,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mFeatureIdColumnEdit->setPlaceholderText( QStringLiteral( DEFAULT_OGR_FID_COLUMN_TITLE ) );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text Data" ), "text" );
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number (integer)" ), "integer" );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -100,6 +100,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mFeatureIdColumnEdit->setPlaceholderText( QStringLiteral( DEFAULT_OGR_FID_COLUMN_TITLE ) );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
 
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text Data" ), "text" );
   mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number (integer)" ), "integer" );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -80,7 +80,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
   mCrsSelector->setEnabled( false );
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text" ), "string" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number" ), "integer" );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -80,6 +80,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
   mCrsSelector->setEnabled( false );
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
 
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text" ), "string" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number" ), "integer" );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -80,7 +80,7 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mGeometryWithZCheckBox->setEnabled( false );
   mGeometryWithMCheckBox->setEnabled( false );
   mCrsSelector->setEnabled( false );
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), tr( "Text" ), "string" );
   mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), tr( "Whole Number" ), "integer" );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -87,7 +87,7 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
     mFileFormatLabel->setVisible( false );
   }
 
-  mCrsSelector->showAccuracyWarnings( true );
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   mFileFormatComboBox->setCurrentIndex( 0 );
 

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -87,6 +87,8 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
     mFileFormatLabel->setVisible( false );
   }
 
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
+
   mFileFormatComboBox->setCurrentIndex( 0 );
 
   mFileEncoding->addItems( QgsVectorDataProvider::availableEncodings() );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -87,7 +87,7 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
     mFileFormatLabel->setVisible( false );
   }
 
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   mFileFormatComboBox->setCurrentIndex( 0 );
 

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -137,7 +137,7 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
     validate();
   } );
 
-  mCrs->setShowDatumEnsembleWarnings( true );
+  mCrs->showAccuracyWarnings( true );
 
   // geometry types
   const bool hasSinglePart { conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePart ) };

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -137,6 +137,8 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
     validate();
   } );
 
+  mCrs->setShowDatumEnsembleWarnings( true );
+
   // geometry types
   const bool hasSinglePart { conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePart ) };
 

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -137,7 +137,7 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
     validate();
   } );
 
-  mCrs->showAccuracyWarnings( true );
+  mCrs->setShowAccuracyWarnings( true );
 
   // geometry types
   const bool hasSinglePart { conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePart ) };

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -67,7 +67,7 @@ QgsProjectionSelectionWidget::QgsProjectionSelectionWidget( QWidget *parent )
   warningLayout->insertWidget( 1, mWarningLabel );
   mWarningLabelContainer->setLayout( warningLayout );
   layout->addWidget( mWarningLabelContainer );
-  updateWarning();
+  mWarningLabelContainer->hide();
 
   layout->addSpacing( labelMargin / 2 );
 

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -22,18 +22,20 @@
 #include "qgssettings.h"
 #include "qgshighlightablecombobox.h"
 #include "qgscoordinatereferencesystemregistry.h"
+#include "qgsdatums.h"
 
 QgsProjectionSelectionWidget::QgsProjectionSelectionWidget( QWidget *parent )
   : QWidget( parent )
 {
-  QHBoxLayout *layout = new QHBoxLayout();
-  layout->setContentsMargins( 0, 0, 0, 0 );
-  layout->setSpacing( 6 );
-  setLayout( layout );
-
   mCrsComboBox = new QgsHighlightableComboBox( this );
   mCrsComboBox->addItem( tr( "invalid projection" ), QgsProjectionSelectionWidget::CurrentCrs );
   mCrsComboBox->setSizePolicy( QSizePolicy::Ignored, QSizePolicy::Preferred );
+
+  const int labelMargin = static_cast< int >( std::round( mCrsComboBox->fontMetrics().horizontalAdvance( 'X' ) ) );
+  QHBoxLayout *layout = new QHBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->setSpacing( 0 );
+  setLayout( layout );
 
   mProjectCrs = QgsProject::instance()->crs();
   addProjectCrsOption();
@@ -49,7 +51,25 @@ QgsProjectionSelectionWidget::QgsProjectionSelectionWidget( QWidget *parent )
 
   addRecentCrs();
 
-  layout->addWidget( mCrsComboBox );
+  layout->addWidget( mCrsComboBox, 1 );
+
+  // bit of fiddlyness here -- we want the initial spacing to only be visible
+  // when the warning label is shown, so it's embedded inside mWarningLabel
+  // instead of outside it
+  mWarningLabelContainer = new QWidget();
+  QHBoxLayout *warningLayout = new QHBoxLayout();
+  warningLayout->setContentsMargins( 0, 0, 0, 0 );
+  mWarningLabel = new QLabel();
+  QIcon icon = QgsApplication::getThemeIcon( QStringLiteral( "mIconWarning.svg" ) );
+  const int size = static_cast< int >( std::max( 24.0, mCrsComboBox->minimumSize().height() * 0.5 ) );
+  mWarningLabel->setPixmap( icon.pixmap( icon.actualSize( QSize( size, size ) ) ) );
+  warningLayout->insertSpacing( 0, labelMargin / 2 );
+  warningLayout->insertWidget( 1, mWarningLabel );
+  mWarningLabelContainer->setLayout( warningLayout );
+  layout->addWidget( mWarningLabelContainer );
+  updateWarning();
+
+  layout->addSpacing( labelMargin / 2 );
 
   mButton = new QToolButton( this );
   mButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSetProjection.svg" ) ) );
@@ -269,6 +289,20 @@ void QgsProjectionSelectionWidget::dropEvent( QDropEvent *event )
   update();
 }
 
+bool QgsProjectionSelectionWidget::showDatumEnsembleWarnings() const
+{
+  return mShowDatumEnsembleWarnings;
+}
+
+void QgsProjectionSelectionWidget::setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings )
+{
+  mShowDatumEnsembleWarnings = showDatumEnsembleWarnings;
+  if ( !mShowDatumEnsembleWarnings )
+    mWarningLabelContainer->hide();
+  else
+    updateWarning();
+}
+
 void QgsProjectionSelectionWidget::addNotSetOption()
 {
   mCrsComboBox->insertItem( 0, mNotSetText, QgsProjectionSelectionWidget::CrsNotSet );
@@ -305,6 +339,70 @@ void QgsProjectionSelectionWidget::comboIndexChanged( int idx )
       break;
   }
   updateTooltip();
+}
+
+void QgsProjectionSelectionWidget::updateWarning()
+{
+  if ( !mShowDatumEnsembleWarnings )
+  {
+    if ( mWarningLabelContainer->isVisible() )
+      mWarningLabelContainer->hide();
+    return;
+  }
+
+  try
+  {
+    const QgsDatumEnsemble ensemble = crs().datumEnsemble();
+    if ( !ensemble.isValid() )
+    {
+      mWarningLabelContainer->hide();
+    }
+    else
+    {
+      mWarningLabelContainer->show();
+
+      QString warning = QStringLiteral( "<p>" );
+
+      QString id;
+      if ( !ensemble.code().isEmpty() )
+        id = QStringLiteral( "<i>%1</i> (%2:%3)" ).arg( ensemble.name(), ensemble.authority(), ensemble.code() );
+      else
+        id = QStringLiteral( "<i>%</i>”" ).arg( ensemble.name() );
+
+      if ( ensemble.accuracy() > 0 )
+      {
+        warning = tr( "The selected CRS is based on %1, which has a limited accuracy of <b>at best %2 meters</b>." ).arg( id ).arg( ensemble.accuracy() );
+      }
+      else
+      {
+        warning = tr( "The selected CRS is based on %1, which has a limited accuracy." ).arg( id );
+      }
+      warning += QStringLiteral( "</p><p>" ) + tr( "Use an alternative CRS if accurate positioning is required." ) + QStringLiteral( "</p>" );
+
+      const QList< QgsDatumEnsembleMember > members = ensemble.members();
+      if ( !members.isEmpty() )
+      {
+        warning += QStringLiteral( "<p>" ) + tr( "%1 consists of the datums:" ).arg( ensemble.name() ) + QStringLiteral( "</p><ul>" );
+
+        for ( const QgsDatumEnsembleMember &member : members )
+        {
+          if ( !member.code().isEmpty() )
+            id = QStringLiteral( "%1 (%2:%3)" ).arg( member.name(), member.authority(), member.code() );
+          else
+            id = member.name();
+          warning += QStringLiteral( "<li>%1</li>" ).arg( id );
+        }
+
+        warning += QStringLiteral( "</ul>" );
+      }
+
+      mWarningLabel->setToolTip( warning );
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+    mWarningLabelContainer->hide();
+  }
 }
 
 void QgsProjectionSelectionWidget::setCrs( const QgsCoordinateReferenceSystem &crs )
@@ -439,6 +537,7 @@ void QgsProjectionSelectionWidget::updateTooltip()
     setToolTip( c.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED, true ) );
   else
     setToolTip( QString() );
+  updateWarning();
 }
 
 QgsMapLayer *QgsProjectionSelectionWidget::mapLayerFromMimeData( const QMimeData *data ) const

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -289,6 +289,20 @@ void QgsProjectionSelectionWidget::dropEvent( QDropEvent *event )
   update();
 }
 
+QString QgsProjectionSelectionWidget::sourceEnsemble() const
+{
+  return mSourceEnsemble;
+}
+
+void QgsProjectionSelectionWidget::setSourceEnsemble( const QString &ensemble )
+{
+  if ( mSourceEnsemble == ensemble )
+    return;
+
+  mSourceEnsemble = ensemble;
+  updateWarning();
+}
+
 bool QgsProjectionSelectionWidget::showAccuracyWarnings() const
 {
   return mShowAccuracyWarnings;
@@ -353,7 +367,7 @@ void QgsProjectionSelectionWidget::updateWarning()
   try
   {
     const QgsDatumEnsemble ensemble = crs().datumEnsemble();
-    if ( !ensemble.isValid() )
+    if ( !ensemble.isValid() || ensemble.name() == mSourceEnsemble )
     {
       mWarningLabelContainer->hide();
     }

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -366,8 +366,10 @@ void QgsProjectionSelectionWidget::updateWarning()
 
   try
   {
+    const double crsAccuracyWarningThreshold = QgsSettings().value( QStringLiteral( "/projections/crsAccuracyWarningThreshold" ), 0.0, QgsSettings::App ).toDouble();
+
     const QgsDatumEnsemble ensemble = crs().datumEnsemble();
-    if ( !ensemble.isValid() || ensemble.name() == mSourceEnsemble )
+    if ( !ensemble.isValid() || ensemble.name() == mSourceEnsemble || ( ensemble.accuracy() > 0 && ensemble.accuracy() < crsAccuracyWarningThreshold ) )
     {
       mWarningLabelContainer->hide();
     }

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -294,7 +294,7 @@ bool QgsProjectionSelectionWidget::showAccuracyWarnings() const
   return mShowAccuracyWarnings;
 }
 
-void QgsProjectionSelectionWidget::showAccuracyWarnings( bool show )
+void QgsProjectionSelectionWidget::setShowAccuracyWarnings( bool show )
 {
   mShowAccuracyWarnings = show;
   if ( !mShowAccuracyWarnings )

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -289,15 +289,15 @@ void QgsProjectionSelectionWidget::dropEvent( QDropEvent *event )
   update();
 }
 
-bool QgsProjectionSelectionWidget::showDatumEnsembleWarnings() const
+bool QgsProjectionSelectionWidget::showAccuracyWarnings() const
 {
-  return mShowDatumEnsembleWarnings;
+  return mShowAccuracyWarnings;
 }
 
-void QgsProjectionSelectionWidget::setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings )
+void QgsProjectionSelectionWidget::showAccuracyWarnings( bool show )
 {
-  mShowDatumEnsembleWarnings = showDatumEnsembleWarnings;
-  if ( !mShowDatumEnsembleWarnings )
+  mShowAccuracyWarnings = show;
+  if ( !mShowAccuracyWarnings )
     mWarningLabelContainer->hide();
   else
     updateWarning();
@@ -343,7 +343,7 @@ void QgsProjectionSelectionWidget::comboIndexChanged( int idx )
 
 void QgsProjectionSelectionWidget::updateWarning()
 {
-  if ( !mShowDatumEnsembleWarnings )
+  if ( !mShowAccuracyWarnings )
   {
     if ( mWarningLabelContainer->isVisible() )
       mWarningLabelContainer->hide();

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -174,7 +174,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     QString mNotSetText;
     QString mMessage;
 
-    bool mShowDatumEnsembleWarnings = true;
+    bool mShowDatumEnsembleWarnings = false;
     QWidget *mWarningLabelContainer = nullptr;
     QLabel *mWarningLabel = nullptr;
 

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -105,7 +105,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      * Returns TRUE if the widget will show a warning to users when they select a CRS which has
      * low accuracy.
      *
-     * \see showAccuracyWarnings()
+     * \see setShowAccuracyWarnings()
      * \since QGIS 3.20
      */
     bool showAccuracyWarnings() const;
@@ -117,7 +117,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      * \see showAccuracyWarnings()
      * \since QGIS 3.20
      */
-    void showAccuracyWarnings( bool show );
+    void setShowAccuracyWarnings( bool show );
 
   signals:
 

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -119,6 +119,28 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      */
     void setShowAccuracyWarnings( bool show );
 
+    /**
+     * Sets the original source \a ensemble datum name.
+     *
+     * If set, CRS accuracy warnings will not be shown when the selected CRS in the widget has a matching
+     * ensemble datum, regardless of the ensemble's accuracy.
+     *
+     * \see sourceEnsemble()
+     * \since QGIS 3.20
+     */
+    void setSourceEnsemble( const QString &ensemble );
+
+    /**
+     * Returns the original source ensemble datum name.
+     *
+     * If set, CRS accuracy warnings will not be shown when the selected CRS in the widget has a matching
+     * ensemble datum, regardless of the ensemble's accuracy.
+     *
+     * \see setSourceEnsemble()
+     * \since QGIS 3.20
+     */
+    QString sourceEnsemble() const;
+
   signals:
 
     /**
@@ -171,6 +193,8 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     QString mMessage;
 
     bool mShowAccuracyWarnings = false;
+    QString mSourceEnsemble;
+
     QWidget *mWarningLabelContainer = nullptr;
     QLabel *mWarningLabel = nullptr;
 

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -28,6 +28,7 @@
 
 class QgsProjectionSelectionDialog;
 class QgsHighlightableComboBox;
+class QLabel;
 
 /**
  * \class QgsProjectionSelectionWidget
@@ -100,6 +101,28 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      */
     static QString crsOptionText( const QgsCoordinateReferenceSystem &crs ) SIP_SKIP;
 
+    /**
+     * Returns TRUE if the widget will show a warning to users when they select a CRS which uses
+     * a datum ensemble.
+     *
+     * \warning Determining datum ensembles requires PROJ 8.0 or later.
+     *
+     * \see setShowDatumEnsembleWarnings()
+     * \since QGIS 3.20
+     */
+    bool showDatumEnsembleWarnings() const;
+
+    /**
+     * Sets whether the widget will show a warning to users when they select a CRS which uses
+     * a datum ensemble.
+     *
+     * \warning Determining datum ensembles requires PROJ 8.0 or later.
+     *
+     * \see showDatumEnsembleWarnings()
+     * \since QGIS 3.20
+     */
+    void setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings );
+
   signals:
 
     /**
@@ -151,6 +174,10 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     QString mNotSetText;
     QString mMessage;
 
+    bool mShowDatumEnsembleWarnings = true;
+    QWidget *mWarningLabelContainer = nullptr;
+    QLabel *mWarningLabel = nullptr;
+
     void addNotSetOption();
     void addProjectCrsOption();
     void addDefaultCrsOption();
@@ -167,6 +194,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
   private slots:
 
     void comboIndexChanged( int idx );
+    void updateWarning();
 
 };
 

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -102,26 +102,22 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     static QString crsOptionText( const QgsCoordinateReferenceSystem &crs ) SIP_SKIP;
 
     /**
-     * Returns TRUE if the widget will show a warning to users when they select a CRS which uses
-     * a datum ensemble.
+     * Returns TRUE if the widget will show a warning to users when they select a CRS which has
+     * low accuracy.
      *
-     * \warning Determining datum ensembles requires PROJ 8.0 or later.
-     *
-     * \see setShowDatumEnsembleWarnings()
+     * \see showAccuracyWarnings()
      * \since QGIS 3.20
      */
-    bool showDatumEnsembleWarnings() const;
+    bool showAccuracyWarnings() const;
 
     /**
-     * Sets whether the widget will show a warning to users when they select a CRS which uses
-     * a datum ensemble.
+     * Sets whether the widget will \a show warnings to users when they select a CRS which has
+     * low accuracy.
      *
-     * \warning Determining datum ensembles requires PROJ 8.0 or later.
-     *
-     * \see showDatumEnsembleWarnings()
+     * \see showAccuracyWarnings()
      * \since QGIS 3.20
      */
-    void setShowDatumEnsembleWarnings( bool showDatumEnsembleWarnings );
+    void showAccuracyWarnings( bool show );
 
   signals:
 
@@ -174,7 +170,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     QString mNotSetText;
     QString mMessage;
 
-    bool mShowDatumEnsembleWarnings = false;
+    bool mShowAccuracyWarnings = false;
     QWidget *mWarningLabelContainer = nullptr;
     QLabel *mWarningLabel = nullptr;
 

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -32,6 +32,7 @@
 #include "qgsmessagelog.h"
 #include "qgsgui.h"
 #include "qgsdoublevalidator.h"
+#include "qgsdatums.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -140,7 +141,18 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
   // don't restore nodata, it needs user input
   // pyramids are not necessarily built every time
 
-  mCrsSelector->showAccuracyWarnings( true );
+  try
+  {
+    const QgsDatumEnsemble ensemble = mLayerCrs.datumEnsemble();
+    if ( ensemble.isValid() )
+    {
+      mCrsSelector->setSourceEnsemble( ensemble.name() );
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+  }
+  mCrsSelector->setShowAccuracyWarnings( true );
 
   mCrsSelector->setLayerCrs( mLayerCrs );
   //default to layer CRS - see https://github.com/qgis/QGIS/issues/22211 for discussion

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -140,6 +140,8 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
   // don't restore nodata, it needs user input
   // pyramids are not necessarily built every time
 
+  mCrsSelector->setShowDatumEnsembleWarnings( true );
+
   mCrsSelector->setLayerCrs( mLayerCrs );
   //default to layer CRS - see https://github.com/qgis/QGIS/issues/22211 for discussion
   mCrsSelector->setCrs( mLayerCrs );

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -140,7 +140,7 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
   // don't restore nodata, it needs user input
   // pyramids are not necessarily built every time
 
-  mCrsSelector->setShowDatumEnsembleWarnings( true );
+  mCrsSelector->showAccuracyWarnings( true );
 
   mCrsSelector->setLayerCrs( mLayerCrs );
   //default to layer CRS - see https://github.com/qgis/QGIS/issues/22211 for discussion

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1760,6 +1760,13 @@
                 </widget>
                </item>
                <item row="5" column="0">
+                <widget class="QCheckBox" name="mPlanimetricMeasurementsComboBox">
+                 <property name="text">
+                  <string>Planimetric measurements</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
                 <spacer name="verticalSpacer">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
@@ -1825,10 +1832,45 @@
                 </widget>
                </item>
                <item row="4" column="0">
-                <widget class="QCheckBox" name="mPlanimetricMeasurementsComboBox">
-                 <property name="text">
-                  <string>Planimetric measurements</string>
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_26">
+                 <property name="title">
+                  <string>Accuracy Warnings</string>
                  </property>
+                 <layout class="QGridLayout" name="gridLayout_37" columnstretch="0,1,2">
+                  <item row="0" column="1">
+                   <widget class="QgsDoubleSpinBox" name="mCrsAccuracySpin">
+                    <property name="toolTip">
+                     <string>If the inherent inaccuracy in a selected CRS exceeds this threshold a warning message will be shown</string>
+                    </property>
+                    <property name="suffix">
+                     <string> meters</string>
+                    </property>
+                    <property name="maximum">
+                     <double>10000.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_71">
+                    <property name="text">
+                     <string>Only show CRS accuracy warnings for inaccuracies which exceed</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <spacer name="horizontalSpacer_23">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>


### PR DESCRIPTION
Shows a warning in the projection selection widget when a CRS based on a datum ensemble is selected, warning the user that
there's an inherent lack of accuracy in the selected CRS

Requires PROJ 8+


https://user-images.githubusercontent.com/1829991/117229831-1efdae80-ae5f-11eb-8b18-8158aa97ebef.mp4

