### PR TITLE
[authentication] Add a pair of APIs to export and import configurations to/from XML

### DIFF
--- a/python/core/auto_generated/auth/qgsauthconfig.sip.in
+++ b/python/core/auto_generated/auth/qgsauthconfig.sip.in
@@ -204,7 +204,6 @@ Stores the configuration in a DOM
 from a DOM element.
 
 :param element: is the DOM node corresponding to item (e.g. 'LayoutItem' element)
-:param document: DOM document
 
 .. versionadded:: 3.20
 %End

--- a/python/core/auto_generated/auth/qgsauthconfig.sip.in
+++ b/python/core/auto_generated/auth/qgsauthconfig.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsAuthMethodConfig
 {
 %Docstring(signature="appended")
@@ -184,6 +185,28 @@ against the config's :py:func:`~QgsAuthMethodConfig.uri` for auto-selecting auth
 :param accessurl: A URL to process
 :param resource: Output variable for result
 :param withpath: Whether to include the URI's path in output
+%End
+
+    bool writeXml( QDomElement &parentElement, QDomDocument &document );
+%Docstring
+Stores the configuration in a DOM
+
+:param parentElement: parent DOM element
+:param document: DOM document
+
+.. seealso:: :py:func:`readXml`
+
+.. versionadded:: 3.20
+%End
+
+    bool readXml( const QDomElement &element );
+%Docstring
+from a DOM element.
+
+:param element: is the DOM node corresponding to item (e.g. 'LayoutItem' element)
+:param document: DOM document
+
+.. versionadded:: 3.20
 %End
 
 };

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -300,6 +300,23 @@ Remove an authentication config in the database
 :return: Whether operation succeeded
 %End
 
+    bool exportAuthenticationConfigsToXml( const QString &filename, const QStringList &authcfgs, const QString &password = QString() );
+%Docstring
+Export authentication configurations to an XML file
+
+:param filename: The file path to save the XML content to
+:param authcfgs: The list of configuration IDs to export
+:param password: A password string to encrypt the XML content
+%End
+
+    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
+%Docstring
+Import authentication configurations from an XML file
+
+:param filename: The file path from which the XML content will be read
+:param password: A password string to decrypt the XML content
+%End
+
     bool removeAllAuthenticationConfigs();
 %Docstring
 Clear all authentication configs from table in database and from provider caches

--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -307,6 +307,8 @@ Export authentication configurations to an XML file
 :param filename: The file path to save the XML content to
 :param authcfgs: The list of configuration IDs to export
 :param password: A password string to encrypt the XML content
+
+.. versionadded:: 3.20
 %End
 
     bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
@@ -315,6 +317,8 @@ Import authentication configurations from an XML file
 
 :param filename: The file path from which the XML content will be read
 :param password: A password string to decrypt the XML content
+
+.. versionadded:: 3.20
 %End
 
     bool removeAllAuthenticationConfigs();

--- a/python/gui/auto_generated/auth/qgsauthconfigeditor.sip.in
+++ b/python/gui/auto_generated/auth/qgsauthconfigeditor.sip.in
@@ -35,6 +35,11 @@ Widget for editing authentication configurations directly in database
 Hide the widget's title, e.g. when embedding
 %End
 
+    QStringList selectedAuthenticationConfigIds() const;
+%Docstring
+Returns the list of selected authentication configuration IDs
+%End
+
   public slots:
     void setShowUtilitiesButton( bool show = true );
 %Docstring

--- a/python/gui/auto_generated/auth/qgsauthconfigeditor.sip.in
+++ b/python/gui/auto_generated/auth/qgsauthconfigeditor.sip.in
@@ -38,6 +38,8 @@ Hide the widget's title, e.g. when embedding
     QStringList selectedAuthenticationConfigIds() const;
 %Docstring
 Returns the list of selected authentication configuration IDs
+
+.. versionadded:: 3.20
 %End
 
   public slots:

--- a/src/core/auth/qgsauthconfig.cpp
+++ b/src/core/auth/qgsauthconfig.cpp
@@ -157,6 +157,34 @@ bool QgsAuthMethodConfig::uriToResource( const QString &accessurl, QString *reso
 }
 
 
+bool QgsAuthMethodConfig::writeXml( QDomElement &parentElement, QDomDocument &document )
+{
+  QDomElement element = document.createElement( QStringLiteral( "AuthMethodConfig" ) );
+  element.setAttribute( QStringLiteral( "method" ), mMethod );
+  element.setAttribute( QStringLiteral( "id" ), mId );
+  element.setAttribute( QStringLiteral( "name" ), mName );
+  element.setAttribute( QStringLiteral( "version" ), QString::number( mVersion ) );
+  element.setAttribute( QStringLiteral( "uri" ), mUri );
+  element.setAttribute( QStringLiteral( "config" ), configString() );
+  parentElement.appendChild( element );
+  return true;
+}
+
+bool QgsAuthMethodConfig::readXml( const QDomElement &element )
+{
+  if ( element.nodeName() != QLatin1String( "AuthMethodConfig" ) )
+    return false;
+
+  mMethod = element.attribute( QStringLiteral( "method" ) );
+  mId = element.attribute( QStringLiteral( "id" ) );
+  mName = element.attribute( QStringLiteral( "name" ) );
+  mVersion = element.attribute( QStringLiteral( "version" ) ).toInt();
+  mUri = element.attribute( QStringLiteral( "uri" ) );
+  loadConfigString( element.attribute( QStringLiteral( "config" ) ) );
+
+  return true;
+}
+
 #ifndef QT_NO_SSL
 
 //////////////////////////////////////////////////////

--- a/src/core/auth/qgsauthconfig.h
+++ b/src/core/auth/qgsauthconfig.h
@@ -18,8 +18,11 @@
 #define QGSAUTHCONFIG_H
 
 #include "qgis_core.h"
+
 #include <QHash>
 #include <QString>
+#include <QDomElement>
+#include <QDomDocument>
 
 #ifndef QT_NO_SSL
 #include <QSslCertificate>
@@ -159,6 +162,23 @@ class CORE_EXPORT QgsAuthMethodConfig
      * \param withpath Whether to include the URI's path in output
      */
     static bool uriToResource( const QString &accessurl, QString *resource, bool withpath = false );
+
+    /**
+     * Stores the configuration in a DOM
+     * \param parentElement parent DOM element
+     * \param document DOM document
+     * \see readXml()
+     * \since QGIS 3.20
+     */
+    bool writeXml( QDomElement &parentElement, QDomDocument &document );
+
+    /**
+     *  from a DOM element.
+     * \param element is the DOM node corresponding to item (e.g. 'LayoutItem' element)
+     * \param document DOM document
+     * \since QGIS 3.20
+     */
+    bool readXml( const QDomElement &element );
 
   private:
     QString mId;

--- a/src/core/auth/qgsauthconfig.h
+++ b/src/core/auth/qgsauthconfig.h
@@ -175,7 +175,6 @@ class CORE_EXPORT QgsAuthMethodConfig
     /**
      *  from a DOM element.
      * \param element is the DOM node corresponding to item (e.g. 'LayoutItem' element)
-     * \param document DOM document
      * \since QGIS 3.20
      */
     bool readXml( const QDomElement &element );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -31,6 +31,8 @@
 #include <QTimer>
 #include <QVariant>
 #include <QSqlDriver>
+#include <QDomElement>
+#include <QDomDocument>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 #include <QRandomGenerator>
@@ -1320,6 +1322,118 @@ bool QgsAuthManager::removeAuthenticationConfig( const QString &authcfg )
 
   QgsDebugMsgLevel( QStringLiteral( "REMOVED config for authcfg: %1" ).arg( authcfg ), 2 );
 
+  return true;
+}
+
+bool QgsAuthManager::exportAuthenticationConfigsToXml( const QString &filename, const QStringList &authcfgs, const QString &password )
+{
+  if ( filename.isEmpty() )
+    return false;
+
+  QDomDocument document( QStringLiteral( "qgis_authentication" ) );
+  QDomElement root = document.createElement( QStringLiteral( "qgis_authentication" ) );
+  document.appendChild( root );
+
+  QString civ;
+  if ( !password.isEmpty() )
+  {
+    QString salt;
+    QString hash;
+    QgsAuthCrypto::passwordKeyHash( password, &salt, &hash, &civ );
+    root.setAttribute( QStringLiteral( "salt" ), salt );
+    root.setAttribute( QStringLiteral( "hash" ), hash );
+    root.setAttribute( QStringLiteral( "civ" ), civ );
+  }
+
+  QDomElement configurations = document.createElement( QStringLiteral( "configurations" ) );
+  for ( const QString &authcfg : authcfgs )
+  {
+    QgsAuthMethodConfig authMethodConfig;
+
+    bool ok = loadAuthenticationConfig( authcfg, authMethodConfig, true );
+    if ( ok )
+    {
+      authMethodConfig.writeXml( configurations, document );
+    }
+  }
+  if ( !password.isEmpty() )
+  {
+    QString configurationsString;
+    QTextStream ts( &configurationsString );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    ts.setCodec( "UTF-8" );
+#endif
+    configurations.save( ts, 2 );
+    root.appendChild( document.createTextNode( QgsAuthCrypto::encrypt( password, civ, configurationsString ) ) );
+  }
+  else
+  {
+    root.appendChild( configurations );
+  }
+
+  QFile file( filename );
+  if ( !file.open( QFile::WriteOnly | QIODevice::Truncate ) )
+    return false;
+
+  QTextStream ts( &file );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  ts.setCodec( "UTF-8" );
+#endif
+  document.save( ts, 2 );
+  file.close();
+  return true;
+}
+
+bool QgsAuthManager::importAuthenticationConfigsFromXml( const QString &filename, const QString &password )
+{
+  QFile f( filename );
+  if ( !f.open( QFile::ReadOnly ) )
+  {
+    return false;
+  }
+
+  QDomDocument document( QStringLiteral( "qgis_authentication" ) );
+  if ( !document.setContent( &f ) )
+  {
+    f.close();
+    return false;
+  }
+  f.close();
+
+  QDomElement root = document.documentElement();
+  if ( root.tagName() != QLatin1String( "qgis_authentication" ) )
+  {
+    return false;
+  }
+
+  QDomElement configurations;
+  if ( root.hasAttribute( QStringLiteral( "salt" ) ) )
+  {
+    QString salt = root.attribute( QStringLiteral( "salt" ) );
+    QString hash = root.attribute( QStringLiteral( "hash" ) );
+    QString civ = root.attribute( QStringLiteral( "civ" ) );
+    if ( !QgsAuthCrypto::verifyPasswordKeyHash( password, salt, hash ) )
+      return false;
+
+    document.setContent( QgsAuthCrypto::decrypt( password, civ, root.text() ) );
+    configurations = document.firstChild().toElement();
+  }
+  else
+  {
+    configurations = root.firstChildElement( QStringLiteral( "configurations" ) );
+  }
+
+  QDomElement configuration = configurations.firstChildElement();
+  while ( !configuration.isNull() )
+  {
+    QgsAuthMethodConfig authMethodConfig;
+    authMethodConfig.readXml( configuration );
+    qDebug() << configuration.nodeName();
+    qDebug() << authMethodConfig.id();
+    storeAuthenticationConfig( authMethodConfig );
+
+    configuration = configuration.nextSiblingElement();
+  }
   return true;
 }
 

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1386,19 +1386,19 @@ bool QgsAuthManager::exportAuthenticationConfigsToXml( const QString &filename, 
 
 bool QgsAuthManager::importAuthenticationConfigsFromXml( const QString &filename, const QString &password )
 {
-  QFile f( filename );
-  if ( !f.open( QFile::ReadOnly ) )
+  QFile file( filename );
+  if ( !file.open( QFile::ReadOnly ) )
   {
     return false;
   }
 
   QDomDocument document( QStringLiteral( "qgis_authentication" ) );
-  if ( !document.setContent( &f ) )
+  if ( !document.setContent( &file ) )
   {
-    f.close();
+    file.close();
     return false;
   }
-  f.close();
+  file.close();
 
   QDomElement root = document.documentElement();
   if ( root.tagName() != QLatin1String( "qgis_authentication" ) )

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1428,8 +1428,6 @@ bool QgsAuthManager::importAuthenticationConfigsFromXml( const QString &filename
   {
     QgsAuthMethodConfig authMethodConfig;
     authMethodConfig.readXml( configuration );
-    qDebug() << configuration.nodeName();
-    qDebug() << authMethodConfig.id();
     storeAuthenticationConfig( authMethodConfig );
 
     configuration = configuration.nextSiblingElement();

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -301,6 +301,21 @@ class CORE_EXPORT QgsAuthManager : public QObject
     bool removeAuthenticationConfig( const QString &authcfg );
 
     /**
+     * Export authentication configurations to an XML file
+     * \param filename The file path to save the XML content to
+     * \param authcfgs The list of configuration IDs to export
+     * \param password A password string to encrypt the XML content
+     */
+    bool exportAuthenticationConfigsToXml( const QString &filename, const QStringList &authcfgs, const QString &password = QString() );
+
+    /**
+     * Import authentication configurations from an XML file
+     * \param filename The file path from which the XML content will be read
+     * \param password A password string to decrypt the XML content
+     */
+    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
+
+    /**
      * Clear all authentication configs from table in database and from provider caches
      * \returns Whether operation succeeded
      */

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -305,6 +305,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * \param filename The file path to save the XML content to
      * \param authcfgs The list of configuration IDs to export
      * \param password A password string to encrypt the XML content
+     * \since QGIS 3.20
      */
     bool exportAuthenticationConfigsToXml( const QString &filename, const QStringList &authcfgs, const QString &password = QString() );
 
@@ -312,6 +313,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Import authentication configurations from an XML file
      * \param filename The file path from which the XML content will be read
      * \param password A password string to decrypt the XML content
+     * \since QGIS 3.20
      */
     bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
 

--- a/src/gui/auth/qgsauthconfigeditor.cpp
+++ b/src/gui/auth/qgsauthconfigeditor.cpp
@@ -90,6 +90,8 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
     checkSelection();
 
     // set up utility actions menu
+    mActionImportAuthenticationConfigs = new QAction( tr( "Import authentication configurations from file" ), this );
+    mActionExportSelectedAuthenticationConfigs = new QAction( tr( "Export selected authentication configurations to file" ), this );
     mActionSetMasterPassword = new QAction( QStringLiteral( "Input master password" ), this );
     mActionClearCachedMasterPassword = new QAction( QStringLiteral( "Clear cached master password" ), this );
     mActionResetMasterPassword = new QAction( QStringLiteral( "Reset master password" ), this );
@@ -97,6 +99,8 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
     mActionRemoveAuthConfigs = new QAction( QStringLiteral( "Remove all authentication configurations" ), this );
     mActionEraseAuthDatabase = new QAction( QStringLiteral( "Erase authentication database" ), this );
 
+    connect( mActionImportAuthenticationConfigs, &QAction::triggered, this, &QgsAuthConfigEditor::importAuthenticationConfigs );
+    connect( mActionExportSelectedAuthenticationConfigs, &QAction::triggered, this, &QgsAuthConfigEditor::exportSelectedAuthenticationConfigs );
     connect( mActionSetMasterPassword, &QAction::triggered, this, &QgsAuthConfigEditor::setMasterPassword );
     connect( mActionClearCachedMasterPassword, &QAction::triggered, this, &QgsAuthConfigEditor::clearCachedMasterPassword );
     connect( mActionResetMasterPassword, &QAction::triggered, this, &QgsAuthConfigEditor::resetMasterPassword );
@@ -112,11 +116,24 @@ QgsAuthConfigEditor::QgsAuthConfigEditor( QWidget *parent, bool showUtilities, b
     mAuthUtilitiesMenu->addAction( mActionClearCachedAuthConfigs );
     mAuthUtilitiesMenu->addAction( mActionRemoveAuthConfigs );
     mAuthUtilitiesMenu->addSeparator();
+    mAuthUtilitiesMenu->addAction( mActionImportAuthenticationConfigs );
+    mAuthUtilitiesMenu->addAction( mActionExportSelectedAuthenticationConfigs );
+    mAuthUtilitiesMenu->addSeparator();
     mAuthUtilitiesMenu->addAction( mActionEraseAuthDatabase );
 
     btnAuthUtilities->setMenu( mAuthUtilitiesMenu );
     lblAuthConfigDb->setVisible( false );
   }
+}
+
+void QgsAuthConfigEditor::importAuthenticationConfigs()
+{
+  QgsAuthGuiUtils::importAuthenticationConfigs( messageBar() );
+}
+
+void QgsAuthConfigEditor::exportSelectedAuthenticationConfigs()
+{
+  QgsAuthGuiUtils::exportSelectedAuthenticationConfigs( selectedAuthenticationConfigIds(), messageBar() );
 }
 
 void QgsAuthConfigEditor::setMasterPassword()
@@ -161,6 +178,17 @@ void QgsAuthConfigEditor::toggleTitleVisibility( bool visible )
   {
     lblAuthConfigDb->setVisible( visible );
   }
+}
+
+QStringList QgsAuthConfigEditor::selectedAuthenticationConfigIds() const
+{
+  QStringList ids;
+  QModelIndexList selection = tableViewConfigs->selectionModel()->selectedRows( 0 );
+  for ( QModelIndex index : selection )
+  {
+    ids << index.sibling( index.row(), 0 ).data().toString();
+  }
+  return ids;
 }
 
 void QgsAuthConfigEditor::setShowUtilitiesButton( bool show )
@@ -255,16 +283,18 @@ void QgsAuthConfigEditor::btnRemoveConfig_clicked()
   if ( selection.empty() )
     return;
 
-  QModelIndex indx = selection.at( 0 );
-  QString name = indx.sibling( indx.row(), 1 ).data().toString();
-
-  if ( QMessageBox::warning( this, tr( "Remove Configuration" ),
-                             tr( "Are you sure you want to remove '%1'?\n\n"
-                                 "Operation can NOT be undone!" ).arg( name ),
-                             QMessageBox::Ok | QMessageBox::Cancel,
-                             QMessageBox::Cancel ) == QMessageBox::Ok )
+  for ( QModelIndex index : selection )
   {
-    mConfigModel->removeRow( indx.row() );
+    QString name = index.sibling( index.row(), 1 ).data().toString();
+
+    if ( QMessageBox::warning( this, tr( "Remove Configuration" ),
+                               tr( "Are you sure you want to remove '%1'?\n\n"
+                                   "Operation can NOT be undone!" ).arg( name ),
+                               QMessageBox::Ok | QMessageBox::Cancel,
+                               QMessageBox::Cancel ) == QMessageBox::Ok )
+    {
+      mConfigModel->removeRow( index.row() );
+    }
   }
 }
 

--- a/src/gui/auth/qgsauthconfigeditor.h
+++ b/src/gui/auth/qgsauthconfigeditor.h
@@ -48,7 +48,10 @@ class GUI_EXPORT QgsAuthConfigEditor : public QWidget, private Ui::QgsAuthConfig
     //! Hide the widget's title, e.g. when embedding
     void toggleTitleVisibility( bool visible );
 
-    //! Returns the list of selected authentication configuration IDs
+    /**
+     * Returns the list of selected authentication configuration IDs
+     * \since QGIS 3.20
+     */
     QStringList selectedAuthenticationConfigIds() const;
 
   public slots:

--- a/src/gui/auth/qgsauthconfigeditor.h
+++ b/src/gui/auth/qgsauthconfigeditor.h
@@ -48,6 +48,9 @@ class GUI_EXPORT QgsAuthConfigEditor : public QWidget, private Ui::QgsAuthConfig
     //! Hide the widget's title, e.g. when embedding
     void toggleTitleVisibility( bool visible );
 
+    //! Returns the list of selected authentication configuration IDs
+    QStringList selectedAuthenticationConfigIds() const;
+
   public slots:
     //! Sets whether to show the widget's utilities button, e.g. when embedding
     void setShowUtilitiesButton( bool show = true );
@@ -58,6 +61,12 @@ class GUI_EXPORT QgsAuthConfigEditor : public QWidget, private Ui::QgsAuthConfig
   private slots:
     //! Repopulate the view with table contents
     void refreshTableView();
+
+    //! Import authentication configurations from a XML file
+    void importAuthenticationConfigs();
+
+    //! Exports selected authentication configurations to a XML file
+    void exportSelectedAuthenticationConfigs();
 
     //! Sets the cached master password (and verifies it if its hash is in authentication database)
     void setMasterPassword();
@@ -100,6 +109,8 @@ class GUI_EXPORT QgsAuthConfigEditor : public QWidget, private Ui::QgsAuthConfig
     QSqlTableModel *mConfigModel = nullptr;
 
     QMenu *mAuthUtilitiesMenu = nullptr;
+    QAction *mActionImportAuthenticationConfigs = nullptr;
+    QAction *mActionExportSelectedAuthenticationConfigs = nullptr;
     QAction *mActionSetMasterPassword = nullptr;
     QAction *mActionClearCachedMasterPassword = nullptr;
     QAction *mActionResetMasterPassword = nullptr;

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -142,6 +142,8 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
            this, &QgsAuthEditorWidgets::authMessageOut );
 
   // set up utility actions menu
+  mActionImportAuthenticationConfigs = new QAction( tr( "Import authentication configurations from file" ), this );
+  mActionExportSelectedAuthenticationConfigs = new QAction( tr( "Export selected authentication configurations to file" ), this );
   mActionSetMasterPassword = new QAction( tr( "Input master password" ), this );
   mActionClearCachedMasterPassword = new QAction( tr( "Clear cached master password" ), this );
   mActionResetMasterPassword = new QAction( tr( "Reset master password" ), this );
@@ -168,6 +170,8 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mActionPasswordHelperLoggingEnable->setCheckable( true );
   mActionPasswordHelperLoggingEnable->setChecked( QgsApplication::authManager()->passwordHelperLoggingEnabled() );
 
+  connect( mActionImportAuthenticationConfigs, &QAction::triggered, this, &QgsAuthEditorWidgets::importAuthenticationConfigs );
+  connect( mActionExportSelectedAuthenticationConfigs, &QAction::triggered, this, &QgsAuthEditorWidgets::exportSelectedAuthenticationConfigs );
   connect( mActionSetMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::setMasterPassword );
   connect( mActionClearCachedMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::clearCachedMasterPassword );
   connect( mActionResetMasterPassword, &QAction::triggered, this, &QgsAuthEditorWidgets::resetMasterPassword );
@@ -206,9 +210,25 @@ void QgsAuthEditorWidgets::setupUtilitiesMenu()
   mAuthUtilitiesMenu->addAction( mActionClearCachedAuthConfigs );
   mAuthUtilitiesMenu->addAction( mActionRemoveAuthConfigs );
   mAuthUtilitiesMenu->addSeparator();
+  mAuthUtilitiesMenu->addAction( mActionImportAuthenticationConfigs );
+  mAuthUtilitiesMenu->addAction( mActionExportSelectedAuthenticationConfigs );
+  mAuthUtilitiesMenu->addSeparator();
   mAuthUtilitiesMenu->addAction( mActionEraseAuthDatabase );
 
   btnAuthUtilities->setMenu( mAuthUtilitiesMenu );
+}
+
+void QgsAuthEditorWidgets::importAuthenticationConfigs()
+{
+  QgsAuthGuiUtils::importAuthenticationConfigs( messageBar() );
+}
+
+void QgsAuthEditorWidgets::exportSelectedAuthenticationConfigs()
+{
+  if ( !wdgtConfigEditor )
+    return;
+
+  QgsAuthGuiUtils::exportSelectedAuthenticationConfigs( wdgtConfigEditor->selectedAuthenticationConfigIds(), messageBar() );
 }
 
 void QgsAuthEditorWidgets::setMasterPassword()

--- a/src/gui/auth/qgsautheditorwidgets.h
+++ b/src/gui/auth/qgsautheditorwidgets.h
@@ -70,6 +70,12 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     void btnCertManager_clicked();
     void btnAuthPlugins_clicked();
 
+    //! Import authentication configurations from a XML file
+    void importAuthenticationConfigs();
+
+    //! Exports selected authentication configurations to a XML file
+    void exportSelectedAuthenticationConfigs();
+
     //! Sets the cached master password (and verifies it if its hash is in authentication database)
     void setMasterPassword();
 
@@ -109,6 +115,8 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     QgsMessageBar *messageBar();
 
     QMenu *mAuthUtilitiesMenu = nullptr;
+    QAction *mActionExportSelectedAuthenticationConfigs = nullptr;
+    QAction *mActionImportAuthenticationConfigs = nullptr;
     QAction *mActionSetMasterPassword = nullptr;
     QAction *mActionClearCachedMasterPassword = nullptr;
     QAction *mActionResetMasterPassword = nullptr;
@@ -121,6 +129,7 @@ class GUI_EXPORT QgsAuthEditorWidgets : public QWidget, private Ui::QgsAuthEdito
     QAction *mActionPasswordHelperLoggingEnable = nullptr;
     QAction *mActionClearAccessCacheNow = nullptr;
     QAction *mActionAutoClearAccessCache = nullptr;
+
 };
 
 #endif // QGSAUTHEDITORWIDGETS_H

--- a/src/gui/auth/qgsauthguiutils.h
+++ b/src/gui/auth/qgsauthguiutils.h
@@ -60,10 +60,16 @@ class GUI_EXPORT QgsAuthGuiUtils
     //! Verify the authentication system is active, else notify user
     static bool isDisabled( QgsMessageBar *msgbar );
 
-    //! Import authentication configurations from a XML file
+    /**
+     * Import authentication configurations from a XML file
+     * \since QGIS 3.20
+     */
     static void importAuthenticationConfigs( QgsMessageBar *msgbar );
 
-    //! Exports selected authentication configurations to a XML file
+    /**
+     * Exports selected authentication configurations to a XML file
+     * \since QGIS 3.20
+     */
     static void exportSelectedAuthenticationConfigs( QStringList authenticationConfigIds, QgsMessageBar *msgbar );
 
     //! Sets the cached master password (and verifies it if its hash is in authentication database)

--- a/src/gui/auth/qgsauthguiutils.h
+++ b/src/gui/auth/qgsauthguiutils.h
@@ -60,6 +60,12 @@ class GUI_EXPORT QgsAuthGuiUtils
     //! Verify the authentication system is active, else notify user
     static bool isDisabled( QgsMessageBar *msgbar );
 
+    //! Import authentication configurations from a XML file
+    static void importAuthenticationConfigs( QgsMessageBar *msgbar );
+
+    //! Exports selected authentication configurations to a XML file
+    static void exportSelectedAuthenticationConfigs( QStringList authenticationConfigIds, QgsMessageBar *msgbar );
+
     //! Sets the cached master password (and verifies it if its hash is in authentication database)
     static void setMasterPassword( QgsMessageBar *msgbar );
 

--- a/src/ui/auth/qgsauthconfigeditor.ui
+++ b/src/ui/auth/qgsauthconfigeditor.ui
@@ -128,7 +128,7 @@
         <bool>true</bool>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::SingleSelection</enum>
+        <enum>QAbstractItemView::ExtendedSelection</enum>
        </property>
        <property name="selectionBehavior">
         <enum>QAbstractItemView::SelectRows</enum>

--- a/tests/src/core/testqgsauthmanager.cpp
+++ b/tests/src/core/testqgsauthmanager.cpp
@@ -323,6 +323,21 @@ void TestQgsAuthManager::testAuthConfigs()
     QVERIFY( authm->storeAuthenticationConfig( config ) );
     idcfgmap.insert( config.id(), config );
   }
+
+  QCOMPARE( authm->availableAuthMethodConfigs().size(), 3 );
+
+  // Password-less export / import
+  QVERIFY( authm->exportAuthenticationConfigsToXml( mTempDir + QStringLiteral( "/configs.xml" ), idcfgmap.keys() ) );
+  QVERIFY( authm->removeAllAuthenticationConfigs() );
+  QVERIFY( authm->importAuthenticationConfigsFromXml( mTempDir + QStringLiteral( "/configs.xml" ) ) );
+
+  QCOMPARE( authm->availableAuthMethodConfigs().size(), 3 );
+
+  // Password-protected export / import
+  QVERIFY( authm->exportAuthenticationConfigsToXml( mTempDir + QStringLiteral( "/configs.xml" ), idcfgmap.keys(), QStringLiteral( "1234" ) ) );
+  QVERIFY( authm->removeAllAuthenticationConfigs() );
+  QVERIFY( authm->importAuthenticationConfigsFromXml( mTempDir + QStringLiteral( "/configs.xml" ), QStringLiteral( "1234" ) ) );
+
   QgsAuthMethodConfigsMap authmap( authm->availableAuthMethodConfigs() );
   QCOMPARE( authmap.size(), 3 );
 


### PR DESCRIPTION
## Description

This PR adds an export and import functions to the QGIS authentication manager. The exposure of this new function in the UI will come in a separate PR.

Exporting authentication method configuration(s) can come in very handy for complex methods such as oauth2 where the settings are numerous.

The exported XML can either be encrypted via a provided password (that is _not_ the master password), or can be created in plain text if no password is provided.