### PR TITLE
[PostgreSQL provider] Retrieve CRS from spatial_ref_sys

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -251,7 +251,9 @@ bool QgsCoordinateReferenceSystem::createFromId( const long id, CrsType type )
       result = createFromSrsId( id );
       break;
     case PostgisCrsId:
-      result = createFromPostgisSrid( id );
+      Q_NOWARN_DEPRECATED_PUSH
+      result = createFromSrid( id );
+      Q_NOWARN_DEPRECATED_POP
       break;
     case EpsgCrsId:
       result = createFromOgcWmsCrs( QStringLiteral( "EPSG:%1" ).arg( id ) );
@@ -294,7 +296,9 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
     else if ( authName == QLatin1String( "postgis" ) )
     {
       const long id = match.captured( 2 ).toLong();
-      result = createFromPostgisSrid( id );
+      Q_NOWARN_DEPRECATED_PUSH
+      result = createFromSrid( id );
+      Q_NOWARN_DEPRECATED_POP
     }
     else if ( authName == QLatin1String( "esri" ) || authName == QLatin1String( "osgeo" ) || authName == QLatin1String( "ignf" ) || authName == QLatin1String( "zangi" ) || authName == QLatin1String( "iau2000" ) )
     {
@@ -491,11 +495,6 @@ void QgsCoordinateReferenceSystem::validate()
 }
 
 bool QgsCoordinateReferenceSystem::createFromSrid( const long id )
-{
-  return createFromPostgisSrid( id );
-}
-
-bool QgsCoordinateReferenceSystem::createFromPostgisSrid( const long id )
 {
   QgsReadWriteLocker locker( *sSrIdCacheLock(), QgsReadWriteLocker::Read );
   if ( !sDisableSrIdCache )

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -1091,7 +1091,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     static const QHash< long, QgsCoordinateReferenceSystem > &srIdCache();
 
     friend class TestQgsCoordinateReferenceSystem;
-    friend class QgsPostgresProvider;
     friend class QgsCoordinateReferenceSystemRegistry;
     friend bool CORE_EXPORT operator> ( const QgsCoordinateReferenceSystem &c1, const QgsCoordinateReferenceSystem &c2 );
     friend bool CORE_EXPORT operator< ( const QgsCoordinateReferenceSystem &c1, const QgsCoordinateReferenceSystem &c2 );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -365,7 +365,9 @@ void TestQgsCoordinateReferenceSystem::ogcWmsCrsCache()
 void TestQgsCoordinateReferenceSystem::createFromSrid()
 {
   QgsCoordinateReferenceSystem myCrs;
-  myCrs.createFromPostgisSrid( GEOSRID );
+  Q_NOWARN_DEPRECATED_PUSH
+  myCrs.createFromSrid( GEOSRID );
+  Q_NOWARN_DEPRECATED_POP
   debugPrint( myCrs );
   QVERIFY( myCrs.isValid() );
   QCOMPARE( myCrs.srsid(), GEOCRS_ID );
@@ -374,30 +376,34 @@ void TestQgsCoordinateReferenceSystem::createFromSrid()
 
 void TestQgsCoordinateReferenceSystem::sridCache()
 {
+  Q_NOWARN_DEPRECATED_PUSH
+
   // test that crs can be retrieved correctly from cache
   QgsCoordinateReferenceSystem crs;
-  crs.createFromPostgisSrid( 3112 );
+  crs.createFromSrid( 3112 );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.authid(), QStringLiteral( "EPSG:3112" ) );
   QVERIFY( QgsCoordinateReferenceSystem::srIdCache().contains( 3112 ) );
   // a second time, so crs is fetched from cache
   QgsCoordinateReferenceSystem crs2;
-  crs2.createFromPostgisSrid( 3112 );
+  crs2.createFromSrid( 3112 );
   QVERIFY( crs2.isValid() );
   QCOMPARE( crs2.authid(), QStringLiteral( "EPSG:3112" ) );
 
   // invalid
   QgsCoordinateReferenceSystem crs3;
-  QVERIFY( !crs3.createFromPostgisSrid( -3141 ) );
+  QVERIFY( !crs3.createFromSrid( -3141 ) );
   QVERIFY( !crs3.isValid() );
   QVERIFY( QgsCoordinateReferenceSystem::srIdCache().contains( -3141 ) );
   // a second time, so invalid crs is fetched from cache
   QgsCoordinateReferenceSystem crs4;
-  QVERIFY( !crs4.createFromPostgisSrid( -3141 ) );
+  QVERIFY( !crs4.createFromSrid( -3141 ) );
   QVERIFY( !crs4.isValid() );
 
   QgsCoordinateReferenceSystem::invalidateCache();
   QVERIFY( !QgsCoordinateReferenceSystem::srIdCache().contains( 3112 ) );
+
+  Q_NOWARN_DEPRECATED_POP
 }
 
 void TestQgsCoordinateReferenceSystem::createFromWkt()
@@ -593,7 +599,9 @@ QString TestQgsCoordinateReferenceSystem::testESRIWkt( int i, QgsCoordinateRefer
 void TestQgsCoordinateReferenceSystem::createFromSrId()
 {
   QgsCoordinateReferenceSystem myCrs;
-  QVERIFY( myCrs.createFromPostgisSrid( GEOSRID ) );
+  Q_NOWARN_DEPRECATED_PUSH
+  QVERIFY( myCrs.createFromSrid( GEOSRID ) );
+  Q_NOWARN_DEPRECATED_POP
   QVERIFY( myCrs.isValid() );
   QCOMPARE( myCrs.srsid(), GEOCRS_ID );
 }
@@ -1235,7 +1243,9 @@ void TestQgsCoordinateReferenceSystem::customSrsValidation()
 void TestQgsCoordinateReferenceSystem::postgisSrid()
 {
   QgsCoordinateReferenceSystem myCrs;
-  myCrs.createFromPostgisSrid( GEOSRID );
+  Q_NOWARN_DEPRECATED_PUSH
+  myCrs.createFromSrid( GEOSRID );
+  Q_NOWARN_DEPRECATED_POP
   QVERIFY( myCrs.postgisSrid() == GEOSRID );
   debugPrint( myCrs );
 }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2607,6 +2607,34 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         _test(vl, QgsRectangle(-181, -90, 181, 90), [1, 2, 3])  # no use of spatial index currently
 
+    def testReadCustomSRID(self):
+        """Test that we can correctly read the SRS from a custom SRID"""
+
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(self.dbconn, {})
+
+        # Cleanup if needed
+        try:
+            conn.dropVectorTable('qgis_test', 'test_custom_srid')
+        except QgsProviderConnectionException:
+            pass
+
+        conn.executeSql("DELETE FROM spatial_ref_sys WHERE srid = 543210 AND auth_name='FOO' AND auth_srid=32600;")
+        conn.executeSql("""INSERT INTO spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text) VALUES (543210, 'FOO', 32600, 'PROJCS["my_projection",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]','+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');""")
+
+        conn.executeSql('''
+        CREATE TABLE "qgis_test"."test_custom_srid" (
+            gid serial primary key,
+            geom geometry(Point, 543210)
+        );''')
+
+        layer = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'gid\'table="qgis_test"."test_custom_srid" (geom) sql=', 'test', 'postgres')
+
+        conn.executeSql("DELETE FROM spatial_ref_sys WHERE srid = 543210 AND auth_name='FOO' AND auth_srid=32600;")
+
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.crs().description(), 'my_projection')
+
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 


### PR DESCRIPTION
instead of relying on QgsCoordinateReferenceSystem::createFromPostgisSrid()
which contrary to what its name suggest doesn't use postgis at all, but
the QGIS CRS database.

I detected the issue initially on a database where my spatial_ref_sys
table had been emptied and a few entries where assigned with SRIDs in
the EPSG range but with definitions that weren't the ones from EPSG.
There is no guarantee that EPSG:XXXX gets a SRID of XXXX

And the past implementation of the fallback case of QgsPostgresProvider::crs()
only looked at proj4text instead of using the WKT from srtext.
