### PR TITLE
Use a safer approach to update renderers after symbol levels are changed 

### DIFF
--- a/python/gui/auto_generated/symbology/qgs25drendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgs25drendererwidget.sip.in
@@ -33,6 +33,7 @@ Constructor
 :param style:
 :param renderer: the mask renderer (will not take ownership)
 %End
+    ~Qgs25DRendererWidget();
 
     virtual QgsFeatureRenderer *renderer();
 

--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -88,6 +88,10 @@ from the XML file with a matching name.
 .. versionadded:: 2.9
 %End
 
+  protected:
+    virtual void setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled );
+
+
   protected slots:
 
     virtual void pasteSymbolToSelection();

--- a/python/gui/auto_generated/symbology/qgsembeddedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsembeddedsymbolrendererwidget.sip.in
@@ -38,6 +38,7 @@ Constructor
 :param style:
 :param renderer: the merged feature renderer (will not take ownership)
 %End
+    ~QgsEmbeddedSymbolRendererWidget();
 
     virtual QgsFeatureRenderer *renderer();
 

--- a/python/gui/auto_generated/symbology/qgsgraduatedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsgraduatedsymbolrendererwidget.sip.in
@@ -71,6 +71,10 @@ Refreshes the ranges for the renderer.
 The ``reset`` argument is deprecated and has no effect.
 %End
 
+  protected:
+    virtual void setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled );
+
+
   protected slots:
 
     virtual void pasteSymbolToSelection();

--- a/python/gui/auto_generated/symbology/qgsheatmaprendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsheatmaprendererwidget.sip.in
@@ -33,6 +33,7 @@ Constructor
 :param style:
 :param renderer: the mask renderer (will not take ownership)
 %End
+    ~QgsHeatmapRendererWidget();
 
     virtual QgsFeatureRenderer *renderer();
 

--- a/python/gui/auto_generated/symbology/qgsinvertedpolygonrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsinvertedpolygonrendererwidget.sip.in
@@ -38,6 +38,7 @@ Constructor
 :param style:
 :param renderer: the mask renderer (will not take ownership)
 %End
+    ~QgsInvertedPolygonRendererWidget();
 
     virtual QgsFeatureRenderer *renderer();
 

--- a/python/gui/auto_generated/symbology/qgsmergedfeaturerendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsmergedfeaturerendererwidget.sip.in
@@ -38,6 +38,7 @@ Constructor
 :param style:
 :param renderer: the merged feature renderer (will not take ownership)
 %End
+    ~QgsMergedFeatureRendererWidget();
 
     virtual QgsFeatureRenderer *renderer();
 

--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -107,6 +107,17 @@ Returns newly created panel - may be ``None`` if it could not be opened. Ownersh
 .. versionadded:: 3.0
 %End
 
+    virtual void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled );
+%Docstring
+Sets the symbol levels for the renderer defined in the widget.
+
+The ``levels`` argument defines the updated list of symbols with rendering passes set.
+
+The ``enabled`` arguments specifies if symbol levels should be enabled for the renderer.
+
+.. versionadded:: 3.20
+%End
+
   protected slots:
     void  contextMenuViewCategories( QPoint p );
     void changeSymbolColor();

--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -35,7 +35,7 @@ Returns pointer to the renderer (no transfer of ownership)
 
     void showSymbolLevelsDialog( QgsFeatureRenderer *r );
 %Docstring
-show a dialog with renderer's symbol level settings
+Show a dialog with renderer's symbol level settings.
 %End
 
     virtual void setContext( const QgsSymbolWidgetContext &context );
@@ -73,6 +73,7 @@ This method should be called whenever the renderer is actually set on the layer.
     virtual void setDockMode( bool dockMode );
 
 
+
   signals:
 
     void layerVariablesChanged();
@@ -82,9 +83,12 @@ vector layers have been changed. Will request the parent dialog
 to re-synchronize with the variables.
 %End
 
-    void symbolLevelsChanged();
+ void symbolLevelsChanged() /Deprecated/;
 %Docstring
 Emitted when the symbol levels settings have been changed.
+
+.. deprecated:: QGIS 3.20
+   -- no longer emitted.
 %End
 
   protected:

--- a/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
@@ -140,6 +140,9 @@ Opens the dialog for refining a rule using ranges
 %End
     void refineRuleScalesGui( const QModelIndexList &index );
 
+    virtual void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled );
+
+
     QgsRuleBasedRenderer::Rule *currentRule();
 
     virtual QList<QgsSymbol *> selectedSymbols();

--- a/python/gui/auto_generated/symbology/qgssinglesymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssinglesymbolrendererwidget.sip.in
@@ -36,6 +36,10 @@ widgets and not open dialogs
 :param dockMode: ``True`` to enable dock mode.
 %End
 
+  protected:
+    virtual void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled );
+
+
 };
 
 

--- a/python/gui/auto_generated/symbology/qgssinglesymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssinglesymbolrendererwidget.sip.in
@@ -26,15 +26,8 @@ class QgsSingleSymbolRendererWidget : QgsRendererWidget
 
     virtual void setContext( const QgsSymbolWidgetContext &context );
 
-
     virtual void setDockMode( bool dockMode );
 
-%Docstring
-Set the widget in dock mode which tells the widget to emit panel
-widgets and not open dialogs
-
-:param dockMode: ``True`` to enable dock mode.
-%End
 
   protected:
     virtual void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled );

--- a/python/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollevelsdialog.sip.in
@@ -23,14 +23,29 @@ A widget which allows the user to modify the rendering order of symbol layers.
 #include "qgssymbollevelsdialog.h"
 %End
   public:
+
     QgsSymbolLevelsWidget( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsSymbolLevelsWidget
 %End
 
+    QgsSymbolLevelsWidget( const QgsLegendSymbolList &symbols, bool usingSymbolLevels, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsSymbolLevelsWidget, which takes a list of ``symbols`` to show in the dialog.
+
+.. versionadded:: 3.20
+%End
+
     bool usingLevels() const;
 %Docstring
 Returns whether the level ordering is enabled
+%End
+
+    QgsLegendSymbolList symbolLevels() const;
+%Docstring
+Returns the current legend symbols with rendering passes set, as defined in the widget.
+
+.. versionadded:: 3.20
 %End
 
     void setForceOrderingEnabled( bool enabled );
@@ -41,20 +56,17 @@ Sets whether the level ordering is always forced on and hide the checkbox (used 
 %End
 
   public slots:
-    void apply();
+
+ void apply() /Deprecated/;
 %Docstring
-Apply button
+Apply button.
+
+.. deprecated:: QGIS 3.20.
+   Use :py:func:`~QgsSymbolLevelsWidget.symbolLevels` and manually apply the changes to the renderer as appropriate.
 %End
 
-  protected:
-
-
-
-
-  private:
-    QgsSymbolLevelsWidget();
-
 };
+
 
 class QgsSymbolLevelsDialog : QDialog
 {
@@ -75,6 +87,20 @@ Constructor for QgsSymbolLevelsDialog.
 %End
 
     void setForceOrderingEnabled( bool enabled );
+
+    bool usingLevels() const;
+%Docstring
+Returns whether the level ordering is enabled.
+
+.. versionadded:: 3.20
+%End
+
+    QgsLegendSymbolList symbolLevels() const;
+%Docstring
+Returns the current legend symbols with rendering passes set, as defined in the widget.
+
+.. versionadded:: 3.20
+%End
 
 };
 

--- a/src/gui/symbology/qgs25drendererwidget.cpp
+++ b/src/gui/symbology/qgs25drendererwidget.cpp
@@ -18,6 +18,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgssymbol.h"
 
 Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
   : QgsRendererWidget( layer, style )
@@ -54,7 +55,7 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
 
   if ( renderer )
   {
-    mRenderer = Qgs25DRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( Qgs25DRenderer::convertFromRenderer( renderer ) );
   }
 
   mHeightWidget->setLayer( layer );
@@ -85,9 +86,11 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
   connect( mWallExpositionShading, &QAbstractButton::toggled, this, &Qgs25DRendererWidget::updateRenderer );
 }
 
+Qgs25DRendererWidget::~Qgs25DRendererWidget() = default;
+
 QgsFeatureRenderer *Qgs25DRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void Qgs25DRendererWidget::updateRenderer()

--- a/src/gui/symbology/qgs25drendererwidget.h
+++ b/src/gui/symbology/qgs25drendererwidget.h
@@ -48,6 +48,7 @@ class GUI_EXPORT Qgs25DRendererWidget : public QgsRendererWidget, protected Ui::
      * \param renderer the mask renderer (will not take ownership)
      */
     Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer SIP_TRANSFER );
+    ~Qgs25DRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
 
@@ -57,7 +58,7 @@ class GUI_EXPORT Qgs25DRendererWidget : public QgsRendererWidget, protected Ui::
   private:
     void apply() override SIP_FORCE;
 
-    Qgs25DRenderer *mRenderer = nullptr;
+    std::unique_ptr< Qgs25DRenderer > mRenderer;
 
     friend class QgsAppScreenShots;
 };

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -1096,6 +1096,21 @@ void QgsCategorizedSymbolRendererWidget::matchToSymbolsFromXml()
   }
 }
 
+void QgsCategorizedSymbolRendererWidget::setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled )
+{
+  for ( const QgsLegendSymbolItem &legendSymbol : levels )
+  {
+    QgsSymbol *sym = legendSymbol.symbol();
+    for ( int layer = 0; layer < sym->symbolLayerCount(); layer++ )
+    {
+      mRenderer->setLegendSymbolItem( legendSymbol.ruleKey(), sym->clone() );
+    }
+  }
+  mRenderer->setUsingSymbolLevels( enabled );
+  mModel->updateSymbology();
+  emit widgetChanged();
+}
+
 void QgsCategorizedSymbolRendererWidget::pasteSymbolToSelection()
 {
   std::unique_ptr< QgsSymbol > tempSymbol( QgsSymbolLayerUtils::symbolFromMimeData( QApplication::clipboard()->mimeData() ) );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -577,9 +577,9 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   // menus for data-defined rotation/size
   QMenu *advMenu = new QMenu;
 
-  advMenu->addAction( tr( "Match to Saved Symbols" ), this, SLOT( matchToSymbolsFromLibrary() ) );
-  advMenu->addAction( tr( "Match to Symbols from File…" ), this, SLOT( matchToSymbolsFromXml() ) );
-  advMenu->addAction( tr( "Symbol Levels…" ), this, SLOT( showSymbolLevels() ) );
+  advMenu->addAction( tr( "Match to Saved Symbols" ), this, &QgsCategorizedSymbolRendererWidget::matchToSymbolsFromLibrary );
+  advMenu->addAction( tr( "Match to Symbols from File…" ), this, &QgsCategorizedSymbolRendererWidget::matchToSymbolsFromXml );
+  mActionLevels = advMenu->addAction( tr( "Symbol Levels…" ), this, &QgsCategorizedSymbolRendererWidget::showSymbolLevels );
   if ( mCategorizedSymbol && mCategorizedSymbol->type() == Qgis::SymbolType::Marker )
   {
     QAction *actionDdsLegend = advMenu->addAction( tr( "Data-defined Size Legend…" ) );
@@ -644,6 +644,12 @@ void QgsCategorizedSymbolRendererWidget::setContext( const QgsSymbolWidgetContex
   QgsRendererWidget::setContext( context );
   btnChangeCategorizedSymbol->setMapCanvas( context.mapCanvas() );
   btnChangeCategorizedSymbol->setMessageBar( context.messageBar() );
+}
+
+void QgsCategorizedSymbolRendererWidget::disableSymbolLevels()
+{
+  delete mActionLevels;
+  mActionLevels = nullptr;
 }
 
 void QgsCategorizedSymbolRendererWidget::changeSelectedSymbols()

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -100,6 +100,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     QgsFeatureRenderer *renderer() override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
+    void disableSymbolLevels() override SIP_SKIP;
 
     /**
      * Replaces category symbols with the symbols from a style that have a matching
@@ -219,6 +220,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     QMenu *mContextMenu = nullptr;
     QAction *mMergeCategoriesAction = nullptr;
     QAction *mUnmergeCategoriesAction = nullptr;
+    QAction *mActionLevels = nullptr;
 
     QgsExpressionContext createExpressionContext() const override;
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -149,6 +149,9 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
      */
     void matchToSymbolsFromXml();
 
+  protected:
+    void setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled ) override;
+
   protected slots:
 
     void pasteSymbolToSelection() override;

--- a/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
@@ -79,6 +79,8 @@ QgsEmbeddedSymbolRendererWidget::QgsEmbeddedSymbolRendererWidget( QgsVectorLayer
   } );
 }
 
+QgsEmbeddedSymbolRendererWidget::~QgsEmbeddedSymbolRendererWidget() = default;
+
 QgsFeatureRenderer *QgsEmbeddedSymbolRendererWidget::renderer()
 {
   return mRenderer.get();

--- a/src/gui/symbology/qgsembeddedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsembeddedsymbolrendererwidget.h
@@ -17,11 +17,11 @@
 
 #include "ui_qgsembeddedsymbolrendererwidgetbase.h"
 #include "qgis_sip.h"
-#include "qgsembeddedsymbolrenderer.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"
 
 class QMenu;
+class QgsEmbeddedSymbolRenderer;
 
 /**
  * \ingroup gui
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsEmbeddedSymbolRendererWidget : public QgsRendererWidget, pub
      * \param renderer the merged feature renderer (will not take ownership)
      */
     QgsEmbeddedSymbolRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer );
+    ~QgsEmbeddedSymbolRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
     void setContext( const QgsSymbolWidgetContext &context ) override;

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -911,6 +911,21 @@ void QgsGraduatedSymbolRendererWidget::refreshRanges( bool )
   emit widgetChanged();
 }
 
+void QgsGraduatedSymbolRendererWidget::setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled )
+{
+  for ( const QgsLegendSymbolItem &legendSymbol : levels )
+  {
+    QgsSymbol *sym = legendSymbol.symbol();
+    for ( int layer = 0; layer < sym->symbolLayerCount(); layer++ )
+    {
+      mRenderer->setLegendSymbolItem( legendSymbol.ruleKey(), sym->clone() );
+    }
+  }
+  mRenderer->setUsingSymbolLevels( enabled );
+  mModel->updateSymbology();
+  emit widgetChanged();
+}
+
 void QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector( QgsPanelWidget *container )
 {
   QgsSymbolSelectorWidget *dlg = qobject_cast<QgsSymbolSelectorWidget *>( container );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -576,7 +576,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   // menus for data-defined rotation/size
   QMenu *advMenu = new QMenu( this );
 
-  advMenu->addAction( tr( "Symbol Levels…" ), this, SLOT( showSymbolLevels() ) );
+  mActionLevels = advMenu->addAction( tr( "Symbol Levels…" ), this, &QgsGraduatedSymbolRendererWidget::showSymbolLevels );
   if ( mGraduatedSymbol && mGraduatedSymbol->type() == Qgis::SymbolType::Marker )
   {
     QAction *actionDdsLegend = advMenu->addAction( tr( "Data-defined Size Legend…" ) );
@@ -620,6 +620,12 @@ void QgsGraduatedSymbolRendererWidget::setContext( const QgsSymbolWidgetContext 
   QgsRendererWidget::setContext( context );
   btnChangeGraduatedSymbol->setMapCanvas( context.mapCanvas() );
   btnChangeGraduatedSymbol->setMessageBar( context.messageBar() );
+}
+
+void QgsGraduatedSymbolRendererWidget::disableSymbolLevels()
+{
+  delete mActionLevels;
+  mActionLevels = nullptr;
 }
 
 // Connect/disconnect event handlers which trigger updating renderer

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -464,7 +464,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   // setup user interface
   setupUi( this );
 
-  mSymmetryPointValidator = new QDoubleValidator();
+  mSymmetryPointValidator = new QDoubleValidator( this );
   cboSymmetryPoint->setEditable( true );
   cboSymmetryPoint->setValidator( mSymmetryPointValidator );
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -133,6 +133,9 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
      */
     void refreshRanges( bool reset );
 
+  protected:
+    void setSymbolLevels( const QgsLegendSymbolList &levels, bool enabled ) override;
+
   private slots:
     void mSizeUnitWidget_changed();
     void methodComboBox_currentIndexChanged( int );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -196,7 +196,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
 
     QgsRangeList mCopyBuffer;
 
-    QDoubleValidator *mSymmetryPointValidator;
+    QDoubleValidator *mSymmetryPointValidator = nullptr;
 
     std::vector< std::unique_ptr< QgsAbstractProcessingParameterWidgetWrapper >> mParameterWidgetWrappers;
 };

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -100,6 +100,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
 
     QgsFeatureRenderer *renderer() override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
+    void disableSymbolLevels() override SIP_SKIP;
 
   public slots:
     void graduatedColumnChanged( const QString &field );
@@ -197,7 +198,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     QgsRangeList mCopyBuffer;
 
     QDoubleValidator *mSymmetryPointValidator = nullptr;
-
+    QAction *mActionLevels = nullptr;
     std::vector< std::unique_ptr< QgsAbstractProcessingParameterWidgetWrapper >> mParameterWidgetWrappers;
 };
 

--- a/src/gui/symbology/qgsheatmaprendererwidget.cpp
+++ b/src/gui/symbology/qgsheatmaprendererwidget.cpp
@@ -105,11 +105,11 @@ QgsHeatmapRendererWidget::QgsHeatmapRendererWidget( QgsVectorLayer *layer, QgsSt
 
   if ( renderer )
   {
-    mRenderer = QgsHeatmapRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( QgsHeatmapRenderer::convertFromRenderer( renderer ) );
   }
   if ( !mRenderer )
   {
-    mRenderer = new QgsHeatmapRenderer();
+    mRenderer = std::make_unique< QgsHeatmapRenderer >();
   }
 
   btnColorRamp->setShowGradientOnly( true );
@@ -141,9 +141,11 @@ QgsHeatmapRendererWidget::QgsHeatmapRendererWidget( QgsVectorLayer *layer, QgsSt
   connect( mWeightExpressionWidget, static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) >( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsHeatmapRendererWidget::weightExpressionChanged );
 }
 
+QgsHeatmapRendererWidget::~QgsHeatmapRendererWidget() = default;
+
 QgsFeatureRenderer *QgsHeatmapRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void QgsHeatmapRendererWidget::setContext( const QgsSymbolWidgetContext &context )

--- a/src/gui/symbology/qgsheatmaprendererwidget.h
+++ b/src/gui/symbology/qgsheatmaprendererwidget.h
@@ -48,12 +48,13 @@ class GUI_EXPORT QgsHeatmapRendererWidget : public QgsRendererWidget, private Ui
      * \param renderer the mask renderer (will not take ownership)
      */
     QgsHeatmapRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer );
+    ~QgsHeatmapRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
 
   private:
-    QgsHeatmapRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsHeatmapRenderer > mRenderer;
 
     QgsExpressionContext createExpressionContext() const override;
 

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
@@ -100,6 +100,8 @@ QgsInvertedPolygonRendererWidget::QgsInvertedPolygonRendererWidget( QgsVectorLay
   }
 }
 
+QgsInvertedPolygonRendererWidget::~QgsInvertedPolygonRendererWidget() = default;
+
 QgsFeatureRenderer *QgsInvertedPolygonRendererWidget::renderer()
 {
   if ( mRenderer && mEmbeddedRendererWidget )

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
@@ -139,6 +139,7 @@ void QgsInvertedPolygonRendererWidget::mRendererComboBox_currentIndexChanged( in
     mEmbeddedRendererWidget.reset( m->createRendererWidget( mLayer, mStyle, oldRenderer.get() ) );
     connect( mEmbeddedRendererWidget.get(), &QgsRendererWidget::widgetChanged, this, &QgsInvertedPolygonRendererWidget::widgetChanged );
     mEmbeddedRendererWidget->setContext( mContext );
+    mEmbeddedRendererWidget->disableSymbolLevels();
     mEmbeddedRendererWidget->setDockMode( this->dockMode() );
     connect( mEmbeddedRendererWidget.get(), &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
 

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.h
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.h
@@ -17,11 +17,11 @@
 
 #include "ui_qgsinvertedpolygonrendererwidgetbase.h"
 #include "qgis_sip.h"
-#include "qgsinvertedpolygonrenderer.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"
 
 class QMenu;
+class QgsInvertedPolygonRenderer;
 
 /**
  * \ingroup gui
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsInvertedPolygonRendererWidget : public QgsRendererWidget, pr
      * \param renderer the mask renderer (will not take ownership)
      */
     QgsInvertedPolygonRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer );
+    ~QgsInvertedPolygonRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
 

--- a/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
+++ b/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
@@ -97,6 +97,8 @@ QgsMergedFeatureRendererWidget::QgsMergedFeatureRendererWidget( QgsVectorLayer *
   }
 }
 
+QgsMergedFeatureRendererWidget::~QgsMergedFeatureRendererWidget() = default;
+
 QgsFeatureRenderer *QgsMergedFeatureRendererWidget::renderer()
 {
   if ( mRenderer && mEmbeddedRendererWidget )

--- a/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
+++ b/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
@@ -136,6 +136,7 @@ void QgsMergedFeatureRendererWidget::mRendererComboBox_currentIndexChanged( int 
     mEmbeddedRendererWidget.reset( m->createRendererWidget( mLayer, mStyle, oldRenderer.get() ) );
     connect( mEmbeddedRendererWidget.get(), &QgsRendererWidget::widgetChanged, this, &QgsMergedFeatureRendererWidget::widgetChanged );
     mEmbeddedRendererWidget->setContext( mContext );
+    mEmbeddedRendererWidget->disableSymbolLevels();
     mEmbeddedRendererWidget->setDockMode( this->dockMode() );
     connect( mEmbeddedRendererWidget.get(), &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
 

--- a/src/gui/symbology/qgsmergedfeaturerendererwidget.h
+++ b/src/gui/symbology/qgsmergedfeaturerendererwidget.h
@@ -17,11 +17,11 @@
 
 #include "ui_qgsmergedfeaturerendererwidgetbase.h"
 #include "qgis_sip.h"
-#include "qgsmergedfeaturerenderer.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"
 
 class QMenu;
+class QgsMergedFeatureRenderer;
 
 /**
  * \ingroup gui
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsMergedFeatureRendererWidget : public QgsRendererWidget, priv
      * \param renderer the merged feature renderer (will not take ownership)
      */
     QgsMergedFeatureRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer );
+    ~QgsMergedFeatureRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
     void setContext( const QgsSymbolWidgetContext &context ) override;

--- a/src/gui/symbology/qgsnullsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsnullsymbolrendererwidget.cpp
@@ -26,15 +26,14 @@ QgsRendererWidget *QgsNullSymbolRendererWidget::create( QgsVectorLayer *layer, Q
 
 QgsNullSymbolRendererWidget::QgsNullSymbolRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
   : QgsRendererWidget( layer, style )
-
 {
   if ( renderer )
   {
-    mRenderer = QgsNullSymbolRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( QgsNullSymbolRenderer::convertFromRenderer( renderer ) );
   }
   if ( !mRenderer )
   {
-    mRenderer = new QgsNullSymbolRenderer();
+    mRenderer = std::make_unique< QgsNullSymbolRenderer >();
   }
 
   QGridLayout *layout = new QGridLayout( this );
@@ -42,12 +41,9 @@ QgsNullSymbolRendererWidget::QgsNullSymbolRendererWidget( QgsVectorLayer *layer,
   layout->addWidget( label );
 }
 
-QgsNullSymbolRendererWidget::~QgsNullSymbolRendererWidget()
-{
-  delete mRenderer;
-}
+QgsNullSymbolRendererWidget::~QgsNullSymbolRendererWidget() = default;
 
 QgsFeatureRenderer *QgsNullSymbolRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }

--- a/src/gui/symbology/qgsnullsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsnullsymbolrendererwidget.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsNullSymbolRendererWidget : public QgsRendererWidget
   protected:
 
     //! Renderer being configured by the widget
-    QgsNullSymbolRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsNullSymbolRenderer > mRenderer;
 
 };
 

--- a/src/gui/symbology/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology/qgspointclusterrendererwidget.cpp
@@ -162,6 +162,7 @@ void QgsPointClusterRendererWidget::mRendererSettingsButton_clicked()
     QgsSymbolWidgetContext context = mContext;
     context.setAdditionalExpressionContextScopes( scopes );
     w->setContext( context );
+    w->disableSymbolLevels();
     connect( w, &QgsPanelWidget::widgetChanged, this, &QgsPointClusterRendererWidget::updateRendererFromWidget );
     w->setDockMode( this->dockMode() );
     openPanel( w );

--- a/src/gui/symbology/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology/qgspointclusterrendererwidget.cpp
@@ -63,11 +63,11 @@ QgsPointClusterRendererWidget::QgsPointClusterRendererWidget( QgsVectorLayer *la
 
   if ( renderer )
   {
-    mRenderer = QgsPointClusterRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( QgsPointClusterRenderer::convertFromRenderer( renderer ) );
   }
   if ( !mRenderer )
   {
-    mRenderer = new QgsPointClusterRenderer();
+    mRenderer = std::make_unique< QgsPointClusterRenderer >();
   }
 
   blockAllSignals( true );
@@ -109,14 +109,11 @@ QgsPointClusterRendererWidget::QgsPointClusterRendererWidget( QgsVectorLayer *la
   mCenterSymbolToolButton->registerExpressionContextGenerator( this );
 }
 
-QgsPointClusterRendererWidget::~QgsPointClusterRendererWidget()
-{
-  delete mRenderer;
-}
+QgsPointClusterRendererWidget::~QgsPointClusterRendererWidget() = default;
 
 QgsFeatureRenderer *QgsPointClusterRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void QgsPointClusterRendererWidget::setContext( const QgsSymbolWidgetContext &context )

--- a/src/gui/symbology/qgspointclusterrendererwidget.h
+++ b/src/gui/symbology/qgspointclusterrendererwidget.h
@@ -64,7 +64,7 @@ class GUI_EXPORT QgsPointClusterRendererWidget: public QgsRendererWidget, public
     QgsExpressionContext createExpressionContext() const override;
 
   private:
-    QgsPointClusterRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsPointClusterRenderer > mRenderer;
 
     void blockAllSignals( bool block );
     void setupBlankUi( const QString &layerName );

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
@@ -71,11 +71,11 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
 
   if ( renderer )
   {
-    mRenderer = QgsPointDisplacementRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( QgsPointDisplacementRenderer::convertFromRenderer( renderer ) );
   }
   if ( !mRenderer )
   {
-    mRenderer = new QgsPointDisplacementRenderer();
+    mRenderer = std::make_unique< QgsPointDisplacementRenderer >();
   }
 
   blockAllSignals( true );
@@ -176,14 +176,11 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
   mCenterSymbolToolButton->registerExpressionContextGenerator( this );
 }
 
-QgsPointDisplacementRendererWidget::~QgsPointDisplacementRendererWidget()
-{
-  delete mRenderer;
-}
+QgsPointDisplacementRendererWidget::~QgsPointDisplacementRendererWidget() = default;
 
 QgsFeatureRenderer *QgsPointDisplacementRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void QgsPointDisplacementRendererWidget::setContext( const QgsSymbolWidgetContext &context )

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
@@ -279,6 +279,7 @@ void QgsPointDisplacementRendererWidget::mRendererSettingsButton_clicked()
     QList< QgsExpressionContextScope > scopes = context.additionalExpressionContextScopes();
     scopes << scope;
     context.setAdditionalExpressionContextScopes( scopes );
+    w->disableSymbolLevels();
     w->setContext( context );
 
     connect( w, &QgsPanelWidget::widgetChanged, this, &QgsPointDisplacementRendererWidget::updateRendererFromWidget );

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.h
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.h
@@ -44,7 +44,7 @@ class GUI_EXPORT QgsPointDisplacementRendererWidget: public QgsRendererWidget, p
     QgsExpressionContext createExpressionContext() const override;
 
   private:
-    QgsPointDisplacementRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsPointDisplacementRenderer > mRenderer;
 
     void blockAllSignals( bool block );
     void setupBlankUi( const QString &layerName );

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -320,19 +320,21 @@ void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
   if ( panel && panel->dockMode() )
   {
-    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( r, r->usingSymbolLevels(), panel );
+    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( r->legendSymbolItems(), r->usingSymbolLevels(), panel );
     widget->setPanelTitle( tr( "Symbol Levels" ) );
-    connect( widget, &QgsPanelWidget::widgetChanged, widget, &QgsSymbolLevelsWidget::apply );
-    connect( widget, &QgsPanelWidget::widgetChanged, this, [ = ]() { emit widgetChanged(); emit symbolLevelsChanged(); } );
+    connect( widget, &QgsPanelWidget::widgetChanged, this, [ = ]()
+    {
+      setSymbolLevels( widget->symbolLevels(), widget->usingLevels() );
+    } );
     panel->openPanel( widget );
-    return;
   }
-
-  QgsSymbolLevelsDialog dlg( r, r->usingSymbolLevels(), panel );
-  if ( dlg.exec() )
+  else
   {
-    emit widgetChanged();
-    emit symbolLevelsChanged();
+    QgsSymbolLevelsDialog dlg( r, r->usingSymbolLevels(), panel );
+    if ( dlg.exec() )
+    {
+      setSymbolLevels( dlg.symbolLevels(), dlg.usingLevels() );
+    }
   }
 }
 
@@ -378,6 +380,10 @@ QgsDataDefinedSizeLegendWidget *QgsRendererWidget::createDataDefinedSizeLegendWi
   return panel;
 }
 
+void QgsRendererWidget::setSymbolLevels( const QList< QgsLegendSymbolItem > &, bool )
+{
+
+}
 
 //
 // QgsDataDefinedValueDialog

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -366,6 +366,10 @@ void QgsRendererWidget::setDockMode( bool dockMode )
   QgsPanelWidget::setDockMode( dockMode );
 }
 
+void QgsRendererWidget::disableSymbolLevels()
+{
+}
+
 QgsDataDefinedSizeLegendWidget *QgsRendererWidget::createDataDefinedSizeLegendWidget( const QgsMarkerSymbol *symbol, const QgsDataDefinedSizeLegend *ddsLegend )
 {
   QgsProperty ddSize = symbol->dataDefinedSize();

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -28,6 +28,7 @@ class QgsStyle;
 class QgsFeatureRenderer;
 class QgsMapCanvas;
 class QgsMarkerSymbol;
+class QgsLegendSymbolItem;
 
 /**
  * \ingroup gui
@@ -50,7 +51,9 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
     //! Returns pointer to the renderer (no transfer of ownership)
     virtual QgsFeatureRenderer *renderer() = 0;
 
-    //! show a dialog with renderer's symbol level settings
+    /**
+     * Show a dialog with renderer's symbol level settings.
+     */
     void showSymbolLevelsDialog( QgsFeatureRenderer *r );
 
     /**
@@ -92,8 +95,10 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
 
     /**
      * Emitted when the symbol levels settings have been changed.
+     *
+     * \deprecated since QGIS 3.20 -- no longer emitted.
      */
-    void symbolLevelsChanged();
+    Q_DECL_DEPRECATED void symbolLevelsChanged() SIP_DEPRECATED;
 
   protected:
     QgsVectorLayer *mLayer = nullptr;
@@ -130,6 +135,17 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
      * \since QGIS 3.0
      */
     QgsDataDefinedSizeLegendWidget *createDataDefinedSizeLegendWidget( const QgsMarkerSymbol *symbol, const QgsDataDefinedSizeLegend *ddsLegend ) SIP_FACTORY;
+
+    /**
+     * Sets the symbol levels for the renderer defined in the widget.
+     *
+     * The \a levels argument defines the updated list of symbols with rendering passes set.
+     *
+     * The \a enabled arguments specifies if symbol levels should be enabled for the renderer.
+     *
+     * \since QGIS 3.20
+     */
+    virtual void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled );
 
   protected slots:
     void  contextMenuViewCategories( QPoint p );

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -84,6 +84,14 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
 
     void setDockMode( bool dockMode ) override;
 
+    /**
+     * Disables symbol level modification on the widget.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.20
+     */
+    virtual void disableSymbolLevels() SIP_SKIP;
+
   signals:
 
     /**

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -61,20 +61,20 @@ QgsRuleBasedRendererWidget::QgsRuleBasedRendererWidget( QgsVectorLayer *layer, Q
 
   if ( renderer )
   {
-    mRenderer = QgsRuleBasedRenderer::convertFromRenderer( renderer, layer );
+    mRenderer.reset( QgsRuleBasedRenderer::convertFromRenderer( renderer, layer ) );
   }
   if ( !mRenderer )
   {
     // some default options
     QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 
-    mRenderer = new QgsRuleBasedRenderer( symbol );
+    mRenderer = std::make_unique< QgsRuleBasedRenderer >( symbol );
   }
 
   setupUi( this );
   this->layout()->setContentsMargins( 0, 0, 0, 0 );
 
-  mModel = new QgsRuleBasedRendererModel( mRenderer, viewRules );
+  mModel = new QgsRuleBasedRendererModel( mRenderer.get(), viewRules );
 #ifdef ENABLE_MODELTEST
   new ModelTest( mModel, this ); // for model validity checking
 #endif
@@ -135,12 +135,11 @@ QgsRuleBasedRendererWidget::QgsRuleBasedRendererWidget( QgsVectorLayer *layer, Q
 QgsRuleBasedRendererWidget::~QgsRuleBasedRendererWidget()
 {
   qDeleteAll( mCopyBuffer );
-  delete mRenderer;
 }
 
 QgsFeatureRenderer *QgsRuleBasedRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void QgsRuleBasedRendererWidget::setDockMode( bool dockMode )
@@ -452,7 +451,7 @@ void QgsRuleBasedRendererWidget::setRenderingOrder()
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
   if ( panel && panel->dockMode() )
   {
-    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( mRenderer, true, panel );
+    QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( mRenderer.get(), true, panel );
     widget->setForceOrderingEnabled( true );
     widget->setPanelTitle( tr( "Symbol Levels" ) );
     connect( widget, &QgsPanelWidget::widgetChanged, this, [ = ]()
@@ -463,7 +462,7 @@ void QgsRuleBasedRendererWidget::setRenderingOrder()
   }
   else
   {
-    QgsSymbolLevelsDialog dlg( mRenderer, true, panel );
+    QgsSymbolLevelsDialog dlg( mRenderer.get(), true, panel );
     dlg.setForceOrderingEnabled( true );
     if ( dlg.exec() )
     {

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -166,7 +166,7 @@ class GUI_EXPORT QgsRuleBasedRendererWidget : public QgsRendererWidget, private 
     void refreshSymbolView() override;
     void keyPressEvent( QKeyEvent *event ) override;
 
-    QgsRuleBasedRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsRuleBasedRenderer > mRenderer;
     QgsRuleBasedRendererModel *mModel = nullptr;
 
     QMenu *mRefineMenu = nullptr;

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -157,6 +157,8 @@ class GUI_EXPORT QgsRuleBasedRendererWidget : public QgsRendererWidget, private 
     void refineRuleRangesGui();
     void refineRuleScalesGui( const QModelIndexList &index );
 
+    void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled ) override;
+
     QgsRuleBasedRenderer::Rule *currentRule();
 
     QList<QgsSymbol *> selectedSymbols() override;

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -60,12 +60,6 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
   mSelector = new QgsSymbolSelectorWidget( mSingleSymbol, mStyle, mLayer, nullptr );
   connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, &QgsSingleSymbolRendererWidget::changeSingleSymbol );
   connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
-  connect( this, &QgsRendererWidget::symbolLevelsChanged, [ = ]()
-  {
-    delete mSingleSymbol;
-    mSingleSymbol = mRenderer->symbol()->clone();
-    mSelector->loadSymbol( mSingleSymbol );
-  } );
 
   QVBoxLayout *layout = new QVBoxLayout( this );
   layout->setContentsMargins( 0, 0, 0, 0 );
@@ -111,6 +105,15 @@ void QgsSingleSymbolRendererWidget::setDockMode( bool dockMode )
   QgsRendererWidget::setDockMode( dockMode );
   if ( mSelector )
     mSelector->setDockMode( dockMode );
+}
+
+void QgsSingleSymbolRendererWidget::setSymbolLevels( const QList<QgsLegendSymbolItem> &levels, bool enabled )
+{
+  mSingleSymbol.reset( levels.at( 0 ).symbol()->clone() );
+  mRenderer->setSymbol( mSingleSymbol->clone() );
+  mRenderer->setUsingSymbolLevels( enabled );
+  mSelector->loadSymbol( mSingleSymbol.get() );
+  emit widgetChanged();
 }
 
 void QgsSingleSymbolRendererWidget::changeSingleSymbol()

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -35,29 +35,28 @@ QgsRendererWidget *QgsSingleSymbolRendererWidget::create( QgsVectorLayer *layer,
 
 QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
   : QgsRendererWidget( layer, style )
-
 {
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
 
   if ( renderer )
   {
-    mRenderer = QgsSingleSymbolRenderer::convertFromRenderer( renderer );
+    mRenderer.reset( QgsSingleSymbolRenderer::convertFromRenderer( renderer ) );
   }
   if ( !mRenderer )
   {
     QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 
     if ( symbol )
-      mRenderer = new QgsSingleSymbolRenderer( symbol );
+      mRenderer = std::make_unique< QgsSingleSymbolRenderer >( symbol );
   }
 
   // load symbol from it
   if ( mRenderer )
-    mSingleSymbol = mRenderer->symbol()->clone();
+    mSingleSymbol.reset( mRenderer->symbol()->clone() );
 
   // setup ui
-  mSelector = new QgsSymbolSelectorWidget( mSingleSymbol, mStyle, mLayer, nullptr );
+  mSelector = new QgsSymbolSelectorWidget( mSingleSymbol.get(), mStyle, mLayer, nullptr );
   connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, &QgsSingleSymbolRendererWidget::changeSingleSymbol );
   connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
 
@@ -73,24 +72,21 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
   if ( mSingleSymbol && mSingleSymbol->type() == Qgis::SymbolType::Marker )
   {
     QAction *actionDdsLegend = advMenu->addAction( tr( "Data-defined Size Legend…" ) );
-    // only from Qt 5.6 there is convenience addAction() with new style connection
     connect( actionDdsLegend, &QAction::triggered, this, &QgsSingleSymbolRendererWidget::dataDefinedSizeLegend );
   }
 }
 
 QgsSingleSymbolRendererWidget::~QgsSingleSymbolRendererWidget()
 {
-  delete mSingleSymbol;
-
-  delete mRenderer;
+  mSingleSymbol.reset();
+  mRenderer.reset();
 
   delete mSelector;
 }
 
-
 QgsFeatureRenderer *QgsSingleSymbolRendererWidget::renderer()
 {
-  return mRenderer;
+  return mRenderer.get();
 }
 
 void QgsSingleSymbolRendererWidget::setContext( const QgsSymbolWidgetContext &context )
@@ -125,12 +121,12 @@ void QgsSingleSymbolRendererWidget::changeSingleSymbol()
 
 void QgsSingleSymbolRendererWidget::showSymbolLevels()
 {
-  showSymbolLevelsDialog( mRenderer );
+  showSymbolLevelsDialog( mRenderer.get() );
 }
 
 void QgsSingleSymbolRendererWidget::dataDefinedSizeLegend()
 {
-  QgsMarkerSymbol *s = static_cast<QgsMarkerSymbol *>( mSingleSymbol ); // this should be only enabled for marker symbols
+  QgsMarkerSymbol *s = static_cast<QgsMarkerSymbol *>( mSingleSymbol.get() ); // this should be only enabled for marker symbols
   QgsDataDefinedSizeLegendWidget *panel = createDataDefinedSizeLegendWidget( s, mRenderer->dataDefinedSizeLegend() );
   if ( panel )
   {

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -67,8 +67,8 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
   // advanced actions - data defined rendering
   QMenu *advMenu = mSelector->advancedMenu();
 
-  QAction *actionLevels = advMenu->addAction( tr( "Symbol Levels…" ) );
-  connect( actionLevels, &QAction::triggered, this, &QgsSingleSymbolRendererWidget::showSymbolLevels );
+  mActionLevels = advMenu->addAction( tr( "Symbol Levels…" ) );
+  connect( mActionLevels, &QAction::triggered, this, &QgsSingleSymbolRendererWidget::showSymbolLevels );
   if ( mSingleSymbol && mSingleSymbol->type() == Qgis::SymbolType::Marker )
   {
     QAction *actionDdsLegend = advMenu->addAction( tr( "Data-defined Size Legend…" ) );
@@ -101,6 +101,12 @@ void QgsSingleSymbolRendererWidget::setDockMode( bool dockMode )
   QgsRendererWidget::setDockMode( dockMode );
   if ( mSelector )
     mSelector->setDockMode( dockMode );
+}
+
+void QgsSingleSymbolRendererWidget::disableSymbolLevels()
+{
+  delete mActionLevels;
+  mActionLevels = nullptr;
 }
 
 void QgsSingleSymbolRendererWidget::setSymbolLevels( const QList<QgsLegendSymbolItem> &levels, bool enabled )

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.h
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.h
@@ -49,6 +49,9 @@ class GUI_EXPORT QgsSingleSymbolRendererWidget : public QgsRendererWidget
      */
     void setDockMode( bool dockMode ) override;
 
+  protected:
+    void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled ) override;
+
   private slots:
     void changeSingleSymbol();
 

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.h
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.h
@@ -41,13 +41,8 @@ class GUI_EXPORT QgsSingleSymbolRendererWidget : public QgsRendererWidget
     QgsFeatureRenderer *renderer() override;
 
     void setContext( const QgsSymbolWidgetContext &context ) override;
-
-    /**
-     * Set the widget in dock mode which tells the widget to emit panel
-     * widgets and not open dialogs
-     * \param dockMode TRUE to enable dock mode.
-     */
     void setDockMode( bool dockMode ) override;
+    void disableSymbolLevels() override SIP_SKIP;
 
   protected:
     void setSymbolLevels( const QList< QgsLegendSymbolItem > &levels, bool enabled ) override;
@@ -64,6 +59,7 @@ class GUI_EXPORT QgsSingleSymbolRendererWidget : public QgsRendererWidget
     std::unique_ptr< QgsSingleSymbolRenderer > mRenderer;
     QgsSymbolSelectorWidget *mSelector = nullptr;
     std::unique_ptr< QgsSymbol > mSingleSymbol;
+    QAction *mActionLevels = nullptr;
 };
 
 

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.h
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.h
@@ -61,9 +61,9 @@ class GUI_EXPORT QgsSingleSymbolRendererWidget : public QgsRendererWidget
 
   private:
 
-    QgsSingleSymbolRenderer *mRenderer = nullptr;
+    std::unique_ptr< QgsSingleSymbolRenderer > mRenderer;
     QgsSymbolSelectorWidget *mSelector = nullptr;
-    QgsSymbol *mSingleSymbol = nullptr;
+    std::unique_ptr< QgsSymbol > mSingleSymbol;
 };
 
 

--- a/src/gui/symbology/qgssymbollevelsdialog.h
+++ b/src/gui/symbology/qgssymbollevelsdialog.h
@@ -38,11 +38,28 @@ class GUI_EXPORT QgsSymbolLevelsWidget : public QgsPanelWidget, private Ui::QgsS
 {
     Q_OBJECT
   public:
-    //! Constructor for QgsSymbolLevelsWidget
+
+    /**
+     * Constructor for QgsSymbolLevelsWidget
+     */
     QgsSymbolLevelsWidget( QgsFeatureRenderer *renderer, bool usingSymbolLevels, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Constructor for QgsSymbolLevelsWidget, which takes a list of \a symbols to show in the dialog.
+     *
+     * \since QGIS 3.20
+     */
+    QgsSymbolLevelsWidget( const QgsLegendSymbolList &symbols, bool usingSymbolLevels, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     //! Returns whether the level ordering is enabled
     bool usingLevels() const;
+
+    /**
+     * Returns the current legend symbols with rendering passes set, as defined in the widget.
+     *
+     * \since QGIS 3.20
+     */
+    QgsLegendSymbolList symbolLevels() const;
 
     /**
      * Sets whether the level ordering is always forced on and hide the checkbox (used by rule-based renderer)
@@ -51,35 +68,33 @@ class GUI_EXPORT QgsSymbolLevelsWidget : public QgsPanelWidget, private Ui::QgsS
     void setForceOrderingEnabled( bool enabled );
 
   public slots:
-    //! Apply button
-    void apply();
+
+    /**
+     * Apply button.
+     *
+     * \deprecated since QGIS 3.20. Use symbolLevels() and manually apply the changes to the renderer as appropriate.
+     */
+    Q_DECL_DEPRECATED void apply() SIP_DEPRECATED;
 
   private slots:
     void updateUi();
 
     void renderingPassChanged( int row, int column );
 
-  protected:
-    //! \note not available in Python bindings
-    void populateTable() SIP_SKIP;
-    //! \note not available in Python bindings
-    void setDefaultLevels() SIP_SKIP;
+  private:
+    void populateTable();
+    void setDefaultLevels();
 
     //! maximal number of layers from all symbols
-    int mMaxLayers;
+    int mMaxLayers = 0;
 
     QgsFeatureRenderer *mRenderer = nullptr;
     QgsLegendSymbolList mLegendSymbols;
 
     //! whether symbol layers always should be used (default FALSE)
-    bool mForceOrderingEnabled;
-
-  private:
-#ifdef SIP_RUN
-    QgsSymbolLevelsWidget();
-
-#endif
+    bool mForceOrderingEnabled = false;
 };
+
 
 /**
  * \class QgsSymbolLevelsDialog
@@ -97,6 +112,20 @@ class GUI_EXPORT QgsSymbolLevelsDialog : public QDialog
 
     // used by rule-based renderer (to hide checkbox to enable/disable ordering)
     void setForceOrderingEnabled( bool enabled );
+
+    /**
+     * Returns whether the level ordering is enabled.
+     *
+     * \since QGIS 3.20
+     */
+    bool usingLevels() const;
+
+    /**
+     * Returns the current legend symbols with rendering passes set, as defined in the widget.
+     *
+     * \since QGIS 3.20
+     */
+    QgsLegendSymbolList symbolLevels() const;
 
   private:
 

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -404,6 +404,12 @@ void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol, SymbolLayerItem *pa
   layersTree->setExpanded( symbolItem->index(), true );
 }
 
+  if ( mSymbol == symbol && !layersTree->currentIndex().isValid() )
+  {
+    // make sure root item for symbol is selected in tree
+    layersTree->setCurrentIndex( symbolItem->index() );
+  }
+}
 
 void QgsSymbolSelectorWidget::reloadSymbol()
 {

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -258,7 +258,7 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
     QMenu *mAdvancedMenu = nullptr;
     QgsVectorLayer *mVectorLayer = nullptr;
 
-    QStandardItemModel *model = nullptr;
+    QStandardItemModel *mSymbolLayersModel = nullptr;
     QWidget *mPresentWidget = nullptr;
 
     std::unique_ptr<DataDefinedRestorer> mDataDefineRestorer;


### PR DESCRIPTION
Instead of directly changing the renderer in place in the symbol levels
widget, we delegate responsibility for handling the changes to symbol
levels to the parent QgsRendererWidget subclass. This allows us to
implement different logic in the various subclasses which correctly
handle how that particular widget subclass should update any internal
symbol references and ultimately update the renderer.

Fixes instability and crashes after editing symbol levels.

Fixes #42671

Also other smaller cleanups and fixes