### PR TITLE
Update r.clump.txt

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.clump.txt
+++ b/python/plugins/processing/algs/grass7/description/r.clump.txt
@@ -5,3 +5,4 @@ QgsProcessingParameterRasterLayer|input|Input layer|None|False
 QgsProcessingParameterString|title|Title for output raster map|None|True
 *QgsProcessingParameterBoolean|-d|Clump also diagonal cells|False
 QgsProcessingParameterRasterDestination|output|Clumps
+QgsProcessingParameterNumber|threshold|Threshold to identify similar cells|QgsProcessingParameterNumber.Double|None|False|0|1

--- a/python/plugins/processing/algs/grass7/description/r.clump.txt
+++ b/python/plugins/processing/algs/grass7/description/r.clump.txt
@@ -5,4 +5,4 @@ QgsProcessingParameterRasterLayer|input|Input layer|None|False
 QgsProcessingParameterString|title|Title for output raster map|None|True
 *QgsProcessingParameterBoolean|-d|Clump also diagonal cells|False
 QgsProcessingParameterRasterDestination|output|Clumps
-QgsProcessingParameterNumber|threshold|Threshold to identify similar cells|QgsProcessingParameterNumber.Double|None|False|0|1
+QgsProcessingParameterNumber|threshold|Threshold to identify similar cells|QgsProcessingParameterNumber.Double|0|False|0|1


### PR DESCRIPTION
## Description
The GRASS GIS r.clump function has a parameter 'threshold'. This allows to set a threshold to identify similar cells. Input is a floating number, with valid range  0 = identical to < 1 = maximal difference and default value  0. The proposed change adds this parameter. 
