### PR TITLE
Update provider metadata after adding new connection in browser

### DIFF
--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -216,7 +216,7 @@ void QgsGeoPackageCollectionItem::addConnection()
 
 void QgsGeoPackageCollectionItem::deleteConnection()
 {
-  QgsOgrDbConnection::deleteConnection( name(), QStringLiteral( "GPKG" ) );
+  QgsOgrDbConnection::deleteConnection( name() );
   mParent->refreshConnections( QStringLiteral( "GPKG" ) );
 }
 

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -434,9 +434,6 @@ bool QgsOgrDataCollectionItem::saveConnection( const QString &path, const QStrin
     }
     if ( ok && ! connName.isEmpty() )
     {
-      QgsOgrDbConnection connection( connName, ogrDriverName );
-      connection.setPath( path );
-      connection.save();
       QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
       QgsGeoPackageProviderConnection *providerConnection =  static_cast<QgsGeoPackageProviderConnection *>( providerMetadata->createConnection( connName ) );
       providerMetadata->saveConnection( providerConnection, connName );

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -25,6 +25,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
 #include "qgsgeopackagedataitems.h"
+#include "qgsgeopackageproviderconnection.h"
 #include "qgsogrutils.h"
 #include "qgsproviderregistry.h"
 #include "qgssqliteutils.h"
@@ -436,6 +437,9 @@ bool QgsOgrDataCollectionItem::saveConnection( const QString &path, const QStrin
       QgsOgrDbConnection connection( connName, ogrDriverName );
       connection.setPath( path );
       connection.save();
+      QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
+      QgsGeoPackageProviderConnection *providerConnection =  static_cast<QgsGeoPackageProviderConnection *>( providerMetadata->createConnection( connName ) );
+      providerMetadata->saveConnection( providerConnection, connName );
       return true;
     }
   }

--- a/src/core/providers/ogr/qgsogrdbconnection.cpp
+++ b/src/core/providers/ogr/qgsogrdbconnection.cpp
@@ -87,11 +87,8 @@ void QgsOgrDbConnection::setSelectedConnection( const QString &connName, const Q
   settings.setValue( QStringLiteral( "%1/selected" ).arg( connectionsPath( settingsKey ) ), connName );
 }
 
-void QgsOgrDbConnection::deleteConnection( const QString &connName, const QString &settingsKey )
+void QgsOgrDbConnection::deleteConnection( const QString &connName )
 {
-  QgsSettings settings;
-  settings.remove( QStringLiteral( "%1/%2" ).arg( connectionsPath( settingsKey ), connName ) );
-
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
   providerMetadata->deleteConnection( connName );
 }

--- a/src/core/providers/ogr/qgsogrdbconnection.cpp
+++ b/src/core/providers/ogr/qgsogrdbconnection.cpp
@@ -21,6 +21,8 @@
 #include "qgis.h"
 #include "qgsdatasourceuri.h"
 #include "qgssettings.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
 
 #include "qgslogger.h"
 
@@ -89,6 +91,9 @@ void QgsOgrDbConnection::deleteConnection( const QString &connName, const QStrin
 {
   QgsSettings settings;
   settings.remove( QStringLiteral( "%1/%2" ).arg( connectionsPath( settingsKey ), connName ) );
+
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
+  providerMetadata->deleteConnection( connName );
 }
 
 ///@endcond

--- a/src/core/providers/ogr/qgsogrdbconnection.h
+++ b/src/core/providers/ogr/qgsogrdbconnection.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsOgrDbConnection : public QObject
     explicit QgsOgrDbConnection( const QString &connName, const QString &settingsKey );
 
     static const QStringList connectionList( const QString &driverName = QStringLiteral( "GPKG" ) );
-    static void deleteConnection( const QString &connName, const QString &settingsKey );
+    static void deleteConnection( const QString &connName );
     static QString selectedConnection( const QString &settingsKey );
     static void setSelectedConnection( const QString &connName, const QString &settingsKey );
 

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -247,7 +247,7 @@ void QgsOgrDbSourceSelect::btnDelete_clicked()
   if ( result != QMessageBox::Yes )
     return;
 
-  QgsOgrDbConnection::deleteConnection( subKey, ogrDriverName() );
+  QgsOgrDbConnection::deleteConnection( subKey );
   populateConnectionList();
   emit connectionsChanged();
 }

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -24,6 +24,8 @@
 #include "qgsoracletablemodel.h"
 #include "qgssettings.h"
 #include "qgsoracleconnpool.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
 
 #include <QSqlError>
 

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -24,8 +24,6 @@
 #include "qgsoracletablemodel.h"
 #include "qgssettings.h"
 #include "qgsoracleconnpool.h"
-#include "qgsprovidermetadata.h"
-#include "qgsproviderregistry.h"
 
 #include <QSqlError>
 

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -313,7 +313,8 @@ void QgsOracleConnectionItem::deleteConnection()
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  QgsOracleConn::deleteConnection( mName );
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
+  providerMetadata->deleteConnection( mName );
 
   // the parent should be updated
   if ( mParent )

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -160,15 +160,16 @@ void QgsOracleNewConnection::accept()
   settings.setValue( baseKey + QStringLiteral( "/schema" ), txtSchema->text() );
 
   QVariantMap configuration;
-  configuration.insert("geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
-  configuration.insert("allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
-  configuration.insert("onlyExistingTypes", cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
-  configuration.insert("saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
-  configuration.insert("savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
+  configuration.insert( "geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
+  configuration.insert( "allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
+  configuration.insert( "onlyExistingTypes", cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  configuration.insert( "saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
+  configuration.insert( "savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
   QgsOracleProviderConnection *providerConnection =  static_cast<QgsOracleProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
-  providerConnection->setConfiguration(configuration);
+  providerConnection->setUri( QgsOracleConn::connUri( txtName->text() ).uri( false ) );
+  providerConnection->setConfiguration( configuration );
   providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -159,8 +159,16 @@ void QgsOracleNewConnection::accept()
   settings.setValue( baseKey + QStringLiteral( "/dbworkspace" ), txtWorkspace->text() );
   settings.setValue( baseKey + QStringLiteral( "/schema" ), txtSchema->text() );
 
+  QVariantMap configuration;
+  configuration.insert("geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
+  configuration.insert("allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
+  configuration.insert("onlyExistingTypes", cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  configuration.insert("saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
+  configuration.insert("savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
+
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
   QgsOracleProviderConnection *providerConnection =  static_cast<QgsOracleProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
+  providerConnection->setConfiguration(configuration);
   providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -21,6 +21,9 @@
 
 #include "qgssettings.h"
 #include "qgsoraclenewconnection.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
+#include "qgsoracleproviderconnection.h"
 #include "qgsdatasourceuri.h"
 #include "qgsoracletablemodel.h"
 #include "qgsoracleconnpool.h"
@@ -155,6 +158,10 @@ void QgsOracleNewConnection::accept()
   settings.setValue( baseKey + QStringLiteral( "/dboptions" ), txtOptions->text() );
   settings.setValue( baseKey + QStringLiteral( "/dbworkspace" ), txtWorkspace->text() );
   settings.setValue( baseKey + QStringLiteral( "/schema" ), txtSchema->text() );
+
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
+  QgsOracleProviderConnection *providerConnection =  static_cast<QgsOracleProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
+  providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();
 }

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -268,7 +268,8 @@ void QgsOracleSourceSelect::on_btnDelete_clicked()
   if ( QMessageBox::Ok != QMessageBox::information( this, tr( "Confirm Delete" ), msg, QMessageBox::Ok | QMessageBox::Cancel ) )
     return;
 
-  QgsOracleConn::deleteConnection( cmbConnections->currentText() );
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "oracle" ) );
+  providerMetadata->deleteConnection( cmbConnections->currentText() );
 
   QgsOracleTableCache::removeFromCache( cmbConnections->currentText() );
 

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -21,6 +21,9 @@
 #include <QRegularExpression>
 
 #include "qgspgnewconnection.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
+#include "qgspostgresproviderconnection.h"
 #include "qgsauthmanager.h"
 #include "qgsdatasourceuri.h"
 #include "qgspostgresconn.h"
@@ -173,6 +176,10 @@ void QgsPgNewConnection::accept()
 
   // remove old save setting
   settings.remove( baseKey + "/save" );
+
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
+  QgsPostgresProviderConnection *providerConnection =  static_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
+  providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();
 }

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -177,8 +177,20 @@ void QgsPgNewConnection::accept()
   // remove old save setting
   settings.remove( baseKey + "/save" );
 
+  QVariantMap configuration;
+  configuration.insert("publicOnly", cb_publicSchemaOnly->isChecked() );
+  configuration.insert("geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
+  configuration.insert("dontResolveType", cb_dontResolveType->isChecked() );
+  configuration.insert("allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
+  configuration.insert("sslmode", cbxSSLmode->currentData().toInt() );
+  configuration.insert("saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
+  configuration.insert("savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
+  configuration.insert("estimatedMetadata", cb_useEstimatedMetadata->isChecked() );
+  configuration.insert("projectsInDatabase", cb_projectsInDatabase->isChecked() );
+
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   QgsPostgresProviderConnection *providerConnection =  static_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
+  providerConnection->setConfiguration(configuration);
   providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -178,19 +178,20 @@ void QgsPgNewConnection::accept()
   settings.remove( baseKey + "/save" );
 
   QVariantMap configuration;
-  configuration.insert("publicOnly", cb_publicSchemaOnly->isChecked() );
-  configuration.insert("geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
-  configuration.insert("dontResolveType", cb_dontResolveType->isChecked() );
-  configuration.insert("allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
-  configuration.insert("sslmode", cbxSSLmode->currentData().toInt() );
-  configuration.insert("saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
-  configuration.insert("savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
-  configuration.insert("estimatedMetadata", cb_useEstimatedMetadata->isChecked() );
-  configuration.insert("projectsInDatabase", cb_projectsInDatabase->isChecked() );
+  configuration.insert( "publicOnly", cb_publicSchemaOnly->isChecked() );
+  configuration.insert( "geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
+  configuration.insert( "dontResolveType", cb_dontResolveType->isChecked() );
+  configuration.insert( "allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
+  configuration.insert( "sslmode", cbxSSLmode->currentData().toInt() );
+  configuration.insert( "saveUsername", mAuthSettings->storeUsernameIsChecked( ) ? "true" : "false" );
+  configuration.insert( "savePassword", mAuthSettings->storePasswordIsChecked( ) && !hasAuthConfigID ? "true" : "false" );
+  configuration.insert( "estimatedMetadata", cb_useEstimatedMetadata->isChecked() );
+  configuration.insert( "projectsInDatabase", cb_projectsInDatabase->isChecked() );
 
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
   QgsPostgresProviderConnection *providerConnection =  static_cast<QgsPostgresProviderConnection *>( providerMetadata->createConnection( txtName->text() ) );
-  providerConnection->setConfiguration(configuration);
+  providerConnection->setUri( QgsPostgresConn::connUri( txtName->text() ).uri( false ) );
+  providerConnection->setConfiguration( configuration );
   providerMetadata->saveConnection( providerConnection, txtName->text() );
 
   QDialog::accept();

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -331,7 +331,8 @@ void QgsPgSourceSelect::btnDelete_clicked()
   if ( QMessageBox::Yes != QMessageBox::question( this, tr( "Confirm Delete" ), msg, QMessageBox::Yes | QMessageBox::No ) )
     return;
 
-  QgsPostgresConn::deleteConnection( cmbConnections->currentText() );
+  QgsPostgresProviderMetadata md = QgsPostgresProviderMetadata();
+  md.deleteConnection( cmbConnections->currentText() );
 
   populateConnectionList();
   emit connectionsChanged();

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -219,7 +219,9 @@ void QgsPostgresDataItemGuiProvider::deleteConnection( QgsDataItem *item )
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  QgsPostgresConn::deleteConnection( item->name() );
+  QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "postgres" ) );
+  md->deleteConnection( item->name() );
+
   // the parent should be updated
   if ( item->parent() )
     item->parent()->refreshConnections();

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -36,14 +36,6 @@ QStringList QgsSpatiaLiteConnection::connectionList()
   return settings.childGroups();
 }
 
-void QgsSpatiaLiteConnection::deleteConnection( const QString &name )
-{
-  QgsSettings settings;
-  QString key = "/SpatiaLite/connections/" + name;
-  settings.remove( key + "/sqlitepath" );
-  settings.remove( key );
-}
-
 QString QgsSpatiaLiteConnection::connectionPath( const QString &name )
 {
   QgsSettings settings;

--- a/src/providers/spatialite/qgsspatialiteconnection.h
+++ b/src/providers/spatialite/qgsspatialiteconnection.h
@@ -39,7 +39,6 @@ class QgsSpatiaLiteConnection : public QObject
     QString path() { return mPath; }
 
     static QStringList connectionList();
-    static void deleteConnection( const QString &name );
     static QString connectionPath( const QString &name );
 
     typedef struct TableEntry

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
@@ -19,6 +19,7 @@
 #include "qgsspatialitesourceselect.h"
 #include "qgsproviderregistry.h"
 #include "qgsprovidermetadata.h"
+#include "qgsspatialiteproviderconnection.h"
 
 #include "qgsapplication.h"
 #include "qgsmessageoutput.h"
@@ -118,8 +119,9 @@ void QgsSpatiaLiteDataItemGuiProvider::createDatabase( QgsDataItem *item )
   QString errCause;
   if ( SpatiaLiteUtils::createDb( filename, errCause ) )
   {
-    // add connection
-    settings.setValue( "/SpatiaLite/connections/" + QFileInfo( filename ).fileName() + "/sqlitepath", filename );
+    QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) );
+    QgsSpatiaLiteProviderConnection *providerConnection =  static_cast<QgsSpatiaLiteProviderConnection *>( providerMetadata->createConnection( filename ) );
+    providerMetadata->saveConnection( providerConnection, filename );
 
     item->refresh();
   }

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
@@ -17,6 +17,8 @@
 #include "qgsspatialiteconnection.h"
 #include "qgsspatialitedataitems.h"
 #include "qgsspatialitesourceselect.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
 
 #include "qgsapplication.h"
 #include "qgsmessageoutput.h"
@@ -134,7 +136,9 @@ void QgsSpatiaLiteDataItemGuiProvider::deleteConnection( QgsDataItem *item )
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  QgsSpatiaLiteConnection::deleteConnection( item->name() );
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) );
+  providerMetadata->deleteConnection( item->name() );
+
   // the parent should be updated
   item->parent()->refreshConnections();
 }

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -28,6 +28,8 @@ email                : a.furieri@lqt.it
 #include "qgsproviderregistry.h"
 #include "qgsproject.h"
 #include "qgsgui.h"
+#include "qgsprovidermetadata.h"
+#include "qgsspatialiteproviderconnection.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -312,6 +314,11 @@ bool QgsSpatiaLiteSourceSelect::newConnection( QWidget *parent )
   // inserting this SQLite DB path
   settings.setValue( baseKey + "selected", savedName );
   settings.setValue( baseKey + savedName + "/sqlitepath", myFI.canonicalFilePath() );
+
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) );
+  QgsSpatiaLiteProviderConnection *providerConnection =  static_cast<QgsSpatiaLiteProviderConnection *>( providerMetadata->createConnection( savedName ) );
+  providerMetadata->saveConnection( providerConnection, savedName );
+
   return true;
 }
 

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -312,9 +312,6 @@ bool QgsSpatiaLiteSourceSelect::newConnection( QWidget *parent )
   // Persist last used SpatiaLite dir
   settings.setValue( QStringLiteral( "UI/lastSpatiaLiteDir" ), myPath );
   // inserting this SQLite DB path
-  settings.setValue( baseKey + "selected", savedName );
-  settings.setValue( baseKey + savedName + "/sqlitepath", myFI.canonicalFilePath() );
-
   QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) );
   QgsSpatiaLiteProviderConnection *providerConnection =  static_cast<QgsSpatiaLiteProviderConnection *>( providerMetadata->createConnection( savedName ) );
   providerMetadata->saveConnection( providerConnection, savedName );
@@ -378,7 +375,8 @@ void QgsSpatiaLiteSourceSelect::btnDelete_clicked()
   if ( result != QMessageBox::Yes )
     return;
 
-  QgsSpatiaLiteConnection::deleteConnection( subKey );
+  QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) );
+  providerMetadata->deleteConnection( subKey );
 
   populateConnectionList();
   emit connectionsChanged();


### PR DESCRIPTION
## Description

Fix #43382

When a new connection is added using browser, the provider metadata is not updated. In consequence, the new connection is not listed in the provider metadata. This connection will be available only after relaunching QGIS.

This is true for GPKG, spatialite, postgres, oracle provider.

In consequence, QgsProviderConnectionComboBox will not list new connections

Futhermore, when a connection is removed, the provider metadata is not updated too.

Until now the connection was removed only, with the PR QGIS removes the connection from the provider metadata which will remove the connection
