### PR TITLE
Add missing NoButton enum value to avoid losing relation editor button configuration

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorrelation.sip.in
@@ -165,7 +165,6 @@ Sets the relation editor configuration
 QFlags<QgsAttributeEditorRelation::Button> operator|(QgsAttributeEditorRelation::Button f1, QFlags<QgsAttributeEditorRelation::Button> f2);
 
 
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -36,6 +36,7 @@ The default relation widget in QGIS.
 
     enum Button
     {
+      NoButton,
       Link,
       Unlink,
       SaveChildEdits,

--- a/src/core/editform/qgsattributeeditorrelation.cpp
+++ b/src/core/editform/qgsattributeeditorrelation.cpp
@@ -66,16 +66,20 @@ void QgsAttributeEditorRelation::loadConfiguration( const QDomElement &element, 
   {
     if ( element.hasAttribute( "buttons" ) )
     {
+      Q_NOWARN_DEPRECATED_PUSH
       QString buttonString = element.attribute( QStringLiteral( "buttons" ), qgsFlagValueToKeys( QgsAttributeEditorRelation::Button::AllButtons ) );
       config.insert( "buttons", qgsFlagValueToKeys( qgsFlagKeysToValue( buttonString, QgsAttributeEditorRelation::Button::AllButtons ) ) );
+      Q_NOWARN_DEPRECATED_POP
     }
     else
     {
       // pre QGIS 3.16 compatibility
+      Q_NOWARN_DEPRECATED_PUSH
       QgsAttributeEditorRelation::Buttons buttons = QgsAttributeEditorRelation::Button::AllButtons;
       buttons.setFlag( QgsAttributeEditorRelation::Button::Link, element.attribute( QStringLiteral( "showLinkButton" ), QStringLiteral( "1" ) ).toInt() );
       buttons.setFlag( QgsAttributeEditorRelation::Button::Unlink, element.attribute( QStringLiteral( "showUnlinkButton" ), QStringLiteral( "1" ) ).toInt() );
       buttons.setFlag( QgsAttributeEditorRelation::Button::SaveChildEdits, element.attribute( QStringLiteral( "showSaveChildEditsButton" ), QStringLiteral( "1" ) ).toInt() );
+      Q_NOWARN_DEPRECATED_POP
       config.insert( "buttons", qgsFlagValueToKeys( buttons ) );
     }
   }

--- a/src/core/editform/qgsattributeeditorrelation.cpp
+++ b/src/core/editform/qgsattributeeditorrelation.cpp
@@ -67,6 +67,10 @@ void QgsAttributeEditorRelation::loadConfiguration( const QDomElement &element, 
     if ( element.hasAttribute( "buttons" ) )
     {
       Q_NOWARN_DEPRECATED_PUSH
+      // QgsAttributeEditorRelation::Button has been deprecated in favor of QgsRelationEditorWidget::Button
+      // we cannot use it here since the new flags are in gui, while the current code is in core
+      // TODO: remove this compatibility code in QGIS 4
+      //       or make the enum private if we really want to keep the backward compatibility (but not worth it!)
       QString buttonString = element.attribute( QStringLiteral( "buttons" ), qgsFlagValueToKeys( QgsAttributeEditorRelation::Button::AllButtons ) );
       config.insert( "buttons", qgsFlagValueToKeys( qgsFlagKeysToValue( buttonString, QgsAttributeEditorRelation::Button::AllButtons ) ) );
       Q_NOWARN_DEPRECATED_POP

--- a/src/core/editform/qgsattributeeditorrelation.h
+++ b/src/core/editform/qgsattributeeditorrelation.h
@@ -36,9 +36,10 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
 
     /**
        * Possible buttons shown in the relation editor
+       * \deprecated since QGIS 3.18 use QgsRelationEditorWidget::Button instead
        * \since QGIS 3.16
        */
-    enum Button
+    enum Q_DECL_DEPRECATED Button
     {
       Link = 1 << 1, //!< Link button
       Unlink = 1 << 2, //!< Unlink button
@@ -49,9 +50,11 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
       ZoomToChildFeature = 1 << 7, //!< Zoom to child feature
       AllButtons = Link | Unlink | SaveChildEdits | AddChildFeature | DuplicateChildFeature | DeleteChildFeature | ZoomToChildFeature //!< All buttons
     };
+    Q_NOWARN_DEPRECATED_PUSH
     Q_ENUM( Button )
     Q_DECLARE_FLAGS( Buttons, Button )
     Q_FLAG( Buttons )
+    Q_NOWARN_DEPRECATED_POP
 
     /**
      * \deprecated since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
@@ -183,7 +186,9 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QString typeIdentifier() const override;
     QString mRelationId;
     QgsRelation mRelation;
+    Q_NOWARN_DEPRECATED_PUSH
     Buttons mButtons = Buttons( Button::AllButtons );
+    Q_NOWARN_DEPRECATED_POP
     bool mForceSuppressFormPopup = false;
     QVariant mNmRelationId;
     QString mLabel;
@@ -191,7 +196,8 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QVariantMap mRelationEditorConfig;
 };
 
+Q_NOWARN_DEPRECATED_PUSH
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAttributeEditorRelation::Buttons )
-
+Q_NOWARN_DEPRECATED_POP
 
 #endif // QGSATTRIBUTEEDITORRELATION_H

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -99,6 +99,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
      */
     enum Button
     {
+      NoButton = 0, //!< No button
       Link = 1 << 1, //!< Link button
       Unlink = 1 << 2, //!< Unlink button
       SaveChildEdits = 1 << 3, //!< Save child edits button

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -99,7 +99,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
      */
     enum Button
     {
-      NoButton = 0, //!< No button
+      NoButton = 0, //!< No button (since QGIS 3.20)
       Link = 1 << 1, //!< Link button
       Unlink = 1 << 2, //!< Unlink button
       SaveChildEdits = 1 << 3, //!< Save child edits button

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -95,6 +95,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     /**
      * Possible buttons shown in the relation editor
+     * \since QGIS 3.18
      */
     enum Button
     {

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -71,7 +71,6 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     {
       operator QVariant();
 
-      QgsAttributeEditorRelation::Buttons buttons = QgsAttributeEditorRelation::Button::AllButtons;
       QString mRelationWidgetType;
       QVariantMap mRelationWidgetConfig;
       QVariant nmRelationId;

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -24,7 +24,7 @@
 #include "qgis.h"
 #include "qgsmaplayermodel.h"
 #include "qgsattributeeditorelement.h"
-#include "qgsattributeeditorrelation.h"
+#include "qgsfieldproxymodel.h"
 
 /**
  * \ingroup UnitTests
@@ -451,13 +451,13 @@ void TestQgis::testQgsEnumKeyToValue()
 
 void TestQgis::testQgsFlagValueToKeys()
 {
-  QgsAttributeEditorRelation::Buttons buttons = QgsAttributeEditorRelation::Button::Link | QgsAttributeEditorRelation::Button::AddChildFeature;
-  QCOMPARE( qgsFlagValueToKeys( buttons ), QStringLiteral( "Link|AddChildFeature" ) );
+  QgsFieldProxyModel::Filters filters = QgsFieldProxyModel::Filter::String | QgsFieldProxyModel::Filter::Double;
+  QCOMPARE( qgsFlagValueToKeys( filters ), QStringLiteral( "String|Double" ) );
 }
 void TestQgis::testQgsFlagKeysToValue()
 {
-  QCOMPARE( qgsFlagKeysToValue( QStringLiteral( "Link|AddChildFeature" ), QgsAttributeEditorRelation::Buttons( QgsAttributeEditorRelation::Button::AllButtons ) ), QgsAttributeEditorRelation::Button::Link | QgsAttributeEditorRelation::Button::AddChildFeature );
-  QCOMPARE( qgsFlagKeysToValue( QStringLiteral( "UnknownKey" ), QgsAttributeEditorRelation::Buttons( QgsAttributeEditorRelation::Button::AllButtons ) ), QgsAttributeEditorRelation::Buttons( QgsAttributeEditorRelation::Button::AllButtons ) );
+  QCOMPARE( qgsFlagKeysToValue( QStringLiteral( "String|Double" ), QgsFieldProxyModel::Filters( QgsFieldProxyModel::Filter::AllTypes ) ), QgsFieldProxyModel::Filter::String | QgsFieldProxyModel::Filter::Double );
+  QCOMPARE( qgsFlagKeysToValue( QStringLiteral( "UnknownKey" ), QgsFieldProxyModel::Filters( QgsFieldProxyModel::Filter::AllTypes ) ), QgsFieldProxyModel::Filters( QgsFieldProxyModel::Filter::AllTypes ) );
 }
 
 void TestQgis::testQMapQVariantList()


### PR DESCRIPTION
The buttons config has been moved from `QgsAttributeEditorRelation` to `QgsRelationEditorWidget`. The logic is that the buttons are a configuration of the default implementation of relation editor (we now have a registry for these).

The enum had to be duplicated in the two classes, I added some documentation to the enums to reflect this and deprecated the former one.

To fix the issue, I added a NoButton (key = 0) to the enum entries, and it works perfectly.

Fixes #43123