### PR TITLE
Fix incorrect handling of data type in grass raster data provider

### DIFF
--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -148,7 +148,7 @@ QgsGrassRasterProvider::QgsGrassRasterProvider( QString const &uri )
   // We have to decide some reasonable block size, not to big to occupate too much
   // memory, not too small to result in too many calls to readBlock -> qgis.d.rast
   // for statistics
-  int typeSize = dataTypeSize( dataType( 1 ) );
+  int typeSize = QgsRasterBlock::typeSize( dataType( 1 ) );
   if ( mCols > 0 && typeSize > 0 )
   {
     const int cache_size = 10000000; // ~ 10 MB


### PR DESCRIPTION
(cherry picked from commit 50b2ac4c89a669cf08b5db81f62a4f3cf88fc495)

I'm not sure of the consequences of this bug -- it was found automatically during an enum -> enum class conversion. QgsRasterDataProvider::dataTypeSize has a single int argument which is the band number, not a data type.