### PR TITLE
Push image to DockerHub only if rep_owner == qgis

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,7 +88,7 @@ jobs:
           popd
 
       - name: Push deps image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.repository_owner == 'qgis' && github.event_name != 'pull_request' }}
         run: |
           docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
           docker push "qgis/qgis3-build-deps:${DOCKER_TAG}"


### PR DESCRIPTION
Allow a more comfortable play with tests in a forked repository.