### PR TITLE
Make "topo roads" and "topo main road" symbols render beautifully out-of-the-box

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -53,6 +53,10 @@ QgsSymbol.DynamicRotation = Qgis.SymbolRenderHint.DynamicRotation
 QgsSymbol.DynamicRotation.__doc__ = "Rotation of symbol may be changed during rendering and symbol should not be cached"
 Qgis.SymbolRenderHint.__doc__ = 'Flags controlling behavior of symbols during rendering\n\n.. versionadded:: 3.20\n\n' + '* ``DynamicRotation``: ' + Qgis.SymbolRenderHint.DynamicRotation.__doc__
 # --
+# monkey patching scoped based enum
+Qgis.SymbolFlag.RendererShouldUseSymbolLevels.__doc__ = "If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results"
+Qgis.SymbolFlag.__doc__ = 'Flags controlling behavior of symbols\n\n.. versionadded:: 3.20\n\n' + '* ``RendererShouldUseSymbolLevels``: ' + Qgis.SymbolFlag.RendererShouldUseSymbolLevels.__doc__
+# --
 QgsSymbol.PreviewFlag = Qgis.SymbolPreviewFlag
 # monkey patching scoped based enum
 QgsSymbol.FlagIncludeCrosshairsForMarkerSymbols = Qgis.SymbolPreviewFlag.FlagIncludeCrosshairsForMarkerSymbols

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -138,6 +138,13 @@ The development version
     typedef QFlags<Qgis::SymbolRenderHint> SymbolRenderHints;
 
 
+    enum class SymbolFlag
+    {
+      RendererShouldUseSymbolLevels,
+    };
+    typedef QFlags<Qgis::SymbolFlag> SymbolFlags;
+
+
     enum class SymbolPreviewFlag
       {
       FlagIncludeCrosshairsForMarkerSymbols,
@@ -244,6 +251,8 @@ GEOS string version linked
 };
 
 QFlags<Qgis::SymbolRenderHint> operator|(Qgis::SymbolRenderHint f1, QFlags<Qgis::SymbolRenderHint> f2);
+
+QFlags<Qgis::SymbolFlag> operator|(Qgis::SymbolFlag f1, QFlags<Qgis::SymbolFlag> f2);
 
 QFlags<Qgis::SymbolPreviewFlag> operator|(Qgis::SymbolPreviewFlag f1, QFlags<Qgis::SymbolPreviewFlag> f2);
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -439,6 +439,24 @@ Returns the rendering hint flags for the symbol.
 .. seealso:: :py:func:`setRenderHints`
 %End
 
+    void setFlags( Qgis::SymbolFlags flags );
+%Docstring
+Sets ``flags`` for the symbol.
+
+.. seealso:: :py:func:`flags`
+
+.. versionadded:: 3.320
+%End
+
+    Qgis::SymbolFlags flags() const;
+%Docstring
+Returns flags for the symbol.
+
+.. seealso:: :py:func:`setFlags`
+
+.. versionadded:: 3.20
+%End
+
     void setClipFeaturesToExtent( bool clipFeaturesToExtent );
 %Docstring
 Sets whether features drawn by the symbol should be clipped to the render context's
@@ -663,6 +681,8 @@ Render editing vertex marker at specified point
 
 .. versionadded:: 2.16
 %End
+
+
 
 
 

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -4879,7 +4879,7 @@
         </data_defined_properties>
       </layer>
     </symbol>
-    <symbol favorite="1" force_rhr="0" name="topo main road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+    <symbol favorite="1" force_rhr="0" renderer_should_use_levels="1" name="topo main road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
       <layer enabled="1" class="SimpleLine" locked="1" pass="0">
         <prop k="capstyle" v="round"/>
         <prop k="customdash" v="5;2"/>
@@ -5186,7 +5186,7 @@
         </symbol>
       </layer>
     </symbol>
-    <symbol favorite="1" force_rhr="0" name="topo road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+    <symbol favorite="1" force_rhr="0" renderer_should_use_levels="1" name="topo road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
       <layer enabled="1" class="SimpleLine" locked="1" pass="0">
         <prop k="capstyle" v="round"/>
         <prop k="customdash" v="5;2"/>

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -193,6 +193,17 @@ class CORE_EXPORT Qgis
     Q_DECLARE_FLAGS( SymbolRenderHints, SymbolRenderHint )
 
     /**
+     * \brief Flags controlling behavior of symbols
+     *
+     * \since QGIS 3.20
+     */
+    enum class SymbolFlag : int
+    {
+      RendererShouldUseSymbolLevels = 1 << 0, //!< If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results
+    };
+    Q_DECLARE_FLAGS( SymbolFlags, SymbolFlag )
+
+    /**
      * Flags for controlling how symbol preview images are generated.
      *
      * \since QGIS 3.20
@@ -366,6 +377,7 @@ class CORE_EXPORT Qgis
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolRenderHints )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolPreviewFlags )
 
 

--- a/src/core/symbology/qgsfillsymbol.cpp
+++ b/src/core/symbology/qgsfillsymbol.cpp
@@ -150,6 +150,7 @@ QgsFillSymbol *QgsFillSymbol::clone() const
   cloneSymbol->setClipFeaturesToExtent( mClipFeaturesToExtent );
   cloneSymbol->setForceRHR( mForceRHR );
   cloneSymbol->setDataDefinedProperties( dataDefinedProperties() );
+  cloneSymbol->setFlags( mSymbolFlags );
   return cloneSymbol;
 }
 

--- a/src/core/symbology/qgslinesymbol.cpp
+++ b/src/core/symbology/qgslinesymbol.cpp
@@ -281,5 +281,6 @@ QgsLineSymbol *QgsLineSymbol::clone() const
   cloneSymbol->setClipFeaturesToExtent( mClipFeaturesToExtent );
   cloneSymbol->setForceRHR( mForceRHR );
   cloneSymbol->setDataDefinedProperties( dataDefinedProperties() );
+  cloneSymbol->setFlags( mSymbolFlags );
   return cloneSymbol;
 }

--- a/src/core/symbology/qgsmarkersymbol.cpp
+++ b/src/core/symbology/qgsmarkersymbol.cpp
@@ -484,6 +484,7 @@ QgsMarkerSymbol *QgsMarkerSymbol::clone() const
   cloneSymbol->setClipFeaturesToExtent( mClipFeaturesToExtent );
   cloneSymbol->setForceRHR( mForceRHR );
   cloneSymbol->setDataDefinedProperties( dataDefinedProperties() );
+  cloneSymbol->setFlags( mSymbolFlags );
   return cloneSymbol;
 }
 

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -448,6 +448,22 @@ class CORE_EXPORT QgsSymbol
     Qgis::SymbolRenderHints renderHints() const { return mRenderHints; }
 
     /**
+     * Sets \a flags for the symbol.
+     *
+     * \see flags()
+     * \since QGIS 3.320
+     */
+    void setFlags( Qgis::SymbolFlags flags ) { mSymbolFlags = flags; }
+
+    /**
+     * Returns flags for the symbol.
+     *
+     * \see setFlags()
+     * \since QGIS 3.20
+     */
+    Qgis::SymbolFlags flags() const { return mSymbolFlags; }
+
+    /**
      * Sets whether features drawn by the symbol should be clipped to the render context's
      * extent. If this option is enabled then features which are partially outside the extent
      * will be clipped. This speeds up rendering of the feature, but may have undesirable
@@ -680,6 +696,14 @@ class CORE_EXPORT QgsSymbol
     qreal mOpacity = 1.0;
 
     Qgis::SymbolRenderHints mRenderHints;
+
+    /**
+     * Symbol flags.
+     *
+     * \since QGIS 3.20
+     */
+    Qgis::SymbolFlags mSymbolFlags = Qgis::SymbolFlags();
+
     bool mClipFeaturesToExtent = true;
     bool mForceRHR = false;
 

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1148,6 +1148,10 @@ QgsSymbol *QgsSymbolLayerUtils::loadSymbol( const QDomElement &element, const Qg
   symbol->setOpacity( element.attribute( QStringLiteral( "alpha" ), QStringLiteral( "1.0" ) ).toDouble() );
   symbol->setClipFeaturesToExtent( element.attribute( QStringLiteral( "clip_to_extent" ), QStringLiteral( "1" ) ).toInt() );
   symbol->setForceRHR( element.attribute( QStringLiteral( "force_rhr" ), QStringLiteral( "0" ) ).toInt() );
+  Qgis::SymbolFlags flags;
+  if ( element.attribute( QStringLiteral( "renderer_should_use_levels" ), QStringLiteral( "0" ) ).toInt() )
+    flags |= Qgis::SymbolFlag::RendererShouldUseSymbolLevels;
+  symbol->setFlags( flags );
 
   QDomElement ddProps = element.firstChildElement( QStringLiteral( "data_defined_properties" ) );
   if ( !ddProps.isNull() )
@@ -1230,6 +1234,9 @@ QDomElement QgsSymbolLayerUtils::saveSymbol( const QString &name, const QgsSymbo
   symEl.setAttribute( QStringLiteral( "alpha" ), QString::number( symbol->opacity() ) );
   symEl.setAttribute( QStringLiteral( "clip_to_extent" ), symbol->clipFeaturesToExtent() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   symEl.setAttribute( QStringLiteral( "force_rhr" ), symbol->forceRHR() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  if ( symbol->flags() & Qgis::SymbolFlag::RendererShouldUseSymbolLevels )
+    symEl.setAttribute( QStringLiteral( "renderer_should_use_levels" ), QStringLiteral( "1" ) );
+
   //QgsDebugMsg( "num layers " + QString::number( symbol->symbolLayerCount() ) );
 
   QDomElement ddProps = doc.createElement( QStringLiteral( "data_defined_properties" ) );

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -112,6 +112,12 @@ void QgsSingleSymbolRendererWidget::disableSymbolLevels()
 void QgsSingleSymbolRendererWidget::setSymbolLevels( const QList<QgsLegendSymbolItem> &levels, bool enabled )
 {
   mSingleSymbol.reset( levels.at( 0 ).symbol()->clone() );
+  if ( !enabled )
+  {
+    // remove the renderer symbol levels flag (if present), as we don't symbol levels automatically re-enabling when other changes
+    // are made to the symbol
+    mSingleSymbol->setFlags( mSingleSymbol->flags() & ~Qgis::SymbolFlags( Qgis::SymbolFlag::RendererShouldUseSymbolLevels ) );
+  }
   mRenderer->setSymbol( mSingleSymbol->clone() );
   mRenderer->setUsingSymbolLevels( enabled );
   mSelector->loadSymbol( mSingleSymbol.get() );
@@ -122,6 +128,10 @@ void QgsSingleSymbolRendererWidget::changeSingleSymbol()
 {
   // update symbol from the GUI
   mRenderer->setSymbol( mSingleSymbol->clone() );
+
+  if ( mSingleSymbol->flags() & Qgis::SymbolFlag::RendererShouldUseSymbolLevels )
+    mRenderer->setUsingSymbolLevels( true );
+
   emit widgetChanged();
 }
 

--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -581,6 +581,7 @@ void QgsSymbolsListWidget::setSymbolFromStyle( const QString &name, QgsStyle::St
     mSymbol->appendSymbolLayer( sl );
   }
   mSymbol->setOpacity( s->opacity() );
+  mSymbol->setFlags( s->flags() );
 
   updateSymbolInfo();
   emit changed();

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -55,7 +55,8 @@ from qgis.core import (QgsGeometry,
                        QgsSymbolLayerUtils,
                        QgsMarkerLineSymbolLayer,
                        QgsArrowSymbolLayer,
-                       QgsSymbol
+                       QgsSymbol,
+                       Qgis
                        )
 
 from qgis.testing import unittest, start_app
@@ -167,6 +168,27 @@ class TestQgsSymbol(unittest.TestCase):
         self.assertEqual(QgsSymbol.symbolTypeForGeometryType(QgsWkbTypes.PolygonGeometry), QgsSymbol.Fill)
         self.assertEqual(QgsSymbol.symbolTypeForGeometryType(QgsWkbTypes.NullGeometry), QgsSymbol.Hybrid)
         self.assertEqual(QgsSymbol.symbolTypeForGeometryType(QgsWkbTypes.UnknownGeometry), QgsSymbol.Hybrid)
+
+    def testFlags(self):
+        """
+        Test symbol flags
+        """
+        s = QgsLineSymbol.createSimple({})
+        self.assertEqual(s.flags(), Qgis.SymbolFlags())
+
+        s.setFlags(Qgis.SymbolFlag.RendererShouldUseSymbolLevels)
+        self.assertEqual(s.flags(), Qgis.SymbolFlag.RendererShouldUseSymbolLevels)
+
+        s2 = s.clone()
+        self.assertEqual(s2.flags(), Qgis.SymbolFlag.RendererShouldUseSymbolLevels)
+
+        # test that flags are saved/restored via XML
+        doc = QDomDocument()
+        context = QgsReadWriteContext()
+        element = QgsSymbolLayerUtils.saveSymbol('test', s, doc, context)
+
+        s2 = QgsSymbolLayerUtils.loadSymbol(element, context)
+        self.assertEqual(s2.flags(), Qgis.SymbolFlag.RendererShouldUseSymbolLevels)
 
     def testCanCauseArtifactsBetweenAdjacentTiles(self):
         """


### PR DESCRIPTION
Instead of seeing this when users pick the "topo main road" symbol:

![image](https://user-images.githubusercontent.com/1829991/119592321-98b00900-be1b-11eb-9285-5b779445478c.png)

Give them this:

![image](https://user-images.githubusercontent.com/1829991/119592344-a36a9e00-be1b-11eb-92f7-4bdace3615fb.png)

MUCH nicer!
