### PR TITLE
Move QgsMapLayerType to separate generic header for core enums

### DIFF
--- a/python/core/auto_additions/qgscoreenums.py
+++ b/python/core/auto_additions/qgscoreenums.py
@@ -1,0 +1,19 @@
+# The following has been generated automatically from src/core/qgscoreenums.h
+QgsMapLayer.LayerType = QgsMapLayerType
+# monkey patching scoped based enum
+QgsMapLayer.VectorLayer = QgsMapLayerType.VectorLayer
+QgsMapLayer.VectorLayer.__doc__ = ""
+QgsMapLayer.RasterLayer = QgsMapLayerType.RasterLayer
+QgsMapLayer.RasterLayer.__doc__ = ""
+QgsMapLayer.PluginLayer = QgsMapLayerType.PluginLayer
+QgsMapLayer.PluginLayer.__doc__ = ""
+QgsMapLayer.MeshLayer = QgsMapLayerType.MeshLayer
+QgsMapLayer.MeshLayer.__doc__ = "Added in 3.2"
+QgsMapLayer.VectorTileLayer = QgsMapLayerType.VectorTileLayer
+QgsMapLayer.VectorTileLayer.__doc__ = "Added in 3.14"
+QgsMapLayer.AnnotationLayer = QgsMapLayerType.AnnotationLayer
+QgsMapLayer.AnnotationLayer.__doc__ = "Contains freeform, georeferenced annotations. Added in QGIS 3.16"
+QgsMapLayer.PointCloudLayer = QgsMapLayerType.PointCloudLayer
+QgsMapLayer.PointCloudLayer.__doc__ = "Added in 3.18"
+QgsMapLayerType.__doc__ = 'Types of layers that can be added to a map\n\n.. versionadded:: 3.8\n\n' + '* ``VectorLayer``: ' + QgsMapLayerType.VectorLayer.__doc__ + '\n' + '* ``RasterLayer``: ' + QgsMapLayerType.RasterLayer.__doc__ + '\n' + '* ``PluginLayer``: ' + QgsMapLayerType.PluginLayer.__doc__ + '\n' + '* ``MeshLayer``: ' + QgsMapLayerType.MeshLayer.__doc__ + '\n' + '* ``VectorTileLayer``: ' + QgsMapLayerType.VectorTileLayer.__doc__ + '\n' + '* ``AnnotationLayer``: ' + QgsMapLayerType.AnnotationLayer.__doc__ + '\n' + '* ``PointCloudLayer``: ' + QgsMapLayerType.PointCloudLayer.__doc__
+# --

--- a/python/core/auto_additions/qgsmaplayer.py
+++ b/python/core/auto_additions/qgsmaplayer.py
@@ -1,22 +1,4 @@
 # The following has been generated automatically from src/core/qgsmaplayer.h
-QgsMapLayer.LayerType = QgsMapLayerType
-# monkey patching scoped based enum
-QgsMapLayer.VectorLayer = QgsMapLayerType.VectorLayer
-QgsMapLayer.VectorLayer.__doc__ = ""
-QgsMapLayer.RasterLayer = QgsMapLayerType.RasterLayer
-QgsMapLayer.RasterLayer.__doc__ = ""
-QgsMapLayer.PluginLayer = QgsMapLayerType.PluginLayer
-QgsMapLayer.PluginLayer.__doc__ = ""
-QgsMapLayer.MeshLayer = QgsMapLayerType.MeshLayer
-QgsMapLayer.MeshLayer.__doc__ = "Added in 3.2"
-QgsMapLayer.VectorTileLayer = QgsMapLayerType.VectorTileLayer
-QgsMapLayer.VectorTileLayer.__doc__ = "Added in 3.14"
-QgsMapLayer.AnnotationLayer = QgsMapLayerType.AnnotationLayer
-QgsMapLayer.AnnotationLayer.__doc__ = "Contains freeform, georeferenced annotations. Added in QGIS 3.16"
-QgsMapLayer.PointCloudLayer = QgsMapLayerType.PointCloudLayer
-QgsMapLayer.PointCloudLayer.__doc__ = "Added in 3.18"
-QgsMapLayerType.__doc__ = 'Types of layers that can be added to a map\n\n.. versionadded:: 3.8\n\n' + '* ``VectorLayer``: ' + QgsMapLayerType.VectorLayer.__doc__ + '\n' + '* ``RasterLayer``: ' + QgsMapLayerType.RasterLayer.__doc__ + '\n' + '* ``PluginLayer``: ' + QgsMapLayerType.PluginLayer.__doc__ + '\n' + '* ``MeshLayer``: ' + QgsMapLayerType.MeshLayer.__doc__ + '\n' + '* ``VectorTileLayer``: ' + QgsMapLayerType.VectorTileLayer.__doc__ + '\n' + '* ``AnnotationLayer``: ' + QgsMapLayerType.AnnotationLayer.__doc__ + '\n' + '* ``PointCloudLayer``: ' + QgsMapLayerType.PointCloudLayer.__doc__
-# --
 QgsMapLayer.LayerFlag.baseClass = QgsMapLayer
 QgsMapLayer.LayerFlags.baseClass = QgsMapLayer
 LayerFlags = QgsMapLayer  # dirty hack since SIP seems to introduce the flags in module

--- a/python/core/auto_generated/qgscoreenums.sip.in
+++ b/python/core/auto_generated/qgscoreenums.sip.in
@@ -1,0 +1,29 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgscoreenums.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+enum class QgsMapLayerType
+  {
+  VectorLayer,
+  RasterLayer,
+  PluginLayer,
+  MeshLayer,
+  VectorTileLayer,
+  AnnotationLayer,
+  PointCloudLayer,
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgscoreenums.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -14,17 +14,6 @@
 
 
 
-enum class QgsMapLayerType
-  {
-  VectorLayer,
-  RasterLayer,
-  PluginLayer,
-  MeshLayer,
-  VectorTileLayer,
-  AnnotationLayer,
-  PointCloudLayer,
-};
-
 class QgsMapLayer : QObject
 {
 %Docstring(signature="appended")
@@ -36,7 +25,7 @@ This is the base class for all map layer types (vector, raster).
 #include "qgsmaplayer.h"
 %End
 %ConvertToSubClassCode
-    QgsMapLayer * layer = qobject_cast<QgsMapLayer *>( sipCpp );
+    QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sipCpp );
 
     sipType = 0;
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -30,6 +30,7 @@
 %Include auto_generated/qgsconditionalstyle.sip
 %Include auto_generated/qgsconnectionregistry.sip
 %Include auto_generated/qgscoordinateformatter.sip
+%Include auto_generated/qgscoreenums.sip
 %Include auto_generated/qgscredentials.sip
 %Include auto_generated/qgsdartmeasurement.sip
 %Include auto_generated/qgsdatabaseschemamodel.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -882,6 +882,7 @@ set(QGIS_CORE_HDRS
   qgsconnectionregistry.h
   qgscoordinateformatter.h
   qgscoordinateutils.h
+  qgscoreenums.h
   qgscredentials.h
   qgsdartmeasurement.h
   qgsdatabaseschemamodel.h

--- a/src/core/qgscoreenums.h
+++ b/src/core/qgscoreenums.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+                             qgscoreenums.h
+                             ----------
+    begin                : May 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCOREENUMS_H
+#define QGSCOREENUMS_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+
+/**
+ * \ingroup core
+ * \brief Types of layers that can be added to a map
+ * \since QGIS 3.8
+ */
+enum class QgsMapLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayer, LayerType ) : int
+  {
+  VectorLayer,
+  RasterLayer,
+  PluginLayer,
+  MeshLayer,      //!< Added in 3.2
+  VectorTileLayer, //!< Added in 3.14
+  AnnotationLayer, //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
+  PointCloudLayer, //!< Added in 3.18
+};
+
+#endif // QGSCOREENUMS_H

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -39,6 +39,7 @@
 #include "qgsmaplayerstyle.h"
 #include "qgsreadwritecontext.h"
 #include "qgsdataprovider.h"
+#include "qgscoreenums.h"
 
 class QgsAbstract3DRenderer;
 class QgsDataProvider;
@@ -62,22 +63,6 @@ class QPainter;
 
 /**
  * \ingroup core
- * \brief Types of layers that can be added to a map
- * \since QGIS 3.8
- */
-enum class QgsMapLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayer, LayerType ) : int
-  {
-  VectorLayer,
-  RasterLayer,
-  PluginLayer,
-  MeshLayer,      //!< Added in 3.2
-  VectorTileLayer, //!< Added in 3.14
-  AnnotationLayer, //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
-  PointCloudLayer, //!< Added in 3.18
-};
-
-/**
- * \ingroup core
  * \brief Base class for all map layer types.
  * This is the base class for all map layer types (vector, raster).
  */
@@ -95,7 +80,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    QgsMapLayer * layer = qobject_cast<QgsMapLayer *>( sipCpp );
+    QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sipCpp );
 
     sipType = 0;
 


### PR DESCRIPTION
Avoids the need to include the whole qgsmaplayer.h header and
all its dependancies when only the QgsMapLayerType enum is required.
