### PR TITLE
 Factor common code of QgsMapToolAddCircle/Ellipse/Rectangle/RegularRectangle

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -150,6 +150,7 @@ set(QGIS_APP_SRCS
   qgsundowidget.cpp
   qgsmapthemes.cpp
   qgshandlebadlayers.cpp
+  qgsmaptooladdabstract.cpp
   qgsmaptooladdcircularstring.cpp
   qgsmaptoolcircularstringcurvepoint.cpp
   qgsmaptoolcircularstringradius.cpp

--- a/src/app/qgsmaptooladdabstract.cpp
+++ b/src/app/qgsmaptooladdabstract.cpp
@@ -1,0 +1,119 @@
+/***************************************************************************
+    qgsmaptooladdabstract.cpp  -  abstract class for map tools of the 'add' kind
+    ---------------------
+    begin                : July 2017
+    copyright            : (C) 2017
+    email                : lbartoletti at tuxfamily dot org
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptooladdabstract.h"
+#include "qgsgeometryrubberband.h"
+#include "qgsgeometryutils.h"
+#include "qgsmapcanvas.h"
+#include "qgspoint.h"
+#include "qgisapp.h"
+#include "qgssnapindicator.h"
+
+QgsMapToolAddAbstract::QgsMapToolAddAbstract( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode )
+  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), mode )
+  , mParentTool( parentTool )
+  , mSnapIndicator( std::make_unique< QgsSnapIndicator>( canvas ) )
+{
+  QgsMapToolAddAbstract::clean();
+
+  connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddAbstract::stopCapturing );
+  connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddAbstract::stopCapturing );
+}
+
+QgsMapToolAddAbstract::~QgsMapToolAddAbstract()
+{
+  QgsMapToolAddAbstract::clean();
+}
+
+void QgsMapToolAddAbstract::keyPressEvent( QKeyEvent *e )
+{
+  if ( e && e->isAutoRepeat() )
+  {
+    return;
+  }
+
+  if ( e && e->key() == Qt::Key_Escape )
+  {
+    clean();
+    if ( mParentTool )
+      mParentTool->keyPressEvent( e );
+  }
+
+  if ( e && e->key() == Qt::Key_Backspace )
+  {
+    if ( mPoints.size() == 1 )
+    {
+
+      if ( mTempRubberBand )
+      {
+        delete mTempRubberBand;
+        mTempRubberBand = nullptr;
+      }
+
+      mPoints.clear();
+    }
+    else if ( mPoints.size() > 1 )
+    {
+      mPoints.removeLast();
+
+    }
+    if ( mParentTool )
+      mParentTool->keyPressEvent( e );
+  }
+}
+
+void QgsMapToolAddAbstract::keyReleaseEvent( QKeyEvent *e )
+{
+  if ( e && e->isAutoRepeat() )
+  {
+    return;
+  }
+}
+
+void QgsMapToolAddAbstract::activate()
+{
+  clean();
+  QgsMapToolCapture::activate();
+}
+
+void QgsMapToolAddAbstract::clean()
+{
+  if ( mTempRubberBand )
+  {
+    delete mTempRubberBand;
+    mTempRubberBand = nullptr;
+  }
+
+  mPoints.clear();
+
+  if ( mParentTool )
+  {
+    mParentTool->deleteTempRubberBand();
+  }
+
+  QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( QgisApp::instance()->activeLayer() );
+  if ( vLayer )
+    mLayerType = vLayer->geometryType();
+}
+
+void QgsMapToolAddAbstract::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdabstract.h
+++ b/src/app/qgsmaptooladdabstract.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+    qgsmaptooladdabstract.h  -  abstract class for map tools of the 'add' kind
+    ---------------------
+    begin                : May 2017
+    copyright            : (C) 2017
+    email                : lbartoletti at tuxfamily dot org
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLADDABSTRACT_H
+#define QGSMAPTOOLADDABSTRACT_H
+
+#include "qgsmaptoolcapture.h"
+#include "qgsellipse.h"
+#include "qgssettingsregistrycore.h"
+#include "qgis_app.h"
+
+class QgsGeometryRubberBand;
+class QgsSnapIndicator;
+
+class APP_EXPORT QgsMapToolAddAbstract: public QgsMapToolCapture
+{
+    Q_OBJECT
+  public:
+    QgsMapToolAddAbstract( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode = CaptureLine );
+    ~QgsMapToolAddAbstract() override;
+
+    void keyPressEvent( QKeyEvent *e ) override;
+    void keyReleaseEvent( QKeyEvent *e ) override;
+
+    void deactivate() override = 0;
+
+    void activate() override;
+    void clean() override;
+
+  protected:
+    explicit QgsMapToolAddAbstract( QgsMapCanvas *canvas ) = delete; //forbidden
+
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
+    /**
+     * The parent map tool, e.g. the add feature tool.
+     * Completed geometry will be added to this tool by calling its toLineString() method.
+     */
+    QPointer<QgsMapToolCapture> mParentTool;
+    //! Ellipse points (in map coordinates)
+    QgsPointSequence mPoints;
+    //! The rubberband to show the geometry currently working on
+    QgsGeometryRubberBand *mTempRubberBand = nullptr;
+
+    //! Layer type which will be used for rubberband
+    QgsWkbTypes::GeometryType mLayerType = QgsWkbTypes::LineGeometry;
+
+    //! Snapping indicators
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
+
+};
+
+#endif // QGSMAPTOOLADDABSTRACT_H

--- a/src/app/qgsmaptooladdcircle.cpp
+++ b/src/app/qgsmaptooladdcircle.cpp
@@ -25,65 +25,9 @@
 #include "qgssnapindicator.h"
 
 QgsMapToolAddCircle::QgsMapToolAddCircle( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode )
-  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), mode )
-  , mParentTool( parentTool )
-  , mSnapIndicator( std::make_unique< QgsSnapIndicator>( canvas ) )
+  : QgsMapToolAddAbstract( parentTool, canvas, mode )
 {
   mToolName = tr( "Add circle" );
-
-  clean();
-  connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddCircle::stopCapturing );
-  connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddCircle::stopCapturing );
-}
-
-QgsMapToolAddCircle::~QgsMapToolAddCircle()
-{
-  clean();
-}
-
-void QgsMapToolAddCircle::keyPressEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
-
-  if ( e && e->key() == Qt::Key_Escape )
-  {
-    clean();
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-
-  if ( e && e->key() == Qt::Key_Backspace )
-  {
-    if ( mPoints.size() == 1 )
-    {
-
-      if ( mTempRubberBand )
-      {
-        delete mTempRubberBand;
-        mTempRubberBand = nullptr;
-      }
-
-      mPoints.clear();
-    }
-    else if ( mPoints.size() > 1 )
-    {
-      mPoints.removeLast();
-
-    }
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-}
-
-void QgsMapToolAddCircle::keyReleaseEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
 }
 
 void QgsMapToolAddCircle::deactivate()
@@ -114,40 +58,8 @@ void QgsMapToolAddCircle::deactivate()
   QgsMapToolCapture::deactivate();
 }
 
-void QgsMapToolAddCircle::activate()
-{
-  clean();
-  QgsMapToolCapture::activate();
-}
-
 void QgsMapToolAddCircle::clean()
 {
-  if ( mTempRubberBand )
-  {
-    delete mTempRubberBand;
-    mTempRubberBand = nullptr;
-  }
-
-  mPoints.clear();
-
-  if ( mParentTool )
-  {
-    mParentTool->deleteTempRubberBand();
-  }
-
+  QgsMapToolAddAbstract::clean();
   mCircle = QgsCircle();
-
-  QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( QgisApp::instance()->activeLayer() );
-  if ( vLayer )
-    mLayerType = vLayer->geometryType();
-}
-
-void QgsMapToolAddCircle::release( QgsMapMouseEvent *e )
-{
-  deactivate();
-  if ( mParentTool )
-  {
-    mParentTool->canvasReleaseEvent( e );
-  }
-  activate();
 }

--- a/src/app/qgsmaptooladdcircle.h
+++ b/src/app/qgsmaptooladdcircle.h
@@ -16,55 +16,30 @@
 #ifndef QGSMAPTOOLADDCIRCLE_H
 #define QGSMAPTOOLADDCIRCLE_H
 
-#include "qgsmaptoolcapture.h"
+#include "qgsmaptooladdabstract.h"
 #include "qgscircle.h"
 #include "qgis_app.h"
-
-class QgsGeometryRubberBand;
-class QgsSnapIndicator;
 
 struct EdgesOnlyFilter : public QgsPointLocator::MatchFilter
 {
   bool acceptMatch( const QgsPointLocator::Match &m ) override { return m.hasEdge(); }
 };
 
-class APP_EXPORT QgsMapToolAddCircle: public QgsMapToolCapture
+class APP_EXPORT QgsMapToolAddCircle: public QgsMapToolAddAbstract
 {
     Q_OBJECT
 
   public:
     QgsMapToolAddCircle( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode = CaptureLine );
-    ~QgsMapToolAddCircle() override;
-
-    void keyPressEvent( QKeyEvent *e ) override;
-    void keyReleaseEvent( QKeyEvent *e ) override;
 
     void deactivate() override;
-    void activate() override;
     void clean() override;
 
   protected:
     explicit QgsMapToolAddCircle( QgsMapCanvas *canvas ) = delete; //forbidden
 
-    //! Convenient method to release (activate/deactivate) tools
-    void release( QgsMapMouseEvent *e );
-
-    /**
-     * The parent map tool, e.g. the add feature tool.
-     * Completed circle will be added to this tool by calling its addCurve() method.
-     */
-    QPointer<QgsMapToolCapture> mParentTool;
-    //! Circle points (in map coordinates)
-    QgsPointSequence mPoints;
-    //! The rubberband to show the circular string currently working on
-    QgsGeometryRubberBand *mTempRubberBand = nullptr;
     //! Circle
     QgsCircle mCircle;
-    //! Layer type which will be used for rubberband
-    QgsWkbTypes::GeometryType mLayerType = QgsWkbTypes::LineGeometry;
-
-    //! Snapping indicators
-    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
 };
 

--- a/src/app/qgsmaptooladdellipse.cpp
+++ b/src/app/qgsmaptooladdellipse.cpp
@@ -14,8 +14,6 @@
  ***************************************************************************/
 
 #include "qgsmaptooladdellipse.h"
-#include "qgscompoundcurve.h"
-#include "qgscurvepolygon.h"
 #include "qgsgeometryrubberband.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
@@ -25,65 +23,9 @@
 #include "qgssnapindicator.h"
 
 QgsMapToolAddEllipse::QgsMapToolAddEllipse( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode )
-  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), mode )
-  , mParentTool( parentTool )
-  , mSnapIndicator( std::make_unique< QgsSnapIndicator>( canvas ) )
+  : QgsMapToolAddAbstract( parentTool, canvas, mode )
 {
   mToolName = tr( "Add ellipse" );
-
-  clean();
-  connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddEllipse::stopCapturing );
-  connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddEllipse::stopCapturing );
-}
-
-QgsMapToolAddEllipse::~QgsMapToolAddEllipse()
-{
-  clean();
-}
-
-void QgsMapToolAddEllipse::keyPressEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
-
-  if ( e && e->key() == Qt::Key_Escape )
-  {
-    clean();
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-
-  if ( e && e->key() == Qt::Key_Backspace )
-  {
-    if ( mPoints.size() == 1 )
-    {
-
-      if ( mTempRubberBand )
-      {
-        delete mTempRubberBand;
-        mTempRubberBand = nullptr;
-      }
-
-      mPoints.clear();
-    }
-    else if ( mPoints.size() > 1 )
-    {
-      mPoints.removeLast();
-
-    }
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-}
-
-void QgsMapToolAddEllipse::keyReleaseEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
 }
 
 void QgsMapToolAddEllipse::deactivate()
@@ -114,40 +56,8 @@ void QgsMapToolAddEllipse::deactivate()
   QgsMapToolCapture::deactivate();
 }
 
-void QgsMapToolAddEllipse::activate()
-{
-  clean();
-  QgsMapToolCapture::activate();
-}
-
 void QgsMapToolAddEllipse::clean()
 {
-  if ( mTempRubberBand )
-  {
-    delete mTempRubberBand;
-    mTempRubberBand = nullptr;
-  }
-
-  mPoints.clear();
-
-  if ( mParentTool )
-  {
-    mParentTool->deleteTempRubberBand();
-  }
-
+  QgsMapToolAddAbstract::clean();
   mEllipse = QgsEllipse();
-
-  QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( QgisApp::instance()->activeLayer() );
-  if ( vLayer )
-    mLayerType = vLayer->geometryType();
-}
-
-void QgsMapToolAddEllipse::release( QgsMapMouseEvent *e )
-{
-  deactivate();
-  if ( mParentTool )
-  {
-    mParentTool->canvasReleaseEvent( e );
-  }
-  activate();
 }

--- a/src/app/qgsmaptooladdellipse.h
+++ b/src/app/qgsmaptooladdellipse.h
@@ -16,7 +16,7 @@
 #ifndef QGSMAPTOOLADDELLIPSE_H
 #define QGSMAPTOOLADDELLIPSE_H
 
-#include "qgsmaptoolcapture.h"
+#include "qgsmaptooladdabstract.h"
 #include "qgsellipse.h"
 #include "qgssettingsregistrycore.h"
 #include "qgis_app.h"
@@ -24,46 +24,23 @@
 class QgsGeometryRubberBand;
 class QgsSnapIndicator;
 
-class APP_EXPORT QgsMapToolAddEllipse: public QgsMapToolCapture
+class APP_EXPORT QgsMapToolAddEllipse: public QgsMapToolAddAbstract
 {
     Q_OBJECT
   public:
     QgsMapToolAddEllipse( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode = CaptureLine );
-    ~QgsMapToolAddEllipse() override;
-
-    void keyPressEvent( QKeyEvent *e ) override;
-    void keyReleaseEvent( QKeyEvent *e ) override;
 
     void deactivate() override;
-
-    void activate() override;
     void clean() override;
 
   protected:
     explicit QgsMapToolAddEllipse( QgsMapCanvas *canvas ) = delete; //forbidden
 
-    //! Convenient method to release (activate/deactivate) tools
-    void release( QgsMapMouseEvent *e );
-
-    /**
-     * The parent map tool, e.g. the add feature tool.
-     * Completed ellipse will be added to this tool by calling its toLineString() method.
-     */
-    QPointer<QgsMapToolCapture> mParentTool;
-    //! Ellipse points (in map coordinates)
-    QgsPointSequence mPoints;
-    //! The rubberband to show the ellipse currently working on
-    QgsGeometryRubberBand *mTempRubberBand = nullptr;
     //! Ellipse
     QgsEllipse mEllipse;
+
     //! convenient method to return the number of segments
     unsigned int segments( ) { return QgsSettingsRegistryCore::settingsDigitizingOffsetQuadSeg.value() * 12; }
-    //! Layer type which will be used for rubberband
-    QgsWkbTypes::GeometryType mLayerType = QgsWkbTypes::LineGeometry;
-
-    //! Snapping indicators
-    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
-
 };
 
 #endif // QGSMAPTOOLADDELLIPSE_H

--- a/src/app/qgsmaptooladdrectangle.cpp
+++ b/src/app/qgsmaptooladdrectangle.cpp
@@ -26,65 +26,9 @@
 #include "qgssnapindicator.h"
 
 QgsMapToolAddRectangle::QgsMapToolAddRectangle( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode )
-  : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), mode )
-  , mParentTool( parentTool )
-  , mSnapIndicator( std::make_unique< QgsSnapIndicator>( canvas ) )
+  : QgsMapToolAddAbstract( parentTool, canvas, mode )
 {
   mToolName = tr( "Add rectangle" );
-
-  clean();
-  connect( QgisApp::instance(), &QgisApp::newProject, this, &QgsMapToolAddRectangle::stopCapturing );
-  connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddRectangle::stopCapturing );
-}
-
-QgsMapToolAddRectangle::~QgsMapToolAddRectangle()
-{
-  clean();
-}
-
-void QgsMapToolAddRectangle::keyPressEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
-
-  if ( e && e->key() == Qt::Key_Escape )
-  {
-    clean();
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-
-  if ( e && e->key() == Qt::Key_Backspace )
-  {
-    if ( mPoints.size() == 1 )
-    {
-
-      if ( mTempRubberBand )
-      {
-        delete mTempRubberBand;
-        mTempRubberBand = nullptr;
-      }
-
-      mPoints.clear();
-    }
-    else if ( mPoints.size() > 1 )
-    {
-      mPoints.removeLast();
-
-    }
-    if ( mParentTool )
-      mParentTool->keyPressEvent( e );
-  }
-}
-
-void QgsMapToolAddRectangle::keyReleaseEvent( QKeyEvent *e )
-{
-  if ( e && e->isAutoRepeat() )
-  {
-    return;
-  }
 }
 
 void QgsMapToolAddRectangle::deactivate( )
@@ -115,40 +59,8 @@ void QgsMapToolAddRectangle::deactivate( )
   QgsMapToolCapture::deactivate();
 }
 
-void QgsMapToolAddRectangle::activate()
-{
-  clean();
-  QgsMapToolCapture::activate();
-}
-
 void QgsMapToolAddRectangle::clean()
 {
-  if ( mTempRubberBand )
-  {
-    delete mTempRubberBand;
-    mTempRubberBand = nullptr;
-  }
-
-  mPoints.clear();
-
-  if ( mParentTool )
-  {
-    mParentTool->deleteTempRubberBand();
-  }
-
+  QgsMapToolAddAbstract::clean();
   mRectangle = QgsQuadrilateral();
-
-  QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( QgisApp::instance()->activeLayer() );
-  if ( vLayer )
-    mLayerType = vLayer->geometryType();
-}
-
-void QgsMapToolAddRectangle::release( QgsMapMouseEvent *e )
-{
-  deactivate();
-  if ( mParentTool )
-  {
-    mParentTool->canvasReleaseEvent( e );
-  }
-  activate();
 }

--- a/src/app/qgsmaptooladdrectangle.h
+++ b/src/app/qgsmaptooladdrectangle.h
@@ -16,53 +16,26 @@
 #ifndef QGSMAPTOOLADDRECTANGLE_H
 #define QGSMAPTOOLADDRECTANGLE_H
 
+#include "qgsmaptooladdabstract.h"
 #include "qgspolygon.h"
-#include "qgsmaptoolcapture.h"
 #include "qgsquadrilateral.h"
 #include "qgis_app.h"
 
-class QgsPolygon;
-class QgsSnapIndicator;
-
-class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolCapture
+class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolAddAbstract
 {
     Q_OBJECT
 
   public:
     QgsMapToolAddRectangle( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode = CaptureLine );
-    ~QgsMapToolAddRectangle() override;
-
-    void keyPressEvent( QKeyEvent *e ) override;
-    void keyReleaseEvent( QKeyEvent *e ) override;
 
     void deactivate( ) override;
-
-    void activate() override;
     void clean() override;
 
   protected:
     explicit QgsMapToolAddRectangle( QgsMapCanvas *canvas ) = delete; //forbidden
 
-    //! Convenient method to release (activate/deactivate) tools
-    void release( QgsMapMouseEvent *e );
-
-    /**
-     * The parent map tool, e.g. the add feature tool.
-     * Completed regular shape will be added to this tool by calling its addCurve() method.
-     */
-    QPointer<QgsMapToolCapture> mParentTool;
-    //! Regular Shape points (in map coordinates)
-    QgsPointSequence mPoints;
-    //! The rubberband to show the rectangle currently working on
-    QgsGeometryRubberBand *mTempRubberBand = nullptr;
     //! Rectangle
     QgsQuadrilateral mRectangle;
-
-    //! Layer type which will be used for rubberband
-    QgsWkbTypes::GeometryType mLayerType = QgsWkbTypes::LineGeometry;
-
-    //! Snapping indicators
-    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 };
 
 #endif // QGSMAPTOOLADDRECTANGLE_H

--- a/src/app/qgsmaptooladdregularpolygon.h
+++ b/src/app/qgsmaptooladdregularpolygon.h
@@ -16,28 +16,21 @@
 #ifndef QGSMAPTOOLADDREGULARPOLYGON_H
 #define QGSMAPTOOLADDREGULARPOLYGON_H
 
+#include "qgsmaptooladdabstract.h"
 #include "qgsregularpolygon.h"
-#include "qgsmaptoolcapture.h"
 #include "qgsspinbox.h"
 #include "qgis_app.h"
 
 class QSpinBox;
-class QgsSnapIndicator;
 
-class APP_EXPORT QgsMapToolAddRegularPolygon: public QgsMapToolCapture
+class APP_EXPORT QgsMapToolAddRegularPolygon: public QgsMapToolAddAbstract
 {
     Q_OBJECT
 
   public:
     QgsMapToolAddRegularPolygon( QgsMapToolCapture *parentTool, QgsMapCanvas *canvas, CaptureMode mode = CaptureLine );
-    ~QgsMapToolAddRegularPolygon() override;
-
-    void keyPressEvent( QKeyEvent *e ) override;
-    void keyReleaseEvent( QKeyEvent *e ) override;
 
     void deactivate() override;
-
-    void activate() override;
     void clean() override;
 
   protected:
@@ -51,27 +44,8 @@ class APP_EXPORT QgsMapToolAddRegularPolygon: public QgsMapToolCapture
     //! delete the spin box to enter the number of sides, if it exists
     void deleteNumberSidesSpinBox();
 
-    //! Convenient method to release (activate/deactivate) tools
-    void release( QgsMapMouseEvent *e );
-
-    /**
-     * The parent map tool, e.g. the add feature tool.
-     * Completed regular polygon will be added to this tool by calling its addCurve() method.
-     */
-    QPointer<QgsMapToolCapture> mParentTool;
-    //! Regular Shape points (in map coordinates)
-    QgsPointSequence mPoints;
-    //! The rubberband to show the regular polygon currently working on
-    QgsGeometryRubberBand *mTempRubberBand = nullptr;
     //! Regular shape as a regular polygon
     QgsRegularPolygon mRegularPolygon;
-
-    //! Layer type which will be used for rubberband
-    QgsWkbTypes::GeometryType mLayerType = QgsWkbTypes::LineGeometry;
-
-    //! Snapping indicators
-    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
-
 };
 
 #endif // QGSMAPTOOLADDREGULARPOLYGON_H


### PR DESCRIPTION
Those classes have identical implementations for a number of methods.
Add a QgsMapToolAddAbstract class for that, and make them derive for it.