### PR TITLE
[expression editor] Enable backslash escapes for proper syntax highlighting

### DIFF
--- a/src/gui/codeeditors/qgscodeeditorexpression.cpp
+++ b/src/gui/codeeditors/qgscodeeditorexpression.cpp
@@ -166,6 +166,7 @@ void QgsCodeEditorExpression::updateApis()
 QgsLexerExpression::QgsLexerExpression( QObject *parent )
   : QsciLexerSQL( parent )
 {
+  setBackslashEscapes( true );
 }
 
 const char *QgsLexerExpression::language() const


### PR DESCRIPTION
## Description

Without this fix, an expression like `'City\'s employees: ' || "employees_nb"` would not have the syntax highlighted properly.