### PR TITLE
[PostgreSQL] Get Features by IDs for Multi Column PK, "WHERE" -string replace with: WHERE (a,b,...) IN ( VALUES (1,2,...),(3,4,...)... )

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1884,7 +1884,7 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
         mPrimaryKeyType = PktFidMap; // Map by default
         if ( mPrimaryKeyAttrs.size() == 1 )
         {
-          QgsField fld = mAttributeFields.at( 0 );
+          QgsField fld = mAttributeFields.at( mPrimaryKeyAttrs.at( 0 ) );
           mPrimaryKeyType = pkType( fld );
         }
       }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -720,6 +720,10 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
 
         QList<QString> allowedValuesWithCastTypeName;
         allowedValuesWithCastTypeName << QLatin1String( "uuid" );
+        allowedValuesWithCastTypeName << QLatin1String( "inet" );
+        allowedValuesWithCastTypeName << QLatin1String( "cidr" );
+        allowedValuesWithCastTypeName << QLatin1String( "macaddr" );
+        allowedValuesWithCastTypeName << QLatin1String( "macaddr8" );
 
         for ( int i = 0; i < pkAttrs.size(); i++ )
         {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1166,6 +1166,9 @@ bool QgsPostgresProvider::loadFields()
                 fieldTypeName == QLatin1String( "geometry" ) ||
                 fieldTypeName == QLatin1String( "geography" ) ||
                 fieldTypeName == QLatin1String( "inet" ) ||
+                fieldTypeName == QLatin1String( "cidr" ) ||
+                fieldTypeName == QLatin1String( "macaddr" ) ||
+                fieldTypeName == QLatin1String( "macaddr8" ) ||
                 fieldTypeName == QLatin1String( "money" ) ||
                 fieldTypeName == QLatin1String( "ltree" ) ||
                 fieldTypeName == QLatin1String( "uuid" ) ||

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -713,6 +713,11 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
         allowedValuesType << QVariant::LongLong;
         bool canUseVALUES = true;
 
+        QList<QString> allowedValuesTypeName;
+        allowedValuesTypeName << QLatin1String( "char" );
+        allowedValuesTypeName << QLatin1String( "varchar" );
+        allowedValuesTypeName << QLatin1String( "character" );
+
         QList<QString> allowedValuesWithCastTypeName;
         allowedValuesWithCastTypeName << QLatin1String( "uuid" );
 
@@ -723,6 +728,7 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
 
           if ( canUseVALUES
                && !allowedValuesType.contains( fields.at( pkAttrs[i] ).type() )
+               && !allowedValuesTypeName.contains( fields.at( pkAttrs[i] ).typeName() )
                && !allowedValuesWithCastTypeName.contains( fields.at( pkAttrs[i] ).typeName() ) )
             canUseVALUES = false;
         }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -623,14 +623,19 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
         whereValuesList << whereValues;
       }
     }
+
     if ( 1 ==  pkAttrs.size() )
+    {
       return whereValuesList.isEmpty() ? QString() :
              whereKeys.append( QStringLiteral( " IN " ) ) +
              whereValuesList.join( QLatin1Char( ',' ) ).prepend( QLatin1Char( '(' ) ).append( QLatin1Char( ')' ) );
-
-    return whereValuesList.isEmpty() ? QString() :
-           whereKeys.prepend( QLatin1Char( '(' ) ).append( QStringLiteral( ") IN " ) ) +
-           whereValuesList.join( QStringLiteral( "),(" ) ).prepend( QStringLiteral( "( VALUES (" ) ).append( QStringLiteral( ") )" ) );
+    }
+    else
+    {
+      return whereValuesList.isEmpty() ? QString() :
+             whereKeys.prepend( QLatin1Char( '(' ) ).append( QStringLiteral( ") IN " ) ) +
+             whereValuesList.join( QStringLiteral( "),(" ) ).prepend( QStringLiteral( "( VALUES (" ) ).append( QStringLiteral( ") )" ) );
+    }
   };
 
   switch ( pkType )
@@ -666,7 +671,7 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
       QList<int> allowedType;
       allowedType << QVariant::String;
       allowedType << QVariant::Int;
-      //allowedType << QVariant::LongLong;
+      allowedType << QVariant::LongLong;
       bool canUseIN = true;
       for ( int i = 0; i < pkAttrs.size(); i++ )
       {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -634,7 +634,7 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds &featureIds, const Qg
     {
       return whereValuesList.isEmpty() ? QString() :
              whereKeys.prepend( QLatin1Char( '(' ) ).append( QStringLiteral( ") IN " ) ) +
-             whereValuesList.join( QStringLiteral( "),(" ) ).prepend( QStringLiteral( "( VALUES (" ) ).append( QStringLiteral( ") )" ) );
+             whereValuesList.join( QStringLiteral( "),(" ) ).prepend( QStringLiteral( "( (" ) ).append( QStringLiteral( ") )" ) );
     }
   };
 

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -327,7 +327,7 @@ void TestQgsPostgresProvider::testWhereClauseFids()
 
 #define CHECK_IN_VALUES_2FLD_CLAUSE(whereClause,expectedValues)         \
   {                                                                     \
-    QRegularExpression inRe("\\( ?\\\"fld1\\\", ?\\\"fld2\\\" ?\\) ?IN ?\\( ?VALUES ?\\(([^)]*)\\),\\(([^)]*)\\) ?\\)");\
+    QRegularExpression inRe("\\( ?\\\"fld1\\\", ?\\\"fld2\\\" ?\\) ?IN ?\\( ?\\(([^)]*)\\),\\(([^)]*)\\) ?\\)");\
     QVERIFY(inRe.isValid());                                            \
     QRegularExpressionMatch match = inRe.match( whereClause );          \
     QVERIFY( match.hasMatch() );                                        \
@@ -422,7 +422,7 @@ void TestQgsPostgresProvider::testWhereClauseFids()
   CHECK_IN_CLAUSE( QgsPostgresUtils::whereClause( QgsFeatureIds() << 1LL << 2LL, fields, NULL, QgsPostgresPrimaryKeyType::PktFidMap, pkAttrs, std::shared_ptr<QgsPostgresSharedData>( sdata ) ),
                    QStringList() << "'PostGIS too!'" << "'QGIS ''Rocks''!'" );
 
-  // Composite text + int -> IN VALUES clause
+  // Composite text + int -> IN clause
   f0.setName( "fld1" );
   f3.setName( "fld2" );
   pkAttrs.clear();

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -304,7 +304,6 @@ void TestQgsPostgresProvider::testWhereClauseFids()
 
   QgsFields fields;
   QList<int> pkAttrs;
-  QString clause;
 
   std::shared_ptr< QgsPostgresSharedData > sdata( new QgsPostgresSharedData() );
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2639,7 +2639,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         """Test Multi Column PK & `Small` Data"""
         from itertools import combinations
 
-        def test_for_pk_combinations(pk_column_name, fids_get_count):
+        def test_for_pk_combinations(test_type_list, pk_column_name_list, fids_get_count):
+            pk_column_name = ','.join(pk_column_name_list)
             set_new_pk = '''
                 ALTER TABLE qgis_test.multi_column_pk_small_data_table DROP CONSTRAINT multi_column_pk_small_data_pk;
                 ALTER TABLE qgis_test.multi_column_pk_small_data_table
@@ -2647,8 +2648,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             set_new_layer = ' sslmode=disable key=\'{}\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data_{}" (geom) sql='
             error_string = 'from {} with PK - {} : expected {}, got {}'
 
-            self.execSQLCommand(set_new_pk.format(pk_column_name))
-            for test_type in ['table', 'view', 'mat_view']:
+            if 'table' in test_type_list:
+                self.execSQLCommand(set_new_pk.format(pk_column_name))
+            for test_type in test_type_list:
                 vl = QgsVectorLayer(self.dbconn + set_new_layer.format(pk_column_name, test_type), 'test_multi_column_pk_small_data', 'postgres')
                 fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
                 fids2 = [f.id() for f in vl.getFeatures(fids)]
@@ -2672,7 +2674,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
           id_macaddr macaddr NOT NULL,
           id_macaddr8 macaddr8 NOT NULL,
           id_timestamp timestamp with time zone NOT NULL,
-          --id_  NOT NULL,
+          id_half_null_uuid uuid,
+          id_all_null_uuid uuid,
           geom geometry(Polygon,3857),
           CONSTRAINT multi_column_pk_small_data_pk
             PRIMARY KEY (id_serial, id_uuid, id_int, id_bigint, id_str) );''')
@@ -2686,7 +2689,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         TRUNCATE qgis_test.multi_column_pk_small_data_table;
         INSERT INTO qgis_test.multi_column_pk_small_data_table(
           id_uuid, id_int, id_bigint, id_str, id_inet4, id_inet6, id_cidr4, id_cidr6,
-            id_macaddr, id_macaddr8, id_timestamp, geom)
+            id_macaddr, id_macaddr8, id_timestamp, id_half_null_uuid, id_all_null_uuid, geom)
           SELECT
             ( (10000000)::text || (100000000000 + dy)::text || (100000000000 + dx)::text )::uuid,
             dx + 1000000 * dy,                                                    --id_int
@@ -2699,20 +2702,27 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             ((112233445566 + dx + 100 * dy)::text)::macaddr,                      --id_macaddr
             ((1122334455667788 + dx + 100 * dy)::text)::macaddr8,                 --id_macaddr8
             now() - ((dx||\' hour\')::text)::interval - ((dy||\' day\')::text)::interval,
+            NULLIF( ( (10000000)::text || (100000000000 + dy)::text || (100000000000 + dx)::text )::uuid,
+              ( (10000000)::text || (100000000000 + dy + dy%2)::text || (100000000000 + dx)::text )::uuid ),
+            NULL,
             ST_Translate(
               ST_GeomFromText(\'POLYGON((3396900.0 6521800.0,3396900.0 6521870.0,
                   3396830.0 6521870.0,3396830.0 6521800.0,3396900.0 6521800.0))\', 3857 ),
               100.0 * dx,
               100.0 * dy )
-          FROM generate_series(1,10) dx, generate_series(1,10) dy;
+          FROM generate_series(1,8) dx, generate_series(1,8) dy;
         REFRESH MATERIALIZED VIEW qgis_test.multi_column_pk_small_data_mat_view;''')
 
         pk_col_list = ("id_serial", "id_uuid", "id_int", "id_bigint", "id_str", "id_inet4", "id_inet6", "id_cidr4", "id_cidr6", "id_macaddr", "id_macaddr8")
+        test_type_list = ["table", "view", "mat_view"]
         for n in [1, 2, len(pk_col_list)]:
             pk_col_set_list = list(combinations(pk_col_list, n))
             for pk_col_set in pk_col_set_list:
-                pk_column_name = ','.join(pk_col_set)
-                test_for_pk_combinations(pk_column_name, 42)
+                test_for_pk_combinations(test_type_list, pk_col_set, 42)
+
+        for col_name in ["id_serial", "id_uuid", "id_int", "id_bigint", "id_str", "id_inet4"]:
+            test_for_pk_combinations(["view", "mat_view"], ["id_half_null_uuid", col_name], 42)
+            test_for_pk_combinations(["view", "mat_view"], ["id_all_null_uuid", col_name], 42)
 
     def testMultiColumnPkBigData(self):
         """Test Multi Column PK & `Big` Data"""

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2803,8 +2803,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
         fids2 = [f.id() for f in vl.getFeatures(fids)]
         self.assertEqual(len(fids), fids_get_count)
-        """ ! TEST FAIL ! with OR WHERE string """
-        #self.assertEqual(len(fids2), fids_get_count)
+        """ ! TEST FAIL ! with OR WHERE string
+        self.assertEqual(len(fids2), fids_get_count) """
 
         """ Composite PK: serial, uuid, int, bigint, str, inet4, inet6,cidr4, cidr6, macaddr, macaddr8 """
         fids_get_count = 42

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2670,9 +2670,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                         100.0 * dy )
                 FROM generate_series(1,333) dx, generate_series(1,333) dy;''')
 
-        """ Composite PK: uuid, bigint, string
-            if set fids_get_count > 9000 - test FAIL"""
-        fids_get_count = 5000
+        """ Composite PK: uuid, bigint, string """
+        fids_get_count = 20000
         vl = QgsVectorLayer(
             self.dbconn +
             ' sslmode=disable key=\'"id_uuid","id_int","id_str"\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql=',

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2637,6 +2637,24 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
     def testMultiColumnPkSmallData(self):
         """Test Multi Column PK & `Small` Data"""
+        from itertools import combinations
+
+        def test_for_pk_combinations(pk_column_name, fids_get_count):
+            set_new_pk = '''
+                ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
+                ALTER TABLE qgis_test.multi_column_pk_small_data
+                    ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY ({});'''
+            set_new_layer = ' sslmode=disable key=\'{}\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql='
+            error_string = 'for PK - {} : expected {}, got {}'
+
+            self.execSQLCommand(set_new_pk.format(pk_column_name))
+            vl = QgsVectorLayer(self.dbconn + set_new_layer.format(pk_column_name), 'test_multi_column_pk_small_data', 'postgres')
+            fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
+            fids2 = [f.id() for f in vl.getFeatures(fids)]
+            self.assertEqual(fids_get_count, len(fids), "Get with limit " +
+                             error_string.format(pk_column_name, fids_get_count, len(fids)))
+            self.assertEqual(fids_get_count, len(fids2), "Get by fids " +
+                             error_string.format(pk_column_name, fids_get_count, len(fids2)))
 
         self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.multi_column_pk_small_data CASCADE;')
         self.execSQLCommand('''
@@ -2681,151 +2699,37 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
               100.0 * dy )
           FROM generate_series(1,10) dx, generate_series(1,10) dy;''')
 
-        """ Composite PK: serial, uuid, int, bigint, str """
-        fids_get_count = 42
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_serial","id_uuid","id_int","id_bigint","id_str"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: inet4 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_inet4);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_inet4"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: inet6 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_inet6);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_inet6"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: cidr4 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_cidr4);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_cidr4"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: cidr6 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_cidr6);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_cidr6"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: macaddr """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_macaddr);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_macaddr"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: macaddr8 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_macaddr8);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_macaddr8"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ single column PK: timestamp """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_timestamp);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_timestamp"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        """ ! TEST FAIL ! with OR WHERE string
-        self.assertEqual(len(fids2), fids_get_count) """
-
-        """ Composite PK: serial, uuid, int, bigint, str, inet4, inet6,cidr4, cidr6, macaddr, macaddr8 """
-        fids_get_count = 42
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_small_data DROP CONSTRAINT multi_column_pk_small_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_small_data
-                ADD CONSTRAINT multi_column_pk_small_data_pk PRIMARY KEY (id_serial,id_uuid,id_int,id_bigint,id_str,
-                id_inet4,id_inet6,id_cidr4,id_cidr6,id_macaddr, id_macaddr8);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_serial","id_uuid","id_int","id_bigint","id_str",' +
-            '"id_inet4","id_inet6","id_cidr4","id_cidr6","id_macaddr","id_macaddr8"\' ' +
-            'srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_small_data" (geom) sql=',
-            'test_multi_column_pk_small_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
+        pk_col_list = ("id_serial", "id_uuid", "id_int", "id_bigint", "id_str", "id_inet4", "id_inet6", "id_cidr4", "id_cidr6", "id_macaddr", "id_macaddr8")
+        for n in [1, 2, len(pk_col_list)]:
+            pk_col_set_list = list(combinations(pk_col_list, n))
+            for pk_col_set in pk_col_set_list:
+                pk_column_name = ','.join(pk_col_set)
+                test_for_pk_combinations(pk_column_name, 42)
 
     def testMultiColumnPkBigData(self):
         """Test Multi Column PK & `Big` Data"""
+
+        def test_for_pk_from_list(pk_column_name_list, fids_get_count):
+            pk_column_name = ','.join(pk_column_name_list)
+            set_new_pk = '''
+                ALTER TABLE qgis_test.multi_column_pk_big_data DROP CONSTRAINT multi_column_pk_big_data_pk;
+                ALTER TABLE qgis_test.multi_column_pk_big_data
+                    ADD CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY ({});
+                DROP INDEX qgis_test.multi_column_pk_big_data_indx;
+                CREATE UNIQUE INDEX multi_column_pk_big_data_indx
+                    ON qgis_test.multi_column_pk_big_data USING btree
+                    ({});'''
+            set_new_layer = ' sslmode=disable key=\'{}\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql='
+            error_string = 'for PK - {} : expected {}, got {}'
+
+            self.execSQLCommand(set_new_pk.format(pk_column_name, ' ASC NULLS LAST, '.join(pk_column_name_list) + ' ASC NULLS LAST'))
+            vl = QgsVectorLayer(self.dbconn + set_new_layer.format(pk_column_name), 'test_multi_column_pk_big_data', 'postgres')
+            fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
+            fids2 = [f.id() for f in vl.getFeatures(fids)]
+            self.assertEqual(fids_get_count, len(fids), "Get with limit " +
+                             error_string.format(pk_column_name, fids_get_count, len(fids)))
+            self.assertEqual(fids_get_count, len(fids2), "Get by fids " +
+                             error_string.format(pk_column_name, fids_get_count, len(fids2)))
 
         self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.multi_column_pk_big_data CASCADE;')
         self.execSQLCommand('''
@@ -2835,14 +2739,14 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 id_int2 bigint NOT NULL,
                 id_str character varying(20) COLLATE pg_catalog."default" NOT NULL,
                 geom geometry(Polygon,3857),
-                CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_uuid, id_int, id_str) );''')
+                CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_int) );''')
         self.execSQLCommand('''
             CREATE INDEX multi_column_pk_big_data_geom_indx
                 ON qgis_test.multi_column_pk_big_data USING gist
                 (geom);
             CREATE UNIQUE INDEX multi_column_pk_big_data_indx
                 ON qgis_test.multi_column_pk_big_data USING btree
-                (id_uuid ASC NULLS LAST, id_int ASC NULLS LAST, id_str ASC NULLS LAST);''')
+                (id_int ASC NULLS LAST);''')
         self.execSQLCommand('TRUNCATE qgis_test.multi_column_pk_big_data')
         self.execSQLCommand('''
             INSERT INTO qgis_test.multi_column_pk_big_data(
@@ -2859,73 +2763,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                         100.0 * dy )
                 FROM generate_series(1,333) dx, generate_series(1,333) dy;''')
 
-        """ Composite PK: uuid, bigint, string """
-        fids_get_count = 20000
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_uuid","id_int","id_str"\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql=',
-            'test_multi_column_pk_big_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ PK: uuid """
-        fids_get_count = 20000
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_big_data DROP CONSTRAINT multi_column_pk_big_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_big_data
-                ADD CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_uuid);
-            DROP INDEX qgis_test.multi_column_pk_big_data_indx;
-            CREATE UNIQUE INDEX multi_column_pk_big_data_indx
-                ON qgis_test.multi_column_pk_big_data USING btree
-                (id_uuid ASC NULLS LAST);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_uuid"\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql=',
-            'test_multi_column_pk_big_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ Composite PK: bigint, bigint """
-        fids_get_count = 20000
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_big_data DROP CONSTRAINT multi_column_pk_big_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_big_data
-                ADD CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_int, id_int2);
-            DROP INDEX qgis_test.multi_column_pk_big_data_indx;
-            CREATE UNIQUE INDEX multi_column_pk_big_data_indx
-                ON qgis_test.multi_column_pk_big_data USING btree
-                (id_int ASC NULLS LAST, id_int2 ASC NULLS LAST);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_int","id_int2"\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql=',
-            'test_multi_column_pk_big_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
-
-        """ Composite PK: uuid, bigint """
-        fids_get_count = 20000
-        self.execSQLCommand('''
-            ALTER TABLE qgis_test.multi_column_pk_big_data DROP CONSTRAINT multi_column_pk_big_data_pk;
-            ALTER TABLE qgis_test.multi_column_pk_big_data
-                ADD CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_uuid, id_int);
-            DROP INDEX qgis_test.multi_column_pk_big_data_indx;
-            CREATE UNIQUE INDEX multi_column_pk_big_data_indx
-                ON qgis_test.multi_column_pk_big_data USING btree
-                (id_uuid ASC NULLS LAST, id_int ASC NULLS LAST);''')
-        vl = QgsVectorLayer(
-            self.dbconn +
-            ' sslmode=disable key=\'"id_uuid","id_int"\' srid=3857 type=POLYGON table="qgis_test"."multi_column_pk_big_data" (geom) sql=',
-            'test_multi_column_pk_big_data', 'postgres')
-        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(fids_get_count))]
-        fids2 = [f.id() for f in vl.getFeatures(fids)]
-        self.assertEqual(len(fids), fids_get_count)
-        self.assertEqual(len(fids2), fids_get_count)
+        test_for_pk_from_list(['id_uuid', 'id_int', 'id_str', ], 20000)
+        test_for_pk_from_list(['id_uuid', ], 20000)
+        test_for_pk_from_list(['id_int', 'id_int2', ], 20000)
 
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2710,7 +2710,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                   3396830.0 6521870.0,3396830.0 6521800.0,3396900.0 6521800.0))\', 3857 ),
               100.0 * dx,
               100.0 * dy )
-          FROM generate_series(1,8) dx, generate_series(1,8) dy;
+          FROM generate_series(1,3) dx, generate_series(1,3) dy;
         REFRESH MATERIALIZED VIEW qgis_test.multi_column_pk_small_data_mat_view;''')
 
         pk_col_list = ("id_serial", "id_uuid", "id_int", "id_bigint", "id_str", "id_inet4", "id_inet6", "id_cidr4", "id_cidr6", "id_macaddr", "id_macaddr8")
@@ -2718,11 +2718,11 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         for n in [1, 2, len(pk_col_list)]:
             pk_col_set_list = list(combinations(pk_col_list, n))
             for pk_col_set in pk_col_set_list:
-                test_for_pk_combinations(test_type_list, pk_col_set, 42)
+                test_for_pk_combinations(test_type_list, pk_col_set, 7)
 
         for col_name in ["id_serial", "id_uuid", "id_int", "id_bigint", "id_str", "id_inet4"]:
-            test_for_pk_combinations(["view", "mat_view"], ["id_half_null_uuid", col_name], 42)
-            test_for_pk_combinations(["view", "mat_view"], ["id_all_null_uuid", col_name], 42)
+            test_for_pk_combinations(["view", "mat_view"], ["id_half_null_uuid", col_name], 7)
+            test_for_pk_combinations(["view", "mat_view"], ["id_all_null_uuid", col_name], 7)
 
     def testMultiColumnPkBigData(self):
         """Test Multi Column PK & `Big` Data"""
@@ -2759,9 +2759,6 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 geom geometry(Polygon,3857),
                 CONSTRAINT multi_column_pk_big_data_pk PRIMARY KEY (id_int) );''')
         self.execSQLCommand('''
-            CREATE INDEX multi_column_pk_big_data_geom_indx
-                ON qgis_test.multi_column_pk_big_data USING gist
-                (geom);
             CREATE UNIQUE INDEX multi_column_pk_big_data_indx
                 ON qgis_test.multi_column_pk_big_data USING btree
                 (id_int ASC NULLS LAST);''')
@@ -2779,11 +2776,11 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                               3396830.0 6521870.0,3396830.0 6521800.0,3396900.0 6521800.0))', 3857 ),
                         100.0 * dx,
                         100.0 * dy )
-                FROM generate_series(1,333) dx, generate_series(1,333) dy;''')
+                FROM generate_series(1,115) dx, generate_series(1,115) dy;''')
 
-        test_for_pk_from_list(['id_uuid', 'id_int', 'id_str', ], 20000)
-        test_for_pk_from_list(['id_uuid', ], 20000)
-        test_for_pk_from_list(['id_int', 'id_int2', ], 20000)
+        test_for_pk_from_list(['id_uuid', 'id_int', 'id_str', ], 12000)
+        test_for_pk_from_list(['id_uuid', ], 12000)
+        test_for_pk_from_list(['id_int', 'id_int2', ], 12000)
 
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):


### PR DESCRIPTION
fix: #43364
fix: #37437

IF PRIMARY KEY ("id_int1", "id_str2", ...)

Befor:

```SQL
SELECT ... FROM ...
  WHERE
    ("id_int1" = 130 AND "id_str2" = E'\\0''') OR ("id_int1" = 130 AND "id_str2" = E'\\1''') OR
    ("id_int1" = 130 AND "id_str2" = E'\\2''') OR ("id_int1" = 139 AND "id_str2" = E'\\0''') OR
    ("id_int1" = 139 AND "id_str2" = E'\\1''') OR ("id_int1" = 139 AND "id_str2" = E'\\2''') OR
    ("id_int1" = 139 AND "id_str2" = E'\\3''') OR ("id_int1" = 139 AND "id_str2" = E'\\4''') OR
    ("id_int1" = 139 AND "id_str2" = E'\\5''');
```

After:
```SQL
SELECT ... FROM ...
  WHERE  ("id_int1","id_str2") IN ( VALUES 
    (130,E'\\0'''),(130,E'\\1'''),(130,E'\\2'''),(139,E'\\0'''),(139,E'\\1'''),
    (139,E'\\2'''),(139,E'\\3'''),(139,E'\\4'''),(139,E'\\5''')
  );
```

Only for limited field types:
```
      allowedType << QVariant::String;
      allowedType << QVariant::Int;
      allowedType << QVariant::LongLong;
```

Reincarnation of PR #42644
~One of the tests fails because it requires the use of "OR" in WHERE string for a multi-column index.~
https://github.com/qgis/QGIS/blob/9c868dbcad59403c09c0ea999949657ca3c0fcca/tests/src/providers/testqgspostgresprovider.cpp#L413
Also [[fallthrough]] is part of C++17 standart, can I use it?

<details><summary>A PG table that can be used for manual tests with QGIS.</summary>

```sql
-- DROP TABLE public.test_poly;
CREATE TABLE public.test_poly(
    id_int integer NOT NULL,
    id_int1 integer NOT NULL,
    id_int2 integer NOT NULL,
    id_str character varying(20),
    id_str1 character varying(10),
    id_str2 character varying(10),
    id_uuid uuid,
    id_uuid1 uuid,
    id_uuid2 uuid,
    geom geometry(Polygon,3857),
    CONSTRAINT test_poly_pk PRIMARY KEY (id_int1, id_str2)
) TABLESPACE pg_default;

CREATE INDEX test_poly_geom_indx ON test_poly USING GIST (geom);

CREATE UNIQUE INDEX test_poly_id_int_idx
    ON public.test_poly USING btree
    (id_int ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_intm_idx
    ON public.test_poly USING btree
    (id_int1 ASC NULLS LAST, id_int2 ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_str_idx
    ON public.test_poly USING btree
    (id_str ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_strm_idx
    ON public.test_poly USING btree
    (id_str1 ASC NULLS LAST, id_str2 ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_uuid_idx
    ON public.test_poly USING btree
    (id_uuid ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_uuidm_idx
    ON public.test_poly USING btree
    (id_uuid1 ASC NULLS LAST, id_uuid2 ASC NULLS LAST)
    TABLESPACE pg_default;

CREATE UNIQUE INDEX test_poly_id_int1_str2_idx
    ON public.test_poly USING btree
    (id_int1 ASC NULLS LAST, id_str2 ASC NULLS LAST)
    TABLESPACE pg_default;

INSERT INTO public.test_poly(
    id_int, id_int1, id_int2,
    id_str, id_str1, id_str2,
    id_uuid, id_uuid1, id_uuid2,
    geom
  )
  SELECT 
    dx + 1024 * dy, dx, dy,
    dx || E'\\\'' || dy, E'\\' || dx || E'\'', E'\\' || dy || E'\'',
    ((10000000)::text || (100000000000 + dy)::text || (100000000000 + dx)::text)::uuid,
    ((10000000)::text || (100000000000)::text || (100000000000 + dx)::text)::uuid,
    ((10000000)::text || (100000000000 + dy)::text || (100000000000)::text)::uuid,
    ST_Translate(
      ST_GeomFromText('POLYGON((3396900.0 6521800.0,
                                3396900.0 6521870.0,
                                3396830.0 6521870.0,
                                3396830.0 6521800.0,
                                3396900.0 6521800.0))', 3857
      ),
      100.0 * dx,
      100.0 * dy
    )
  FROM generate_series(0,1023) dx, generate_series(0,1024) dy;
```
</details>

<details><summary>query plan, INT + STR with OR</summary>

```SQL
EXPLAIN SELECT * FROM public.test_poly
	WHERE
	("id_int1" = 130 AND "id_str2" = E'\\0''') OR ("id_int1" = 130 AND "id_str2" = E'\\1''') OR ("id_int1" = 130 AND "id_str2" = E'\\2''') OR ("id_int1" = 139 AND "id_str2" = E'\\0''') OR ("id_int1" = 139 AND "id_str2" = E'\\1''') OR ("id_int1" = 139 AND "id_str2" = E'\\2''') OR ("id_int1" = 139 AND "id_str2" = E'\\3''') OR ("id_int1" = 139 AND "id_str2" = E'\\4''') OR ("id_int1" = 139 AND "id_str2" = E'\\5''');
```

```
Bitmap Heap Scan on test_poly  (cost=39.96..75.99 rows=9 width=198)
  Recheck Cond: (((id_int1 = 130) AND ((id_str2)::text = '\0'''::text)) OR ((id_int1 = 130) AND ((id_str2)::text = '\1'''::text)) OR ((id_int1 = 130) AND ((id_str2)::text = '\2'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\0'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\1'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\2'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\3'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\4'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\5'''::text)))
  ->  BitmapOr  (cost=39.96..39.96 rows=9 width=0)
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\0'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\1'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\2'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\0'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\1'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\2'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\3'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\4'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\5'''::text))
```
</details>

<details><summary>query plan, INT + STR with IN</summary>

```SQL
EXPLAIN SELECT * FROM public.test_poly
	WHERE ("id_int1","id_str2")
  IN ( (130,E'\\0'''),(130,E'\\1'''),(130,E'\\2'''),(139,E'\\0'''),(139,E'\\1'''),(139,E'\\2'''),(139,E'\\3'''),(139,E'\\4'''),(139,E'\\5''') );
```

```
Bitmap Heap Scan on test_poly  (cost=39.96..75.99 rows=9 width=198)
  Recheck Cond: (((id_int1 = 130) AND ((id_str2)::text = '\0'''::text)) OR ((id_int1 = 130) AND ((id_str2)::text = '\1'''::text)) OR ((id_int1 = 130) AND ((id_str2)::text = '\2'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\0'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\1'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\2'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\3'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\4'''::text)) OR ((id_int1 = 139) AND ((id_str2)::text = '\5'''::text)))
  ->  BitmapOr  (cost=39.96..39.96 rows=9 width=0)
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\0'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\1'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 130) AND ((id_str2)::text = '\2'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\0'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\1'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\2'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\3'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\4'''::text))
        ->  Bitmap Index Scan on test_poly_id_int1_str2_idx  (cost=0.00..4.44 rows=1 width=0)
              Index Cond: ((id_int1 = 139) AND ((id_str2)::text = '\5'''::text))
```
</details>

<details><summary>query plan, INT + STR with IN VALUES</summary>

```SQL
EXPLAIN SELECT * FROM public.test_poly
	WHERE ("id_int1","id_str2")
  IN ( VALUES (130,E'\\0'''),(130,E'\\1'''),(130,E'\\2'''),(139,E'\\0'''),(139,E'\\1'''),(139,E'\\2'''),(139,E'\\3'''),(139,E'\\4'''),(139,E'\\5''') );
```

```
Nested Loop  (cost=0.58..76.28 rows=81 width=198)
  ->  HashAggregate  (cost=0.16..0.25 rows=9 width=36)
        Group Key: "*VALUES*".column1, "*VALUES*".column2
        ->  Values Scan on "*VALUES*"  (cost=0.00..0.11 rows=9 width=36)
  ->  Index Scan using test_poly_id_int1_str2_idx on test_poly  (cost=0.43..8.45 rows=1 width=198)
        Index Cond: ((id_int1 = "*VALUES*".column1) AND ((id_str2)::text = "*VALUES*".column2))
```
</details>
