### PR TITLE
fix classification of singleband pseudocolor (#43346)

### DIFF
--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -190,8 +190,8 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
 {
   QgsDebugMsg( QStringLiteral( "theBandNo = %1 min = %2 max = %3" ).arg( bandNo ).arg( min ).arg( max ) );
 
-  QString oldMinTextvalue = mMinLineEdit->text();
-  QString oldMaxTextvalue = mMaxLineEdit->text();
+  const QString oldMinTextvalue = mMinLineEdit->text();
+  const QString oldMaxTextvalue = mMaxLineEdit->text();
 
   if ( std::isnan( min ) )
   {

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -190,6 +190,9 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
 {
   QgsDebugMsg( QStringLiteral( "theBandNo = %1 min = %2 max = %3" ).arg( bandNo ).arg( min ).arg( max ) );
 
+  QString oldMinTextvalue = mMinLineEdit->text();
+  QString oldMaxTextvalue = mMaxLineEdit->text();
+
   if ( std::isnan( min ) )
   {
     whileBlocking( mMinLineEdit )->clear();
@@ -211,7 +214,7 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
   // We compare old min and new min as text because QString::number keeps a fixed number of significant
   // digits (default 6) and so loaded min/max will always differ from current one, which triggers a
   // classification, and wipe out every user modification (see https://github.com/qgis/QGIS/issues/36172)
-  if ( mMinLineEdit->text() != displayValueWithMaxPrecision( min ) || mMaxLineEdit->text() != displayValueWithMaxPrecision( max ) )
+  if ( mMinLineEdit->text() != oldMinTextvalue || mMaxLineEdit->text() != oldMaxTextvalue )
   {
     whileBlocking( mColorRampShaderWidget )->setRasterBand( bandNo );
     whileBlocking( mColorRampShaderWidget )->setMinimumMaximumAndClassify( min, max );

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -84,6 +84,7 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     // Convert min/max to localized display value with maximum precision for the current data type
     QString displayValueWithMaxPrecision( const double value );
 
+    friend class TestQgsSingleBandPseudoColorRendererWidget;
 };
 
 #endif // QGSSINGLEBANDCOLORRENDERERWIDGET_H

--- a/tests/src/gui/testqgssinglebandpseudocolorrendererwidget.cpp
+++ b/tests/src/gui/testqgssinglebandpseudocolorrendererwidget.cpp
@@ -112,6 +112,21 @@ void TestQgsSingleBandPseudoColorRendererWidget::testEditLabel()
 
   QList<QgsColorRampShader::ColorRampItem> newColorRampItems = newColorRampShader->colorRampItemList();
   QCOMPARE( newColorRampItems.at( 0 ).label, QStringLiteral( "zero" ) );
+
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->minimum() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->maximum() ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().minimumValue() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().maximumValue() ) );
+
+  // change the min/max
+  widget.loadMinMax( 1, min + 1.0, max - 1.0 );
+
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( min + 1.0 ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( max - 1.0 ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->minimum() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->maximum() ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().minimumValue() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().maximumValue() ) );
 }
 
 


### PR DESCRIPTION
fix #43346 that was introduced by #36376
Also fix the color ramp shader that was not filled when the Singleband pseudocolor renderer became the active renderer.