### PR TITLE
pyogctest and six module

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sudo apt-get install python3-virtualenv virtualenv git
           git clone https://github.com/pblottiere/pyogctest
-          cd pyogctest && git checkout 1.0.3 && cd -
+          cd pyogctest && git checkout 1.0.4 && cd -
           virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install -e pyogctest/
 
       - name: Extract WMS 1.3.0 dataset


### PR DESCRIPTION
## Description

Recently, the OGC workflow is failing due to the next issue:

``` bash
Run source venv/bin/activate && ./pyogctest/pyogctest.py -s wms130 -e
Traceback (most recent call last):
  File "./pyogctest/pyogctest.py", line 14, in <module>
    from pyogctest.data.data import Data
  File "/home/runner/work/QGIS/QGIS/pyogctest/pyogctest/data/data.py", line 14, in <module
    from pyogctest.teamengine import Teamengin
  File "/home/runner/work/QGIS/QGIS/pyogctest/pyogctest/teamengine.py", line 8, in <module>
    import docker
  File "/home/runner/work/QGIS/QGIS/venv/lib/python3.8/site-packages/docker/__init__.py", line 2, in <module>
    from .api import APIClient
  File "/home/runner/work/QGIS/QGIS/venv/lib/python3.8/site-packages/docker/api/__init__.py", line 2, in <module>
    from .client import APIClient
  File "/home/runner/work/QGIS/QGIS/venv/lib/python3.8/site-packages/docker/api/client.py", line 10, in <module>
    from .. import auth
  File "/home/runner/work/QGIS/QGIS/venv/lib/python3.8/site-packages/docker/auth.py", line 5, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```

I'll do a new release of `pyogctest` once the bugfix is validated.