### PR TITLE
Add ""Convert to Static Text" option 

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlabel.sip.in
@@ -232,6 +232,14 @@ Returns the label font color.
     virtual void refresh();
 
 
+    void convertToStaticText();
+%Docstring
+Converts the label's :py:func:`~QgsLayoutItemLabel.text` to a static string, by evaluating any expressions included in the text
+and replacing them with their current values.
+
+.. versionadded:: 3.20
+%End
+
   protected:
     virtual void draw( QgsLayoutItemRenderContext &context );
 

--- a/src/core/layout/qgslayoutitemlabel.cpp
+++ b/src/core/layout/qgslayoutitemlabel.cpp
@@ -516,6 +516,15 @@ void QgsLayoutItemLabel::refresh()
   refreshExpressionContext();
 }
 
+void QgsLayoutItemLabel::convertToStaticText()
+{
+  const QString evaluated = currentText();
+  if ( evaluated == mText )
+    return; // no changes
+
+  setText( evaluated );
+}
+
 void QgsLayoutItemLabel::itemShiftAdjustSize( double newWidth, double newHeight, double &xShift, double &yShift ) const
 {
   //keep alignment point constant

--- a/src/core/layout/qgslayoutitemlabel.h
+++ b/src/core/layout/qgslayoutitemlabel.h
@@ -218,6 +218,14 @@ class CORE_EXPORT QgsLayoutItemLabel: public QgsLayoutItem
 
     void refresh() override;
 
+    /**
+     * Converts the label's text() to a static string, by evaluating any expressions included in the text
+     * and replacing them with their current values.
+     *
+     * \since QGIS 3.20
+     */
+    void convertToStaticText();
+
   protected:
     void draw( QgsLayoutItemRenderContext &context ) override;
     bool writePropertiesToElement( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;

--- a/src/gui/layout/qgslayoutlabelwidget.cpp
+++ b/src/gui/layout/qgslayoutlabelwidget.cpp
@@ -88,6 +88,11 @@ QgsLayoutLabelWidget::QgsLayoutLabelWidget( QgsLayoutItemLabel *label )
     }
   } );
 
+  QMenu *expressionMenu = new QMenu( this );
+  QAction *convertToStaticAction = new QAction( tr( "Convert to Static Text" ), this );
+  expressionMenu->addAction( convertToStaticAction );
+  connect( convertToStaticAction, &QAction::triggered, mLabel, &QgsLayoutItemLabel::convertToStaticText );
+  mInsertExpressionButton->setMenu( expressionMenu );
 }
 
 void QgsLayoutLabelWidget::setMasterLayout( QgsMasterLayoutInterface *masterLayout )

--- a/src/ui/layout/qgslayoutlabelwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlabelwidgetbase.ui
@@ -62,7 +62,7 @@
         <x>0</x>
         <y>0</y>
         <width>358</width>
-        <height>682</height>
+        <height>680</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -110,6 +110,15 @@
             </property>
             <property name="text">
              <string>Insert/Edit Expression…</string>
+            </property>
+            <property name="popupMode">
+             <enum>QToolButton::MenuButtonPopup</enum>
+            </property>
+            <property name="toolButtonStyle">
+             <enum>Qt::ToolButtonTextOnly</enum>
+            </property>
+            <property name="arrowType">
+             <enum>Qt::DownArrow</enum>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Add ""Convert to Static Text" option to dropdown menu next to "Insert/Edit Expression…" in layout label properties
widget

When selected any dynamic parts of the label's contents will be evaluated and replaced with their current values.

Provides an easy way to convert a dynamic label to a static one, so that the user can then manually tweak the resulting tweak
when needed.
