### PR TITLE
add a new Chinese simplified translator

### DIFF
--- a/scripts/tsstat.pl
+++ b/scripts/tsstat.pl
@@ -94,7 +94,7 @@ my $translators= {
 	'uk' => 'Alexander Bruy, Daria Svidzinska, Svitlana Shulik, Alesya Shushova',
 	'vi' => 'Phùng Văn Doanh, Bùi Hữu Mạnh, Nguyễn Văn Thanh, Nguyễn Hữu Phúc, Cao Minh Tu',
 	'zh-Hant' => 'Calvin Ngei, Zhang Jun, Richard Xie, Dennis Raylin Chen',
-	'zh-Hans' => 'Calvin Ngei, Lisashen, Wang Shuai, Xubaocai',
+	'zh-Hans' => 'Calvin Ngei, Lisashen, Wang Shuai, Xu Baocai',
 };
 
 my $maxn;

--- a/scripts/tsstat.pl
+++ b/scripts/tsstat.pl
@@ -94,7 +94,7 @@ my $translators= {
 	'uk' => 'Alexander Bruy, Daria Svidzinska, Svitlana Shulik, Alesya Shushova',
 	'vi' => 'Phùng Văn Doanh, Bùi Hữu Mạnh, Nguyễn Văn Thanh, Nguyễn Hữu Phúc, Cao Minh Tu',
 	'zh-Hant' => 'Calvin Ngei, Zhang Jun, Richard Xie, Dennis Raylin Chen',
-	'zh-Hans' => 'Calvin Ngei, Lisashen, Wang Shuai',
+	'zh-Hans' => 'Calvin Ngei, Lisashen, Wang Shuai, Xubaocai',
 };
 
 my $maxn;


### PR DESCRIPTION
## Description
Add a new Chinese simplified translator `Xu Baocai`.

`Xu Baocai` has translated a lot of strings recently. 

You can check it out at transifex QGIS Desktop translate page:
https://www.transifex.com/qgis/QGIS/translate/#zh-Hans/qgis-application/114102303?q=translator%3Axubaocai

![image](https://user-images.githubusercontent.com/5787131/118392257-40cf1080-b66b-11eb-8680-7606830d8fa5.png)



