### PR TITLE
Server: fix unreported QGIS_OPTIONS_PATH not really working for proj

### DIFF
--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -192,7 +192,10 @@ bool QgsServer::init()
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );
   QCoreApplication::setApplicationName( QgsApplication::QGIS_APPLICATION_NAME );
 
-  QgsApplication::init();
+  // TODO: remove QGIS_OPTIONS_PATH from settings and rely on QgsApplication's env var QGIS_CUSTOM_CONFIG_PATH
+  //       Note that QGIS_CUSTOM_CONFIG_PATH gives /tmp/qt_temp-rUpsId/profiles/default/QGIS/QGIS3.ini
+  //       while     QGIS_OPTIONS_PATH gives       /tmp/qt_temp-rUpsId/QGIS/QGIS3.ini
+  QgsApplication::init( qgetenv( "QGIS_OPTIONS_PATH" ) );
 
 #if defined(SERVER_SKIP_ECW)
   QgsMessageLog::logMessage( "Skipping GDAL ECW drivers in server.", "Server", Qgis::Info );


### PR DESCRIPTION
Symptom: PROJ search path not including QGIS_OPTIONS_PATH because
initialization of QgsApplication happens before QgsServer loads
the settings.

TODO for the future:
remove QGIS_OPTIONS_PATH from settings and rely on QgsApplication's
env var QGIS_CUSTOM_CONFIG_PATH

```
Note that QGIS_CUSTOM_CONFIG_PATH gives /tmp/qt_temp-rUpsId/profiles/default/QGIS/QGIS3.ini
   while  QGIS_OPTIONS_PATH       gives /tmp/qt_temp-rUpsId/QGIS/QGIS3.ini
```

I tried to write a test for this but I've found no way to get the search path after `proj_context_set_search_paths`.
