### PR TITLE
Reorganize sequences of callout properties

### DIFF
--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -22,7 +22,7 @@
 #include <Qt3DRender/QCamera>
 
 //
-// QgsCodeEditorOptionsWidget
+// Qgs3DOptionsWidget
 //
 
 Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )

--- a/src/ui/callouts/widget_ballooncallout.ui
+++ b/src/ui/callouts/widget_ballooncallout.ui
@@ -244,207 +244,207 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QgsCollapsibleGroupBox" name="mMarginsGroupBox">
-     <property name="title">
-      <string> Margins</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="4" column="1">
-       <widget class="QgsUnitSelectionWidget" name="mMarginUnitWidget" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>10</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Units</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Data defined</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Bottom</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinBottomMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="suffix">
-         <string/>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Left</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Top</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinRightMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="suffix">
-         <string/>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinLeftMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="suffix">
-         <string/>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinTopMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="suffix">
-         <string/>
-        </property>
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="minimum">
-         <double>-10000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QgsPropertyOverrideButton" name="mMarginsDDBtn">
-          <property name="text">
-           <string>…</string>
+     <item row="3" column="0" colspan="4">
+      <widget class="QgsCollapsibleGroupBox" name="mMarginsGroupBox">
+       <property name="title">
+        <string> Margins</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="4" column="1">
+         <widget class="QgsUnitSelectionWidget" name="mMarginUnitWidget" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>10</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
           </property>
          </widget>
         </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Units</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Data defined</string>
           </property>
-         </spacer>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Bottom</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QgsDoubleSpinBox" name="mSpinBottomMargin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+          <property name="minimum">
+           <double>-10000000.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10000000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.200000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Left</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Top</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QgsDoubleSpinBox" name="mSpinRightMargin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+          <property name="minimum">
+           <double>-10000000.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10000000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.200000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QgsDoubleSpinBox" name="mSpinLeftMargin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+          <property name="minimum">
+           <double>-10000000.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10000000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.200000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Right</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QgsDoubleSpinBox" name="mSpinTopMargin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+          <property name="minimum">
+           <double>-10000000.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10000000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.200000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QgsPropertyOverrideButton" name="mMarginsDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QGroupBox" name="mPlacementDDGroupBox">

--- a/src/ui/callouts/widget_ballooncallout.ui
+++ b/src/ui/callouts/widget_ballooncallout.ui
@@ -45,14 +45,14 @@
      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
      </item>
      <item row="5" column="0">
-     <widget class="QLabel" name="label_18">
+      <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
        <string>Blend mode</string>
        </property>
      </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_47">
+      <widget class="QLabel" name="mWedgeWidthLbl">
        <property name="text">
         <string>Wedge width</string>
        </property>
@@ -85,14 +85,14 @@
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="mCalloutFillStyleLbl">
        <property name="text">
         <string>Fill style</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_46">
+      <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
        </property>
@@ -193,7 +193,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_48">
+      <widget class="QLabel" name="mCornerRadiusLbl">
        <property name="text">
         <string>Corner radius</string>
        </property>

--- a/src/ui/callouts/widget_ballooncallout.ui
+++ b/src/ui/callouts/widget_ballooncallout.ui
@@ -156,7 +156,7 @@
      <item row="5" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
-        <string>Anchor point</string>
+        <string>Feature anchor point</string>
        </property>
       </widget>
      </item>

--- a/src/ui/callouts/widget_ballooncallout.ui
+++ b/src/ui/callouts/widget_ballooncallout.ui
@@ -27,38 +27,38 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout_45" columnstretch="0,0,0,0,0">
+    <layout class="QGridLayout" name="gridLayout_45" columnstretch="0,0,0,0">
      <property name="leftMargin">
       <number>0</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="5" column="3">
-     <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
+     <item row="6" column="3">
+      <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
        <property name="text">
-       <string>…</string>
+        <string>…</string>
        </property>
-     </widget>
+      </widget>
      </item>
-     <item row="5" column="1" colspan="2">
-     <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
+     <item row="6" column="1" colspan="2">
+      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox" native="true"/>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
-       <string>Blend mode</string>
+        <string>Blend mode</string>
        </property>
-     </widget>
+      </widget>
      </item>
-     <item row="4" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="mWedgeWidthLbl">
        <property name="text">
         <string>Wedge width</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="3">
+     <item row="0" column="1" colspan="2">
       <widget class="QgsSymbolButton" name="mCalloutFillStyleButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -71,7 +71,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="2" colspan="2">
+     <item row="2" column="2">
       <widget class="QgsUnitSelectionWidget" name="mWedgeWidthUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -91,14 +91,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="4" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromAnchorSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -123,14 +123,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="4">
+     <item row="4" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromAnchorDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="2" colspan="2">
+     <item row="4" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromAnchorUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -143,24 +143,24 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="3">
+     <item row="5" column="1" colspan="2">
       <widget class="QComboBox" name="mAnchorPointComboBox"/>
      </item>
-     <item row="2" column="4">
+     <item row="5" column="3">
       <widget class="QgsPropertyOverrideButton" name="mAnchorPointDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
         <string>Anchor point</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="2" column="1">
       <widget class="QgsDoubleSpinBox" name="mWedgeWidthSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -185,21 +185,21 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="4">
+     <item row="2" column="3">
       <widget class="QgsPropertyOverrideButton" name="mWedgeWidthDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="mCornerRadiusLbl">
        <property name="text">
         <string>Corner radius</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="1" column="1">
       <widget class="QgsDoubleSpinBox" name="mCornerRadiusSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -224,7 +224,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2" colspan="2">
+     <item row="1" column="2">
       <widget class="QgsUnitSelectionWidget" name="mCornerRadiusUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -237,7 +237,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
+     <item row="1" column="3">
       <widget class="QgsPropertyOverrideButton" name="mCornerRadiusDDBtn">
        <property name="text">
         <string>…</string>
@@ -592,16 +592,14 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mCalloutFillStyleButton</tabstop>
-  <tabstop>mOffsetFromAnchorSpin</tabstop>
-  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
-  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
-  <tabstop>mAnchorPointComboBox</tabstop>
-  <tabstop>mAnchorPointDDBtn</tabstop>
-  <tabstop>mCalloutBlendComboBox</tabstop>
-  <tabstop>mCalloutBlendModeDDBtn</tabstop>
   <tabstop>mCornerRadiusSpin</tabstop>
   <tabstop>mCornerRadiusUnitWidget</tabstop>
   <tabstop>mCornerRadiusDDBtn</tabstop>
@@ -614,6 +612,13 @@
   <tabstop>mSpinBottomMargin</tabstop>
   <tabstop>mMarginUnitWidget</tabstop>
   <tabstop>mMarginsDDBtn</tabstop>
+  <tabstop>mOffsetFromAnchorSpin</tabstop>
+  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
+  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
+  <tabstop>mAnchorPointComboBox</tabstop>
+  <tabstop>mAnchorPointDDBtn</tabstop>
+  <tabstop>mCalloutBlendComboBox</tabstop>
+  <tabstop>mCalloutBlendModeDDBtn</tabstop>
   <tabstop>mDestXDDBtn</tabstop>
   <tabstop>mDestYDDBtn</tabstop>
  </tabstops>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -34,7 +34,7 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="7" column="3">
+     <item row="8" column="3">
       <widget class="QgsPropertyOverrideButton" name="mAnchorPointDDBtn">
        <property name="text">
         <string>…</string>
@@ -48,21 +48,21 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="3">
+     <item row="7" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromAnchorDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
+     <item row="7" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromAnchorUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -92,14 +92,14 @@
        </property>
      </widget>
      </item>
-     <item row="8" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="mAnchorPointLbl_2">
        <property name="text">
         <string>Label anchor point</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromLabelSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -145,14 +145,14 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="3">
+     <item row="4" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromLabelDDBtn">
        <property name="text">
         <string>…</string>
@@ -229,7 +229,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="7" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromAnchorSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -254,20 +254,20 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1" colspan="2">
+     <item row="8" column="1" colspan="2">
       <widget class="QComboBox" name="mAnchorPointComboBox"/>
      </item>
-     <item row="8" column="3">
+     <item row="5" column="3">
       <widget class="QgsPropertyOverrideButton" name="mLabelAnchorPointDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1" colspan="2">
+     <item row="5" column="1" colspan="2">
       <widget class="QComboBox" name="mLabelAnchorPointComboBox"/>
      </item>
-     <item row="5" column="2">
+     <item row="4" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromLabelUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -305,7 +305,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
         <string>Anchor point</string>
@@ -559,18 +559,18 @@
   <tabstop>mMinCalloutLengthSpin</tabstop>
   <tabstop>mMinCalloutWidthUnitWidget</tabstop>
   <tabstop>mMinCalloutLengthDDBtn</tabstop>
-  <tabstop>mOffsetFromAnchorSpin</tabstop>
-  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
-  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
   <tabstop>mOffsetFromLabelSpin</tabstop>
   <tabstop>mOffsetFromLabelUnitWidget</tabstop>
   <tabstop>mOffsetFromLabelDDBtn</tabstop>
-  <tabstop>mDrawToAllPartsCheck</tabstop>
-  <tabstop>mDrawToAllPartsDDBtn</tabstop>
-  <tabstop>mAnchorPointComboBox</tabstop>
-  <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mLabelAnchorPointComboBox</tabstop>
   <tabstop>mLabelAnchorPointDDBtn</tabstop>
+  <tabstop>mDrawToAllPartsCheck</tabstop>
+  <tabstop>mDrawToAllPartsDDBtn</tabstop>
+  <tabstop>mOffsetFromAnchorSpin</tabstop>
+  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
+  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
+  <tabstop>mAnchorPointComboBox</tabstop>
+  <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mCalloutBlendComboBox</tabstop>
   <tabstop>mCalloutBlendModeDDBtn</tabstop>
   <tabstop>mOriginXDDBtn</tabstop>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -76,21 +76,21 @@
       </widget>
      </item>
      <item row="9" column="3">
-     <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
+      <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
        <property name="text">
-       <string>…</string>
+        <string>…</string>
        </property>
-     </widget>
+      </widget>
      </item>
      <item row="9" column="1" colspan="2">
-     <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
+      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox" native="true"/>
      </item>
      <item row="9" column="0">
-     <widget class="QLabel" name="mCalloutBlendModeLbl">
+      <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
-       <string>Blend mode</string>
+        <string>Blend mode</string>
        </property>
-     </widget>
+      </widget>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="mAnchorPointLbl_2">
@@ -533,20 +533,25 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -308,7 +308,7 @@
      <item row="8" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
-        <string>Anchor point</string>
+        <string>Feature anchor point</string>
        </property>
       </widget>
      </item>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -49,7 +49,7 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_46">
+      <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
        </property>
@@ -86,7 +86,7 @@
      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
      </item>
      <item row="9" column="0">
-     <widget class="QLabel" name="label_18">
+     <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
        <string>Blend mode</string>
        </property>
@@ -125,7 +125,7 @@
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="mCalloutLineStyleLbl">
        <property name="text">
         <string>Line style</string>
        </property>
@@ -146,7 +146,7 @@
       </widget>
      </item>
      <item row="5" column="0">
-      <widget class="QLabel" name="label_47">
+      <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
        </property>
@@ -216,14 +216,14 @@
       </layout>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_45">
+      <widget class="QLabel" name="mMinCalloutLengthLbl">
        <property name="text">
         <string>Minimum length</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="mCurvatureLbl">
        <property name="text">
         <string>Curvature</string>
        </property>
@@ -326,7 +326,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="mCalloutOrientationLbl">
        <property name="text">
         <string>Orientation</string>
        </property>
@@ -380,7 +380,7 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_24">
            <item>
-            <widget class="QLabel" name="mCoordXLabel_3">
+            <widget class="QLabel" name="mCoordXLabel_2">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                <horstretch>0</horstretch>
@@ -400,7 +400,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="mCoordYLabel_3">
+            <widget class="QLabel" name="mCoordYLabel_2">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                <horstretch>0</horstretch>
@@ -447,7 +447,7 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_23">
         <item>
-         <widget class="QLabel" name="mCoordXLabel_2">
+         <widget class="QLabel" name="mCoordXLabel">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -467,7 +467,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="mCoordYLabel_2">
+         <widget class="QLabel" name="mCoordYLabel">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
             <horstretch>0</horstretch>

--- a/src/ui/callouts/widget_curvedlinecallout.ui
+++ b/src/ui/callouts/widget_curvedlinecallout.ui
@@ -99,7 +99,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="6" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromLabelSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -131,28 +131,28 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0" colspan="3">
+     <item row="4" column="0" colspan="3">
       <widget class="QCheckBox" name="mDrawToAllPartsCheck">
        <property name="text">
         <string>Draw lines to all feature parts</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
+     <item row="4" column="3">
       <widget class="QgsPropertyOverrideButton" name="mDrawToAllPartsDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="3">
+     <item row="6" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromLabelDDBtn">
        <property name="text">
         <string>…</string>
@@ -267,7 +267,7 @@
      <item row="5" column="1" colspan="2">
       <widget class="QComboBox" name="mLabelAnchorPointComboBox"/>
      </item>
-     <item row="4" column="2">
+     <item row="6" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromLabelUnitWidget" native="true">
        <property name="minimumSize">
         <size>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -271,7 +271,7 @@
      <item row="6" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
-        <string>Anchor point</string>
+        <string>Feature anchor point</string>
        </property>
       </widget>
      </item>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -34,7 +34,7 @@
      <property name="topMargin">
       <number>0</number>
      </property>
-     <item row="4" column="3">
+     <item row="2" column="3">
       <widget class="QgsPropertyOverrideButton" name="mDrawToAllPartsDDBtn">
        <property name="text">
         <string>…</string>
@@ -48,7 +48,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="4" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromLabelSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -113,7 +113,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
+     <item row="4" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromLabelDDBtn">
        <property name="text">
         <string>…</string>
@@ -150,7 +150,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
@@ -206,7 +206,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="4" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromLabelUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -219,7 +219,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="3">
+     <item row="2" column="0" colspan="3">
       <widget class="QCheckBox" name="mDrawToAllPartsCheck">
        <property name="text">
         <string>Draw lines to all feature parts</string>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -183,21 +183,21 @@
       </widget>
      </item>
      <item row="7" column="3">
-     <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
+      <widget class="QgsPropertyOverrideButton" name="mCalloutBlendModeDDBtn">
        <property name="text">
-       <string>…</string>
+        <string>…</string>
        </property>
-     </widget>
+      </widget>
      </item>
      <item row="7" column="1" colspan="2">
-     <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
+      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox" native="true"/>
      </item>
      <item row="7" column="0">
-     <widget class="QLabel" name="mCalloutBlendModeLbl">
+      <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
-       <string>Blend mode</string>
+        <string>Blend mode</string>
        </property>
-     </widget>
+      </widget>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="mAnchorPointLbl_2">
@@ -466,14 +466,14 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -483,7 +483,7 @@
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
-   <extends>QComboBox</extends>
+   <extends>QWidget</extends>
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -48,7 +48,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="2" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromLabelSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -73,7 +73,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
@@ -93,14 +93,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
+     <item row="5" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromAnchorDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="5" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromAnchorUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -113,7 +113,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="3">
+     <item row="2" column="3">
       <widget class="QgsPropertyOverrideButton" name="mOffsetFromLabelDDBtn">
        <property name="text">
         <string>…</string>
@@ -140,24 +140,24 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1" colspan="2">
+     <item row="3" column="1" colspan="2">
       <widget class="QComboBox" name="mLabelAnchorPointComboBox"/>
      </item>
-     <item row="5" column="3">
+     <item row="6" column="3">
       <widget class="QgsPropertyOverrideButton" name="mAnchorPointDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="5" column="1">
       <widget class="QgsDoubleSpinBox" name="mOffsetFromAnchorSpin">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -199,14 +199,14 @@
        </property>
      </widget>
      </item>
-     <item row="6" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="mAnchorPointLbl_2">
        <property name="text">
         <string>Label anchor point</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="2" column="2">
       <widget class="QgsUnitSelectionWidget" name="mOffsetFromLabelUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -251,7 +251,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="2">
+     <item row="6" column="1" colspan="2">
       <widget class="QComboBox" name="mAnchorPointComboBox"/>
      </item>
      <item row="1" column="0">
@@ -261,14 +261,14 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
+     <item row="3" column="3">
       <widget class="QgsPropertyOverrideButton" name="mLabelAnchorPointDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="mAnchorPointLbl">
        <property name="text">
         <string>Anchor point</string>
@@ -492,18 +492,18 @@
   <tabstop>mMinCalloutLengthSpin</tabstop>
   <tabstop>mMinCalloutWidthUnitWidget</tabstop>
   <tabstop>mMinCalloutLengthDDBtn</tabstop>
-  <tabstop>mOffsetFromAnchorSpin</tabstop>
-  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
-  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
   <tabstop>mOffsetFromLabelSpin</tabstop>
   <tabstop>mOffsetFromLabelUnitWidget</tabstop>
   <tabstop>mOffsetFromLabelDDBtn</tabstop>
-  <tabstop>mDrawToAllPartsCheck</tabstop>
-  <tabstop>mDrawToAllPartsDDBtn</tabstop>
-  <tabstop>mAnchorPointComboBox</tabstop>
-  <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mLabelAnchorPointComboBox</tabstop>
   <tabstop>mLabelAnchorPointDDBtn</tabstop>
+  <tabstop>mDrawToAllPartsCheck</tabstop>
+  <tabstop>mDrawToAllPartsDDBtn</tabstop>
+  <tabstop>mOffsetFromAnchorSpin</tabstop>
+  <tabstop>mOffsetFromAnchorUnitWidget</tabstop>
+  <tabstop>mOffsetFromAnchorDDBtn</tabstop>
+  <tabstop>mAnchorPointComboBox</tabstop>
+  <tabstop>mAnchorPointDDBtn</tabstop>
   <tabstop>mCalloutBlendComboBox</tabstop>
   <tabstop>mCalloutBlendModeDDBtn</tabstop>
   <tabstop>mOriginXDDBtn</tabstop>

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -74,7 +74,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_46">
+      <widget class="QLabel" name="mOffsetFromAnchorLbl">
        <property name="text">
         <string>Offset from feature</string>
        </property>
@@ -121,7 +121,7 @@
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="mCalloutLineStyleLbl">
        <property name="text">
         <string>Line style</string>
        </property>
@@ -151,7 +151,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_47">
+      <widget class="QLabel" name="mOffsetFromLabelLbl">
        <property name="text">
         <string>Offset from label area</string>
        </property>
@@ -193,7 +193,7 @@
      <widget class="QgsBlendModeComboBox" name="mCalloutBlendComboBox"/>
      </item>
      <item row="7" column="0">
-     <widget class="QLabel" name="label_18">
+     <widget class="QLabel" name="mCalloutBlendModeLbl">
        <property name="text">
        <string>Blend mode</string>
        </property>
@@ -255,7 +255,7 @@
       <widget class="QComboBox" name="mAnchorPointComboBox"/>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_45">
+      <widget class="QLabel" name="mMinCalloutLengthLbl">
        <property name="text">
         <string>Minimum length</string>
        </property>
@@ -313,7 +313,7 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_24">
            <item>
-            <widget class="QLabel" name="mCoordXLabel_3">
+            <widget class="QLabel" name="mCoordXLabel_2">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                <horstretch>0</horstretch>
@@ -333,7 +333,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="mCoordYLabel_3">
+            <widget class="QLabel" name="mCoordYLabel_2">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                <horstretch>0</horstretch>
@@ -380,7 +380,7 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_23">
         <item>
-         <widget class="QLabel" name="mCoordXLabel_2">
+         <widget class="QLabel" name="mCoordXLabel">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -400,7 +400,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="mCoordYLabel_2">
+         <widget class="QLabel" name="mCoordYLabel">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
             <horstretch>0</horstretch>


### PR DESCRIPTION
This PR groups callouts properties, first showing settings affecting the callout rendering and then its relation with the feature (mainly, `offset from feature` and `anchor point`). The logic behind is:
1. configure the look of the callout
2. configure how it relates with its origin, ie the label (label anchor point and its offset)
3. configure how it relates with the destination, ie the feature (feature anchor point and its offset)

This allows to have the common settings at the "same" place regardless the callout type, and makes documenting them easier, more linear (avoids readers/writers going back and forth to find explanation)

![oldCalloutsCurved](https://user-images.githubusercontent.com/7983394/119279075-9e45fd00-bc29-11eb-8d75-277ca05e61a0.png)
![newSimpleCallout](https://user-images.githubusercontent.com/7983394/119279082-a736ce80-bc29-11eb-9428-d87887b6f6a1.png)
![new_callout](https://user-images.githubusercontent.com/7983394/119279103-c897ba80-bc29-11eb-8e37-2e932b06ecef.png)
(no strong opinion with moving the margins back to the bottom)
