### PR TITLE
Add groups property to operators and NULL value

### DIFF
--- a/resources/function_help/json/AND
+++ b/resources/function_help/json/AND
@@ -1,6 +1,7 @@
 {
   "name": "AND",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 when condition a and b are true.",
   "arguments": [
         { "arg": "a", "description": "condition" },

--- a/resources/function_help/json/ILIKE
+++ b/resources/function_help/json/ILIKE
@@ -1,6 +1,7 @@
 {
   "name": "ILIKE",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 if the first parameter matches case-insensitive the supplied pattern. LIKE can be used instead of ILIKE to make the match case-sensitive. Works with numbers also.",
   "arguments": [
     {"arg":"string/number","description":"string to search"},

--- a/resources/function_help/json/IN
+++ b/resources/function_help/json/IN
@@ -1,6 +1,7 @@
 {
   "name": "IN",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 if value is found within a list of values.",
   "arguments": [
 	{"arg":"a","description":"value"},

--- a/resources/function_help/json/IS
+++ b/resources/function_help/json/IS
@@ -1,6 +1,7 @@
 {
   "name": "IS",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 if a is the same as b.",
   "arguments": [
 	{"arg":"a","description":"any value"},

--- a/resources/function_help/json/IS NOT
+++ b/resources/function_help/json/IS NOT
@@ -1,6 +1,7 @@
 {
   "name": "IS NOT",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 if a is not the same as b.",
   "arguments": [
 	{"arg":"a","description":"value"},

--- a/resources/function_help/json/LIKE
+++ b/resources/function_help/json/LIKE
@@ -1,6 +1,7 @@
 {
   "name": "LIKE",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 if the first parameter matches the supplied pattern. Works with numbers also.",
   "arguments": [
     {"arg":"string/number","description":"value"},

--- a/resources/function_help/json/NOT
+++ b/resources/function_help/json/NOT
@@ -1,6 +1,7 @@
 {
   "name": "NOT",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Negates a condition.",
   "arguments": [
 	{"arg":"a","description":"condition"}

--- a/resources/function_help/json/NULL
+++ b/resources/function_help/json/NULL
@@ -6,5 +6,5 @@
   "examples": [
        { "expression":"NULL", "returns":"a NULL value" }
   ],
-  "notes": "To test for NULL use an <pre>IS NULL</pre> or <pre>IS NOT NULL</pre> expression."
+  "notes": "To test for NULL use an <i>IS NULL</i> or <i>IS NOT NULL</i> expression."
 }

--- a/resources/function_help/json/NULL
+++ b/resources/function_help/json/NULL
@@ -1,6 +1,7 @@
 {
   "name": "NULL",
   "type": "value",
+  "groups": ["Fields and Values"],
   "description": "Equates to a NULL value.",
   "examples": [
        { "expression":"NULL", "returns":"a NULL value" }

--- a/resources/function_help/json/OR
+++ b/resources/function_help/json/OR
@@ -1,6 +1,7 @@
 {
   "name": "OR",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Returns 1 when condition a or b is true.",
   "arguments": [
 	{"arg":"a","description":"condition"},

--- a/resources/function_help/json/op_asterisk
+++ b/resources/function_help/json/op_asterisk
@@ -1,6 +1,7 @@
 {
   "name": "*",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Multiplication of two values",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_concat
+++ b/resources/function_help/json/op_concat
@@ -1,6 +1,7 @@
 {
   "name": "||",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Joins two values together into a string.<br><br>If one of the values is NULL the result will be NULL. See the CONCAT function for a different behavior.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_div
+++ b/resources/function_help/json/op_div
@@ -1,6 +1,7 @@
 {
   "name": "/",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Division of two values",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_eq
+++ b/resources/function_help/json/op_eq
@@ -1,6 +1,7 @@
 {
   "name": "=",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if they are equal.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_exp
+++ b/resources/function_help/json/op_exp
@@ -1,6 +1,7 @@
 {
   "name": "^",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Power of two values.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_ge
+++ b/resources/function_help/json/op_ge
@@ -1,6 +1,7 @@
 {
   "name": ">=",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if the left value is greater or equal than the right value.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_gt
+++ b/resources/function_help/json/op_gt
@@ -1,6 +1,7 @@
 {
   "name": ">",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if the left value is greater than the right value.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_index
+++ b/resources/function_help/json/op_index
@@ -1,6 +1,7 @@
 {
   "name": "[]",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Index operator. Returns an element from an array or map value.",
   "arguments": [
         { "arg": "index", "description": "array index or map key value" }

--- a/resources/function_help/json/op_le
+++ b/resources/function_help/json/op_le
@@ -1,6 +1,7 @@
 {
   "name": "<=",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if the left value is less or equal than the right value.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_lt
+++ b/resources/function_help/json/op_lt
@@ -1,6 +1,7 @@
 {
   "name": "<",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if the left value is less than the right value.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_minus
+++ b/resources/function_help/json/op_minus
@@ -1,6 +1,7 @@
 {
   "name": "-",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Subtraction of two values. If one of the values is NULL the result will be NULL.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_modulo
+++ b/resources/function_help/json/op_modulo
@@ -1,6 +1,7 @@
 {
   "name": "%",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Remainder of division",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_ne
+++ b/resources/function_help/json/op_ne
@@ -1,6 +1,7 @@
 {
   "name": "<>",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Compares two values and evaluates to 1 if they are not equal.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -1,6 +1,7 @@
 {
   "name": "+",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Addition of two values. If one of the values is NULL the result will be NULL.",
   "arguments": [
         { "arg": "a", "description": "value" },

--- a/resources/function_help/json/op_regex
+++ b/resources/function_help/json/op_regex
@@ -1,6 +1,7 @@
 {
   "name": "~",
   "type": "operator",
+  "groups": ["Operators"],
   "description": "Performs a regular expression match on a string value. Backslash characters must be double escaped (e.g., \"\\\\\\\\s\" to match a white space character).",
   "arguments": [
         { "arg": "string", "description": "A string value" },


### PR DESCRIPTION
This is a complement to #43134 (if someone can review it, please. Thanks), in that it will help us display the operators help also in QGIS docs
While doing this, I tweaked the note in NULL because it'd need more rewrite (and dev) of our code to handle \<pre> while \<i> is straightforward and without losing anything in QGIS.

Btw, there's an "IS NOT" file but no entry of this in the GUI. Intended (we have IS and NOT) or bug?