### PR TITLE
[Backport 3.16] [WMS provider] Fix crash on WMS-T layer uri without timeDimensionExtent

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -88,7 +88,8 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mTemporalExtent = uri.param( QStringLiteral( "timeDimensionExtent" ) );
     mTimeDimensionExtent = parseTemporalExtent( mTemporalExtent );
 
-    if ( mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.size() > 0 )
+    if ( !mTimeDimensionExtent.datesResolutionList.isEmpty() &&
+         !mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.empty() )
     {
       QDateTime begin = mTimeDimensionExtent.datesResolutionList.constFirst().dates.dateTimes.first();
       QDateTime end = mTimeDimensionExtent.datesResolutionList.constLast().dates.dateTimes.last();

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -230,6 +230,13 @@ class TestQgsWmsProvider: public QObject
       return myResultFlag;
     }
 
+    void testParseWmstUriWithoutTemporalExtent()
+    {
+      // test fix for https://github.com/qgis/QGIS/issues/43158
+      // we just check we don't crash
+      QgsWmsProvider provider( QStringLiteral( "allowTemporalUpdates=true&temporalSource=provider&type=wmst&layers=foostyles=bar&crs=EPSG:3857&format=image/png&url=file:///dummy" ), QgsDataProvider::ProviderOptions(), mCapabilities );
+    }
+
   private:
     QgsWmsCapabilities *mCapabilities = nullptr;
 


### PR DESCRIPTION
Fixes #43158

Backport of https://github.com/qgis/QGIS/pull/43310