### PR TITLE
Allow clearing data defined buttons which are set to non-existing fields

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -600,6 +600,7 @@ void QgsPropertyOverrideButton::menuActionTriggered( QAction *action )
     mProperty.setStaticValue( QVariant() );
     mProperty.setTransformer( nullptr );
     mExpressionString.clear();
+    mFieldName.clear();
     updateSiblingWidgets( isActive() );
     updateGui();
     emit changed();


### PR DESCRIPTION
As reported in https://twitter.com/antoniolocandro/status/1397340362616852482?s=20 (this has annoyed me for a long time!!)
