### PR TITLE
Server standalone: fix unreported project storage not supported with -p

### DIFF
--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -588,11 +588,13 @@ int main( int argc, char *argv[] )
   qputenv( "QGIS_SERVER_LOG_LEVEL", logLevel.toUtf8() );
   qputenv( "QGIS_SERVER_LOG_STDERR", "1" );
 
+  QgsServer server;
+
   if ( ! parser.value( projectOption ).isEmpty( ) )
   {
     // Check it!
     const QString projectFilePath { parser.value( projectOption ) };
-    if ( ! QFile::exists( projectFilePath ) )
+    if ( ! QgsProject::instance()->read( projectFilePath, QgsProject::ReadFlag::FlagDontResolveLayers | QgsProject::ReadFlag::FlagDontLoadLayouts  | QgsProject::ReadFlag::FlagDontStoreOriginalStyles ) )
     {
       std::cout << QObject::tr( "Project file not found, the option will be ignored." ).toStdString() << std::endl;
     }
@@ -605,8 +607,6 @@ int main( int argc, char *argv[] )
   // Disable parallel rendering because if its internal loop
   //qputenv( "QGIS_SERVER_PARALLEL_RENDERING", "0" );
 
-
-  QgsServer server;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   server.initPython();


### PR DESCRIPTION
-p only supported filesystem storage only, this PR fixes this
behavior by initializing providers before the project
is loaded and by attempting a project read instead of
just checking for the file.

Unreported.
