### PR TITLE
[authentication manager] Allow configurations to be overwritten when importing

### DIFF
--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -262,11 +262,12 @@ Returns the regular expression for authcfg=.{7} key/value token for authenticati
 Gets list of authentication ids from database
 %End
 
-    bool storeAuthenticationConfig( QgsAuthMethodConfig &mconfig /In,Out/ );
+    bool storeAuthenticationConfig( QgsAuthMethodConfig &mconfig /In,Out/, bool overwrite = false );
 %Docstring
 Store an authentication config in the database
 
 :param mconfig: Associated authentication config id
+:param overwrite: If set to ``True``, pre-existing authentication configurations will be overwritten
 
 :return: Whether operation succeeded
 %End
@@ -311,12 +312,13 @@ Export authentication configurations to an XML file
 .. versionadded:: 3.20
 %End
 
-    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
+    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString(), bool overwrite = false );
 %Docstring
 Import authentication configurations from an XML file
 
 :param filename: The file path from which the XML content will be read
 :param password: A password string to decrypt the XML content
+:param overwrite: If set to ``True``, pre-existing authentication configurations will be overwritten
 
 .. versionadded:: 3.20
 %End

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -273,9 +273,10 @@ class CORE_EXPORT QgsAuthManager : public QObject
     /**
      * Store an authentication config in the database
      * \param mconfig Associated authentication config id
+     * \param overwrite If set to TRUE, pre-existing authentication configurations will be overwritten
      * \returns Whether operation succeeded
      */
-    bool storeAuthenticationConfig( QgsAuthMethodConfig &mconfig SIP_INOUT );
+    bool storeAuthenticationConfig( QgsAuthMethodConfig &mconfig SIP_INOUT, bool overwrite = false );
 
     /**
      * Update an authentication config in the database
@@ -313,9 +314,10 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Import authentication configurations from an XML file
      * \param filename The file path from which the XML content will be read
      * \param password A password string to decrypt the XML content
+     * \param overwrite If set to TRUE, pre-existing authentication configurations will be overwritten
      * \since QGIS 3.20
      */
-    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString() );
+    bool importAuthenticationConfigsFromXml( const QString &filename, const QString &password = QString(), bool overwrite = false );
 
     /**
      * Clear all authentication configs from table in database and from provider caches


### PR DESCRIPTION
## Description

Small API follow up (an overwrite configurations flag) to the recent addition of configuration import / export in the authentication manager. 