### PR TITLE
Use opencl.hpp header instead of cl2.hpp if present

### DIFF
--- a/cmake/FindOpenCLhpp.cmake
+++ b/cmake/FindOpenCLhpp.cmake
@@ -19,7 +19,7 @@ if (OPENCL_HPP_INCLUDE_DIR)
     SET(OPENCL_HPP_FOUND TRUE)
 else ()
     find_path(OPENCL_HPP_INCLUDE_DIR
-        NAMES CL/cl2.hpp
+        NAMES CL/opencl.hpp CL/cl2.hpp
         PATHS
         ${LIB_DIR}/include
         "$ENV{LIB_DIR}/include"
@@ -36,6 +36,19 @@ endif ()
 
 
 if (OPENCL_HPP_FOUND)
+    # see if newer opencl.hpp file exists in include dir -- if so we should use this
+    # instead of the deprecated cl2.hpp header
+    find_path(OPENCL_HPP_RENAMED_PATH
+        NAMES CL/opencl.hpp
+        PATHS
+        ${OPENCL_HPP_INCLUDE_DIR}
+    )
+    if (OPENCL_HPP_RENAMED_PATH)
+        SET(OPENCL_USE_NEW_HEADER TRUE)
+    else ()
+        SET(OPENCL_USE_NEW_HEADER FALSE)
+    endif ()
+
     if (NOT OPENCLHPP_FIND_QUIETLY)
         message(STATUS "Found OpenCL C++ headers: ${OPENCL_HPP_INCLUDE_DIR}")
     endif ()

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -70,6 +70,7 @@
 #cmakedefine HAVE_SERVER_PYTHON_PLUGINS
 
 #cmakedefine HAVE_OPENCL
+#cmakedefine OPENCL_USE_NEW_HEADER
 
 #cmakedefine ENABLE_MODELTEST
 

--- a/src/core/qgsopenclutils.h
+++ b/src/core/qgsopenclutils.h
@@ -31,7 +31,13 @@
 #define CL_TARGET_OPENCL_VERSION 200
 #endif
 
+#include "qgsconfig.h"
+
+#ifdef OPENCL_USE_NEW_HEADER
+#include <CL/opencl.hpp>
+#else
 #include <CL/cl2.hpp>
+#endif
 
 #include "qgis_core.h"
 #include "qgis.h"


### PR DESCRIPTION
Avoids a "cl2.hpp has been renamed to opencl.hpp" warning being
spammed out on newer opencl environments
