### PR TITLE
[Postgres]  don't quote integer array elements to match array_out()

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1203,7 +1203,7 @@ static QString quotedList( const QVariantList &list )
     }
 
     QString inner = i->toString();
-    if ( inner.startsWith( '{' ) )
+    if ( inner.startsWith( '{' ) || i->type() == QVariant::Int || i->type() == QVariant::LongLong )
     {
       ret.append( inner );
     }

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -139,7 +139,7 @@ class TestQgsPostgresConn: public QObject
       QVariantList list;
       list << 1 << -5;
       const QString actual = QgsPostgresConn::quotedValue( list );
-      QCOMPARE( actual, QString( "E'{\"1\",\"-5\"}'" ) );
+      QCOMPARE( actual, QString( "E'{1,-5}'" ) );
     }
 
     void quotedValue2DimArray()


### PR DESCRIPTION
Fixes #42778 : Integer array list returned by *quotedValue* must be this way `{1,2,3}` and not this way `{"1","2","3"}` so it could match Postgres function *array_out* output when writing where clause.