### PR TITLE
Relation editor widget label implementation moved to attribute form

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -40,20 +40,26 @@ Constructor for QgsRelationWidgetWrapper
 Constructor for QgsRelationWidgetWrapper
 %End
 
-    bool showLabel() const;
+ bool showLabel() const /Deprecated/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
 
 .. versionadded:: 2.18
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
-    void setShowLabel( bool showLabel );
+ void setShowLabel( bool showLabel ) /Deprecated/;
 %Docstring
 Defines if a title label should be shown for this widget.
 Only has an effect after :py:func:`~QgsRelationWidgetWrapper.widget` has been called at least once.
 
 .. versionadded:: 2.18
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
  bool showLinkButton() const /Deprecated/;
@@ -185,19 +191,25 @@ If it's empty, then it's considered as a 1:M relationship.
 .. versionadded:: 3.16
 %End
 
-    QString label() const;
+ QString label() const /Deprecated/;
 %Docstring
 Determines the label of this element
 
 .. versionadded:: 3.16
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
-    void setLabel( const QString &label = QString() );
+ void setLabel( const QString &label = QString() ) /Deprecated/;
 %Docstring
 Sets ``label`` for this element
 If it's empty it takes the relation id as label
 
 .. versionadded:: 3.16
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
     QgsRelation relation() const;

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -91,14 +91,20 @@ Sets the editor ``context``
 Returns the attribute editor context.
 %End
 
-    bool showLabel() const;
+ bool showLabel() const /Deprecated/;
 %Docstring
 Defines if a title label should be shown for this widget.
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
-    void setShowLabel( bool showLabel );
+ void setShowLabel( bool showLabel ) /Deprecated/;
 %Docstring
 Defines if a title label should be shown for this widget.
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
     QVariant nmRelationId() const;
@@ -112,9 +118,12 @@ Sets ``nmRelationId`` for the relation id of the second relation involved in an 
 If it's empty, then it's considered as a 1:M relationship.
 %End
 
-    QString label() const;
+ QString label() const /Deprecated/;
 %Docstring
 Determines the label of this element
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
     void setLabel( const QString &label = QString() );
@@ -208,9 +217,12 @@ Duplicates features
 
 
 
-    void updateTitle();
+ void updateTitle() /Deprecated/;
 %Docstring
 Updates the title contents to reflect the current state of the widget
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
     void deleteFeatures( const QgsFeatureIds &fids );
@@ -232,10 +244,12 @@ Should be used to refresh the UI regarding the new data.
 Check :py:class:`QgsRealationEditorWidget` as an example.
 %End
 
-    virtual void setTitle( const QString &title );
+ virtual void setTitle( const QString &title ) /Deprecated/;
 %Docstring
 Sets the title of the widget, if it is wrapped within a :py:class:`QgsCollapsibleGroupBox`
-Check :py:class:`QgsRealationEditorWidget` as an example.
+
+.. deprecated:: QGIS 3.20
+   label is handled directly in :py:class:`QgsAttributeForm`.
 %End
 
     virtual void beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature );

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -135,12 +135,6 @@ Returns the current configuration
 Defines the current configuration
 %End
 
-    virtual void setTitle( const QString &title );
-
-%Docstring
-Sets the title of the root groupbox
-%End
-
   public slots:
     virtual void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -138,17 +138,12 @@ void QgsRelationWidgetWrapper::setShowSaveChildEditsButton( bool showSaveChildEd
 
 bool QgsRelationWidgetWrapper::showLabel() const
 {
-  if ( mWidget )
-  {
-    return mWidget->showLabel();
-  }
   return false;
 }
 
 void QgsRelationWidgetWrapper::setShowLabel( bool showLabel )
 {
-  if ( mWidget )
-    mWidget->setShowLabel( showLabel );
+  Q_UNUSED( showLabel )
 }
 
 void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
@@ -297,14 +292,11 @@ QVariant QgsRelationWidgetWrapper::nmRelationId() const
 
 void QgsRelationWidgetWrapper::setLabel( const QString &label )
 {
-  if ( mWidget )
-    mWidget->setLabel( label );
+  Q_UNUSED( label )
 }
 
 QString QgsRelationWidgetWrapper::label() const
 {
-  if ( mWidget )
-    return mWidget->label();
   return QString();
 }
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -57,16 +57,18 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      * Only has an effect after widget() has been called at least once.
      *
      * \since QGIS 2.18
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    bool showLabel() const;
+    Q_DECL_DEPRECATED bool showLabel() const SIP_DEPRECATED;
 
     /**
      * Defines if a title label should be shown for this widget.
      * Only has an effect after widget() has been called at least once.
      *
      * \since QGIS 2.18
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    void setShowLabel( bool showLabel );
+    Q_DECL_DEPRECATED void setShowLabel( bool showLabel ) SIP_DEPRECATED;
 
     /**
      * Determines if the "link feature" button should be shown
@@ -170,15 +172,17 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     /**
      * Determines the label of this element
      * \since QGIS 3.16
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    QString label() const;
+    Q_DECL_DEPRECATED QString label() const SIP_DEPRECATED;
 
     /**
      * Sets \a label for this element
      * If it's empty it takes the relation id as label
      * \since QGIS 3.16
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    void setLabel( const QString &label = QString() );
+    Q_DECL_DEPRECATED void setLabel( const QString &label = QString() ) SIP_DEPRECATED;
 
     /**
      * The relation for which this wrapper is created.

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -28,25 +28,14 @@
 #include "qgsproject.h"
 #include "qgstransactiongroup.h"
 #include "qgsvectorlayerutils.h"
-#include "qgscollapsiblegroupbox.h"
 
 #include <QMessageBox>
 #include <QPushButton>
-#include <QVBoxLayout>
 
 QgsAbstractRelationEditorWidget::QgsAbstractRelationEditorWidget( const QVariantMap &config, QWidget *parent )
   : QWidget( parent )
 {
   Q_UNUSED( config );
-
-  QVBoxLayout *rootLayout = new QVBoxLayout( this );
-  rootLayout->setContentsMargins( 0, 0, 0, 0 );
-
-  mRootCollapsibleGroupBox = new QgsCollapsibleGroupBox( QString(), this );
-  rootLayout->addWidget( mRootCollapsibleGroupBox );
-
-  mTopVBoxLayout = new QVBoxLayout( mRootCollapsibleGroupBox );
-  mTopVBoxLayout->setContentsMargins( 0, 9, 0, 0 );
 }
 
 void QgsAbstractRelationEditorWidget::setRelationFeature( const QgsRelation &relation, const QgsFeature &feature )
@@ -141,26 +130,22 @@ QVariant QgsAbstractRelationEditorWidget::nmRelationId() const
 
 QString QgsAbstractRelationEditorWidget::label() const
 {
-  return mLabel;
+  return QString();
 }
 
 void QgsAbstractRelationEditorWidget::setLabel( const QString &label )
 {
-  mLabel = label;
-
-  updateTitle();
+  Q_UNUSED( label )
 }
 
 bool QgsAbstractRelationEditorWidget::showLabel() const
 {
-  return mShowLabel;
+  return false;
 }
 
 void QgsAbstractRelationEditorWidget::setShowLabel( bool showLabel )
 {
-  mShowLabel = showLabel;
-
-  updateTitle();
+  Q_UNUSED( showLabel )
 }
 
 void QgsAbstractRelationEditorWidget::setForceSuppressFormPopup( bool forceSuppressFormPopup )
@@ -175,18 +160,6 @@ bool QgsAbstractRelationEditorWidget::forceSuppressFormPopup() const
 
 void QgsAbstractRelationEditorWidget::updateTitle()
 {
-  if ( mShowLabel && !mLabel.isEmpty() )
-  {
-    setTitle( mLabel );
-  }
-  else if ( mShowLabel && mRelation.isValid() )
-  {
-    setTitle( mRelation.name() );
-  }
-  else
-  {
-    setTitle( QString() );
-  }
 }
 
 QgsFeature QgsAbstractRelationEditorWidget::feature() const
@@ -617,7 +590,7 @@ void QgsAbstractRelationEditorWidget::updateUi()
 
 void QgsAbstractRelationEditorWidget::setTitle( const QString &title )
 {
-  mRootCollapsibleGroupBox->setTitle( title );
+  Q_UNUSED( title )
 }
 
 void QgsAbstractRelationEditorWidget::beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature )
@@ -637,11 +610,6 @@ void QgsAbstractRelationEditorWidget::beforeSetRelations( const QgsRelation &new
 
 void QgsAbstractRelationEditorWidget::afterSetRelations()
 {}
-
-QVBoxLayout *QgsAbstractRelationEditorWidget::rootTopVBoxLayout() const
-{
-  return mTopVBoxLayout;
-}
 
 void QgsAbstractRelationEditorWidget::duplicateFeature( const QgsFeatureId &fid )
 {

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -47,7 +47,6 @@ void QgsAbstractRelationEditorWidget::setRelationFeature( const QgsRelation &rel
 
   setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 
-  updateTitle();
   afterSetRelationFeature();
   updateUi();
 }
@@ -85,8 +84,6 @@ void QgsAbstractRelationEditorWidget::setRelations( const QgsRelation &relation,
         mLayerInSameTransactionGroup = true;
     }
   }
-
-  updateTitle();
 
   setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -28,15 +28,25 @@
 #include "qgsproject.h"
 #include "qgstransactiongroup.h"
 #include "qgsvectorlayerutils.h"
+#include "qgscollapsiblegroupbox.h"
 
 #include <QMessageBox>
 #include <QPushButton>
-
+#include <QVBoxLayout>
 
 QgsAbstractRelationEditorWidget::QgsAbstractRelationEditorWidget( const QVariantMap &config, QWidget *parent )
   : QWidget( parent )
 {
   Q_UNUSED( config );
+
+  QVBoxLayout *rootLayout = new QVBoxLayout( this );
+  rootLayout->setContentsMargins( 0, 0, 0, 0 );
+
+  mRootCollapsibleGroupBox = new QgsCollapsibleGroupBox( QString(), this );
+  rootLayout->addWidget( mRootCollapsibleGroupBox );
+
+  mTopVBoxLayout = new QVBoxLayout( mRootCollapsibleGroupBox );
+  mTopVBoxLayout->setContentsMargins( 0, 9, 0, 0 );
 }
 
 void QgsAbstractRelationEditorWidget::setRelationFeature( const QgsRelation &relation, const QgsFeature &feature )
@@ -607,7 +617,7 @@ void QgsAbstractRelationEditorWidget::updateUi()
 
 void QgsAbstractRelationEditorWidget::setTitle( const QString &title )
 {
-  Q_UNUSED( title )
+  mRootCollapsibleGroupBox->setTitle( title );
 }
 
 void QgsAbstractRelationEditorWidget::beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature )
@@ -627,6 +637,11 @@ void QgsAbstractRelationEditorWidget::beforeSetRelations( const QgsRelation &new
 
 void QgsAbstractRelationEditorWidget::afterSetRelations()
 {}
+
+QVBoxLayout *QgsAbstractRelationEditorWidget::rootTopVBoxLayout() const
+{
+  return mTopVBoxLayout;
+}
 
 void QgsAbstractRelationEditorWidget::duplicateFeature( const QgsFeatureId &fid )
 {

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -33,10 +33,8 @@
 % End
 #endif
 
-class QVBoxLayout;
 class QgsFeature;
 class QgsVectorLayer;
-class QgsCollapsibleGroupBox;
 
 /**
  * Base class to build new relation widgets.
@@ -113,13 +111,15 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Defines if a title label should be shown for this widget.
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    bool showLabel() const;
+    Q_DECL_DEPRECATED bool showLabel() const SIP_DEPRECATED;
 
     /**
      * Defines if a title label should be shown for this widget.
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    void setShowLabel( bool showLabel );
+    Q_DECL_DEPRECATED void setShowLabel( bool showLabel ) SIP_DEPRECATED;
 
     /**
     * Determines the relation id of the second relation involved in an N:M relation.
@@ -134,8 +134,9 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Determines the label of this element
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    QString label() const;
+    Q_DECL_DEPRECATED QString label() const SIP_DEPRECATED;
 
     /**
      * Sets \a label for this element
@@ -230,19 +231,15 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     QgsRelation mNmRelation;
     QgsFeature mFeature;
 
-    bool mShowLabel = true;
     bool mLayerInSameTransactionGroup = false;
 
     bool mForceSuppressFormPopup = false;
-    QString mLabel;
-
-    QgsCollapsibleGroupBox *mRootCollapsibleGroupBox = nullptr;
-    QVBoxLayout *mTopVBoxLayout = nullptr;
 
     /**
      * Updates the title contents to reflect the current state of the widget
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    void updateTitle();
+    Q_DECL_DEPRECATED void updateTitle() SIP_DEPRECATED;
 
     /**
      * Deletes the features with \a fids
@@ -266,8 +263,9 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Sets the title of the widget, if it is wrapped within a QgsCollapsibleGroupBox
+     * \deprecated since QGIS 3.20 label is handled directly in QgsAttributeForm.
      */
-    virtual void setTitle( const QString &title );
+    Q_DECL_DEPRECATED virtual void setTitle( const QString &title ) SIP_DEPRECATED;
 
     /**
      * A hook called right before setRelationFeature() is executed. Used to update the UI once setting the relation feature is done.
@@ -292,11 +290,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * Check QgsRealationEditorWidget as an example.
      */
     virtual void afterSetRelations();
-
-    /**
-     * The root collapsible group box to insert content into
-     */
-    QVBoxLayout *rootTopVBoxLayout() const;
 };
 
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -33,8 +33,10 @@
 % End
 #endif
 
+class QVBoxLayout;
 class QgsFeature;
 class QgsVectorLayer;
+class QgsCollapsibleGroupBox;
 
 /**
  * Base class to build new relation widgets.
@@ -234,6 +236,9 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     bool mForceSuppressFormPopup = false;
     QString mLabel;
 
+    QgsCollapsibleGroupBox *mRootCollapsibleGroupBox = nullptr;
+    QVBoxLayout *mTopVBoxLayout = nullptr;
+
     /**
      * Updates the title contents to reflect the current state of the widget
      */
@@ -261,7 +266,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Sets the title of the widget, if it is wrapped within a QgsCollapsibleGroupBox
-     * Check QgsRealationEditorWidget as an example.
      */
     virtual void setTitle( const QString &title );
 
@@ -288,6 +292,11 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * Check QgsRealationEditorWidget as an example.
      */
     virtual void afterSetRelations();
+
+    /**
+     * The root collapsible group box to insert content into
+     */
+    QVBoxLayout *rootTopVBoxLayout() const;
 };
 
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -98,6 +98,9 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   : QgsAbstractRelationEditorWidget( config, parent )
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
 {
+  QVBoxLayout *rootLayout = new QVBoxLayout( this );
+  rootLayout->setContentsMargins( 0, 9, 0, 0 );
+
   // buttons
   QHBoxLayout *buttonLayout = new QHBoxLayout();
   buttonLayout->setContentsMargins( 0, 0, 0, 0 );
@@ -187,11 +190,11 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   mViewModeButtonGroup->addButton( mTableViewButton, QgsDualView::AttributeTable );
 
   // add buttons layout
-  rootTopVBoxLayout()->addLayout( buttonLayout );
+  rootLayout->addLayout( buttonLayout );
 
   mRelationLayout = new QGridLayout();
   mRelationLayout->setContentsMargins( 0, 0, 0, 0 );
-  rootTopVBoxLayout()->addLayout( mRelationLayout );
+  rootLayout->addLayout( mRelationLayout );
 
   connect( mViewModeButtonGroup, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ),
            this, static_cast<void ( QgsRelationEditorWidget::* )( int )>( &QgsRelationEditorWidget::setViewMode ) );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -35,6 +35,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsmessagebar.h"
 #include "qgsmessagebaritem.h"
+#include "qgscollapsiblegroupbox.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -97,15 +98,6 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   : QgsAbstractRelationEditorWidget( config, parent )
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
 {
-  QVBoxLayout *rootLayout = new QVBoxLayout( this );
-  rootLayout->setContentsMargins( 0, 0, 0, 0 );
-
-  mRootCollapsibleGroupBox = new QgsCollapsibleGroupBox( QString(), this );
-  rootLayout->addWidget( mRootCollapsibleGroupBox );
-
-  QVBoxLayout *topLayout = new QVBoxLayout( mRootCollapsibleGroupBox );
-  topLayout->setContentsMargins( 0, 9, 0, 0 );
-
   // buttons
   QHBoxLayout *buttonLayout = new QHBoxLayout();
   buttonLayout->setContentsMargins( 0, 0, 0, 0 );
@@ -195,13 +187,12 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   mViewModeButtonGroup->addButton( mTableViewButton, QgsDualView::AttributeTable );
 
   // add buttons layout
-  topLayout->addLayout( buttonLayout );
+  rootTopVBoxLayout()->addLayout( buttonLayout );
 
   mRelationLayout = new QGridLayout();
   mRelationLayout->setContentsMargins( 0, 0, 0, 0 );
-  topLayout->addLayout( mRelationLayout );
+  rootTopVBoxLayout()->addLayout( mRelationLayout );
 
-  connect( mRootCollapsibleGroupBox, &QgsCollapsibleGroupBoxBasic::collapsedStateChanged, this, &QgsRelationEditorWidget::onCollapsedStateChanged );
   connect( mViewModeButtonGroup, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ),
            this, static_cast<void ( QgsRelationEditorWidget::* )( int )>( &QgsRelationEditorWidget::setViewMode ) );
   connect( mToggleEditingButton, &QAbstractButton::clicked, this, &QgsRelationEditorWidget::toggleEditing );
@@ -366,48 +357,33 @@ void QgsRelationEditorWidget::toggleEditing( bool state )
   updateButtons();
 }
 
-void QgsRelationEditorWidget::onCollapsedStateChanged( bool collapsed )
-{
-  if ( !collapsed )
-  {
-    if ( !mVisible )
-    {
-      mVisible = true;
-      updateUi();
-    }
-  }
-}
-
 void QgsRelationEditorWidget::updateUi()
 {
-  // If not yet initialized, it is not (yet) visible, so we don't load it to be faster (lazy loading)
-  // If it is already initialized, it has been set visible before and the currently shown feature is changing
-  // and the widget needs updating
-  if ( mVisible && mRelation.isValid() && mFeature.isValid() )
+  if ( !mRelation.isValid() || !mFeature.isValid() )
+    return;
+
+  QgsFeatureRequest request = mRelation.getRelatedFeaturesRequest( mFeature );
+
+  if ( mNmRelation.isValid() )
   {
-    QgsFeatureRequest request = mRelation.getRelatedFeaturesRequest( mFeature );
+    QgsFeatureIterator it = mRelation.referencingLayer()->getFeatures( request );
+    QgsFeature fet;
+    QStringList filters;
 
-    if ( mNmRelation.isValid() )
+    while ( it.nextFeature( fet ) )
     {
-      QgsFeatureIterator it = mRelation.referencingLayer()->getFeatures( request );
-      QgsFeature fet;
-      QStringList filters;
-
-      while ( it.nextFeature( fet ) )
-      {
-        QString filter = mNmRelation.getReferencedFeatureRequest( fet ).filterExpression()->expression();
-        filters << filter.prepend( '(' ).append( ')' );
-      }
-
-      QgsFeatureRequest nmRequest;
-      nmRequest.setFilterExpression( filters.join( QLatin1String( " OR " ) ) );
-
-      initDualView( mNmRelation.referencedLayer(), nmRequest );
+      QString filter = mNmRelation.getReferencedFeatureRequest( fet ).filterExpression()->expression();
+      filters << filter.prepend( '(' ).append( ')' );
     }
-    else if ( mRelation.referencingLayer() )
-    {
-      initDualView( mRelation.referencingLayer(), request );
-    }
+
+    QgsFeatureRequest nmRequest;
+    nmRequest.setFilterExpression( filters.join( QLatin1String( " OR " ) ) );
+
+    initDualView( mNmRelation.referencedLayer(), nmRequest );
+  }
+  else if ( mRelation.referencingLayer() )
+  {
+    initDualView( mRelation.referencingLayer(), request );
   }
 }
 
@@ -510,11 +486,6 @@ void QgsRelationEditorWidget::setConfig( const QVariantMap &config )
   updateButtons();
 }
 
-void QgsRelationEditorWidget::setTitle( const QString &title )
-{
-  mRootCollapsibleGroupBox->setTitle( title );
-}
-
 void QgsRelationEditorWidget::beforeSetRelationFeature( const QgsRelation &newRelation, const QgsFeature &newFeature )
 {
   Q_UNUSED( newRelation );
@@ -549,15 +520,8 @@ void QgsRelationEditorWidget::afterSetRelationFeature()
     mToggleEditingButton->setEnabled( false );
   }
 
-  // If not yet initialized, it is not (yet) visible, so we don't load it to be faster (lazy loading)
-  // If it is already initialized, it has been set visible before and the currently shown feature is changing
-  // and the widget needs updating
-
-  if ( mVisible )
-  {
-    QgsFeatureRequest myRequest = mRelation.getRelatedFeaturesRequest( mFeature );
-    initDualView( mRelation.referencingLayer(), myRequest );
-  }
+  QgsFeatureRequest myRequest = mRelation.getRelatedFeaturesRequest( mFeature );
+  initDualView( mRelation.referencingLayer(), myRequest );
 }
 
 void QgsRelationEditorWidget::beforeSetRelations( const QgsRelation &newRelation, const QgsRelation &newNmRelation )

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -27,7 +27,6 @@
 #include "qgsabstractrelationeditorwidget.h"
 #include "qobjectuniqueptr.h"
 #include "qgsattributeeditorcontext.h"
-#include "qgscollapsiblegroupbox.h"
 #include "qgsdualview.h"
 #include "qgsrelation.h"
 #include "qgsvectorlayerselectionmanager.h"
@@ -185,11 +184,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
      */
     void setConfig( const QVariantMap &config ) override;
 
-    /**
-      * Sets the title of the root groupbox
-      */
-    void setTitle( const QString &title ) override;
-
   public slots:
     void parentFormValueChanged( const QString &attribute, const QVariant &newValue ) override;
 
@@ -206,7 +200,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     void addFeatureGeometry();
     void toggleEditing( bool state );
-    void onCollapsedStateChanged( bool collapsed );
     void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );
     void mapToolDeactivated();
     void onKeyPressed( QKeyEvent *e );
@@ -217,7 +210,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();
 
-    QgsCollapsibleGroupBox *mRootCollapsibleGroupBox = nullptr;
     QgsDualView *mDualView = nullptr;
     QPointer<QgsMessageBarItem> mMessageBarItem;
     QgsDualView::ViewMode mViewMode = QgsDualView::AttributeEditor;
@@ -239,7 +231,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;
 
     Buttons mButtonsVisibility = Button::AllButtons;
-    bool mVisible = true;
 };
 
 

--- a/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
@@ -29,6 +29,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="toolTip">
+      <string>If left empty the relation name is used.</string>
+     </property>
     </widget>
    </item>
    <item row="1" column="0">


### PR DESCRIPTION
Relation editor widget label implementation moved to attribute form for more consistency with other edit widgets.
Unused member functions where marked as deprecated.