### PR TITLE
remove read-only line edit in QgsRelationReferenceWidget

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -94,7 +94,7 @@ determines if the form of the related feature will be shown
 
     bool readOnlySelector();
 %Docstring
-determines if the foreign key is shown in a combox box or a read-only line edit
+determines if the drop-down is enabled
 %End
     void setReadOnlySelector( bool readOnly );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -123,7 +123,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool embedForm() { return mEmbedForm; }
     void setEmbedForm( bool display );
 
-    //! determines if the foreign key is shown in a combox box or a read-only line edit
+    //! determines if the drop-down is enabled
     bool readOnlySelector() { return mReadOnlySelector; }
     void setReadOnlySelector( bool readOnly );
 
@@ -361,7 +361,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QHBoxLayout *mFilterLayout = nullptr;
     QgsCollapsibleGroupBox *mAttributeEditorFrame = nullptr;
     QVBoxLayout *mAttributeEditorLayout = nullptr;
-    QLineEdit *mLineEdit = nullptr;
     QLabel *mInvalidLabel = nullptr;
 
     friend class TestQgsRelationReferenceWidget;

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -572,24 +572,6 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
   w.featureIdentified( feature );
   QCOMPARE( w.mComboBox->currentData( Qt::DisplayRole ).toInt(), 10 );
 
-  w.setReadOnlySelector( true );
-
-  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 11 ) ).nextFeature( feature );
-  QVERIFY( feature.isValid() );
-  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 11 );
-  w.featureIdentified( feature );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "11" ) );
-  QCOMPARE( w.mForeignKeys.count(), 1 );
-  QCOMPARE( w.mForeignKeys.at( 0 ).toInt(), 11 );
-
-  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 10 ) ).nextFeature( feature );
-  QVERIFY( feature.isValid() );
-  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 10 );
-  w.featureIdentified( feature );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "10" ) );
-  QCOMPARE( w.mForeignKeys.count(), 1 );
-  QCOMPARE( w.mForeignKeys.at( 0 ).toInt(), 10 );
-
   mLayer1->rollBack();
 }
 


### PR DESCRIPTION
keep the read-only config and make the drop-down read-only instead

fixes #42813

