### PR TITLE
Add support for filtering by multiple attributes to get_feature expression

### DIFF
--- a/resources/function_help/json/get_feature
+++ b/resources/function_help/json/get_feature
@@ -3,8 +3,19 @@
   "type": "function",
   "groups": ["Record and Attributes"],
   "description": "Returns the first feature of a layer matching a given attribute value.",
-  "arguments": [ {"arg":"layer","description":"layer name or ID"},
-                 {"arg":"attribute","description":"attribute name"},
-                 {"arg":"value","description":"attribute value to match"}],
-  "examples": [ { "expression":"get_feature('streets','name','main st')", "returns":"first feature found in \"streets\" layer with \"main st\" value in the \"name\" field"}]
+  "variants": [
+  { "variant": "Single value variant",
+      "variant_description": "Along with the layer ID, a single column and value are specified.",
+      "arguments": [ {"arg":"layer","description":"layer name or ID"},
+                     {"arg":"attribute","description":"attribute name to use for the match"},
+                     {"arg":"value","description":"attribute value to match"}],
+      "examples": [ { "expression":"get_feature('streets','name','main st')", "returns":"first feature found in \"streets\" layer with \"main st\" value in the \"name\" field"} ]
+  },
+  {
+      "variant": "Map variant",
+      "variant_description": "Along with the layer ID, a map containing the columns (key) and their respective value to be used.",
+      "arguments": [ {"arg":"layer","description":"layer name or ID"},
+                     {"arg":"map","description":"Map containing the column and value pairs to use"}],
+      "examples": [ { "expression":"get_feature('streets',map('name','main st','lane_num','4'))", "returns":"first feature found in \"streets\" layer with \"main st\" value in the \"name\" field and  \"4\" value in the \"lane_num\" field"} ]
+  } ]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -7800,8 +7800,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     functions
         << new QgsStaticExpressionFunction( QStringLiteral( "get_feature" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )
-                                            << QgsExpressionFunction::Parameter( QStringLiteral( "attribute" ) )
-                                            << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ),
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "attribute(s)" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "value" ), true ),
                                             fcnGetFeature, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "QgsExpressionUtils::getFeature" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "get_feature_by_id" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "feature_id" ) ),

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5489,8 +5489,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
       {
         filterString.append( " AND " );
       }
-      filterString.append( QStringLiteral( "( %1 = %2 )" ).arg( QgsExpression::quotedColumnRef( i.key() ),
-                           QgsExpression::quotedString( i.value().toString() ) ) );
+      filterString.append( QgsExpression::createFieldEqualityExpression( i.key(), i.value() ) );
     }
     cacheValueKey = QStringLiteral( "getfeature:%1:%2" ).arg( featureSource->id(), filterString );
     if ( context && context->hasCachedValue( cacheValueKey ) )
@@ -5516,8 +5515,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
       return context->cachedValue( cacheValueKey );
     }
 
-    req.setFilterExpression( QStringLiteral( "%1=%2" ).arg( QgsExpression::quotedColumnRef( attribute ),
-                             QgsExpression::quotedString( attVal.toString() ) ) );
+    req.setFilterExpression( QgsExpression::createFieldEqualityExpression( attribute, attVal ) );
   }
   req.setLimit( 1 );
   req.setTimeout( 10000 );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5490,7 +5490,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
         filterString.append( " AND " );
       }
       filterString.append( QStringLiteral( "( %1 = %2 )" ).arg( QgsExpression::quotedColumnRef( i.key() ),
-                           QgsExpression::quotedString( i.value()->toString() ) ) );
+                           QgsExpression::quotedString( i.value().toString() ) ) );
     }
     cacheValueKey = QStringLiteral( "getfeature:%1:%2" ).arg( featureSource->id(),
                                                               filterString );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5477,7 +5477,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   }
   QgsFeatureRequest req;
   QString cacheValueKey;
-  if ( values.size() == 2 && values.at( 1 ).type() == QVariant::Map )
+  if ( values.at( 1 ).type() == QVariant::Map )
   {
     QVariantMap attributeMap = QgsExpressionUtils::getMapValue( values.at( 1 ), parent );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5477,13 +5477,13 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   }
   QgsFeatureRequest req;
   QString cacheValueKey;
-  if ( values.size() == 2 && values.at( 1 ).canConvert<QVariantMap>() )
+  if ( values.size() == 2 && values.at( 1 ).type() == QVariant::Map  )
   {
-    QVariantMap map = values.at( 1 ).toMap();
+    QVariantMap attributeMap = QgsExpressionUtils::getMapValue( values.at( 1 ), parent );
 
-    QMap <QString, QVariant>::const_iterator i = map.constBegin();
+    QMap <QString, QVariant>::const_iterator i = attributeMap.constBegin();
     QString filterString;
-    for ( ; i != map.constEnd(); ++i )
+    for ( ; i != attributeMap.constEnd(); ++i )
     {
       if ( !filterString.isEmpty() )
       {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5477,7 +5477,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   }
   QgsFeatureRequest req;
   QString cacheValueKey;
-  if ( values.size() == 2 && values.at( 1 ).type() == QVariant::Map  )
+  if ( values.size() == 2 && values.at( 1 ).type() == QVariant::Map )
   {
     QVariantMap attributeMap = QgsExpressionUtils::getMapValue( values.at( 1 ), parent );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5479,11 +5479,11 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   QString cacheValueKey;
   if ( values.size() == 2 && values.at( 1 ).canConvert<QVariantMap>() )
   {
-    QVariantMap map= values.at( 1 ).toMap();
+    QVariantMap map = values.at( 1 ).toMap();
 
     QMap <QString, QVariant>::const_iterator i = map.constBegin();
     QString filterString;
-    for (  ; i != map.constEnd(); ++i )
+    for ( ; i != map.constEnd(); ++i )
     {
       if ( !filterString.isEmpty() )
       {
@@ -5492,8 +5492,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
       filterString.append( QStringLiteral( "( %1 = %2 )" ).arg( QgsExpression::quotedColumnRef( i.key() ),
                            QgsExpression::quotedString( i.value().toString() ) ) );
     }
-    cacheValueKey = QStringLiteral( "getfeature:%1:%2" ).arg( featureSource->id(),
-                                                              filterString );
+    cacheValueKey = QStringLiteral( "getfeature:%1:%2" ).arg( featureSource->id(), filterString );
     if ( context && context->hasCachedValue( cacheValueKey ) )
     {
       return context->cachedValue( cacheValueKey );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -15,6 +15,7 @@
 #include "qgstest.h"
 #include <QObject>
 #include <QString>
+#include <QDate>
 #include <QtConcurrentMap>
 
 #include <qgsapplication.h>
@@ -130,20 +131,24 @@ class TestQgsExpression: public QObject
       QgsProject::instance()->addMapLayer( mMeshLayer );
 
       // test memory layer for get_feature tests
-      mMemoryLayer = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer&field=col2:string" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+      mMemoryLayer = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer&field=col2:string&field=datef:date(0,0)" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
       QVERIFY( mMemoryLayer->isValid() );
       QgsFeature f1( mMemoryLayer->dataProvider()->fields(), 1 );
       f1.setAttribute( QStringLiteral( "col1" ), 10 );
       f1.setAttribute( QStringLiteral( "col2" ), "test1" );
+      f1.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2021, 09, 23 ) );
       QgsFeature f2( mMemoryLayer->dataProvider()->fields(), 2 );
       f2.setAttribute( QStringLiteral( "col1" ), 11 );
       f2.setAttribute( QStringLiteral( "col2" ), "test2" );
+      f2.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2022, 09, 23 ) );
       QgsFeature f3( mMemoryLayer->dataProvider()->fields(), 3 );
       f3.setAttribute( QStringLiteral( "col1" ), 3 );
       f3.setAttribute( QStringLiteral( "col2" ), "test3" );
+      f3.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2021, 09, 23 ) );
       QgsFeature f4( mMemoryLayer->dataProvider()->fields(), 4 );
       f4.setAttribute( QStringLiteral( "col1" ), 41 );
       f4.setAttribute( QStringLiteral( "col2" ), "test4" );
+      f4.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2022, 09, 23 ) );
       mMemoryLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 << f4 );
       QgsProject::instance()->addMapLayer( mMemoryLayer );
 
@@ -2249,11 +2254,13 @@ class TestQgsExpression: public QObject
 
       // multi-param
       QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1','11','col2','test2'))" << true << 2;
-      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','3','col2','test3'))" << true << 3;
+      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1',3,'col2','test3'))" << true << 3;
+      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','41','datef',to_date('2022-09-23')))" << true << 4;
 
       // multi-param no match
       QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',map('col1','col2'),'no match!')" << false << -1;
       QTest::newRow( "get_feature no match-multi2" ) << "get_feature('test',map('col2','10','col4','test3'))" << false << -1;
+      QTest::newRow( "get_feature no match-multi2" ) << "get_feature('test',map('col1',10,'datef',to_date('2021-09-24')))" << false << -1;
 
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2252,8 +2252,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','3','col2','test3'))" << true << 3;
 
       // multi-param no match
-      QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',array('col1','col2'),'no match!')" << false << -1;
-      QTest::newRow( "get_feature no match-multi2" ) << "get_feature('test',array('col1','col2'),array('10','test3'))" << false << -1;
+      QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',map('col1','col2'),'no match!')" << false << -1;
+      QTest::newRow( "get_feature no match-multi2" ) << "get_feature('test',map('col2','10','col4','test3'))" << false << -1;
 
     }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2246,6 +2246,15 @@ class TestQgsExpression: public QObject
 
       // get_feature_by_id
       QTest::newRow( "get_feature_by_id" ) << "get_feature_by_id('test', 1)" << true << 1;
+
+      // multi-param
+      QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1','11','col2','test2'))" << true << 2;
+      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','3','col2','test3'))" << true << 3;
+
+      // multi-param no match
+      QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',array('col1','col2'),'no match!')" << false << -1;
+      QTest::newRow( "get_feature no match-multi2" ) << "get_feature('test',array('col1','col2'),array('10','test3'))" << false << -1;
+
     }
 
     void eval_get_feature()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -135,7 +135,7 @@ class TestQgsExpression: public QObject
       QgsFeature f1( mMemoryLayer->dataProvider()->fields(), 1 );
       f1.setAttribute( QStringLiteral( "col1" ), 10 );
       f1.setAttribute( QStringLiteral( "col2" ), "test1" );
-      f1.setAttribute( QStringLiteral( "datef" ), Date( 2021, 9, 23 ) );
+      f1.setAttribute( QStringLiteral( "datef" ), QDate( 2021, 9, 23 ) );
       QgsFeature f2( mMemoryLayer->dataProvider()->fields(), 2 );
       f2.setAttribute( QStringLiteral( "col1" ), 11 );
       f2.setAttribute( QStringLiteral( "col2" ), "test2" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2248,8 +2248,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "get_feature_by_id" ) << "get_feature_by_id('test', 1)" << true << 1;
 
       // multi-param
-      QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1','11','col2','test2'))" << true << 2;
-      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','3','col2','test3'))" << true << 3;
+      QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1',11,'col2','test2'))" << true << 2;
+      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1',3,'col2','test3'))" << true << 3;
 
       // multi-param no match
       QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',map('col1','col2'),'no match!')" << false << -1;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2248,8 +2248,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "get_feature_by_id" ) << "get_feature_by_id('test', 1)" << true << 1;
 
       // multi-param
-      QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1',11,'col2','test2'))" << true << 2;
-      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1',3,'col2','test3'))" << true << 3;
+      QTest::newRow( "get_feature multi1" ) << "get_feature('test',map('col1','11','col2','test2'))" << true << 2;
+      QTest::newRow( "get_feature multi2" ) << "get_feature('test',map('col1','3','col2','test3'))" << true << 3;
 
       // multi-param no match
       QTest::newRow( "get_feature no match-multi1" ) << "get_feature('test',map('col1','col2'),'no match!')" << false << -1;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -15,7 +15,6 @@
 #include "qgstest.h"
 #include <QObject>
 #include <QString>
-#include <QDate>
 #include <QtConcurrentMap>
 
 #include <qgsapplication.h>
@@ -136,19 +135,19 @@ class TestQgsExpression: public QObject
       QgsFeature f1( mMemoryLayer->dataProvider()->fields(), 1 );
       f1.setAttribute( QStringLiteral( "col1" ), 10 );
       f1.setAttribute( QStringLiteral( "col2" ), "test1" );
-      f1.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2021, 09, 23 ) );
+      f1.setAttribute( QStringLiteral( "datef" ), Date( 2021, 9, 23 ) );
       QgsFeature f2( mMemoryLayer->dataProvider()->fields(), 2 );
       f2.setAttribute( QStringLiteral( "col1" ), 11 );
       f2.setAttribute( QStringLiteral( "col2" ), "test2" );
-      f2.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2022, 09, 23 ) );
+      f2.setAttribute( QStringLiteral( "datef" ), QDate( 2022, 9, 23 ) );
       QgsFeature f3( mMemoryLayer->dataProvider()->fields(), 3 );
       f3.setAttribute( QStringLiteral( "col1" ), 3 );
       f3.setAttribute( QStringLiteral( "col2" ), "test3" );
-      f3.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2021, 09, 23 ) );
+      f3.setAttribute( QStringLiteral( "datef" ), QDate( 2021, 9, 23 ) );
       QgsFeature f4( mMemoryLayer->dataProvider()->fields(), 4 );
       f4.setAttribute( QStringLiteral( "col1" ), 41 );
       f4.setAttribute( QStringLiteral( "col2" ), "test4" );
-      f4.setAttribute( QStringLiteral( "datef" ), QDate::QDate( 2022, 09, 23 ) );
+      f4.setAttribute( QStringLiteral( "datef" ), QDate( 2022, 9, 23 ) );
       mMemoryLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 << f4 );
       QgsProject::instance()->addMapLayer( mMemoryLayer );
 


### PR DESCRIPTION
## Description

This PR extends the `get_feature` function by adding the option to pass array as inputs. This enable multi-variable filtering by stacking the key/value pairs provided as is already supported in the featureRequest.

Array were used to maintain the input numbers and behaviour.