### PR TITLE
Basic support for coordinate epoch of dynamic (non-plate fixed) crs

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -793,6 +793,16 @@ Returns whether the CRS is a geographic CRS (using lat/lon coordinates)
 :return: ``True`` if CRS is geographic, or ``False`` if it is a projected CRS
 %End
 
+    bool isDynamic() const;
+%Docstring
+Returns ``True`` if the CRS is a dynamic CRS.
+
+A dynamic CRS relies on a dynamic datum, that is a datum that is not
+plate-fixed.
+
+.. versionadded:: 3.20
+%End
+
     QgsDatumEnsemble datumEnsemble() const throw( QgsNotSupportedException );
 %Docstring
 Attempts to retrieve datum ensemble details from the CRS.

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -820,6 +820,50 @@ be returned.
 .. versionadded:: 3.20
 %End
 
+    void setCoordinateEpoch( double epoch );
+%Docstring
+Sets the coordinate ``epoch``, as a decimal year.
+
+In a dynamic CRS (see :py:func:`~QgsCoordinateReferenceSystem.isDynamic`), coordinates of a point on the surface of the Earth may
+change with time. To be unambiguous the coordinates must always be qualified
+with the epoch at which they are valid. The coordinate epoch is not necessarily
+the epoch at which the observation was collected.
+
+Pedantically the coordinate epoch of an observation belongs to the
+observation, and not to the CRS, however it is often more practical to
+bind it to the CRS. The coordinate epoch should be specified for dynamic
+CRS (see :py:func:`~QgsCoordinateReferenceSystem.isDynamic`).
+
+:param epoch: Coordinate epoch as decimal year (e.g. 2021.3)
+
+.. seealso:: :py:func:`coordinateEpoch`
+
+
+.. versionadded:: 3.20
+%End
+
+    double coordinateEpoch() const;
+%Docstring
+Returns the coordinate epoch, as a decimal year.
+
+In a dynamic CRS, coordinates of a point on the surface of the Earth may
+change with time. To be unambiguous the coordinates must always be qualified
+with the epoch at which they are valid. The coordinate epoch is not necessarily
+the epoch at which the observation was collected.
+
+Pedantically the coordinate epoch of an observation belongs to the
+observation, and not to the CRS, however it is often more practical to
+bind it to the CRS. The coordinate epoch should be specified for dynamic
+CRS (see :py:func:`~QgsCoordinateReferenceSystem.isDynamic`).
+
+:return: Coordinate epoch as decimal year (e.g. 2021.3), or NaN if not set, or relevant.
+
+.. seealso:: :py:func:`setCoordinateEpoch`
+
+
+.. versionadded:: 3.20
+%End
+
     QgsProjectionFactors factors( const QgsPoint &point ) const;
 %Docstring
 Calculate various cartographic properties, such as scale factors, angular distortion and meridian convergence for

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -969,7 +969,7 @@ Returns auth id of related geographic CRS
     SIP_PYOBJECT __repr__();
 %MethodCode
     const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1%2>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ),
-                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " (%1)" ).arg( sipCpp->coordinateEpoch() ) : QString() )
+                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " @ %1" ).arg( sipCpp->coordinateEpoch() ) : QString() )
                         : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -968,7 +968,8 @@ Returns auth id of related geographic CRS
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) )
+    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1%2>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ),
+                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " (%1)" ).arg( sipCpp->coordinateEpoch() ) : QString() )
                         : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1101,25 +1101,29 @@ QString QgsCoordinateReferenceSystem::description() const
 
 QString QgsCoordinateReferenceSystem::userFriendlyIdentifier( IdentifierType type ) const
 {
+  QString id;
   if ( !authid().isEmpty() )
   {
     if ( type != ShortString && !description().isEmpty() )
-      return QStringLiteral( "%1 - %2" ).arg( authid(), description() );
-    return authid();
+      id = QStringLiteral( "%1 - %2" ).arg( authid(), description() );
+    else
+      id = authid();
   }
   else if ( !description().isEmpty() )
-    return description();
+    id = description();
   else if ( type == ShortString )
-    return isValid() ? QObject::tr( "Custom CRS" ) : QObject::tr( "Unknown CRS" );
+    id = isValid() ? QObject::tr( "Custom CRS" ) : QObject::tr( "Unknown CRS" );
   else if ( !toWkt( WKT_PREFERRED ).isEmpty() )
-    return QObject::tr( "Custom CRS: %1" ).arg(
-             type == MediumString ? ( toWkt( WKT_PREFERRED ).left( 50 ) + QString( QChar( 0x2026 ) ) )
-             : toWkt( WKT_PREFERRED ) );
+    id = QObject::tr( "Custom CRS: %1" ).arg(
+           type == MediumString ? ( toWkt( WKT_PREFERRED ).left( 50 ) + QString( QChar( 0x2026 ) ) )
+           : toWkt( WKT_PREFERRED ) );
   else if ( !toProj().isEmpty() )
-    return QObject::tr( "Custom CRS: %1" ).arg( type == MediumString ? ( toProj().left( 50 ) + QString( QChar( 0x2026 ) ) )
-           : toProj() );
-  else
-    return QString();
+    id = QObject::tr( "Custom CRS: %1" ).arg( type == MediumString ? ( toProj().left( 50 ) + QString( QChar( 0x2026 ) ) )
+         : toProj() );
+  if ( !id.isEmpty() && !std::isnan( d->mCoordinateEpoch ) )
+    id += QStringLiteral( " (%1)" ).arg( d->mCoordinateEpoch );
+
+  return id;
 }
 
 QString QgsCoordinateReferenceSystem::projectionAcronym() const

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1121,7 +1121,7 @@ QString QgsCoordinateReferenceSystem::userFriendlyIdentifier( IdentifierType typ
     id = QObject::tr( "Custom CRS: %1" ).arg( type == MediumString ? ( toProj().left( 50 ) + QString( QChar( 0x2026 ) ) )
          : toProj() );
   if ( !id.isEmpty() && !std::isnan( d->mCoordinateEpoch ) )
-    id += QStringLiteral( " (%1)" ).arg( d->mCoordinateEpoch );
+    id += QStringLiteral( " @ %1" ).arg( d->mCoordinateEpoch );
 
   return id;
 }

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1197,6 +1197,15 @@ bool QgsCoordinateReferenceSystem::isGeographic() const
   return d->mIsGeographic;
 }
 
+bool QgsCoordinateReferenceSystem::isDynamic() const
+{
+  const PJ *pj = projObject();
+  if ( !pj )
+    return false;
+
+  return QgsProjUtils::isDynamic( pj );
+}
+
 QgsDatumEnsemble QgsCoordinateReferenceSystem::datumEnsemble() const
 {
   QgsDatumEnsemble res;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1640,7 +1640,9 @@ bool QgsCoordinateReferenceSystem::operator==( const QgsCoordinateReferenceSyste
   if ( !d->mIsValid || !srs.d->mIsValid )
     return false;
 
-  if ( d->mCoordinateEpoch != srs.d->mCoordinateEpoch )
+  if ( std::isnan( d->mCoordinateEpoch ) != std::isnan( srs.d->mCoordinateEpoch ) )
+    return false;
+  else if ( !std::isnan( d->mCoordinateEpoch ) && d->mCoordinateEpoch != srs.d->mCoordinateEpoch )
     return false;
 
   const bool isUser = d->mSrsId >= USER_CRS_START_ID;

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1801,6 +1801,19 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
       //make sure the map units have been set
       setMapUnits();
     }
+
+    const QString epoch = srsNode.toElement().attribute( QStringLiteral( "coordinateEpoch" ) );
+    if ( !epoch.isEmpty() )
+    {
+      bool epochOk = false;
+      d->mCoordinateEpoch = epoch.toDouble( &epochOk );
+      if ( !epochOk )
+        d->mCoordinateEpoch = std::numeric_limits< double >::quiet_NaN();
+    }
+    else
+    {
+      d->mCoordinateEpoch = std::numeric_limits< double >::quiet_NaN();
+    }
   }
   else
   {
@@ -1815,6 +1828,11 @@ bool QgsCoordinateReferenceSystem::writeXml( QDomNode &node, QDomDocument &doc )
 {
   QDomElement layerNode = node.toElement();
   QDomElement srsElement = doc.createElement( QStringLiteral( "spatialrefsys" ) );
+
+  if ( std::isfinite( d->mCoordinateEpoch ) )
+  {
+    srsElement.setAttribute( QStringLiteral( "coordinateEpoch" ), d->mCoordinateEpoch );
+  }
 
   QDomElement wktElement = doc.createElement( QStringLiteral( "wkt" ) );
   wktElement.appendChild( doc.createTextNode( toWkt( WKT_PREFERRED ) ) );

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -891,7 +891,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) )
+    const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1%2>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ),
+                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " (%1)" ).arg( sipCpp->coordinateEpoch() ) : QString() )
                         : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -733,6 +733,16 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     bool isGeographic() const;
 
     /**
+     * Returns TRUE if the CRS is a dynamic CRS.
+     *
+     * A dynamic CRS relies on a dynamic datum, that is a datum that is not
+     * plate-fixed.
+     *
+     * \since QGIS 3.20
+     */
+    bool isDynamic() const;
+
+    /**
      * Attempts to retrieve datum ensemble details from the CRS.
      *
      * If the CRS does not use a datum ensemble then an invalid QgsDatumEnsemble will

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -892,7 +892,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     SIP_PYOBJECT __repr__();
     % MethodCode
     const QString str = sipCpp->isValid() ? QStringLiteral( "<QgsCoordinateReferenceSystem: %1%2>" ).arg( !sipCpp->authid().isEmpty() ? sipCpp->authid() : sipCpp->toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ),
-                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " (%1)" ).arg( sipCpp->coordinateEpoch() ) : QString() )
+                        std::isfinite( sipCpp->coordinateEpoch() ) ? QStringLiteral( " @ %1" ).arg( sipCpp->coordinateEpoch() ) : QString() )
                         : QStringLiteral( "<QgsCoordinateReferenceSystem: invalid>" );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -757,6 +757,48 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QgsDatumEnsemble datumEnsemble() const SIP_THROW( QgsNotSupportedException );
 
     /**
+     * Sets the coordinate \a epoch, as a decimal year.
+     *
+     * In a dynamic CRS (see isDynamic()), coordinates of a point on the surface of the Earth may
+     * change with time. To be unambiguous the coordinates must always be qualified
+     * with the epoch at which they are valid. The coordinate epoch is not necessarily
+     * the epoch at which the observation was collected.
+     *
+     * Pedantically the coordinate epoch of an observation belongs to the
+     * observation, and not to the CRS, however it is often more practical to
+     * bind it to the CRS. The coordinate epoch should be specified for dynamic
+     * CRS (see isDynamic()).
+     *
+     * \param epoch Coordinate epoch as decimal year (e.g. 2021.3)
+     *
+     * \see coordinateEpoch()
+     *
+     * \since QGIS 3.20
+     */
+    void setCoordinateEpoch( double epoch );
+
+    /**
+     * Returns the coordinate epoch, as a decimal year.
+     *
+     * In a dynamic CRS, coordinates of a point on the surface of the Earth may
+     * change with time. To be unambiguous the coordinates must always be qualified
+     * with the epoch at which they are valid. The coordinate epoch is not necessarily
+     * the epoch at which the observation was collected.
+     *
+     * Pedantically the coordinate epoch of an observation belongs to the
+     * observation, and not to the CRS, however it is often more practical to
+     * bind it to the CRS. The coordinate epoch should be specified for dynamic
+     * CRS (see isDynamic()).
+     *
+     * \returns Coordinate epoch as decimal year (e.g. 2021.3), or NaN if not set, or relevant.
+     *
+     * \see setCoordinateEpoch()
+     *
+     * \since QGIS 3.20
+     */
+    double coordinateEpoch() const;
+
+    /**
      * Calculate various cartographic properties, such as scale factors, angular distortion and meridian convergence for
      * the CRS at the given geodetic \a point (in geographic coordinates).
      *

--- a/src/core/proj/qgscoordinatereferencesystem_p.h
+++ b/src/core/proj/qgscoordinatereferencesystem_p.h
@@ -60,6 +60,7 @@ class QgsCoordinateReferenceSystemPrivate : public QSharedData
       , mSRID( other.mSRID )
       , mAuthId( other.mAuthId )
       , mIsValid( other.mIsValid )
+      , mCoordinateEpoch( other.mCoordinateEpoch )
       , mPj()
       , mProj4( other.mProj4 )
       , mWktPreferred( other.mWktPreferred )
@@ -105,6 +106,9 @@ class QgsCoordinateReferenceSystemPrivate : public QSharedData
 
     //! Whether this CRS is properly defined and valid
     bool mIsValid = false;
+
+    //! Coordinate epoch
+    double mCoordinateEpoch = std::numeric_limits< double >::quiet_NaN();
 
     // this is the "master" proj object, to be used as a template for new proj objects created on different threads ONLY.
     // Always use threadLocalProjObject() instead of this.

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -148,6 +148,16 @@ class CORE_EXPORT QgsProjUtils
     static bool axisOrderIsSwapped( const PJ *crs );
 
     /**
+     * Returns TRUE if the given proj coordinate system is a dynamic CRS.
+     *
+     * A dynamic CRS relies on a dynamic datum, that is a datum that is not
+     * plate-fixed.
+     *
+     * \since QGIS 3.20
+     */
+    static bool isDynamic( const PJ *crs );
+
+    /**
      * Given a PROJ crs (which may be a compound or bound crs, or some other type), extract a single crs
      * from it.
      */

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -22,6 +22,7 @@
 #include "qgssettings.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystemregistry.h"
+#include "qgsdatums.h"
 
 //qt includes
 #include <QFileInfo>
@@ -947,9 +948,46 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
                    .arg( rect.yMaximum(), 0, 'f', 2 );
   }
 
+  QStringList properties;
+  if ( currentCrs.isGeographic() )
+    properties << tr( "Geographic (uses latitude and longitude for coordinates)" );
+  else
+  {
+    properties << tr( "Units: %1" ).arg( QgsUnitTypes::toString( currentCrs.mapUnits() ) );
+  }
+  properties << ( currentCrs.isDynamic() ? tr( "Dynamic (relies on a datum which is not plate-fixed)" ) : tr( "Static (relies on a datum which is plate-fixed)" ) );
+
+  try
+  {
+    const QgsDatumEnsemble ensemble = currentCrs.datumEnsemble();
+    if ( ensemble.isValid() )
+    {
+      QString id;
+      if ( !ensemble.code().isEmpty() )
+        id = QStringLiteral( "<i>%1</i> (%2:%3)" ).arg( ensemble.name(), ensemble.authority(), ensemble.code() );
+      else
+        id = QStringLiteral( "<i>%</i>”" ).arg( ensemble.name() );
+      if ( ensemble.accuracy() > 0 )
+      {
+        properties << tr( "Based on %1, which has a limited accuracy of <b>at best %2 meters</b>." ).arg( id ).arg( ensemble.accuracy() );
+      }
+      else
+      {
+        properties << tr( "Based on %1, which has a limited accuracy." ).arg( id );
+      }
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+
+  }
+
+  const QString propertiesString = QStringLiteral( "<dt><b>%1</b></dt><dd><ul><li>%2</li></ul></dd>" ).arg( tr( "Properties" ),
+                                   properties.join( QStringLiteral( "</li><li>" ) ) );
+
   const QString extentHtml = QStringLiteral( "<dt><b>%1</b></dt><dd>%2</dd>" ).arg( tr( "Extent" ), extentString );
-  const QString wktString = tr( "<dt><b>%1</b></dt><dd><code>%2</code></dd>" ).arg( tr( "WKT" ), currentCrs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED, true ).replace( '\n', QLatin1String( "<br>" ) ).replace( ' ', QLatin1String( "&nbsp;" ) ) );
-  const QString proj4String = tr( "<dt><b>%1</b></dt><dd><code>%2</code></dd>" ).arg( tr( "Proj4" ), currentCrs.toProj() );
+  const QString wktString = QStringLiteral( "<dt><b>%1</b></dt><dd><code>%2</code></dd>" ).arg( tr( "WKT" ), currentCrs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED, true ).replace( '\n', QLatin1String( "<br>" ) ).replace( ' ', QLatin1String( "&nbsp;" ) ) );
+  const QString proj4String = QStringLiteral( "<dt><b>%1</b></dt><dd><code>%2</code></dd>" ).arg( tr( "Proj4" ), currentCrs.toProj() );
 
 #ifdef Q_OS_WIN
   const int smallerPointSize = std::max( font().pointSize() - 1, 8 ); // bit less on windows, due to poor rendering of small point sizes
@@ -957,7 +995,7 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
   const int smallerPointSize = std::max( font().pointSize() - 2, 6 );
 #endif
 
-  teProjection->setText( QStringLiteral( "<div style=\"font-size: %1pt\"><h3>%2</h3><dl>" ).arg( smallerPointSize ).arg( selectedName() ) + wktString + proj4String + extentHtml + QStringLiteral( "</dl></div>" ) );
+  teProjection->setText( QStringLiteral( "<div style=\"font-size: %1pt\"><h3>%2</h3><dl>" ).arg( smallerPointSize ).arg( selectedName() ) + propertiesString + wktString + proj4String + extentHtml + QStringLiteral( "</dl></div>" ) );
 }
 
 QStringList QgsProjectionSelectionTreeWidget::authorities()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -77,6 +77,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void toProj();
     void isGeographic();
     void mapUnits();
+    void isDynamic();
     void setValidationHint();
     void hasAxisInverted();
     void createFromProjInvalid();
@@ -1200,6 +1201,41 @@ void TestQgsCoordinateReferenceSystem::mapUnits()
   // an invalid crs should return unknown unit
   QCOMPARE( QgsCoordinateReferenceSystem().mapUnits(), QgsUnitTypes::DistanceUnknownUnit );
 }
+
+void TestQgsCoordinateReferenceSystem::isDynamic()
+{
+#if (PROJ_VERSION_MAJOR>7 || (PROJ_VERSION_MAJOR==7 && PROJ_VERSION_MINOR >= 2 ) )
+  QgsCoordinateReferenceSystem crs( QStringLiteral( "EPSG:7665" ) );
+  QVERIFY( crs.isDynamic() );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4171" ) );
+  QVERIFY( !crs.isDynamic() );
+
+  // WGS84 (generic), using datum ensemble
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  QVERIFY( crs.isDynamic() );
+
+  // ETRS89 (generic), using datum ensemble
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4258" ) );
+  QVERIFY( !crs.isDynamic() );
+
+  QVERIFY( crs.createFromWkt( QStringLiteral( R"""(GEOGCS["WGS 84",
+      DATUM["WGS_1984",
+          SPHEROID["WGS 84",6378137,298.257223563,
+              AUTHORITY["EPSG","7030"]],
+          AUTHORITY["EPSG","6326"]],
+      PRIMEM["Greenwich",0,
+          AUTHORITY["EPSG","8901"]],
+      UNIT["degree",0.0174532925199433,
+          AUTHORITY["EPSG","9122"]],
+      AXIS["Latitude",NORTH],
+      AXIS["Longitude",EAST],
+      AUTHORITY["EPSG","4326"]])""" ) ) );
+  QVERIFY( crs.isValid() );
+  QVERIFY( crs.isDynamic() );
+#endif
+}
+
 void TestQgsCoordinateReferenceSystem::setValidationHint()
 {
   QgsCoordinateReferenceSystem myCrs;

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1708,7 +1708,7 @@ void TestQgsCoordinateReferenceSystem::displayIdentifier()
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
   QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:4326 - WGS 84" ) );
   crs.setCoordinateEpoch( 2021.3 );
-  QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:4326 - WGS 84 (2021.3)" ) );
+  QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:4326 - WGS 84 @ 2021.3" ) );
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) );
   QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:3111 - GDA94 / Vicgrid" ) );
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1707,6 +1707,8 @@ void TestQgsCoordinateReferenceSystem::displayIdentifier()
   QCOMPARE( crs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), QStringLiteral( "Unknown CRS" ) );
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
   QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:4326 - WGS 84" ) );
+  crs.setCoordinateEpoch( 2021.3 );
+  QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:4326 - WGS 84 (2021.3)" ) );
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) );
   QCOMPARE( crs.userFriendlyIdentifier(), QStringLiteral( "EPSG:3111 - GDA94 / Vicgrid" ) );
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -958,6 +958,16 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QgsCoordinateReferenceSystem myCrs2;
   QVERIFY( myCrs2.readXml( node ) );
   QVERIFY( myCrs == myCrs2 );
+  QVERIFY( std::isnan( myCrs2.coordinateEpoch() ) );
+
+  // with coordinate epoch
+  myCrs.setCoordinateEpoch( 2021.3 );
+  QDomElement node1a = document.createElement( QStringLiteral( "crs" ) );
+  document.appendChild( node1a );
+  QVERIFY( myCrs.writeXml( node1a, document ) );
+  QgsCoordinateReferenceSystem myCrs2a;
+  QVERIFY( myCrs2.readXml( node1a ) );
+  QVERIFY( myCrs == myCrs2 );
 
   // Empty XML made from writeXml operation
   QgsCoordinateReferenceSystem myCrs3;
@@ -989,6 +999,14 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QCOMPARE( myCrs7.authid(), QStringLiteral( "EPSG:3111" ) );
   QCOMPARE( myCrs7.toProj(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
   QCOMPARE( myCrs7.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
+  // with coordinate epoch
+  myCrs6.setCoordinateEpoch( 2021.3 );
+  node = document.createElement( QStringLiteral( "crs" ) );
+  document.appendChild( node );
+  QVERIFY( myCrs6.writeXml( node, document ) );
+  QgsCoordinateReferenceSystem myCrs7a;
+  QVERIFY( myCrs7a.readXml( node ) );
+  QCOMPARE( myCrs7a.coordinateEpoch(), 2021.3 );
 
   // valid CRS from proj string
   QgsCoordinateReferenceSystem myCrs8;

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -189,7 +189,7 @@ class TestPython__repr__(unittest.TestCase):
         crs = QgsCoordinateReferenceSystem('EPSG:4326')
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326>')
         crs.setCoordinateEpoch(2021.3)
-        self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326 (2021.3)>')
+        self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326 @ 2021.3>')
         crs = QgsCoordinateReferenceSystem('EPSG:3111')
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:3111>')
 

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -188,6 +188,8 @@ class TestPython__repr__(unittest.TestCase):
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: invalid>')
         crs = QgsCoordinateReferenceSystem('EPSG:4326')
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326>')
+        crs.setCoordinateEpoch(2021.3)
+        self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:4326 (2021.3)>')
         crs = QgsCoordinateReferenceSystem('EPSG:3111')
         self.assertEqual(crs.__repr__(), '<QgsCoordinateReferenceSystem: EPSG:3111>')
 


### PR DESCRIPTION
Adds basic support for coordinate epoch to QgsCoordinateReferenceSystem, keeping us in step with https://github.com/OSGeo/gdal/pull/3810

Missing parts so far (will be addressed in followup PRs):
- Consider coordinate epoch when creating coordinate transforms
- Read/write coordinate epoch to GDAL srs objects (after https://github.com/OSGeo/gdal/pull/3810 is merged)
- Expose options for manually setting coordinate epoch to users (not planned without sponsorship)