### PR TITLE
[network access manager] handle abortion of browser login request

### DIFF
--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -343,6 +343,18 @@ Forwards an external browser login closure request to the authentication handler
 .. versionadded:: 3.20
 %End
 
+    void abortAuthBrowser();
+%Docstring
+Abort any outstanding external browser login request.
+
+.. note::
+
+   Background threads will listen to aborted browser request signals from the network manager on the main thread.
+
+.. versionadded:: 3.20
+%End
+
+
 
 
   signals:
@@ -483,6 +495,12 @@ See :py:class:`QgsSslErrorHandler` for details on how to handle SSL errors and p
     void requestTimedOut( QNetworkReply * );
 
 
+    void authBrowserAborted();
+%Docstring
+Emitted when external browser login are to be aborted.
+
+.. versionadded:: 3.20
+%End
 
   protected:
     virtual QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = 0 );

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -497,7 +497,7 @@ See :py:class:`QgsSslErrorHandler` for details on how to handle SSL errors and p
 
     void authBrowserAborted();
 %Docstring
-Emitted when external browser login are to be aborted.
+Emitted when external browser logins are to be aborted.
 
 .. versionadded:: 3.20
 %End

--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -195,6 +195,7 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
     QEventLoop loop( nullptr );
     connect( o2, &QgsO2::linkingFailed, &loop, &QEventLoop::quit );
     connect( o2, &QgsO2::linkingSucceeded, &loop, &QEventLoop::quit );
+    connect( QgsNetworkAccessManager::instance(), &QgsNetworkAccessManager::authBrowserAborted, &loop, &QEventLoop::quit );
 
     // add single shot timer to quit linking after an allotted timeout
     // this should keep the local event loop from blocking forever

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -468,6 +468,7 @@ void QgsNetworkAccessManager::requestAuthOpenBrowser( const QUrl &url ) const
   if ( this != sMainNAM )
   {
     sMainNAM->requestAuthOpenBrowser( url );
+    connect( sMainNAM, &QgsNetworkAccessManager::authBrowserAborted, this, &QgsNetworkAccessManager::abortAuthBrowser );
     return;
   }
   mAuthHandler->handleAuthRequestOpenBrowser( url );
@@ -478,9 +479,19 @@ void QgsNetworkAccessManager::requestAuthCloseBrowser() const
   if ( this != sMainNAM )
   {
     sMainNAM->requestAuthCloseBrowser();
+    disconnect( sMainNAM, &QgsNetworkAccessManager::authBrowserAborted, this, &QgsNetworkAccessManager::abortAuthBrowser );
     return;
   }
   mAuthHandler->handleAuthRequestCloseBrowser();
+}
+
+void QgsNetworkAccessManager::abortAuthBrowser()
+{
+  if ( this != sMainNAM )
+  {
+    disconnect( sMainNAM, &QgsNetworkAccessManager::authBrowserAborted, this, &QgsNetworkAccessManager::abortAuthBrowser );
+  }
+  emit authBrowserAborted();
 }
 
 void QgsNetworkAccessManager::handleAuthRequest( QNetworkReply *reply, QAuthenticator *auth )

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -688,7 +688,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 #endif
 
     /**
-     * Emitted when external browser login are to be aborted.
+     * Emitted when external browser logins are to be aborted.
      *
      * \since QGIS 3.20
      */

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -530,6 +530,15 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      */
     void requestAuthCloseBrowser() const;
 
+    /**
+     * Abort any outstanding external browser login request.
+     *
+     * \note Background threads will listen to aborted browser request signals from the network manager on the main thread.
+     * \since QGIS 3.20
+     */
+    void abortAuthBrowser();
+
+
 #ifndef SIP_RUN
     //! Settings entry network timeout
     static const inline QgsSettingsEntryInteger settingsNetworkTimeout = QgsSettingsEntryInteger( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QgsSettings::NoSection, 60000, QObject::tr( "Network timeout" ) );
@@ -678,6 +687,12 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 ///@endcond
 #endif
 
+    /**
+     * Emitted when external browser login are to be aborted.
+     *
+     * \since QGIS 3.20
+     */
+    void authBrowserAborted();
 
   private slots:
     void abortRequest();


### PR DESCRIPTION
## Description

This is needed to get a proper external browser authentication handling. Without this, requests can idle for minutes after a user decided to cancel the login request. 

Follow up to this commig: https://github.com/qgis/QGIS/commit/584283ddaa7cf8d180ce17599c89b3954cb9e2ee