### PR TITLE
External resource image fixes

### DIFF
--- a/python/gui/auto_generated/qgspixmaplabel.sip.in
+++ b/python/gui/auto_generated/qgspixmaplabel.sip.in
@@ -45,8 +45,11 @@ determined from the width with the given aspect ratio.
 %End
 
   public slots:
+
     void setPixmap( const QPixmap & );
     virtual void resizeEvent( QResizeEvent * );
+
+    void clear();
 
 };
 

--- a/python/gui/auto_generated/qgspixmaplabel.sip.in
+++ b/python/gui/auto_generated/qgspixmaplabel.sip.in
@@ -49,7 +49,11 @@ determined from the width with the given aspect ratio.
     void setPixmap( const QPixmap & );
     virtual void resizeEvent( QResizeEvent * );
 
+
     void clear();
+%Docstring
+Clears any label contents.
+%End
 
 };
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -249,7 +249,6 @@ void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, cons
       mQgsWidget->setDocumentPath( value.toString() );
     }
   }
-
 }
 
 void QgsExternalResourceWidgetWrapper::setEnabled( bool enabled )

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -245,9 +245,13 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
       ir.setAutoTransform( true );
       QPixmap pm = QPixmap::fromImage( ir.read() );
       if ( !pm.isNull() )
+      {
         mPixmapLabel->setPixmap( pm );
+      }
       else
+      {
         mPixmapLabel->clear();
+      }
       updateDocumentViewer();
     }
   }

--- a/src/gui/qgspixmaplabel.cpp
+++ b/src/gui/qgspixmaplabel.cpp
@@ -56,6 +56,14 @@ QSize QgsPixmapLabel::sizeHint() const
 void QgsPixmapLabel::resizeEvent( QResizeEvent *e )
 {
   QLabel::resizeEvent( e );
-  QLabel::setPixmap( mPixmap.scaled( this->size(),
-                                     Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
+  if ( !mPixmap.isNull() )
+  {
+    QLabel::setPixmap( mPixmap.scaled( this->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
+  }
+}
+
+void QgsPixmapLabel::clear()
+{
+  mPixmap = QPixmap();
+  QLabel::clear();
 }

--- a/src/gui/qgspixmaplabel.cpp
+++ b/src/gui/qgspixmaplabel.cpp
@@ -32,8 +32,7 @@ void QgsPixmapLabel::setPixmap( const QPixmap &p )
     updateGeometry();
   }
 
-  QLabel::setPixmap( mPixmap.scaled( this->size(),
-                                     Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
+  QLabel::setPixmap( mPixmap.scaled( this->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
 }
 
 int QgsPixmapLabel::heightForWidth( int width ) const
@@ -58,7 +57,8 @@ void QgsPixmapLabel::resizeEvent( QResizeEvent *e )
   QLabel::resizeEvent( e );
   if ( !mPixmap.isNull() )
   {
-    QLabel::setPixmap( mPixmap.scaled( this->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
+    // Avoid infinite resize loop by setting a pixmap that'll always have a width and height less or equal to the label size
+    QLabel::setPixmap( mPixmap.scaled( this->size() -= QSize( 1, 1 ), Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
   }
 }
 

--- a/src/gui/qgspixmaplabel.h
+++ b/src/gui/qgspixmaplabel.h
@@ -53,6 +53,8 @@ class GUI_EXPORT QgsPixmapLabel : public QLabel
 
     void setPixmap( const QPixmap & );
     void resizeEvent( QResizeEvent * ) override;
+
+    //! Clears any label contents.
     void clear();
 
   private:

--- a/src/gui/qgspixmaplabel.h
+++ b/src/gui/qgspixmaplabel.h
@@ -50,9 +50,13 @@ class GUI_EXPORT QgsPixmapLabel : public QLabel
     QSize sizeHint() const override;
 
   public slots:
+
     void setPixmap( const QPixmap & );
     void resizeEvent( QResizeEvent * ) override;
+    void clear();
+
   private:
+
     QPixmap mPixmap;
 };
 


### PR DESCRIPTION
## Description

This primarily fixes an issue whereas browsing through features in dual view mode with an external resource widget set to image would not clear the cached image while going from one feature to another. If the feature your jumping _to_ has no image, it'd still show the cached image.

I was also seeing infinite image growth when the configuration was set to auto width and auto height, that's fixed too.