### PR TITLE
Python entry in history dialog should be processing.run

### DIFF
--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -186,7 +186,7 @@ class HistoryDialog(BASE, WIDGET):
         item = self.tree.currentItem()
         if isinstance(item, TreeLogEntryItem):
             self.text.setText('"""\n' + self.tr('Double-click on the history item or paste the command below to re-run the algorithm') + '\n"""\n\n' +
-                              item.entry.text.replace('processing.run(', 'processing.execAlgorithmDialog(').replace(LOG_SEPARATOR, '\n'))
+                              item.entry.text.replace(LOG_SEPARATOR, '\n'))
 
     def createTest(self):
         item = self.tree.currentItem()


### PR DESCRIPTION
not processing.execAlgorithmDialog

We want this line to be copy/pastable into a script which executes the algorithm without user interaction, same as QGIS <= 3.18

Fixes a regression in master only.

Followup https://github.com/qgis/QGIS/pull/42541
