### PR TITLE
[vector file writer] Fix another FID corner scenario (fixes #34613)

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -237,6 +237,23 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     mOgrDriverName = driverName;
   }
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,3,1)
+  QString fidFieldName;
+  if ( mOgrDriverName == QLatin1String( "GPKG" ) )
+  {
+    for ( const QString &layerOption : layerOptions )
+    {
+      if ( layerOption.startsWith( QStringLiteral( "FID=" ) ) )
+      {
+        fidFieldName = layerOption.mid( 4 );
+        break;
+      }
+    }
+    if ( fidFieldName.isEmpty() )
+      fidFieldName = QStringLiteral( "fid" );
+  }
+#endif
+
   // find driver in OGR
   OGRSFDriverH poDriver;
   QgsApplication::registerOgrDrivers();
@@ -650,6 +667,14 @@ void QgsVectorFileWriter::init( QString vectorFileName,
             break;
 
           case QVariant::Double:
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,3,1)
+            if ( mOgrDriverName == QLatin1String( "GPKG" ) && attrField.precision() == 0 && attrField.name().compare( fidFieldName, Qt::CaseInsensitive ) == 0 )
+            {
+              // Convert field to match required FID type
+              ogrType = OFTInteger64;
+              break;
+            }
+#endif
             ogrType = OFTReal;
             break;
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -1297,6 +1297,25 @@ class PyQgsOGRProvider(unittest.TestCase):
         vl = QgsVectorLayer(os.path.join(d.path(), 'writetest.shp'))
         self.assertEqual(vl.featureCount(), 1)
 
+    def testFidDoubleSaveAsGeopackage(self):
+        """Test issue GH #25795"""
+
+        ml = QgsVectorLayer('Point?crs=epsg:4326&field=fid:double(20,0)', 'test', 'memory')
+        self.assertTrue(ml.isValid())
+        self.assertEqual(ml.fields()[0].type(), QVariant.Double)
+
+        d = QTemporaryDir()
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'fid_double_test'
+        err, _ = QgsVectorFileWriter.writeAsVectorFormatV2(ml, os.path.join(d.path(), 'fid_double_test.gpkg'),
+                                                           QgsCoordinateTransformContext(), options)
+        self.assertEqual(err, QgsVectorFileWriter.NoError)
+        self.assertTrue(os.path.isfile(os.path.join(d.path(), 'fid_double_test.gpkg')))
+
+        vl = QgsVectorLayer(os.path.join(d.path(), 'fid_double_test.gpkg'))
+        self.assertEqual(vl.fields()[0].type(), QVariant.LongLong)
+
     def testNonGeopackageSaveMetadata(self):
         """
         Save layer metadata for a file-based format which doesn't have native metadata support.


### PR DESCRIPTION
## Description

Our old friend FID coming in to complicate things, again.

This PR fixes a corner scenario whereas a user is trying to convert a non-geopackage dataset with a pre-existing FID field to  geopackage which would fail when the FID field was not set to integer. This could easily happen when someone saves an original geopackage as shapefile - which would transform the integer field to double field with precision 0 - and then back to geopackage.

It fixes #25795 and #34613.