### PR TITLE
Do not access join layer from QgsVectorLayerFeatureIterator

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -24,6 +24,8 @@ setDataSource       {#qgis_api_break_3_20_setdatasource}
 
 - QgsMapLayer::setDataSource is no longer virtual. If has been replaced with QgsMapLayer::setDataSourcePrivate. This is only relevant for subclassing QgsMapLayer, for code that only uses the subclasses (QgsVectorLayer, QgsRasterLayer, ...) this has no effect.
 
+- QgsVectorLayerFeatureIterator::FetchJoinInfo::joinLayer was removed. This layer pointer was dangerous and not safe to access in any situation. 
+
 QGIS 3.4        {#qgis_api_break_3_4}
 ========
 

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -111,7 +111,7 @@ end of iterating: free the resources / lock
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
 
- QgsVectorLayer *joinLayer /Deprecated/;
+      QgsVectorLayer *joinLayer /Deprecated/;
 
 
       QgsFields joinLayerFields;

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -104,12 +104,18 @@ end of iterating: free the resources / lock
 %End
 
 
+
     struct FetchJoinInfo
     {
       const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
-      QgsVectorLayer *joinLayer;        //!< Resolved pointer to the joined layer
+
+ QgsVectorLayer *joinLayer /Deprecated/;
+
+
+      QgsFields joinLayerFields;
+
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
 

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -104,17 +104,12 @@ end of iterating: free the resources / lock
 %End
 
 
-
     struct FetchJoinInfo
     {
       const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
 
-      QgsVectorLayer *joinLayer /Deprecated/;
-
-
-      QgsFields joinLayerFields;
 
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
@@ -122,7 +117,6 @@ end of iterating: free the resources / lock
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
-
 
     virtual bool isValid() const;
 

--- a/python/core/auto_generated/vector/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerjoinbuffer.sip.in
@@ -104,6 +104,13 @@ Returns a vector of indices for use in join based on field names from the layer
 .. versionadded:: 2.6
 %End
 
+    static QVector<int> joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset );
+%Docstring
+Returns a vector of indices for use in join based on field names from the join layer's fields.
+
+.. versionadded:: 3.20
+%End
+
     QList<const QgsVectorLayerJoinInfo *> joinsWhereFieldIsId( const QgsField &field ) const;
 %Docstring
 Returns joins where the field of a target layer is considered as an id.

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -702,9 +702,6 @@ void QgsVectorLayerFeatureIterator::prepareJoin( int fieldIdx )
   {
     FetchJoinInfo info;
     info.joinInfo = joinInfo;
-    Q_NOWARN_DEPRECATED_PUSH
-    info.joinLayer = joinLayer;
-    Q_NOWARN_DEPRECATED_POP
     info.joinSource = std::make_shared< QgsVectorLayerFeatureSource >( joinLayer );
     info.indexOffset = mSource->mJoinBuffer->joinedFieldsOffset( joinInfo, mSource->mFields );
     info.targetField = mSource->mFields.indexFromName( joinInfo->targetFieldName() );

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -140,6 +140,8 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     void setInterruptionChecker( QgsFeedback *interruptionChecker ) override SIP_SKIP;
 
+    Q_NOWARN_DEPRECATED_PUSH
+
     /**
      * Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
      * Created in the select() method of QgsVectorLayerJoinBuffer for the joins that contain fetched attributes
@@ -150,13 +152,32 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       QgsAttributeList attributes;      //!< Attributes to fetch
       QMap<int, int> attributesSourceToDestLayerMap SIP_SKIP; //!< Mapping from original attribute index to the joined layer index
       int indexOffset;                  //!< At what position the joined fields start
-      QgsVectorLayer *joinLayer;        //!< Resolved pointer to the joined layer
+
+      /**
+       * Resolved pointer to the joined layer
+       * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
+       */
+      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer SIP_DEPRECATED = nullptr;
+
+      /**
+       * Feature source for join
+       */
+      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource SIP_SKIP;
+
+      /**
+       * Fields from joined layer.
+       *
+       * \since QGIS 3.20
+       */
+      QgsFields joinLayerFields;
+
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
 
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
+    Q_NOWARN_DEPRECATED_POP
 
 
     bool isValid() const override;

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -157,7 +157,11 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
        * Resolved pointer to the joined layer
        * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
        */
-      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer SIP_DEPRECATED = nullptr;
+#ifndef SIP_RUN
+      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer = nullptr;
+#else
+      QgsVectorLayer *joinLayer SIP_DEPRECATED;
+#endif
 
       /**
        * Feature source for join

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -140,8 +140,6 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     void setInterruptionChecker( QgsFeedback *interruptionChecker ) override SIP_SKIP;
 
-    Q_NOWARN_DEPRECATED_PUSH
-
     /**
      * Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
      * Created in the select() method of QgsVectorLayerJoinBuffer for the joins that contain fetched attributes
@@ -153,27 +151,24 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       QMap<int, int> attributesSourceToDestLayerMap SIP_SKIP; //!< Mapping from original attribute index to the joined layer index
       int indexOffset;                  //!< At what position the joined fields start
 
-      /**
-       * Resolved pointer to the joined layer
-       * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
-       */
 #ifndef SIP_RUN
-      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer = nullptr;
-#else
-      QgsVectorLayer *joinLayer SIP_DEPRECATED;
-#endif
 
       /**
        * Feature source for join
+       *
+       * \note Not available in Python bindings
+       * \since QGIS 3.20
        */
-      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource SIP_SKIP;
+      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource;
 
       /**
        * Fields from joined layer.
        *
+       * \note Not available in Python bindings
        * \since QGIS 3.20
        */
       QgsFields joinLayerFields;
+#endif
 
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
@@ -181,8 +176,6 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
-    Q_NOWARN_DEPRECATED_POP
-
 
     bool isValid() const override;
 

--- a/src/core/vector/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/vector/qgsvectorlayerjoinbuffer.cpp
@@ -182,12 +182,16 @@ void QgsVectorLayerJoinBuffer::cacheJoinLayer( QgsVectorLayerJoinInfo &joinInfo 
 
 QVector<int> QgsVectorLayerJoinBuffer::joinSubsetIndices( QgsVectorLayer *joinLayer, const QStringList &joinFieldsSubset )
 {
+  return joinSubsetIndices( joinLayer->fields(), joinFieldsSubset );
+}
+
+QVector<int> QgsVectorLayerJoinBuffer::joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset )
+{
   QVector<int> subsetIndices;
-  const QgsFields &fields = joinLayer->fields();
   for ( int i = 0; i < joinFieldsSubset.count(); ++i )
   {
     QString joinedFieldName = joinFieldsSubset.at( i );
-    int index = fields.lookupField( joinedFieldName );
+    int index = joinLayerFields.lookupField( joinedFieldName );
     if ( index != -1 )
     {
       subsetIndices.append( index );

--- a/src/core/vector/qgsvectorlayerjoinbuffer.h
+++ b/src/core/vector/qgsvectorlayerjoinbuffer.h
@@ -104,6 +104,12 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
     static QVector<int> joinSubsetIndices( QgsVectorLayer *joinLayer, const QStringList &joinFieldsSubset );
 
     /**
+     * Returns a vector of indices for use in join based on field names from the join layer's fields.
+     * \since QGIS 3.20
+     */
+    static QVector<int> joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset );
+
+    /**
      * Returns joins where the field of a target layer is considered as an id.
      * \param field the field of a target layer
      * \returns a list of vector joins


### PR DESCRIPTION
This is not thread safe at all - we cannot access a layer from
an iterator, as iterators may be running on background threads.

Instead use a thread safe approach of storing a QgsVectorLayerFeatureSource
and using that instead

Fixes #38551
\