### PR TITLE
Add basic support for coordinate epoch of dynamic (not plate fixed) crs

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -850,6 +850,13 @@ CRS (see :py:func:`~QgsCoordinateReferenceSystem.isDynamic`).
 
 :param epoch: Coordinate epoch as decimal year (e.g. 2021.3)
 
+.. warning::
+
+   The :py:class:`QgsCoordinateTransform` class can perform time-dependent transformations
+   between a static and dynamic CRS based on either the source or destination CRS coordinate epoch,
+   however dynamic CRS to dynamic CRS transformations are not currently supported.
+
+
 .. seealso:: :py:func:`coordinateEpoch`
 
 
@@ -870,7 +877,14 @@ observation, and not to the CRS, however it is often more practical to
 bind it to the CRS. The coordinate epoch should be specified for dynamic
 CRS (see :py:func:`~QgsCoordinateReferenceSystem.isDynamic`).
 
+.. warning::
+
+   The :py:class:`QgsCoordinateTransform` class can perform time-dependent transformations
+   between a static and dynamic CRS based on either the source or destination CRS coordinate epoch,
+   however dynamic CRS to dynamic CRS transformations are not currently supported.
+
 :return: Coordinate epoch as decimal year (e.g. 2021.3), or NaN if not set, or relevant.
+
 
 .. seealso:: :py:func:`setCoordinateEpoch`
 

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -29,6 +29,12 @@ transforms coordinates from the layer's coordinate system to the map canvas.
 
    Since QGIS 3.0 :py:class:`QgsCoordinateReferenceSystem` objects are implicitly shared.
 
+.. warning::
+
+   Since QGIS 3.20 The :py:class:`QgsCoordinateTransform` class can perform time-dependent transformations
+   between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+   however dynamic CRS to dynamic CRS transformations are not currently supported.
+
 .. seealso:: :py:class:`QgsDatumTransform`
 
 .. seealso:: :py:class:`QgsCoordinateTransformContext`
@@ -66,12 +72,19 @@ a :py:class:`QgsProject` instance instead of this constructor.
 
 .. warning::
 
+   Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
+   between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+   however dynamic CRS to dynamic CRS transformations are not currently supported.
+
+.. warning::
+
    Do NOT use an empty/default constructed QgsCoordinateTransformContext()
    object when creating QgsCoordinateTransform objects. This prevents correct
    datum transform handling and may result in inaccurate transformations. Always
    ensure that the :py:class:`QgsCoordinateTransformContext` object is correctly retrieved
    based on the current code context, or use the constructor variant which
    accepts a :py:class:`QgsProject` argument instead.
+
 
 .. versionadded:: 3.0
 %End
@@ -96,6 +109,12 @@ correctly respected during coordinate transforms. E.g.
 
        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem("EPSG:3111"),
                                           QgsCoordinateReferenceSystem("EPSG:4326"), QgsProject.instance())
+
+.. warning::
+
+   Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
+   between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+   however dynamic CRS to dynamic CRS transformations are not currently supported.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -100,14 +100,17 @@ correctly respected during coordinate transforms. E.g.
 .. versionadded:: 3.0
 %End
 
-    explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
-                                     const QgsCoordinateReferenceSystem &destination,
-                                     int sourceDatumTransformId,
-                                     int destinationDatumTransformId );
+ explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
+        const QgsCoordinateReferenceSystem &destination,
+        int sourceDatumTransformId,
+        int destinationDatumTransformId ) /Deprecated/;
 %Docstring
 Constructs a QgsCoordinateTransform to transform from the ``source``
 to ``destination`` coordinate reference system, with the specified
 datum transforms (see :py:class:`QgsDatumTransform`).
+
+.. deprecated::
+   will be removed in QGIS 4.0. Use the constructor with a :py:class:`QgsCoordinateTransformContext` argument instead.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -182,6 +182,16 @@ Returns a string representation of a double
 :param precision: number of decimal places to retain
 %End
 
+bool qgsNanCompatibleEquals( double a, double b );
+%Docstring
+Compare two doubles, treating nan values as equal
+
+:param a: first double
+:param b: second double
+
+.. versionadded:: 3.20
+%End
+
 bool qgsDoubleNear( double a, double b, double epsilon = 4 * DBL_EPSILON );
 %Docstring
 Compare two doubles (but allow some difference)

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -63,11 +63,18 @@ QgsAppMissingGridHandler::QgsAppMissingGridHandler( QObject *parent )
     emit fallbackOperationOccurred( sourceCrs, destinationCrs, desired );
   } );
 
+  QgsCoordinateTransform::setDynamicCrsToDynamicCrsWarningHandler( [ = ]( const QgsCoordinateReferenceSystem & sourceCrs,
+      const QgsCoordinateReferenceSystem & destinationCrs )
+  {
+    emit dynamicToDynamicWarning( sourceCrs, destinationCrs );
+  } );
+
   connect( this, &QgsAppMissingGridHandler::missingRequiredGrid, this, &QgsAppMissingGridHandler::onMissingRequiredGrid, Qt::QueuedConnection );
   connect( this, &QgsAppMissingGridHandler::missingPreferredGrid, this, &QgsAppMissingGridHandler::onMissingPreferredGrid, Qt::QueuedConnection );
   connect( this, &QgsAppMissingGridHandler::coordinateOperationCreationError, this, &QgsAppMissingGridHandler::onCoordinateOperationCreationError, Qt::QueuedConnection );
   connect( this, &QgsAppMissingGridHandler::missingGridUsedByContextHandler, this, &QgsAppMissingGridHandler::onMissingGridUsedByContextHandler, Qt::QueuedConnection );
   connect( this, &QgsAppMissingGridHandler::fallbackOperationOccurred, this, &QgsAppMissingGridHandler::onFallbackOperationOccurred, Qt::QueuedConnection );
+  connect( this, &QgsAppMissingGridHandler::dynamicToDynamicWarning, this, &QgsAppMissingGridHandler::onDynamicToDynamicWarning, Qt::QueuedConnection );
 
   connect( QgsProject::instance(), &QgsProject::cleared, this, [ = ]
   {
@@ -301,6 +308,30 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
   bar->pushWidget( widget, Qgis::Warning, 0 );
 }
 
+void QgsAppMissingGridHandler::onDynamicToDynamicWarning( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs )
+{
+  if ( !shouldWarnAboutDynamicCrsForCurrentProject( sourceCrs, destinationCrs ) )
+    return;
+
+  const QString shortMessage = tr( "Cannot transform between dynamic CRS at difference coordinate epochs" );
+  const QString longMessage = tr( "<p>Transformation between %1 and %3 is not currently supported.</p><p><b>The results will be unpredictable and should not be used for high accuracy work.</b>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier() );
+
+  QgsMessageBar *bar = QgisApp::instance()->messageBar();
+  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
+  connect( detailsButton, &QPushButton::clicked, this, [longMessage]
+  {
+    // dlg has deleted on close
+    QgsMessageOutput * dlg( QgsMessageOutput::createMessageOutput() );
+    dlg->setTitle( tr( "Unsupported Transformation" ) );
+    dlg->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dlg->showMessage();
+  } );
+
+  widget->layout()->addWidget( detailsButton );
+  bar->pushWidget( widget, Qgis::Critical, 0 );
+}
+
 bool QgsAppMissingGridHandler::shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest )
 {
   if ( mAlreadyWarnedPairs.contains( qMakePair( source, dest ) ) || mAlreadyWarnedPairs.contains( qMakePair( dest, source ) ) )
@@ -331,5 +362,16 @@ bool QgsAppMissingGridHandler::shouldWarnAboutBallparkPairForCurrentProject( con
   }
 
   mAlreadyWarnedBallparkPairsForProject.append( qMakePair( source, dest ) );
+  return true;
+}
+
+bool QgsAppMissingGridHandler::shouldWarnAboutDynamicCrsForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest )
+{
+  if ( mAlreadyWarnedDynamicCrsForProject.contains( qMakePair( source, dest ) ) || mAlreadyWarnedDynamicCrsForProject.contains( qMakePair( dest, source ) ) )
+  {
+    return false;
+  }
+
+  mAlreadyWarnedDynamicCrsForProject.append( qMakePair( source, dest ) );
   return true;
 }

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -314,7 +314,7 @@ void QgsAppMissingGridHandler::onDynamicToDynamicWarning( const QgsCoordinateRef
     return;
 
   const QString shortMessage = tr( "Cannot transform between dynamic CRS at difference coordinate epochs" );
-  const QString longMessage = tr( "<p>Transformation between %1 and %3 is not currently supported.</p><p><b>The results will be unpredictable and should not be used for high accuracy work.</b>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier() );
+  const QString longMessage = tr( "<p>Transformation between %1 and %2 is not currently supported.</p><p><b>The results will be unpredictable and should not be used for high accuracy work.</b>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier() );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
   QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );

--- a/src/app/qgsappcoordinateoperationhandlers.h
+++ b/src/app/qgsappcoordinateoperationhandlers.h
@@ -53,6 +53,9 @@ class QgsAppMissingGridHandler : public QObject
                                     const QgsCoordinateReferenceSystem &destinationCrs,
                                     const QString &desired );
 
+    void dynamicToDynamicWarning( const QgsCoordinateReferenceSystem &sourceCrs,
+                                  const QgsCoordinateReferenceSystem &destinationCrs );
+
   private slots:
 
     void onMissingRequiredGrid( const QgsCoordinateReferenceSystem &sourceCrs,
@@ -76,15 +79,20 @@ class QgsAppMissingGridHandler : public QObject
                                       const QgsCoordinateReferenceSystem &destinationCrs,
                                       const QString &desired );
 
+    void onDynamicToDynamicWarning( const QgsCoordinateReferenceSystem &sourceCrs,
+                                    const QgsCoordinateReferenceSystem &destinationCrs );
+
   private:
 
     bool shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
     bool shouldWarnAboutPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
     bool shouldWarnAboutBallparkPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
+    bool shouldWarnAboutDynamicCrsForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
 
     QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairs;
     QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairsForProject;
     QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedBallparkPairsForProject;
+    QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedDynamicCrsForProject;
 };
 
 #endif // QGSAPPCOORDINATEOPERATIONHANDLERS_H

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1678,9 +1678,7 @@ bool QgsCoordinateReferenceSystem::operator==( const QgsCoordinateReferenceSyste
   if ( !d->mIsValid || !srs.d->mIsValid )
     return false;
 
-  if ( std::isnan( d->mCoordinateEpoch ) != std::isnan( srs.d->mCoordinateEpoch ) )
-    return false;
-  else if ( !std::isnan( d->mCoordinateEpoch ) && d->mCoordinateEpoch != srs.d->mCoordinateEpoch )
+  if ( !qgsNanCompatibleEquals( d->mCoordinateEpoch, srs.d->mCoordinateEpoch ) )
     return false;
 
   const bool isUser = d->mSrsId >= USER_CRS_START_ID;

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -783,6 +783,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * \param epoch Coordinate epoch as decimal year (e.g. 2021.3)
      *
+     * \warning The QgsCoordinateTransform class can perform time-dependent transformations
+     * between a static and dynamic CRS based on either the source or destination CRS coordinate epoch,
+     * however dynamic CRS to dynamic CRS transformations are not currently supported.
+     *
      * \see coordinateEpoch()
      *
      * \since QGIS 3.20
@@ -801,6 +805,10 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * observation, and not to the CRS, however it is often more practical to
      * bind it to the CRS. The coordinate epoch should be specified for dynamic
      * CRS (see isDynamic()).
+     *
+     * \warning The QgsCoordinateTransform class can perform time-dependent transformations
+     * between a static and dynamic CRS based on either the source or destination CRS coordinate epoch,
+     * however dynamic CRS to dynamic CRS transformations are not currently supported.
      *
      * \returns Coordinate epoch as decimal year (e.g. 2021.3), or NaN if not set, or relevant.
      *

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -1052,3 +1052,8 @@ void QgsCoordinateTransform::setFallbackOperationOccurredHandler( const std::fun
 {
   sFallbackOperationOccurredHandler = handler;
 }
+
+void QgsCoordinateTransform::setDynamicCrsToDynamicCrsWarningHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem & )> &handler )
+{
+  QgsCoordinateTransformPrivate::setDynamicCrsToDynamicCrsWarningHandler( handler );
+}

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -901,13 +901,8 @@ bool QgsCoordinateTransform::setFromCache( const QgsCoordinateReferenceSystem &s
   {
     if ( ( *valIt ).coordinateOperation() == coordinateOperationProj
          && ( *valIt ).allowFallbackTransforms() == allowFallback
-
-         // careful here, nan != nan, so we need to explicitly handle the case when both crses have nan coordinateEpoch
-         && ( std::isnan( ( *valIt ).sourceCrs().coordinateEpoch() ) == std::isnan( src.coordinateEpoch() )
-              && ( std::isnan( src.coordinateEpoch() ) || src.coordinateEpoch() == ( *valIt ).sourceCrs().coordinateEpoch() ) )
-
-         && ( std::isnan( ( *valIt ).destinationCrs().coordinateEpoch() ) == std::isnan( dest.coordinateEpoch() )
-              && ( std::isnan( dest.coordinateEpoch() ) || dest.coordinateEpoch() == ( *valIt ).destinationCrs().coordinateEpoch() ) )
+         && qgsNanCompatibleEquals( src.coordinateEpoch(), ( *valIt ).sourceCrs().coordinateEpoch() )
+         && qgsNanCompatibleEquals( dest.coordinateEpoch(), ( *valIt ).destinationCrs().coordinateEpoch() )
        )
     {
       // need to save, and then restore the context... we don't want this to be cached or to use the values from the cache

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -118,12 +118,13 @@ class CORE_EXPORT QgsCoordinateTransform
      * to \a destination coordinate reference system, with the specified
      * datum transforms (see QgsDatumTransform).
      *
+     * \deprecated will be removed in QGIS 4.0. Use the constructor with a QgsCoordinateTransformContext argument instead.
      * \since QGIS 3.0
      */
-    explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
-                                     const QgsCoordinateReferenceSystem &destination,
-                                     int sourceDatumTransformId,
-                                     int destinationDatumTransformId );
+    Q_DECL_DEPRECATED explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
+        const QgsCoordinateReferenceSystem &destination,
+        int sourceDatumTransformId,
+        int destinationDatumTransformId ) SIP_DEPRECATED;
 
     /**
      * Copy constructor

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -47,6 +47,10 @@ class QgsVector3D;
 * transforms coordinates from the layer's coordinate system to the map canvas.
 * \note Since QGIS 3.0 QgsCoordinateReferenceSystem objects are implicitly shared.
 *
+* \warning Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
+* between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+* however dynamic CRS to dynamic CRS transformations are not currently supported.
+*
 * \see QgsDatumTransform
 * \see QgsCoordinateTransformContext
 */
@@ -75,6 +79,10 @@ class CORE_EXPORT QgsCoordinateTransform
      *
      * Python scripts should generally use the constructor variant which accepts
      * a QgsProject instance instead of this constructor.
+     *
+     * \warning Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
+     * between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+     * however dynamic CRS to dynamic CRS transformations are not currently supported.
      *
      * \warning Do NOT use an empty/default constructed QgsCoordinateTransformContext()
      * object when creating QgsCoordinateTransform objects. This prevents correct
@@ -107,6 +115,9 @@ class CORE_EXPORT QgsCoordinateTransform
      *                                      QgsCoordinateReferenceSystem("EPSG:4326"), QgsProject.instance())
      * \endcode
      *
+     * \warning Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
+     * between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
+     * however dynamic CRS to dynamic CRS transformations are not currently supported.
      * \since QGIS 3.0
      */
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
@@ -701,7 +712,15 @@ class CORE_EXPORT QgsCoordinateTransform
 
     // cache
     static QReadWriteLock sCacheLock;
-    static QMultiHash< QPair< QString, QString >, QgsCoordinateTransform > sTransforms; //same auth_id pairs might have different datum transformations
+
+    /**
+     * Map of cached transforms. The keys are formed by pairs of strings uniquely identifying the source and
+     * destination CRS, using the auth:id were available or a full WKT2 definition where an auth:id is not available.
+     *
+     * The same auth_id pairs might have multiple transformations, as they can be based on different coordinate
+     * operations, allowance of ballpark transforms, and the source or destination coordinate epoch.
+     */
+    static QMultiHash< QPair< QString, QString >, QgsCoordinateTransform > sTransforms;
     static bool sDisableCache;
 
 

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -679,6 +679,15 @@ class CORE_EXPORT QgsCoordinateTransform
         const QgsCoordinateReferenceSystem &destinationCrs,
         const QString &desiredOperation )> &handler );
 
+    /**
+     * Sets a custom \a handler to use when the desired coordinate operation for use between \a sourceCrs and
+     * \a destinationCrs is a dynamic CRS to dynamic CRS transform, not currently supported by PROJ.
+     *
+     * \since QGIS 3.20
+     */
+    static void setDynamicCrsToDynamicCrsWarningHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+        const QgsCoordinateReferenceSystem &destinationCrs )> &handler );
+
 #endif
 
   private:

--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -173,8 +173,7 @@ bool QgsCoordinateTransformPrivate::initialize()
                  : ( mDestIsDynamic && !std::isnan( mDestCoordinateEpoch ) && !mSourceIsDynamic )
                  ? mDestCoordinateEpoch : std::numeric_limits< double >::quiet_NaN();
 
-  if ( mSourceIsDynamic && mDestIsDynamic
-       && !std::isnan( mSourceCoordinateEpoch ) && mSourceCoordinateEpoch != mDestCoordinateEpoch )
+  if ( mSourceIsDynamic && mDestIsDynamic && !qgsNanCompatibleEquals( mSourceCoordinateEpoch, mDestCoordinateEpoch ) )
   {
     // transforms from dynamic crs to dynamic crs with different coordinate epochs are not yet supported by PROJ
     if ( sDynamicCrsToDynamicCrsWarningHandler )

--- a/src/core/proj/qgscoordinatetransform_p.cpp
+++ b/src/core/proj/qgscoordinatetransform_p.cpp
@@ -48,6 +48,9 @@ std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                      const QgsCoordinateReferenceSystem &destinationCrs,
                      const QgsDatumTransform::TransformDetails &desiredOperation )> QgsCoordinateTransformPrivate::sMissingGridUsedByContextHandler = nullptr;
 
+std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+                     const QgsCoordinateReferenceSystem &destinationCrs )> QgsCoordinateTransformPrivate::sDynamicCrsToDynamicCrsWarningHandler = nullptr;
+
 Q_NOWARN_DEPRECATED_PUSH // because of deprecated members
 QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate()
 {
@@ -174,7 +177,10 @@ bool QgsCoordinateTransformPrivate::initialize()
        && !std::isnan( mSourceCoordinateEpoch ) && mSourceCoordinateEpoch != mDestCoordinateEpoch )
   {
     // transforms from dynamic crs to dynamic crs with different coordinate epochs are not yet supported by PROJ
-
+    if ( sDynamicCrsToDynamicCrsWarningHandler )
+    {
+      sDynamicCrsToDynamicCrsWarningHandler( mSourceCRS, mDestCRS );
+    }
   }
 
   // init the projections (destination and source)
@@ -558,6 +564,11 @@ void QgsCoordinateTransformPrivate::setCustomCoordinateOperationCreationErrorHan
 void QgsCoordinateTransformPrivate::setCustomMissingGridUsedByContextHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem &, const QgsDatumTransform::TransformDetails & )> &handler )
 {
   sMissingGridUsedByContextHandler = handler;
+}
+
+void QgsCoordinateTransformPrivate::setDynamicCrsToDynamicCrsWarningHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem & )> &handler )
+{
+  sDynamicCrsToDynamicCrsWarningHandler = handler;
 }
 
 void QgsCoordinateTransformPrivate::freeProj()

--- a/src/core/proj/qgscoordinatetransform_p.h
+++ b/src/core/proj/qgscoordinatetransform_p.h
@@ -103,6 +103,12 @@ class QgsCoordinateTransformPrivate : public QSharedData
     bool mShouldReverseCoordinateOperation = false;
     bool mAllowFallbackTransforms = true;
 
+    bool mSourceIsDynamic = false;
+    bool mDestIsDynamic = false;
+    double mSourceCoordinateEpoch = std::numeric_limits< double >::quiet_NaN();
+    double mDestCoordinateEpoch = std::numeric_limits< double >::quiet_NaN();
+    double mDefaultTime = std::numeric_limits< double >::quiet_NaN();
+
     //! True if the proj transform corresponds to the reverse direction, and must be flipped when transforming...
     bool mIsReversed = false;
 

--- a/src/core/proj/qgscoordinatetransform_p.h
+++ b/src/core/proj/qgscoordinatetransform_p.h
@@ -165,6 +165,15 @@ class QgsCoordinateTransformPrivate : public QSharedData
         const QgsCoordinateReferenceSystem &destinationCrs,
         const QgsDatumTransform::TransformDetails &desiredOperation )> &handler );
 
+    /**
+     * Sets a custom \a handler to use when the desired coordinate operation for use between \a sourceCrs and
+     * \a destinationCrs is a dynamic CRS to dynamic CRS transform, not currently supported by PROJ.
+     *
+     * \since QGIS 3.20
+     */
+    static void setDynamicCrsToDynamicCrsWarningHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+        const QgsCoordinateReferenceSystem &destinationCrs )> &handler );
+
   private:
 
     void freeProj();
@@ -185,6 +194,9 @@ class QgsCoordinateTransformPrivate : public QSharedData
     static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                                 const QgsCoordinateReferenceSystem &destinationCrs,
                                 const QgsDatumTransform::TransformDetails &desiredOperation )> sMissingGridUsedByContextHandler;
+
+    static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+                                const QgsCoordinateReferenceSystem &destinationCrs )> sDynamicCrsToDynamicCrsWarningHandler;
 
     QgsCoordinateTransformPrivate &operator= ( const QgsCoordinateTransformPrivate & ) = delete;
 };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -342,6 +342,22 @@ inline QString qgsDoubleToString( double a, int precision = 17 )
 }
 
 /**
+ * Compare two doubles, treating nan values as equal
+ * \param a first double
+ * \param b second double
+ * \since QGIS 3.20
+ */
+inline bool qgsNanCompatibleEquals( double a, double b )
+{
+  const bool aIsNan = std::isnan( a );
+  const bool bIsNan = std::isnan( b );
+  if ( aIsNan || bIsNan )
+    return aIsNan && bIsNan;
+
+  return a == b;
+}
+
+/**
  * Compare two doubles (but allow some difference)
  * \param a first double
  * \param b second double
@@ -349,8 +365,10 @@ inline QString qgsDoubleToString( double a, int precision = 17 )
  */
 inline bool qgsDoubleNear( double a, double b, double epsilon = 4 * std::numeric_limits<double>::epsilon() )
 {
-  if ( std::isnan( a ) || std::isnan( b ) )
-    return std::isnan( a ) && std::isnan( b ) ;
+  const bool aIsNan = std::isnan( a );
+  const bool bIsNan = std::isnan( b );
+  if ( aIsNan || bIsNan )
+    return aIsNan && bIsNan;
 
   const double diff = a - b;
   return diff > -epsilon && diff <= epsilon;
@@ -364,8 +382,10 @@ inline bool qgsDoubleNear( double a, double b, double epsilon = 4 * std::numeric
  */
 inline bool qgsFloatNear( float a, float b, float epsilon = 4 * FLT_EPSILON )
 {
-  if ( std::isnan( a ) || std::isnan( b ) )
-    return std::isnan( a ) && std::isnan( b ) ;
+  const bool aIsNan = std::isnan( a );
+  const bool bIsNan = std::isnan( b );
+  if ( aIsNan || bIsNan )
+    return aIsNan && bIsNan;
 
   const float diff = a - b;
   return diff > -epsilon && diff <= epsilon;
@@ -374,8 +394,10 @@ inline bool qgsFloatNear( float a, float b, float epsilon = 4 * FLT_EPSILON )
 //! Compare two doubles using specified number of significant digits
 inline bool qgsDoubleNearSig( double a, double b, int significantDigits = 10 )
 {
-  if ( std::isnan( a ) || std::isnan( b ) )
-    return std::isnan( a ) && std::isnan( b ) ;
+  const bool aIsNan = std::isnan( a );
+  const bool bIsNan = std::isnan( b );
+  if ( aIsNan || bIsNan )
+    return aIsNan && bIsNan;
 
   // The most simple would be to print numbers as %.xe and compare as strings
   // but that is probably too costly

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -47,6 +47,8 @@ class TestQgis : public QObject
     void signalBlocker();
     void qVariantCompare_data();
     void qVariantCompare();
+    void testNanCompatibleEquals_data();
+    void testNanCompatibleEquals();
     void testQgsAsConst();
     void testQgsRound();
     void testQgsVariantEqual();
@@ -318,6 +320,29 @@ void TestQgis::qVariantCompare()
 
   QCOMPARE( qgsVariantLessThan( lhs, rhs ), lessThan );
   QCOMPARE( qgsVariantGreaterThan( lhs, rhs ), greaterThan );
+}
+
+void TestQgis::testNanCompatibleEquals_data()
+{
+  QTest::addColumn<double>( "lhs" );
+  QTest::addColumn<double>( "rhs" );
+  QTest::addColumn<bool>( "expected" );
+
+  QTest::newRow( "both nan" ) << std::numeric_limits< double >::quiet_NaN() << std::numeric_limits< double >::quiet_NaN() << true;
+  QTest::newRow( "first is nan" ) << std::numeric_limits< double >::quiet_NaN() << 5.0 << false;
+  QTest::newRow( "second is nan" ) << 5.0 << std::numeric_limits< double >::quiet_NaN() << false;
+  QTest::newRow( "two numbers, not equal" ) << 5.0 << 6.0 << false;
+  QTest::newRow( "two numbers, equal" ) << 5.0 << 5.0 << true;
+}
+
+void TestQgis::testNanCompatibleEquals()
+{
+  QFETCH( double, lhs );
+  QFETCH( double, rhs );
+  QFETCH( bool, expected );
+
+  QCOMPARE( qgsNanCompatibleEquals( lhs, rhs ), expected );
+  QCOMPARE( qgsNanCompatibleEquals( rhs, lhs ), expected );
 }
 
 class ConstTester

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -366,8 +366,8 @@ void TestQgsCoordinateTransform::transformEpoch_data()
   QTest::addColumn<double>( "sourceEpoch" );
   QTest::addColumn<QgsCoordinateReferenceSystem>( "destCrs" );
   QTest::addColumn<double>( "destEpoch" );
-  QTest::addColumn<double>( "x" );
-  QTest::addColumn<double>( "y" );
+  QTest::addColumn<double>( "srcX" );
+  QTest::addColumn<double>( "srcY" );
   QTest::addColumn<int>( "direction" );
   QTest::addColumn<double>( "outX" );
   QTest::addColumn<double>( "outY" );
@@ -436,8 +436,8 @@ void TestQgsCoordinateTransform::transformEpoch()
   QFETCH( double, sourceEpoch );
   QFETCH( QgsCoordinateReferenceSystem, destCrs );
   QFETCH( double, destEpoch );
-  QFETCH( double, x );
-  QFETCH( double, y );
+  QFETCH( double, srcX );
+  QFETCH( double, srcY );
   QFETCH( int, direction );
   QFETCH( double, outX );
   QFETCH( double, outY );
@@ -449,7 +449,17 @@ void TestQgsCoordinateTransform::transformEpoch()
   double z = 0;
   QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
 
+  double x = srcX;
+  double y = srcY;
   ct.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
+  QGSCOMPARENEAR( x, outX, precision );
+  QGSCOMPARENEAR( y, outY, precision );
+
+  // make a second transform so that it's fetched from the cache this time
+  QgsCoordinateTransform ct2( sourceCrs, destCrs, QgsProject::instance() );
+  x = srcX;
+  y = srcY;
+  ct2.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
   QGSCOMPARENEAR( x, outX, precision );
   QGSCOMPARENEAR( y, outY, precision );
 }

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -269,11 +269,11 @@ void TestQgsCoordinateTransform::transform_data()
   QTest::newRow( "To geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 2545059.0 << 2393190.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.512750 << -37.961375 << 0.000001;
+      << 2545059.0 << 2393190.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.512750 << -37.961375 << 0.000015;
   QTest::newRow( "From geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
-      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 2545059.0 << 2393190.0 << 0.1;
+      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 2545059.0 << 2393190.0 << 1.5;
   QTest::newRow( "From geographic to geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )
@@ -281,11 +281,11 @@ void TestQgsCoordinateTransform::transform_data()
   QTest::newRow( "To geographic (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 2545059.0 << 2393190.0 << 0.1;
+      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 2545059.0 << 2393190.0 << 1.5;
   QTest::newRow( "From geographic (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
-      << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 145.512750 << -37.961375 << 0.000001;
+      << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 145.512750 << -37.961375 << 0.000015;
   QTest::newRow( "From geographic to geographic reverse" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )


### PR DESCRIPTION
Follow up https://github.com/qgis/QGIS/pull/43143, and add support for respecting the source OR destination coordinate epoch when transforming to/from dynamic CRS.

Uses the same approach as https://github.com/OSGeo/gdal/pull/3810

If a dynamic crs -> dynamic CRS transform at different epochs is attempted (not currently supported by PROJ), a user facing warning message will be shown advising them that the results may be misleading and should not be used for high accuracy work.