### PR TITLE
Fix compiler warnings introduced recently in master

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -1576,7 +1576,17 @@ std::unique_ptr<QgsSymbol> QgsOgrUtils::symbolFromStyleString( const QString &st
           case 10:
             shape = QgsSimpleMarkerSymbolLayer::Shape::Line;
             break;
+
+          default:
+            isFilled = false;
+            shape = QgsSimpleMarkerSymbolLayer::Shape::Square; // to initialize the variable
+            break;
         }
+      }
+      else
+      {
+        isFilled = false;
+        shape = QgsSimpleMarkerSymbolLayer::Shape::Square; // to initialize the variable
       }
 
       std::unique_ptr< QgsSimpleMarkerSymbolLayer > simpleMarker = std::make_unique< QgsSimpleMarkerSymbolLayer >( shape, symbolSize, -angle );

--- a/src/core/symbology/qgsmapinfosymbolconverter.cpp
+++ b/src/core/symbology/qgsmapinfosymbolconverter.cpp
@@ -1400,6 +1400,7 @@ QgsMarkerSymbol *QgsMapInfoSymbolConverter::convertMarkerSymbol( int identifier,
   {
     case 31:
       // null symbol
+      shape = QgsSimpleMarkerSymbolLayer::Shape::Square; // to initialize the variable
       isNull = true;
       break;
 
@@ -1518,7 +1519,7 @@ QgsMarkerSymbol *QgsMapInfoSymbolConverter::convertMarkerSymbol( int identifier,
     simpleMarker->setFillColor( QColor( 0, 0, 0, 0 ) );
     simpleMarker->setStrokeStyle( Qt::NoPen );
   }
-  if ( isFilled && QgsSimpleMarkerSymbolLayer::shapeIsFilled( shape ) )
+  else if ( isFilled && QgsSimpleMarkerSymbolLayer::shapeIsFilled( shape ) )
   {
     simpleMarker->setColor( color );
     simpleMarker->setStrokeColor( QColor( 0, 0, 0 ) );


### PR DESCRIPTION
Fixes:
```
/home/even/qgis/qgis/src/core/symbology/qgsmapinfosymbolconverter.cpp: In static member function ‘static QgsMarkerSymbol* QgsMapInfoSymbolConverter::convertMarkerSymbol(int, QgsMapInfoSymbolConversionContext&, const QColor&, double, QgsUnitTypes::RenderUnit)’:
/home/even/qgis/qgis/src/core/symbology/qgsmapinfosymbolconverter.cpp:1521:61: warning: ‘shape’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1521 |   if ( isFilled && QgsSimpleMarkerSymbolLayer::shapeIsFilled( shape ) )
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~

/home/even/qgis/qgis/src/core/qgsogrutils.cpp: In static member function ‘static std::unique_ptr<QgsSymbol> QgsOgrUtils::symbolFromStyleString(const QString&, QgsSymbol::SymbolType)’:
/home/even/qgis/qgis/src/core/qgsogrutils.cpp:1585:65: warning: ‘shape’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1585 |       if ( isFilled && QgsSimpleMarkerSymbolLayer::shapeIsFilled( shape ) )
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```

CC @nyalldawson 