### PR TITLE
Fix Python module enviroment setup on Windows

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -55,10 +55,14 @@ def setupenv():
 
     with open(envfile) as f:
         for line in f:
-            linedata = line.split("=")
-            name = linedata[0]
-            data = linedata[1]
-            os.environ[name] = data
+            line = line.rstrip("\n")
+            if line.startswith("#") or "" == line:
+                continue
+            try:
+                env_key, env_value = line.split("=", maxsplit=1)
+                os.environ[env_key] = env_value
+            except ValueError:
+                pass
 
 
 if os.name == 'nt':

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -56,7 +56,7 @@ def setupenv():
     with open(envfile) as f:
         for line in f:
             line = line.rstrip("\n")
-            if line.startswith("#") or "" == line:
+            if line.startswith("#") or not line:
                 continue
             try:
                 env_key, env_value = line.split("=", maxsplit=1)


### PR DESCRIPTION
## Description

Necessary environment variables are loaded from .env file on Windows, if QGIS_PREFIX_PATH is not set when importing any qgis python module. Current parsing includes newlines in the paths, and starting the app and creating layers in Python script fails in strange ways.

Fix the parsing by trimming trailing newline, skip invalid, empty or commented lines and allow = to be present in the values.

Needs backporting to 3.16.

Fixes #43308.