### PR TITLE
implement setDataSource for mesh layer

### DIFF
--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -65,7 +65,7 @@ void QgsMeshDatasetGroupStore::setPersistentProvider( QgsMeshDataProvider *provi
   //Once everything is in place, initialize the extra dataset groups
   if ( mExtraDatasets )
   {
-    int groupCount = mExtraDatasets->datasetGroupCount();
+    const int groupCount = mExtraDatasets->datasetGroupCount();
     for ( int i = 0; i < groupCount; ++i )
       if ( mExtraDatasets->datasetGroup( i ) )
         mExtraDatasets->datasetGroup( i )->initialize();

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -48,11 +48,6 @@ QgsMeshDatasetGroupStore::QgsMeshDatasetGroupStore( QgsMeshLayer *layer ):
   mDatasetGroupTreeRootItem( new QgsMeshDatasetGroupTreeItem )
 {}
 
-void QgsMeshDatasetGroupStore::setPersistentProvider( QgsMeshDataProvider *provider )
-{
-  setPersistentProvider( provider, QStringList() );
-}
-
 void QgsMeshDatasetGroupStore::setPersistentProvider( QgsMeshDataProvider *provider, const QStringList &extraDatasetUri )
 {
   removePersistentProvider();

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -474,8 +474,6 @@ void QgsMeshDatasetGroupStore::checkDatasetConsistency( QgsMeshDatasetSourceInte
 
   if ( !indexes.isEmpty() )
     createDatasetGroupTreeItems( indexes );
-//  for ( int index : std::as_const( indexes ) )
-//    syncItemToDatasetGroup( index );
 
   for ( int globalIndex : mRegistery.keys() )
   {

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -112,7 +112,7 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
  * The native group index is not exposed and global index can be obtained with datasetGroupIndexes() that returns the list of global index available.
  * The dataset index is the same than in the native source (data provider or other dataset source)
  *
- * This class has also the responsibility to handle the dataset group tree item that contain information to display the available dataset (\see QgsMeshDatasetGroupTreeItem)
+ * This class also has the responsibility to handle the dataset group tree item that contain information to display the available dataset (\see QgsMeshDatasetGroupTreeItem)
  *
  * \since QGIS 3.16
  */
@@ -127,18 +127,7 @@ class QgsMeshDatasetGroupStore: public QObject
     //! Constructor
     QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
 
-    /**
-     *  Sets the persistent mesh data provider
-     *
-     * \deprecated since QGIS 3.20
-     */
-    Q_DECL_DEPRECATED void setPersistentProvider( QgsMeshDataProvider *provider );
-
-    /**
-     *  Sets the persistent mesh data provider with the path of its extra dataset
-     *
-     *  \since QGIS 3.20
-     */
+    //!  Sets the persistent mesh data provider with the path of its extra dataset
     void setPersistentProvider( QgsMeshDataProvider *provider, const QStringList &extraDatasetUri );
 
     //! Adds persistent datasets from a file with \a path

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -112,7 +112,7 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
  * The native group index is not exposed and global index can be obtained with datasetGroupIndexes() that returns the list of global index available.
  * The dataset index is the same than in the native source (data provider or other dataset source)
  *
- * This class as also the responsibility to handle the dataset group tree item that contain information to display the available dataset (\see QgsMeshDatasetGroupTreeItem)
+ * This class has also the responsibility to handle the dataset group tree item that contain information to display the available dataset (\see QgsMeshDatasetGroupTreeItem)
  *
  * \since QGIS 3.16
  */
@@ -127,8 +127,19 @@ class QgsMeshDatasetGroupStore: public QObject
     //! Constructor
     QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
 
-    //! Sets the persistent mesh data provider
-    void setPersistentProvider( QgsMeshDataProvider *provider );
+    /**
+     *  Sets the persistent mesh data provider
+     *
+     * \deprecated since QGIS 3.20
+     */
+    Q_DECL_DEPRECATED void setPersistentProvider( QgsMeshDataProvider *provider );
+
+    /**
+     *  Sets the persistent mesh data provider with the path of its extra dataset
+     *
+     *  \since QGIS 3.20
+     */
+    void setPersistentProvider( QgsMeshDataProvider *provider, const QStringList &extraDatasetUri );
 
     //! Adds persistent datasets from a file with \a path
     bool addPersistentDatasets( const QString &path );
@@ -220,6 +231,7 @@ class QgsMeshDatasetGroupStore: public QObject
   private:
     QgsMeshLayer *mLayer = nullptr;
     QgsMeshDataProvider *mPersistentProvider = nullptr;
+    QList<int> mPersistentExtraDatasetGroupIndexes;
     std::unique_ptr<QgsMeshExtraDatasetStore> mExtraDatasets;
     QMap < int, DatasetGroup> mRegistery;
     std::unique_ptr<QgsMeshDatasetGroupTreeItem> mDatasetGroupTreeRootItem;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -51,31 +51,18 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
 {
   mShouldValidateCrs = !options.skipCrsValidation;
 
-  setProviderType( providerKey );
-  // if we’re given a provider type, try to create and bind one to this layer
-  bool ok = false;
-  if ( !meshLayerPath.isEmpty() && !providerKey.isEmpty() )
+  QgsDataProvider::ProviderOptions providerOptions { options.transformContext };
+  QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags();
+  if ( mReadFlags & QgsMapLayer::FlagTrustLayerMetadata )
   {
-    QgsDataProvider::ProviderOptions providerOptions { options.transformContext };
-    QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags();
-    if ( mReadFlags & QgsMapLayer::FlagTrustLayerMetadata )
-    {
-      flags |= QgsDataProvider::FlagTrustDataSource;
-    }
-    ok = setDataProvider( providerKey, providerOptions, flags );
+    flags |= QgsDataProvider::FlagTrustDataSource;
   }
-
+  setDataSourcePrivate( meshLayerPath, baseName, providerKey, providerOptions, flags );
+  resetDatasetGroupTreeItem();
   setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
-  if ( ok )
-  {
-    setDefaultRendererSettings( mDatasetGroupStore->datasetGroupIndexes() );
 
-    if ( mDataProvider )
-    {
-      mTemporalProperties->setDefaultsFromDataProviderTemporalCapabilities( mDataProvider->temporalCapabilities() );
-      resetDatasetGroupTreeItem();
-    }
-  }
+  if ( isValid() )
+    setDefaultRendererSettings( mDatasetGroupStore->datasetGroupIndexes() );
 
   connect( mDatasetGroupStore.get(), &QgsMeshDatasetGroupStore::datasetGroupsAdded, this, &QgsMeshLayer::onDatasetGroupsAdded );
 }
@@ -199,6 +186,7 @@ bool QgsMeshLayer::addDatasets( const QString &path, const QDateTime &defaultRef
   bool isTemporalBefore = dataProvider()->temporalCapabilities()->hasTemporalCapabilities();
   if ( mDatasetGroupStore->addPersistentDatasets( path ) )
   {
+    mExtraDatasetUri.append( path );
     QgsMeshLayerTemporalProperties *temporalProperties = qobject_cast< QgsMeshLayerTemporalProperties * >( mTemporalProperties );
     if ( !isTemporalBefore && dataProvider()->temporalCapabilities()->hasTemporalCapabilities() )
     {
@@ -920,6 +908,26 @@ void QgsMeshLayer::updateActiveDatasetGroups()
     emit activeVectorDatasetGroupChanged( settings.activeVectorDatasetGroup() );
 }
 
+void QgsMeshLayer::setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
+{
+  mDataSource = dataSource;
+  mLayerName = baseName;
+  setProviderType( provider );
+
+  // if we’re given a provider type, try to create and bind one to this layer
+  bool ok = false;
+  if ( !mDataSource.isEmpty() && !provider.isEmpty() )
+  {
+    ok = setDataProvider( provider, options, flags );
+  }
+
+  if ( ok )
+  {
+    mTemporalProperties->setDefaultsFromDataProviderTemporalCapabilities( mDataProvider->temporalCapabilities() );
+    mDataProvider->setTemporalUnit( mTemporalUnit );
+  }
+}
+
 QgsPointXY QgsMeshLayer::snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius )
 {
   switch ( elementType )
@@ -1170,10 +1178,6 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
   {
     flags |= QgsDataProvider::FlagTrustDataSource;
   }
-  if ( !setDataProvider( mProviderKey, providerOptions, flags ) )
-  {
-    return false;
-  }
 
   QDomElement elemExtraDatasets = layer_node.firstChildElement( QStringLiteral( "extra-datasets" ) );
   if ( !elemExtraDatasets.isNull() )
@@ -1182,21 +1186,10 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     while ( !elemUri.isNull() )
     {
       QString uri = context.pathResolver().readPath( elemUri.text() );
-
-      bool res = mDataProvider->addDataset( uri );
-#ifdef QGISDEBUG
-      QgsDebugMsg( QStringLiteral( "extra dataset (res %1): %2" ).arg( res ).arg( uri ) );
-#else
-      ( void )res; // avoid unused warning in release builds
-#endif
-
+      mExtraDatasetUri.append( uri );
       elemUri = elemUri.nextSiblingElement( QStringLiteral( "uri" ) );
     }
   }
-
-  if ( mDataProvider && pkeyNode.toElement().hasAttribute( QStringLiteral( "time-unit" ) ) )
-    mDataProvider->setTemporalUnit(
-      static_cast<QgsUnitTypes::TemporalUnit>( pkeyNode.toElement().attribute( QStringLiteral( "time-unit" ) ).toInt() ) );
 
   // read dataset group store
   QDomElement elemDatasetGroupsStore = layer_node.firstChildElement( QStringLiteral( "mesh-dataset-groups-store" ) );
@@ -1204,6 +1197,8 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     resetDatasetGroupTreeItem();
   else
     mDatasetGroupStore->readXml( elemDatasetGroupsStore, context );
+
+  setDataProvider( mProviderKey, providerOptions, flags );
 
   QString errorMsg;
   readSymbology( layer_node, errorMsg, context );
@@ -1400,12 +1395,14 @@ QString QgsMeshLayer::htmlMetadata() const
 
 bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
 {
-  delete mDataProvider;
+  mDatasetGroupStore->setPersistentProvider( nullptr, QStringList() );
 
+  delete mDataProvider;
   mProviderKey = provider;
   QString dataSource = mDataSource;
 
   mDataProvider = qobject_cast<QgsMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options, flags ) );
+
   if ( !mDataProvider )
   {
     QgsDebugMsgLevel( QStringLiteral( "Unable to get mesh data provider" ), 2 );
@@ -1422,6 +1419,8 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
     return false;
   }
 
+  mDatasetGroupStore->setPersistentProvider( mDataProvider, mExtraDatasetUri );
+
   setCrs( mDataProvider->crs() );
 
   if ( provider == QLatin1String( "mesh_memory" ) )
@@ -1429,8 +1428,6 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
     // required so that source differs between memory layers
     mDataSource = mDataSource + QStringLiteral( "&uid=%1" ).arg( QUuid::createUuid().toString() );
   }
-
-  mDatasetGroupStore->setPersistentProvider( mDataProvider );
 
   for ( int i = 0; i < mDataProvider->datasetGroupCount(); ++i )
     assignDefaultStyleToDatasetGroup( i );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -924,7 +924,6 @@ void QgsMeshLayer::setDataSourcePrivate( const QString &dataSource, const QStrin
   if ( ok )
   {
     mTemporalProperties->setDefaultsFromDataProviderTemporalCapabilities( mDataProvider->temporalCapabilities() );
-    mDataProvider->setTemporalUnit( mTemporalUnit );
   }
 }
 
@@ -1191,6 +1190,9 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     }
   }
 
+  if ( pkeyNode.toElement().hasAttribute( QStringLiteral( "time-unit" ) ) )
+    mTemporalUnit = static_cast<QgsUnitTypes::TemporalUnit>( pkeyNode.toElement().attribute( QStringLiteral( "time-unit" ) ).toInt() );
+
   // read dataset group store
   QDomElement elemDatasetGroupsStore = layer_node.firstChildElement( QStringLiteral( "mesh-dataset-groups-store" ) );
   if ( elemDatasetGroupsStore.isNull() )
@@ -1419,8 +1421,8 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
     return false;
   }
 
+  mDataProvider->setTemporalUnit( mTemporalUnit );
   mDatasetGroupStore->setPersistentProvider( mDataProvider, mExtraDatasetUri );
-
   setCrs( mDataProvider->crs() );
 
   if ( provider == QLatin1String( "mesh_memory" ) )

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -788,6 +788,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! Pointer to data provider derived from the abastract base class QgsMeshDataProvider
     QgsMeshDataProvider *mDataProvider = nullptr;
 
+    //! List of extra dataset uri associated with this layer
+    QStringList mExtraDatasetUri;
+
     std::unique_ptr<QgsMeshDatasetGroupStore> mDatasetGroupStore;
 
     //! Pointer to native mesh structure, used as cache for rendering
@@ -808,7 +811,10 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! Simplify mesh configuration
     QgsMeshSimplificationSettings mSimplificationSettings;
 
-    QgsMeshLayerTemporalProperties *mTemporalProperties;
+    QgsMeshLayerTemporalProperties *mTemporalProperties = nullptr;
+
+    //! Temporal unit used by the provider
+    QgsUnitTypes::TemporalUnit mTemporalUnit = QgsUnitTypes::TemporalHours;
 
     int mStaticScalarDatasetIndex = 0;
     int mStaticVectorDatasetIndex = 0;
@@ -825,6 +831,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QgsPointXY snapOnFace( const QgsPointXY &point, double searchRadius );
 
     void updateActiveDatasetGroups();
+
+    void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
+                               const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags ) override;
 };
 
 #endif //QGSMESHLAYER_H

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -90,6 +90,8 @@ class TestQgsMeshLayer : public QObject
 
     void test_memory_dataset_group();
     void test_memory_dataset_group_1d();
+
+    void test_setDataSource();
 };
 
 QString TestQgsMeshLayer::readFile( const QString &fname ) const
@@ -1480,6 +1482,100 @@ void TestQgsMeshLayer::test_memory_dataset_group_1d()
 
   QCOMPARE( mMdal1DLayer->datasetGroupCount(), 7 );
   QCOMPARE( mMdal1DLayer->extraDatasetGroupCount(), 2 );
+}
+
+void TestQgsMeshLayer::test_setDataSource()
+{
+  // MDAL Layer
+  QString uri( mDataDir + "/quad_and_triangle.2dm" );
+  QgsMeshLayer *firstLayer = new QgsMeshLayer( uri, "Triangle and Quad MDAL", "mdal" );
+  QCOMPARE( firstLayer->dataProvider()->datasetGroupCount(), 1 ); //bed elevation is already in the 2dm
+  QCOMPARE( firstLayer->datasetGroupTreeRootItem()->childCount(), 1 );
+
+  //! Add extra dataset from file
+  firstLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
+  firstLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_vertex_vector.dat" );
+  QCOMPARE( firstLayer->dataProvider()->extraDatasets().count(), 2 );
+  QCOMPARE( firstLayer->datasetGroupTreeRootItem()->childCount(), 3 );
+  QVERIFY( firstLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
+
+  //! Add memory dataset
+  std::unique_ptr<QgsMeshMemoryDatasetGroup> memoryDataset( new QgsMeshMemoryDatasetGroup );
+  memoryDataset->setName( QStringLiteral( "memory dataset" ) );
+  memoryDataset->setDataType( QgsMeshDatasetGroupMetadata::DataOnVertices );
+  int vertexCount = firstLayer->dataProvider()->vertexCount();
+  for ( int i = 1; i < 10; i++ )
+  {
+    std::shared_ptr<QgsMeshMemoryDataset> ds = std::make_shared<QgsMeshMemoryDataset>();
+    for ( int v = 0; v < vertexCount; ++v )
+      ds->values.append( QgsMeshDatasetValue( v / 2.0 ) );
+    ds->valid = true;
+    memoryDataset->addDataset( ds );
+  }
+  firstLayer->addDatasets( memoryDataset.release() );
+
+  QCOMPARE( firstLayer->dataProvider()->extraDatasets().count(), 2 );
+  QCOMPARE( firstLayer->datasetGroupTreeRootItem()->childCount(), 4 );
+
+  //! add another dataset from file
+  firstLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+
+  QCOMPARE( firstLayer->dataProvider()->extraDatasets().count(), 3 );
+  QCOMPARE( firstLayer->datasetGroupTreeRootItem()->childCount(), 5 );
+
+  QgsReadWriteContext readWriteContext;
+  QDomDocument doc( "savedLayer" );
+  QDomElement layerElement = doc.createElement( "maplayer" );
+  firstLayer->writeLayerXml( layerElement, doc, readWriteContext );
+
+  QgsMeshLayer layerWithGoodDataSource;
+  layerWithGoodDataSource.readLayerXml( layerElement, readWriteContext );
+  QCOMPARE( layerWithGoodDataSource.dataProvider()->extraDatasets().count(), 3 );
+  QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->childCount(), 4 );
+  QVERIFY( layerWithGoodDataSource.dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
+  QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 0 )->description(), uri );
+  QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 1 )->description(), mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
+  QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 2 )->description(), mDataDir + "/quad_and_triangle_vertex_vector.dat" );
+  QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 3 )->description(), mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+
+  QCOMPARE( QgsMeshDatasetValue( 30.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 0, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 1, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0, 1.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 2, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 4, 0 ), 1 ) );
+
+  layerElement.removeChild( layerElement.firstChildElement( QStringLiteral( "datasource" ) ) );
+  QDomElement dataSourceElement = doc.createElement( QStringLiteral( "datasource" ) );
+  QString src = firstLayer->encodedSource( "bad", readWriteContext );
+  QDomText dataSourceText = doc.createTextNode( src );
+  dataSourceElement.appendChild( dataSourceText );
+  layerElement.appendChild( dataSourceElement );
+
+  QgsMeshLayer layerWithBadDataSource;
+  QVERIFY( !layerWithBadDataSource.readLayerXml( layerElement, readWriteContext ) );
+  QVERIFY( !layerWithBadDataSource.isValid() );
+
+  QCOMPARE( layerWithBadDataSource.dataProvider()->extraDatasets().count(), 0 );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->childCount(), 5 ); //keep trace of all invalid dataset group, even the memory one that do no exist anymore
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 0 )->description(), uri );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 1 )->description(), mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 2 )->description(), mDataDir + "/quad_and_triangle_vertex_vector.dat" );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 3 )->name(),  QStringLiteral( "memory dataset" ) );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 4 )->description(), mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+
+  layerWithBadDataSource.setDataSource( uri, "Triangle and Quad MDAL", "mdal" );
+
+  QVERIFY( layerWithBadDataSource.dataProvider()->isValid() );
+  QCOMPARE( layerWithBadDataSource.dataProvider()->extraDatasets().count(), 3 );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->childCount(), 4 ); // memory dataset group is not here anymore
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 0 )->description(), uri );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 1 )->description(), mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 2 )->description(), mDataDir + "/quad_and_triangle_vertex_vector.dat" );
+  QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 3 )->description(), mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+
+  QCOMPARE( QgsMeshDatasetValue( 30.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 0, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 1, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0, 1.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 2, 0 ), 1 ) );
+  QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 4, 0 ), 1 ) );
 }
 
 void TestQgsMeshLayer::test_temporal()

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1523,6 +1523,8 @@ void TestQgsMeshLayer::test_setDataSource()
   QCOMPARE( firstLayer->dataProvider()->extraDatasets().count(), 3 );
   QCOMPARE( firstLayer->datasetGroupTreeRootItem()->childCount(), 5 );
 
+  firstLayer->dataProvider()->temporalCapabilities()->setTemporalUnit( QgsUnitTypes::TemporalMinutes );
+
   QgsReadWriteContext readWriteContext;
   QDomDocument doc( "savedLayer" );
   QDomElement layerElement = doc.createElement( "maplayer" );
@@ -1537,6 +1539,7 @@ void TestQgsMeshLayer::test_setDataSource()
   QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 1 )->description(), mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
   QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 2 )->description(), mDataDir + "/quad_and_triangle_vertex_vector.dat" );
   QCOMPARE( layerWithGoodDataSource.datasetGroupTreeRootItem()->child( 3 )->description(), mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+  QCOMPARE( layerWithGoodDataSource.dataProvider()->temporalCapabilities()->temporalUnit(), QgsUnitTypes::TemporalMinutes );
 
   QCOMPARE( QgsMeshDatasetValue( 30.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 0, 0 ), 1 ) );
   QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithGoodDataSource.datasetValue( QgsMeshDatasetIndex( 1, 0 ), 1 ) );
@@ -1571,6 +1574,7 @@ void TestQgsMeshLayer::test_setDataSource()
   QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 1 )->description(), mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
   QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 2 )->description(), mDataDir + "/quad_and_triangle_vertex_vector.dat" );
   QCOMPARE( layerWithBadDataSource.datasetGroupTreeRootItem()->child( 3 )->description(), mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
+  QCOMPARE( layerWithGoodDataSource.dataProvider()->temporalCapabilities()->temporalUnit(), QgsUnitTypes::TemporalMinutes );
 
   QCOMPARE( QgsMeshDatasetValue( 30.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 0, 0 ), 1 ) );
   QCOMPARE( QgsMeshDatasetValue( 2.0 ), layerWithBadDataSource.datasetValue( QgsMeshDatasetIndex( 1, 0 ), 1 ) );


### PR DESCRIPTION
With this PR, it will be possible to repair the mesh layer path if it is broken.
That needs to change a bit the logic of the mesh layer loading, especially with extra dataset groups (from file and virtual).
fix #42170

Interaction with current PR #41208 