### PR TITLE
Add QgsFileUtils::pathIsSlowDevice 

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -88,3 +88,14 @@ QgsVectorLayerExporter.ErrUserCanceled.__doc__ = "User canceled the export"
 Qgis.VectorExportResult.__doc__ = 'Vector layer export result codes.\n\n.. versionadded:: 3.20\n\n' + '* ``NoError``: ' + Qgis.VectorExportResult.Success.__doc__ + '\n' + '* ``ErrCreateDataSource``: ' + Qgis.VectorExportResult.ErrorCreatingDataSource.__doc__ + '\n' + '* ``ErrCreateLayer``: ' + Qgis.VectorExportResult.ErrorCreatingLayer.__doc__ + '\n' + '* ``ErrAttributeTypeUnsupported``: ' + Qgis.VectorExportResult.ErrorAttributeTypeUnsupported.__doc__ + '\n' + '* ``ErrAttributeCreationFailed``: ' + Qgis.VectorExportResult.ErrorAttributeCreationFailed.__doc__ + '\n' + '* ``ErrProjection``: ' + Qgis.VectorExportResult.ErrorProjectingFeatures.__doc__ + '\n' + '* ``ErrFeatureWriteFailed``: ' + Qgis.VectorExportResult.ErrorFeatureWriteFailed.__doc__ + '\n' + '* ``ErrInvalidLayer``: ' + Qgis.VectorExportResult.ErrorInvalidLayer.__doc__ + '\n' + '* ``ErrInvalidProvider``: ' + Qgis.VectorExportResult.ErrorInvalidProvider.__doc__ + '\n' + '* ``ErrProviderUnsupportedFeature``: ' + Qgis.VectorExportResult.ErrorProviderUnsupportedFeature.__doc__ + '\n' + '* ``ErrConnectionFailed``: ' + Qgis.VectorExportResult.ErrorConnectionFailed.__doc__ + '\n' + '* ``ErrUserCanceled``: ' + Qgis.VectorExportResult.UserCanceled.__doc__
 # --
 Qgis.VectorExportResult.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.DriveType.Unknown.__doc__ = "Unknown type"
+Qgis.DriveType.Invalid.__doc__ = "Invalid path"
+Qgis.DriveType.Removable.__doc__ = "Removable drive"
+Qgis.DriveType.Fixed.__doc__ = "Fixed drive"
+Qgis.DriveType.Remote.__doc__ = "Remote drive"
+Qgis.DriveType.CdRom.__doc__ = "CD-ROM"
+Qgis.DriveType.RamDisk.__doc__ = "RAM disk"
+Qgis.DriveType.__doc__ = 'Drive types\n\n.. versionadded:: 3.20\n\n' + '* ``Unknown``: ' + Qgis.DriveType.Unknown.__doc__ + '\n' + '* ``Invalid``: ' + Qgis.DriveType.Invalid.__doc__ + '\n' + '* ``Removable``: ' + Qgis.DriveType.Removable.__doc__ + '\n' + '* ``Fixed``: ' + Qgis.DriveType.Fixed.__doc__ + '\n' + '* ``Remote``: ' + Qgis.DriveType.Remote.__doc__ + '\n' + '* ``CdRom``: ' + Qgis.DriveType.CdRom.__doc__ + '\n' + '* ``RamDisk``: ' + Qgis.DriveType.RamDisk.__doc__
+# --
+Qgis.DriveType.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -161,6 +161,17 @@ The development version
       UserCanceled,
     };
 
+    enum class DriveType
+    {
+      Unknown,
+      Invalid,
+      Removable,
+      Fixed,
+      Remote,
+      CdRom,
+      RamDisk,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -138,6 +138,14 @@ Returns the drive type for the given ``path``.
 .. versionadded:: 3.20
 %End
 
+    static bool pathIsSlowDevice( const QString &path );
+%Docstring
+Returns ``True`` if the specified ``path`` is known to reside on a slow device, e.g. a remote
+network drive or other non-fixed device.
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -118,6 +118,26 @@ Will check ``basepath`` in an outward spiral up to ``maxClimbs`` levels to check
 .. versionadded:: 3.12
 %End
 
+    enum DriveType
+    {
+      Unknown,
+      Invalid,
+      Removable,
+      Fixed,
+      Remote,
+      CdRom,
+      RamDisk,
+    };
+
+    static DriveType driveType( const QString &path ) throw( QgsNotSupportedException );
+%Docstring
+Returns the drive type for the given ``path``.
+
+:raises :: py:class:`QgsNotSupportedException` if determining the drive type is not supported on the current platform.
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -118,18 +118,7 @@ Will check ``basepath`` in an outward spiral up to ``maxClimbs`` levels to check
 .. versionadded:: 3.12
 %End
 
-    enum DriveType
-    {
-      Unknown,
-      Invalid,
-      Removable,
-      Fixed,
-      Remote,
-      CdRom,
-      RamDisk,
-    };
-
-    static DriveType driveType( const QString &path ) throw( QgsNotSupportedException );
+    static Qgis::DriveType driveType( const QString &path ) throw( QgsNotSupportedException );
 %Docstring
 Returns the drive type for the given ``path``.
 
@@ -140,7 +129,7 @@ Returns the drive type for the given ``path``.
 
     static bool pathIsSlowDevice( const QString &path );
 %Docstring
-Returns ``True`` if the specified ``path`` is known to reside on a slow device, e.g. a remote
+Returns ``True`` if the specified ``path`` is assumed to reside on a slow device, e.g. a remote
 network drive or other non-fixed device.
 
 .. versionadded:: 3.20

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -226,6 +226,22 @@ class CORE_EXPORT Qgis
     Q_ENUM( VectorExportResult )
 
     /**
+     * Drive types
+     * \since QGIS 3.20
+     */
+    enum class DriveType : int
+    {
+      Unknown, //!< Unknown type
+      Invalid, //!< Invalid path
+      Removable, //!< Removable drive
+      Fixed, //!< Fixed drive
+      Remote, //!< Remote drive
+      CdRom, //!< CD-ROM
+      RamDisk, //!< RAM disk
+    };
+    Q_ENUM( DriveType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -281,7 +281,7 @@ std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 }
 #endif
 
-QgsFileUtils::DriveType QgsFileUtils::driveType( const QString &path )
+Qgis::DriveType QgsFileUtils::driveType( const QString &path )
 {
 #ifdef MSVC
   auto pathType = [ = ]( const QString & path ) -> DriveType
@@ -291,25 +291,25 @@ QgsFileUtils::DriveType QgsFileUtils::driveType( const QString &path )
     switch ( type )
     {
       case DRIVE_UNKNOWN:
-        return Unknown;
+        return Qgis::DriveType::Unknown;
 
       case DRIVE_NO_ROOT_DIR:
-        return Invalid;
+        return Qgis::DriveType::Invalid;
 
       case DRIVE_REMOVABLE:
-        return Removable;
+        return Qgis::DriveType::Removable;
 
       case DRIVE_FIXED:
-        return Fixed;
+        return Qgis::DriveType::Fixed;
 
       case DRIVE_REMOTE:
-        return Remote;
+        return Qgis::DriveType::Remote;
 
       case DRIVE_CDROM:
-        return CdRom;
+        return Qgis::DriveType::CdRom;
 
       case DRIVE_RAMDISK:
-        return RamDisk;
+        return Qgis::DriveType::RamDisk;
     }
 
     return Unknown;
@@ -339,18 +339,18 @@ bool QgsFileUtils::pathIsSlowDevice( const QString &path )
 {
   try
   {
-    const DriveType type = driveType( path );
+    const Qgis::DriveType type = driveType( path );
     switch ( type )
     {
-      case QgsFileUtils::Unknown:
-      case QgsFileUtils::Invalid:
-      case QgsFileUtils::Fixed:
-      case QgsFileUtils::RamDisk:
+      case Qgis::DriveType::Unknown:
+      case Qgis::DriveType::Invalid:
+      case Qgis::DriveType::Fixed:
+      case Qgis::DriveType::RamDisk:
         return false;
 
-      case QgsFileUtils::Removable:
-      case QgsFileUtils::Remote:
-      case QgsFileUtils::CdRom:
+      case Qgis::DriveType::Removable:
+      case Qgis::DriveType::Remote:
+      case Qgis::DriveType::CdRom:
         return true;
     }
   }

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -22,7 +22,7 @@
 #include <QSet>
 #include <QDirIterator>
 
-#ifdef Q_OS_WIN
+#ifdef MSVC
 #include <Windows.h>
 #include <ShlObj.h>
 #pragma comment(lib,"Shell32.lib")
@@ -269,7 +269,7 @@ QStringList QgsFileUtils::findFile( const QString &file, const QString &basePath
   return foundFiles;
 }
 
-#ifdef Q_OS_WIN
+#ifdef MSVC
 std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 {
   const QString nativePath = QDir::toNativeSeparators( path );
@@ -283,7 +283,7 @@ std::unique_ptr< wchar_t[] > pathToWChar( const QString &path )
 
 QgsFileUtils::DriveType QgsFileUtils::driveType( const QString &path )
 {
-#ifdef Q_OS_WIN
+#ifdef MSVC
   auto pathType = [ = ]( const QString & path ) -> DriveType
   {
     std::unique_ptr< wchar_t[] > pathArray = pathToWChar( path );

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -335,3 +335,28 @@ QgsFileUtils::DriveType QgsFileUtils::driveType( const QString &path )
 #endif
 }
 
+bool QgsFileUtils::pathIsSlowDevice( const QString &path )
+{
+  try
+  {
+    const DriveType type = driveType( path );
+    switch ( type )
+    {
+      case QgsFileUtils::Unknown:
+      case QgsFileUtils::Invalid:
+      case QgsFileUtils::Fixed:
+      case QgsFileUtils::RamDisk:
+        return false;
+
+      case QgsFileUtils::Removable:
+      case QgsFileUtils::Remote:
+      case QgsFileUtils::CdRom:
+        return true;
+    }
+  }
+  catch ( QgsNotSupportedException & )
+  {
+
+  }
+  return false;
+}

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -143,6 +143,14 @@ class CORE_EXPORT QgsFileUtils
      */
     static DriveType driveType( const QString &path ) SIP_THROW( QgsNotSupportedException );
 
+    /**
+     * Returns TRUE if the specified \a path is known to reside on a slow device, e.g. a remote
+     * network drive or other non-fixed device.
+     *
+     * \since QGIS 3.20
+     */
+    static bool pathIsSlowDevice( const QString &path );
+
 };
 
 #endif // QGSFILEUTILS_H

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgis.h"
 #include <QString>
 
 /**
@@ -120,31 +121,16 @@ class CORE_EXPORT QgsFileUtils
     static QStringList findFile( const QString &file, const QString &basepath = QString(), int maxClimbs = 4, int searchCeiling = 4, const QString &currentDir = QString() );
 
     /**
-     * Drive types
-     * \since QGIS 3.20
-     */
-    enum DriveType
-    {
-      Unknown, //!< Unknown type
-      Invalid, //!< Invalid path
-      Removable, //!< Removable drive
-      Fixed, //!< Fixed drive
-      Remote, //!< Remote drive
-      CdRom, //!< CD-ROM
-      RamDisk, //!< RAM disk
-    };
-
-    /**
      * Returns the drive type for the given \a path.
      *
      * \throws QgsNotSupportedException if determining the drive type is not supported on the current platform.
      *
      * \since QGIS 3.20
      */
-    static DriveType driveType( const QString &path ) SIP_THROW( QgsNotSupportedException );
+    static Qgis::DriveType driveType( const QString &path ) SIP_THROW( QgsNotSupportedException );
 
     /**
-     * Returns TRUE if the specified \a path is known to reside on a slow device, e.g. a remote
+     * Returns TRUE if the specified \a path is assumed to reside on a slow device, e.g. a remote
      * network drive or other non-fixed device.
      *
      * \since QGIS 3.20

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -19,6 +19,7 @@
 #define QGSFILEUTILS_H
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 #include <QString>
 
 /**
@@ -117,6 +118,30 @@ class CORE_EXPORT QgsFileUtils
      * \since QGIS 3.12
      */
     static QStringList findFile( const QString &file, const QString &basepath = QString(), int maxClimbs = 4, int searchCeiling = 4, const QString &currentDir = QString() );
+
+    /**
+     * Drive types
+     * \since QGIS 3.20
+     */
+    enum DriveType
+    {
+      Unknown, //!< Unknown type
+      Invalid, //!< Invalid path
+      Removable, //!< Removable drive
+      Fixed, //!< Fixed drive
+      Remote, //!< Remote drive
+      CdRom, //!< CD-ROM
+      RamDisk, //!< RAM disk
+    };
+
+    /**
+     * Returns the drive type for the given \a path.
+     *
+     * \throws QgsNotSupportedException if determining the drive type is not supported on the current platform.
+     *
+     * \since QGIS 3.20
+     */
+    static DriveType driveType( const QString &path ) SIP_THROW( QgsNotSupportedException );
 
 };
 


### PR DESCRIPTION
Tries to determine whether a file path likely resides on a slow device (eg. a remote network location). This will be used in a follow up PR to disable the automatic browser file system scanning/watching on these devices, which is known to cause general slow-downs in QGIS.