### PR TITLE
Map postgresraster source string to GDAL Postgis raster connection

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -170,7 +170,7 @@ class ClipRasterByExtent(GdalAlgorithm):
             tiled = re.search(r"Is Tiled</td><td>([^<]+)", metadata)
             if (tiled):
                 if (tiled.group(1) == 'true'):
-                    uri_config['mode'] = 2 
+                    uri_config['mode'] = 2
             for item in layerSource.split(' '):
                 column = re.search(r"^\((.*)\)$", item)
                 if (column):

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -247,7 +247,7 @@ class ClipRasterByMask(GdalAlgorithm):
             tiled = re.search(r"Is Tiled</td><td>([^<]+)", metadata)
             if (tiled):
                 if (tiled.group(1) == 'true'):
-                    uri_config['mode'] = 2 
+                    uri_config['mode'] = 2
             for item in layerSource.split(' '):
                 column = re.search(r"^\((.*)\)$", item)
                 if (column):

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -22,6 +22,7 @@ __date__ = 'September 2013'
 __copyright__ = '(C) 2013, Alexander Bruy'
 
 import os
+import re
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -238,7 +239,32 @@ class ClipRasterByMask(GdalAlgorithm):
             extra = self.parameterAsString(parameters, self.EXTRA, context)
             arguments.append(extra)
 
-        arguments.append(inLayer.source())
+        layerSource = inLayer.source()
+        layerProvider = inLayer.dataProvider()
+        if (layerProvider.name() == 'postgresraster'):
+            metadata = layerProvider.htmlMetadata()
+            uri_config = {}
+            tiled = re.search(r"Is Tiled</td><td>([^<]+)", metadata)
+            if (tiled):
+                if (tiled.group(1) == 'true'):
+                    uri_config['mode'] = 2 
+            for item in layerSource.split(' '):
+                column = re.search(r"^\((.*)\)$", item)
+                if (column):
+                    uri_config['column'] = column.group(1)
+                    continue
+                schema = re.search(r"table=([^.]+)\.(.+)$", item)
+                if (schema):
+                    uri_config['schema'] = schema.group(1)
+                    uri_config['table'] = schema.group(2)
+                    continue
+                pair = re.search(r"([^=]+)=(.+)", item)
+                if (pair):
+                    if pair.group(1) != 'srid':
+                        uri_config[pair.group(1)] = pair.group(2)
+            layerSource = 'PG: ' + " ".join(["=".join([key, str(val)]) for key, val in uri_config.items()])
+
+        arguments.append(layerSource)
         arguments.append(out)
 
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]


### PR DESCRIPTION
## Description

Currently, we can add a Postgis raster layer using DB Manager or the Browser panel. While the result is almost the same to the user, the layer source/uri is different.

### Adding a Postgis layer with DB Manager

```
QgsProject.instance().mapLayersByName('ortos_2018_2k_desertas_db')[0].source()
' dbname=\'ortos\' host=madeira.pt user=drote password=xxxx port=5432 column=\'rast\' table="ortos"."desertas"'
```
### Adding a Postgis layer with the Browser panel

```
QgsProject.instance().mapLayersByName('ortos_2018_2k_desertas_browser')[0].source()
'dbname=\'ortos\' host=madeira.pt port=5432 user=\'drote\' password=\'xxxx\' sslmode=disable srid=5016 table="ortos"."desertas" (rast)'
```

## The problem

The problem is the that the `postgresraster` layer uri might not conform GDAL connection string (issue #43030). 

## Band-aid fix 

This PR enhances both `ClipRasterByExtent.py` and `ClipRasterByMask.py` to reorganize the connection string, to meet [GDAL Postgis raster driver](https://gdal.org/drivers/raster/postgisraster.html) requirements, **only if the provider is `postgresraster`**.

- [x] Tested only with basic authentication.
- [x] Tested also with service based connections. 

Not tested with other authentication methods provided by QGIS Authentication infrastructure.

Fixes #43030

### Other possible solutions

A better solution could be adding a method to the provider to expose the uri as a GDAL compatible one (something like `gdalSource()`, so it can be used in other places of the code and exposed to plugins. Such method could handle more complex authentication methods.

Contributions to this are very welcome.

