### PR TITLE
[processing][grass] Fix r.proj in Windows

### DIFF
--- a/python/plugins/processing/algs/grass7/ext/r_proj.py
+++ b/python/plugins/processing/algs/grass7/ext/r_proj.py
@@ -69,7 +69,7 @@ def processInputs(alg, parameters, context, feedback):
     if isWindows():
         # TODO: make some tests under a non POSIX shell
         alg.commands.append('set regVar=')
-        alg.commands.append('for /f "delims=" %%a in (\'r.proj -g input="{}" location="{}"\') do @set theValue=%%a'.format(
+        alg.commands.append('for /f "delims=" %%a in (\'r.proj -g input^="{}" location^="{}"\') do @set regVar=%%a'.format(
             grassName, newLocation))
         alg.commands.append('g.region -a %regVar%')
     else:

--- a/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests2.yaml
@@ -806,3 +806,21 @@ tests:
         type: regex
         rules:
           - '1.0|0.0|1.0|1.0|1|2'
+
+  - algorithm: grass7:r.proj
+    name: GRASS7 r.proj
+    params:
+      -n: false
+      GRASS_RASTER_FORMAT_META: ''
+      GRASS_RASTER_FORMAT_OPT: ''
+      GRASS_REGION_CELLSIZE_PARAMETER: 0.0
+      crs: EPSG:32634
+      input:
+        name: dem.tif
+        type: raster
+      memory: 300
+      method: 0
+    results:
+      output:
+        hash: caa4870e0f0f1a42583cd562c26f0ad6b7795116961c7f6053f1ccde
+        type: rasterhash


### PR DESCRIPTION
## Description

Fixes the GRASS r.proj processing tool (r_proj.py) in Windows by escaping the equal signs in the `for /f` command and by fixing a typo in the variable name used to store the results from `r.proj -g` and to pass it to `g.region -a`.

Without the fix, r.proj fails; the following relevant part of the log shows the issue (as you can see, the not escaped equal signs are missing):

```
[...]
F:\QGIS\OSGeo4W>set regVar=
F:\QGIS\OSGeo4W>for /F "delims=" %a in ('r.proj -g input "rast_60b953bcd92492" location "newProjc2bd6cc09eec42898266b45bc493641c"') do @set theValue=%a
Re-projects a raster map from given location to the current location.
Usage:
r.proj [-lnpg] location=name [mapset=name] [input=name] [dbase=path]
[output=name] [method=string] [memory=memory in MB] [resolution=value]
[pipeline=string] [--overwrite] [--help] [--verbose] [--quiet] [--ui]
[...]
ERROR: Sorry <rast_60b953bcd92492> is not a valid option
ERROR: Sorry <location> is not a valid option
ERROR: Sorry <newProjc2bd6cc09eec42898266b45bc493641c> is not a valid option
F:\QGIS\OSGeo4W>g.region -a
[...]
```

With the fix, r.proj succeeds; see the same part of the log:

```
[...]
F:\QGIS\OSGeo4W>set regVar=
F:\QGIS\OSGeo4W>for /F "delims=" %a in ('r.proj -g input="rast_60b9558ea20782" location="newProjd4124748867041ad8a703ca730389a26"') do @set regVar=%a
Input CRS definition converted from '+proj=longlat +no_defs +a=6378137 +rf=298.257223563 +towgs84=0.000,0.000,0.000 +type=crs ' to '+proj=longlat +ellps=WGS84 +no_defs +type=crs'
Output CRS definition converted from '+proj=utm +no_defs +zone=33 +a=6378137 +rf=298.257223563 +towgs84=0.000,0.000,0.000 +type=crs ' to '+proj=utm +zone=33 +ellps=WGS84 +units=m +no_defs +type=crs'
Input map <rast_60b9558ea20782@PERMANENT> in location <newProjd4124748867041ad8a703ca730389a26>:
F:\QGIS\OSGeo4W>g.region -a n=4654130.89132331 s=4316776.58321008 w=500000 e=759800.19212245 rows=30 cols=30
[...]
```

This fix needs to be backported to 3.16 branch.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
