### PR TITLE
[Backport 3.16] [OGR provider] Workaround crash on SQLite layers with GDAL 3.3.0

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -587,10 +587,10 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
     QMutex *mutex = nullptr;
     OGRLayerH layer = mOgrOrigLayer->getHandleAndMutex( mutex );
     QMutexLocker locker( mutex );
-    const QString identifier = GDALGetMetadataItem( layer, "IDENTIFIER", nullptr );
+    const QString identifier = GDALGetMetadataItem( layer, "IDENTIFIER", "" );
     if ( !identifier.isEmpty() )
       mLayerMetadata.setTitle( identifier ); // see geopackage specs -- "'identifier' is analogous to 'title'"
-    const QString abstract = GDALGetMetadataItem( layer, "DESCRIPTION", nullptr );
+    const QString abstract = GDALGetMetadataItem( layer, "DESCRIPTION", "" );
     if ( !abstract.isEmpty() )
       mLayerMetadata.setAbstract( abstract );
   }


### PR DESCRIPTION
Fixes #43224

Proper fix is in GDAL in https://github.com/OSGeo/gdal/pull/3862

Backport of https://github.com/qgis/QGIS/pull/43306