### PR TITLE
[backport] Fix unreported scratch layer icon not update after save

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8833,6 +8833,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
         source += QStringLiteral( "|layername=%1" ).arg( newLayerName );
       vl->setDataSource( source, vl->name(), QStringLiteral( "ogr" ), options );
       vl->triggerRepaint();
+      mLayerTreeView->refreshLayerSymbology( vl->id() );
       this->visibleMessageBar()->pushMessage( tr( "Layer Saved" ),
                                               tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
                                               Qgis::Success, messageTimeout() );


### PR DESCRIPTION
When saving a scratch layer to a persistent one the small icon
in the layer tree is not updated (it should disappear).

Cherry-picked from master afb3efecf2d34577bad54bd3f2c12009cd9fe8d1
