### PR TITLE
Fix accidental api break

### DIFF
--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -289,11 +289,18 @@ Returns the capabilities for the data item.
 .. seealso:: :py:func:`setCapabilities`
 %End
 
-    virtual void setCapabilities( Qgis::BrowserItemCapabilities capabilities );
+    virtual void setCapabilities( Qgis::BrowserItemCapabilities capabilities ) /PyName=setCapabilitiesV2/;
 %Docstring
 Sets the capabilities for the data item.
 
 .. seealso:: :py:func:`capabilities2`
+%End
+
+ void setCapabilities( int capabilities ) /Deprecated/;
+%Docstring
+
+.. deprecated::
+   use setCapabilitiesV2 instead.
 %End
 
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -325,7 +325,7 @@ matches the settings from that context.
 .. seealso:: :py:func:`drawPreviewIcon`
 %End
 
-    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, Qgis::SymbolPreviewFlags flags = Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols );
+    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, Qgis::SymbolPreviewFlags flags = Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) /PyName=bigSymbolPreviewImageV2/;
 %Docstring
 Returns a large (roughly 100x100 pixel) preview image for the symbol.
 
@@ -336,6 +336,13 @@ Returns a large (roughly 100x100 pixel) preview image for the symbol.
 .. seealso:: :py:func:`asImage`
 
 .. seealso:: :py:func:`drawPreviewIcon`
+%End
+
+ QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = 0, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) /Deprecated/;
+%Docstring
+
+.. deprecated::
+   use bigSymbolPreviewImageV2 instead.
 %End
 
     QString dump() const;

--- a/src/core/browser/qgsdataitem.cpp
+++ b/src/core/browser/qgsdataitem.cpp
@@ -525,6 +525,11 @@ bool QgsDataItem::rename( const QString & )
   return false;
 }
 
+void QgsDataItem::setCapabilities( int capabilities )
+{
+  setCapabilities( static_cast< Qgis::BrowserItemCapabilities >( capabilities ) );
+}
+
 Qgis::BrowserItemState QgsDataItem::state() const
 {
   return mState;

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -291,7 +291,12 @@ class CORE_EXPORT QgsDataItem : public QObject
      *
      * \see capabilities2()
      */
-    virtual void setCapabilities( Qgis::BrowserItemCapabilities capabilities ) { mCapabilities = capabilities; }
+    virtual void setCapabilities( Qgis::BrowserItemCapabilities capabilities ) SIP_PYNAME( setCapabilitiesV2 ) { mCapabilities = capabilities; }
+
+    /**
+     * \deprecated use setCapabilitiesV2 instead.
+     */
+    Q_DECL_DEPRECATED void setCapabilities( int capabilities ) SIP_DEPRECATED;
 
     // static methods
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -720,6 +720,10 @@ QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext
   return preview;
 }
 
+QImage QgsSymbol::bigSymbolPreviewImage( QgsExpressionContext *expressionContext, int flags )
+{
+  return bigSymbolPreviewImage( expressionContext, static_cast< Qgis::SymbolPreviewFlags >( flags ) );
+}
 
 QString QgsSymbol::dump() const
 {

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -354,7 +354,12 @@ class CORE_EXPORT QgsSymbol
      * \see asImage()
      * \see drawPreviewIcon()
      */
-    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = nullptr, Qgis::SymbolPreviewFlags flags = Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols );
+    QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = nullptr, Qgis::SymbolPreviewFlags flags = Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) SIP_PYNAME( bigSymbolPreviewImageV2 );
+
+    /**
+     * \deprecated use bigSymbolPreviewImageV2 instead.
+     */
+    Q_DECL_DEPRECATED QImage bigSymbolPreviewImage( QgsExpressionContext *expressionContext = nullptr, int flags = static_cast< int >( Qgis::SymbolPreviewFlag::FlagIncludeCrosshairsForMarkerSymbols ) ) SIP_DEPRECATED;
 
     /**
      * Returns a string dump of the symbol's properties.

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -445,7 +445,7 @@ void QgsSymbolSelectorWidget::updatePreview()
     return;
 
   std::unique_ptr< QgsSymbol > symbolClone( mSymbol->clone() );
-  QImage preview = symbolClone->bigSymbolPreviewImage( &mPreviewExpressionContext );
+  QImage preview = symbolClone->bigSymbolPreviewImage( &mPreviewExpressionContext, Qgis::SymbolPreviewFlags() );
   lblPreview->setPixmap( QPixmap::fromImage( preview ) );
   // Hope this is a appropriate place
   if ( !mBlockModified )

--- a/tests/src/core/testqgssimplemarker.cpp
+++ b/tests/src/core/testqgssimplemarker.cpp
@@ -255,7 +255,7 @@ void TestQgsSimpleMarkerSymbol::simpleMarkerSymbolPreviewRotation()
   simpleMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::PropertyAngle, QgsProperty::fromExpression( expression ) );
 
   QgsExpressionContext ec;
-  QImage image = markerSymbol.bigSymbolPreviewImage( &ec );
+  QImage image = markerSymbol.bigSymbolPreviewImage( &ec, Qgis::SymbolPreviewFlags() );
   image.save( _fileNameForTest( name ) );
   QVERIFY( _verifyImage( name, mReport ) );
 }


### PR DESCRIPTION
QFlags created from enum classes aren't automatically converted
from an int value passed by Python code, so we need to create
compatibility functions for the older variants which accept
plain ints

Master only