### PR TITLE
 [FEATURE][offline editing] Handle list of strings and numbers in offline geopackage

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -588,6 +588,11 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
         {
           dataType = QStringLiteral( "TEXT" );
         }
+        else if ( type == QVariant::StringList  || type == QVariant::List )
+        {
+          dataType = QStringLiteral( "TEXT" );
+          showWarning( tr( "Field '%1' from layer %2 has been converted from a list to a string of comma-separated values." ).arg( field.name(), layer->name() ) );
+        }
         else
         {
           showWarning( tr( "%1: Unknown data type %2. Not using type affinity for the field." ).arg( field.name(), QVariant::typeToName( type ) ) );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1037,7 +1037,7 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVec
       QVariant attr = attrs.at( it );
       if ( remoteLayer->fields().at( remoteAttributeIndex ).type() == QVariant::StringList )
       {
-        attr = attr.toString().split( ',' );
+        attr = convertStringToStringList( attr.toString() );
       }
       else if ( remoteLayer->fields().at( remoteAttributeIndex ).type() == QVariant::List )
       {
@@ -1056,7 +1056,12 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVec
 
 QStringList QgsOfflineEditing::convertStringToStringList( const QString &string )
 {
-  return string.split( QRegularExpression( "(?<!\\\\)\\s*,\\s*" ) );
+  QStringList stringList = string.split( QRegularExpression( "(?<!\\\\)\\s*,\\s*" ) );
+  for ( QString &string : stringList )
+  {
+    string.replace( QStringLiteral( "\\," ), QStringLiteral( "," ) );
+  }
+  return stringList;
 }
 
 QString QgsOfflineEditing::convertStringListToString( const QStringList &stringList )
@@ -1066,7 +1071,7 @@ QString QgsOfflineEditing::convertStringListToString( const QStringList &stringL
   {
     string.replace( QStringLiteral( "," ), QStringLiteral( "\\," ) );
   }
-  return modifiedStringList.join( QStringLiteral( " , " ) );
+  return modifiedStringList.join( QStringLiteral( "," ) );
 }
 
 QVariantList QgsOfflineEditing::convertStringToList( const QString &string, QVariant::Type type )

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -756,6 +756,11 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
           ogrType = OFTInteger;
           ogrSubType = OFSTBoolean;
         }
+        else if ( type == QVariant::StringList || type == QVariant::List )
+        {
+          ogrType = OFTString;
+          showWarning( tr( "Field '%1' from layer %2 has been converted from a list to a string of comma-separated values." ).arg( fieldName, layer->name() ) );
+        }
         else
           ogrType = OFTString;
 

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -128,6 +128,9 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );
     void copySymbology( QgsVectorLayer *sourceLayer, QgsVectorLayer *targetLayer );
 
+    QString convertStringListToString( const QStringList &stringList );
+    QStringList convertStringToStringList( const QString &string );
+
     QVariantList convertStringToList( const QString &string, QVariant::Type type );
 
     /**

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -128,6 +128,8 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );
     void copySymbology( QgsVectorLayer *sourceLayer, QgsVectorLayer *targetLayer );
 
+    QVariantList convertStringToList( const QString &string, QVariant::Type type );
+
     /**
      * Updates all relations that reference or are referenced by the source layer to the targetLayer.
      */

--- a/tests/testdata/points.geojson
+++ b/tests/testdata/points.geojson
@@ -1,0 +1,24 @@
+{
+"type": "FeatureCollection",
+"name": "remote_lists",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 90, "Importance": 3.0, "Pilots": 2, "Cabin Crew": 0, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -117.23257, 37.21877 ] } },
+{ "type": "Feature", "properties": { "Class": "Biplane", "Heading": 0, "Importance": 1.0, "Pilots": 3, "Cabin Crew": 3, "Staff": 6, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -83.33333, 33.88889 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 85, "Importance": 3.0, "Pilots": 1, "Cabin Crew": 1, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -109.61353, 35.71946 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 95, "Importance": 3.0, "Pilots": 1, "Cabin Crew": 1, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -97.79848, 34.83609 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 90, "Importance": 3.0, "Pilots": 1, "Cabin Crew": 0, "Staff": 1, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -88.30228, 33.73188 ] } },
+{ "type": "Feature", "properties": { "Class": "Biplane", "Heading": 340, "Importance": 1.0, "Pilots": 3, "Cabin Crew": 3, "Staff": 6, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -85.65217, 38.92167 ] } },
+{ "type": "Feature", "properties": { "Class": "Biplane", "Heading": 300, "Importance": 1.0, "Pilots": 3, "Cabin Crew": 2, "Staff": 5, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -93.1608, 40.68841 ] } },
+{ "type": "Feature", "properties": { "Class": "Biplane", "Heading": 270, "Importance": 1.0, "Pilots": 3, "Cabin Crew": 4, "Staff": 7, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -102.43616, 41.24051 ] } },
+{ "type": "Feature", "properties": { "Class": "Biplane", "Heading": 240, "Importance": 1.0, "Pilots": 3, "Cabin Crew": 2, "Staff": 5, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -112.26363, 39.36335 ] } },
+{ "type": "Feature", "properties": { "Class": "B52", "Heading": 0, "Importance": 10.0, "Pilots": 2, "Cabin Crew": 1, "Staff": 3, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -103.31953, 22.80021 ] } },
+{ "type": "Feature", "properties": { "Class": "B52", "Heading": 12, "Importance": 10.0, "Pilots": 1, "Cabin Crew": 1, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -102.87785, 31.52346 ] } },
+{ "type": "Feature", "properties": { "Class": "B52", "Heading": 34, "Importance": 10.0, "Pilots": 2, "Cabin Crew": 1, "Staff": 3, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -99.56522, 40.57798 ] } },
+{ "type": "Feature", "properties": { "Class": "B52", "Heading": 80, "Importance": 10.0, "Pilots": 2, "Cabin Crew": 1, "Staff": 3, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -94.26501, 46.87198 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 160, "Importance": 4.0, "Pilots": 2, "Cabin Crew": 0, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -114.196, 42.39993 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 180, "Importance": 3.0, "Pilots": 1, "Cabin Crew": 0, "Staff": 1, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -113.25742, 35.9403 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 140, "Importance": 10.0, "Pilots": 1, "Cabin Crew": 1, "Staff": 2, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -110.05521, 31.52346 ] } },
+{ "type": "Feature", "properties": { "Class": "Jet", "Heading": 100, "Importance": 20.0, "Pilots": 3, "Cabin Crew": 0, "Staff": 3, "StaffNames": ["Bob", "Alice"], "StaffAges": [22, 33] }, "geometry": { "type": "Point", "coordinates": [ -104.97585, 28.65252 ] } }
+]
+}


### PR DESCRIPTION
## Description

This PR unlocks offline editing of {string,number} list fields. The feature was requested through issue #32712 . 

Since sqlite (and therefore spatialite and geopackage) doesn't have native list support, the offline editing plugin transforms {string,number} list fields into string fields where values are separated by commas. This allows both for consumers of offline layers to be able to read the content of those fields, as well as editing those.

Edit: for the record, expressions wanting to handle both the field from the original layer and the offline layer could easily use the try() expression function, e.g.: `try(array_contains("field",1),array_contains(string_to_array("field"),1))`