### PR TITLE
Raise a user-visible warning message if fonts referenced in a QGIS project/QLR file are not available on system

### DIFF
--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -64,14 +64,14 @@ Returns path resolver for conversion between relative and absolute paths
 Sets up path resolver for conversion between relative and absolute paths
 %End
 
-    void pushMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning );
+    void pushMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning ) const;
 %Docstring
 Append a message to the context
 
 .. versionadded:: 3.2
 %End
 
-QgsReadWriteContextCategoryPopper enterCategory( const QString &category, const QString &details = QString() ) /PyName=_enterCategory/;
+QgsReadWriteContextCategoryPopper enterCategory( const QString &category, const QString &details = QString() ) const /PyName=_enterCategory/;
 %Docstring
 Push a category to the stack
 
@@ -148,7 +148,7 @@ This would happen when it gets out of scope.
 #include "qgsreadwritecontext.h"
 %End
   public:
-    QgsReadWriteContextCategoryPopper( QgsReadWriteContext &context );
+    QgsReadWriteContextCategoryPopper( const QgsReadWriteContext &context );
 %Docstring
 Creates a popper
 %End

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -45,6 +45,16 @@ Returns the message level
 Returns the stack of categories of the message
 %End
 
+        bool operator==( const QgsReadWriteContext::ReadWriteMessage &other ) const;
+
+        bool operator!=( const QgsReadWriteContext::ReadWriteMessage &other ) const;
+
+        SIP_PYOBJECT __repr__();
+%MethodCode
+        QString str = QStringLiteral( "<QgsReadWriteContext.ReadWriteMessage: %1>" ).arg( sipCpp->message() );
+        sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     };
 
     QgsReadWriteContext();

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -25,7 +25,7 @@ The class is used as a container of context for various read/write operations on
 
     struct ReadWriteMessage
     {
-        ReadWriteMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning, const QStringList &categories = QStringList() );
+        ReadWriteMessage( const QString &message = QString(), Qgis::MessageLevel level = Qgis::Warning, const QStringList &categories = QStringList() );
 %Docstring
 Construct a container for QgsReadWriteContext error or warning messages
 %End

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -974,6 +974,14 @@ Creates a new QgsFontMarkerSymbolLayer from a property map (see :py:func:`~QgsFo
 Creates a new QgsFontMarkerSymbolLayer from an SLD XML ``element``.
 %End
 
+    static void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
+%Docstring
+Resolves fonts from a ``properties`` map, raising warnings in the specified ``context`` if the
+required fonts are not available on the system.
+
+.. versionadded:: 3.20
+%End
+
 
     virtual QString layerType() const;
 

--- a/python/core/auto_generated/symbology/qgssymbollayerregistry.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerregistry.sip.in
@@ -65,6 +65,16 @@ instances the paths are always absolute
 .. versionadded:: 3.0
 %End
 
+    virtual void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
+%Docstring
+Resolve fonts from the  symbol layer's ``properties``.
+
+This tests whether the required fonts from the encoded ``properties`` are available on the system, and records
+warnings in the ``context`` if not.
+
+.. versionadded:: 3.20
+%End
+
   protected:
 };
 
@@ -87,7 +97,10 @@ Convenience metadata class that uses static functions to create symbol layer and
     virtual QgsSymbolLayer *createSymbolLayerFromSld( QDomElement &elem ) /Factory/;
     virtual void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 
+    virtual void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
+
   protected:
+
 
   private:
     QgsSymbolLayerMetadata();
@@ -139,6 +152,16 @@ This normally means converting relative paths to absolute paths when loading
 and converting absolute paths to relative paths when saving.
 
 .. versionadded:: 3.0
+%End
+
+    void resolveFonts( const QString &name, QVariantMap &properties, const QgsReadWriteContext &context ) const;
+%Docstring
+Resolve fonts from the ``properties`` of a particular symbol layer.
+
+This tests whether the required fonts from the encoded ``properties`` are available on the system, and records
+warnings in the ``context`` if not.
+
+.. versionadded:: 3.20
 %End
 
     QStringList symbolLayersForType( Qgis::SymbolType type );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14433,9 +14433,15 @@ void QgisApp::showStatusMessage( const QString &message )
 
 void QgisApp::loadingLayerMessages( const QString &layerName, const QList<QgsReadWriteContext::ReadWriteMessage> &messages )
 {
-  for ( const auto &message : messages )
+  QVector<QgsReadWriteContext::ReadWriteMessage> shownMessages;
+  for ( const QgsReadWriteContext::ReadWriteMessage &message : messages )
   {
+    if ( shownMessages.contains( message ) )
+      continue;
+
     visibleMessageBar()->pushMessage( layerName, message.message(), message.categories().join( '\n' ), message.level() );
+
+    shownMessages.append( message );
   }
 }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1743,6 +1743,8 @@ void QgsMapLayer::readCommonStyle( const QDomElement &layerElement, const QgsRea
 {
   if ( categories.testFlag( Symbology3D ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "3D Symbology" ) );
+
     QgsAbstract3DRenderer *r3D = nullptr;
     QDomElement renderer3DElem = layerElement.firstChildElement( QStringLiteral( "renderer-3d" ) );
     if ( !renderer3DElem.isNull() )
@@ -1803,12 +1805,16 @@ void QgsMapLayer::readCommonStyle( const QDomElement &layerElement, const QgsRea
 
   if ( categories.testFlag( Temporal ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Temporal" ) );
+
     if ( QgsMapLayerTemporalProperties *properties = temporalProperties() )
       properties->readXml( layerElement.toElement(), context );
   }
 
   if ( categories.testFlag( Elevation ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Elevation" ) );
+
     if ( QgsMapLayerElevationProperties *properties = elevationProperties() )
       properties->readXml( layerElement.toElement(), context );
   }

--- a/src/core/qgsreadwritecontext.cpp
+++ b/src/core/qgsreadwritecontext.cpp
@@ -54,12 +54,12 @@ void QgsReadWriteContext::setPathResolver( const QgsPathResolver &resolver )
   mPathResolver = resolver;
 }
 
-void QgsReadWriteContext::pushMessage( const QString &message, Qgis::MessageLevel level )
+void QgsReadWriteContext::pushMessage( const QString &message, Qgis::MessageLevel level ) const
 {
   mMessages.append( ReadWriteMessage( message, level, mCategories ) );
 }
 
-QgsReadWriteContextCategoryPopper QgsReadWriteContext::enterCategory( const QString &category, const QString &details )
+QgsReadWriteContextCategoryPopper QgsReadWriteContext::enterCategory( const QString &category, const QString &details ) const
 {
   QString message = category;
   if ( !details.isEmpty() )
@@ -68,7 +68,7 @@ QgsReadWriteContextCategoryPopper QgsReadWriteContext::enterCategory( const QStr
   return QgsReadWriteContextCategoryPopper( *this );
 }
 
-void QgsReadWriteContext::leaveCategory()
+void QgsReadWriteContext::leaveCategory() const
 {
   if ( !mCategories.isEmpty() )
     mCategories.pop_back();

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -57,6 +57,24 @@ class CORE_EXPORT QgsReadWriteContext
         //! Returns the stack of categories of the message
         QStringList categories() const {return mCategories;}
 
+        bool operator==( const QgsReadWriteContext::ReadWriteMessage &other ) const
+        {
+          return mMessage == other.mMessage && mLevel == other.mLevel && mCategories == other.mCategories;
+        }
+
+        bool operator!=( const QgsReadWriteContext::ReadWriteMessage &other ) const
+        {
+          return !( *this == other );
+        }
+
+#ifdef SIP_RUN
+        SIP_PYOBJECT __repr__();
+        % MethodCode
+        QString str = QStringLiteral( "<QgsReadWriteContext.ReadWriteMessage: %1>" ).arg( sipCpp->message() );
+        sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+        % End
+#endif
+
       private:
         QString mMessage;
         Qgis::MessageLevel mLevel;

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsReadWriteContext
      * Append a message to the context
      * \since QGIS 3.2
      */
-    void pushMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning );
+    void pushMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning ) const;
 
     /**
      * Push a category to the stack
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsReadWriteContext
      * \endcode
      * \since QGIS 3.2
      */
-    MAYBE_UNUSED NODISCARD QgsReadWriteContextCategoryPopper enterCategory( const QString &category, const QString &details = QString() ) SIP_PYNAME( _enterCategory );
+    MAYBE_UNUSED NODISCARD QgsReadWriteContextCategoryPopper enterCategory( const QString &category, const QString &details = QString() ) const SIP_PYNAME( _enterCategory );
 
     /**
      * Returns the stored messages and remove them
@@ -136,11 +136,11 @@ class CORE_EXPORT QgsReadWriteContext
   private:
 
     //! Pop the last category
-    void leaveCategory();
+    void leaveCategory() const;
 
     QgsPathResolver mPathResolver;
-    QList<ReadWriteMessage> mMessages;
-    QStringList mCategories = QStringList();
+    mutable QList<ReadWriteMessage> mMessages;
+    mutable QStringList mCategories = QStringList();
     QgsProjectTranslator *mProjectTranslator = nullptr;
     friend class QgsReadWriteContextCategoryPopper;
     QgsCoordinateTransformContext mCoordinateTransformContext = QgsCoordinateTransformContext();
@@ -159,14 +159,14 @@ class CORE_EXPORT QgsReadWriteContextCategoryPopper
 {
   public:
     //! Creates a popper
-    QgsReadWriteContextCategoryPopper( QgsReadWriteContext &context ) : mContext( context ) {}
+    QgsReadWriteContextCategoryPopper( const QgsReadWriteContext &context ) : mContext( context ) {}
     ~QgsReadWriteContextCategoryPopper() {mContext.leaveCategory();}
   private:
 #ifdef SIP_RUN
     QgsReadWriteContextCategoryPopper &operator=( const QgsReadWriteContextCategoryPopper & );
 #endif
 
-    QgsReadWriteContext &mContext;
+    const QgsReadWriteContext &mContext;
 };
 
 #endif // QGSREADWRITECONTEXT_H

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsReadWriteContext
     struct ReadWriteMessage
     {
         //! Construct a container for QgsReadWriteContext error or warning messages
-        ReadWriteMessage( const QString &message, Qgis::MessageLevel level = Qgis::Warning, const QStringList &categories = QStringList() )
+        ReadWriteMessage( const QString &message = QString(), Qgis::MessageLevel level = Qgis::Warning, const QStringList &categories = QStringList() )
           : mMessage( message )
           , mLevel( level )
           , mCategories( categories )

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3666,6 +3666,14 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
   return m;
 }
 
+void QgsFontMarkerSymbolLayer::resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context )
+{
+  const QString fontFamily = properties.value( QStringLiteral( "font" ), DEFAULT_FONTMARKER_FONT ).toString();
+  if ( !QgsFontUtils::fontFamilyMatchOnSystem( fontFamily ) )
+  {
+    context.pushMessage( QObject::tr( "Font “%1” not available on system" ).arg( fontFamily ) );
+  }
+}
 
 void QgsSvgMarkerSymbolLayer::prepareExpressions( const QgsSymbolRenderContext &context )
 {

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -895,6 +895,14 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
      */
     static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
 
+    /**
+     * Resolves fonts from a \a properties map, raising warnings in the specified \a context if the
+     * required fonts are not available on the system.
+     *
+     * \since QGIS 3.20
+     */
+    static void resolveFonts( const QVariantMap &properties, const QgsReadWriteContext &context );
+
     // implemented from base classes
 
     QString layerType() const override;

--- a/src/core/symbology/qgssymbollayerregistry.cpp
+++ b/src/core/symbology/qgssymbollayerregistry.cpp
@@ -48,7 +48,7 @@ QgsSymbolLayerRegistry::QgsSymbolLayerRegistry()
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "RasterMarker" ), QObject::tr( "Raster Image Marker" ), Qgis::SymbolType::Marker,
                       QgsRasterMarkerSymbolLayer::create, nullptr, QgsRasterFillSymbolLayer::resolvePaths ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "FontMarker" ), QObject::tr( "Font Marker" ), Qgis::SymbolType::Marker,
-                      QgsFontMarkerSymbolLayer::create, QgsFontMarkerSymbolLayer::createFromSld ) );
+                      QgsFontMarkerSymbolLayer::create, QgsFontMarkerSymbolLayer::createFromSld, nullptr, nullptr, QgsFontMarkerSymbolLayer::resolveFonts ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "EllipseMarker" ), QObject::tr( "Ellipse Marker" ), Qgis::SymbolType::Marker,
                       QgsEllipseSymbolLayer::create, QgsEllipseSymbolLayer::createFromSld ) );
   addSymbolLayerType( new QgsSymbolLayerMetadata( QStringLiteral( "VectorField" ), QObject::tr( "Vector Field Marker" ), Qgis::SymbolType::Marker,
@@ -142,6 +142,14 @@ void QgsSymbolLayerRegistry::resolvePaths( const QString &name, QVariantMap &pro
     return;
 
   mMetadata[name]->resolvePaths( properties, pathResolver, saving );
+}
+
+void QgsSymbolLayerRegistry::resolveFonts( const QString &name, QVariantMap &properties, const QgsReadWriteContext &context ) const
+{
+  if ( !mMetadata.contains( name ) )
+    return;
+
+  mMetadata[name]->resolveFonts( properties, context );
 }
 
 QStringList QgsSymbolLayerRegistry::symbolLayersForType( Qgis::SymbolType type )

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1171,6 +1171,8 @@ QgsSymbolLayer *QgsSymbolLayerUtils::loadSymbolLayer( QDomElement &element, cons
   // if there are any paths stored in properties, convert them from relative to absolute
   QgsApplication::symbolLayerRegistry()->resolvePaths( layerClass, props, context.pathResolver(), false );
 
+  QgsApplication::symbolLayerRegistry()->resolveFonts( layerClass, props, context );
+
   QgsSymbolLayer *layer = nullptr;
   layer = QgsApplication::symbolLayerRegistry()->createSymbolLayer( layerClass, props );
   if ( layer )

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -467,6 +467,11 @@ void QgsTextFormat::readXml( const QDomElement &elem, const QgsReadWriteContext 
     mTextFontFound = true;
   }
 
+  if ( !mTextFontFound )
+  {
+    context.pushMessage( QObject::tr( "Font “%1” not available on system" ).arg( mTextFontFamily ) );
+  }
+
   if ( textStyleElem.hasAttribute( QStringLiteral( "fontSize" ) ) )
   {
     d->fontSize = textStyleElem.attribute( QStringLiteral( "fontSize" ) ).toDouble();

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2151,8 +2151,6 @@ void QgsVectorLayer::resolveReferences( QgsProject *project )
 bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMessage,
                                     QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories )
 {
-  QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Symbology" ) );
-
   if ( categories.testFlag( Fields ) )
   {
     if ( !mExpressionFieldBuffer )
@@ -2164,6 +2162,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
 
   if ( categories.testFlag( Relations ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Relations" ) );
 
     const QgsPathResolver resolver { QgsProject::instance()->pathResolver() };
 
@@ -2346,6 +2345,8 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
   // load field configuration
   if ( categories.testFlag( Fields ) || categories.testFlag( Forms ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Forms" ) );
+
     QDomElement widgetsElem = layerNode.namedItem( QStringLiteral( "fieldConfiguration" ) ).toElement();
     QDomNodeList fieldConfigurationElementList = widgetsElem.elementsByTagName( QStringLiteral( "field" ) );
     for ( int i = 0; i < fieldConfigurationElementList.size(); ++i )
@@ -2427,6 +2428,8 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
 
   if ( categories.testFlag( Legend ) )
   {
+    QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Legend" ) );
+
     const QDomElement legendElem = layerNode.firstChildElement( QStringLiteral( "legend" ) );
     if ( !legendElem.isNull() )
     {
@@ -2458,6 +2461,8 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage,
     // try renderer v2 first
     if ( categories.testFlag( Symbology ) )
     {
+      QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Symbology" ) );
+
       QDomElement rendererElement = node.firstChildElement( RENDERER_TAG_NAME );
       if ( !rendererElement.isNull() )
       {
@@ -2481,6 +2486,8 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage,
     // read labeling definition
     if ( categories.testFlag( Labeling ) )
     {
+      QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Labeling" ) );
+
       QDomElement labelingElement = node.firstChildElement( QStringLiteral( "labeling" ) );
       QgsAbstractVectorLayerLabeling *labeling = nullptr;
       if ( labelingElement.isNull() ||
@@ -2571,6 +2578,8 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage,
     //diagram renderer and diagram layer settings
     if ( categories.testFlag( Diagrams ) )
     {
+      QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Diagrams" ) );
+
       delete mDiagramRenderer;
       mDiagramRenderer = nullptr;
       QDomElement singleCatDiagramElem = node.firstChildElement( QStringLiteral( "SingleCategoryDiagramRenderer" ) );

--- a/tests/src/python/test_qgsreadwritecontext.py
+++ b/tests/src/python/test_qgsreadwritecontext.py
@@ -49,6 +49,16 @@ class TestQgsReadWriteContext(unittest.TestCase):
         self.assertEqual(messages[4].message(), 'msg4')
         self.assertEqual(messages[4].categories(), [])
 
+    def test_message_equality(self):
+        """
+        Test QgsReadWriteContext.ReadWriteMessage equality operator
+        """
+        m1 = QgsReadWriteContext.ReadWriteMessage('m1', Qgis.Info, ['cat1', 'cat2'])
+        self.assertEqual(m1, QgsReadWriteContext.ReadWriteMessage('m1', Qgis.Info, ['cat1', 'cat2']))
+        self.assertNotEqual(m1, QgsReadWriteContext.ReadWriteMessage('m2', Qgis.Info, ['cat1', 'cat2']))
+        self.assertNotEqual(m1, QgsReadWriteContext.ReadWriteMessage('m1', Qgis.Warning, ['cat1', 'cat2']))
+        self.assertNotEqual(m1, QgsReadWriteContext.ReadWriteMessage('m1', Qgis.Info, ['cat3', 'cat2']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently shown for any labeling or font marker symbol layer fonts restored when opening the project