### PR TITLE
fix expression help for operators and improve exception message

### DIFF
--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -4,6 +4,7 @@ import sys
 import os
 import json
 import glob
+from copy import deepcopy
 
 sys.path.append(
     os.path.join(
@@ -75,6 +76,9 @@ for f in sorted(glob.glob('resources/function_help/json/*')):
         for v in json_params['variants']:
             if 'arguments' not in v:
                 raise BaseException("%s: arguments expected for operator" % f)
+            a_list = list(deepcopy(v['arguments']))
+            if not 1 <= len(a_list) <= 2:
+                raise BaseException("%s: 1 or 2 arguments expected for operator found %i" % (f, len(a_list)))
 
     cpp.write("\n\n    functionHelpTexts().insert( QStringLiteral( {0} ),\n      Help( QStringLiteral( {0} ), tr( \"{1}\" ), tr( \"{2}\" ),\n        QList<HelpVariant>()".format(
         name, json_params['type'], json_params['description'])

--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -74,9 +74,7 @@ for f in sorted(glob.glob('resources/function_help/json/*')):
     if json_params['type'] == 'operator':
         for v in json_params['variants']:
             if 'arguments' not in v:
-                raise BaseException("%s: arguments expected for operator")
-            if len(list(v['arguments'])) < 1 or len(list(v['arguments'])) > 2:
-                raise BaseException("%s: 1 or 2 arguments expected for operator")
+                raise BaseException("%s: arguments expected for operator" % f)
 
     cpp.write("\n\n    functionHelpTexts().insert( QStringLiteral( {0} ),\n      Help( QStringLiteral( {0} ), tr( \"{1}\" ), tr( \"{2}\" ),\n        QList<HelpVariant>()".format(
         name, json_params['type'], json_params['description'])


### PR DESCRIPTION
Fixes broken expression help display for operators.

<strike>Unfortunately, we lose an exception, even if it is not a critical one. The problem is the Python function list(). Through this, only an empty set is iterated over in line 88. I am open for suggestions how we can count the number of arguments from the map object without affecting the following code...</strike>

fix #43080