### PR TITLE
Add utility function QgsSymbolLayerUtils::condenseFillAndOutline

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -684,6 +684,20 @@ Converts a QColor into a premultiplied ARGB QColor value using a specified alpha
 .. versionadded:: 2.3
 %End
 
+    static bool condenseFillAndOutline( QgsFillSymbolLayer *fill, QgsLineSymbolLayer *outline );
+%Docstring
+Attempts to condense a ``fill`` and ``outline`` layer, by moving the outline layer to the
+fill symbol's stroke.
+
+This will only be done if the ``outline`` can be transformed into a stroke on the fill layer
+losslessly. If so, ``fill`` will be updated in place with the new stroke. Any existing stroke
+settings in ``fill`` will be replaced.
+
+Returns ``True`` if the fill and outline were successfully condensed.
+
+.. versionadded:: 3.20
+%End
+
     static void sortVariantList( QList<QVariant> &list, Qt::SortOrder order );
 %Docstring
 Sorts the passed list in requested order

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -623,6 +623,20 @@ class CORE_EXPORT QgsSymbolLayerUtils
      */
     static void premultiplyColor( QColor &rgb, int alpha );
 
+    /**
+     * Attempts to condense a \a fill and \a outline layer, by moving the outline layer to the
+     * fill symbol's stroke.
+     *
+     * This will only be done if the \a outline can be transformed into a stroke on the fill layer
+     * losslessly. If so, \a fill will be updated in place with the new stroke. Any existing stroke
+     * settings in \a fill will be replaced.
+     *
+     * Returns TRUE if the fill and outline were successfully condensed.
+     *
+     * \since QGIS 3.20
+     */
+    static bool condenseFillAndOutline( QgsFillSymbolLayer *fill, QgsLineSymbolLayer *outline );
+
     //! Sorts the passed list in requested order
     static void sortVariantList( QList<QVariant> &list, Qt::SortOrder order );
     //! Returns a point on the line from startPoint to directionPoint that is a certain distance away from the starting point

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -30,7 +30,14 @@ from qgis.core import (
     QgsArrowSymbolLayer,
     QgsUnitTypes,
     QgsRenderChecker,
-    QgsGradientColorRamp
+    QgsGradientColorRamp,
+    QgsShapeburstFillSymbolLayer,
+    QgsMarkerLineSymbolLayer,
+    QgsSimpleLineSymbolLayer,
+    QgsSimpleFillSymbolLayer,
+    QgsSymbolLayer,
+    QgsProperty,
+    QgsMapUnitScale
 )
 from qgis.testing import unittest, start_app
 
@@ -469,6 +476,77 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
         pix = QgsSymbolLayerUtils.colorRampPreviewPixmap(r, QSize(100, 200), direction=Qt.Vertical, flipDirection=True)
         img = QImage(pix)
         self.assertTrue(self.imageCheck('color_ramp_vertical_flipped', 'color_ramp_vertical_flipped', img))
+
+    def testCondenseFillAndOutline(self):
+        """
+        Test QgsSymbolLayerUtils.condenseFillAndOutline
+        """
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(None, None))
+
+        # not simple fill or line
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(QgsShapeburstFillSymbolLayer(), QgsSimpleLineSymbolLayer()))
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(QgsSimpleFillSymbolLayer(), QgsMarkerLineSymbolLayer()))
+
+        # simple fill/line
+        fill = QgsSimpleFillSymbolLayer()
+        line = QgsSimpleLineSymbolLayer()
+
+        # set incompatible settings on outline
+        line.setUseCustomDashPattern(True)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setDashPatternOffset(1)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setAlignDashPattern(True)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setTweakDashPatternOnCorners(True)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setTrimDistanceStart(1)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setTrimDistanceEnd(1)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setDrawInsidePolygon(True)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setRingFilter(QgsSimpleLineSymbolLayer.ExteriorRingOnly)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setOffset(1)
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        line = QgsSimpleLineSymbolLayer()
+        line.setDataDefinedProperty(QgsSymbolLayer.PropertyTrimEnd, QgsProperty.fromValue(4))
+        self.assertFalse(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        # compatible!
+        line = QgsSimpleLineSymbolLayer()
+        line.setColor(QColor(255, 0, 0))
+        line.setWidth(1.2)
+        line.setWidthUnit(QgsUnitTypes.RenderPoints)
+        line.setWidthMapUnitScale(QgsMapUnitScale(1, 2))
+        line.setPenJoinStyle(Qt.MiterJoin)
+        line.setPenStyle(Qt.DashDotDotLine)
+        self.assertTrue(QgsSymbolLayerUtils.condenseFillAndOutline(fill, line))
+
+        self.assertEqual(fill.strokeColor(), QColor(255, 0, 0))
+        self.assertEqual(fill.strokeWidth(), 1.2)
+        self.assertEqual(fill.strokeWidthUnit(), QgsUnitTypes.RenderPoints)
+        self.assertEqual(fill.strokeWidthMapUnitScale(), QgsMapUnitScale(1, 2))
+        self.assertEqual(fill.penJoinStyle(), Qt.MiterJoin)
+        self.assertEqual(fill.strokeStyle(), Qt.DashDotDotLine)
 
     def imageCheck(self, name, reference_image, image):
         self.report += "<h2>Render {}</h2>\n".format(name)


### PR DESCRIPTION
Attempts to condense a fill and outline layer, by moving the outline layer to the fill symbol's stroke if possible.
