### PR TITLE
[PyQGIS] : Fix QgsFeatureFilterModel SIP interface

### DIFF
--- a/python/core/auto_generated/qgsfeaturefiltermodel.sip.in
+++ b/python/core/auto_generated/qgsfeaturefiltermodel.sip.in
@@ -97,6 +97,9 @@ Allows specifying one value that does not need to match the filter criteria but 
 still be available in the model.
 %End
 
+  private:
+    virtual void requestToReloadCurrentFeature( QgsFeatureRequest &request );
+
 };
 
 /************************************************************************

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsFeatureFilterModel : public QgsFeaturePickerModelBase
   private:
     QgsFeatureExpressionValuesGatherer *createValuesGatherer( const QgsFeatureRequest &request ) const override;
 
-    void requestToReloadCurrentFeature( QgsFeatureRequest &request ) override;
+    void requestToReloadCurrentFeature( QgsFeatureRequest &request ) override SIP_FORCE;
 
     QSet<QString> requestedAttributes() const override;
 


### PR DESCRIPTION
Fixes #42488 : private methods are not part of SIP files and *requestToReloadCurrentFeature* needs to be known by SIP so it doesn't consider QgsFeatureFilterModel abstract.
