### PR TITLE
Add a dedicated "refresh" item to the context menu for directories 

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -74,6 +74,12 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
 
   QgsSettings settings;
 
+  QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+  connect( actionRefresh, &QAction::triggered, this, [ = ] { directoryItem->refresh(); } );
+  menu->addAction( actionRefresh );
+
+  menu->addSeparator();
+
   QMenu *newMenu = new QMenu( tr( "New" ), menu );
 
   QAction *createFolder = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionNewFolder.svg" ) ), tr( "Directory…" ), menu );


### PR DESCRIPTION
(which only refreshes the selected directory)

If large/remote directories are expanded then it is not efficient
to force the user to use the toolbar "refresh" button which refreshes
EVERY expanded node in the browser

Pt 2 of fixing the browser to properly handle slow network folders which cause the QGIS application to constantly hang