### PR TITLE
Add tags for gdal_edit processing algorithm

### DIFF
--- a/python/plugins/processing/algs/gdal/AssignProjection.py
+++ b/python/plugins/processing/algs/gdal/AssignProjection.py
@@ -64,6 +64,9 @@ class AssignProjection(GdalAlgorithm):
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'projection-add.png'))
 
+    def tags(self):
+        return ['assign', 'set', 'transform', 'reproject', 'crs', 'srs', 'warp', self.commandName()]
+    
     def group(self):
         return self.tr('Raster projections')
 

--- a/python/plugins/processing/algs/gdal/AssignProjection.py
+++ b/python/plugins/processing/algs/gdal/AssignProjection.py
@@ -66,7 +66,7 @@ class AssignProjection(GdalAlgorithm):
 
     def tags(self):
         return ['assign', 'set', 'transform', 'reproject', 'crs', 'srs', 'warp', self.commandName()]
-    
+
     def group(self):
         return self.tr('Raster projections')
 

--- a/python/plugins/processing/algs/gdal/AssignProjection.py
+++ b/python/plugins/processing/algs/gdal/AssignProjection.py
@@ -65,7 +65,9 @@ class AssignProjection(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'projection-add.png'))
 
     def tags(self):
-        return ['assign', 'set', 'transform', 'reproject', 'crs', 'srs', 'warp', self.commandName()]
+        tags = self.tr('assign,set,transform,reproject,crs,srs').split(',')
+        tags.extend(super().tags())
+        return tags
 
     def group(self):
         return self.tr('Raster projections')


### PR DESCRIPTION
## Description

Add tags for gdal_edit processing algorithm (GDAL>Raster projections>Assign projection).
Now it is consistent with the vector "assign projection algorithm", and I can find it by searching e.g. for crs.

## Note

Tagging of processing algorithms is currently pretty inconsistent and could do with a systematic review.
It particularly bothers me when a search will find a vector algorithm but not a raster algorithm that does the same thing.
