### PR TITLE
Limit the damage when the temporary directory with qgd file is deleted

### DIFF
--- a/python/core/auto_generated/qgsarchive.sip.in
+++ b/python/core/auto_generated/qgsarchive.sip.in
@@ -89,6 +89,11 @@ Returns the current temporary directory.
 %End
 
     bool exists() const;
+%Docstring
+Returns ``True`` if the archive exists on the filesystem, ``False`` otherwise.
+
+.. versionadded:: 3.20
+%End
 
 };
 

--- a/python/core/auto_generated/qgsarchive.sip.in
+++ b/python/core/auto_generated/qgsarchive.sip.in
@@ -61,7 +61,7 @@ Clear the current content of this archive and create a new temporary
 directory.
 %End
 
-    void addFile( const QString &filename, bool copy = false );
+    void addFile( const QString &filename );
 %Docstring
 Add a new file to this archive. During a zip action, this file will be
 part of the resulting zipped file.
@@ -87,6 +87,8 @@ Returns the list of files within this archive
 %Docstring
 Returns the current temporary directory.
 %End
+
+    bool exists() const;
 
 };
 

--- a/python/core/auto_generated/qgsarchive.sip.in
+++ b/python/core/auto_generated/qgsarchive.sip.in
@@ -61,7 +61,7 @@ Clear the current content of this archive and create a new temporary
 directory.
 %End
 
-    void addFile( const QString &filename );
+    void addFile( const QString &filename, bool copy = false );
 %Docstring
 Add a new file to this archive. During a zip action, this file will be
 part of the resulting zipped file.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7289,6 +7289,7 @@ bool QgisApp::fileSave()
     QMessageBox::critical( this,
                            tr( "Unable to save project %1" ).arg( QDir::toNativeSeparators( QgsProject::instance()->fileName() ) ),
                            QgsProject::instance()->error() );
+    mProjectLastModified = QgsProject::instance()->lastModified();
     return false;
   }
 
@@ -7351,7 +7352,6 @@ void QgisApp::fileSaveAs()
     mStatusBar->showMessage( tr( "Saved project to: %1" ).arg( QDir::toNativeSeparators( QgsProject::instance()->fileName() ) ), 5000 );
     // add this to the list of recently used project files
     saveRecentProjectPath();
-    mProjectLastModified = fullPath.lastModified();
   }
   else
   {
@@ -7361,6 +7361,7 @@ void QgisApp::fileSaveAs()
                            QMessageBox::Ok,
                            Qt::NoButton );
   }
+  mProjectLastModified = fullPath.lastModified();
 } // QgisApp::fileSaveAs
 
 void QgisApp::dxfExport()

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3365,7 +3365,12 @@ bool QgsProject::zip( const QString &filename )
   }
   else
   {
-    archive->addFile( asFileName );
+    // in this case, an empty filename means that the auxiliary database is
+    // empty, so we don't want to save it
+    if ( QFile::exists( asFileName ) )
+    {
+      archive->addFile( asFileName );
+    }
   }
 
   // create the archive
@@ -3560,7 +3565,7 @@ bool QgsProject::saveAuxiliaryStorage( const QString &filename )
     }
   }
 
-  if ( !mAuxiliaryStorage->exists( *this ) && filename.isEmpty() && empty )
+  if ( !mAuxiliaryStorage->exists( *this ) && empty )
   {
     return true; // it's not an error
   }

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3341,12 +3341,12 @@ bool QgsProject::zip( const QString &filename )
   const QFileInfo info( qgsFile );
   const QString asFileName = info.path() + QDir::separator() + info.completeBaseName() + "." + QgsAuxiliaryStorage::extension();
 
-  bool asOk = true;
+  bool auxiliaryStorageSavedOk = true;
   if ( ! saveAuxiliaryStorage( asFileName ) )
   {
     const QString err = mAuxiliaryStorage->errorString();
-    setError( tr( "Unable to save auxiliary storage file ('%1'). The project is still saved but last changes on auxiliary data are lost. It is recommended to reload the project." ).arg( err ) );
-    asOk = false;
+    setError( tr( "Unable to save auxiliary storage file ('%1'). The project has been saved but the latest changes to auxiliary data cannot be recovered. It is recommended to reload the project." ).arg( err ) );
+    auxiliaryStorageSavedOk = false;
 
     // fixes the current archive and keep the previous version of qgd
     if ( !mArchive->exists() )
@@ -3355,11 +3355,11 @@ bool QgsProject::zip( const QString &filename )
       mArchive->unzip( mFile.fileName() );
       mArchive->clearProjectFile();
 
-      const QString asFile = mArchive->auxiliaryStorageFile();
-      if ( ! asFile.isEmpty() )
+      const QString auxiliaryStorageFile = mArchive->auxiliaryStorageFile();
+      if ( ! auxiliaryStorageFile.isEmpty() )
       {
-        archive->addFile( asFile );
-        mAuxiliaryStorage.reset( new QgsAuxiliaryStorage( asFile, false ) );
+        archive->addFile( auxiliaryStorageFile );
+        mAuxiliaryStorage.reset( new QgsAuxiliaryStorage( auxiliaryStorageFile, false ) );
       }
     }
   }
@@ -3384,7 +3384,7 @@ bool QgsProject::zip( const QString &filename )
     zipOk = false;
   }
 
-  return asOk && zipOk;
+  return auxiliaryStorageSavedOk && zipOk;
 }
 
 bool QgsProject::isZipped() const

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3346,8 +3346,13 @@ bool QgsProject::zip( const QString &filename )
   if ( ! saveAuxiliaryStorage( asFileName ) )
   {
     const QString err = mAuxiliaryStorage->errorString();
-    setError( tr( "Unable to save auxiliary storage ('%1')" ).arg( err ) );
+    setError( tr( "Unable to save auxiliary storage file ('%1'). The project is still saved but last changes on auxiliary data are lost." ).arg( err ) );
     asOk = false;
+
+    // try to retrieve the previous version
+    QgsProjectArchive tmpArchive;
+    tmpArchive.unzip( mFile.fileName() );
+    archive->addFile( tmpArchive.auxiliaryStorageFile(), true );
   }
   else
   {

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -672,6 +672,7 @@ QgsProjectStorage *QgsProject::projectStorage() const
 
 QDateTime QgsProject::lastModified() const
 {
+  std::cout << "QgsProject::lastModified " << mFile.fileName().toStdString() << std::endl;
   if ( QgsProjectStorage *storage = projectStorage() )
   {
     QgsProjectStorage::Metadata metadata;
@@ -3341,25 +3342,30 @@ bool QgsProject::zip( const QString &filename )
   const QFileInfo info( qgsFile );
   const QString asFileName = info.path() + QDir::separator() + info.completeBaseName() + "." + QgsAuxiliaryStorage::extension();
 
+  bool asOk = true;
   if ( ! saveAuxiliaryStorage( asFileName ) )
   {
     const QString err = mAuxiliaryStorage->errorString();
     setError( tr( "Unable to save auxiliary storage ('%1')" ).arg( err ) );
-    return false;
+    asOk = false;
+  }
+  else
+  {
+    archive->addFile( asFileName );
   }
 
   // create the archive
   archive->addFile( qgsFile.fileName() );
-  archive->addFile( asFileName );
 
   // zip
+  bool zipOk = true;
   if ( !archive->zip( filename ) )
   {
     setError( tr( "Unable to perform zip" ) );
-    return false;
+    zipOk = false;
   }
 
-  return true;
+  return asOk && zipOk;
 }
 
 bool QgsProject::isZipped() const

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -672,7 +672,6 @@ QgsProjectStorage *QgsProject::projectStorage() const
 
 QDateTime QgsProject::lastModified() const
 {
-  std::cout << "QgsProject::lastModified " << mFile.fileName().toStdString() << std::endl;
   if ( QgsProjectStorage *storage = projectStorage() )
   {
     QgsProjectStorage::Metadata metadata;

--- a/src/core/qgsarchive.cpp
+++ b/src/core/qgsarchive.cpp
@@ -104,9 +104,22 @@ bool QgsArchive::unzip( const QString &filename )
   return QgsZipUtils::unzip( filename, mDir->path(), mFiles );
 }
 
-void QgsArchive::addFile( const QString &file )
+void QgsArchive::addFile( const QString &file, bool copy )
 {
-  mFiles.append( file );
+  if ( copy )
+  {
+    QFileInfo fi( file );
+    if ( ! fi.exists() )
+      return;
+
+    const QString newFile = mDir->path() + QDir::separator() + fi.fileName();
+    QFile::copy( file, newFile );
+    mFiles.append( newFile );
+  }
+  else
+  {
+    mFiles.append( file );
+  }
 }
 
 bool QgsArchive::removeFile( const QString &file )

--- a/src/core/qgsarchive.cpp
+++ b/src/core/qgsarchive.cpp
@@ -104,22 +104,9 @@ bool QgsArchive::unzip( const QString &filename )
   return QgsZipUtils::unzip( filename, mDir->path(), mFiles );
 }
 
-void QgsArchive::addFile( const QString &file, bool copy )
+void QgsArchive::addFile( const QString &file )
 {
-  if ( copy )
-  {
-    QFileInfo fi( file );
-    if ( ! fi.exists() )
-      return;
-
-    const QString newFile = mDir->path() + QDir::separator() + fi.fileName();
-    QFile::copy( file, newFile );
-    mFiles.append( newFile );
-  }
-  else
-  {
-    mFiles.append( file );
-  }
+  mFiles.append( file );
 }
 
 bool QgsArchive::removeFile( const QString &file )
@@ -137,6 +124,11 @@ bool QgsArchive::removeFile( const QString &file )
 QStringList QgsArchive::files() const
 {
   return mFiles;
+}
+
+bool QgsArchive::exists() const
+{
+  return QFileInfo::exists( mDir->path() );
 }
 
 QString QgsProjectArchive::projectFile() const

--- a/src/core/qgsarchive.h
+++ b/src/core/qgsarchive.h
@@ -79,7 +79,7 @@ class CORE_EXPORT QgsArchive
      * part of the resulting zipped file.
      * \param filename A file to add when zipping this archive
      */
-    void addFile( const QString &filename, bool copy = false );
+    void addFile( const QString &filename );
 
     /**
      * Remove a file from this archive and from the filesystem.
@@ -97,6 +97,8 @@ class CORE_EXPORT QgsArchive
      * Returns the current temporary directory.
      */
     QString dir() const;
+
+    bool exists() const;
 
   private:
     // content of the archive

--- a/src/core/qgsarchive.h
+++ b/src/core/qgsarchive.h
@@ -79,7 +79,7 @@ class CORE_EXPORT QgsArchive
      * part of the resulting zipped file.
      * \param filename A file to add when zipping this archive
      */
-    void addFile( const QString &filename );
+    void addFile( const QString &filename, bool copy = false );
 
     /**
      * Remove a file from this archive and from the filesystem.

--- a/src/core/qgsarchive.h
+++ b/src/core/qgsarchive.h
@@ -98,6 +98,10 @@ class CORE_EXPORT QgsArchive
      */
     QString dir() const;
 
+    /**
+     * Returns TRUE if the archive exists on the filesystem, FALSE otherwise.
+     * \since QGIS 3.20
+     */
     bool exists() const;
 
   private:

--- a/tests/src/python/test_qgsauxiliarystorage.py
+++ b/tests/src/python/test_qgsauxiliarystorage.py
@@ -594,11 +594,11 @@ class TestQgsAuxiliaryStorage(unittest.TestCase):
         self.assertTrue(p.write(qgz))
         self.assertTrue(os.path.exists(qgz))
 
-        # Check the content of the archive: auxiliary database doesn't exist
-        # because it's empty
+        # Check the content of the archive: auxiliary database exist
+        # because it's not empty
         archive = QgsProjectArchive()
         archive.unzip(qgz)
-        self.assertTrue(archive.auxiliaryStorageFile())
+        self.assertNotEqual(archive.auxiliaryStorageFile(), '')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsauxiliarystorage.py
+++ b/tests/src/python/test_qgsauxiliarystorage.py
@@ -23,6 +23,7 @@ from qgis.core import (QgsAuxiliaryStorage,
                        QgsPropertyDefinition,
                        QgsProperty,
                        QgsProject,
+                       QgsProjectArchive,
                        QgsFeatureRequest,
                        QgsPalLayerSettings,
                        QgsSymbolLayer,
@@ -555,6 +556,49 @@ class TestQgsAuxiliaryStorage(unittest.TestCase):
 
         self.assertEqual(al, None)
         self.assertTrue("CREATE TABLE IF NOT EXISTS" in s.errorString())
+
+    def testQgdCreationInQgz(self):
+        # New project
+        p = QgsProject()
+        self.assertTrue(p.auxiliaryStorage().isValid())
+
+        # Save the project
+        path = tmpPath()
+        qgz = path + '.qgz'
+        self.assertTrue(p.write(qgz))
+        self.assertTrue(os.path.exists(qgz))
+
+        # Check the content of the archive: auxiliary database doesn't exist
+        # because it's empty
+        archive = QgsProjectArchive()
+        archive.unzip(qgz)
+        self.assertEqual(archive.auxiliaryStorageFile(), "")
+
+        # Add a vector layer and an auxiliary layer in the project
+        vl = createLayer()
+        self.assertTrue(vl.isValid())
+        p.addMapLayers([vl])
+
+        pkf = vl.fields().field(vl.fields().indexOf('pk'))
+        al = p.auxiliaryStorage().createAuxiliaryLayer(pkf, vl)
+        self.assertTrue(al.isValid())
+        vl.setAuxiliaryLayer(al)
+
+        # Add an auxiliary field to have a non empty auxiliary storage
+        pdef = QgsPropertyDefinition('propname', QgsPropertyDefinition.DataTypeNumeric, '', '', 'ut')
+        self.assertTrue(al.addAuxiliaryField(pdef))
+
+        # Save the project
+        path = tmpPath()
+        qgz = path + '.qgz'
+        self.assertTrue(p.write(qgz))
+        self.assertTrue(os.path.exists(qgz))
+
+        # Check the content of the archive: auxiliary database doesn't exist
+        # because it's empty
+        archive = QgsProjectArchive()
+        archive.unzip(qgz)
+        self.assertTrue(archive.auxiliaryStorageFile())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

There's a lot of issues about the *Unable to save auxiliary storage* message (see https://github.com/qgis/QGIS/issues/26365 for example). Actually, this error occurs when the temporary directory where the .qgd file is stored is deleted (probably by a third party component like some kind of "cleaning" tool).

In this case, last changes on the project are lost forever and it may be very frustrating. I don't know how to prevent the temporary directory from being deleted, but I propose in this PR to limit the damage by:

1. saving the qgs project in the qgz archive even if the qgd file doesn't exist anymore 
2. saving the last version of the qgd file in the qgz archive
3. auto-fix the auxiliary storage mechanism (reset archive and auxiliary storage instances)

This way, only the last changes on the auxiliary file are lost. I don't really know how to reproduce the error while a simple `rm -rf /tmp/QGIS3*` does the trick...

Good idea or bad idea? Opinions are welcome :).

TODO:
- [x] don't create the qgd file by default when saving in qgz
- [x] add some tests
