### PR TITLE
[locator] add open form action, automatically open form for non geometric layers

### DIFF
--- a/src/app/locator/qgsactivelayerfeatureslocatorfilter.h
+++ b/src/app/locator/qgsactivelayerfeatureslocatorfilter.h
@@ -30,6 +30,12 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
 
   public:
 
+    enum ContextMenuEntry
+    {
+      NoEntry,
+      OpenForm
+    };
+
     QgsActiveLayerFeaturesLocatorFilter( QObject *parent = nullptr );
     QgsActiveLayerFeaturesLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "features" ); }
@@ -40,6 +46,7 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     QStringList prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
+    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
     bool hasConfigWidget() const override {return true;}
     void openConfigWidget( QWidget *parent ) override;
 
@@ -63,6 +70,7 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     QgsFeatureIterator mDisplayTitleIterator;
     QgsFeatureIterator mFieldIterator;
     QString mLayerId;
+    bool mLayerIsSpatial = false;
     QIcon mLayerIcon;
     QStringList mAttributeAliases;
     QStringList mFieldsCompletion;

--- a/src/app/locator/qgsactivelayerfeatureslocatorfilter.h
+++ b/src/app/locator/qgsactivelayerfeatureslocatorfilter.h
@@ -29,13 +29,6 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     Q_OBJECT
 
   public:
-
-    enum ContextMenuEntry
-    {
-      NoEntry,
-      OpenForm
-    };
-
     QgsActiveLayerFeaturesLocatorFilter( QObject *parent = nullptr );
     QgsActiveLayerFeaturesLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "features" ); }
@@ -58,6 +51,11 @@ class APP_EXPORT QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
     Q_ENUM( ResultType )
 
   private:
+    enum ContextMenuEntry
+    {
+      NoEntry,
+      OpenForm
+    };
 
     /**
      * Returns the field restriction if defined (starting with @)

--- a/src/app/locator/qgsalllayersfeatureslocatorfilter.h
+++ b/src/app/locator/qgsalllayersfeatureslocatorfilter.h
@@ -30,6 +30,21 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
     Q_OBJECT
 
   public:
+    QgsAllLayersFeaturesLocatorFilter( QObject *parent = nullptr );
+    QgsAllLayersFeaturesLocatorFilter *clone() const override;
+    QString name() const override { return QStringLiteral( "allfeatures" ); }
+    QString displayName() const override { return tr( "Features in All Layers" ); }
+    Priority priority() const override { return Medium; }
+    QString prefix() const override { return QStringLiteral( "af" ); }
+
+    QStringList prepare( const QString &string, const QgsLocatorContext &context ) override;
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
+    bool hasConfigWidget() const override {return true;}
+    void openConfigWidget( QWidget *parent ) override;
+
+  private:
     enum ContextMenuEntry
     {
       NoEntry,
@@ -50,21 +65,6 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
         bool layerIsSpatial;
     };
 
-    QgsAllLayersFeaturesLocatorFilter( QObject *parent = nullptr );
-    QgsAllLayersFeaturesLocatorFilter *clone() const override;
-    QString name() const override { return QStringLiteral( "allfeatures" ); }
-    QString displayName() const override { return tr( "Features in All Layers" ); }
-    Priority priority() const override { return Medium; }
-    QString prefix() const override { return QStringLiteral( "af" ); }
-
-    QStringList prepare( const QString &string, const QgsLocatorContext &context ) override;
-    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
-    void triggerResult( const QgsLocatorResult &result ) override;
-    void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
-    bool hasConfigWidget() const override {return true;}
-    void openConfigWidget( QWidget *parent ) override;
-
-  private:
     int mMaxResultsPerLayer = 8;
     int mMaxTotalResults = 15;
     QList<std::shared_ptr<PreparedLayer>> mPreparedLayers;

--- a/src/app/locator/qgsalllayersfeatureslocatorfilter.h
+++ b/src/app/locator/qgsalllayersfeatureslocatorfilter.h
@@ -47,6 +47,7 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
         QString layerName;
         QString layerId;
         QIcon layerIcon;
+        bool layerIsSpatial;
     };
 
     QgsAllLayersFeaturesLocatorFilter( QObject *parent = nullptr );


### PR DESCRIPTION
instead of showing of warning

This is for the "Active Layer Locator Filter".

I consider this as a bugfix as it replicates what is done in the other similar filter: "All Layers".