### PR TITLE
[server] Fix incorrect response code used for exception

### DIFF
--- a/src/server/qgsserverapiutils.cpp
+++ b/src/server/qgsserverapiutils.cpp
@@ -120,13 +120,13 @@ template<typename T, class T2> T QgsServerApiUtils::parseTemporalInterval( const
   const QStringList parts { interval.split( '/' ) };
   if ( parts.length() != 2 )
   {
-    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval." ).arg( interval ), QStringLiteral( "Server" ), Qgis::MessageLevel::Critical );
+    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval." ).arg( interval ), QStringLiteral( "Server" ) );
   }
   T result { parseDate( parts[0] ), parseDate( parts[1] ) };
   // Check validity
   if ( result.isEmpty() )
   {
-    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval (empty)." ).arg( interval ), QStringLiteral( "Server" ), Qgis::MessageLevel::Critical );
+    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval (empty)." ).arg( interval ), QStringLiteral( "Server" ) );
   }
   return result;
 }


### PR DESCRIPTION
Discovered in https://github.com/qgis/QGIS/pull/43423 -- the final argument to QgsServerApiBadRequestException is `int responseCode = 400`, not a Qgis::MessageLevel value.