### PR TITLE
Only relink qgis core if version changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ endif()
 math(EXPR QGIS_VERSION_INT "${CPACK_PACKAGE_VERSION_MAJOR}*10000+${CPACK_PACKAGE_VERSION_MINOR}*100+${CPACK_PACKAGE_VERSION_PATCH}")
 message(STATUS "QGIS version: ${COMPLETE_VERSION} ${RELEASE_NAME} (${QGIS_VERSION_INT})")
 
+set (ENABLE_LOCAL_BUILD_SHORTCUTS FALSE CACHE BOOL "Disables some build steps which are only relevant for releases to speed up compilation time for development")
+
 #############################################################
 if (APPLE)
   # QGIS custom dependencies package from qgis/QGIS-Mac-Packager

--- a/cmake/CreateQgsVersion.cmake
+++ b/cmake/CreateQgsVersion.cmake
@@ -1,3 +1,7 @@
+# Creates version files
+#  qgsversion.h that defines QGSVERSION
+#  qgsversion.inc for doxygen
+
 MACRO(CREATE_QGSVERSION)
   IF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
     FIND_PROGRAM(GITCOMMAND git PATHS c:/cygwin/bin)

--- a/cmake/CreateQgsVersion.cmake
+++ b/cmake/CreateQgsVersion.cmake
@@ -3,51 +3,57 @@
 #  qgsversion.inc for doxygen
 
 MACRO(CREATE_QGSVERSION)
-  IF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
-    FIND_PROGRAM(GITCOMMAND git PATHS c:/cygwin/bin)
-    IF(GITCOMMAND)
-      IF(WIN32 AND NOT CMAKE_CROSS_COMPILING)
-        IF(USING_NINJA)
-         SET(ARG %a)
-        ELSE(USING_NINJA)
-         SET(ARG %%a)
-        ENDIF(USING_NINJA)
-        ADD_CUSTOM_COMMAND(
-          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.inc
-          COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo \#define QGSVERSION \"${ARG}\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
-          COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(${ARG}\)\" >${CMAKE_BINARY_DIR}/qgsversion.inc
-          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h.out -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
-          MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        )
-      ELSE(WIN32 AND NOT CMAKE_CROSS_COMPILING)
-        ADD_CUSTOM_COMMAND(
-          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.inc
-          COMMAND ${GITCOMMAND} log -n1 --pretty=\#define\\ QGSVERSION\\ \\"%h\\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
-          COMMAND ${GITCOMMAND} log -n1 --pretty='PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(%h\)\"' >${CMAKE_BINARY_DIR}/qgsversion.inc
-          COMMAND ${GITCOMMAND} config remote.$$\(${GITCOMMAND} config branch.$$\(${GITCOMMAND} name-rev --name-only HEAD\).remote\).url | sed -e 's/^/\#define QGS_GIT_REMOTE_URL \"/' -e 's/$$/\"/' >>${CMAKE_BINARY_DIR}/qgsversion.h.temp
-          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h.out -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
-          MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        )
-      ENDIF(WIN32 AND NOT CMAKE_CROSS_COMPILING)
-    ELSE(GITCOMMAND)
-      MESSAGE(STATUS "git marker, but no git found - version will be unknown")
+  IF (${ENABLE_LOCAL_BUILD_SHORTCUTS})
+    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"dev\"\n")
+    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (dev)\"\n")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.h)
+  ELSE (${ENABLE_LOCAL_BUILD_SHORTCUTS})
+    IF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
+      FIND_PROGRAM(GITCOMMAND git PATHS c:/cygwin/bin)
+      IF(GITCOMMAND)
+        IF(WIN32 AND NOT CMAKE_CROSS_COMPILING)
+          IF(USING_NINJA)
+           SET(ARG %a)
+          ELSE(USING_NINJA)
+           SET(ARG %%a)
+          ENDIF(USING_NINJA)
+          ADD_CUSTOM_COMMAND(
+            OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h ${CMAKE_BINARY_DIR}/qgsversion.inc
+            COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo \#define QGSVERSION \"${ARG}\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
+            COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(${ARG}\)\" >${CMAKE_BINARY_DIR}/qgsversion.inc
+            COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
+            MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+        ELSE(WIN32 AND NOT CMAKE_CROSS_COMPILING)
+          ADD_CUSTOM_COMMAND(
+            OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h ${CMAKE_BINARY_DIR}/qgsversion.inc
+            COMMAND ${GITCOMMAND} log -n1 --pretty=\#define\\ QGSVERSION\\ \\"%h\\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
+            COMMAND ${GITCOMMAND} log -n1 --pretty='PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(%h\)\"' >${CMAKE_BINARY_DIR}/qgsversion.inc
+            COMMAND ${GITCOMMAND} config remote.$$\(${GITCOMMAND} config branch.$$\(${GITCOMMAND} name-rev --name-only HEAD\).remote\).url | sed -e 's/^/\#define QGS_GIT_REMOTE_URL \"/' -e 's/$$/\"/' >>${CMAKE_BINARY_DIR}/qgsversion.h.temp
+            COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
+            MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+        ENDIF(WIN32 AND NOT CMAKE_CROSS_COMPILING)
+      ELSE(GITCOMMAND)
+        MESSAGE(STATUS "git marker, but no git found - version will be unknown")
+        IF(NOT SHA)
+          SET(SHA "unknown")
+        ENDIF(NOT SHA)
+        FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"${SHA}\"\n")
+        FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (${SHA})\"\n")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.h)
+      ENDIF(GITCOMMAND)
+    ELSE (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
       IF(NOT SHA)
-        SET(SHA "unknown")
+        SET(SHA "exported")
       ENDIF(NOT SHA)
       FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"${SHA}\"\n")
       FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (${SHA})\"\n")
-    ENDIF(GITCOMMAND)
-  ELSE (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
-    IF(NOT SHA)
-      SET(SHA "exported")
-    ENDIF(NOT SHA)
-    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"${SHA}\"\n")
-    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (${SHA})\"\n")
-  ENDIF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
-
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.h)
+      execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.h)
+    ENDIF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
+  ENDIF (${ENABLE_LOCAL_BUILD_SHORTCUTS})
 
   ADD_CUSTOM_TARGET(version ALL DEPENDS ${CMAKE_BINARY_DIR}/qgsversion.h)
 ENDMACRO(CREATE_QGSVERSION)

--- a/cmake/CreateQgsVersion.cmake
+++ b/cmake/CreateQgsVersion.cmake
@@ -9,20 +9,20 @@ MACRO(CREATE_QGSVERSION)
          SET(ARG %%a)
         ENDIF(USING_NINJA)
         ADD_CUSTOM_COMMAND(
-          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h ${CMAKE_BINARY_DIR}/qgsversion.inc
+          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.inc
           COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo \#define QGSVERSION \"${ARG}\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
           COMMAND for /f \"usebackq tokens=1\" ${ARG} in "(`\"${GITCOMMAND}\" log -n1 --oneline`)" do echo PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(${ARG}\)\" >${CMAKE_BINARY_DIR}/qgsversion.inc
-          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
+          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h.out -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
           MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
       ELSE(WIN32 AND NOT CMAKE_CROSS_COMPILING)
         ADD_CUSTOM_COMMAND(
-          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h ${CMAKE_BINARY_DIR}/qgsversion.inc
+          OUTPUT ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.inc
           COMMAND ${GITCOMMAND} log -n1 --pretty=\#define\\ QGSVERSION\\ \\"%h\\" >${CMAKE_BINARY_DIR}/qgsversion.h.temp
           COMMAND ${GITCOMMAND} log -n1 --pretty='PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} \(%h\)\"' >${CMAKE_BINARY_DIR}/qgsversion.inc
           COMMAND ${GITCOMMAND} config remote.$$\(${GITCOMMAND} config branch.$$\(${GITCOMMAND} name-rev --name-only HEAD\).remote\).url | sed -e 's/^/\#define QGS_GIT_REMOTE_URL \"/' -e 's/$$/\"/' >>${CMAKE_BINARY_DIR}/qgsversion.h.temp
-          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
+          COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_BINARY_DIR}/qgsversion.h.temp -DDST=${CMAKE_BINARY_DIR}/qgsversion.h.out -P ${CMAKE_SOURCE_DIR}/cmake/CopyIfChanged.cmake
           MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/.git/index
           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
@@ -32,16 +32,18 @@ MACRO(CREATE_QGSVERSION)
       IF(NOT SHA)
         SET(SHA "unknown")
       ENDIF(NOT SHA)
-      FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h "#define QGSVERSION \"${SHA}\"\n")
+      FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"${SHA}\"\n")
       FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (${SHA})\"\n")
     ENDIF(GITCOMMAND)
   ELSE (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
     IF(NOT SHA)
       SET(SHA "exported")
     ENDIF(NOT SHA)
-    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h "#define QGSVERSION \"${SHA}\"\n")
+    FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.h.out "#define QGSVERSION \"${SHA}\"\n")
     FILE(WRITE ${CMAKE_BINARY_DIR}/qgsversion.inc "PROJECT_NUMBER = \"${COMPLETE_VERSION}-${RELEASE_NAME} (${SHA})\"\n")
   ENDIF (EXISTS ${CMAKE_SOURCE_DIR}/.git/index)
+
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/qgsversion.h.out ${CMAKE_BINARY_DIR}/qgsversion.h)
 
   ADD_CUSTOM_TARGET(version ALL DEPENDS ${CMAKE_BINARY_DIR}/qgsversion.h)
 ENDMACRO(CREATE_QGSVERSION)


### PR DESCRIPTION
qgis_core is linked again, whenever cmake is run, because qgsversion.h is regenerated every time.
This commit only touches the file if the content actually changed and speeds up compiling in some cases.

It also adds a new cmake option `ENABLE_LOCAL_BUILD_SHORTCUTS` to completely avoid including the git sha (which triggers relinking qgis_core after every git commit by design, and is irrelevant for development)