### PR TITLE
Projection info improvements

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -893,6 +893,14 @@ The function also calculates the partial derivatives of the given coordinate.
 .. versionadded:: 3.20
 %End
 
+    QgsProjOperation operation() const;
+%Docstring
+Returns information about the PROJ operation associated with the coordinate reference system, for example
+the projection method used by the CRS.
+
+.. versionadded:: 3.20
+%End
+
     bool hasAxisInverted() const;
 %Docstring
 Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS.

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -113,6 +113,15 @@ Returns ``False`` if the CRS could not be removed.
 .. seealso:: :py:func:`userCrsRemoved`
 %End
 
+    QMap< QString, QgsProjOperation > projOperations() const;
+%Docstring
+Returns a map of all valid PROJ operations.
+
+The map keys correspond to PROJ operation IDs.
+
+.. versionadded:: 3.20
+%End
+
     QList< QgsCelestialBody > celestialBodies() const;
 %Docstring
 Returns a list of all known celestial bodies.

--- a/python/core/auto_generated/proj/qgsprojoperation.sip.in
+++ b/python/core/auto_generated/proj/qgsprojoperation.sip.in
@@ -1,0 +1,67 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/proj/qgsprojoperation.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsProjOperation
+{
+%Docstring(signature="appended")
+Contains information about a PROJ operation.
+
+.. versionadded:: 3.20
+%End
+
+%TypeHeaderCode
+#include "qgsprojoperation.h"
+%End
+  public:
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if the body is a valid object, or ``False`` if it is a null/invalid
+object.
+%End
+
+    QString id() const;
+%Docstring
+ID of operation.
+%End
+
+    QString description() const;
+%Docstring
+Description.
+%End
+
+    QString details() const;
+%Docstring
+Additional details.
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str;
+    if ( !sipCpp->isValid() )
+    {
+      str = QStringLiteral( "<QgsProjOperation: invalid>" );
+    }
+    else
+    {
+      str = QStringLiteral( "<QgsProjOperation: %1>" ).arg( sipCpp->id() );
+    }
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/proj/qgsprojoperation.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1881,6 +1881,7 @@ this method is now deprecated and always return ``False``, because circular depe
 
 
 
+
 };
 
 QFlags<QgsMapLayer::LayerFlag> operator|(QgsMapLayer::LayerFlag f1, QFlags<QgsMapLayer::LayerFlag> f2);

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -436,6 +436,7 @@
 %Include auto_generated/proj/qgsdatums.sip
 %Include auto_generated/proj/qgsdatumtransform.sip
 %Include auto_generated/proj/qgsellipsoidutils.sip
+%Include auto_generated/proj/qgsprojoperation.sip
 %Include auto_generated/proj/qgsprojutils.sip
 %Include auto_generated/proj/qgsprojectionfactors.sip
 %Include auto_generated/metadata/qgsabstractmetadatabase.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1365,6 +1365,7 @@ set(QGIS_CORE_HDRS
   proj/qgsdatums.h
   proj/qgsdatumtransform.h
   proj/qgsellipsoidutils.h
+  proj/qgsprojoperation.h
   proj/qgsprojutils.h
   proj/qgsprojectionfactors.h
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -786,6 +786,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of the map (full definition)." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the coordinate reference system of the map." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "map_crs_projection" ), QCoreApplication::translate( "variable_help", "Projection method used by the coordinate reference system of the map." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "map_crs_ellipsoid" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the map." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "map_crs_proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system of the map." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "map_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system of the map." ) );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -32,6 +32,7 @@
 #include "qgsfeatureid.h"
 #include "qgslayoutitemmap.h"
 #include "qgsmaplayerlistutils.h"
+#include "qgsprojoperation.h"
 
 QgsExpressionContextScope *QgsExpressionContextUtils::globalScope()
 {
@@ -456,6 +457,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapSettings.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapSettings.destinationCrs().description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapSettings.destinationCrs().projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_projection" ), mapSettings.destinationCrs().operation().description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_ellipsoid" ), mapSettings.destinationCrs().ellipsoidAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapSettings.destinationCrs().toProj(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapSettings.destinationCrs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ), true ) );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -35,6 +35,7 @@
 #include "qgsstyleentityvisitor.h"
 #include "qgsannotationlayer.h"
 #include "qgscoordinatereferencesystemregistry.h"
+#include "qgsprojoperation.h"
 
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
@@ -1676,6 +1677,7 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_projection" ), mapCrs.operation().description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_ellipsoid" ), mapCrs.ellipsoidAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapCrs.toProj(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapCrs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ), true ) );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1331,23 +1331,8 @@ QString QgsMeshLayer::htmlMetadata() const
   if ( publicSource() != path )
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
-  // EPSG
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );
-  if ( crs().isValid() )
-  {
-    myMetadata += crs().userFriendlyIdentifier( QgsCoordinateReferenceSystem::FullString ) + QStringLiteral( " - " );
-    if ( crs().isGeographic() )
-      myMetadata += tr( "Geographic" );
-    else
-      myMetadata += tr( "Projected" );
-  }
-  myMetadata += QLatin1String( "</td></tr>\n" );
-
   // Extent
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extent().toString() + QStringLiteral( "</td></tr>\n" );
-
-  // unit
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Unit" ) + QStringLiteral( "</td><td>" ) + QgsUnitTypes::toString( crs().mapUnits() ) + QStringLiteral( "</td></tr>\n" );
 
   // feature count
   QLocale locale = QLocale();
@@ -1375,6 +1360,9 @@ QString QgsMeshLayer::htmlMetadata() const
 
   // End Provider section
   myMetadata += QLatin1String( "</table>\n<br><br>" );
+
+  // CRS
+  myMetadata += crsHtmlMetadata();
 
   // identification section
   myMetadata += QStringLiteral( "<h1>" ) + tr( "Identification" ) + QStringLiteral( "</h1>\n<hr>\n" );

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -453,23 +453,8 @@ QString QgsPointCloudLayer::htmlMetadata() const
   if ( publicSource() != path )
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
-  // EPSG
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );
-  if ( crs().isValid() )
-  {
-    myMetadata += crs().userFriendlyIdentifier( QgsCoordinateReferenceSystem::FullString ) + QStringLiteral( " - " );
-    if ( crs().isGeographic() )
-      myMetadata += tr( "Geographic" );
-    else
-      myMetadata += tr( "Projected" );
-  }
-  myMetadata += QLatin1String( "</td></tr>\n" );
-
   // Extent
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extent().toString() + QStringLiteral( "</td></tr>\n" );
-
-  // unit
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Unit" ) + QStringLiteral( "</td><td>" ) + QgsUnitTypes::toString( crs().mapUnits() ) + QStringLiteral( "</td></tr>\n" );
 
   // feature count
   QLocale locale = QLocale();
@@ -479,7 +464,13 @@ QString QgsPointCloudLayer::htmlMetadata() const
                 + tr( "Point count" ) + QStringLiteral( "</td><td>" )
                 + ( pointCount < 0 ? tr( "unknown" ) : locale.toString( static_cast<qlonglong>( pointCount ) ) )
                 + QStringLiteral( "</td></tr>\n" );
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
 
+  // CRS
+  myMetadata += crsHtmlMetadata();
+
+  // provider metadata section
+  myMetadata += QStringLiteral( "<h1>" ) + tr( "Metadata" ) + QStringLiteral( "</h1>\n<hr>\n" ) + QStringLiteral( "<table class=\"list-view\">\n" );
   const QVariantMap originalMetadata = mDataProvider ? mDataProvider->originalMetadata() : QVariantMap();
 
   if ( originalMetadata.value( QStringLiteral( "creation_year" ) ).toInt() > 0 && originalMetadata.contains( QStringLiteral( "creation_doy" ) ) )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -41,6 +41,7 @@ class QDomDocument;
 class QgsCoordinateReferenceSystemPrivate;
 class QgsDatumEnsemble;
 class QgsProjectionFactors;
+class QgsProjOperation;
 
 #ifndef SIP_RUN
 struct PJconsts;
@@ -821,6 +822,14 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \since QGIS 3.20
      */
     QgsProjectionFactors factors( const QgsPoint &point ) const;
+
+    /**
+     * Returns information about the PROJ operation associated with the coordinate reference system, for example
+     * the projection method used by the CRS.
+     *
+     * \since QGIS 3.20
+     */
+    QgsProjOperation operation() const;
 
     /**
      * Returns whether axis is inverted (e.g., for WMS 1.3) for the CRS.

--- a/src/core/proj/qgscoordinatereferencesystemregistry.h
+++ b/src/core/proj/qgscoordinatereferencesystemregistry.h
@@ -19,9 +19,11 @@
 #define QGSCOORDINATEREFERENCESYSTEMREGISTRY_H
 
 #include <QObject>
+#include <QMap>
 #include "qgscoordinatereferencesystem.h"
 
 class QgsCelestialBody;
+class QgsProjOperation;
 
 /**
  * \class QgsCoordinateReferenceSystemRegistry
@@ -124,6 +126,15 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
     bool removeUserCrs( long id );
 
     /**
+     * Returns a map of all valid PROJ operations.
+     *
+     * The map keys correspond to PROJ operation IDs.
+     *
+     * \since QGIS 3.20
+     */
+    QMap< QString, QgsProjOperation > projOperations() const;
+
+    /**
      * Returns a list of all known celestial bodies.
      *
      * \warning This method requires PROJ 8.1 or later
@@ -179,6 +190,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystemRegistry : public QObject
     bool insertProjection( const QString &projectionAcronym );
 
     mutable QList< QgsCelestialBody > mCelestialBodies;
+    mutable QMap< QString, QgsProjOperation > mProjOperations;
 
 };
 

--- a/src/core/proj/qgsprojoperation.h
+++ b/src/core/proj/qgsprojoperation.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+               qgsprojoperation.h
+               ------------------------
+    begin                : May 2021
+    copyright            : (C) 2021 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSPROJOPERATION_H
+#define QGSPROJOPERATION_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <QString>
+
+/**
+ * \ingroup core
+ * \brief Contains information about a PROJ operation.
+ *
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsProjOperation
+{
+  public:
+
+    /**
+     * Returns TRUE if the body is a valid object, or FALSE if it is a null/invalid
+     * object.
+     */
+    bool isValid() const { return mValid; }
+
+    /**
+     * ID of operation.
+     */
+    QString id() const { return mId; }
+
+    /**
+     * Description.
+     */
+    QString description() const { return mDescription; }
+
+    /**
+     * Additional details.
+     */
+    QString details() const { return mDetails; }
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str;
+    if ( !sipCpp->isValid() )
+    {
+      str = QStringLiteral( "<QgsProjOperation: invalid>" );
+    }
+    else
+    {
+      str = QStringLiteral( "<QgsProjOperation: %1>" ).arg( sipCpp->id() );
+    }
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
+  private:
+
+    bool mValid = false;
+    QString mId;
+    QString mDescription;
+    QString mDetails;
+
+    friend class QgsCoordinateReferenceSystemRegistry;
+    friend class QgsCoordinateReferenceSystem;
+};
+
+#endif // QGSCELESTIALBODY_H

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2196,7 +2196,7 @@ QString QgsMapLayer::crsHtmlMetadata() const
     // dynamic crs with no epoch?
     if ( c.isDynamic() && std::isnan( c.coordinateEpoch() ) )
     {
-      accuracyString = tr( "Based on a dynamic CRS, but no coordinate epoch is set! Coordinates are ambiguous and of limited accuracy." );
+      accuracyString = tr( "Based on a dynamic CRS, but no coordinate epoch is set. Coordinates are ambiguous and of limited accuracy." );
     }
 
     // based on datum ensemble?

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1739,6 +1739,19 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     double mLayerOpacity = 1.0;
 
+#ifndef SIP_RUN
+
+    /**
+     * Returns a HTML fragment containing the layer's CRS metadata, for use
+     * in the htmlMetadata() method.
+     *
+     * \note Not available in Python bindings.
+     *
+     * \since QGIS 3.20
+     */
+    QString crsHtmlMetadata() const;
+#endif
+
   private:
 
     virtual QString baseURI( PropertyType type ) const;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -351,23 +351,17 @@ QString QgsRasterLayer::htmlMetadata() const
   if ( publicSource() != path || !isLocalPath )
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() != path ? publicSource() : path ) + QStringLiteral( "</td></tr>\n" );
 
-  // EPSG
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "CRS" ) + QStringLiteral( "</td><td>" );
-  if ( crs().isValid() )
-  {
-    myMetadata += crs().userFriendlyIdentifier( QgsCoordinateReferenceSystem::FullString ) % QStringLiteral( " - " );
-    if ( crs().isGeographic() )
-      myMetadata += tr( "Geographic" );
-    else
-      myMetadata += tr( "Projected" );
-  }
-  myMetadata += QStringLiteral( "</td></tr>\n" ) %
+  myMetadata += QLatin1String( "</table>\n<br><br>" );
+
+  // CRS
+  myMetadata += crsHtmlMetadata();
+
+  myMetadata += QStringLiteral( "<h1>" ) + tr( "Properties" ) + QStringLiteral( "</h1>\n<hr>\n" ) + QStringLiteral( "<table class=\"list-view\">\n" );
+
+  myMetadata += QStringLiteral( "\n" ) %
 
                 // Extent
                 QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Extent" ) % QStringLiteral( "</td><td>" ) % extent().toString() % QStringLiteral( "</td></tr>\n" ) %
-
-                // unit
-                QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Unit" ) % QStringLiteral( "</td><td>" ) % QgsUnitTypes::toString( crs().mapUnits() ) % QStringLiteral( "</td></tr>\n" ) %
 
                 // Raster Width
                 QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Width" ) % QStringLiteral( "</td><td>" );

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5116,24 +5116,8 @@ QString QgsVectorLayer::htmlMetadata() const
       myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Geometry" ) + QStringLiteral( "</td><td>" ) + typeString + QStringLiteral( "</td></tr>\n" );
     }
 
-    // EPSG
-    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );
-    if ( crs().isValid() )
-    {
-      myMetadata += crs().userFriendlyIdentifier( QgsCoordinateReferenceSystem::FullString ) + QStringLiteral( " - " );
-      if ( crs().isGeographic() )
-        myMetadata += tr( "Geographic" );
-      else
-        myMetadata += tr( "Projected" );
-    }
-    myMetadata += QLatin1String( "</td></tr>\n" );
-
     // Extent
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extent().toString() + QStringLiteral( "</td></tr>\n" );
-
-    // unit
-    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Unit" ) + QStringLiteral( "</td><td>" ) + QgsUnitTypes::toString( crs().mapUnits() ) + QStringLiteral( "</td></tr>\n" );
-
   }
 
   // feature count
@@ -5146,6 +5130,12 @@ QString QgsVectorLayer::htmlMetadata() const
 
   // End Provider section
   myMetadata += QLatin1String( "</table>\n<br><br>" );
+
+  if ( isSpatial() )
+  {
+    // CRS
+    myMetadata += crsHtmlMetadata();
+  }
 
   // identification section
   myMetadata += QStringLiteral( "<h1>" ) + tr( "Identification" ) + QStringLiteral( "</h1>\n<hr>\n" );

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -605,10 +605,11 @@ QString QgsVectorTileLayer::htmlMetadata() const
   info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Source path" ) % QStringLiteral( "</td><td>%1" ).arg( QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl( url ).toString(), sourcePath() ) ) + QStringLiteral( "</td></tr>\n" );
 
   info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Zoom levels" ) % QStringLiteral( "</td><td>" ) % QStringLiteral( "%1 - %2" ).arg( sourceMinZoom() ).arg( sourceMaxZoom() ) % QStringLiteral( "</td></tr>\n" );
-  info += QLatin1String( "</table>" );
 
-  // End Provider section
   info += QLatin1String( "</table>\n<br><br>" );
+
+  // CRS
+  info += crsHtmlMetadata();
 
   // Identification section
   info += QStringLiteral( "<h1>" ) % tr( "Identification" ) % QStringLiteral( "</h1>\n<hr>\n" ) %

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsguiutils.h"
 #include "qgslayoutitemmap.h"
 #include "qgsvectorlayer.h"
+#include "qgsprojoperation.h"
 
 #include <QColorDialog>
 #include <QFontDialog>
@@ -145,6 +146,7 @@ void QgsLayoutLabelWidget::buildInsertDynamicTextMenu( QgsLayout *layout, QMenu 
             std::make_pair( tr( "CRS Name (%1)" ).arg( map->crs().description() ),  QStringLiteral( "item_variables('%1')['map_crs_description']" ).arg( map->id() ) ),
             std::make_pair( tr( "Ellipsoid Name (%1)" ).arg( map->crs().ellipsoidAcronym() ),  QStringLiteral( "item_variables('%1')['map_crs_ellipsoid']" ).arg( map->id() ) ),
             std::make_pair( tr( "Units (%1)" ).arg( QgsUnitTypes::toString( map->crs().mapUnits() ) ),  QStringLiteral( "item_variables('%1')['map_units']" ).arg( map->id() ) ),
+            std::make_pair( tr( "Projection (%1)" ).arg( map->crs().operation().description() ),  QStringLiteral( "item_variables('%1')['map_crs_projection']" ).arg( map->id() ) ),
           } )
     {
       addExpression( mapMenu, expression.first, expression.second );

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystemregistry.h"
 #include "qgsdatums.h"
+#include "qgsprojoperation.h"
 
 //qt includes
 #include <QFileInfo>
@@ -994,6 +995,9 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
   {
 
   }
+
+  const QgsProjOperation operation = currentCrs.operation();
+  properties << tr( "Method: %1" ).arg( operation.description() );
 
   const QString propertiesString = QStringLiteral( "<dt><b>%1</b></dt><dd><ul><li>%2</li></ul></dd>" ).arg( tr( "Properties" ),
                                    properties.join( QStringLiteral( "</li><li>" ) ) );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -26,6 +26,7 @@ Email                : sherman at mrcc dot com
 #include "qgsproject.h"
 #include "qgsprojutils.h"
 #include "qgsprojectionfactors.h"
+#include "qgsprojoperation.h"
 #include <proj.h>
 #include <gdal.h>
 #include <cpl_conv.h>
@@ -80,6 +81,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void mapUnits();
     void isDynamic();
     void celestialBody();
+    void operation();
     void setValidationHint();
     void hasAxisInverted();
     void createFromProjInvalid();
@@ -1346,6 +1348,23 @@ void TestQgsCoordinateReferenceSystem::celestialBody()
   crs = QgsCoordinateReferenceSystem( QStringLiteral( "ESRI:104903" ) );
   QCOMPARE( crs.celestialBodyName(), QStringLiteral( "Moon" ) );
 #endif
+}
+
+void TestQgsCoordinateReferenceSystem::operation()
+{
+  QgsCoordinateReferenceSystem crs;
+  QVERIFY( !crs.operation().isValid() );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  QVERIFY( crs.operation().isValid() );
+  QCOMPARE( crs.operation().id(), QStringLiteral( "longlat" ) );
+  QCOMPARE( crs.operation().description(),  QStringLiteral( "Lat/long (Geodetic alias)" ) );
+
+  crs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28356" ) );
+  QVERIFY( crs.operation().isValid() );
+  QCOMPARE( crs.operation().id(), QStringLiteral( "utm" ) );
+  QCOMPARE( crs.operation().description(),  QStringLiteral( "Universal Transverse Mercator (UTM)" ) );
+  QVERIFY( crs.operation().details().contains( QStringLiteral( "south approx" ) ) );
 }
 
 void TestQgsCoordinateReferenceSystem::setValidationHint()

--- a/tests/src/core/testqgscoordinatereferencesystemregistry.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystemregistry.cpp
@@ -23,6 +23,7 @@
 //header for class being tested
 #include "qgscoordinatereferencesystemregistry.h"
 #include "qgsapplication.h"
+#include "qgsprojoperation.h"
 
 class TestQgsCoordinateReferenceSystemRegistry: public QObject
 {
@@ -33,6 +34,7 @@ class TestQgsCoordinateReferenceSystemRegistry: public QObject
     void addUserCrs();
     void changeUserCrs();
     void removeUserCrs();
+    void projOperations();
 
   private:
 
@@ -301,6 +303,17 @@ void TestQgsCoordinateReferenceSystemRegistry::removeUserCrs()
   // doesn't exist anymore...
   QgsCoordinateReferenceSystem crs3( authid );
   QVERIFY( !crs3.isValid() );
+}
+
+void TestQgsCoordinateReferenceSystemRegistry::projOperations()
+{
+  QMap< QString, QgsProjOperation > operations = QgsApplication::coordinateReferenceSystemRegistry()->projOperations();
+
+  QVERIFY( operations.contains( QStringLiteral( "lcc" ) ) );
+  QVERIFY( operations.value( QStringLiteral( "lcc" ) ).isValid() );
+  QCOMPARE( operations.value( QStringLiteral( "lcc" ) ).id(), QStringLiteral( "lcc" ) );
+  QCOMPARE( operations.value( QStringLiteral( "lcc" ) ).description(), QStringLiteral( "Lambert Conformal Conic" ) );
+  QVERIFY( operations.value( QStringLiteral( "lcc" ) ).details().contains( QStringLiteral( "Conic" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystemRegistry )

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -704,6 +704,10 @@ void TestQgsLayoutMap::expressionContext()
   r = e6.evaluate( &c );
   QCOMPARE( r.toString(), QString( "longlat" ) );
 
+  QgsExpression e6a( QStringLiteral( "@map_crs_projection" ) );
+  r = e6a.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "Lat/long (Geodetic alias)" ) );
+
   QgsExpression e7( QStringLiteral( "@map_crs_proj4" ) );
   r = e7.evaluate( &c );
   QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -520,6 +520,10 @@ void TestQgsMapSettings::testExpressionContext()
   r = e.evaluate( &c );
   QCOMPARE( r.toString(), QStringLiteral( "longlat" ) );
 
+  QgsExpression e6a( QStringLiteral( "@map_crs_projection" ) );
+  r = e6a.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "Lat/long (Geodetic alias)" ) );
+
   e = QgsExpression( QStringLiteral( "@map_crs_proj4" ) );
   r = e.evaluate( &c );
   QCOMPARE( r.toString(), QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" ) );


### PR DESCRIPTION
- add api to retrieve PROJ operation details for CRSes
- show extended information about a layer's crs in the layer properties info tab (including accuracy warnings)
- add @map_crs_projection variable for retrieving a friendly name of a map's projection (eg "Albers Equal Area")
-