### PR TITLE
[Oracle] Re-set the QT_NO_DEBUG option for ocispatial library so it won't crash on QT_ASSERT in Debug mode

### DIFF
--- a/src/providers/oracle/ocispatial/CMakeLists.txt
+++ b/src/providers/oracle/ocispatial/CMakeLists.txt
@@ -8,6 +8,12 @@ add_definitions(${QT_DEFINITIONS})
 add_definitions(-DQT_PLUGIN)
 add_definitions(-DQT_SHARED)
 
+# QT_NO_DEBUG disable Q_ASSERT() and we need to disable them if we want the provider
+# to run correctly. It would be better to work without this workaround and fix the oracle
+# provider (or maybe oci?), but for now, it's better to let it here
+# If later, you want to remove it, please launch ALL oracle tests.
+add_definitions(-DQT_NO_DEBUG)
+
 include_directories(SYSTEM
 	${OCI_INCLUDE_DIR}
 	${Qt5Sql_PRIVATE_INCLUDE_DIRS}


### PR DESCRIPTION
This is a partial revert of #42500

It appears that Q_ASSERT calls were disabled with QT_NO_DEBUG definition in ocispatial library. Since #42500 which removed this definition, the provider is sometimes crashing in Debug mode  #43295 #42857.

When disabled, even if the Q_ASSERT condition is matched, the provider continue to work quite normally.

There is no issue in Release mode because the definition is set on the whole application by Qt. And that the same with the CI which build in release.

#42857 has been fixed with #43048 (@uclaros this explains why it was working all this time without anyone noticing) but for #43295, it's gonna be complicated because it looks like an issue inside the Oracle Instant Client library and we have no way of fixing.

So I propose to restore this definition in order to make everything works in Debug mode.


