### PR TITLE
Regroup modeler specific alg in the modeler group

### DIFF
--- a/src/analysis/processing/qgsalgorithmcreatedirectory.cpp
+++ b/src/analysis/processing/qgsalgorithmcreatedirectory.cpp
@@ -40,12 +40,12 @@ QStringList QgsCreateDirectoryAlgorithm::tags() const
 
 QString QgsCreateDirectoryAlgorithm::group() const
 {
-  return QObject::tr( "File tools" );
+  return QObject::tr( "Modeler tools" );
 }
 
 QString QgsCreateDirectoryAlgorithm::groupId() const
 {
-  return QStringLiteral( "filetools" );
+  return QStringLiteral( "modelertools" );
 }
 
 QString QgsCreateDirectoryAlgorithm::shortHelpString() const

--- a/src/analysis/processing/qgsalgorithmfilter.cpp
+++ b/src/analysis/processing/qgsalgorithmfilter.cpp
@@ -37,12 +37,12 @@ QStringList QgsFilterAlgorithm::tags() const
 
 QString QgsFilterAlgorithm::group() const
 {
-  return QObject::tr( "Vector table" );
+  return QObject::tr( "Modeler tools" );
 }
 
 QString QgsFilterAlgorithm::groupId() const
 {
-  return QStringLiteral( "vectortable" );
+  return QStringLiteral( "modelertools" );
 }
 
 QgsProcessingAlgorithm::Flags QgsFilterAlgorithm::flags() const

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
@@ -36,12 +36,12 @@ QStringList QgsFilterByGeometryAlgorithm::tags() const
 
 QString QgsFilterByGeometryAlgorithm::group() const
 {
-  return QObject::tr( "Vector selection" );
+  return QObject::tr( "Modeler tools" );
 }
 
 QString QgsFilterByGeometryAlgorithm::groupId() const
 {
-  return QStringLiteral( "vectorselection" );
+  return QStringLiteral( "modelertools" );
 }
 
 QgsProcessingAlgorithm::Flags QgsFilterByGeometryAlgorithm::flags() const
@@ -242,12 +242,12 @@ QStringList QgsFilterByLayerTypeAlgorithm::tags() const
 
 QString QgsFilterByLayerTypeAlgorithm::group() const
 {
-  return QObject::tr( "Layer tools" );
+  return QObject::tr( "Modeler tools" );
 }
 
 QString QgsFilterByLayerTypeAlgorithm::groupId() const
 {
-  return QStringLiteral( "layertools" );
+  return QStringLiteral( "modelertools" );
 }
 
 QgsProcessingAlgorithm::Flags QgsFilterByLayerTypeAlgorithm::flags() const


### PR DESCRIPTION
Regroup modeler specific tools in the same group.

## Description

Theee goal is to have all modeler specific tool in the dedicated to prevent some confusion with possible inconsistencies of the content of the other groups.

Also help users find and discover tools that are unique to the modeler instead of having to compare between group or discovering a tool that seem to be absent in the standard algs.