### PR TITLE
Do not monitor remote/network directories by default in browser, allow users to opt-in to this

### DIFF
--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -97,5 +97,7 @@
 #define PDAL_VERSION_MINOR "${PDAL_VERSION_MINOR}"
 #define PDAL_VERSION_MICRO "${PDAL_VERSION_MICRO}"
 
+#cmakedefine ENABLE_TESTS
+
 #endif
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -177,6 +177,13 @@ QgsLayerItem.PointCloud.__doc__ = "Point cloud layer"
 Qgis.BrowserLayerType.__doc__ = 'Browser item layer types\n\n.. versionadded:: 3.20\n\n' + '* ``NoType``: ' + Qgis.BrowserLayerType.NoType.__doc__ + '\n' + '* ``Vector``: ' + Qgis.BrowserLayerType.Vector.__doc__ + '\n' + '* ``Raster``: ' + Qgis.BrowserLayerType.Raster.__doc__ + '\n' + '* ``Point``: ' + Qgis.BrowserLayerType.Point.__doc__ + '\n' + '* ``Line``: ' + Qgis.BrowserLayerType.Line.__doc__ + '\n' + '* ``Polygon``: ' + Qgis.BrowserLayerType.Polygon.__doc__ + '\n' + '* ``TableLayer``: ' + Qgis.BrowserLayerType.TableLayer.__doc__ + '\n' + '* ``Database``: ' + Qgis.BrowserLayerType.Database.__doc__ + '\n' + '* ``Table``: ' + Qgis.BrowserLayerType.Table.__doc__ + '\n' + '* ``Plugin``: ' + Qgis.BrowserLayerType.Plugin.__doc__ + '\n' + '* ``Mesh``: ' + Qgis.BrowserLayerType.Mesh.__doc__ + '\n' + '* ``VectorTile``: ' + Qgis.BrowserLayerType.VectorTile.__doc__ + '\n' + '* ``PointCloud``: ' + Qgis.BrowserLayerType.PointCloud.__doc__
 # --
 Qgis.BrowserLayerType.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.BrowserDirectoryMonitoring.Default.__doc__ = "Use default logic to determine whether directory should be monitored"
+Qgis.BrowserDirectoryMonitoring.NeverMonitor.__doc__ = "Never monitor the directory, regardless of the default logic"
+Qgis.BrowserDirectoryMonitoring.AlwaysMonitor.__doc__ = "Always monitor the directory, regardless of the default logic"
+Qgis.BrowserDirectoryMonitoring.__doc__ = 'Browser directory item monitoring switches.\n\n.. versionadded:: 3.20\n\n' + '* ``Default``: ' + Qgis.BrowserDirectoryMonitoring.Default.__doc__ + '\n' + '* ``NeverMonitor``: ' + Qgis.BrowserDirectoryMonitoring.NeverMonitor.__doc__ + '\n' + '* ``AlwaysMonitor``: ' + Qgis.BrowserDirectoryMonitoring.AlwaysMonitor.__doc__
+# --
+Qgis.BrowserDirectoryMonitoring.baseClass = Qgis
 QgsVectorLayerExporter.ExportError = Qgis.VectorExportResult
 # monkey patching scoped based enum
 QgsVectorLayerExporter.NoError = Qgis.VectorExportResult.Success

--- a/python/core/auto_generated/browser/qgsconnectionsitem.sip.in
+++ b/python/core/auto_generated/browser/qgsconnectionsitem.sip.in
@@ -35,6 +35,12 @@ The optional ``providerKey`` string can be used to specify the key for the :py:c
 %End
 
     ~QgsConnectionsRootItem();
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsConnectionsRootItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
 };
 
 

--- a/python/core/auto_generated/browser/qgsdatabaseschemaitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdatabaseschemaitem.sip.in
@@ -36,6 +36,12 @@ The optional ``providerKey`` string can be used to specify the key for the :py:c
 
     ~QgsDatabaseSchemaItem();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsDatabaseSchemaItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QgsAbstractDatabaseProviderConnection *databaseConnection() const;
 
 

--- a/python/core/auto_generated/browser/qgsdatacollectionitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdatacollectionitem.sip.in
@@ -34,6 +34,12 @@ The optional ``providerKey`` string can be used to specify the key for the :py:c
 
     ~QgsDataCollectionItem();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsDataCollectionItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     void addChild( QgsDataItem *item /Transfer/ );
 
     static QIcon iconDir( const QColor &fillColor = QColor(), const QColor &strokeColor = QColor() );

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -63,6 +63,12 @@ The optional ``providerKey`` string (added in QGIS 3.12) can be used to specify 
 
     ~QgsDataItem();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsDataItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     bool hasChildren();
 
     virtual bool layerCollection() const;
@@ -501,6 +507,12 @@ Data item that can be used to report problems (e.g. network error)
   public:
 
     QgsErrorItem( QgsDataItem *parent, const QString &error, const QString &path );
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsErrorItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
 
 };
 

--- a/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -52,6 +52,11 @@ items pointing to different ``dirPaths`` should always use a different item ``pa
 The optional ``providerKey`` string can be used to specify the key for the :py:class:`QgsDataItemProvider` that created this item.
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsDirectoryItem: %1 - %2>" ).arg( sipCpp->dirPath(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
     virtual void setState( Qgis::BrowserItemState state );
 
 

--- a/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -118,6 +118,68 @@ If ``color`` is an invalid color then the default icon color will be used.
 Check if the given path is hidden from the browser model
 %End
 
+    static Qgis::BrowserDirectoryMonitoring monitoringForPath( const QString &path );
+%Docstring
+Returns the monitoring setting for a directory ``path``.
+
+This method returns the monitoring setting for ``path`` only. If no explicit monitoring setting
+is in place for the path then Qgis.BrowserDirectoryMonitoring.Default is returned.
+
+This method does not consider the monitoring setting of parent directories.
+
+.. versionadded:: 3.20
+%End
+
+    static bool pathShouldByMonitoredByDefault( const QString &path );
+%Docstring
+Returns ``True`` if a directory ``path`` should be monitored by default.
+
+In the absence of any other settings this will dictate whether the directory is monitored. This method
+does not consider an explicit monitoring setting set for the path, which can be determined by
+calling :py:func:`~QgsDirectoryItem.monitoringForPath`.
+
+All parent directories will be checked to determine whether they have monitoring
+manually enabled or disabled. As soon as a parent directory is found which has monitoring
+manually enabled or disabled then the corresponding value will be returned.
+
+Paths are monitored by default, so if no explicit setting is in place for a parent directory then
+the function will return ``True``.
+
+.. seealso:: :py:func:`isMonitored`
+
+.. seealso:: :py:func:`setMonitoring`
+
+.. versionadded:: 3.20
+%End
+
+    bool isMonitored() const;
+%Docstring
+Returns ``True`` if the directory is currently being monitored for changes and the item auto-refreshed
+when these occur.
+
+.. versionadded:: 3.20
+%End
+
+    Qgis::BrowserDirectoryMonitoring monitoring() const;
+%Docstring
+Returns the monitoring setting for this directory item.
+
+.. seealso:: :py:func:`setMonitoring`
+
+.. versionadded:: 3.20
+%End
+
+    void setMonitoring( Qgis::BrowserDirectoryMonitoring monitoring );
+%Docstring
+Sets the ``monitoring`` setting for this directory.
+
+This is a persistent setting, which is saved in QSettings.
+
+.. seealso:: :py:func:`monitoring`
+
+.. versionadded:: 3.20
+%End
+
   public slots:
     virtual void childrenCreated();
 
@@ -125,6 +187,8 @@ Check if the given path is hidden from the browser model
 
   protected:
     void init();
+
+
 
 };
 

--- a/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -142,8 +142,9 @@ All parent directories will be checked to determine whether they have monitoring
 manually enabled or disabled. As soon as a parent directory is found which has monitoring
 manually enabled or disabled then the corresponding value will be returned.
 
-Paths are monitored by default, so if no explicit setting is in place for a parent directory then
-the function will return ``True``.
+If no explicit setting is in place for a parent directory, then a check will be made to determine
+whether the path resides on a known slow drive. If so, monitoring is disabled by default and
+``False`` will be returned. Otherwise paths are monitored by default and the function will return ``True``.
 
 .. seealso:: :py:func:`isMonitored`
 

--- a/python/core/auto_generated/browser/qgsfavoritesitem.sip.in
+++ b/python/core/auto_generated/browser/qgsfavoritesitem.sip.in
@@ -28,6 +28,12 @@ Constructor for QgsFavoritesItem. Accepts a path argument specifying the file pa
 the item.
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsFavoritesItem: \"%1\">" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QVector<QgsDataItem *> createChildren();
 
 

--- a/python/core/auto_generated/browser/qgsfieldsitem.sip.in
+++ b/python/core/auto_generated/browser/qgsfieldsitem.sip.in
@@ -42,6 +42,12 @@ The ``schema`` and ``tableName`` are used to retrieve the layer and field inform
 
     ~QgsFieldsItem();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsFieldsItem: %1>" ).arg( sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QVector<QgsDataItem *> createChildren();
 
 
@@ -104,6 +110,12 @@ Constructor for QgsFieldItem, with the specified ``parent`` item and ``field``.
 %End
 
     ~QgsFieldItem();
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsFieldItem: %1>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
 
     virtual QIcon icon();
 

--- a/python/core/auto_generated/browser/qgslayeritem.sip.in
+++ b/python/core/auto_generated/browser/qgslayeritem.sip.in
@@ -24,6 +24,12 @@ Item that represents a layer that can be opened with one of the providers
 Constructor for QgsLayerItem.
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsLayerItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
 
     virtual bool equal( const QgsDataItem *other );
 

--- a/python/core/auto_generated/browser/qgsprojectitem.sip.in
+++ b/python/core/auto_generated/browser/qgsprojectitem.sip.in
@@ -29,6 +29,12 @@ A data item holding a reference to a QGIS project file.
 :param providerKey: key of the provider that created this item
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsProjectItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual bool hasDragEnabled() const;
 
     virtual QgsMimeDataUtils::UriList mimeUris() const;

--- a/python/core/auto_generated/browser/qgszipitem.sip.in
+++ b/python/core/auto_generated/browser/qgszipitem.sip.in
@@ -30,6 +30,12 @@ Constructor
 Constructor
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsZipItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     virtual QVector<QgsDataItem *> createChildren();
 
     QStringList getZipFileList();

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -202,6 +202,13 @@ The development version
       PointCloud
     };
 
+    enum class BrowserDirectoryMonitoring
+    {
+      Default,
+      NeverMonitor,
+      AlwaysMonitor,
+    };
+
     enum class VectorExportResult
       {
       Success,

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -263,15 +263,28 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     menu->addAction( actionClearIconColor );
   }
 
-  QAction *fastScanAction = new QAction( tr( "Fast Scan this Directory" ), menu );
+  QMenu *scanningMenu = new QMenu( tr( "Scanning" ), menu );
+
+  QAction *monitorAction = new QAction( tr( "Monitor for Changes" ), scanningMenu );
+  connect( monitorAction, &QAction::triggered, this, [ = ]
+  {
+    toggleMonitor( directoryItem );
+  } );
+  monitorAction->setCheckable( true );
+  monitorAction->setChecked( directoryItem->isMonitored() );
+  scanningMenu->addAction( monitorAction );
+
+  QAction *fastScanAction = new QAction( tr( "Fast Scan this Directory" ), scanningMenu );
   connect( fastScanAction, &QAction::triggered, this, [ = ]
   {
     toggleFastScan( directoryItem );
   } );
-  menu->addAction( fastScanAction );
   fastScanAction->setCheckable( true );
   fastScanAction->setChecked( settings.value( QStringLiteral( "qgis/scanItemsFastScanUris" ),
                               QStringList() ).toStringList().contains( item->path() ) );
+
+  scanningMenu->addAction( fastScanAction );
+  menu->addMenu( scanningMenu );
 
   menu->addSeparator();
 
@@ -380,6 +393,14 @@ void QgsAppDirectoryItemGuiProvider::toggleFastScan( QgsDirectoryItem *item )
     fastScanDirs << item->path();
   }
   settings.setValue( QStringLiteral( "qgis/scanItemsFastScanUris" ), fastScanDirs );
+}
+
+void QgsAppDirectoryItemGuiProvider::toggleMonitor( QgsDirectoryItem *item )
+{
+  if ( item->isMonitored() )
+    item->setMonitoring( Qgis::BrowserDirectoryMonitoring::NeverMonitor );
+  else
+    item->setMonitoring( Qgis::BrowserDirectoryMonitoring::AlwaysMonitor );
 }
 
 void QgsAppDirectoryItemGuiProvider::showProperties( QgsDirectoryItem *item, QgsDataItemGuiContext context )

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -50,6 +50,7 @@ class QgsAppDirectoryItemGuiProvider : public QObject, public QgsDataItemGuiProv
     void clearDirectoryColor( QgsDirectoryItem *item );
     void hideDirectory( QgsDirectoryItem *item );
     void toggleFastScan( QgsDirectoryItem *item );
+    void toggleMonitor( QgsDirectoryItem *item );
     void showProperties( QgsDirectoryItem *item, QgsDataItemGuiContext context );
 };
 

--- a/src/core/browser/qgsconnectionsitem.h
+++ b/src/core/browser/qgsconnectionsitem.h
@@ -45,6 +45,14 @@ class CORE_EXPORT QgsConnectionsRootItem : public QgsDataCollectionItem
     QgsConnectionsRootItem( QgsDataItem *parent SIP_TRANSFERTHIS, const QString &name, const QString &path = QString(), const QString &providerKey = QString() );
 
     ~QgsConnectionsRootItem() override = default;
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsConnectionsRootItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 };
 
 #endif // QGSCONNECTIONSITEM_H

--- a/src/core/browser/qgsdatabaseschemaitem.h
+++ b/src/core/browser/qgsdatabaseschemaitem.h
@@ -46,6 +46,14 @@ class CORE_EXPORT QgsDatabaseSchemaItem : public QgsDataCollectionItem
 
     ~QgsDatabaseSchemaItem() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsDatabaseSchemaItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 
     /**

--- a/src/core/browser/qgsdatacollectionitem.h
+++ b/src/core/browser/qgsdatacollectionitem.h
@@ -45,6 +45,14 @@ class CORE_EXPORT QgsDataCollectionItem : public QgsDataItem
 
     ~QgsDataCollectionItem() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsDataCollectionItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     void addChild( QgsDataItem *item SIP_TRANSFER ) { mChildren.append( item ); }
 
     /**

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -93,6 +93,14 @@ class CORE_EXPORT QgsDataItem : public QObject
 
     ~QgsDataItem() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsDataItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     bool hasChildren();
 
     /**
@@ -522,6 +530,14 @@ class CORE_EXPORT QgsErrorItem : public QgsDataItem
   public:
 
     QgsErrorItem( QgsDataItem *parent, const QString &error, const QString &path );
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsErrorItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
 };
 

--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -23,6 +23,7 @@
 #include "qgsdataprovider.h"
 #include "qgszipitem.h"
 #include "qgsprojectitem.h"
+#include "qgsfileutils.h"
 #include <QFileSystemWatcher>
 #include <QDir>
 #include <QMouseEvent>
@@ -448,6 +449,11 @@ bool QgsDirectoryItem::pathShouldByMonitoredByDefault( const QString &path )
         break;
     }
   }
+
+  // else if we know that the path is on a slow device, we don't monitor by default
+  // as this can be very expensive and slow down QGIS
+  if ( QgsFileUtils::pathIsSlowDevice( path ) )
+    return false;
 
   // paths are monitored by default if no explicit setting is in place
   return true;

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -150,8 +150,9 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
      * manually enabled or disabled. As soon as a parent directory is found which has monitoring
      * manually enabled or disabled then the corresponding value will be returned.
      *
-     * Paths are monitored by default, so if no explicit setting is in place for a parent directory then
-     * the function will return TRUE.
+     * If no explicit setting is in place for a parent directory, then a check will be made to determine
+     * whether the path resides on a known slow drive. If so, monitoring is disabled by default and
+     * FALSE will be returned. Otherwise paths are monitored by default and the function will return TRUE.
      *
      * \see isMonitored()
      * \see setMonitoring()

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -127,19 +127,94 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     //! Check if the given path is hidden from the browser model
     static bool hiddenPath( const QString &path );
 
+    /**
+     * Returns the monitoring setting for a directory \a path.
+     *
+     * This method returns the monitoring setting for \a path only. If no explicit monitoring setting
+     * is in place for the path then Qgis::BrowserDirectoryMonitoring::Default is returned.
+     *
+     * This method does not consider the monitoring setting of parent directories.
+     *
+     * \since QGIS 3.20
+     */
+    static Qgis::BrowserDirectoryMonitoring monitoringForPath( const QString &path );
+
+    /**
+     * Returns TRUE if a directory \a path should be monitored by default.
+     *
+     * In the absence of any other settings this will dictate whether the directory is monitored. This method
+     * does not consider an explicit monitoring setting set for the path, which can be determined by
+     * calling monitoringForPath().
+     *
+     * All parent directories will be checked to determine whether they have monitoring
+     * manually enabled or disabled. As soon as a parent directory is found which has monitoring
+     * manually enabled or disabled then the corresponding value will be returned.
+     *
+     * Paths are monitored by default, so if no explicit setting is in place for a parent directory then
+     * the function will return TRUE.
+     *
+     * \see isMonitored()
+     * \see setMonitoring()
+     * \since QGIS 3.20
+     */
+    static bool pathShouldByMonitoredByDefault( const QString &path );
+
+    /**
+     * Returns TRUE if the directory is currently being monitored for changes and the item auto-refreshed
+     * when these occur.
+     *
+     * \since QGIS 3.20
+     */
+    bool isMonitored() const { return mMonitored; }
+
+    /**
+     * Returns the monitoring setting for this directory item.
+     *
+     * \see setMonitoring()
+     * \since QGIS 3.20
+     */
+    Qgis::BrowserDirectoryMonitoring monitoring() const;
+
+    /**
+     * Sets the \a monitoring setting for this directory.
+     *
+     * This is a persistent setting, which is saved in QSettings.
+     *
+     * \see monitoring()
+     * \since QGIS 3.20
+     */
+    void setMonitoring( Qgis::BrowserDirectoryMonitoring monitoring );
+
   public slots:
     void childrenCreated() override;
     void directoryChanged();
 
   protected:
     void init();
+
+    /**
+     * Re-evaluate whether the directory item should be monitored for changes.
+     *
+     * Should be called whenever the parent directory item's monitoring is overridden.
+     *
+     * \since QGIS 3.20
+     */
+    void reevaluateMonitoring() SIP_SKIP;
+
     QString mDirPath;
 
   private:
+
+    void createOrDestroyFileSystemWatcher();
+
+    Qgis::BrowserDirectoryMonitoring mMonitoring = Qgis::BrowserDirectoryMonitoring::Default;
+    bool mMonitored = true;
     QFileSystemWatcher *mFileSystemWatcher = nullptr;
     bool mRefreshLater;
     QDateTime mLastScan;
     QColor mIconColor;
+
+    friend class TestQgsDataItem;
 };
 
 // ---------

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -69,6 +69,13 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
      */
     QgsDirectoryItem( QgsDataItem *parent SIP_TRANSFERTHIS, const QString &name, const QString &dirPath, const QString &path, const QString &providerKey = QString() );
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsDirectoryItem: %1 - %2>" ).arg( sipCpp->dirPath(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
     void setState( Qgis::BrowserItemState state ) override;
 
     QVector<QgsDataItem *> createChildren() override;

--- a/src/core/browser/qgsfavoritesitem.h
+++ b/src/core/browser/qgsfavoritesitem.h
@@ -40,6 +40,14 @@ class CORE_EXPORT QgsFavoritesItem : public QgsDataCollectionItem
      */
     QgsFavoritesItem( QgsDataItem *parent, const QString &name, const QString &path = QString() );
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsFavoritesItem: \"%1\">" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QVector<QgsDataItem *> createChildren() override;
 
     /**

--- a/src/core/browser/qgsfieldsitem.h
+++ b/src/core/browser/qgsfieldsitem.h
@@ -55,6 +55,14 @@ class CORE_EXPORT QgsFieldsItem : public QgsDataItem
 
     ~QgsFieldsItem() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsFieldsItem: %1>" ).arg( sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QVector<QgsDataItem *> createChildren() override;
 
     QIcon icon() override;
@@ -115,6 +123,14 @@ class CORE_EXPORT QgsFieldItem : public QgsDataItem
                   const QgsField &field );
 
     ~QgsFieldItem() override;
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsFieldItem: %1>" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
     QIcon icon() override;
 

--- a/src/core/browser/qgslayeritem.h
+++ b/src/core/browser/qgslayeritem.h
@@ -37,6 +37,14 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
      */
     QgsLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &uri, Qgis::BrowserLayerType layerType, const QString &providerKey );
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsLayerItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     // --- reimplemented from QgsDataItem ---
 
     bool equal( const QgsDataItem *other ) override;

--- a/src/core/browser/qgsprojectitem.h
+++ b/src/core/browser/qgsprojectitem.h
@@ -39,6 +39,14 @@ class CORE_EXPORT QgsProjectItem : public QgsDataItem
      */
     QgsProjectItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &providerKey = QString() );
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsProjectItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     bool hasDragEnabled() const override { return true; }
 
     QgsMimeDataUtils::UriList mimeUris() const override;

--- a/src/core/browser/qgszipitem.h
+++ b/src/core/browser/qgszipitem.h
@@ -42,6 +42,14 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     //! Constructor
     QgsZipItem( QgsDataItem *parent, const QString &name, const QString &filePath, const QString &path, const QString &providerKey = QString() );
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsZipItem: \"%1\" %2>" ).arg( sipCpp->name(), sipCpp->path() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     QVector<QgsDataItem *> createChildren() override;
     QStringList getZipFileList();
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -287,6 +287,19 @@ class CORE_EXPORT Qgis
     Q_ENUM( BrowserLayerType )
 
     /**
+     * Browser directory item monitoring switches.
+     *
+     * \since QGIS 3.20
+     */
+    enum class BrowserDirectoryMonitoring : int
+    {
+      Default, //!< Use default logic to determine whether directory should be monitored
+      NeverMonitor, //!< Never monitor the directory, regardless of the default logic
+      AlwaysMonitor, //!< Always monitor the directory, regardless of the default logic
+    };
+    Q_ENUM( BrowserDirectoryMonitoring )
+
+    /**
      * Vector layer export result codes.
      *
      * \since QGIS 3.20

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -15,6 +15,7 @@
 #include "qgsfileutils.h"
 #include "qgis.h"
 #include "qgsexception.h"
+#include "qgsconfig.h"
 #include <QObject>
 #include <QRegularExpression>
 #include <QFileInfo>
@@ -337,6 +338,11 @@ Qgis::DriveType QgsFileUtils::driveType( const QString &path )
 
 bool QgsFileUtils::pathIsSlowDevice( const QString &path )
 {
+#ifdef ENABLE_TESTS
+  if ( path.contains( QLatin1String( "fake_slow_path_for_unit_tests" ) ) )
+    return true;
+#endif
+
   try
   {
     const Qgis::DriveType type = driveType( path );


### PR DESCRIPTION
This PR changes the logic used to determine whether a directory item in the browser panel will be automatically monitored for changes. This automatic monitoring is expensive to do in some circumstances (e.g. for network drives or cloud based drives), and has been a cause of long reported hangs in the QGIS interface.

Now:
- We no longer automatically monitor directories which reside on a remote or network drive (on Windows)
- The context menu shown when right clicking a directory in browser has a new option "Monitor for Changes", which allows users to manually control whether a particular directory should be monitored. This setting applies to the selected directory and all subdirectories. So users can manually opt-in to monitoring of network drives if they know there's no issue, OR manually opt-out of monitoring of large directories which they don't want monitored for other reasons.

Together these changes should help improve QGIS responsiveness when used in remote/work-from-home environments.