### PR TITLE
[Processing] Fix getParameterFromString to get Vector Layer data types like Feature Source

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -116,7 +116,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = [int(p) for p in params[2].split(';')]
-                    except:
+                    except ValueError:
                         params[2] = [getattr(QgsProcessing, p.split(".")[1]) for p in params[2].split(';')]
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
@@ -125,7 +125,7 @@ def getParameterFromString(s, context=''):
                     params[3] = True if params[3].lower() == 'true' else False
                     try:
                         params[4] = [int(p) for p in params[4].split(';')]
-                    except:
+                    except ValueError:
                         params[4] = [getattr(QgsProcessing, p.split(".")[1]) for p in params[4].split(';')]
             elif clazz == QgsProcessingParameterBoolean:
                 if len(params) > 2:
@@ -141,7 +141,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 4:
                     try:
                         params[4] = [int(p) for p in params[4].split(';')]
-                    except:
+                    except ValueError:
                         params[4] = [getattr(QgsWkbTypes, p.split(".")[1]) for p in params[4].split(';')]
                 if len(params) > 5:
                     params[5] = True if params[5].lower() == 'true' else False
@@ -152,7 +152,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = int(params[2])
-                    except:
+                    except ValueError:
                         params[2] = getattr(QgsProcessingParameterNumber, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
@@ -179,7 +179,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = [int(p) for p in params[2].split(';')]
-                    except:
+                    except ValueError:
                         params[2] = [getattr(QgsProcessing, p.split(".")[1]) for p in params[2].split(';')]
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
@@ -187,7 +187,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = int(params[2])
-                    except:
+                    except ValueError:
                         params[2] = getattr(QgsProcessing, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
@@ -204,7 +204,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 4:
                     try:
                         params[4] = int(params[4])
-                    except:
+                    except ValueError:
                         params[4] = getattr(QgsProcessingParameterField, params[4].split(".")[1])
                 if len(params) > 5:
                     params[5] = True if params[5].lower() == 'true' else False
@@ -216,7 +216,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = int(params[2])
-                    except:
+                    except ValueError:
                         params[2] = getattr(QgsProcessingParameterFile, params[2].split(".")[1])
                 if len(params) > 5:
                     params[5] = True if params[5].lower() == 'true' else False
@@ -224,7 +224,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = int(params[2])
-                    except:
+                    except ValueError:
                         params[2] = getattr(QgsProcessingParameterNumber, params[2].split(".")[1])
                 if len(params) > 3:
                     params[3] = float(params[3].strip()) if params[3] is not None else None
@@ -263,7 +263,7 @@ def getParameterFromString(s, context=''):
                 if len(params) > 2:
                     try:
                         params[2] = int(params[2])
-                    except:
+                    except ValueError:
                         params[2] = getattr(QgsProcessing, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -114,7 +114,10 @@ def getParameterFromString(s, context=''):
                     params[5] = True if params[5].lower() == 'true' else False
             elif clazz == QgsProcessingParameterVectorLayer:
                 if len(params) > 2:
-                    params[2] = [int(p) for p in params[2].split(';')]
+                    try:
+                        params[2] = [int(p) for p in params[2].split(';')]
+                    except:
+                        params[2] = [getattr(QgsProcessing, p.split(".")[1]) for p in params[2].split(';')]
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
             elif clazz == QgsProcessingParameterMapLayer:

--- a/python/plugins/processing/tests/ParametersTest.py
+++ b/python/plugins/processing/tests/ParametersTest.py
@@ -619,17 +619,15 @@ class ParametersTest(unittest.TestCase):
         self.assertIsNone(param.defaultValue())
         self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
-        # QgsProcessingParameterVectorLayer multi data types does not work
-        # as QgsProcessingParameterFeatureSource
-        # desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorPoint'
-        # param = getParameterFromString(desc)
-        # self.assertIsNotNone(param)
-        # self.assertEqual(param.type(), 'vector')
-        # self.assertEqual(param.name(), 'in_vector')
-        # self.assertEqual(param.description(), 'Input Vector')
-        # self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorPoint])
-        # self.assertIsNone(param.defaultValue())
-        # self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorPoint'
+        param = getParameterFromString(desc)
+        self.assertIsNotNone(param)
+        self.assertEqual(param.type(), 'vector')
+        self.assertEqual(param.name(), 'in_vector')
+        self.assertEqual(param.description(), 'Input Vector')
+        self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorPoint])
+        self.assertIsNone(param.defaultValue())
+        self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
         desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|1'
         param = getParameterFromString(desc)
@@ -641,17 +639,15 @@ class ParametersTest(unittest.TestCase):
         self.assertIsNone(param.defaultValue())
         self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
-        # QgsProcessingParameterVectorLayer multi data types does not work
-        # as QgsProcessingParameterFeatureSource
-        # desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorLine'
-        # param = getParameterFromString(desc)
-        # self.assertIsNotNone(param)
-        # self.assertEqual(param.type(), 'vector')
-        # self.assertEqual(param.name(), 'in_vector')
-        # self.assertEqual(param.description(), 'Input Vector')
-        # self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorLine])
-        # self.assertIsNone(param.defaultValue())
-        # self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorLine'
+        param = getParameterFromString(desc)
+        self.assertIsNotNone(param)
+        self.assertEqual(param.type(), 'vector')
+        self.assertEqual(param.name(), 'in_vector')
+        self.assertEqual(param.description(), 'Input Vector')
+        self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorLine])
+        self.assertIsNone(param.defaultValue())
+        self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
         desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|2'
         param = getParameterFromString(desc)
@@ -663,17 +659,15 @@ class ParametersTest(unittest.TestCase):
         self.assertIsNone(param.defaultValue())
         self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
-        # QgsProcessingParameterVectorLayer multi data types does not work
-        # as QgsProcessingParameterFeatureSource
-        # desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorPolygon'
-        # param = getParameterFromString(desc)
-        # self.assertIsNotNone(param)
-        # self.assertEqual(param.type(), 'vector')
-        # self.assertEqual(param.name(), 'in_vector')
-        # self.assertEqual(param.description(), 'Input Vector')
-        # self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorPolygon])
-        # self.assertIsNone(param.defaultValue())
-        # self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorPolygon'
+        param = getParameterFromString(desc)
+        self.assertIsNotNone(param)
+        self.assertEqual(param.type(), 'vector')
+        self.assertEqual(param.name(), 'in_vector')
+        self.assertEqual(param.description(), 'Input Vector')
+        self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorPolygon])
+        self.assertIsNone(param.defaultValue())
+        self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
         desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|5'
         param = getParameterFromString(desc)
@@ -685,17 +679,15 @@ class ParametersTest(unittest.TestCase):
         self.assertIsNone(param.defaultValue())
         self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
-        # QgsProcessingParameterVectorLayer multi data types does not work
-        # as QgsProcessingParameterFeatureSource
-        # desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVector'
-        # param = getParameterFromString(desc)
-        # self.assertIsNotNone(param)
-        # self.assertEqual(param.type(), 'vector')
-        # self.assertEqual(param.name(), 'in_vector')
-        # self.assertEqual(param.description(), 'Input Vector')
-        # self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVector])
-        # self.assertIsNone(param.defaultValue())
-        # self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVector'
+        param = getParameterFromString(desc)
+        self.assertIsNotNone(param)
+        self.assertEqual(param.type(), 'vector')
+        self.assertEqual(param.name(), 'in_vector')
+        self.assertEqual(param.description(), 'Input Vector')
+        self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVector])
+        self.assertIsNone(param.defaultValue())
+        self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
         desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|1;2'
         param = getParameterFromString(desc)
@@ -707,17 +699,15 @@ class ParametersTest(unittest.TestCase):
         self.assertIsNone(param.defaultValue())
         self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
-        # QgsProcessingParameterVectorLayer multi data types does not work
-        # as QgsProcessingParameterFeatureSource
-        # desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorLine;QgsProcessing.TypeVectorPolygon'
-        # param = getParameterFromString(desc)
-        # self.assertIsNotNone(param)
-        # self.assertEqual(param.type(), 'vector')
-        # self.assertEqual(param.name(), 'in_vector')
-        # self.assertEqual(param.description(), 'Input Vector')
-        # self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon])
-        # self.assertIsNone(param.defaultValue())
-        # self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|QgsProcessing.TypeVectorLine;QgsProcessing.TypeVectorPolygon'
+        param = getParameterFromString(desc)
+        self.assertIsNotNone(param)
+        self.assertEqual(param.type(), 'vector')
+        self.assertEqual(param.name(), 'in_vector')
+        self.assertEqual(param.description(), 'Input Vector')
+        self.assertListEqual(param.dataTypes(), [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon])
+        self.assertIsNone(param.defaultValue())
+        self.assertFalse(param.flags() & QgsProcessingParameterDefinition.FlagOptional)
 
         desc = 'QgsProcessingParameterVectorLayer|in_vector|Input Vector|-1|None|True'
         param = getParameterFromString(desc)


### PR DESCRIPTION
## Description

When writing tests for  #43075, I discovered that in Processing parameter description QgsProcessingParameterVectorLayer multi data types does not work as QgsProcessingParameterFeatureSource.
