### PR TITLE
Fix QTextStream encode with UTF-8

### DIFF
--- a/src/analysis/interpolation/qgsgridfilewriter.cpp
+++ b/src/analysis/interpolation/qgsgridfilewriter.cpp
@@ -48,6 +48,9 @@ int QgsGridFileWriter::writeFile( QgsFeedback *feedback )
   }
 
   QTextStream outStream( &outputFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  outStream.setCodec( "UTF-8" );
+#endif
   outStream.setRealNumberPrecision( 8 );
   writeHeader( outStream );
 

--- a/src/analysis/processing/qgsalgorithmexportmesh.cpp
+++ b/src/analysis/processing/qgsalgorithmexportmesh.cpp
@@ -1276,10 +1276,13 @@ QVariantMap QgsMeshExportCrossSection::processAlgorithm( const QVariantMap &para
 
   QString outputFileName = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
   QFile file( outputFileName );
-  if ( ! file.open( QIODevice::WriteOnly ) )
+  if ( ! file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     throw QgsProcessingException( QObject::tr( "Unable to create the outputfile" ) );
 
   QTextStream textStream( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  textStream.setCodec( "UTF-8" );
+#endif
   QStringList header;
   header << QStringLiteral( "fid" ) << QStringLiteral( "x" ) << QStringLiteral( "y" ) << QObject::tr( "offset" );
   for ( const DataGroup &datagroup : mDataPerGroup )
@@ -1588,10 +1591,13 @@ QVariantMap QgsMeshExportTimeSeries::processAlgorithm( const QVariantMap &parame
 
   QString outputFileName = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
   QFile file( outputFileName );
-  if ( ! file.open( QIODevice::WriteOnly ) )
+  if ( ! file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     throw QgsProcessingException( QObject::tr( "Unable to create the outputfile" ) );
 
   QTextStream textStream( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  textStream.setCodec( "UTF-8" );
+#endif
   QStringList header;
   header << QStringLiteral( "fid" ) << QStringLiteral( "x" ) << QStringLiteral( "y" ) << QObject::tr( "time" );
 

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
@@ -134,7 +134,7 @@ QVariantMap QgsNearestNeighbourAnalysisAlgorithm::processAlgorithm( const QVaria
   if ( !outputFile.isEmpty() )
   {
     QFile file( outputFile );
-    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream out( &file );
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -329,10 +329,13 @@ QVariantMap QgsPointsToPathsAlgorithm::processAlgorithm( const QVariantMap &para
     {
       const QString filename = QDir( textDir ).filePath( hit.key().toString() + QString( ".txt" ) );
       QFile textFile( filename );
-      if ( !textFile.open( QIODevice::WriteOnly | QIODevice::Text ) )
+      if ( !textFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
         throw QgsProcessingException( QObject::tr( "Cannot open file for writing " ) + filename );
 
       QTextStream out( &textFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+      out.setCodec( "UTF-8" );
+#endif
       out << QString( "angle=Azimuth\n"
                       "heading=Coordinate_System\n"
                       "dist_units=Default\n"

--- a/src/analysis/processing/qgsalgorithmrasterlayerproperties.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayerproperties.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsalgorithmrasterlayerproperties.h"
 #include "qgsstringutils.h"
-#include <QTextStream>
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -180,7 +180,7 @@ QVariantMap QgsRasterLayerUniqueValuesReportAlgorithm::processAlgorithm( const Q
   if ( !outputFile.isEmpty() )
   {
     QFile file( outputFile );
-    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       const QString encodedAreaUnit = QgsStringUtils::ampersandEncode( areaUnit );
 

--- a/src/analysis/processing/qgsalgorithmrasterstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterstatistics.cpp
@@ -100,7 +100,7 @@ QVariantMap QgsRasterStatisticsAlgorithm::processAlgorithm( const QVariantMap &p
   if ( !outputFile.isEmpty() )
   {
     QFile file( outputFile );
-    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream out( &file );
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/analysis/processing/qgsalgorithmrastersurfacevolume.cpp
+++ b/src/analysis/processing/qgsalgorithmrastersurfacevolume.cpp
@@ -216,7 +216,7 @@ QVariantMap QgsRasterSurfaceVolumeAlgorithm::processAlgorithm( const QVariantMap
   if ( !outputFile.isEmpty() )
   {
     QFile file( outputFile );
-    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       const QString encodedAreaUnit = QgsStringUtils::ampersandEncode( areaUnit );
 

--- a/src/analysis/processing/qgsalgorithmsavelog.cpp
+++ b/src/analysis/processing/qgsalgorithmsavelog.cpp
@@ -84,6 +84,9 @@ QVariantMap QgsSaveLogToFileAlgorithm::processAlgorithm( const QVariantMap &para
       throw QgsProcessingException( QObject::tr( "Could not save log to file %1" ).arg( file ) );
     }
     QTextStream fout( &exportFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    fout.setCodec( "UTF-8" );
+#endif
     fout << ( useHtml ? feedback->htmlLog() : feedback->textLog() );
   }
   QVariantMap res;

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -543,6 +543,9 @@ bool QgsRelief::exportFrequencyDistributionToCsv( const QString &file )
   }
 
   QTextStream outstream( &outFile );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  outstream.setCodec( "UTF-8" );
+#endif
   for ( int i = 0; i < 252; ++i )
   {
     outstream << QString::number( i ) + ',' + QString::number( frequency[i] ) << endl;


### PR DESCRIPTION
Some alg output text files dont encode with UTF-8.  
And this PR is the same with #42544. And reference to #42514, Qt6 uses utf-8 by default.
![image](https://user-images.githubusercontent.com/55835958/117250931-86732880-ae76-11eb-84b2-6ae228d5242b.png)
![image](https://user-images.githubusercontent.com/55835958/117251237-f4b7eb00-ae76-11eb-9e63-f7a93a80b894.png)

Affected algorithms are:

- gridfilewriter
- exportmesh
- nearestneighbouranalysis
- pointstopaths
- rasterlayerproperties
- rasterlayeruniquevalues
- rasterstatistics
- rastersurfacevolume
- savelog