### PR TITLE
Avoid styleChanged() signals being raised before new labeling configuration is set when changing a vector layer's style preset

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1611,6 +1611,11 @@ Signal emitted whenever a change affects the layer's style. Ie this may be trigg
 by renderer changes, label style changes, or other style changes such as blend
 mode or layer opacity changes.
 
+.. warning::
+
+   This signal should never be manually emitted. Instead call the :py:func:`~QgsMapLayer.emitStyleChanged` method
+   to ensure that the signal is only emitted when appropriate.
+
 .. seealso:: :py:func:`rendererChanged`
 
 .. versionadded:: 2.16
@@ -1863,6 +1868,7 @@ this method is now deprecated and always return ``False``, because circular depe
 
 .. deprecated:: QGIS 3.10
 %End
+
 
 
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -644,5 +644,5 @@ void QgsPointCloudLayer::setRenderer( QgsPointCloudRenderer *renderer )
 
   mRenderer.reset( renderer );
   emit rendererChanged();
-  emit styleChanged();
+  emitStyleChanged();
 }

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -89,39 +89,6 @@
 // canonical project instance
 QgsProject *QgsProject::sProject = nullptr;
 
-///@cond PRIVATE
-class ScopedIntIncrementor
-{
-  public:
-
-    ScopedIntIncrementor( int *variable )
-      : mVariable( variable )
-    {
-      ( *mVariable )++;
-    }
-
-    ScopedIntIncrementor( const ScopedIntIncrementor &other ) = delete;
-    ScopedIntIncrementor &operator=( const ScopedIntIncrementor &other ) = delete;
-
-    void release()
-    {
-      if ( mVariable )
-        ( *mVariable )--;
-
-      mVariable = nullptr;
-    }
-
-    ~ScopedIntIncrementor()
-    {
-      release();
-    }
-
-  private:
-    int *mVariable = nullptr;
-};
-///@endcond
-
-
 /**
  * Takes the given scope and key and convert them to a string list of key
  * tokens that will be used to navigate through a Property hierarchy

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -821,6 +821,38 @@ void CORE_EXPORT qgsFree( void *ptr ) SIP_SKIP;
 #define CONSTLATIN1STRING constexpr QLatin1String
 #endif
 
+///@cond PRIVATE
+class ScopedIntIncrementor
+{
+  public:
+
+    ScopedIntIncrementor( int *variable )
+      : mVariable( variable )
+    {
+      ( *mVariable )++;
+    }
+
+    ScopedIntIncrementor( const ScopedIntIncrementor &other ) = delete;
+    ScopedIntIncrementor &operator=( const ScopedIntIncrementor &other ) = delete;
+
+    void release()
+    {
+      if ( mVariable )
+        ( *mVariable )--;
+
+      mVariable = nullptr;
+    }
+
+    ~ScopedIntIncrementor()
+    {
+      release();
+    }
+
+  private:
+    int *mVariable = nullptr;
+};
+///@endcond
+
 /**
 * Wkt string that represents a geographic coord sys
 * \since QGIS GEOWkt

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -217,7 +217,7 @@ void QgsMapLayer::setBlendMode( const QPainter::CompositionMode blendMode )
 
   mBlendMode = blendMode;
   emit blendModeChanged( blendMode );
-  emit styleChanged();
+  emitStyleChanged();
 }
 
 QPainter::CompositionMode QgsMapLayer::blendMode() const
@@ -231,7 +231,7 @@ void QgsMapLayer::setOpacity( double opacity )
     return;
   mLayerOpacity = opacity;
   emit opacityChanged( opacity );
-  emit styleChanged();
+  emitStyleChanged();
 }
 
 double QgsMapLayer::opacity() const
@@ -2001,7 +2001,8 @@ QDateTime QgsMapLayer::timestamp() const
 
 void QgsMapLayer::emitStyleChanged()
 {
-  emit styleChanged();
+  if ( !mBlockStyleChangedSignal )
+    emit styleChanged();
 }
 
 void QgsMapLayer::setExtent( const QgsRectangle &extent )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1429,6 +1429,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * Signal emitted whenever a change affects the layer's style. Ie this may be triggered
      * by renderer changes, label style changes, or other style changes such as blend
      * mode or layer opacity changes.
+     *
+     * \warning This signal should never be manually emitted. Instead call the emitStyleChanged() method
+     * to ensure that the signal is only emitted when appropriate.
+     *
      * \see rendererChanged()
      * \since QGIS 2.16
     */
@@ -1723,6 +1727,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.18
      */
     double mLayerOpacity = 1.0;
+
+    /**
+     * If non-zero, the styleChanged signal should not be emitted.
+     *
+     * \since QGIS 3.20
+     */
+    int mBlockStyleChangedSignal = 0;
 
 #ifndef SIP_RUN
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -597,7 +597,7 @@ void QgsRasterLayer::setOpacity( double opacity )
 
   mPipe.renderer()->setOpacity( opacity );
   emit opacityChanged( opacity );
-  emit styleChanged();
+  emitStyleChanged();
 }
 
 double QgsRasterLayer::opacity() const
@@ -957,7 +957,7 @@ void QgsRasterLayer::setDataSourcePrivate( const QString &dataSource, const QStr
       {
         restoredStyle = true;
         emit repaintRequested();
-        emit styleChanged();
+        emitStyleChanged();
         emit rendererChanged();
       }
     }
@@ -1219,7 +1219,7 @@ void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnh
   if ( rasterRenderer == renderer() )
   {
     emit repaintRequested();
-    emit styleChanged();
+    emitStyleChanged();
     emit rendererChanged();
   }
 }
@@ -1328,7 +1328,7 @@ void QgsRasterLayer::refreshRenderer( QgsRasterRenderer *rasterRenderer, const Q
       }
 
       emit repaintRequested();
-      emit styleChanged();
+      emitStyleChanged();
       emit rendererChanged();
       return;
     }
@@ -1364,7 +1364,7 @@ void QgsRasterLayer::refreshRenderer( QgsRasterRenderer *rasterRenderer, const Q
         }
       }
 
-      emit styleChanged();
+      emitStyleChanged();
       emit rendererChanged();
     }
   }
@@ -1741,7 +1741,7 @@ void QgsRasterLayer::setRenderer( QgsRasterRenderer *renderer )
 
   mPipe.set( renderer );
   emit rendererChanged();
-  emit styleChanged();
+  emitStyleChanged();
 }
 
 void QgsRasterLayer::showStatusMessage( QString const &message )


### PR DESCRIPTION
This causes the layer styling dock to update before the layer's
new labeling settings are set, so the dock shows the incorrect
label settings for the previously used style

Fixes #42310
