### PR TITLE
[ogr] Fix broken feature attribute value change for stringlist fields

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2564,12 +2564,13 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
             int pos = 0;
             for ( const QString &string : list )
             {
-              lst[pos] = mCodec->fromUnicode( string ).data();
+              lst[pos] = CPLStrdup( mCodec->fromUnicode( string ).data() );
               pos++;
             }
           }
           lst[count] = nullptr;
           OGR_F_SetFieldStringList( poFeature.get(), ogrField, lst );
+          CSLDestroy( lst );
         }
         else
         {
@@ -2592,12 +2593,13 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
               int pos = 0;
               for ( const QString &string : list )
               {
-                lst[pos] = mCodec->fromUnicode( string ).data();
+                lst[pos] = CPLStrdup( mCodec->fromUnicode( string ).data() );
                 pos++;
               }
             }
             lst[count] = nullptr;
             OGR_F_SetFieldStringList( poFeature.get(), ogrField, lst );
+            CSLDestroy( lst );
           }
           else
           {


### PR DESCRIPTION
## Description

This PR (partially) fixes editing of string list fields for the OGR provider. Instead of ending up with a null field value when edited, we have a proper string list, with the right number of strings in the list. However, there's a problem (~~I suspect with OGR~~ it's with us :) ) whereas all string values in the list end up being the value of the _last_ item in the list passed onto OGR_F_SetFieldStringList.