### PR TITLE
Add option to save layer metadata to Package Layers algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.h
+++ b/src/analysis/processing/qgsalgorithmpackage.h
@@ -55,7 +55,7 @@ class QgsPackageAlgorithm : public QgsProcessingAlgorithm
   private:
 
     bool packageVectorLayer( QgsVectorLayer *layer, const QString &path, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
-                             bool saveStyles, bool selectedFeaturesOnly );
+                             bool saveStyles, bool saveMetadata, bool selectedFeaturesOnly );
 
     std::vector< std::unique_ptr< QgsMapLayer> > mLayers;
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -132,6 +132,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->setCrs( crs() );
   layer->setCustomProperties( mCustomProperties );
   layer->setOpacity( mLayerOpacity );
+  layer->setMetadata( mMetadata );
 }
 
 QgsMapLayerType QgsMapLayer::type() const

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -59,6 +59,7 @@ from qgis.core import (QgsWkbTypes,
                        QgsTextFormat,
                        QgsVectorLayerSelectedFeatureSource,
                        QgsExpression,
+                       QgsLayerMetadata,
                        NULL)
 from qgis.gui import (QgsAttributeTableModel,
                       QgsGui
@@ -3029,8 +3030,14 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         action = QgsAction(QgsAction.Unix, "MyActionDescription", "MyActionCmd")
         layer.actions().addAction(action)
 
+        metadata = QgsLayerMetadata()
+        metadata.setFees('a handful of roos')
+        layer.setMetadata(metadata)
+
         # clone layer
         clone = layer.clone()
+
+        self.assertEqual(layer.metadata().fees(), 'a handful of roos')
 
         # generate xml from layer
         layer_doc = QDomDocument("doc")


### PR DESCRIPTION
If checked, this option copies the source layer metadata into the
geopackage so that it will be used as the default metadata for the
layer.