### PR TITLE
Fix extreme zoom out

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -19,10 +19,17 @@ This page tries to maintain a list with incompatible changes that happened in pr
 QGIS 3.20        {#qgis_api_break_3_20}
 =========
 
+QgsMapRendererJob       {#qgis_api_break_3_20_qgsmaprendererjob}
+-----------------
+
+- QgsMapRendererJob::start is no longer virtual. It has been replaced with QgsMapRendererJob::startPrivate. The method QgsMapRendererJob::start checks if the map can be rendered before calling QgsMapRendererJob::startPrivate.
+Subclasses have to implement the virtual method startPrivate to start the rendering of the map. For the actual subclasses (QgsMapRendererParallelJob, QgsMapRendererSequentialJob, ...), the start method
+is replaced by startPrivate method without change.
+
 setDataSource       {#qgis_api_break_3_20_setdatasource}
 -------------
 
-- QgsMapLayer::setDataSource is no longer virtual. If has been replaced with QgsMapLayer::setDataSourcePrivate. This is only relevant for subclassing QgsMapLayer, for code that only uses the subclasses (QgsVectorLayer, QgsRasterLayer, ...) this has no effect.
+- QgsMapLayer::setDataSource is no longer virtual. It has been replaced with QgsMapLayer::setDataSourcePrivate. This is only relevant for subclassing QgsMapLayer, for code that only uses the subclasses (QgsVectorLayer, QgsRasterLayer, ...) this has no effect.
 
 QGIS 3.4        {#qgis_api_break_3_4}
 ========

--- a/python/core/auto_generated/maprenderer/qgsmaprenderercustompainterjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprenderercustompainterjob.sip.in
@@ -9,7 +9,7 @@
 
 
 
-class QgsMapRendererAbstractCustomPainterJob : QgsMapRendererJob
+class QgsMapRendererAbstractCustomPainterJob : QgsMapRendererJob /Abstract/
 {
 %Docstring(signature="appended")
 Abstract base class for map renderer jobs which use custom painters.

--- a/python/core/auto_generated/maprenderer/qgsmaprenderercustompainterjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprenderercustompainterjob.sip.in
@@ -58,8 +58,6 @@ platforms).
     QgsMapRendererCustomPainterJob( const QgsMapSettings &settings, QPainter *painter );
     ~QgsMapRendererCustomPainterJob();
 
-    virtual void start();
-
     virtual void cancel();
 
     virtual void cancelWithoutBlocking();
@@ -124,6 +122,7 @@ and an alternative to :py:func:`~QgsMapRendererCustomPainterJob.renderSynchronou
 
 .. versionadded:: 3.10
 %End
+
 
 };
 

--- a/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
@@ -49,7 +49,7 @@ The following subclasses are available:
 
     QgsMapRendererJob( const QgsMapSettings &settings );
 
-    virtual void start() = 0;
+    void start();
 %Docstring
 Start the rendering job and immediately return.
 Does nothing if the rendering is already in progress.

--- a/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
@@ -13,7 +13,7 @@
 
 
 
-class QgsMapRendererJob : QObject
+class QgsMapRendererJob : QObject /Abstract/
 {
 %Docstring(signature="appended")
 Abstract base class for map rendering implementations.
@@ -198,7 +198,7 @@ emitted when asynchronous rendering is finished (or canceled).
 };
 
 
-class QgsMapRendererQImageJob : QgsMapRendererJob
+class QgsMapRendererQImageJob : QgsMapRendererJob /Abstract/
 {
 %Docstring(signature="appended")
 Intermediate base class adding functionality that allows client to query the rendered image.

--- a/python/core/auto_generated/maprenderer/qgsmaprendererparalleljob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprendererparalleljob.sip.in
@@ -26,8 +26,6 @@ It is safe to call that function while rendering is active to see preview of the
     QgsMapRendererParallelJob( const QgsMapSettings &settings );
     ~QgsMapRendererParallelJob();
 
-    virtual void start();
-
     virtual void cancel();
 
     virtual void cancelWithoutBlocking();

--- a/python/core/auto_generated/maprenderer/qgsmaprenderersequentialjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprenderersequentialjob.sip.in
@@ -27,8 +27,6 @@ It is safe to call that function while rendering is active to see preview of the
     QgsMapRendererSequentialJob( const QgsMapSettings &settings );
     ~QgsMapRendererSequentialJob();
 
-    virtual void start();
-
     virtual void cancel();
 
     virtual void cancelWithoutBlocking();

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -183,7 +183,7 @@ Set parameters for use in transforming coordinates
 
 .. note::
 
-   if parameters leads to a non valid transform, parameters are not changed
+   if the specified parameters result in an invalid transform then no changes will be applied to the object
 
 .. versionadded:: 2.8
 %End

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -181,8 +181,13 @@ Set parameters for use in transforming coordinates
 :param heightPixels: Output height, in pixels
 :param rotation: clockwise rotation in degrees
 
+.. note::
+
+   if parameters leads to a non valid transform, parameters are not changed
+
 .. versionadded:: 2.8
 %End
+
 
     QString showParameters() const;
 %Docstring

--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -95,6 +95,9 @@ void QgsMeshTerrainGenerator::setLayer( QgsMeshLayer *layer )
   mLayer = QgsMapLayerRef( layer );
   mIsValid = layer != nullptr;
 
+  if ( layer )
+    mTerrainTilingScheme = QgsTilingScheme( layer->extent(), layer->crs() );
+
   updateTriangularMesh();
 }
 
@@ -108,7 +111,7 @@ QgsTerrainGenerator *QgsMeshTerrainGenerator::clone() const
 {
   QgsMeshTerrainGenerator *cloned = new QgsMeshTerrainGenerator();
   cloned->mLayer = mLayer;
-  cloned->mTerrainTilingScheme = QgsTilingScheme();
+  cloned->mTerrainTilingScheme = mTerrainTilingScheme;
   cloned->mCrs = mCrs;
   cloned->mSymbol.reset( mSymbol->clone() );
   cloned->mTransformContext = mTransformContext;

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -75,7 +75,7 @@ QgsMapRendererCustomPainterJob::~QgsMapRendererCustomPainterJob()
   //cancel();
 }
 
-void QgsMapRendererCustomPainterJob::start()
+void QgsMapRendererCustomPainterJob::startPrivate()
 {
   if ( isActive() )
     return;

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.h
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.h
@@ -28,7 +28,7 @@
  *
  * \since QGIS 3.10
  */
-class CORE_EXPORT QgsMapRendererAbstractCustomPainterJob : public QgsMapRendererJob
+class CORE_EXPORT QgsMapRendererAbstractCustomPainterJob : public QgsMapRendererJob SIP_ABSTRACT
 {
     Q_OBJECT
   public:

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.h
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.h
@@ -67,7 +67,6 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererAbstract
     QgsMapRendererCustomPainterJob( const QgsMapSettings &settings, QPainter *painter );
     ~QgsMapRendererCustomPainterJob() override;
 
-    void start() override;
     void cancel() override;
     void cancelWithoutBlocking() override;
     void waitForFinished() override;
@@ -128,11 +127,14 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererAbstract
      */
     void renderPrepared();
 
+
   private slots:
     void futureFinished();
 
   private:
     static void staticRender( QgsMapRendererCustomPainterJob *self ); // function to be used within the thread
+
+    void startPrivate() override;
 
     // these methods are called within worker thread
     void doRender();

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -70,10 +70,18 @@ bool LayerRenderJob::imageCanBeComposed() const
 
 QgsMapRendererJob::QgsMapRendererJob( const QgsMapSettings &settings )
   : mSettings( settings )
+{}
 
+void QgsMapRendererJob::start()
 {
+  if ( mSettings.hasValidSettings() )
+    startPrivate();
+  else
+  {
+    mErrors.append( QgsMapRendererJob::Error( QString(), tr( "Invalid map settings" ) ) );
+    emit finished();
+  }
 }
-
 
 QgsMapRendererQImageJob::QgsMapRendererQImageJob( const QgsMapSettings &settings )
   : QgsMapRendererJob( settings )

--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -221,7 +221,7 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      * Start the rendering job and immediately return.
      * Does nothing if the rendering is already in progress.
      */
-    virtual void start() = 0;
+    void start();
 
     /**
      * Stop the rendering job - does not return until the job has terminated.
@@ -490,6 +490,14 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
 
     //! Convenient method to allocate a new image and a new QPainter on this image
     QPainter *allocateImageAndPainter( QString layerId, QImage *&image );
+
+    /**
+     *  This virtual method has to be implemented in derived class for starting the rendering.
+     *  This method is called in start() method after ckecking if the map can be rendered.
+     *  \since QGIS 3.20
+     */
+    virtual void startPrivate() {};
+
 };
 
 

--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -210,7 +210,7 @@ struct LabelRenderJob
  *
  * \since QGIS 2.4
  */
-class CORE_EXPORT QgsMapRendererJob : public QObject
+class CORE_EXPORT QgsMapRendererJob : public QObject SIP_ABSTRACT
 {
     Q_OBJECT
   public:
@@ -492,11 +492,11 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     QPainter *allocateImageAndPainter( QString layerId, QImage *&image );
 
     /**
-     *  This virtual method has to be implemented in derived class for starting the rendering.
+     *  This pure virtual method has to be implemented in derived class for starting the rendering.
      *  This method is called in start() method after ckecking if the map can be rendered.
      *  \since QGIS 3.20
      */
-    virtual void startPrivate() {};
+    virtual void startPrivate() = 0;
 
 };
 
@@ -509,7 +509,7 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
  *
  * \since QGIS 2.4
  */
-class CORE_EXPORT QgsMapRendererQImageJob : public QgsMapRendererJob
+class CORE_EXPORT QgsMapRendererQImageJob : public QgsMapRendererJob SIP_ABSTRACT
 {
     Q_OBJECT
 

--- a/src/core/maprenderer/qgsmaprendererparalleljob.cpp
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.cpp
@@ -40,7 +40,7 @@ QgsMapRendererParallelJob::~QgsMapRendererParallelJob()
   }
 }
 
-void QgsMapRendererParallelJob::start()
+void QgsMapRendererParallelJob::startPrivate()
 {
   if ( isActive() )
     return;

--- a/src/core/maprenderer/qgsmaprendererparalleljob.h
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.h
@@ -36,7 +36,6 @@ class CORE_EXPORT QgsMapRendererParallelJob : public QgsMapRendererQImageJob
     QgsMapRendererParallelJob( const QgsMapSettings &settings );
     ~QgsMapRendererParallelJob() override;
 
-    void start() override;
     void cancel() override;
     void cancelWithoutBlocking() override;
     void waitForFinished() override;
@@ -62,6 +61,8 @@ class CORE_EXPORT QgsMapRendererParallelJob : public QgsMapRendererQImageJob
     static void renderLayerStatic( LayerRenderJob &job ) SIP_SKIP;
     //! \note not available in Python bindings
     static void renderLabelsStatic( QgsMapRendererParallelJob *self ) SIP_SKIP;
+
+    void startPrivate() override;
 
     QImage mFinalImage;
 

--- a/src/core/maprenderer/qgsmaprenderersequentialjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderersequentialjob.cpp
@@ -47,7 +47,7 @@ QgsMapRendererSequentialJob::~QgsMapRendererSequentialJob()
 }
 
 
-void QgsMapRendererSequentialJob::start()
+void QgsMapRendererSequentialJob::startPrivate()
 {
   if ( isActive() )
     return; // do nothing if we are already running

--- a/src/core/maprenderer/qgsmaprenderersequentialjob.h
+++ b/src/core/maprenderer/qgsmaprenderersequentialjob.h
@@ -37,7 +37,6 @@ class CORE_EXPORT QgsMapRendererSequentialJob : public QgsMapRendererQImageJob
     QgsMapRendererSequentialJob( const QgsMapSettings &settings );
     ~QgsMapRendererSequentialJob() override;
 
-    void start() override;
     void cancel() override;
     void cancelWithoutBlocking() override;
     void waitForFinished() override;
@@ -54,6 +53,8 @@ class CORE_EXPORT QgsMapRendererSequentialJob : public QgsMapRendererQImageJob
     void internalFinished();
 
   private:
+
+    void startPrivate() override;
 
     QgsMapRendererCustomPainterJob *mInternalJob = nullptr;
     QImage mImage;

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
@@ -36,7 +36,7 @@ QgsMapRendererStagedRenderJob::~QgsMapRendererStagedRenderJob()
 }
 
 
-void QgsMapRendererStagedRenderJob::start()
+void QgsMapRendererStagedRenderJob::startPrivate()
 {
   mRenderingStart.start();
   mErrors.clear();

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.h
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.h
@@ -62,7 +62,6 @@ class CORE_EXPORT QgsMapRendererStagedRenderJob : public QgsMapRendererAbstractC
     QgsMapRendererStagedRenderJob( const QgsMapSettings &settings, Flags flags = Flags() );
     ~QgsMapRendererStagedRenderJob() override;
 
-    void start() override;
     void cancel() override;
     void cancelWithoutBlocking() override;
     void waitForFinished() override;
@@ -115,6 +114,8 @@ class CORE_EXPORT QgsMapRendererStagedRenderJob : public QgsMapRendererAbstractC
     RenderStage currentStage() const;
 
   private:
+
+    void startPrivate() override;
 
     std::unique_ptr< QgsLabelingEngine > mLabelingEngineV2;
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -194,12 +194,16 @@ void QgsMapSettings::updateDerived()
   mScaleCalculator.setDpi( mDpi * mDevicePixelRatio );
   mScale = mScaleCalculator.calculate( mVisibleExtent, mSize.width() );
 
-  mMapToPixel.setParameters( mapUnitsPerPixel(),
-                             visibleExtent().center().x(),
-                             visibleExtent().center().y(),
-                             outputSize().width(),
-                             outputSize().height(),
-                             mRotation );
+  bool ok = true;
+  mMapToPixel.setParameters(
+    mapUnitsPerPixel(),
+    visibleExtent().center().x(),
+    visibleExtent().center().y(),
+    outputSize().width(),
+    outputSize().height(),
+    mRotation, &ok );
+
+  mValid = ok;
 
 #if 1 // set visible extent taking rotation in consideration
   if ( mRotation )
@@ -228,7 +232,6 @@ void QgsMapSettings::updateDerived()
   QgsDebugMsgLevel( QStringLiteral( "Visible Extent: %1" ).arg( mVisibleExtent.asWktCoordinates() ), 5 );
   QgsDebugMsgLevel( QStringLiteral( "Magnification factor: %1" ).arg( mMagnificationFactor ), 5 );
 
-  mValid = true;
 }
 
 

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -118,7 +118,8 @@ void QgsMapToPixel::setParameters( double mapUnitsPerPixel,
                                    double yc,
                                    int width,
                                    int height,
-                                   double rotation )
+                                   double rotation,
+                                   bool *ok )
 {
   double oldMUPP = mMapUnitsPerPixel;
   double oldXCenter = mXCenter;
@@ -148,7 +149,23 @@ void QgsMapToPixel::setParameters( double mapUnitsPerPixel,
     mRotation = oldRotation;
     mXMin = oldXMin;
     mYMin = oldYMin;
+    *ok = false;
   }
+  else
+  {
+    *ok = true;
+  }
+}
+
+void QgsMapToPixel::setParameters( double mapUnitsPerPixel,
+                                   double xc,
+                                   double yc,
+                                   int width,
+                                   int height,
+                                   double rotation )
+{
+  bool ok;
+  setParameters( mapUnitsPerPixel, xc, yc, width, height, rotation, &ok );
 }
 
 QString QgsMapToPixel::showParameters() const
@@ -185,3 +202,4 @@ QTransform QgsMapToPixel::transform() const
            .translate( -mXCenter, -mYCenter );
   }
 }
+

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -237,9 +237,25 @@ class CORE_EXPORT QgsMapToPixel
      * \param widthPixels Output width, in pixels
      * \param heightPixels Output height, in pixels
      * \param rotation clockwise rotation in degrees
+     *
+     * \note if parameters leads to a non valid transform, parameters are not changed
      * \since QGIS 2.8
      */
     void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );
+
+    /**
+     * Set parameters for use in transforming coordinates
+     * \param mapUnitsPerPixel Map units per pixel
+     * \param centerX X coordinate of map center, in geographical units
+     * \param centerY Y coordinate of map center, in geographical units
+     * \param widthPixels Output width, in pixels
+     * \param heightPixels Output height, in pixels
+     * \param rotation clockwise rotation in degrees
+     * \param ok will be set to true if parameters leads to a valid transform, otherwise  parameters are not changed and ok will be set to false
+     *
+     * \since QGIS 3.20
+     */
+    void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation, bool *ok ) SIP_SKIP;
 
     //! String representation of the parameters used in the transform
     QString showParameters() const;

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsMapToPixel
      * \param heightPixels Output height, in pixels
      * \param rotation clockwise rotation in degrees
      *
-     * \note if parameters leads to a non valid transform, parameters are not changed
+     * \note if the specified parameters result in an invalid transform then no changes will be applied to the object
      * \since QGIS 2.8
      */
     void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );
@@ -251,7 +251,7 @@ class CORE_EXPORT QgsMapToPixel
      * \param widthPixels Output width, in pixels
      * \param heightPixels Output height, in pixels
      * \param rotation clockwise rotation in degrees
-     * \param ok will be set to true if parameters leads to a valid transform, otherwise  parameters are not changed and ok will be set to false
+     * \param ok will be set to TRUE if the specified parameters result in a valid transform, otherwise the changes are ignored and ok will be set to FALSE.
      *
      * \since QGIS 3.20
      */


### PR DESCRIPTION
When there is an extreme zoom out, QgsMaptoPixel parameters produce an invalid transform. In that case, parameter are not changed but the map extent changes anyway, and map extent and the QgsMapToPixel instance of QgsMapsettings are not longer sync. With zoom out map extent grows while map to pixels does not change. 
That induces a increasing output size of the mesh layer rendering that finishes with an overflow.

To fix that, this PR invalidates the QgsMapSettings instance when QgsMapToPixel parameters induce invalid transform.

Then, the rendering is not done when map settings are invalid.

fix #40283