### PR TITLE
Fix geographicflag loading

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1835,7 +1835,7 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
       d->mEllipsoidAcronym = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "geographicflag" ) );
-      d->mIsGeographic = node.toElement().text().compare( QLatin1String( "true" ) );
+      d->mIsGeographic = node.toElement().text() == QLatin1String( "true" );
 
       d->mWktPreferred.clear();
 


### PR DESCRIPTION
`QString::compare` will return 0 if the strings match

Fixes #43556
