### PR TITLE
Fix emtpy labels in custom ssl options

### DIFF
--- a/src/gui/auth/qgsauthsslconfigwidget.cpp
+++ b/src/gui/auth/qgsauthsslconfigwidget.cpp
@@ -120,14 +120,18 @@ void QgsAuthSslConfigWidget::setUpSslConfigTree()
   mProtocolCmbBx = new QComboBox( treeSslConfig );
   mProtocolCmbBx->addItem( QgsAuthCertUtils::getSslProtocolName( QSsl::SecureProtocols ),
                            static_cast<int>( QSsl::SecureProtocols ) );
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   mProtocolCmbBx->addItem( QgsAuthCertUtils::getSslProtocolName( QSsl::TlsV1SslV3 ),
                            static_cast<int>( QSsl::TlsV1SslV3 ) );
+#endif
   mProtocolCmbBx->addItem( QgsAuthCertUtils::getSslProtocolName( QSsl::TlsV1_0 ),
                            static_cast<int>( QSsl::TlsV1_0 ) );
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
   mProtocolCmbBx->addItem( QgsAuthCertUtils::getSslProtocolName( QSsl::SslV3 ),
                            static_cast<int>( QSsl::SslV3 ) );
   mProtocolCmbBx->addItem( QgsAuthCertUtils::getSslProtocolName( QSsl::SslV2 ),
                            static_cast<int>( QSsl::SslV2 ) );
+#endif
   mProtocolCmbBx->setMaximumWidth( 300 );
   mProtocolCmbBx->setCurrentIndex( 0 );
   QTreeWidgetItem *protocolitem = new QTreeWidgetItem(


### PR DESCRIPTION
The unsupported protocols have been removed from the
name method but they were still in the combo (with empty
labels).
