### PR TITLE
Add support for postgresraster based rasters in Raster Calculator

### DIFF
--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -735,7 +735,7 @@ QVector<QgsRasterCalculatorEntry> QgsRasterCalculatorEntry::rasterEntries()
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
     QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layerIt.value() );
-    if ( rlayer && rlayer->dataProvider() && rlayer->providerType() == QLatin1String( "gdal" ) )
+    if ( rlayer && rlayer->dataProvider() && ( rlayer->providerType() == QLatin1String( "gdal" ) || rlayer->providerType() == QLatin1String( "postgresraster" ) ) )
     {
       //get number of bands
       for ( int i = 0; i < rlayer->bandCount(); ++i )

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -735,7 +735,7 @@ QVector<QgsRasterCalculatorEntry> QgsRasterCalculatorEntry::rasterEntries()
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
     QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layerIt.value() );
-    if ( rlayer && rlayer->dataProvider() && ( rlayer->providerType() == QLatin1String( "gdal" ) || rlayer->providerType() == QLatin1String( "postgresraster" ) ) )
+    if ( rlayer && ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size ) )
     {
       //get number of bands
       for ( int i = 0; i < rlayer->bandCount(); ++i )

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -735,7 +735,7 @@ QVector<QgsRasterCalculatorEntry> QgsRasterCalculatorEntry::rasterEntries()
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
     QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layerIt.value() );
-    if ( rlayer && ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size ) )
+    if ( rlayer && rlayer->dataProvider() && ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size ) )
     {
       //get number of bands
       for ( int i = 0; i < rlayer->bandCount(); ++i )

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -186,7 +186,7 @@ void QgsRasterCalcDialog::insertAvailableRasterBands()
   for ( const auto &entry : std::as_const( mAvailableRasterBands ) )
   {
     QgsRasterLayer *rlayer = entry.raster;
-    if ( rlayer && rlayer->dataProvider() && rlayer->providerType() == QLatin1String( "gdal" ) )
+    if ( rlayer && rlayer->dataProvider() && ( rlayer->providerType() == QLatin1String( "gdal" ) || rlayer->providerType() == QLatin1String( "postgresraster" ) ) )
     {
       if ( !mExtentSizeSet ) //set bounding box / resolution of output to the values of the first possible input layer
       {

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -186,17 +186,14 @@ void QgsRasterCalcDialog::insertAvailableRasterBands()
   for ( const auto &entry : std::as_const( mAvailableRasterBands ) )
   {
     QgsRasterLayer *rlayer = entry.raster;
-    if ( rlayer && rlayer->dataProvider() && ( rlayer->providerType() == QLatin1String( "gdal" ) || rlayer->providerType() == QLatin1String( "postgresraster" ) ) )
+    if ( !mExtentSizeSet ) //set bounding box / resolution of output to the values of the first possible input layer
     {
-      if ( !mExtentSizeSet ) //set bounding box / resolution of output to the values of the first possible input layer
-      {
-        setExtentSize( rlayer->width(), rlayer->height(), rlayer->extent() );
-        mCrsSelector->setCrs( rlayer->crs() );
-      }
-      QListWidgetItem *item = new QListWidgetItem( entry.ref, mRasterBandsListWidget );
-      item->setData( Qt::ToolTipRole, rlayer->publicSource() );
-      mRasterBandsListWidget->addItem( item );
+      setExtentSize( rlayer->width(), rlayer->height(), rlayer->extent() );
+      mCrsSelector->setCrs( rlayer->crs() );
     }
+    QListWidgetItem *item = new QListWidgetItem( entry.ref, mRasterBandsListWidget );
+    item->setData( Qt::ToolTipRole, rlayer->publicSource() );
+    mRasterBandsListWidget->addItem( item );
   }
 }
 


### PR DESCRIPTION
## Description

This PR makes both gdal and postgresraster based rasters available in the Raster Calculator.

Fix #43439

![postgresraster](https://user-images.githubusercontent.com/163681/120066565-128c0080-c06f-11eb-842f-e98fbf49a412.png)

I've tested two or three raster operations and it worked fine with theses rasters (as expected).

The Raster Calculator, opened from processing tool also include these rasters now.