### PR TITLE
force time to be UTC for mesh layer

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1922,15 +1922,9 @@ void QgsLayoutItemMap::refreshDataDefinedProperty( const QgsLayoutObject::DataDe
     QDateTime end = temporalRange().end();
 
     if ( property == QgsLayoutObject::StartDateTime || property == QgsLayoutObject::AllProperties )
-    {
       begin = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::StartDateTime, context, temporalRange().begin() );
-      begin.setTimeSpec( Qt::UTC );
-    }
     if ( property == QgsLayoutObject::EndDateTime || property == QgsLayoutObject::AllProperties )
-    {
       end = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::EndDateTime, context, temporalRange().end() );
-      end.setTimeSpec( Qt::UTC );
-    }
 
     setTemporalRange( QgsDateTimeRange( begin, end, true, begin == end ) );
   }

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1922,9 +1922,15 @@ void QgsLayoutItemMap::refreshDataDefinedProperty( const QgsLayoutObject::DataDe
     QDateTime end = temporalRange().end();
 
     if ( property == QgsLayoutObject::StartDateTime || property == QgsLayoutObject::AllProperties )
+    {
       begin = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::StartDateTime, context, temporalRange().begin() );
+      begin.setTimeSpec( Qt::UTC );
+    }
     if ( property == QgsLayoutObject::EndDateTime || property == QgsLayoutObject::AllProperties )
+    {
       end = mDataDefinedProperties.valueAsDateTime( QgsLayoutObject::EndDateTime, context, temporalRange().end() );
+      end.setTimeSpec( Qt::UTC );
+    }
 
     setTemporalRange( QgsDateTimeRange( begin, end, true, begin == end ) );
   }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -548,7 +548,10 @@ QgsMeshDatasetIndex QgsMeshLayer::datasetIndexAtTime( const QgsDateTimeRange &ti
     return QgsMeshDatasetIndex( datasetGroupIndex, -1 );
 
   const QDateTime layerReferenceTime = mTemporalProperties->referenceTime();
-  qint64 startTime = layerReferenceTime.msecsTo( timeRange.begin() );
+  QDateTime utcTime = timeRange.begin();
+  if ( utcTime.timeSpec() != Qt::UTC )
+    utcTime.setTimeSpec( Qt::UTC );
+  qint64 startTime = layerReferenceTime.msecsTo( utcTime );
 
   return  mDatasetGroupStore->datasetIndexAtTime( startTime, datasetGroupIndex, mTemporalProperties->matchingMethod() );
 }


### PR DESCRIPTION
Force the override time in the map layout properties to be UTC.
fix #43242 and make consistent the time specification of the override temporal range with the temporal range given by the date/time edit widget of the main canvas and of the layout properties.
