### PR TITLE
[Geometry checker] Fix the error resolution ui. Fixes #42489

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -586,12 +586,13 @@ void QgsGeometryCheckerResultTab::setDefaultResolutionMethods()
     radioGroup->setProperty( "errorType", check->id() );
     int checkedId = QgsSettings().value( sSettingsGroup + check->id(), QVariant::fromValue<int>( 0 ) ).toInt();
     const QList<QgsGeometryCheckResolutionMethod> resolutionMethods = check->availableResolutionMethods();
+    int id = 0;
     for ( const QgsGeometryCheckResolutionMethod &method : resolutionMethods )
     {
       QRadioButton *radio = new QRadioButton( method.name(), groupBox );
-      radio->setChecked( method.id() == checkedId );
+      radio->setChecked( id == checkedId );
       groupBoxLayout->addWidget( radio );
-      radioGroup->addButton( radio, method.id() );
+      radioGroup->addButton( radio, id++ );
     }
     connect( radioGroup, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ), this, &QgsGeometryCheckerResultTab::storeDefaultResolutionMethod );
 


### PR DESCRIPTION
## Description

method.id() always returns 0, I put back the old mechanism which works.

For users who have already used the tool, there may be a small conflict in the preferences of this interface. However, once the new settings are saved, there is no problem.

cc @agiudiceandrea 

![geometry_checker_error_ui-2021-06-04_06 55 13 mkv](https://user-images.githubusercontent.com/7521540/120748334-e525d380-c502-11eb-8b06-399eb4fe426b.gif)
