### PR TITLE
Add celestial body support from PROJ 8.1

### DIFF
--- a/python/core/auto_generated/proj/qgscelestialbody.sip.in
+++ b/python/core/auto_generated/proj/qgscelestialbody.sip.in
@@ -1,0 +1,71 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/proj/qgscelestialbody.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsCelestialBody
+{
+%Docstring(signature="appended")
+Contains information about a celestial body.
+
+.. note::
+
+   Only used in builds based on on PROJ 8.1 or later
+
+.. versionadded:: 3.20
+%End
+
+%TypeHeaderCode
+#include "qgscelestialbody.h"
+%End
+  public:
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the body is a valid object, or ``False`` if it is a null/invalid
+object.
+%End
+
+    QString name() const;
+%Docstring
+Name of celestial body.
+%End
+
+    QString authority() const;
+%Docstring
+Authority name, e.g. EPSG.
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str;
+    if ( !sipCpp->isValid() )
+    {
+      str = QStringLiteral( "<QgsCelestialBody: invalid>" );
+    }
+    else
+    {
+      QString id;
+      if ( !sipCpp->authority().isEmpty() )
+        id = QStringLiteral( "%1 (%2)" ).arg( sipCpp->name(), sipCpp->authority() );
+      else
+        id = sipCpp->name();
+      str = QStringLiteral( "<QgsCelestialBody: %1>" ).arg( id );
+    }
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/proj/qgscelestialbody.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -820,6 +820,20 @@ be returned.
 .. versionadded:: 3.20
 %End
 
+    QString celestialBodyName() const throw( QgsNotSupportedException );
+%Docstring
+Attempts to retrieve the name of the celestial body associated with the CRS (e.g. "Earth").
+
+.. warning::
+
+   This method requires PROJ 8.1 or later
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+
+
+.. versionadded:: 3.20
+%End
+
     void setCoordinateEpoch( double epoch );
 %Docstring
 Sets the coordinate ``epoch``, as a decimal year.

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsCoordinateReferenceSystemRegistry : QObject
 {
 %Docstring(signature="appended")
@@ -30,6 +31,8 @@ any user-defined CRSes.
 %Docstring
 Constructor for QgsCoordinateReferenceSystemRegistry, with the specified ``parent`` object.
 %End
+
+    ~QgsCoordinateReferenceSystemRegistry();
 
     class UserCrsDetails
 {
@@ -108,6 +111,20 @@ Removes the existing user CRS with matching ``id``.
 Returns ``False`` if the CRS could not be removed.
 
 .. seealso:: :py:func:`userCrsRemoved`
+%End
+
+    QList< QgsCelestialBody > celestialBodies() const;
+%Docstring
+Returns a list of all known celestial bodies.
+
+.. warning::
+
+   This method requires PROJ 8.1 or later
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+
+
+.. versionadded:: 3.20
 %End
 
   signals:

--- a/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
+++ b/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
@@ -40,6 +40,8 @@ Contains utility functions for working with ellipsoids and querying the ellipsoi
       QString acronym;
       QString description;
       QgsEllipsoidUtils::EllipsoidParameters parameters;
+
+      QString celestialBodyName;
     };
 
     static EllipsoidParameters ellipsoidParameters( const QString &ellipsoid );

--- a/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
+++ b/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsEllipsoidUtils
 {
 %Docstring(signature="appended")
@@ -33,6 +34,7 @@ Contains utility functions for working with ellipsoids and querying the ellipsoi
       double inverseFlattening;
 
       QgsCoordinateReferenceSystem crs;
+
     };
 
     struct EllipsoidDefinition
@@ -64,6 +66,25 @@ Returns a list of all known ellipsoid acronyms from the internal
 ellipsoid database.
 
 .. seealso:: :py:func:`definitions`
+%End
+
+    static QList< QgsCelestialBody > celestialBodies();
+%Docstring
+Returns a list of all known celestial bodies.
+
+.. note::
+
+   This method is an alias for :py:func:`QgsCoordinateReferenceSystemRegistry.celestialBodies()`.
+
+.. warning::
+
+   This method requires PROJ 8.1 or later
+
+
+:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+
+
+.. versionadded:: 3.20
 %End
 
 };

--- a/python/core/auto_generated/proj/qgsprojutils.sip.in
+++ b/python/core/auto_generated/proj/qgsprojutils.sip.in
@@ -29,6 +29,13 @@ Utility functions for working with the proj library.
 Returns the proj library major version number.
 %End
 
+    static int projVersionMinor();
+%Docstring
+Returns the proj library minor version number.
+
+.. versionadded:: 3.20
+%End
+
     static QString epsgRegistryVersion();
 %Docstring
 Returns the EPSG registry database version used by the proj library (e.g. "v9.8.6").

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -428,6 +428,7 @@
 %Include auto_generated/pointcloud/qgspointcloudrenderer.sip
 %Include auto_generated/pointcloud/qgspointcloudrendererregistry.sip
 %Include auto_generated/pointcloud/qgspointcloudrgbrenderer.sip
+%Include auto_generated/proj/qgscelestialbody.sip
 %Include auto_generated/proj/qgscoordinatereferencesystem.sip
 %Include auto_generated/proj/qgscoordinatereferencesystemregistry.sip
 %Include auto_generated/proj/qgscoordinatetransform.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1357,6 +1357,7 @@ set(QGIS_CORE_HDRS
   pointcloud/qgspointcloudrendererregistry.h
   pointcloud/qgspointcloudrgbrenderer.h
 
+  proj/qgscelestialbody.h
   proj/qgscoordinatereferencesystem.h
   proj/qgscoordinatereferencesystemregistry.h
   proj/qgscoordinatetransform.h

--- a/src/core/proj/qgscelestialbody.h
+++ b/src/core/proj/qgscelestialbody.h
@@ -1,0 +1,81 @@
+/***************************************************************************
+               qgscelestialbody.h
+               ------------------------
+    begin                : May 2021
+    copyright            : (C) 2021 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCELESTIALBODY_H
+#define QGSCELESTIALBODY_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <QString>
+
+/**
+ * \ingroup core
+ * \brief Contains information about a celestial body.
+ *
+ * \note Only used in builds based on on PROJ 8.1 or later
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsCelestialBody
+{
+  public:
+
+    /**
+     * Returns TRUE if the body is a valid object, or FALSE if it is a null/invalid
+     * object.
+     */
+    bool isValid() const { return mValid; }
+
+    /**
+     * Name of celestial body.
+     */
+    QString name() const { return mName; }
+
+    /**
+     * Authority name, e.g. EPSG.
+     */
+    QString authority() const { return mAuthority; }
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str;
+    if ( !sipCpp->isValid() )
+    {
+      str = QStringLiteral( "<QgsCelestialBody: invalid>" );
+    }
+    else
+    {
+      QString id;
+      if ( !sipCpp->authority().isEmpty() )
+        id = QStringLiteral( "%1 (%2)" ).arg( sipCpp->name(), sipCpp->authority() );
+      else
+        id = sipCpp->name();
+      str = QStringLiteral( "<QgsCelestialBody: %1>" ).arg( id );
+    }
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
+  private:
+
+    bool mValid = false;
+    QString mName;
+    QString mAuthority;
+
+    friend class QgsCoordinateReferenceSystemRegistry;
+};
+
+#endif // QGSCELESTIALBODY_H

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1210,6 +1210,21 @@ bool QgsCoordinateReferenceSystem::isDynamic() const
   return QgsProjUtils::isDynamic( pj );
 }
 
+QString QgsCoordinateReferenceSystem::celestialBodyName() const
+{
+  const PJ *pj = projObject();
+  if ( !pj )
+    return QString();
+
+#if PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR>=1)
+  PJ_CONTEXT *context = QgsProjContext::get();
+
+  return QString( proj_get_celestial_body_name( context, pj ) );
+#else
+  throw QgsNotSupportedException( QStringLiteral( "Retrieving celestial body requires a QGIS build based on PROJ 8.1 or later" ) );
+#endif
+}
+
 void QgsCoordinateReferenceSystem::setCoordinateEpoch( double epoch )
 {
   if ( d->mCoordinateEpoch == epoch )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -757,6 +757,17 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QgsDatumEnsemble datumEnsemble() const SIP_THROW( QgsNotSupportedException );
 
     /**
+     * Attempts to retrieve the name of the celestial body associated with the CRS (e.g. "Earth").
+     *
+     * \warning This method requires PROJ 8.1 or later
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on PROJ 8.0 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    QString celestialBodyName() const SIP_THROW( QgsNotSupportedException );
+
+    /**
      * Sets the coordinate \a epoch, as a decimal year.
      *
      * In a dynamic CRS (see isDynamic()), coordinates of a point on the surface of the Earth may

--- a/src/core/proj/qgscoordinatereferencesystemregistry.h
+++ b/src/core/proj/qgscoordinatereferencesystemregistry.h
@@ -21,6 +21,8 @@
 #include <QObject>
 #include "qgscoordinatereferencesystem.h"
 
+class QgsCelestialBody;
+
 /**
  * \class QgsCoordinateReferenceSystemRegistry
  * \ingroup core
@@ -41,6 +43,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
      * Constructor for QgsCoordinateReferenceSystemRegistry, with the specified \a parent object.
      */
     explicit QgsCoordinateReferenceSystemRegistry( QObject *parent = nullptr );
+
+    ~QgsCoordinateReferenceSystemRegistry();
 
     /**
      * \brief Contains details of a custom (user defined) CRS.
@@ -119,6 +123,17 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
      */
     bool removeUserCrs( long id );
 
+    /**
+     * Returns a list of all known celestial bodies.
+     *
+     * \warning This method requires PROJ 8.1 or later
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on PROJ 8.0 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    QList< QgsCelestialBody > celestialBodies() const;
+
   signals:
 
     /**
@@ -162,6 +177,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
   private:
 
     bool insertProjection( const QString &projectionAcronym );
+
+    mutable QList< QgsCelestialBody > mCelestialBodies;
 
 };
 

--- a/src/core/proj/qgsellipsoidutils.cpp
+++ b/src/core/proj/qgsellipsoidutils.cpp
@@ -269,6 +269,10 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
             name.replace( '_', ' ' );
             def.description = QStringLiteral( "%1 (%2:%3)" ).arg( name, authority, code );
 
+#if PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR>=1)
+            def.celestialBodyName = proj_get_celestial_body_name( context, ellipsoid.get() );
+#endif
+
             double semiMajor, semiMinor, invFlattening;
             int semiMinorComputed = 0;
             if ( proj_ellipsoid_get_parameters( context, ellipsoid.get(), &semiMajor, &semiMinor, &semiMinorComputed, &invFlattening ) )

--- a/src/core/proj/qgsellipsoidutils.cpp
+++ b/src/core/proj/qgsellipsoidutils.cpp
@@ -22,6 +22,8 @@
 #include "qgsprojutils.h"
 #include "qgsreadwritelocker.h"
 #include "qgsruntimeprofiler.h"
+#include "qgscoordinatereferencesystemregistry.h"
+#include "qgscelestialbody.h"
 
 #include <proj.h>
 #include <mutex>
@@ -334,6 +336,11 @@ QStringList QgsEllipsoidUtils::acronyms()
     result << def.acronym;
   }
   return result;
+}
+
+QList<QgsCelestialBody> QgsEllipsoidUtils::celestialBodies()
+{
+  return QgsApplication::coordinateReferenceSystemRegistry()->celestialBodies();
 }
 
 void QgsEllipsoidUtils::invalidateCache( bool disableCache )

--- a/src/core/proj/qgsellipsoidutils.h
+++ b/src/core/proj/qgsellipsoidutils.h
@@ -21,6 +21,8 @@
 #include "qgscoordinatereferencesystem.h"
 #include <QStringList>
 
+class QgsCelestialBody;
+
 /**
  * \class QgsEllipsoidUtils
  * \ingroup core
@@ -54,6 +56,7 @@ class CORE_EXPORT QgsEllipsoidUtils
 
       //! Associated coordinate reference system
       QgsCoordinateReferenceSystem crs;
+
     };
 
     /**
@@ -98,6 +101,19 @@ class CORE_EXPORT QgsEllipsoidUtils
      * \see definitions()
      */
     static QStringList acronyms();
+
+    /**
+     * Returns a list of all known celestial bodies.
+     *
+     * \note This method is an alias for QgsCoordinateReferenceSystemRegistry::celestialBodies().
+     *
+     * \warning This method requires PROJ 8.1 or later
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on PROJ 8.0 or earlier.
+     *
+     * \since QGIS 3.20
+     */
+    static QList< QgsCelestialBody > celestialBodies();
 
 #ifndef SIP_RUN
 

--- a/src/core/proj/qgsellipsoidutils.h
+++ b/src/core/proj/qgsellipsoidutils.h
@@ -68,6 +68,15 @@ class CORE_EXPORT QgsEllipsoidUtils
       QString description;
       //! Ellipsoid parameters
       QgsEllipsoidUtils::EllipsoidParameters parameters;
+
+      /**
+       * Name of the associated celestial body (e.g. "Earth").
+       *
+       * \warning This method requires PROJ 8.1 or later. On earlier PROJ builds the string will always be empty.
+       *
+       * \since QGIS 3.20
+       */
+      QString celestialBodyName;
     };
 
     /**

--- a/src/core/proj/qgsprojutils.cpp
+++ b/src/core/proj/qgsprojutils.cpp
@@ -359,6 +359,11 @@ int QgsProjUtils::projVersionMajor()
   return PROJ_VERSION_MAJOR;
 }
 
+int QgsProjUtils::projVersionMinor()
+{
+  return PROJ_VERSION_MINOR;
+}
+
 QString QgsProjUtils::epsgRegistryVersion()
 {
   PJ_CONTEXT *context = QgsProjContext::get();

--- a/src/core/proj/qgsprojutils.h
+++ b/src/core/proj/qgsprojutils.h
@@ -51,6 +51,13 @@ class CORE_EXPORT QgsProjUtils
     static int projVersionMajor();
 
     /**
+     * Returns the proj library minor version number.
+     *
+     * \since QGIS 3.20
+     */
+    static int projVersionMinor();
+
+    /**
      * Returns the EPSG registry database version used by the proj library (e.g. "v9.8.6").
      *
      * \see epsgRegistryDate()

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -959,6 +959,19 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
 
   try
   {
+    const QString celestialBody = currentCrs.celestialBodyName();
+    if ( !celestialBody.isEmpty() )
+    {
+      properties << tr( "Celestial body: %1" ).arg( celestialBody );
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+
+  }
+
+  try
+  {
     const QgsDatumEnsemble ensemble = currentCrs.datumEnsemble();
     if ( ensemble.isValid() )
     {

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -79,6 +79,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void isGeographic();
     void mapUnits();
     void isDynamic();
+    void celestialBody();
     void setValidationHint();
     void hasAxisInverted();
     void createFromProjInvalid();
@@ -1330,6 +1331,20 @@ void TestQgsCoordinateReferenceSystem::isDynamic()
       AUTHORITY["EPSG","4326"]])""" ) ) );
   QVERIFY( crs.isValid() );
   QVERIFY( crs.isDynamic() );
+#endif
+}
+
+void TestQgsCoordinateReferenceSystem::celestialBody()
+{
+#if (PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR >= 1 ) )
+  QgsCoordinateReferenceSystem crs;
+  QCOMPARE( crs.celestialBodyName(), QString() );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( crs.celestialBodyName(), QStringLiteral( "Earth" ) );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "ESRI:104903" ) );
+  QCOMPARE( crs.celestialBodyName(), QStringLiteral( "Moon" ) );
 #endif
 }
 

--- a/tests/src/python/test_qgsellipsoidutils.py
+++ b/tests/src/python/test_qgsellipsoidutils.py
@@ -112,6 +112,15 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
         self.assertFalse(gany_defs.parameters.useCustomParameters)
         self.assertEqual(gany_defs.parameters.crs.authid(), '')
 
+    @unittest.skipIf(QgsProjUtils.projVersionMajor() < 8 or (QgsProjUtils.projVersionMajor() == 8 and QgsProjUtils.projVersionMinor() < 1), 'Not a proj >= 8.1 build')
+    def testCelestialBodies(self):
+        bodies = QgsEllipsoidUtils.celestialBodies()
+
+        self.assertTrue(bodies)
+
+        ganymede = [body for body in bodies if body.name() == 'Ganymede' and body.authority() == 'ESRI'][0]
+        self.assertTrue(ganymede.isValid())
+
     def testMappingEllipsoidsToProj6(self):
         old_qgis_ellipsoids = {'Adrastea2000': 'Adrastea2000', 'airy': 'Airy 1830', 'Amalthea2000': 'Amalthea2000',
                                'Ananke2000': 'Ananke2000',

--- a/tests/src/python/test_qgsellipsoidutils.py
+++ b/tests/src/python/test_qgsellipsoidutils.py
@@ -98,6 +98,10 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
         self.assertEqual(gany_defs.acronym, gany_id)
         self.assertEqual(gany_defs.description,
                          'Ganymede 2000 IAU IAG (ESRI:107916)')
+
+        if QgsProjUtils.projVersionMajor() > 8 or (QgsProjUtils.projVersionMajor() == 8 and QgsProjUtils.projVersionMinor() >= 1):
+            self.assertEqual(gany_defs.celestialBodyName, 'Ganymede')
+
         self.assertTrue(gany_defs.parameters.valid)
         self.assertEqual(gany_defs.parameters.semiMajor,
                          2632345.0)


### PR DESCRIPTION
(temporarily includes https://github.com/qgis/QGIS/pull/43143)

Part of my ongoing effort to keep QGIS in step with new functionality introduced in PROJ, this PR adds QGIS api for the newly introduced PROJ celestial body API.

Included is:
- QgsCoordinateReferenceSystem::celestialBodyName() - returns the name of the celestial body associated with a CRS
- EllipsoidDefinition::celestialBodyName  - returns the name of the celestial body associated with an ellipsoid
- QgsCoordinateReferenceSystemRegistry::celestialBodies() - for retrieving a list of all known celestial bodies from PROJ

We could potential use these in future to filter out the projection list to CRS matching a specific celestial body, but for now they are just introduced for API completeness + shown as an additional CRS property in the projection selection widget after a particular CRS is selected
