### PR TITLE
VERSION is now mandatory in WMS 1.3.0

### DIFF
--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -32,6 +32,12 @@ namespace QgsWms
                     const QgsWmsRequest &request,
                     QgsServerResponse &response )
   {
+    if ( request.serverParameters().version().isEmpty() )
+    {
+      throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
+                                 QStringLiteral( "Please add the value of the VERSION parameter" ), 501 );
+    }
+
     // prepare render context
     QgsWmsRenderContext context( project, serverIface );
     context.setFlag( QgsWmsRenderContext::UpdateExtent );


### PR DESCRIPTION
## Description

A new test has been added in the WMS 1.3.0 OGC testsuite (https://github.com/opengeospatial/ets-wms13/commit/598a7b723eb18f5bf123871de270e778d19532bb) and the corresponding docker image has been updated 2 days ago.

QGIS Server is not compliant regarding this new test so the OGC test workflow is currently broken. 