### PR TITLE
Prevent users from setting up relations without at least one field map

### DIFF
--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -206,7 +206,7 @@ bool QgsRelationAddDlg::isDefinitionValid()
     isValid &= !static_cast<QgsFieldComboBox *>( mFieldsMappingTable->cellWidget( i, 1 ) )->currentField().isNull();
   }
 
-  return isValid;
+  return isValid && mFieldsMappingTable->rowCount() > 1;
 }
 
 void QgsRelationAddDlg::updateChildRelationsComboBox()


### PR DESCRIPTION
## Description

This PR improves the `isDefinitionValid()` check to prevent the user from submitting a new relation without any field mapping.

Fix #43444