### PR TITLE
Move misplaced icon in the advanced digitizing toolbar

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3643,8 +3643,7 @@ void QgisApp::createToolBars()
   connect( tbAddRegularPolygon, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
 
   // Cad toolbar
-  mAdvancedDigitizeToolBar->insertAction( mActionRotateFeature, mAdvancedDigitizingDockWidget->enableAction() );
-  mAdvancedDigitizeToolBar->insertAction( mActionScaleFeature, mAdvancedDigitizingDockWidget->enableAction() );
+  mAdvancedDigitizeToolBar->insertAction( mAdvancedDigitizeToolBar->actions().at( 0 ), mAdvancedDigitizingDockWidget->enableAction() );
 
   // move feature tool button
   QToolButton *moveFeatureButton = new QToolButton( mAdvancedDigitizeToolBar );


### PR DESCRIPTION
Places the "Enable Advanced Digitizing Tools" icon at the top of the Advanced Digitizing toolbar as in previous releases (e.g. 3.12)

Before:
![grafik](https://user-images.githubusercontent.com/18557959/118370723-53811100-b5a9-11eb-8c7b-f8f4ca28feae.png)

After:
![Bildschirmfoto vom 2021-05-15 18-25-19](https://user-images.githubusercontent.com/18557959/118371048-fe45ff00-b5aa-11eb-8446-3c62e55217be.png)

fix #43225