### PR TITLE
Use dedicated icons for attribute table filter items

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -365,6 +365,7 @@
         <file>themes/default/mActionViewScaleInCanvas.svg</file>
         <file>themes/default/mActionOffsetCurve.svg</file>
         <file>themes/default/mActionOpenTable.svg</file>
+        <file>themes/default/mActionOpenTableEdited.svg</file>
         <file>themes/default/mActionOpenTableSelected.svg</file>
         <file>themes/default/mActionOpenTableVisible.svg</file>
         <file>themes/default/mActionAddTable.svg</file>

--- a/images/themes/default/mActionOpenTableEdited.svg
+++ b/images/themes/default/mActionOpenTableEdited.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg30"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="mActionOpenTableEdited.svg"
+   inkscape:version="0.91 r13725">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="19.67"
+     inkscape:cx="5.663341"
+     inkscape:cy="16.027777"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g943" />
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <g
+     id="g943">
+    <path
+       d="m 2.5,7.4999999 h 19 V 21.5 h -19 z"
+       id="path2"
+       inkscape:connector-curvature="0"
+       style="fill:#e6e6e6;stroke:#6e97c4" />
+    <path
+       d="m 2.5,2.4999999 h 19 v 5 h -19 z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       style="fill:#bad9ec;stroke:#6e97c4" />
+    <path
+       d="M 5,4.9999999 H 9"
+       id="path6"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#6e97c4;stroke-width:2" />
+    <path
+       d="m 11,4.9999999 h 7.999999"
+       id="path8"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#6e97c4;stroke-width:2" />
+    <g
+       transform="translate(0,-9.2)"
+       id="g28"
+       style="stroke:#6e97c4">
+      <path
+         d="M 5,18.7 H 9"
+         id="path16"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+      <path
+         d="m 11,18.7 h 7.999999"
+         id="path18"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+      <path
+         d="M 5,21.7 H 9"
+         id="path20"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+      <path
+         d="m 11,21.7 h 7.999999"
+         id="path22"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+      <path
+         d="M 5,24.7 H 9"
+         id="path24"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+      <path
+         d="m 11,24.7 h 7.999999"
+         id="path26"
+         inkscape:connector-curvature="0"
+         style="fill:none" />
+    </g>
+    <g
+       style="stroke-linejoin:round;stroke-dashoffset:0.5;enable-background:new"
+       transform="matrix(0.58290926,0.33654275,-0.33654275,0.58290926,12.638737,4.6294758)"
+       id="g8092">
+      <path
+         style="fill:#505050;stroke:#505050;stroke-width:0.75;stroke-linecap:round"
+         inkscape:connector-curvature="0"
+         d="m 8.0961023,18.028419 5.9999997,0 -3.12491,6.990956 z"
+         id="path8094" />
+      <path
+         style="fill:#fce94f;stroke:#8b7617;stroke-width:0.75;stroke-linecap:round"
+         inkscape:connector-curvature="0"
+         d="m 8.0961004,1.0284199 6.0000006,-1e-6 10e-7,17.0000001 -5.9999997,0 z"
+         id="path8096" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#fcffff;stroke-width:2"
+         inkscape:connector-curvature="0"
+         d="m 10.596101,2.0284194 10e-7,14.9999996"
+         id="path8098" />
+      <path
+         style="opacity:0.25;fill-opacity:0.58823494;stroke:#000000;stroke-width:2"
+         inkscape:connector-curvature="0"
+         d="m 12.596101,2.0284192 2e-6,14.9999998"
+         id="path8100" />
+      <path
+         style="opacity:0.5;fill:#fce94f;stroke:#8b7617;stroke-width:0.75;stroke-linecap:round"
+         inkscape:connector-curvature="0"
+         d="m 12.096101,2.0284193 10e-7,15.9999997"
+         id="path8102" />
+      <path
+         style="fill:#969696;stroke:#969696;stroke-width:0.5;stroke-linecap:square"
+         inkscape:connector-curvature="0"
+         d="m 11.463292,23.228968 1.996957,-4.943779 -1.996957,-10e-7 z"
+         id="path8104" />
+      <path
+         style="opacity:0.5;fill:#fce94f;stroke:#8b7617;stroke-width:0.75;stroke-linecap:round"
+         inkscape:connector-curvature="0"
+         d="m 9.5961007,2.0284198 1.5e-6,15.9999982"
+         id="path8106" />
+      <g
+         style="fill:#e6e6e6;stroke-width:0.5"
+         id="g8108">
+        <path
+           style="stroke:#969696;stroke-linecap:round"
+           inkscape:connector-curvature="0"
+           d="m 7.8653316,-0.08727704 6.4615374,0 0,2.17913134 -6.4615374,0 z"
+           id="path8110" />
+        <path
+           style="stroke:#e6e6e6;stroke-linecap:square"
+           inkscape:connector-curvature="0"
+           d="m 10.728912,23.38728 -1.9969556,-5.102091 1.9969556,0 z"
+           id="path8112" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -52,11 +52,11 @@ QgsFeatureFilterWidget::QgsFeatureFilterWidget( QWidget *parent )
   mActionStoredFilterExpressions->setMenu( mStoredFilterExpressionMenu );
 
   // Set filter icon in a couple of places
-  mActionEditedFilter->setIcon( filterIcon );
   mActionShowAllFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTable.svg" ) );
   mActionAdvancedFilter->setIcon( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ) );
   mActionSelectedFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTableSelected.svg" ) );
   mActionVisibleFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTableVisible.svg" ) );
+  mActionEditedFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTableEdited.svg" ) );
 
 
   // Set button to store or delete stored filter expressions

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -52,12 +52,11 @@ QgsFeatureFilterWidget::QgsFeatureFilterWidget( QWidget *parent )
   mActionStoredFilterExpressions->setMenu( mStoredFilterExpressionMenu );
 
   // Set filter icon in a couple of places
-  QIcon filterIcon = QgsApplication::getThemeIcon( "/mActionFilter2.svg" );
-  mActionShowAllFilter->setIcon( filterIcon );
-  mActionAdvancedFilter->setIcon( filterIcon );
-  mActionSelectedFilter->setIcon( filterIcon );
-  mActionVisibleFilter->setIcon( filterIcon );
   mActionEditedFilter->setIcon( filterIcon );
+  mActionShowAllFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTable.svg" ) );
+  mActionAdvancedFilter->setIcon( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ) );
+  mActionSelectedFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTableSelected.svg" ) );
+  mActionVisibleFilter->setIcon( QgsApplication::getThemeIcon( "/mActionOpenTableVisible.svg" ) );
 
 
   // Set button to store or delete stored filter expressions

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1689,7 +1689,7 @@ Shift+R to enable range selection.</string>
      <normaloff>:/images/themes/default/mActionOpenTableSelected.svg</normaloff>:/images/themes/default/mActionOpenTableSelected.svg</iconset>
    </property>
    <property name="text">
-    <string>Open Attribute Table (Selected items)</string>
+    <string>Open Attribute Table (Selected Features)</string>
    </property>
    <property name="shortcut">
     <string>Shift+F6</string>
@@ -1701,7 +1701,7 @@ Shift+R to enable range selection.</string>
      <normaloff>:/images/themes/default/mActionOpenTableVisible.svg</normaloff>:/images/themes/default/mActionOpenTableVisible.svg</iconset>
    </property>
    <property name="text">
-    <string>Open Attribute Table (Visible items)</string>
+    <string>Open Attribute Table (Visible Features)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+F6</string>

--- a/src/ui/qgsfeaturefilterwidget.ui
+++ b/src/ui/qgsfeaturefilterwidget.ui
@@ -204,7 +204,7 @@
   <action name="mActionEditedFilter">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+     <normaloff>:/images/themes/default/mActionOpenTableEdited.svg</normaloff>:/images/themes/default/mActionOpenTableEdited.svg</iconset>
    </property>
    <property name="text">
     <string>Show Edited and New Features</string>

--- a/src/ui/qgsfeaturefilterwidget.ui
+++ b/src/ui/qgsfeaturefilterwidget.ui
@@ -165,7 +165,7 @@
   <action name="mActionShowAllFilter">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+     <normaloff>:/images/themes/default/mActionOpenTable.svg</normaloff>:/images/themes/default/mActionOpenTable.svg</iconset>
    </property>
    <property name="text">
     <string>Show All Features</string>
@@ -186,7 +186,7 @@
   <action name="mActionSelectedFilter">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+     <normaloff>:/images/themes/default/mActionOpenTableSelected.svg</normaloff>:/images/themes/default/mActionOpenTableSelected.svg</iconset>
    </property>
    <property name="text">
     <string>Show Selected Features</string>
@@ -195,7 +195,7 @@
   <action name="mActionVisibleFilter">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+     <normaloff>:/images/themes/default/mActionOpenTableVisible.svg</normaloff>:/images/themes/default/mActionOpenTableVisible.svg</iconset>
    </property>
    <property name="text">
     <string>Show Features Visible On Map</string>


### PR DESCRIPTION
making a visual connection between the drop-down items and their corrsponding tool in Layer menu and attributes toolbar.
Also fixes wording (use features instead of items in the layer menu)
![Capture d’écran du 2021-06-01 03-24-30](https://user-images.githubusercontent.com/7983394/120254032-2c089480-c289-11eb-8ec7-c54182838416.png)
PS: I have a [not pushed commit](https://github.com/qgis/QGIS/commit/7b534052830a85e80ac7fb4dab3eaa6775b8b5eb) that adds a dedicated entry for the filter by "new and edited features". But thought it would probably be considered as a new feature...