### PR TITLE
[windows] Fix form macro encoding from file on windows

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1904,6 +1904,7 @@ void QgsAttributeForm::initPython()
           {
             // Read it into a string
             QTextStream inf( inputFile );
+            inf.setCodec( "UTF-8" );
             initCode = inf.readAll();
             inputFile->close();
           }


### PR DESCRIPTION
When loading a python file in a form on windows, the file is opened using the default system encoding (which may be different than UTF8, at least it wasn't on my tests and on my customer machines).

This patch makes UTF8 the codec used when loading python files from the filesystem before using them for a form.
