### PR TITLE
Fix code-blocks not properly rendered in PyQGIS API docs

### DIFF
--- a/python/core/auto_generated/editform/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/editform/qgseditformconfig.sip.in
@@ -156,6 +156,7 @@ Example
 :return: ``False`` if a field exists with the provided widgetName. In this case
          :py:class:`QgsVectorLayer`.setEditorWidgetSetup should be used.
 
+
 .. seealso:: :py:func:`QgsVectorLayer.setEditorWidgetSetup`
 %End
 

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -17,6 +17,7 @@ Class for parsing and evaluation of expressions (formerly called "search strings
 The expressions try to follow both syntax and semantics of SQL expressions.
 
 Usage:
+
 .. code-block:: python
 
        exp = QgsExpression("gid*2 > 10 and type not in ('D','F')")

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -832,6 +832,8 @@ Example
        for v in geometry.vertices():
            print(v.x(), v.y())
 
+
+
 .. seealso:: :py:func:`parts`
 
 .. versionadded:: 3.0

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -162,6 +162,7 @@ Example
 
 .. code-block:: python
 
+
       # [(0 0), (5 0)] and [(5 5), (10 5)] are parallels
       QgsCircle.from3TangentsMulti(QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 5), QgsPoint(10, 5), QgsPoint(2.5, 0), QgsPoint(7.5, 5))
       # [<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>, <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -440,6 +440,8 @@ Example
        for v in geometry.vertices():
            print(v.x(), v.y())
 
+
+
 .. seealso:: :py:func:`parts`
 
 .. versionadded:: 3.0

--- a/python/core/auto_generated/geometry/qgsgeometrytransformer.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrytransformer.sip.in
@@ -41,6 +41,7 @@ Example
 
 A transformer which multiples the x coordinate by 3 and adds 10 to the y coordinate:
 
+
 .. code-block:: python
 
        class MyTransformer(QgsAbstractGeometryTransformer):

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -294,6 +294,8 @@ Example
        x, y = QgsGeometryUtils.perpendicularOffsetPointAlongSegment( 1, 5, 11, 5, 0.5, -2 )
        # (6.0, 7.0)
 
+
+
 :return: - x: calculated point x-coordinate
          - y: calculated point y-coordinate
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -40,7 +40,7 @@ Data can be populated by setMesh(const QString &vertices, const QString &faces),
 vertices and faces is comma separated coordinates and connections for mesh.
 E.g. to create mesh with one quad and one triangle
 
-.. code-block::
+.. code-block:: python
 
       uri = "1.0, 2.0 \n" \
           "2.0, 2.0 \n" \
@@ -59,10 +59,13 @@ MDAL data provider (mdal)
 Accesses data using the MDAL drivers (https://github.com/lutraconsulting/MDAL). The url
 is the MDAL connection string. QGIS must be built with MDAL support to allow this provider.
 
-.. code-block::
+
+.. code-block:: python
 
          uri = "test/land.2dm"
          scratchLayer = QgsMeshLayer(uri, "My Scratch Layer",  "mdal")
+
+
 
 .. note::
 

--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -22,7 +22,7 @@ The time in a mesh layer is defined by :
 - each dataset is associated with a relative times
 - time extent is defined by the first time and the last time of all dataset
 
-.. code-block:: unparsed
+.. code-block:: raw
 
      Reference time :          AT
      Dataset 1 time            o-----RT------RT-----RT-----------RT
@@ -32,6 +32,8 @@ The time in a mesh layer is defined by :
 
      AT : absolute time (QDateTime)
      RT : relative time (qint64)
+
+
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -57,10 +57,12 @@ For example, the following code will create and inspect "British national grid" 
 
 This will produce the following output:
 
-.. code-block::
+
+.. code-block:: raw
 
      CRS Description: OSGB 1936 / British National Grid
      CRS PROJ text: +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 [output trimmed]
+
 
 CRS Definition Formats
 ----------------------
@@ -89,7 +91,8 @@ on different machines or user profiles.
   format: `+param1=value1 +param2=value2 [...]`. This is the format natively used by the
   underlying proj library. For example, the definition of WGS84 looks like this:
 
-.. code-block::
+
+.. code-block:: raw
 
        +proj=longlat +datum=WGS84 +no_defs
 
@@ -102,7 +105,8 @@ on different machines or user profiles.
 - Well-known text (WKT): Defined by Open Geospatial Consortium (OGC), this is another common
   format to define CRS. For WGS84 the OGC WKT definition is the following:
 
-.. code-block::
+
+.. code-block:: raw
 
            GEOGCS["WGS 84",
                   DATUM["WGS_1984",

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1901,6 +1901,7 @@ Note that :py:class:`QgsProjectDirtyBlocker` only blocks calls which set the pro
 which set the project as clean are not blocked.
 
 Python scripts should not use :py:class:`QgsProjectDirtyBlocker` directly. Instead, use :py:func:`QgsProject.blockDirtying()`
+
 .. code-block:: python
 
        project = QgsProject.instance()

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -375,6 +375,7 @@ Set the feature's ``geometry``. Ownership of the geometry is transferred to the 
 The feature will be made valid after calling this method.
 
 This method is a shortcut for calling:
+
 .. code-block:: python
 
        feature.setGeometry( QgsGeometry( geometry ) )
@@ -393,6 +394,8 @@ Example
        feature.setGeometry( QgsLineString( [ QgsPoint( 210, 41 ), QgsPoint( 301, 55 ) ] ) )
        print(feature.geometry())
        # output: <QgsGeometry: LineString (210 41, 301 55)>
+
+
 
 .. seealso:: :py:func:`geometry`
 

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -41,6 +41,7 @@ The options may be chained, e.g.:
 
 Examples:
 
+
 .. code-block:: python
 
        # fetch all features:

--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -62,7 +62,9 @@ Example - replace an outdated folder path with a new one:
 
        QgsPathResolver.setPathPreprocessor(my_processor)
 
+
 Example - replace a stored database host with a new one:
+
 
 .. code-block:: python
 
@@ -73,6 +75,7 @@ Example - replace a stored database host with a new one:
 
 
 Example - replace stored database credentials with new ones:
+
 
 .. code-block:: python
 

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -92,6 +92,7 @@ Push a category to the stack
 .. note::
 
    It is not aimed at being used in Python. Instead use the context manager.
+
 .. code-block:: python
 
        context = QgsReadWriteContext()

--- a/python/core/auto_generated/qgsruntimeprofiler.sip.in
+++ b/python/core/auto_generated/qgsruntimeprofiler.sip.in
@@ -146,6 +146,7 @@ This class automatically takes care of registering an operation in the :py:func:
 registry upon construction, and recording of the elapsed runtime upon destruction.
 
 Python scripts should not use :py:class:`QgsScopedRuntimeProfile` directly. Instead, use :py:func:`QgsRuntimeProfiler.profile()`
+
 .. code-block:: python
 
        with QgsRuntimeProfiler.profile('My operation'):

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -74,9 +74,12 @@ Since QGIS 3.4 when closing a project, the application shows a warning about pot
 loss if there are any non-empty memory layers present. If your memory layer should not
 trigger such warning, it is possible to suppress that by setting the following custom variable:
 
+
 .. code-block:: python
 
          layer.setCustomProperty("skipMemoryLayersCheck", 1)
+
+
 
 OGR data provider (ogr)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/server/auto_generated/qgsserverapi.sip.in
+++ b/python/server/auto_generated/qgsserverapi.sip.in
@@ -51,6 +51,7 @@ After the API has been registered to the server API registry:
        api = API(server.serverInterface())
        server.serverInterface().serviceRegistry().registerApi(api)
 
+
 the incoming calls with an URL path starting with the API root path
 will be routed to the first matching API and :py:func:`~executeRequest` method
 of the API will be invoked.

--- a/python/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/server/auto_generated/qgsserverogcapi.sip.in
@@ -29,6 +29,9 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
      api.registerHandler(h)
      server.serverInterface().serviceRegistry().registerApi(api)
 
+
+
+
 .. versionadded:: 3.10
 %End
 

--- a/python/server/auto_generated/qgsserverogcapihandler.sip.in
+++ b/python/server/auto_generated/qgsserverogcapihandler.sip.in
@@ -67,6 +67,10 @@ Optionally, override:
        def parameters(self, context):
            return [QgsServerQueryStringParameter("value1", True, QgsServerQueryStringParameter.Type.Double, "a double value")]
 
+
+
+
+
 .. versionadded:: 3.10
 %End
 

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -184,12 +184,14 @@ sub processDoxygenLine {
     my $line = $_[0];
 
     # detect code snippet
-    if ( $line =~ m/\\code(\{\.(\w+)\})?/ ) {
+    if ( $line =~ m/\\code(\{\.?(\w+)\})?/ ) {
         my $codelang = "";
         $codelang = " $2" if (defined $2);
+        $codelang =~ m/(cpp|py|unparsed)/ or exit_with_error("invalid code snippet format: $codelang");
         $COMMENT_CODE_SNIPPET = CODE_SNIPPET;
         $COMMENT_CODE_SNIPPET = CODE_SNIPPET_CPP if ($codelang =~ m/cpp/ );
         $codelang =~ s/py/python/;
+        $codelang =~ s/unparsed/raw/;
         return "\n" if ( $COMMENT_CODE_SNIPPET == CODE_SNIPPET_CPP );
         return "\n.. code-block::$codelang\n\n";
     }

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -191,7 +191,7 @@ sub processDoxygenLine {
         $COMMENT_CODE_SNIPPET = CODE_SNIPPET_CPP if ($codelang =~ m/cpp/ );
         $codelang =~ s/py/python/;
         return "\n" if ( $COMMENT_CODE_SNIPPET == CODE_SNIPPET_CPP );
-        return ".. code-block::$codelang\n\n";
+        return "\n.. code-block::$codelang\n\n";
     }
     if ( $line =~ m/\\endcode/ ) {
         $COMMENT_CODE_SNIPPET = 0;
@@ -199,6 +199,7 @@ sub processDoxygenLine {
     }
     if ($COMMENT_CODE_SNIPPET != 0){
         if ( $COMMENT_CODE_SNIPPET == CODE_SNIPPET_CPP ){
+            # cpp code is stripped out
             return "";
         } else {
             if ( $line ne ''){

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -108,7 +108,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *
  * This will produce the following output:
  *
- * \code
+ * \code{.unparsed}
  * CRS Description: OSGB 1936 / British National Grid
  * CRS PROJ text: +proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 [output trimmed]
  * \endcode
@@ -137,7 +137,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *   format: `+param1=value1 +param2=value2 [...]`. This is the format natively used by the
  *   underlying proj library. For example, the definition of WGS84 looks like this:
  *
- *   \code
+ *   \code{.unparsed}
  *   +proj=longlat +datum=WGS84 +no_defs
  *   \endcode
  *
@@ -147,7 +147,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  * - Well-known text (WKT): Defined by Open Geospatial Consortium (OGC), this is another common
  *   format to define CRS. For WGS84 the OGC WKT definition is the following:
  *
- *   \code
+ *   \code{.unparsed}
  *       GEOGCS["WGS 84",
  *              DATUM["WGS_1984",
  *                SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],


### PR DESCRIPTION
force line return before code blocks in sip files to ensure a proper rendering in sphinx
return an error when the code format is not specified

fixes https://github.com/qgis/pyqgis/issues/70