### PR TITLE
[authentication] Change filter so it registers methods with android ABI suffix in library name

### DIFF
--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -60,7 +60,7 @@ QgsAuthMethodRegistry::QgsAuthMethodRegistry( const QString &pluginPath )
 #if defined(Q_OS_WIN) || defined(__CYGWIN__)
   mLibraryDirectory.setNameFilters( QStringList( "*authmethod.dll" ) );
 #else
-  mLibraryDirectory.setNameFilters( QStringList( QStringLiteral( "*authmethod.so" ) ) );
+  mLibraryDirectory.setNameFilters( QStringList( QStringLiteral( "*authmethod*.so" ) ) );
 #endif
 
   QgsDebugMsgLevel( QStringLiteral( "Checking for auth method plugins in: %1" ).arg( mLibraryDirectory.path() ), 2 );


### PR DESCRIPTION
## Description

On Android platform, the shared library name can look like this: libpkipathsauthmethod_arm64-v8a.so , we need to adjust the filter to take that into account.