### PR TITLE
Fix too large offsets when point labels are offset from symbol bounds and marker symbol is a non-square symbol

### DIFF
--- a/python/core/auto_generated/labeling/qgspallabeling.sip.in
+++ b/python/core/auto_generated/labeling/qgspallabeling.sip.in
@@ -504,17 +504,20 @@ If the text orientation is set to rotation-based, the spaced taken to render
 vertically oriented text will be written to ``rotatedLabelX`` and ``rotatedLabelY`` .
 %End
 
-    void registerFeature( const QgsFeature &f, QgsRenderContext &context  );
-
+    void registerFeature( const QgsFeature &f, QgsRenderContext &context );
 %Docstring
 Register a feature for labeling.
 
 :param f: feature to label
 :param context: render context. The :py:class:`QgsExpressionContext` contained within the render context
                 must have already had the feature and fields sets prior to calling this method.
-:param labelFeature: if using :py:class:`QgsLabelingEngine`, this will receive the label feature. Not available
-                     in Python bindings.
+
+.. warning::
+
+   This method is designed for use by PyQGIS clients only. C++ code should use the
+   variant with additional arguments.
 %End
+
 
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
 %Docstring

--- a/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -292,6 +292,7 @@ Returns the units for the symbol's stroke width.
 
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
+    virtual QgsMarkerSymbolBounds symbolBounds( QPointF, QgsSymbolRenderContext &context );
 
 };
 

--- a/python/core/auto_generated/symbology/qgsmarkersymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbol.sip.in
@@ -263,6 +263,23 @@ and :py:func:`~QgsMarkerSymbol.stopRender` calls, or data defined rotation and o
 .. versionadded:: 2.14
 %End
 
+    QgsMarkerSymbolBounds symbolBounds( QPointF point, QgsRenderContext &context, const QgsFeature &feature = QgsFeature() ) const;
+%Docstring
+Calculates the bounds of the marker symbol.
+
+This includes the bounding box of all symbol layers for the symbol. It is recommended to use this method only between :py:func:`~QgsMarkerSymbol.startRender`
+and :py:func:`~QgsMarkerSymbol.stopRender` calls, or data defined rotation and offset will not be correctly calculated.
+
+:param point: location of rendered point in painter units
+:param context: render context
+:param feature: feature being rendered at point (optional). If not specified, the bounds calculation will not
+                include data defined parameters such as offset and rotation
+
+:return: symbol bounds properties, in painter units
+
+.. versionadded:: 3.20
+%End
+
     virtual QgsMarkerSymbol *clone() const /Factory/;
 
 

--- a/python/core/auto_generated/symbology/qgsmarkersymbolbounds.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbolbounds.sip.in
@@ -48,6 +48,7 @@ the extent of the rendered symbol.
 Unites these bounds with an ``other`` bounds.
 %End
 
+
 };
 
 

--- a/python/core/auto_generated/symbology/qgsmarkersymbolbounds.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbolbounds.sip.in
@@ -1,0 +1,60 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/symbology/qgsmarkersymbolbounds.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsMarkerSymbolBounds
+{
+%Docstring(signature="appended")
+
+Describes the bounds of a marker symbol.
+
+.. versionadded:: 3.20
+%End
+
+%TypeHeaderCode
+#include "qgsmarkersymbolbounds.h"
+%End
+  public:
+
+    bool isNull() const;
+%Docstring
+Returns ``True`` if the bounds are null or unset.
+%End
+
+    QRectF boundingBox() const;
+%Docstring
+Returns the bounding box of the symbol, which represents
+the extent of the rendered symbol.
+
+.. seealso:: :py:func:`setBoundingBox`
+%End
+
+    void setBoundingBox( const QRectF &bounds );
+%Docstring
+Sets the bounding box of the symbol, which represents
+the extent of the rendered symbol.
+
+.. seealso:: :py:func:`boundingBox`
+%End
+
+    void unite( const QgsMarkerSymbolBounds &other );
+%Docstring
+Unites these bounds with an ``other`` bounds.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/symbology/qgsmarkersymbolbounds.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -275,6 +275,8 @@ Creates a new QgsSimpleMarkerSymbolLayer from an SLD XML element.
 
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context );
 
+    virtual QgsMarkerSymbolBounds symbolBounds( QPointF, QgsSymbolRenderContext &context );
+
     virtual QColor fillColor() const;
     virtual void setFillColor( const QColor &color );
     virtual void setColor( const QColor &color );

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -922,6 +922,16 @@ any data defined overrides and offsets which are set for the marker layer.
 .. versionadded:: 2.14
 %End
 
+    virtual QgsMarkerSymbolBounds symbolBounds( QPointF point, QgsSymbolRenderContext &context );
+%Docstring
+Returns the symbol bounds of the marker symbol layer, taking into account
+any data defined overrides and offsets which are set for the marker layer.
+
+:return: symbol bounds, in painter units
+
+.. versionadded:: 3.20
+%End
+
   protected:
 
     QgsMarkerSymbolLayer( bool locked = false );

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -590,6 +590,7 @@
 %Include auto_generated/symbology/qgslinesymbollayer.sip
 %Include auto_generated/symbology/qgsmapinfosymbolconverter.sip
 %Include auto_generated/symbology/qgsmarkersymbol.sip
+%Include auto_generated/symbology/qgsmarkersymbolbounds.sip
 %Include auto_generated/symbology/qgsmarkersymbollayer.sip
 %Include auto_generated/symbology/qgsmergedfeaturerenderer.sip
 %Include auto_generated/symbology/qgsnullsymbolrenderer.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1576,6 +1576,7 @@ set(QGIS_CORE_HDRS
   symbology/qgslinesymbollayer.h
   symbology/qgsmapinfosymbolconverter.h
   symbology/qgsmarkersymbol.h
+  symbology/qgsmarkersymbolbounds.h
   symbology/qgsmarkersymbollayer.h
   symbology/qgsmergedfeaturerenderer.h
   symbology/qgsnullsymbolrenderer.h

--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -24,6 +24,7 @@
 #include "qgsmargins.h"
 #include "qgslabelobstaclesettings.h"
 #include "qgslabeling.h"
+#include "qgsmarkersymbolbounds.h"
 
 namespace pal
 {
@@ -118,21 +119,26 @@ class CORE_EXPORT QgsLabelFeature
     const QgsMargins &visualMargin() const { return mVisualMargin; }
 
     /**
-     * Sets the size of the rendered symbol associated with this feature. This size is taken into
-     * account in certain label placement modes to avoid placing labels over the rendered
+     * Sets the bounds of the rendered marker symbol associated with this feature.
+     *
+     * These bounds are taken into account in certain label placement modes to avoid placing labels over the rendered
      * symbol for this feature.
-     * \see symbolSize()
+     *
+     * \see markerSymbolBounds()
+     * \since QGIS 3.20
      */
-    void setSymbolSize( QSizeF size ) { mSymbolSize = size; }
+    void setMarkerSymbolBounds( const QgsMarkerSymbolBounds &bounds ) { mMarkerSymbolBounds = bounds; }
 
     /**
-     * Returns the size of the rendered symbol associated with this feature, if applicable.
-     * This size is taken into account in certain label placement modes to avoid placing labels over
-     * the rendered symbol for this feature. The size will only be set for labels associated
-     * with a point feature.
-     * \see symbolSize()
+     * Returns the bounds of the rendered marker symbol associated with this feature.
+     *
+     * These bounds are taken into account in certain label placement modes to avoid placing labels over the rendered
+     * symbol for this feature.
+     *
+     * \see setMarkerSymbolBounds()
+     * \since QGIS 3.20
      */
-    const QSizeF &symbolSize() const { return mSymbolSize; }
+    const QgsMarkerSymbolBounds &markerSymbolBounds() const { return mMarkerSymbolBounds; }
 
     /**
      * Returns the feature's labeling priority.
@@ -560,6 +566,10 @@ class CORE_EXPORT QgsLabelFeature
     QgsMargins mVisualMargin;
     //! Size of associated rendered symbol, if applicable
     QSizeF mSymbolSize;
+
+    //! Bounds of associated rendered marker symbol, if applicable
+    QgsMarkerSymbolBounds mMarkerSymbolBounds;
+
     //! Priority of the label
     double mPriority = -1;
     //! Z-index of label (higher z-index labels are rendered on top of lower z-index labels)

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2556,9 +2556,11 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   labelFeature->setMinimumSize( minimumSize );
   if ( geom.type() == QgsWkbTypes::PointGeometry && !obstacleGeometry.isNull() )
   {
-    //register symbol size
-    labelFeature->setSymbolSize( QSizeF( obstacleGeometry.boundingBox().width(),
-                                         obstacleGeometry.boundingBox().height() ) );
+    //register marker symbol bounds. Use the transformed obstacleGeometry to do this,
+    //as it's already been transformed into map units
+    QgsMarkerSymbolBounds bounds = properties.markerBounds;
+    bounds.setBoundingBox( obstacleGeometry.boundingBox().toRectF() );
+    labelFeature->setMarkerSymbolBounds( bounds );
   }
 
   //set label's visual margin so that top visual margin is the leading, and bottom margin is the font's descent

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1670,11 +1670,13 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF *fm, const QSt
 #endif
 }
 
-void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext &context, QgsLabelFeature **labelFeature, QgsGeometry obstacleGeometry, const QgsSymbol *symbol )
+void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext &context )
 {
-  // either used in QgsPalLabeling (palLayer is set) or in QgsLabelingEngine (labelFeature is set)
-  Q_ASSERT( labelFeature );
+  registerFeatureWithDetails( f, context, QgsGeometry(), nullptr );
+}
 
+std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails( const QgsFeature &f, QgsRenderContext &context, QgsGeometry obstacleGeometry, const QgsSymbol *symbol )
+{
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
   mCurFeat = &f;
 
@@ -1687,9 +1689,12 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   {
     if ( isObstacle )
     {
-      registerObstacleFeature( f, context, labelFeature, obstacleGeometry );
+      return registerObstacleFeature( f, context, obstacleGeometry );
     }
-    return;
+    else
+    {
+      return nullptr;
+    }
   }
 
   QgsFeature feature = f;
@@ -1720,7 +1725,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     context.expressionContext().setOriginalValueVariable( true );
     if ( !mDataDefinedProperties.valueAsBool( QgsPalLayerSettings::Show, context.expressionContext(), true ) )
     {
-      return;
+      return nullptr;
     }
   }
 
@@ -1747,7 +1752,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
     if ( !qgsDoubleNear( maxScale, 0.0 ) && context.rendererScale() < maxScale )
     {
-      return;
+      return nullptr;
     }
 
     // data defined min scale?
@@ -1766,7 +1771,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
     if ( !qgsDoubleNear( minScale, 0.0 ) && context.rendererScale() > minScale )
     {
-      return;
+      return nullptr;
     }
   }
 
@@ -1797,14 +1802,14 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   }
   if ( fontSize <= 0.0 )
   {
-    return;
+    return nullptr;
   }
 
   int fontPixelSize = QgsTextRenderer::sizeToPixel( fontSize, context, fontunits, mFormat.sizeMapUnitScale() );
   // don't try to show font sizes less than 1 pixel (Qt complains)
   if ( fontPixelSize < 1 )
   {
-    return;
+    return nullptr;
   }
   labelFont.setPixelSize( fontPixelSize );
 
@@ -1820,7 +1825,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
       if ( fontMinPixel > labelFont.pixelSize() || labelFont.pixelSize() > fontMaxPixel )
       {
-        return;
+        return nullptr;
       }
     }
   }
@@ -1851,14 +1856,14 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     if ( exp->hasParserError() )
     {
       QgsDebugMsgLevel( QStringLiteral( "Expression parser error:%1" ).arg( exp->parserErrorString() ), 4 );
-      return;
+      return nullptr;
     }
 
     QVariant result = exp->evaluate( &context.expressionContext() ); // expression prepared in QgsPalLabeling::prepareLayer()
     if ( exp->hasEvalError() )
     {
       QgsDebugMsgLevel( QStringLiteral( "Expression parser eval error:%1" ).arg( exp->evalErrorString() ), 4 );
-      return;
+      return nullptr;
     }
     labelText = result.isNull() ? QString() : result.toString();
   }
@@ -2012,7 +2017,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   QgsGeometry geom = feature.geometry();
   if ( geom.isNull() )
   {
-    return;
+    return nullptr;
   }
 
   // simplify?
@@ -2132,7 +2137,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     geom = QgsPalLabeling::prepareGeometry( geom, context, ct, doClip ? extentGeom : QgsGeometry(), lineSettings.mergeLines() );
 
     if ( geom.isEmpty() )
-      return;
+      return nullptr;
   }
   geos_geom_clone = QgsGeos::asGeos( geom );
 
@@ -2158,12 +2163,12 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     else
     {
       if ( !checkMinimumSizeMM( context, geom, featureThinningSettings.minimumFeatureSize() ) )
-        return;
+        return nullptr;
     }
   }
 
   if ( !geos_geom_clone )
-    return; // invalid geometry
+    return nullptr; // invalid geometry
 
   // likelihood exists label will be registered with PAL and may be drawn
   // check if max number of features to label (already registered with PAL) has been reached
@@ -2172,11 +2177,11 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   {
     if ( !featureThinningSettings.maximumNumberLabels() )
     {
-      return;
+      return nullptr;
     }
     if ( mFeatsRegPal >= featureThinningSettings.maximumNumberLabels() )
     {
-      return;
+      return nullptr;
     }
 
     int divNum = static_cast< int >( ( static_cast< double >( mFeaturesToLabel ) / featureThinningSettings.maximumNumberLabels() ) + 0.5 ); // NOLINT
@@ -2185,7 +2190,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
       mFeatsSendingToPal += 1;
       if ( divNum &&  mFeatsSendingToPal % divNum )
       {
-        return;
+        return nullptr;
       }
     }
   }
@@ -2520,40 +2525,39 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   }
 
   //  feature to the layer
-  QgsTextLabelFeature *lf = new QgsTextLabelFeature( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
-  lf->setAnchorPosition( anchorPosition );
-  lf->setFeature( feature );
-  lf->setSymbol( symbol );
-  lf->setDocument( doc );
+  std::unique_ptr< QgsTextLabelFeature > labelFeature = std::make_unique< QgsTextLabelFeature>( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
+  labelFeature->setAnchorPosition( anchorPosition );
+  labelFeature->setFeature( feature );
+  labelFeature->setSymbol( symbol );
+  labelFeature->setDocument( doc );
   if ( !qgsDoubleNear( rotatedLabelX, 0.0 ) && !qgsDoubleNear( rotatedLabelY, 0.0 ) )
-    lf->setRotatedSize( QSizeF( rotatedLabelX, rotatedLabelY ) );
+    labelFeature->setRotatedSize( QSizeF( rotatedLabelX, rotatedLabelY ) );
   mFeatsRegPal++;
 
-  *labelFeature = lf;
-  ( *labelFeature )->setHasFixedPosition( dataDefinedPosition );
-  ( *labelFeature )->setFixedPosition( QgsPointXY( xPos, yPos ) );
+  labelFeature->setHasFixedPosition( dataDefinedPosition );
+  labelFeature->setFixedPosition( QgsPointXY( xPos, yPos ) );
   // use layer-level defined rotation, but not if position fixed
-  ( *labelFeature )->setHasFixedAngle( dataDefinedRotation || ( !dataDefinedPosition && !qgsDoubleNear( angle, 0.0 ) ) );
-  ( *labelFeature )->setFixedAngle( angle );
-  ( *labelFeature )->setQuadOffset( QPointF( quadOffsetX, quadOffsetY ) );
-  ( *labelFeature )->setPositionOffset( QgsPointXY( offsetX, offsetY ) );
-  ( *labelFeature )->setOffsetType( offsetType );
-  ( *labelFeature )->setAlwaysShow( alwaysShow );
-  ( *labelFeature )->setRepeatDistance( repeatDist );
-  ( *labelFeature )->setLabelText( labelText );
-  ( *labelFeature )->setPermissibleZone( permissibleZone );
-  ( *labelFeature )->setOverrunDistance( overrunDistanceEval );
-  ( *labelFeature )->setOverrunSmoothDistance( overrunSmoothDist );
-  ( *labelFeature )->setLineAnchorPercent( lineSettings.lineAnchorPercent() );
-  ( *labelFeature )->setLineAnchorType( lineSettings.anchorType() );
-  ( *labelFeature )->setLabelAllParts( labelAll );
-  ( *labelFeature )->setOriginalFeatureCrs( context.coordinateTransform().sourceCrs() );
-  ( *labelFeature )->setMinimumSize( minimumSize );
+  labelFeature->setHasFixedAngle( dataDefinedRotation || ( !dataDefinedPosition && !qgsDoubleNear( angle, 0.0 ) ) );
+  labelFeature->setFixedAngle( angle );
+  labelFeature->setQuadOffset( QPointF( quadOffsetX, quadOffsetY ) );
+  labelFeature->setPositionOffset( QgsPointXY( offsetX, offsetY ) );
+  labelFeature->setOffsetType( offsetType );
+  labelFeature->setAlwaysShow( alwaysShow );
+  labelFeature->setRepeatDistance( repeatDist );
+  labelFeature->setLabelText( labelText );
+  labelFeature->setPermissibleZone( permissibleZone );
+  labelFeature->setOverrunDistance( overrunDistanceEval );
+  labelFeature->setOverrunSmoothDistance( overrunSmoothDist );
+  labelFeature->setLineAnchorPercent( lineSettings.lineAnchorPercent() );
+  labelFeature->setLineAnchorType( lineSettings.anchorType() );
+  labelFeature->setLabelAllParts( labelAll );
+  labelFeature->setOriginalFeatureCrs( context.coordinateTransform().sourceCrs() );
+  labelFeature->setMinimumSize( minimumSize );
   if ( geom.type() == QgsWkbTypes::PointGeometry && !obstacleGeometry.isNull() )
   {
     //register symbol size
-    ( *labelFeature )->setSymbolSize( QSizeF( obstacleGeometry.boundingBox().width(),
-                                      obstacleGeometry.boundingBox().height() ) );
+    labelFeature->setSymbolSize( QSizeF( obstacleGeometry.boundingBox().width(),
+                                         obstacleGeometry.boundingBox().height() ) );
   }
 
   //set label's visual margin so that top visual margin is the leading, and bottom margin is the font's descent
@@ -2562,15 +2566,15 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   double bottomMargin = 1.0 + labelFontMetrics->descent();
   QgsMargins vm( 0.0, topMargin, 0.0, bottomMargin );
   vm *= xform->mapUnitsPerPixel();
-  ( *labelFeature )->setVisualMargin( vm );
+  labelFeature->setVisualMargin( vm );
 
   // store the label's calculated font for later use during painting
   QgsDebugMsgLevel( QStringLiteral( "PAL font stored definedFont: %1, Style: %2" ).arg( labelFont.toString(), labelFont.styleName() ), 4 );
-  lf->setDefinedFont( labelFont );
-  lf->setFontMetrics( *labelFontMetrics );
+  labelFeature->setDefinedFont( labelFont );
+  labelFeature->setFontMetrics( *labelFontMetrics );
 
-  lf->setMaximumCharacterAngleInside( std::clamp( maxcharanglein, 20.0, 60.0 ) * M_PI / 180 );
-  lf->setMaximumCharacterAngleOutside( std::clamp( maxcharangleout, -95.0, -20.0 ) * M_PI / 180 );
+  labelFeature->setMaximumCharacterAngleInside( std::clamp( maxcharanglein, 20.0, 60.0 ) * M_PI / 180 );
+  labelFeature->setMaximumCharacterAngleOutside( std::clamp( maxcharangleout, -95.0, -20.0 ) * M_PI / 180 );
   switch ( placement )
   {
     case QgsPalLayerSettings::AroundPoint:
@@ -2585,7 +2589,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
     case QgsPalLayerSettings::Curved:
     case QgsPalLayerSettings::PerimeterCurved:
-      lf->setTextMetrics( QgsTextLabelFeature::calculateTextMetrics( xform, *labelFontMetrics, labelFont.letterSpacing(), labelFont.wordSpacing(), labelText, format().allowHtmlFormatting() ? &doc : nullptr ) );
+      labelFeature->setTextMetrics( QgsTextLabelFeature::calculateTextMetrics( xform, *labelFontMetrics, labelFont.letterSpacing(), labelFont.wordSpacing(), labelText, format().allowHtmlFormatting() ? &doc : nullptr ) );
       break;
   }
 
@@ -2643,17 +2647,17 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   if ( !qgsDoubleNear( distance, 0.0 ) )
   {
     double d = ptOne.distance( ptZero ) * distance;
-    ( *labelFeature )->setDistLabel( d );
+    labelFeature->setDistLabel( d );
   }
 
   if ( ddFixedQuad )
   {
-    ( *labelFeature )->setHasFixedQuadrant( true );
+    labelFeature->setHasFixedQuadrant( true );
   }
 
-  ( *labelFeature )->setArrangementFlags( lineSettings.placementFlags() );
+  labelFeature->setArrangementFlags( lineSettings.placementFlags() );
 
-  ( *labelFeature )->setPolygonPlacementFlags( polygonPlacement );
+  labelFeature->setPolygonPlacementFlags( polygonPlacement );
 
   // data defined z-index?
   double z = zIndex;
@@ -2662,7 +2666,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     context.expressionContext().setOriginalValueVariable( z );
     z = mDataDefinedProperties.valueAsDouble( QgsPalLayerSettings::ZIndex, context.expressionContext(), z );
   }
-  ( *labelFeature )->setZIndex( z );
+  labelFeature->setZIndex( z );
 
   // data defined priority?
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::Priority ) )
@@ -2677,7 +2681,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
       {
         priorityD = std::clamp( priorityD, 0.0, 10.0 );
         priorityD = 1 - priorityD / 10.0; // convert 0..10 --> 1..0
-        ( *labelFeature )->setPriority( priorityD );
+        labelFeature->setPriority( priorityD );
       }
     }
   }
@@ -2686,7 +2690,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   os.setIsObstacle( isObstacle );
   os.updateDataDefinedProperties( mDataDefinedProperties, context.expressionContext() );
   os.setObstacleGeometry( obstacleGeometry );
-  lf->setObstacleSettings( os );
+  labelFeature->setObstacleSettings( os );
 
   QVector< QgsPalLayerSettings::PredefinedPointPosition > positionOrder = predefinedPositionOrder;
   if ( positionOrder.isEmpty() )
@@ -2701,13 +2705,15 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
       positionOrder = QgsLabelingUtils::decodePredefinedPositionOrder( dataDefinedOrder );
     }
   }
-  ( *labelFeature )->setPredefinedPositionOrder( positionOrder );
+  labelFeature->setPredefinedPositionOrder( positionOrder );
 
   // add parameters for data defined labeling to label feature
-  lf->setDataDefinedValues( dataDefinedValues );
+  labelFeature->setDataDefinedValues( dataDefinedValues );
+
+  return labelFeature;
 }
 
-void QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRenderContext &context, QgsLabelFeature **obstacleFeature, const QgsGeometry &obstacleGeometry )
+std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRenderContext &context, const QgsGeometry &obstacleGeometry )
 {
   mCurFeat = &f;
 
@@ -2723,14 +2729,14 @@ void QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRende
 
   if ( geom.isNull() )
   {
-    return;
+    return nullptr;
   }
 
   // don't even try to register linestrings with only one vertex as an obstacle
   if ( const QgsLineString *ls = qgsgeometry_cast< const QgsLineString * >( geom.constGet() ) )
   {
     if ( ls->numPoints() < 2 )
-      return;
+      return nullptr;
   }
 
   // simplify?
@@ -2754,18 +2760,19 @@ void QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRende
   geos_geom_clone = QgsGeos::asGeos( geom );
 
   if ( !geos_geom_clone )
-    return; // invalid geometry
+    return nullptr; // invalid geometry
 
   //  feature to the layer
-  *obstacleFeature = new QgsLabelFeature( f.id(), std::move( geos_geom_clone ), QSizeF( 0, 0 ) );
-  ( *obstacleFeature )->setFeature( f );
+  std::unique_ptr< QgsLabelFeature > obstacleFeature = std::make_unique< QgsLabelFeature >( f.id(), std::move( geos_geom_clone ), QSizeF( 0, 0 ) );
+  obstacleFeature->setFeature( f );
 
   QgsLabelObstacleSettings os = mObstacleSettings;
   os.setIsObstacle( true );
   os.updateDataDefinedProperties( mDataDefinedProperties, context.expressionContext() );
-  ( *obstacleFeature )->setObstacleSettings( os );
+  obstacleFeature->setObstacleSettings( os );
 
   mFeatsRegPal++;
+  return obstacleFeature;
 }
 
 bool QgsPalLayerSettings::dataDefinedValEval( DataDefinedValueType valType,

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1672,10 +1672,10 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF *fm, const QSt
 
 void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext &context )
 {
-  registerFeatureWithDetails( f, context, QgsGeometry(), nullptr );
+  registerFeatureWithDetails( f, context, QgsLabelProviderFeatureProperties() );
 }
 
-std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails( const QgsFeature &f, QgsRenderContext &context, QgsGeometry obstacleGeometry, const QgsSymbol *symbol )
+std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails( const QgsFeature &f, QgsRenderContext &context, const QgsLabelProviderFeatureProperties &properties )
 {
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
   mCurFeat = &f;
@@ -1685,6 +1685,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::IsObstacle ) )
     isObstacle = mDataDefinedProperties.valueAsBool( QgsPalLayerSettings::IsObstacle, context.expressionContext(), isObstacle ); // default to layer default
 
+  QgsGeometry obstacleGeometry = properties.obstacleGeometry;
   if ( !drawLabels )
   {
     if ( isObstacle )
@@ -2528,7 +2529,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   std::unique_ptr< QgsTextLabelFeature > labelFeature = std::make_unique< QgsTextLabelFeature>( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
   labelFeature->setAnchorPosition( anchorPosition );
   labelFeature->setFeature( feature );
-  labelFeature->setSymbol( symbol );
+  labelFeature->setSymbol( properties.symbol );
   labelFeature->setDocument( doc );
   if ( !qgsDoubleNear( rotatedLabelX, 0.0 ) && !qgsDoubleNear( rotatedLabelY, 0.0 ) )
     labelFeature->setRotatedSize( QSizeF( rotatedLabelX, rotatedLabelY ) );

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -827,18 +827,33 @@ class CORE_EXPORT QgsPalLayerSettings
      * \param f feature to label
      * \param context render context. The QgsExpressionContext contained within the render context
      * must have already had the feature and fields sets prior to calling this method.
-     * \param labelFeature if using QgsLabelingEngine, this will receive the label feature. Not available
-     * in Python bindings.
+     *
+     * \warning This method is designed for use by PyQGIS clients only. C++ code should use the
+     * variant with additional arguments.
+     */
+    void registerFeature( const QgsFeature &f, QgsRenderContext &context );
+
+#ifndef SIP_RUN
+
+    /**
+     * Register a feature for labeling.
+     * \param feature feature to label
+     * \param context render context. The QgsExpressionContext contained within the render context
+     * must have already had the feature and fields sets prior to calling this method.
      * \param obstacleGeometry optional obstacle geometry, if a different geometry to the feature's geometry
      * should be used as an obstacle for labels (e.g., if the feature has been rendered with an offset point
      * symbol, the obstacle geometry should represent the bounds of the offset symbol). If not set,
-     * the feature's original geometry will be used as an obstacle for labels. Not available
-     * in Python bindings.
+     * the feature's original geometry will be used as an obstacle for labels.
      * \param symbol feature symbol to label (ownership is not transferred, and \a symbol must exist until the labeling is complete)
+     *
+     * \returns QgsLabelFeature representing the registered feature, or NULLPTR if the feature will not be labeled
+     * in this context.
+     *
+     * \note Not available in Python bindings
      */
-    void registerFeature( const QgsFeature &f, QgsRenderContext &context,
-                          QgsLabelFeature **labelFeature SIP_PYARGREMOVE = nullptr,
-                          QgsGeometry obstacleGeometry SIP_PYARGREMOVE = QgsGeometry(), const QgsSymbol *symbol SIP_PYARGREMOVE = nullptr );
+    std::unique_ptr< QgsLabelFeature > registerFeatureWithDetails( const QgsFeature &feature, QgsRenderContext &context,
+        QgsGeometry obstacleGeometry = QgsGeometry(), const QgsSymbol *symbol = nullptr );
+#endif
 
     /**
      * Read settings from a DOM element
@@ -1090,7 +1105,7 @@ class CORE_EXPORT QgsPalLayerSettings
     /**
      * Registers a feature as an obstacle only (no label rendered)
      */
-    void registerObstacleFeature( const QgsFeature &f, QgsRenderContext &context, QgsLabelFeature **obstacleFeature, const QgsGeometry &obstacleGeometry = QgsGeometry() );
+    std::unique_ptr< QgsLabelFeature > registerObstacleFeature( const QgsFeature &f, QgsRenderContext &context, const QgsGeometry &obstacleGeometry = QgsGeometry() );
 
     QMap<Property, QVariant> dataDefinedValues;
 

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -48,6 +48,7 @@
 #include "qgslabelposition.h"
 
 class QgsTextDocument;
+class QgsLabelProviderFeatureProperties;
 
 namespace pal SIP_SKIP
 {
@@ -840,11 +841,7 @@ class CORE_EXPORT QgsPalLayerSettings
      * \param feature feature to label
      * \param context render context. The QgsExpressionContext contained within the render context
      * must have already had the feature and fields sets prior to calling this method.
-     * \param obstacleGeometry optional obstacle geometry, if a different geometry to the feature's geometry
-     * should be used as an obstacle for labels (e.g., if the feature has been rendered with an offset point
-     * symbol, the obstacle geometry should represent the bounds of the offset symbol). If not set,
-     * the feature's original geometry will be used as an obstacle for labels.
-     * \param symbol feature symbol to label (ownership is not transferred, and \a symbol must exist until the labeling is complete)
+     * \param properties properties of feature to label
      *
      * \returns QgsLabelFeature representing the registered feature, or NULLPTR if the feature will not be labeled
      * in this context.
@@ -852,7 +849,7 @@ class CORE_EXPORT QgsPalLayerSettings
      * \note Not available in Python bindings
      */
     std::unique_ptr< QgsLabelFeature > registerFeatureWithDetails( const QgsFeature &feature, QgsRenderContext &context,
-        QgsGeometry obstacleGeometry = QgsGeometry(), const QgsSymbol *symbol = nullptr );
+        const QgsLabelProviderFeatureProperties &properties );
 #endif
 
     /**

--- a/src/core/labeling/qgsrulebasedlabeling.cpp
+++ b/src/core/labeling/qgsrulebasedlabeling.cpp
@@ -38,10 +38,10 @@ bool QgsRuleBasedLabelProvider::prepare( QgsRenderContext &context, QSet<QString
   return true;
 }
 
-void QgsRuleBasedLabelProvider::registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsGeometry &obstacleGeometry, const QgsSymbol *symbol )
+void QgsRuleBasedLabelProvider::registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsLabelProviderFeatureProperties &properties )
 {
   // will register the feature to relevant sub-providers
-  mRules->rootRule()->registerFeature( feature, context, mSubProviders, obstacleGeometry, symbol );
+  mRules->rootRule()->registerFeature( feature, context, mSubProviders, properties );
 }
 
 QList<QgsAbstractLabelProvider *> QgsRuleBasedLabelProvider::subProviders()
@@ -345,7 +345,7 @@ void QgsRuleBasedLabeling::Rule::prepare( QgsRenderContext &context, QSet<QStrin
   }
 }
 
-QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerFeature( const QgsFeature &feature, QgsRenderContext &context, QgsRuleBasedLabeling::RuleToProviderMap &subProviders, const QgsGeometry &obstacleGeometry, const QgsSymbol *symbol )
+QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerFeature( const QgsFeature &feature, QgsRenderContext &context, QgsRuleBasedLabeling::RuleToProviderMap &subProviders, const QgsLabelProviderFeatureProperties &properties )
 {
   if ( !isFilterOK( feature, context )
        || !isScaleOK( context.rendererScale() ) )
@@ -358,7 +358,7 @@ QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerF
   // do we have active subprovider for the rule?
   if ( subProviders.contains( this ) && mIsActive )
   {
-    subProviders[this]->registerFeature( feature, context, obstacleGeometry, symbol );
+    subProviders[this]->registerFeature( feature, context, properties );
     registered = true;
   }
 
@@ -370,7 +370,7 @@ QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerF
     // Don't process else rules yet
     if ( !rule->isElse() )
     {
-      RegisterResult res = rule->registerFeature( feature, context, subProviders, obstacleGeometry );
+      RegisterResult res = rule->registerFeature( feature, context, subProviders, properties );
       // consider inactive items as "registered" so the else rule will ignore them
       willRegisterSomething |= ( res == Registered || res == Inactive );
       registered |= willRegisterSomething;
@@ -382,7 +382,7 @@ QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerF
   {
     for ( Rule *rule : std::as_const( mElseRules ) )
     {
-      registered |= rule->registerFeature( feature, context, subProviders, obstacleGeometry, symbol ) != Filtered;
+      registered |= rule->registerFeature( feature, context, subProviders, properties ) != Filtered;
     }
   }
 

--- a/src/core/labeling/qgsrulebasedlabeling.h
+++ b/src/core/labeling/qgsrulebasedlabeling.h
@@ -285,7 +285,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
          * register individual features
          * \note not available in Python bindings
          */
-        RegisterResult registerFeature( const QgsFeature &feature, QgsRenderContext &context, RuleToProviderMap &subProviders, const QgsGeometry &obstacleGeometry = QgsGeometry(), const QgsSymbol *symbol = nullptr ) SIP_SKIP;
+        RegisterResult registerFeature( const QgsFeature &feature, QgsRenderContext &context, RuleToProviderMap &subProviders, const QgsLabelProviderFeatureProperties &properties = QgsLabelProviderFeatureProperties() ) SIP_SKIP;
 
         /**
          * Returns TRUE if this rule or any of its children requires advanced composition effects
@@ -411,7 +411,7 @@ class CORE_EXPORT QgsRuleBasedLabelProvider : public QgsVectorLayerLabelProvider
 
     bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames ) override;
 
-    void registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsGeometry &obstacleGeometry = QgsGeometry(), const QgsSymbol *symbol = nullptr ) override;
+    void registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsLabelProviderFeatureProperties &properties = QgsLabelProviderFeatureProperties() ) override;
 
     //! create a label provider
     virtual QgsVectorLayerLabelProvider *createProvider( QgsVectorLayer *layer, const QString &providerId, bool withFeatureLoop, const QgsPalLayerSettings *settings );

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -230,21 +230,20 @@ void QgsVectorLayerLabelProvider::addPointSymbolProperties( QgsLabelProviderFeat
     context.mapToPixel().transformInPlace( x, y );
 
     QPointF pt( x, y );
-    QgsMarkerSymbolBounds overallBounds;
     for ( QgsSymbol *symbol : symbols )
     {
       if ( symbol->type() == Qgis::SymbolType::Marker )
       {
         const QgsMarkerSymbolBounds symbolBounds = qgis::down_cast< QgsMarkerSymbol * >( symbol )->symbolBounds( pt, context, fet );
-        if ( !overallBounds.isNull() )
-          overallBounds.unite( symbolBounds );
+        if ( !properties.markerBounds.isNull() )
+          properties.markerBounds.unite( symbolBounds );
         else
-          overallBounds = symbolBounds;
+          properties.markerBounds = symbolBounds;
       }
     }
 
     //convert bounds to a geometry
-    const QRectF bounds = overallBounds.boundingBox();
+    const QRectF bounds = properties.markerBounds.boundingBox();
     QVector< double > bX;
     bX << bounds.left() << bounds.right() << bounds.right() << bounds.left();
     QVector< double > bY;

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -192,11 +192,9 @@ QList<QgsLabelFeature *> QgsVectorLayerLabelProvider::labelFeatures( QgsRenderCo
 
 void QgsVectorLayerLabelProvider::registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsGeometry &obstacleGeometry, const QgsSymbol *symbol )
 {
-  QgsLabelFeature *label = nullptr;
-
-  mSettings.registerFeature( feature, context, &label, obstacleGeometry, symbol );
+  std::unique_ptr< QgsLabelFeature > label = mSettings.registerFeature( feature, context, obstacleGeometry, symbol );
   if ( label )
-    mLabels << label;
+    mLabels << label.release();
 }
 
 QgsGeometry QgsVectorLayerLabelProvider::getPointObstacleGeometry( QgsFeature &fet, QgsRenderContext &context, const QgsSymbolList &symbols )

--- a/src/core/labeling/qgsvectorlayerlabelprovider.h
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.h
@@ -22,6 +22,7 @@
 #include "qgslabelingengine.h"
 #include "qgsrenderer.h"
 #include "qgstextrenderer.h"
+#include "qgsmarkersymbolbounds.h"
 
 class QgsAbstractFeatureSource;
 class QgsFeatureRenderer;
@@ -53,6 +54,11 @@ class CORE_EXPORT QgsLabelProviderFeatureProperties
      * \warning ownership is not transferred - the symbol must exist until after labeling is complete.
      */
     const QgsSymbol *symbol = nullptr;
+
+    /**
+     * Marker symbol bounds, for features represented by a marker symbol.
+     */
+    QgsMarkerSymbolBounds markerBounds;
 
 };
 

--- a/src/core/labeling/qgsvectorlayerlabelprovider.h
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.h
@@ -27,6 +27,36 @@ class QgsAbstractFeatureSource;
 class QgsFeatureRenderer;
 class QgsSymbol;
 
+
+/**
+ * \ingroup core
+ * \class QgsLabelProviderFeatureProperties
+ * \brief Encapsulates properties of a feature to be labeled.
+ * \note Not available in Python bindings
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsLabelProviderFeatureProperties
+{
+  public:
+
+    /**
+     * Optional obstacle geometry, if a different geometry to the feature's geometry
+     * should be used as an obstacle for labels (e.g., if the feature has been rendered with an offset point
+     * symbol, the obstacle geometry should represent the bounds of the offset symbol). If not set,
+     * the feature's original geometry will be used as an obstacle for labels.
+     */
+    QgsGeometry obstacleGeometry;
+
+    /**
+     * Symbol used for corresponding feature.
+     *
+     * \warning ownership is not transferred - the symbol must exist until after labeling is complete.
+     */
+    const QgsSymbol *symbol = nullptr;
+
+};
+
+
 /**
  * \ingroup core
  * \brief The QgsVectorLayerLabelProvider class implements a label provider
@@ -83,24 +113,24 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * \param feature feature to label
      * \param context render context. The QgsExpressionContext contained within the render context
      * must have already had the feature and fields sets prior to calling this method.
-     * \param obstacleGeometry optional obstacle geometry, if a different geometry to the feature's geometry
-     * should be used as an obstacle for labels (e.g., if the feature has been rendered with an offset point
-     * symbol, the obstacle geometry should represent the bounds of the offset symbol). If not set,
-     * the feature's original geometry will be used as an obstacle for labels.
-     * \param symbol feature symbol to label (ownership is not transferred - the symbol must exist until after labeling is complete)
+     * \param properties properties of feature to label
      */
-    virtual void registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsGeometry &obstacleGeometry = QgsGeometry(), const QgsSymbol *symbol = nullptr );
+    virtual void registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsLabelProviderFeatureProperties &properties = QgsLabelProviderFeatureProperties() );
 
     /**
-     * Returns the geometry for a point feature which should be used as an obstacle for labels. This
+     * Populates \a properties with the properties for a feature rendered with a point symbol.
+     *
+     * For instance, sets the geometry for a point feature which should be used as an obstacle for labels. This
      * obstacle geometry will respect the dimensions and offsets of the symbol used to render the
      * point, and ensures that labels will not overlap large or offset points.
+     *
+     * \param properties properties to populate
      * \param fet point feature
      * \param context render context
      * \param symbols symbols rendered for point feature
      * \since QGIS 2.14
      */
-    static QgsGeometry getPointObstacleGeometry( QgsFeature &fet, QgsRenderContext &context, const QgsSymbolList &symbols );
+    static void addPointSymbolProperties( QgsLabelProviderFeatureProperties &properties, QgsFeature &fet, QgsRenderContext &context, const QgsSymbolList &symbols );
 
     /**
      * Returns the layer's settings.

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -828,6 +828,32 @@ QRectF QgsEllipseSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &con
   return symbolBounds;
 }
 
+QgsMarkerSymbolBounds QgsEllipseSymbolLayer::symbolBounds( QPointF point, QgsSymbolRenderContext &context )
+{
+  QgsMarkerSymbolBounds res;
+  res.setBoundingBox( bounds( point, context ) );
+
+  switch ( mShape )
+  {
+    case QgsEllipseSymbolLayer::Circle:
+      res.setShape( QgsMarkerSymbolBounds::Ellipse );
+      break;
+
+    case QgsEllipseSymbolLayer::Rectangle:
+    case QgsEllipseSymbolLayer::Diamond:
+    case QgsEllipseSymbolLayer::Cross:
+    case QgsEllipseSymbolLayer::Arrow:
+    case QgsEllipseSymbolLayer::HalfArc:
+    case QgsEllipseSymbolLayer::Triangle:
+    case QgsEllipseSymbolLayer::RightHalfTriangle:
+    case QgsEllipseSymbolLayer::LeftHalfTriangle:
+    case QgsEllipseSymbolLayer::SemiCircle:
+      break;
+  }
+
+  return res;
+}
+
 bool QgsEllipseSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift ) const
 {
   //width

--- a/src/core/symbology/qgsellipsesymbollayer.h
+++ b/src/core/symbology/qgsellipsesymbollayer.h
@@ -239,7 +239,7 @@ class CORE_EXPORT QgsEllipseSymbolLayer: public QgsMarkerSymbolLayer
     QgsMapUnitScale mapUnitScale() const override;
 
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
-
+    QgsMarkerSymbolBounds symbolBounds( QPointF, QgsSymbolRenderContext &context ) override;
   private:
     Shape mShape = Circle;
     double mSymbolWidth = 4;

--- a/src/core/symbology/qgsmarkersymbol.cpp
+++ b/src/core/symbology/qgsmarkersymbol.cpp
@@ -17,6 +17,7 @@
 #include "qgsmarkersymbollayer.h"
 #include "qgssymbollayerutils.h"
 #include "qgspainteffect.h"
+#include "qgsmarkersymbolbounds.h"
 
 QgsMarkerSymbol *QgsMarkerSymbol::createSimple( const QVariantMap &properties )
 {
@@ -469,6 +470,26 @@ QRectF QgsMarkerSymbol::bounds( QPointF point, QgsRenderContext &context, const 
         bound = symbolLayer->bounds( point, symbolContext );
       else
         bound = bound.united( symbolLayer->bounds( point, symbolContext ) );
+    }
+  }
+  return bound;
+}
+
+QgsMarkerSymbolBounds QgsMarkerSymbol::symbolBounds( QPointF point, QgsRenderContext &context, const QgsFeature &feature ) const
+{
+  QgsSymbolRenderContext symbolContext( context, QgsUnitTypes::RenderUnknownUnit, mOpacity, false, mRenderHints, &feature, feature.fields() );
+
+  QgsMarkerSymbolBounds bound;
+  const auto constMLayers = mLayers;
+  for ( QgsSymbolLayer *layer : constMLayers )
+  {
+    if ( layer->type() == Qgis::SymbolType::Marker )
+    {
+      QgsMarkerSymbolLayer *symbolLayer = static_cast< QgsMarkerSymbolLayer * >( layer );
+      if ( bound.isNull() )
+        bound = symbolLayer->symbolBounds( point, symbolContext );
+      else
+        bound.unite( symbolLayer->symbolBounds( point, symbolContext ) );
     }
   }
   return bound;

--- a/src/core/symbology/qgsmarkersymbol.h
+++ b/src/core/symbology/qgsmarkersymbol.h
@@ -20,6 +20,7 @@
 #include "qgssymbol.h"
 
 class QgsMarkerSymbolLayer;
+class QgsMarkerSymbolBounds;
 
 /**
  * \ingroup core
@@ -221,6 +222,21 @@ class CORE_EXPORT QgsMarkerSymbol : public QgsSymbol
      * \since QGIS 2.14
     */
     QRectF bounds( QPointF point, QgsRenderContext &context, const QgsFeature &feature = QgsFeature() ) const;
+
+    /**
+     * Calculates the bounds of the marker symbol.
+     *
+     * This includes the bounding box of all symbol layers for the symbol. It is recommended to use this method only between startRender()
+     * and stopRender() calls, or data defined rotation and offset will not be correctly calculated.
+     *
+     * \param point location of rendered point in painter units
+     * \param context render context
+     * \param feature feature being rendered at point (optional). If not specified, the bounds calculation will not
+     * include data defined parameters such as offset and rotation
+     * \returns symbol bounds properties, in painter units
+     * \since QGIS 3.20
+    */
+    QgsMarkerSymbolBounds symbolBounds( QPointF point, QgsRenderContext &context, const QgsFeature &feature = QgsFeature() ) const;
 
     QgsMarkerSymbol *clone() const override SIP_FACTORY;
 

--- a/src/core/symbology/qgsmarkersymbolbounds.h
+++ b/src/core/symbology/qgsmarkersymbolbounds.h
@@ -59,11 +59,43 @@ class CORE_EXPORT QgsMarkerSymbolBounds
     void unite( const QgsMarkerSymbolBounds &other )
     {
       mBoundingBox = mBoundingBox.united( other.boundingBox() );
+      if ( other.shape() == Rectangle )
+        mShape = Rectangle;
     }
+
+#ifndef SIP_RUN
+
+    /**
+     * Symbol shape.
+     *
+     * \note Not available in Python bindings
+     */
+    enum Shape
+    {
+      Rectangle, //!< Rectangle
+      Ellipse, //!< Ellipse
+    };
+
+    /**
+     * Sets the marker bounds \a shape.
+     *
+     * \note Not available in Python bindings
+     */
+    void setShape( Shape shape ) { mShape = shape; }
+
+    /**
+     * Returns the marker bounds shape.
+     *
+     * \note Not available in Python bindings
+     */
+    Shape shape() const { return mShape; }
+
+#endif
 
   private:
 
     QRectF mBoundingBox;
+    Shape mShape = Rectangle;
 
 };
 

--- a/src/core/symbology/qgsmarkersymbolbounds.h
+++ b/src/core/symbology/qgsmarkersymbolbounds.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+ qgsmarkersymbolbounds.h
+ -----------------------
+ begin                : May 2021
+ copyright            : (C) 2021 by Nyall Dawson
+ email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMARKERSYMBOLBOUNDS_H
+#define QGSMARKERSYMBOLBOUNDS_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <QRectF>
+
+/**
+ * \ingroup core
+ * \class QgsMarkerSymbolBounds
+ *
+ * \brief Describes the bounds of a marker symbol.
+ *
+ * \since QGIS 3.20
+ */
+class CORE_EXPORT QgsMarkerSymbolBounds
+{
+  public:
+
+    /**
+     * Returns TRUE if the bounds are null or unset.
+     */
+    bool isNull() const { return mBoundingBox.isNull(); }
+
+    /**
+     * Returns the bounding box of the symbol, which represents
+     * the extent of the rendered symbol.
+     *
+     * \see setBoundingBox()
+     */
+    QRectF boundingBox() const { return mBoundingBox; }
+
+    /**
+     * Sets the bounding box of the symbol, which represents
+     * the extent of the rendered symbol.
+     *
+     * \see boundingBox()
+     */
+    void setBoundingBox( const QRectF &bounds ) { mBoundingBox = bounds;}
+
+    /**
+     * Unites these bounds with an \a other bounds.
+     */
+    void unite( const QgsMarkerSymbolBounds &other )
+    {
+      mBoundingBox = mBoundingBox.united( other.boundingBox() );
+    }
+
+  private:
+
+    QRectF mBoundingBox;
+
+};
+
+#endif // QGSMARKERSYMBOLBOUNDS_H
+

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1689,6 +1689,51 @@ QRectF QgsSimpleMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext
   return symbolBounds;
 }
 
+QgsMarkerSymbolBounds QgsSimpleMarkerSymbolLayer::symbolBounds( QPointF point, QgsSymbolRenderContext &context )
+{
+  QgsMarkerSymbolBounds res;
+  res.setBoundingBox( bounds( point, context ) );
+
+  switch ( mShape )
+  {
+    case QgsSimpleMarkerSymbolLayerBase::Circle:
+    case QgsSimpleMarkerSymbolLayerBase::SemiCircle:
+    case QgsSimpleMarkerSymbolLayerBase::ThirdCircle:
+    case QgsSimpleMarkerSymbolLayerBase::QuarterCircle:
+      res.setShape( QgsMarkerSymbolBounds::Ellipse );
+      break;
+
+    case QgsSimpleMarkerSymbolLayerBase::Square:
+    case QgsSimpleMarkerSymbolLayerBase::Diamond:
+    case QgsSimpleMarkerSymbolLayerBase::Pentagon:
+    case QgsSimpleMarkerSymbolLayerBase::Hexagon:
+    case QgsSimpleMarkerSymbolLayerBase::Triangle:
+    case QgsSimpleMarkerSymbolLayerBase::EquilateralTriangle:
+    case QgsSimpleMarkerSymbolLayerBase::Star:
+    case QgsSimpleMarkerSymbolLayerBase::Arrow:
+    case QgsSimpleMarkerSymbolLayerBase::Cross:
+    case QgsSimpleMarkerSymbolLayerBase::CrossFill:
+    case QgsSimpleMarkerSymbolLayerBase::Cross2:
+    case QgsSimpleMarkerSymbolLayerBase::Line:
+    case QgsSimpleMarkerSymbolLayerBase::ArrowHead:
+    case QgsSimpleMarkerSymbolLayerBase::ArrowHeadFilled:
+    case QgsSimpleMarkerSymbolLayerBase::QuarterSquare:
+    case QgsSimpleMarkerSymbolLayerBase::HalfSquare:
+    case QgsSimpleMarkerSymbolLayerBase::DiagonalHalfSquare:
+    case QgsSimpleMarkerSymbolLayerBase::RightHalfTriangle:
+    case QgsSimpleMarkerSymbolLayerBase::LeftHalfTriangle:
+    case QgsSimpleMarkerSymbolLayerBase::Octagon:
+    case QgsSimpleMarkerSymbolLayerBase::SquareWithCorners:
+    case QgsSimpleMarkerSymbolLayerBase::AsteriskFill:
+    case QgsSimpleMarkerSymbolLayerBase::HalfArc:
+    case QgsSimpleMarkerSymbolLayerBase::ThirdArc:
+    case QgsSimpleMarkerSymbolLayerBase::QuarterArc:
+      break;
+  }
+
+  return res;
+}
+
 void QgsSimpleMarkerSymbolLayer::setColor( const QColor &color )
 {
   if ( shapeIsFilled( mShape ) )

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -263,6 +263,7 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayer : public QgsSimpleMarkerSymbolLayer
     QgsMapUnitScale mapUnitScale() const override;
     bool usesMapUnits() const override;
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
+    QgsMarkerSymbolBounds symbolBounds( QPointF, QgsSymbolRenderContext &context ) override;
     QColor fillColor() const override { return mColor; }
     void setFillColor( const QColor &color ) override { mColor = color; }
     void setColor( const QColor &color ) override;

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -33,6 +33,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgssymbol.h"
 #include "qgssymbollayerreference.h"
+#include "qgsmarkersymbolbounds.h"
 
 #include <QSize>
 #include <QPainter>
@@ -663,6 +664,13 @@ QgsMapUnitScale QgsMarkerSymbolLayer::mapUnitScale() const
     return mSizeMapUnitScale;
   }
   return QgsMapUnitScale();
+}
+
+QgsMarkerSymbolBounds QgsMarkerSymbolLayer::symbolBounds( QPointF point, QgsSymbolRenderContext &context )
+{
+  QgsMarkerSymbolBounds res;
+  res.setBoundingBox( bounds( point, context ) );
+  return res;
 }
 
 void QgsLineSymbolLayer::setOutputUnit( QgsUnitTypes::RenderUnit unit )

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -41,6 +41,7 @@ class QgsExpression;
 class QgsRenderContext;
 class QgsPaintEffect;
 class QgsSymbolLayerReference;
+class QgsMarkerSymbolBounds;
 
 #ifndef SIP_RUN
 typedef QMap<QString, QString> QgsStringMap;
@@ -858,6 +859,14 @@ class CORE_EXPORT QgsMarkerSymbolLayer : public QgsSymbolLayer
      * \since QGIS 2.14
      */
     virtual QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) = 0;
+
+    /**
+     * Returns the symbol bounds of the marker symbol layer, taking into account
+     * any data defined overrides and offsets which are set for the marker layer.
+     * \returns symbol bounds, in painter units
+     * \since QGIS 3.20
+     */
+    virtual QgsMarkerSymbolBounds symbolBounds( QPointF point, QgsSymbolRenderContext &context );
 
   protected:
 

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -476,18 +476,17 @@ void QgsVectorLayerRenderer::drawRenderer( QgsFeatureRenderer *renderer, QgsFeat
         // new labeling engine
         if ( isMainRenderer && context.labelingEngine() && ( mLabelProvider || mDiagramProvider ) )
         {
-          QgsGeometry obstacleGeometry;
+          QgsLabelProviderFeatureProperties properties;
           QgsSymbolList symbols = renderer->originalSymbolsForFeature( fet, context );
-          QgsSymbol *symbol = nullptr;
           if ( !symbols.isEmpty() && fet.geometry().type() == QgsWkbTypes::PointGeometry )
           {
-            obstacleGeometry = QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, context, symbols );
+            QgsVectorLayerLabelProvider::addPointSymbolProperties( properties, fet, context, symbols );
           }
 
           if ( !symbols.isEmpty() )
           {
-            symbol = symbols.at( 0 );
-            QgsExpressionContextUtils::updateSymbolScope( symbol, symbolScope );
+            properties.symbol = symbols.at( 0 );
+            QgsExpressionContextUtils::updateSymbolScope( properties.symbol, symbolScope );
           }
 
           if ( mApplyLabelClipGeometries )
@@ -495,11 +494,11 @@ void QgsVectorLayerRenderer::drawRenderer( QgsFeatureRenderer *renderer, QgsFeat
 
           if ( mLabelProvider )
           {
-            mLabelProvider->registerFeature( fet, context, obstacleGeometry, symbol );
+            mLabelProvider->registerFeature( fet, context, properties );
           }
           if ( mDiagramProvider )
           {
-            mDiagramProvider->registerFeature( fet, context, obstacleGeometry );
+            mDiagramProvider->registerFeature( fet, context, properties.obstacleGeometry );
           }
 
           if ( mApplyLabelClipGeometries )
@@ -583,27 +582,26 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureRenderer *renderer, Q
     // new labeling engine
     if ( isMainRenderer && context.labelingEngine() && ( mLabelProvider || mDiagramProvider ) )
     {
-      QgsGeometry obstacleGeometry;
+      QgsLabelProviderFeatureProperties properties;
       QgsSymbolList symbols = renderer->originalSymbolsForFeature( fet, context );
-      QgsSymbol *symbol = nullptr;
       if ( !symbols.isEmpty() && fet.geometry().type() == QgsWkbTypes::PointGeometry )
       {
-        obstacleGeometry = QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, context, symbols );
+        QgsVectorLayerLabelProvider::addPointSymbolProperties( properties, fet, context, symbols );
       }
 
       if ( !symbols.isEmpty() )
       {
-        symbol = symbols.at( 0 );
-        QgsExpressionContextUtils::updateSymbolScope( symbol, symbolScope );
+        properties.symbol = symbols.at( 0 );
+        QgsExpressionContextUtils::updateSymbolScope( properties.symbol, symbolScope );
       }
 
       if ( mLabelProvider )
       {
-        mLabelProvider->registerFeature( fet, context, obstacleGeometry, symbol );
+        mLabelProvider->registerFeature( fet, context, properties );
       }
       if ( mDiagramProvider )
       {
-        mDiagramProvider->registerFeature( fet, context, obstacleGeometry );
+        mDiagramProvider->registerFeature( fet, context, properties.obstacleGeometry );
       }
     }
   }


### PR DESCRIPTION
Before -- note how the labels to the top right have a much greater distance from the marker vs the label which is placed over the feature:

![image](https://user-images.githubusercontent.com/1829991/120127583-1b154000-c203-11eb-96e6-e168d538bd0e.png)


After:
![image](https://user-images.githubusercontent.com/1829991/120127590-20728a80-c203-11eb-96b0-46f93a7b7ee3.png)
