### PR TITLE
[Oracle] Remove assert on oracle instant client badly initialized variable

### DIFF
--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -2480,14 +2480,14 @@ bool QOCISpatialCols::convertToWkb( QVariant &v, int index )
   QByteArray ba;
   union wkbPtr ptr;
 
-  int nElems;
+  int nElems = 0;
   if ( !getArraySize( sdoobj->elem_info, nElems ) )
   {
     qWarning() << "could not determine element info array size";
     return false;
   }
 
-  int nOrds;
+  int nOrds = 0;
   if ( !getArraySize( sdoobj->ordinates, nOrds ) )
   {
     qWarning() << "could not determine ordinate array size";
@@ -2508,7 +2508,6 @@ bool QOCISpatialCols::convertToWkb( QVariant &v, int index )
        sdoind->point.x == OCI_IND_NOTNULL &&
        sdoind->point.y == OCI_IND_NOTNULL )
   {
-    Q_ASSERT( nOrds == 0 );
 
     double x, y, z = 0.0;
     if ( !getValue( &sdoobj->point.x, x ) )


### PR DESCRIPTION
Supersedes #43300

`OCICollSize` methods called by `getArraySize` doesn't return a valid nSize/nOrds variable when we have a *SDO_POINT_TYPE*. 

Most of the time, it returns the same value as the previous call....

So we better not assert it equals 0.