### PR TITLE
offer a restriced set of fields as referenced fiels for polymorphic relations

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -143,7 +143,7 @@ set(QGIS_APP_SRCS
   qgsrastercalcdialog.cpp
   qgsrelationmanagerdialog.cpp
   qgsrelationadddlg.cpp
-  qgsrelationaddpolymorphicdlg.cpp
+  qgsrelationaddpolymorphicdialog.cpp
   qgsselectbyformdialog.cpp
   qgsstatisticalsummarydockwidget.cpp
   qgstextannotationdialog.cpp

--- a/src/app/qgsrelationaddpolymorphicdialog.cpp
+++ b/src/app/qgsrelationaddpolymorphicdialog.cpp
@@ -22,7 +22,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
-#include "qgsrelationaddpolymorphicdlg.h"
+#include "qgsrelationaddpolymorphicdialog.h"
 #include "qgsvectorlayer.h"
 #include "qgsmaplayercombobox.h"
 #include "qgsfieldcombobox.h"
@@ -33,7 +33,7 @@
 #include "qgsrelationmanager.h"
 #include "qgsfieldexpressionwidget.h"
 
-QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( bool isEditDialog, QWidget *parent )
+QgsRelationAddPolymorphicDialog::QgsRelationAddPolymorphicDialog( bool isEditDialog, QWidget *parent )
   : QDialog( parent )
   , Ui::QgsRelationManagerAddPolymorphicDialogBase()
   , mIsEditDialog( isEditDialog )
@@ -45,8 +45,8 @@ QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( bool isEditDialog, Q
                   : tr( "Add Polymorphic Relation" ) );
 
   mButtonBox->setStandardButtons( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok );
-  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddPolymorphicDlg::accept );
-  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsRelationAddPolymorphicDlg::reject );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRelationAddPolymorphicDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsRelationAddPolymorphicDialog::reject );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
   {
     QgsHelp::openHelp( QStringLiteral( "working_with_vector/attribute_table.html#defining-polymorphic-relations" ) );
@@ -72,18 +72,18 @@ QgsRelationAddPolymorphicDlg::QgsRelationAddPolymorphicDlg( bool isEditDialog, Q
   updateDialogButtons();
   updateReferencedLayerFieldComboBox();
 
-  connect( mFieldsMappingTable, &QTableWidget::itemSelectionChanged, this, &QgsRelationAddPolymorphicDlg::updateFieldsMappingButtons );
-  connect( mFieldsMappingAddButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::addFieldsRow );
-  connect( mFieldsMappingRemoveButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDlg::removeFieldsRow );
-  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
+  connect( mFieldsMappingTable, &QTableWidget::itemSelectionChanged, this, &QgsRelationAddPolymorphicDialog::updateFieldsMappingButtons );
+  connect( mFieldsMappingAddButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDialog::addFieldsRow );
+  connect( mFieldsMappingRemoveButton, &QToolButton::clicked, this, &QgsRelationAddPolymorphicDialog::removeFieldsRow );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDialog::updateDialogButtons );
   connect( mRelationStrengthComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int index ) { Q_UNUSED( index ); updateDialogButtons(); } );
-  connect( mReferencedLayerExpressionWidget, static_cast<void ( QgsFieldExpressionWidget::* )( const QString & )>( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsRelationAddPolymorphicDlg::updateDialogButtons );
-  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox );
-  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes );
-  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDlg::updateReferencedLayerFieldComboBox );
+  connect( mReferencedLayerExpressionWidget, static_cast<void ( QgsFieldExpressionWidget::* )( const QString & )>( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsRelationAddPolymorphicDialog::updateDialogButtons );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDialog::updateChildRelationsComboBox );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDialog::updateReferencingFieldsComboBoxes );
+  connect( mReferencingLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsRelationAddPolymorphicDialog::updateReferencedLayerFieldComboBox );
 }
 
-void QgsRelationAddPolymorphicDlg::setPolymorphicRelation( const QgsPolymorphicRelation polyRel )
+void QgsRelationAddPolymorphicDialog::setPolymorphicRelation( const QgsPolymorphicRelation polyRel )
 {
   mIdLineEdit->setText( polyRel.id() );
   mReferencingLayerComboBox->setLayer( polyRel.referencingLayer() );
@@ -106,12 +106,12 @@ void QgsRelationAddPolymorphicDlg::setPolymorphicRelation( const QgsPolymorphicR
     mReferencedLayersComboBox->setItemCheckState( mReferencedLayersComboBox->findData( layerId ), Qt::Checked );
 }
 
-void QgsRelationAddPolymorphicDlg::updateTypeConfigWidget()
+void QgsRelationAddPolymorphicDialog::updateTypeConfigWidget()
 {
   updateDialogButtons();
 }
 
-void QgsRelationAddPolymorphicDlg::addFieldsRow()
+void QgsRelationAddPolymorphicDialog::addFieldsRow()
 {
   QgsFieldComboBox *referencingField = new QgsFieldComboBox( this );
   QLineEdit *referencedPolymorphicField = new QLineEdit( this );
@@ -128,7 +128,7 @@ void QgsRelationAddPolymorphicDlg::addFieldsRow()
   updateDialogButtons();
 }
 
-void QgsRelationAddPolymorphicDlg::removeFieldsRow()
+void QgsRelationAddPolymorphicDialog::removeFieldsRow()
 {
   if ( mFieldsMappingTable->selectionModel()->hasSelection() )
   {
@@ -151,7 +151,7 @@ void QgsRelationAddPolymorphicDlg::removeFieldsRow()
   updateDialogButtons();
 }
 
-void QgsRelationAddPolymorphicDlg::updateFieldsMappingButtons()
+void QgsRelationAddPolymorphicDialog::updateFieldsMappingButtons()
 {
   int rowsCount = mFieldsMappingTable->rowCount();
   int selectedRowsCount = mFieldsMappingTable->selectionModel()->selectedRows().count();
@@ -160,7 +160,7 @@ void QgsRelationAddPolymorphicDlg::updateFieldsMappingButtons()
   mFieldsMappingRemoveButton->setEnabled( isRemoveButtonEnabled );
 }
 
-void QgsRelationAddPolymorphicDlg::updateFieldsMappingHeaders()
+void QgsRelationAddPolymorphicDialog::updateFieldsMappingHeaders()
 {
   int rowsCount = mFieldsMappingTable->rowCount();
   QStringList verticalHeaderLabels;
@@ -171,27 +171,27 @@ void QgsRelationAddPolymorphicDlg::updateFieldsMappingHeaders()
   mFieldsMappingTable->setVerticalHeaderLabels( verticalHeaderLabels );
 }
 
-QString QgsRelationAddPolymorphicDlg::referencingLayerId()
+QString QgsRelationAddPolymorphicDialog::referencingLayerId()
 {
   return mReferencingLayerComboBox->currentLayer()->id();
 }
 
-QString QgsRelationAddPolymorphicDlg::referencedLayerField()
+QString QgsRelationAddPolymorphicDialog::referencedLayerField()
 {
   return mReferencedLayerFieldComboBox->currentField();
 }
 
-QString QgsRelationAddPolymorphicDlg::referencedLayerExpression()
+QString QgsRelationAddPolymorphicDialog::referencedLayerExpression()
 {
   return mReferencedLayerExpressionWidget->expression();
 }
 
-QStringList QgsRelationAddPolymorphicDlg::referencedLayerIds()
+QStringList QgsRelationAddPolymorphicDialog::referencedLayerIds()
 {
   return QVariant( mReferencedLayersComboBox->checkedItemsData() ).toStringList();
 }
 
-QList< QPair< QString, QString > > QgsRelationAddPolymorphicDlg::fieldPairs()
+QList< QPair< QString, QString > > QgsRelationAddPolymorphicDialog::fieldPairs()
 {
   QList< QPair< QString, QString > > references;
   for ( int i = 0, l = mFieldsMappingTable->rowCount(); i < l; i++ )
@@ -204,28 +204,28 @@ QList< QPair< QString, QString > > QgsRelationAddPolymorphicDlg::fieldPairs()
   return references;
 }
 
-QString QgsRelationAddPolymorphicDlg::relationId()
+QString QgsRelationAddPolymorphicDialog::relationId()
 {
   return mIdLineEdit->text();
 }
 
-QString QgsRelationAddPolymorphicDlg::relationName()
+QString QgsRelationAddPolymorphicDialog::relationName()
 {
   QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mReferencingLayerComboBox->currentLayer() );
   return tr( "Polymorphic relations for \"%1\"" ).arg( vl ? vl->name() : QStringLiteral( "<NO LAYER>" ) );
 }
 
-QgsRelation::RelationStrength QgsRelationAddPolymorphicDlg::relationStrength()
+QgsRelation::RelationStrength QgsRelationAddPolymorphicDialog::relationStrength()
 {
   return mRelationStrengthComboBox->currentData().value<QgsRelation::RelationStrength>();
 }
 
-void QgsRelationAddPolymorphicDlg::updateDialogButtons()
+void QgsRelationAddPolymorphicDialog::updateDialogButtons()
 {
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( isDefinitionValid() );
 }
 
-bool QgsRelationAddPolymorphicDlg::isDefinitionValid()
+bool QgsRelationAddPolymorphicDialog::isDefinitionValid()
 {
   bool isValid = true;
   return isValid;
@@ -241,7 +241,7 @@ bool QgsRelationAddPolymorphicDlg::isDefinitionValid()
   return isValid;
 }
 
-void QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox()
+void QgsRelationAddPolymorphicDialog::updateChildRelationsComboBox()
 {
   QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( mReferencingLayerComboBox->currentLayer() );
   if ( !vl || !vl->isValid() )
@@ -262,7 +262,7 @@ void QgsRelationAddPolymorphicDlg::updateChildRelationsComboBox()
   }
 }
 
-void QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes()
+void QgsRelationAddPolymorphicDialog::updateReferencingFieldsComboBoxes()
 {
   QgsMapLayer *vl = mReferencingLayerComboBox->currentLayer();
   if ( !vl || !vl->isValid() )
@@ -275,7 +275,7 @@ void QgsRelationAddPolymorphicDlg::updateReferencingFieldsComboBoxes()
   }
 }
 
-void QgsRelationAddPolymorphicDlg::updateReferencedLayerFieldComboBox()
+void QgsRelationAddPolymorphicDialog::updateReferencedLayerFieldComboBox()
 {
   mReferencedLayerFieldComboBox->setLayer( mReferencingLayerComboBox->currentLayer() );
 }

--- a/src/app/qgsrelationaddpolymorphicdialog.h
+++ b/src/app/qgsrelationaddpolymorphicdialog.h
@@ -12,8 +12,8 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSRELATIONADDPOLYMORPHICDLG_H
-#define QGSRELATIONADDPOLYMORPHICDLG_H
+#ifndef QGSRELATIONADDPOLYMORPHICDIALOG_H
+#define QGSRELATIONADDPOLYMORPHICDIALOG_H
 
 #include <QDialog>
 #include "qgis_app.h"
@@ -36,12 +36,12 @@ class QgsMapLayerComboBox;
  * QgsRelationAddDlg allows configuring a new relation.
  * Multiple field pairs can be set.
  */
-class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsRelationManagerAddPolymorphicDialogBase
+class APP_EXPORT QgsRelationAddPolymorphicDialog : public QDialog, private Ui::QgsRelationManagerAddPolymorphicDialogBase
 {
     Q_OBJECT
 
   public:
-    explicit QgsRelationAddPolymorphicDlg( bool isEditDialog, QWidget *parent = nullptr );
+    explicit QgsRelationAddPolymorphicDialog( bool isEditDialog, QWidget *parent = nullptr );
 
     /**
      * Returns the id of the referencing layer
@@ -107,4 +107,4 @@ class APP_EXPORT QgsRelationAddPolymorphicDlg : public QDialog, private Ui::QgsR
 
 };
 
-#endif // QGSRELATIONADDPOLYMORPHICDLG_H
+#endif // QGSRELATIONADDPOLYMORPHICDIALOG_H

--- a/src/app/qgsrelationaddpolymorphicdialog.h
+++ b/src/app/qgsrelationaddpolymorphicdialog.h
@@ -98,6 +98,7 @@ class APP_EXPORT QgsRelationAddPolymorphicDialog : public QDialog, private Ui::Q
     void updateChildRelationsComboBox();
     void updateReferencingFieldsComboBoxes();
     void updateReferencedLayerFieldComboBox();
+    void referencedLayersChanged();
 
   private:
     bool isDefinitionValid();

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -15,7 +15,7 @@
 
 #include "qgsdiscoverrelationsdialog.h"
 #include "qgsrelationadddlg.h"
-#include "qgsrelationaddpolymorphicdlg.h"
+#include "qgsrelationaddpolymorphicdialog.h"
 #include "qgsrelationmanagerdialog.h"
 #include "qgsrelationmanager.h"
 #include "qgspolymorphicrelation.h"
@@ -240,7 +240,7 @@ void QgsRelationManagerDialog::mBtnAddRelation_clicked()
 
 void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
 {
-  QgsRelationAddPolymorphicDlg addDlg( false );
+  QgsRelationAddPolymorphicDialog addDlg( false );
 
   if ( addDlg.exec() )
   {
@@ -268,7 +268,7 @@ void QgsRelationManagerDialog::mActionAddPolymorphicRelation_triggered()
 
 void QgsRelationManagerDialog::mActionEditPolymorphicRelation_triggered()
 {
-  QgsRelationAddPolymorphicDlg addDlg( true );
+  QgsRelationAddPolymorphicDialog addDlg( true );
   const QModelIndexList rows = mRelationsTree->selectionModel()->selectedRows();
 
   if ( rows.size() != 1 )

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -6,25 +6,64 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>454</width>
-    <height>490</height>
+    <width>297</width>
+    <height>487</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Add Polymorphic Relation</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0,0">
+   <item row="7" column="0">
+    <widget class="QLabel" name="mReferencedLayersLabel">
+     <property name="text">
+      <string>Referenced layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mIdLineEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="placeholderText">
+      <string>[Generated automatically]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFieldComboBox" name="mReferencedLayerFieldComboBox"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QComboBox" name="mRelationStrengthComboBox"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
+   </item>
+   <item row="7" column="1">
+    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="mRelationStrengthLabel">
+     <property name="text">
+      <string>Relationship strength</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="mReferencingLayerLabel">
      <property name="text">
       <string>Referencing layer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -42,10 +81,88 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QgsMapLayerComboBox" name="mReferencingLayerComboBox"/>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mReferencedLayerExpressionLabel">
+     <property name="text">
+      <string>Layer field expression</string>
+     </property>
+    </widget>
    </item>
-   <item row="11" column="0" colspan="3">
+   <item row="3" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QWidget" name="mFieldsMappingWidget" native="true">
+     <layout class="QGridLayout" name="mFieldsMappingLayout">
+      <item row="0" column="0">
+       <widget class="QTableWidget" name="mFieldsMappingTable">
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="rowCount">
+         <number>0</number>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>150</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string comment="polymorphic relations">Referenced (parent)</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Referencing (child)</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QVBoxLayout" name="mFieldsMappingButtonsVBoxLayout">
+        <item>
+         <widget class="QToolButton" name="mFieldsMappingAddButton">
+          <property name="toolTip">
+           <string>Add new field pair as part of a composite foreign key</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mFieldsMappingRemoveButton">
+          <property name="toolTip">
+           <string>Remove the selected or last pair of fields</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="mFieldsMappingVSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
     <widget class="QLabel" name="mPolymorphicRelationHelpLabel">
      <property name="text">
       <string>Polymorphic relations are for advanced usage where a set of standard relations have the same referencing layer but the referenced layer is calculated from an expression.</string>
@@ -55,117 +172,12 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="2">
-    <layout class="QVBoxLayout" name="mFieldsMappingButtonsVBoxLayout">
-     <item>
-      <widget class="QToolButton" name="mFieldsMappingAddButton">
-       <property name="toolTip">
-        <string>Add new field pair as part of a composite foreign key</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mFieldsMappingRemoveButton">
-       <property name="toolTip">
-        <string>Remove the selected or last pair of fields</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="mFieldsMappingVSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
    <item row="8" column="0" colspan="2">
     <widget class="QLabel" name="mFieldsMappingLabel">
      <property name="text">
       <string>Fields mapping</string>
      </property>
     </widget>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QgsFieldComboBox" name="mReferencedLayerFieldComboBox"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mReferencedLayerExpressionLabel">
-     <property name="text">
-      <string>Layer field expression</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="2">
-    <widget class="QTableWidget" name="mFieldsMappingTable">
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="rowCount">
-      <number>0</number>
-     </property>
-     <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>150</number>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string comment="polymorphic relations">Referenced (parent)</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Referencing (child)</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QLineEdit" name="mIdLineEdit">
-     <property name="placeholderText">
-      <string>[Generated automatically]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QgsFieldExpressionWidget" name="mReferencedLayerExpressionWidget" native="true"/>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="mRelationStrengthLabel">
-     <property name="text">
-      <string>Relationship strength</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QComboBox" name="mRelationStrengthComboBox"/>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="mReferencedLayersLabel">
-     <property name="text">
-      <string>Referenced layers</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
    </item>
   </layout>
  </widget>
@@ -197,7 +209,6 @@
   <tabstop>mReferencingLayerComboBox</tabstop>
   <tabstop>mReferencedLayerFieldComboBox</tabstop>
   <tabstop>mRelationStrengthComboBox</tabstop>
-  <tabstop>mFieldsMappingTable</tabstop>
   <tabstop>mFieldsMappingAddButton</tabstop>
   <tabstop>mFieldsMappingRemoveButton</tabstop>
  </tabstops>

--- a/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
+++ b/src/ui/qgsrelationmanageraddpolymorphicdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
-    <height>400</height>
+    <width>454</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,13 +39,6 @@
     <widget class="QLabel" name="mIdLabel">
      <property name="text">
       <string>Id</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="mReferencedLayersLabel">
-     <property name="text">
-      <string>Referenced layers</string>
      </property>
     </widget>
    </item>
@@ -118,9 +111,6 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="2">
-    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
-   </item>
    <item row="9" column="0" colspan="2">
     <widget class="QTableWidget" name="mFieldsMappingTable">
      <property name="selectionBehavior">
@@ -167,6 +157,16 @@
    <item row="6" column="1" colspan="2">
     <widget class="QComboBox" name="mRelationStrengthComboBox"/>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="mReferencedLayersLabel">
+     <property name="text">
+      <string>Referenced layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="2">
+    <widget class="QgsCheckableComboBox" name="mReferencedLayersComboBox"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -200,7 +200,6 @@
   <tabstop>mFieldsMappingTable</tabstop>
   <tabstop>mFieldsMappingAddButton</tabstop>
   <tabstop>mFieldsMappingRemoveButton</tabstop>
-  <tabstop>mReferencedLayersComboBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
fixes #41959

when no referenced layer is selected, you cannot define field pairs (widget disabled):
![image](https://user-images.githubusercontent.com/127259/120327122-b680e080-c2e9-11eb-9376-d7f8d21dc911.png)

when one layer is selected, all fields can be used:
![image](https://user-images.githubusercontent.com/127259/120327195-c993b080-c2e9-11eb-837c-35fabe8bf5ef.png)

when more layers are selected, only the intersection of the fields are proposed:
![image](https://user-images.githubusercontent.com/127259/120327271-dadcbd00-c2e9-11eb-9f04-1749cb513786.png)

if there is no field in common:
![image](https://user-images.githubusercontent.com/127259/120327306-e7611580-c2e9-11eb-9b9e-2daf59f32de7.png)

depends on #43487