### PR TITLE
[FreeBSD] remove if statement in FindPyQt5.py and fix #41913

### DIFF
--- a/cmake/FindPyQt5.py
+++ b/cmake/FindPyQt5.py
@@ -41,9 +41,6 @@ except ImportError:
 
     cfg = sipconfig.Configuration()
     sip_dir = cfg.default_sip_dir
-    if sys.platform.startswith('freebsd'):
-        py_version = str(sys.version_info.major) + str(sys.version_info.minor)
-        sip_dir = sip_dir.replace(py_version, '')
     for p in (os.path.join(sip_dir, "PyQt5"),
               os.path.join(sip_dir, "PyQt5-3"),
               sip_dir,
@@ -51,8 +48,6 @@ except ImportError:
         if os.path.exists(os.path.join(p, "QtCore", "QtCoremod.sip")):
             sip_dir = p
             break
-    else:
-        sys.exit(1)
     cfg = {
         'pyqt_mod_dir': os.path.join(cfg.default_mod_dir, "PyQt5"),
         'pyqt_sip_dir': sip_dir,


### PR DESCRIPTION
## Description

Thanks to @mitya57 QGIS built fine with sip5. I had added this line in a transition step to ease the discovery of pyqt on FreeBSD. It is no longer useful since with the latest versions of pyqt and sip on FreeBSD we use the standard path.

At the same time, in the last commit, there was a screw-up on the else statement that remained present. I think we can remove it too as mentioned in #41913.
