### PR TITLE
QgsOgrLayer::GetApproxFeatureCount(): fix wrong test on WFS3 driver name

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -6598,7 +6598,7 @@ GIntBig QgsOgrLayer::GetApproxFeatureCount()
       }
     }
   }
-  if ( driverName == QLatin1String( "OAPIF" ) || driverName == QLatin1String( "OAPIF" ) )
+  if ( driverName == QLatin1String( "OAPIF" ) || driverName == QLatin1String( "WFS3" ) )
   {
     return -1;
   }


### PR DESCRIPTION
WFS3 was the name in GDAL 3.0, before we changed to OAPIF in 3.1