### PR TITLE
Make 2d terrain rendering optional

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -633,7 +633,7 @@ Returns whether the 2D terrain surface will be rendered.
 
 .. seealso:: :py:func:`setTerrainRenderingEnabled`
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
     void setTerrainRenderingEnabled( bool terrainRenderingEnabled );
@@ -642,7 +642,7 @@ Sets whether the 2D terrain surface will be rendered in.
 
 .. seealso:: :py:func:`terrainRenderingEnabled`
 
-.. versionadded:: 3.20
+.. versionadded:: 3.22
 %End
 
   signals:

--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -627,6 +627,24 @@ Sets whether FPS counter label is enabled
 .. versionadded:: 3.18
 %End
 
+    bool terrainRenderingEnabled();
+%Docstring
+Returns whether the 2D terrain surface will be rendered.
+
+.. seealso:: :py:func:`setTerrainRenderingEnabled`
+
+.. versionadded:: 3.20
+%End
+
+    void setTerrainRenderingEnabled( bool terrainRenderingEnabled );
+%Docstring
+Sets whether the 2D terrain surface will be rendered in.
+
+.. seealso:: :py:func:`terrainRenderingEnabled`
+
+.. versionadded:: 3.20
+%End
+
   signals:
     void backgroundColorChanged();
 %Docstring

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -473,8 +473,8 @@ bool Qgs3DMapScene::updateCameraNearFarPlanes()
   }
 
   // set near/far plane - with some tolerance in front/behind expected near/far planes
-  float newFar = ffar;// * 2;
-  float newNear = fnear;// / 2;
+  float newFar = ffar * 2;
+  float newNear = fnear / 2;
   if ( !qgsFloatNear( newFar, camera->farPlane() ) || !qgsFloatNear( newNear, camera->nearPlane() ) )
   {
     camera->setFarPlane( newFar );

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -121,6 +121,12 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
      */
     QVector<const QgsChunkNode *> getLayerActiveChunkNodes( QgsMapLayer *layer ) SIP_SKIP;
 
+    /**
+     * Returns the scene extent in the map's CRS
+     *
+     * \since QGIS 3.20
+     */
+    QgsRectangle sceneExtent();
   signals:
     //! Emitted when the current terrain entity is replaced by a new one
     void terrainEntityChanged();
@@ -163,6 +169,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onDebugDepthMapSettingsChanged();
     void onCameraMovementSpeedChanged();
 
+    bool updateCameraNearFarPlanes();
+
   private:
     void addLayerEntity( QgsMapLayer *layer );
     void removeLayerEntity( QgsMapLayer *layer );
@@ -170,7 +178,6 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void setSceneState( SceneState state );
     void updateSceneState();
     void updateScene();
-    bool updateCameraNearFarPlanes();
     void finalizeNewEntity( Qt3DCore::QEntity *newEntity );
     int maximumTextureSize() const;
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -77,6 +77,7 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mDebugDepthMapEnabled( other.mDebugDepthMapEnabled )
   , mDebugDepthMapCorner( other.mDebugDepthMapCorner )
   , mDebugDepthMapSize( other.mDebugDepthMapSize )
+  , mTerrainRenderingEnabled( other.mTerrainRenderingEnabled )
 {
   for ( QgsAbstract3DRenderer *renderer : std::as_const( other.mRenderers ) )
   {
@@ -121,6 +122,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   mCrs.readXml( elemCrs );
 
   QDomElement elemTerrain = elem.firstChildElement( QStringLiteral( "terrain" ) );
+  mTerrainRenderingEnabled = elemTerrain.attribute( QStringLiteral( "terrain-rendering-enabled" ), QStringLiteral( "1" ) ).toInt();
   mTerrainVerticalScale = elemTerrain.attribute( QStringLiteral( "exaggeration" ), QStringLiteral( "1" ) ).toFloat();
   mMapTileResolution = elemTerrain.attribute( QStringLiteral( "texture-size" ), QStringLiteral( "512" ) ).toInt();
   mMaxTerrainScreenError = elemTerrain.attribute( QStringLiteral( "max-terrain-error" ), QStringLiteral( "3" ) ).toFloat();
@@ -323,6 +325,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elem.appendChild( elemCrs );
 
   QDomElement elemTerrain = doc.createElement( QStringLiteral( "terrain" ) );
+  elemTerrain.setAttribute( QStringLiteral( "terrain-rendering-enabled" ), mTerrainRenderingEnabled ? 1 : 0 );
   elemTerrain.setAttribute( QStringLiteral( "exaggeration" ), QString::number( mTerrainVerticalScale ) );
   elemTerrain.setAttribute( QStringLiteral( "texture-size" ), mMapTileResolution );
   elemTerrain.setAttribute( QStringLiteral( "max-terrain-error" ), QString::number( mMaxTerrainScreenError ) );
@@ -630,8 +633,8 @@ void Qgs3DMapSettings::setTerrainGenerator( QgsTerrainGenerator *gen )
 
   mTerrainGenerator.reset( gen );
   connect( mTerrainGenerator.get(), &QgsTerrainGenerator::extentChanged, this, &Qgs3DMapSettings::terrainGeneratorChanged );
-
-  emit terrainGeneratorChanged();
+  if ( mTerrainRenderingEnabled )
+    emit terrainGeneratorChanged();
 }
 
 void Qgs3DMapSettings::setTerrainShadingEnabled( bool enabled )
@@ -827,4 +830,12 @@ void Qgs3DMapSettings::setIsFpsCounterEnabled( bool fpsCounterEnabled )
     return;
   mIsFpsCounterEnabled = fpsCounterEnabled;
   emit fpsCounterEnabledChanged( mIsFpsCounterEnabled );
+}
+
+void Qgs3DMapSettings::setTerrainRenderingEnabled( bool terrainRenderingEnabled )
+{
+  if ( terrainRenderingEnabled == mTerrainRenderingEnabled )
+    return;
+  mTerrainRenderingEnabled = terrainRenderingEnabled;
+  emit terrainGeneratorChanged();
 }

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -283,7 +283,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setTerrainGenerator( QgsTerrainGenerator *gen SIP_TRANSFER ) SIP_SKIP;
     //! Returns terrain generator. It takes care of producing terrain tiles from the input data.
-    QgsTerrainGenerator *terrainGenerator() const SIP_SKIP { return mTerrainGenerator.get(); }
+    QgsTerrainGenerator *terrainGenerator() const SIP_SKIP
+    {
+      if ( mTerrainRenderingEnabled )
+        return mTerrainGenerator.get();
+      return nullptr;
+    }
 
     /**
      * Sets whether terrain shading is enabled.
@@ -571,6 +576,20 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setIsFpsCounterEnabled( bool fpsCounterEnabled );
 
+    /**
+     * Returns whether the 2D terrain surface will be rendered.
+     * \see setTerrainRenderingEnabled()
+     * \since QGIS 3.20
+     */
+    bool terrainRenderingEnabled() { return mTerrainRenderingEnabled; }
+
+    /**
+     * Sets whether the 2D terrain surface will be rendered in.
+     * \see terrainRenderingEnabled()
+     * \since QGIS 3.20
+     */
+    void setTerrainRenderingEnabled( bool terrainRenderingEnabled );
+
   signals:
     //! Emitted when the background color has changed
     void backgroundColorChanged();
@@ -732,7 +751,6 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
 
     /**
      * Emitted when the FPS counter is enabled or disabled
-     *
      * \since QGIS 3.18
      */
     void fpsCounterEnabledChanged( bool fpsCounterEnabled );
@@ -793,6 +811,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     bool mDebugDepthMapEnabled = false;
     Qt::Corner mDebugDepthMapCorner = Qt::Corner::TopRightCorner;
     double mDebugDepthMapSize = 0.2;
+
+    bool mTerrainRenderingEnabled = true;
 };
 
 

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -579,14 +579,14 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     /**
      * Returns whether the 2D terrain surface will be rendered.
      * \see setTerrainRenderingEnabled()
-     * \since QGIS 3.20
+     * \since QGIS 3.22
      */
     bool terrainRenderingEnabled() { return mTerrainRenderingEnabled; }
 
     /**
      * Sets whether the 2D terrain surface will be rendered in.
      * \see terrainRenderingEnabled()
-     * \since QGIS 3.20
+     * \since QGIS 3.22
      */
     void setTerrainRenderingEnabled( bool terrainRenderingEnabled );
 

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -248,6 +248,8 @@ void Qgs3DSceneExporter::parseTerrain( QgsTerrainEntity *terrain, const  QString
   QgsChunkNode *node = terrain->rootNode();
 
   QgsTerrainGenerator *generator = settings.terrainGenerator();
+  if ( !generator )
+    return;
   QgsTerrainTileEntity *terrainTile = nullptr;
   QgsTerrainTextureGenerator *textureGenerator = terrain->textureGenerator();
   textureGenerator->waitForFinished();

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -256,7 +256,7 @@ float Qgs3DUtils::clampAltitude( const QgsPoint &p, Qgs3DTypes::AltitudeClamping
   if ( altClamp == Qgs3DTypes::AltClampRelative || altClamp == Qgs3DTypes::AltClampTerrain )
   {
     QgsPointXY pt = altBind == Qgs3DTypes::AltBindVertex ? p : centroid;
-    terrainZ = map.terrainGenerator()->heightAt( pt.x(), pt.y(), map );
+    terrainZ = map.terrainGenerator() ? map.terrainGenerator()->heightAt( pt.x(), pt.y(), map ) : 0;
   }
 
   float geomZ = 0;
@@ -284,7 +284,8 @@ void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, Qgs3DTypes::Altitude
       {
         pt.set( centroid.x(), centroid.y() );
       }
-      terrainZ = map.terrainGenerator()->heightAt( pt.x(), pt.y(), map );
+
+      terrainZ = map.terrainGenerator() ? map.terrainGenerator()->heightAt( pt.x(), pt.y(), map ) : 0;
     }
 
     float geomZ = 0;
@@ -357,7 +358,7 @@ void Qgs3DUtils::extractPointPositions( const QgsFeature &f, const Qgs3DMapSetti
     {
       geomZ = pt.z();
     }
-    float terrainZ = map.terrainGenerator()->heightAt( pt.x(), pt.y(), map ) * map.terrainVerticalScale();
+    float terrainZ = map.terrainGenerator() ? map.terrainGenerator()->heightAt( pt.x(), pt.y(), map ) * map.terrainVerticalScale() : 0;
     float h;
     switch ( altClamp )
     {

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -92,9 +92,9 @@ void QgsCameraController::setVerticalAxisInversion( QgsCameraController::Vertica
 void QgsCameraController::setTerrainEntity( QgsTerrainEntity *te )
 {
   mTerrainEntity = te;
-
   // object picker for terrain for correct map panning
-  connect( te->terrainPicker(), &Qt3DRender::QObjectPicker::pressed, this, &QgsCameraController::onPickerMousePressed );
+  if ( mTerrainEntity )
+    connect( te->terrainPicker(), &Qt3DRender::QObjectPicker::pressed, this, &QgsCameraController::onPickerMousePressed );
 }
 
 void QgsCameraController::setCamera( Qt3DRender::QCamera *camera )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -312,7 +312,16 @@ void QgsCameraController::updateCameraFromPose( bool centerPointChanged )
       QgsVector3D centerPoint = mCameraPose.centerPoint();
       centerPoint.set( centerPoint.x(), mTerrainEntity->terrainElevationOffset(), centerPoint.z() );
       mCameraPose.setCenterPoint( centerPoint );
+      mCameraPose.updateCamera( mCamera );
     }
+  }
+
+  if ( mCamera && !mTerrainEntity && centerPointChanged )
+  {
+    QgsVector3D centerPoint = mCameraPose.centerPoint();
+    centerPoint.set( centerPoint.x(), 0, centerPoint.z() );
+    mCameraPose.setCenterPoint( centerPoint );
+    mCameraPose.updateCamera( mCamera );
   }
 
   emit cameraChanged();

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -139,8 +139,8 @@ void Qgs3DMapCanvas::resetView( bool resetExtent )
 {
   if ( resetExtent )
   {
-    if ( map()->terrainGenerator()->type() == QgsTerrainGenerator::Flat ||
-         map()->terrainGenerator()->type() == QgsTerrainGenerator::Online )
+    if ( map()->terrainGenerator() && ( map()->terrainGenerator()->type() == QgsTerrainGenerator::Flat ||
+                                        map()->terrainGenerator()->type() == QgsTerrainGenerator::Online ) )
     {
       const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
       QgsCoordinateTransform ct( extent.crs(), map()->crs(), QgsProject::instance()->transformContext() );
@@ -154,14 +154,29 @@ void Qgs3DMapCanvas::resetView( bool resetExtent )
       {
         rect = extent;
       }
-      map()->terrainGenerator()->setExtent( rect );
+      if ( map()->terrainGenerator() )
+        map()->terrainGenerator()->setExtent( rect );
 
-      // reproject terrain's extent to map CRS
-      QgsRectangle te = map()->terrainGenerator()->extent();
-      QgsCoordinateTransform terrainToMapTransform( map()->terrainGenerator()->crs(), map()->crs(), QgsProject::instance() );
-      te = terrainToMapTransform.transformBoundingBox( te );
-
+      QgsRectangle te = mScene->sceneExtent();
       QgsPointXY center = te.center();
+      map()->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
+    }
+    if ( !map()->terrainGenerator() )
+    {
+      const QgsReferencedRectangle extent = QgsProject::instance()->viewSettings()->fullExtent();
+      QgsCoordinateTransform ct( extent.crs(), map()->crs(), QgsProject::instance()->transformContext() );
+      ct.setBallparkTransformsAreAppropriate( true );
+      QgsRectangle rect;
+      try
+      {
+        rect = ct.transformBoundingBox( extent );
+      }
+      catch ( QgsCsException & )
+      {
+        rect = extent;
+      }
+
+      QgsPointXY center = rect.center();
       map()->setOrigin( QgsVector3D( center.x(), center.y(), 0 ) );
     }
   }

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -51,13 +51,17 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
     emit savedAsImage( mCaptureFileName );
   } );
 
+  mSplitter = new QSplitter( this );
+
   mContainer = QWidget::createWindowContainer( mEngine->window() );
   mNavigationWidget = new Qgs3DNavigationWidget( this );
 
+  mSplitter->addWidget( mContainer );
+  mSplitter->addWidget( mNavigationWidget );
+
   QHBoxLayout *hLayout = new QHBoxLayout( this );
   hLayout->setContentsMargins( 0, 0, 0, 0 );
-  hLayout->addWidget( mContainer, 1 );
-  hLayout->addWidget( mNavigationWidget );
+  hLayout->addWidget( mSplitter );
   this->setOnScreenNavigationVisibility(
     setting.value( QStringLiteral( "/3D/navigationWidget/visibility" ), true, QgsSettings::Gui ).toBool()
   );

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -18,6 +18,7 @@
 
 #include <QWidget>
 #include <Qt3DRender/QRenderCapture>
+#include <QSplitter>
 
 #include "qgsrange.h"
 #include "qgscameracontroller.h"
@@ -145,6 +146,8 @@ class Qgs3DMapCanvas : public QWidget
     Qgs3DNavigationWidget *mNavigationWidget = nullptr;
 
     QgsTemporalController *mTemporalController = nullptr;
+
+    QSplitter *mSplitter = nullptr;
 };
 
 #endif // QGS3DMAPCANVAS_H

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -291,8 +291,8 @@ void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
   mAnimationWidget->setCameraController( mCanvas->scene()->cameraController() );
   mAnimationWidget->setMap( map );
 
-  // Disable button for switching the map theme if the terrain generator is a mesh
-  mBtnMapThemes->setDisabled( mCanvas->map()->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
+  // Disable button for switching the map theme if the terrain generator is a mesh, or if there is no terrain
+  mBtnMapThemes->setDisabled( !mCanvas->map()->terrainGenerator() || mCanvas->map()->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
   mLabelFpsCounter->setVisible( map->isFpsCounterEnabled() );
 
   connect( mCanvas, &Qgs3DMapCanvas::cameraNavigationSpeedChanged, this, &Qgs3DMapCanvasDockWidget::cameraNavigationSpeedChanged );
@@ -346,8 +346,8 @@ void Qgs3DMapCanvasDockWidget::configure()
       mCanvas->cameraController()->setCameraPose( newCameraPose );
     }
 
-    // Disable map theme button if the terrain generator is a mesh
-    mBtnMapThemes->setDisabled( map->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
+    // Disable map theme button if the terrain generator is a mesh, or if there is no terrain
+    mBtnMapThemes->setDisabled( !mCanvas->map()->terrainGenerator() || map->terrainGenerator()->type() == QgsTerrainGenerator::Mesh );
   };
 
   connect( buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept );

--- a/src/app/3d/qgs3dnavigationwidget.cpp
+++ b/src/app/3d/qgs3dnavigationwidget.cpp
@@ -193,32 +193,14 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
 
   mCameraInfoItemModel = new QStandardItemModel( this );
 
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
-
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 0, 0 ), QStringLiteral( "Near plane" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 1, 0 ), QStringLiteral( "Far plane" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 2, 0 ), QStringLiteral( "Camera X pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 3, 0 ), QStringLiteral( "Camera Y pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 4, 0 ), QStringLiteral( "Camera Z pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 5, 0 ), QStringLiteral( "Looking at X" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 6, 0 ), QStringLiteral( "Looking at Y" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 7, 0 ), QStringLiteral( "Looking at Z" ) );
-
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 0, 1 ), QStringLiteral( "Near plane" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 1, 1 ), QStringLiteral( "Far plane" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 2, 1 ), QStringLiteral( "Camera X pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 3, 1 ), QStringLiteral( "Camera Y pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 4, 1 ), QStringLiteral( "Camera Z pos" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 5, 1 ), QStringLiteral( "Looking at X" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 6, 1 ), QStringLiteral( "Looking at Y" ) );
-  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 7, 1 ), QStringLiteral( "Looking at Z" ) );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Near plane" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Far plane" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Camera X pos" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Camera Y pos" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Camera Z pos" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Looking at X" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Looking at Y" ) ), new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem( QStringLiteral( "Looking at Z" ) ), new QStandardItem } );
 
   mCameraInfo->setModel( mCameraInfoItemModel );
   mCameraInfo->verticalHeader()->hide();
@@ -241,17 +223,9 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   mCameraInfo->setVisible( false );
 
   QCheckBox *cameraInfoCheckBox = new QCheckBox( this );
-  cameraInfoCheckBox->setText( "Show camera info" );
+  cameraInfoCheckBox->setText( tr( "Show camera info (for debugging)" ) );
   cameraInfoCheckBox->setChecked( false );
-  QObject::connect( cameraInfoCheckBox, &QCheckBox::stateChanged, parent,
-                    [ = ]( int state )
-  {
-    if ( state == Qt::CheckState::Checked )
-      mCameraInfo->setVisible( true );
-    else
-      mCameraInfo->setVisible( false );
-  }
-                  );
+  QObject::connect( cameraInfoCheckBox, &QCheckBox::clicked, parent, [ = ]( bool enabled ) { mCameraInfo->setVisible( enabled ); } );
 
   gridLayout->addWidget( cameraInfoCheckBox, 4, 0, 1, 4, Qt::AlignLeft );
   gridLayout->addLayout( layout, 5, 0, 1, 4, Qt::AlignCenter );

--- a/src/app/3d/qgs3dnavigationwidget.cpp
+++ b/src/app/3d/qgs3dnavigationwidget.cpp
@@ -236,7 +236,7 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   gridLayout->addWidget( mMoveDownButton, 3, 1, 1, 2, Qt::AlignCenter );
   gridLayout->addWidget( mMoveLeftButton, 1, 0, 2, 1, Qt::AlignCenter );
 
-  QHBoxLayout *layout = new QHBoxLayout( this );
+  QHBoxLayout *layout = new QHBoxLayout;
   layout->addWidget( mCameraInfo );
   mCameraInfo->setVisible( false );
 

--- a/src/app/3d/qgs3dnavigationwidget.cpp
+++ b/src/app/3d/qgs3dnavigationwidget.cpp
@@ -29,6 +29,7 @@ Q_NOWARN_DEPRECATED_POP
 #include "qgscameracontroller.h"
 #include "qgs3dnavigationwidget.h"
 
+#include <Qt3DRender/QCamera>
 
 Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget( parent )
 {
@@ -186,6 +187,10 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   }
   );
 
+  mNearFarPlaneLabel = new QLabel( this );
+  mCameraPositionLabel = new QLabel( this );
+  mCameraLookAtLabel = new QLabel( this );
+
   QGridLayout *gridLayout = new QGridLayout( this );
   gridLayout->addWidget( mTiltUpButton, 0, 0 );
   gridLayout->addWidget( mTiltDownButton, 3, 0 );
@@ -196,6 +201,12 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   gridLayout->addWidget( mMoveRightButton, 1, 3, 2, 1, Qt::AlignCenter );
   gridLayout->addWidget( mMoveDownButton, 3, 1, 1, 2, Qt::AlignCenter );
   gridLayout->addWidget( mMoveLeftButton, 1, 0, 2, 1, Qt::AlignCenter );
+  gridLayout->addWidget( mTiltDownButton, 3, 4 );
+
+  gridLayout->addWidget( mNearFarPlaneLabel, 4, 0, 1, 4, Qt::AlignLeft );
+  gridLayout->addWidget( mCameraPositionLabel, 5, 0, 1, 4, Qt::AlignLeft );
+  gridLayout->addWidget( mCameraLookAtLabel, 6, 0, 1, 4, Qt::AlignLeft );
+
   gridLayout->setAlignment( Qt::AlignTop );
 }
 
@@ -203,4 +214,9 @@ void Qgs3DNavigationWidget::updateFromCamera()
 {
   // Make sure the angle is between 0 - 359
   whileBlocking( mCompas )->setValue( fmod( mParent3DMapCanvas->cameraController()->yaw() + 360, 360 ) );
+  mNearFarPlaneLabel->setText( QStringLiteral( "near: %1, far: %2" ).arg( mParent3DMapCanvas->cameraController()->camera()->nearPlane() ).arg( mParent3DMapCanvas->cameraController()->camera()->farPlane() ) );
+  QVector3D cameraPosition = mParent3DMapCanvas->cameraController()->camera()->position();
+  QgsVector3D lookingAt = mParent3DMapCanvas->cameraController()->lookingAtPoint();
+  mCameraPositionLabel->setText( QStringLiteral( "Camera position x: %1, y: %2, z: %3" ).arg( cameraPosition.x() ).arg( cameraPosition.y() ).arg( cameraPosition.z() ) );
+  mCameraLookAtLabel->setText( QStringLiteral( "Camera looking at x: %1, y: %2, z: %3" ).arg( lookingAt.x() ).arg( lookingAt.y() ).arg( lookingAt.z() ) );
 }

--- a/src/app/3d/qgs3dnavigationwidget.cpp
+++ b/src/app/3d/qgs3dnavigationwidget.cpp
@@ -17,6 +17,7 @@
 #include <QToolButton>
 #include <QObject>
 #include <QHeaderView>
+#include <QCheckBox>
 #include "qgis.h"
 
 Q_NOWARN_DEPRECATED_PUSH
@@ -237,8 +238,23 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
 
   QHBoxLayout *layout = new QHBoxLayout( this );
   layout->addWidget( mCameraInfo );
+  mCameraInfo->setVisible( false );
 
-  gridLayout->addLayout( layout, 4, 0, 1, 4, Qt::AlignCenter );
+  QCheckBox *cameraInfoCheckBox = new QCheckBox( this );
+  cameraInfoCheckBox->setText( "Show camera info" );
+  cameraInfoCheckBox->setChecked( false );
+  QObject::connect( cameraInfoCheckBox, &QCheckBox::stateChanged, parent,
+                    [ = ]( int state )
+  {
+    if ( state == Qt::CheckState::Checked )
+      mCameraInfo->setVisible( true );
+    else
+      mCameraInfo->setVisible( false );
+  }
+                  );
+
+  gridLayout->addWidget( cameraInfoCheckBox, 4, 0, 1, 4, Qt::AlignLeft );
+  gridLayout->addLayout( layout, 5, 0, 1, 4, Qt::AlignCenter );
 
   gridLayout->setAlignment( Qt::AlignTop );
 }

--- a/src/app/3d/qgs3dnavigationwidget.cpp
+++ b/src/app/3d/qgs3dnavigationwidget.cpp
@@ -16,7 +16,7 @@
 #include <QGridLayout>
 #include <QToolButton>
 #include <QObject>
-
+#include <QHeaderView>
 #include "qgis.h"
 
 Q_NOWARN_DEPRECATED_PUSH
@@ -187,9 +187,42 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   }
   );
 
-  mNearFarPlaneLabel = new QLabel( this );
-  mCameraPositionLabel = new QLabel( this );
-  mCameraLookAtLabel = new QLabel( this );
+  mCameraInfo = new QTableView( this );
+  mCameraInfo->setEditTriggers( QAbstractItemView::NoEditTriggers );
+
+  mCameraInfoItemModel = new QStandardItemModel( this );
+
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+  mCameraInfoItemModel->appendRow( QList<QStandardItem *> { new QStandardItem, new QStandardItem } );
+
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 0, 0 ), QStringLiteral( "Near plane" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 1, 0 ), QStringLiteral( "Far plane" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 2, 0 ), QStringLiteral( "Camera X pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 3, 0 ), QStringLiteral( "Camera Y pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 4, 0 ), QStringLiteral( "Camera Z pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 5, 0 ), QStringLiteral( "Looking at X" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 6, 0 ), QStringLiteral( "Looking at Y" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 7, 0 ), QStringLiteral( "Looking at Z" ) );
+
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 0, 1 ), QStringLiteral( "Near plane" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 1, 1 ), QStringLiteral( "Far plane" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 2, 1 ), QStringLiteral( "Camera X pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 3, 1 ), QStringLiteral( "Camera Y pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 4, 1 ), QStringLiteral( "Camera Z pos" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 5, 1 ), QStringLiteral( "Looking at X" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 6, 1 ), QStringLiteral( "Looking at Y" ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 7, 1 ), QStringLiteral( "Looking at Z" ) );
+
+  mCameraInfo->setModel( mCameraInfoItemModel );
+  mCameraInfo->verticalHeader()->hide();
+  mCameraInfo->horizontalHeader()->hide();
+  mCameraInfo->horizontalHeader()->setSectionResizeMode( QHeaderView::ResizeMode::Stretch );
 
   QGridLayout *gridLayout = new QGridLayout( this );
   gridLayout->addWidget( mTiltUpButton, 0, 0 );
@@ -201,11 +234,11 @@ Qgs3DNavigationWidget::Qgs3DNavigationWidget( Qgs3DMapCanvas *parent ) : QWidget
   gridLayout->addWidget( mMoveRightButton, 1, 3, 2, 1, Qt::AlignCenter );
   gridLayout->addWidget( mMoveDownButton, 3, 1, 1, 2, Qt::AlignCenter );
   gridLayout->addWidget( mMoveLeftButton, 1, 0, 2, 1, Qt::AlignCenter );
-  gridLayout->addWidget( mTiltDownButton, 3, 4 );
 
-  gridLayout->addWidget( mNearFarPlaneLabel, 4, 0, 1, 4, Qt::AlignLeft );
-  gridLayout->addWidget( mCameraPositionLabel, 5, 0, 1, 4, Qt::AlignLeft );
-  gridLayout->addWidget( mCameraLookAtLabel, 6, 0, 1, 4, Qt::AlignLeft );
+  QHBoxLayout *layout = new QHBoxLayout( this );
+  layout->addWidget( mCameraInfo );
+
+  gridLayout->addLayout( layout, 4, 0, 1, 4, Qt::AlignCenter );
 
   gridLayout->setAlignment( Qt::AlignTop );
 }
@@ -214,9 +247,13 @@ void Qgs3DNavigationWidget::updateFromCamera()
 {
   // Make sure the angle is between 0 - 359
   whileBlocking( mCompas )->setValue( fmod( mParent3DMapCanvas->cameraController()->yaw() + 360, 360 ) );
-  mNearFarPlaneLabel->setText( QStringLiteral( "near: %1, far: %2" ).arg( mParent3DMapCanvas->cameraController()->camera()->nearPlane() ).arg( mParent3DMapCanvas->cameraController()->camera()->farPlane() ) );
-  QVector3D cameraPosition = mParent3DMapCanvas->cameraController()->camera()->position();
-  QgsVector3D lookingAt = mParent3DMapCanvas->cameraController()->lookingAtPoint();
-  mCameraPositionLabel->setText( QStringLiteral( "Camera position x: %1, y: %2, z: %3" ).arg( cameraPosition.x() ).arg( cameraPosition.y() ).arg( cameraPosition.z() ) );
-  mCameraLookAtLabel->setText( QStringLiteral( "Camera looking at x: %1, y: %2, z: %3" ).arg( lookingAt.x() ).arg( lookingAt.y() ).arg( lookingAt.z() ) );
+
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 0, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->camera()->nearPlane() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 1, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->camera()->farPlane() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 2, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->camera()->position().x() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 3, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->camera()->position().y() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 4, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->camera()->position().z() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 5, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->lookingAtPoint().x() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 6, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->lookingAtPoint().y() ) );
+  mCameraInfoItemModel->setData( mCameraInfoItemModel->index( 7, 1 ), QStringLiteral( "%1" ).arg( mParent3DMapCanvas->cameraController()->lookingAtPoint().z() ) );
 }

--- a/src/app/3d/qgs3dnavigationwidget.h
+++ b/src/app/3d/qgs3dnavigationwidget.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 #include <QGridLayout>
 #include <QToolButton>
+#include <QLabel>
 
 class QwtCompass;
 
@@ -49,6 +50,9 @@ class Qgs3DNavigationWidget : public QWidget
     QToolButton *mMoveDownButton = nullptr;
     QToolButton *mMoveLeftButton = nullptr;
     QwtCompass *mCompas = nullptr;
+    QLabel *mNearFarPlaneLabel = nullptr;
+    QLabel *mCameraPositionLabel = nullptr;
+    QLabel *mCameraLookAtLabel = nullptr;
 };
 
 #endif // QGS3DNAVIGATIONWIDGET_H

--- a/src/app/3d/qgs3dnavigationwidget.h
+++ b/src/app/3d/qgs3dnavigationwidget.h
@@ -20,6 +20,8 @@
 #include <QGridLayout>
 #include <QToolButton>
 #include <QLabel>
+#include <QTableView>
+#include <QStandardItemModel>
 
 class QwtCompass;
 
@@ -50,9 +52,8 @@ class Qgs3DNavigationWidget : public QWidget
     QToolButton *mMoveDownButton = nullptr;
     QToolButton *mMoveLeftButton = nullptr;
     QwtCompass *mCompas = nullptr;
-    QLabel *mNearFarPlaneLabel = nullptr;
-    QLabel *mCameraPositionLabel = nullptr;
-    QLabel *mCameraLookAtLabel = nullptr;
+    QTableView *mCameraInfo = nullptr;
+    QStandardItemModel *mCameraInfoItemModel = nullptr;
 };
 
 #endif // QGS3DNAVIGATIONWIDGET_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16595,7 +16595,7 @@ void QgisApp::readProject( const QDomDocument &doc )
       // these things are not saved in project
       map->setSelectionColor( mMapCanvas->selectionColor() );
       map->setBackgroundColor( mMapCanvas->canvasColor() );
-      if ( map->terrainGenerator()->type() == QgsTerrainGenerator::Flat )
+      if ( map->terrainGenerator() && map->terrainGenerator()->type() == QgsTerrainGenerator::Flat )
       {
         QgsFlatTerrainGenerator *flatTerrainGen = static_cast<QgsFlatTerrainGenerator *>( map->terrainGenerator() );
         flatTerrainGen->setExtent( mMapCanvas->projectExtent() );

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -205,7 +205,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>710</width>
+                <width>709</width>
                 <height>604</height>
                </rect>
               </property>
@@ -226,6 +226,12 @@
                 <widget class="QGroupBox" name="groupTerrain">
                  <property name="title">
                   <string>Terrain</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout1">
                   <item row="3" column="0">
@@ -410,8 +416,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>710</width>
-                <height>604</height>
+                <width>77</width>
+                <height>43</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -494,8 +500,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>710</width>
-                <height>604</height>
+                <width>149</width>
+                <height>43</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -584,8 +590,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>710</width>
-                <height>604</height>
+                <width>234</width>
+                <height>220</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
@@ -724,7 +730,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>696</width>
+                <width>305</width>
                 <height>661</height>
                </rect>
               </property>
@@ -1041,14 +1047,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>


### PR DESCRIPTION
## Description
This PR adds a checkbox to enable or disable the rendering of the 2D terrain in the scene:
![Screenshot from 2021-06-01 14-00-26](https://user-images.githubusercontent.com/29183781/120327657-e7f5ae00-c2e1-11eb-899f-4d2703fd3222.png)
The approach here is to make the terrain object a nullptr and check for validity whenever we use it in the scene. That way the scene is less coupled with the existance of the terrain. 

Funded by QGIS.org grant (https://github.com/qgis/QGIS-Enhancement-Proposals/issues/215)