### PR TITLE
Implement project file attachments

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1254,20 +1254,12 @@ Attaches a file to the project
 
 :return: The path to the file where the contents can be written to.
 
-.. note::
-
-   Attached files are only supported by QGZ file based projects
-
 .. versionadded:: 3.22
 %End
 
     QStringList attachedFiles() const;
 %Docstring
 Returns a map of all attached files with identifier and real paths.
-
-.. note::
-
-   Attached files are only supported by QGZ file based projects
 
 .. seealso:: :py:func:`createAttachedFile`
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1246,7 +1246,46 @@ Returns the current auxiliary storage.
 .. versionadded:: 3.0
 %End
 
+    QString createAttachedFile( const QString &nameTemplate );
+%Docstring
+Attaches a file to the project
 
+:param nameTemplate: Any filename template, used as a basename for attachment file, i.e. "myfile.ext"
+
+:return: The path to the file where the contents can be written to.
+
+.. note::
+
+   Attached files are only supported by QGZ file based projects
+
+.. versionadded:: 3.22
+%End
+
+    QStringList attachedFiles() const;
+%Docstring
+Returns a map of all attached files with identifier and real paths.
+
+.. note::
+
+   Attached files are only supported by QGZ file based projects
+
+.. seealso:: :py:func:`createAttachedFile`
+
+.. versionadded:: 3.22
+%End
+
+    bool removeAttachedFile( const QString &path );
+%Docstring
+Removes the attached file
+
+:param path: Path to the attached file
+
+:return: Whether removal succeeded.
+
+.. seealso:: :py:func:`createAttachedFile`
+
+.. versionadded:: 3.22
+%End
 
     const QgsProjectMetadata &metadata() const;
 %Docstring
@@ -1810,7 +1849,6 @@ Emitted when setDirty(true) is called.
 
 .. versionadded:: 3.20
 %End
-
 
  void mapScalesChanged() /Deprecated/;
 %Docstring

--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -21,7 +21,7 @@ Resolves relative paths into absolute paths and vice versa. Used for writing
 #include "qgspathresolver.h"
 %End
   public:
-    explicit QgsPathResolver( const QString &baseFileName = QString() );
+    explicit QgsPathResolver( const QString &baseFileName = QString(), const QString &attachmentDir = QString() );
 %Docstring
 Initialize path resolver with a base filename. Null filename means no conversion between relative/absolute path
 %End

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1055,7 +1055,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mSnappingUtils = new QgsMapCanvasSnappingUtils( mMapCanvas, this );
   mMapCanvas->setSnappingUtils( mSnappingUtils );
   connect( QgsProject::instance(), &QgsProject::snappingConfigChanged, mSnappingUtils, &QgsSnappingUtils::setConfig );
-  connect( QgsProject::instance(), &QgsProject::collectAttachedFiles, this, &QgisApp::generateProjectAttachedFiles );
 
   endProfile();
 
@@ -16009,16 +16008,6 @@ void QgisApp::onTransactionGroupsChanged()
 void QgisApp::onSnappingConfigChanged()
 {
   mSnappingUtils->setConfig( QgsProject::instance()->snappingConfig() );
-}
-
-void QgisApp::generateProjectAttachedFiles( QgsStringMap &files )
-{
-  QTemporaryFile *previewImage = new QTemporaryFile( QStringLiteral( "preview-XXXXXXXXXXX.png" ) );
-  previewImage->open();
-  previewImage->close();
-  createPreviewImage( previewImage->fileName() );
-  files.insert( QStringLiteral( "preview.png" ), previewImage->fileName() );
-  previewImage->deleteLater();
 }
 
 void QgisApp::createPreviewImage( const QString &path, const QIcon &icon )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1307,8 +1307,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void onSnappingConfigChanged();
 
-    void generateProjectAttachedFiles( QgsStringMap &files );
-
     /**
      * Triggers validation of the specified \a crs.
      */

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1323,7 +1323,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Attaches a file to the project
      * \param nameTemplate Any filename template, used as a basename for attachment file, i.e. "myfile.ext"
      * \return The path to the file where the contents can be written to.
-     * \note Attached files are only supported by QGZ file based projects
      * \since QGIS 3.22
      */
     QString createAttachedFile( const QString &nameTemplate );
@@ -1331,7 +1330,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Returns a map of all attached files with identifier and real paths.
      *
-     * \note Attached files are only supported by QGZ file based projects
      * \see createAttachedFile()
      * \since QGIS 3.22
      */
@@ -2030,7 +2028,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     QVariantMap mCustomVariables;
 
-    std::unique_ptr<QgsProjectArchive> mArchive;
+    std::unique_ptr<QgsArchive> mArchive;
 
     std::unique_ptr<QgsAuxiliaryStorage> mAuxiliaryStorage;
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1320,25 +1320,31 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QgsAuxiliaryStorage *auxiliaryStorage();
 
     /**
-     * Returns the path to an attached file known by \a fileName.
-     *
-     * \note Not available in Python bindings
+     * Attaches a file to the project
+     * \param nameTemplate Any filename template, used as a basename for attachment file, i.e. "myfile.ext"
+     * \return The path to the file where the contents can be written to.
      * \note Attached files are only supported by QGZ file based projects
-     * \see collectAttachedFiles()
-     * \since QGIS 3.8
+     * \since QGIS 3.22
      */
-    QString attachedFile( const QString &fileName ) const SIP_SKIP;
+    QString createAttachedFile( const QString &nameTemplate );
 
     /**
-     * Returns a map of all attached files with relative paths and real paths.
+     * Returns a map of all attached files with identifier and real paths.
      *
-     * \note Not available in Python bindings
      * \note Attached files are only supported by QGZ file based projects
-     * \see collectAttachedFiles()
-     * \see attachedFile()
-     * \since QGIS 3.8
+     * \see createAttachedFile()
+     * \since QGIS 3.22
      */
-    QgsStringMap attachedFiles() const SIP_SKIP;
+    QStringList attachedFiles() const;
+
+    /**
+     * Removes the attached file
+     * \param path Path to the attached file
+     * \return Whether removal succeeded.
+     * \see createAttachedFile()
+     * \since QGIS 3.22
+     */
+    bool removeAttachedFile( const QString &path );
 
     /**
      * Returns a reference to the project's metadata store.
@@ -1832,21 +1838,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \since QGIS 3.20
      */
     void dirtySet();
-
-    /**
-     * Emitted whenever the project is saved to a qgz file.
-     * This can be used to package additional files into the qgz file by modifying the \a files map.
-     *
-     * Map keys represent relative paths inside the qgz file, map values represent the path to
-     * the source file.
-     *
-     * \note Not available in Python bindings
-     * \note Only will be emitted with QGZ project files
-     * \see attachedFiles()
-     * \see attachedFile()
-     * \since QGIS 3.8
-     */
-    void collectAttachedFiles( QgsStringMap &files SIP_INOUT ) SIP_SKIP;
 
     /**
      * Emitted when the list of custom project map scales changes.

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -256,7 +256,7 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   // set data source
   mnl = layerElement.namedItem( QStringLiteral( "datasource" ) );
   mne = mnl.toElement();
-  mDataSource = mne.text();
+  mDataSource = context.pathResolver().readPath( mne.text() );
 
   // if the layer needs authentication, ensure the master password is set
   QRegExp rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
@@ -453,7 +453,7 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 
   // data source
   QDomElement dataSource = document.createElement( QStringLiteral( "datasource" ) );
-  QString src = encodedSource( source(), context );
+  QString src = context.pathResolver().writePath( encodedSource( source(), context ) );
   QDomText dataSourceText = document.createTextNode( src );
   dataSource.appendChild( dataSourceText );
   layerElement.appendChild( dataSource );

--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -54,8 +54,17 @@ QString QgsPathResolver::readPath( const QString &f ) const
 
   if ( src.startsWith( QLatin1String( "localized:" ) ) )
   {
+    QStringList parts = src.split( "|" );
     // strip away "localized:" prefix, replace with actual  inbuilt data folder path
-    return QgsApplication::localizedDataPathRegistry()->globalPath( src.mid( 10 ) ) ;
+    parts[0] = QgsApplication::localizedDataPathRegistry()->globalPath( parts[0].mid( 10 ) ) ;
+    if ( !parts[0].isEmpty() )
+    {
+      return parts.join( "|" );
+    }
+    else
+    {
+      return QString();
+    }
   }
   if ( src.startsWith( QLatin1String( "attachment:" ) ) )
   {

--- a/src/core/qgspathresolver.h
+++ b/src/core/qgspathresolver.h
@@ -32,7 +32,7 @@ class CORE_EXPORT QgsPathResolver
 {
   public:
     //! Initialize path resolver with a base filename. Null filename means no conversion between relative/absolute path
-    explicit QgsPathResolver( const QString &baseFileName = QString() );
+    explicit QgsPathResolver( const QString &baseFileName = QString(), const QString &attachmentDir = QString() );
 
     /**
      * Prepare a filename to save it to the project file.
@@ -284,6 +284,8 @@ class CORE_EXPORT QgsPathResolver
   private:
     //! path to a file that is the base for relative path resolution
     QString mBaseFileName;
+    //! path where attached files are stored
+    QString mAttachmentDir;
 };
 
 #endif // QGSPATHRESOLVER_H

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -55,7 +55,8 @@ class TestQgsProject : public QObject
     void testCrsExpressions();
     void testCrsValidAfterReadingProjectFile();
     void testDefaultRelativePaths();
-    void testAttachments();
+    void testAttachmentsQgs();
+    void testAttachmentsQgz();
 };
 
 void TestQgsProject::init()
@@ -719,7 +720,85 @@ void TestQgsProject::testDefaultRelativePaths()
   QCOMPARE( p1PathsAbsolute_2, true );
 }
 
-void TestQgsProject::testAttachments()
+void TestQgsProject::testAttachmentsQgs()
+{
+  // Test QgsProject::{createAttachedFile,attachedFiles,removeAttachedFile}
+  {
+    QgsProject p;
+
+    QString fileName = p.createAttachedFile( "myattachment" );
+    QVERIFY( QFile( fileName ).exists() );
+    QVERIFY( p.attachedFiles().contains( fileName ) );
+    QVERIFY( p.removeAttachedFile( fileName ) );
+    QVERIFY( !p.attachedFiles().contains( fileName ) );
+    QVERIFY( !p.removeAttachedFile( fileName ) );
+  }
+
+  // Verify that attachment is exists after re-reading project
+  {
+    QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgs" ) );
+    projFile.open();
+
+    QgsProject p;
+    QFile file;
+    QString fileName = p.createAttachedFile( "myattachment" );
+
+    file.setFileName( fileName );
+    QVERIFY( file.open( QIODevice::WriteOnly ) );
+    file.write( "Attachment" );
+    file.close();
+
+    p.write( projFile.fileName() );
+
+    QFileInfo finfo( projFile.fileName() );
+    QString attachmentsZip = finfo.absoluteDir().absoluteFilePath( QStringLiteral( "%1_attachments.zip" ).arg( finfo.completeBaseName() ) );
+    QVERIFY( QFile( attachmentsZip ).exists() );
+
+    QgsProject p2;
+    p2.read( projFile.fileName() );
+    QVERIFY( p2.attachedFiles().size() == 1 );
+
+    file.setFileName( p2.attachedFiles().at( 0 ) );
+    QVERIFY( file.open( QIODevice::ReadOnly ) );
+    QVERIFY( file.readAll() == QByteArray( "Attachment" ) );
+  }
+
+  // Verify that attachment paths can be used as layer filenames
+  {
+    QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgs" ) );
+    projFile.open();
+
+    QgsProject p;
+    QString fileName = p.createAttachedFile( "testlayer.gpx" );
+    QFile file( fileName );
+    file.open( QIODevice::WriteOnly );
+    file.write( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" );
+    file.write( "<gpx version=\"1.0\">" );
+    file.write( "<name>Example gpx</name>" );
+    file.write( "<wpt lat=\"0.0\" lon=\"0.0\">" );
+    file.write( "<name>NULL Island</name>" );
+    file.write( "</wpt>" );
+    file.write( "</gpx>" );
+    file.close();
+
+    QgsVectorLayer *layer = new QgsVectorLayer( fileName, "gpx" );
+    p.addMapLayer( layer );
+    p.write( projFile.fileName() );
+
+    QFileInfo finfo( projFile.fileName() );
+    QString attachmentsZip = finfo.absoluteDir().absoluteFilePath( QStringLiteral( "%1_attachments.zip" ).arg( finfo.completeBaseName() ) );
+    QVERIFY( QFile( attachmentsZip ).exists() );
+
+    QgsProject p2;
+    p2.read( projFile.fileName() );
+    QVERIFY( p2.attachedFiles().size() == 1 );
+    QVERIFY( p2.mapLayers().size() == 1 );
+    QVERIFY( p2.mapLayer( p2.mapLayers().firstKey() )->source() == p2.attachedFiles().first() );
+  }
+
+}
+
+void TestQgsProject::testAttachmentsQgz()
 {
   // Test QgsProject::{createAttachedFile,attachedFiles,removeAttachedFile}
   {


### PR DESCRIPTION
This PR implements project file attachments, specifically the methods `QgsProject::{createAttachedFile,removeAttachedFile,attachedFiles}` to allow bundling arbitrary files to the QGZ archive. It also handles the case where layer sources are project file attachments by extending `QgsPathResolver::{readPath,writePath}`.
