### PR TITLE
reinstate QWTPOLAR_LIBRARY. Fixes #41910

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -510,6 +510,7 @@ add_dependencies(qgis_gui ui)
 
 target_link_libraries(qgis_app
   ${QWT_LIBRARY}
+  ${QWTPOLAR_LIBRARY}
   ${Qt5Sql_LIBRARIES}
   ${Qt5UiTools_LIBRARIES}
   ${OPTIONAL_QTWEBKIT}


### PR DESCRIPTION
## Description

QWTpolar is used for parts of the GPS plugin. This is no longer really maintained and must be replaced by something better integrated. I (and certainly nyall) plan to remove it. Nevertheless, for the moment this part of the code is still present and some people can use it by using the system version of this library ( @antonio-rojas ).
