### PR TITLE
fix filter expression not correctly loaded for relation reference widget after project loading

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -63,6 +63,9 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   {
     mWidget->setFilterFields( config( QStringLiteral( "FilterFields" ) ).toStringList() );
     mWidget->setChainFilters( config( QStringLiteral( "ChainFilters" ) ).toBool() );
+  }
+  if ( !config( QStringLiteral( "FilterExpression" ) ).toString().isEmpty() )
+  {
     mWidget->setFilterExpression( config( QStringLiteral( "FilterExpression" ) ).toString() );
   }
   mWidget->setAllowAddFeatures( config( QStringLiteral( "AllowAddFeatures" ), false ).toBool() );


### PR DESCRIPTION
fixes #42803

the filter expression can exist without chained filters.
a test is a bit difficult to put in place here as it's the config which was not correctly read.