### PR TITLE
Fix SIP issue with return results from calculateStatistics

### DIFF
--- a/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
+++ b/python/analysis/auto_generated/vector/qgszonalstatistics.sip.in
@@ -130,7 +130,9 @@ Returns a short, friendly display name for a ``statistic``, suitable for use in 
 .. versionadded:: 3.12
 %End
 
-    static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+
+
+    static QMap<int, QVariant> calculateStatisticsInt( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics ) /PyName=calculateStatistics/;
 %Docstring
 Calculates the specified ``statistics`` for the pixels of ``rasterBand``
 in ``rasterInterface`` (a raster layer :py:func:`~QgsZonalStatistics.dataProvider` ) within polygon ``geometry``.

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -287,6 +287,19 @@ QString QgsZonalStatistics::shortName( QgsZonalStatistics::Statistic statistic )
   return QString();
 }
 
+///@cond PRIVATE
+QMap<int, QVariant> QgsZonalStatistics::calculateStatisticsInt( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics )
+{
+  const auto result { QgsZonalStatistics::calculateStatistics( rasterInterface, geometry, cellSizeX, cellSizeY, rasterBand, statistics ) };
+  QMap<int, QVariant> pyResult;
+  for ( auto it = result.constBegin(); it != result.constEnd(); ++it )
+  {
+    pyResult.insert( it.key(), it.value() );
+  }
+  return pyResult;
+}
+/// @endcond
+
 QMap<QgsZonalStatistics::Statistic, QVariant> QgsZonalStatistics::calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics )
 {
   QMap<QgsZonalStatistics::Statistic, QVariant> results;
@@ -327,7 +340,7 @@ QMap<QgsZonalStatistics::Statistic, QVariant> QgsZonalStatistics::calculateStati
   }
 
   // calculate the statistics
-  QgsAttributeMap changeAttributeMap;
+
   if ( statistics & QgsZonalStatistics::Count )
     results.insert( QgsZonalStatistics::Count, QVariant( featureStats.count ) );
   if ( statistics & QgsZonalStatistics::Sum )

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -155,7 +155,23 @@ class ANALYSIS_EXPORT QgsZonalStatistics
      *
      * \since QGIS 3.16
      */
+#ifndef SIP_RUN
     static QMap<QgsZonalStatistics::Statistic, QVariant> calculateStatistics( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics );
+#endif
+
+///@cond PRIVATE
+    // Required to fix https://github.com/qgis/QGIS/issues/43245 (SIP is failing to convert the enum to values)
+
+    /**
+     * Calculates the specified \a statistics for the pixels of \a rasterBand
+     * in \a rasterInterface (a raster layer dataProvider() ) within polygon \a geometry.
+     *
+     * Returns a map of statistic to result value.
+     *
+     * \since QGIS 3.16
+     */
+    static QMap<int, QVariant> calculateStatisticsInt( QgsRasterInterface *rasterInterface, const QgsGeometry &geometry, double cellSizeX, double cellSizeY, int rasterBand, QgsZonalStatistics::Statistics statistics ) SIP_PYNAME( calculateStatistics );
+/// @endcond
 
   private:
     QgsZonalStatistics() = default;


### PR DESCRIPTION
Fixes #43245

SIP failed to convert the QMap<QgsZonalStatistics::Statistic, QVariant>
so we give it an QMap<int, QVariant>.
