### PR TITLE
 Add "Open attribute table (edited or new features)" to main GUI

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2710,6 +2710,10 @@ void QgisApp::createActions()
   {
     attributeTable( QgsAttributeTableFilterModel::ShowVisible );
   } );
+  connect( mActionOpenTableEdited, &QAction::triggered, this, [ = ]
+  {
+    attributeTable( QgsAttributeTableFilterModel::ShowEdited );
+  } );
   connect( mActionOpenFieldCalc, &QAction::triggered, this, &QgisApp::fieldCalculator );
   connect( mActionToggleEditing, &QAction::triggered, this, [ = ] { toggleEditing(); } );
   connect( mActionSaveLayerEdits, &QAction::triggered, this, &QgisApp::saveActiveLayerEdits );
@@ -3359,6 +3363,7 @@ void QgisApp::createToolBars()
   bt->addAction( mActionOpenTable );
   bt->addAction( mActionOpenTableSelected );
   bt->addAction( mActionOpenTableVisible );
+  bt->addAction( mActionOpenTableEdited );
 
   QAction *defOpenTableAction = mActionOpenTable;
   switch ( settings.value( QStringLiteral( "UI/openTableTool" ), 0 ).toInt() )
@@ -3371,6 +3376,9 @@ void QgisApp::createToolBars()
       break;
     case 2:
       defOpenTableAction = mActionOpenTableVisible;
+      break;
+    case 3:
+      defOpenTableAction = mActionOpenTableEdited;
       break;
   }
   bt->setDefaultAction( defOpenTableAction );
@@ -4063,6 +4071,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionOpenTable->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTable.svg" ) ) );
   mActionOpenTableSelected->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableSelected.svg" ) ) );
   mActionOpenTableVisible->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableVisible.svg" ) ) );
+  mActionOpenTableEdited->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableEdited.svg" ) ) );
   mActionOpenFieldCalc->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCalculateField.svg" ) ) );
   mActionMeasure->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasure.svg" ) ) );
   mActionMeasureArea->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasureArea.svg" ) ) );
@@ -14815,6 +14824,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionOpenTable->setEnabled( false );
     mActionOpenTableSelected->setEnabled( false );
     mActionOpenTableVisible->setEnabled( false );
+    mActionOpenTableEdited->setEnabled( false );
     mActionSelectAll->setEnabled( false );
     mActionReselect->setEnabled( false );
     mActionInvertSelection->setEnabled( false );
@@ -14967,6 +14977,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( true );
       mActionOpenTableSelected->setEnabled( true );
       mActionOpenTableVisible->setEnabled( true );
+      mActionOpenTableEdited->setEnabled( true );
       mActionSelectAll->setEnabled( true );
       mActionReselect->setEnabled( true );
       mActionInvertSelection->setEnabled( true );
@@ -15211,6 +15222,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15324,6 +15336,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15391,6 +15404,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15458,6 +15472,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -16733,6 +16748,8 @@ void QgisApp::toolButtonActionTriggered( QAction *action )
     settings.setValue( QStringLiteral( "UI/openTableTool" ), 1 );
   else if ( action == mActionOpenTableVisible )
     settings.setValue( QStringLiteral( "UI/openTableTool" ), 2 );
+  else if ( action == mActionOpenTableEdited )
+    settings.setValue( QStringLiteral( "UI/openTableTool" ), 3 );
   else if ( action == mActionMeasure )
     settings.setValue( QStringLiteral( "UI/measureTool" ), 0 );
   else if ( action == mActionMeasureArea )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14822,6 +14822,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionSelectByForm->setEnabled( false );
     mActionLabeling->setEnabled( false );
     mActionOpenTable->setEnabled( false );
+    mMenuFilterTable->setEnabled( false );
     mActionOpenTableSelected->setEnabled( false );
     mActionOpenTableVisible->setEnabled( false );
     mActionOpenTableEdited->setEnabled( false );
@@ -14975,6 +14976,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectByExpression->setEnabled( true );
       mActionSelectByForm->setEnabled( true );
       mActionOpenTable->setEnabled( true );
+      mMenuFilterTable->setEnabled( true );
       mActionOpenTableSelected->setEnabled( true );
       mActionOpenTableVisible->setEnabled( true );
       mActionOpenTableEdited->setEnabled( true );
@@ -15220,6 +15222,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( true );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15334,6 +15337,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15402,6 +15406,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15470,6 +15475,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -315,6 +315,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
       mFeatureFilterWidget->filterSelected();
       break;
 
+    case QgsAttributeTableFilterModel::ShowEdited:
+      mFeatureFilterWidget->filterEdited();
+      break;
+
     case QgsAttributeTableFilterModel::ShowAll:
     default:
       mFeatureFilterWidget->filterShowAll();

--- a/src/gui/attributetable/qgsfeaturefilterwidget_p.h
+++ b/src/gui/attributetable/qgsfeaturefilterwidget_p.h
@@ -70,6 +70,7 @@ class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeature
     void filterShowAll();
     void filterSelected();
     void filterVisible();
+    void filterEdited();
 
 
   private slots:
@@ -83,7 +84,6 @@ class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeature
     void storeExpressionButtonInit();
 
     void filterExpressionBuilder();
-    void filterEdited();
     void filterQueryChanged( const QString &query );
     void filterQueryAccepted();
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -216,6 +216,7 @@
     <addaction name="mActionOpenTable"/>
     <addaction name="mActionOpenTableSelected"/>
     <addaction name="mActionOpenTableVisible"/>
+    <addaction name="mActionOpenTableEdited"/>
     <addaction name="mActionToggleEditing"/>
     <addaction name="mActionSaveLayerEdits"/>
     <addaction name="mActionAllEdits"/>
@@ -1705,6 +1706,15 @@ Shift+R to enable range selection.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+F6</string>
+   </property>
+  </action>
+  <action name="mActionOpenTableEdited">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionOpenTableEdited.svg</normaloff>:/images/themes/default/mActionOpenTableEdited.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Open Attribute Table (Edited and New Features)</string>
    </property>
   </action>
   <action name="mActionToggleEditing">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -201,6 +201,14 @@
      <addaction name="mActionAddVectorTileLayer"/>
      <addaction name="mActionAddPointCloudLayer"/>
     </widget>
+    <widget class="QMenu" name="mMenuFilterTable">
+     <property name="title">
+      <string>Filter Attribute Table</string>
+     </property>
+     <addaction name="mActionOpenTableSelected"/>
+     <addaction name="mActionOpenTableVisible"/>
+     <addaction name="mActionOpenTableEdited"/>
+    </widget>
     <addaction name="mActionDataSourceManager"/>
     <addaction name="mNewLayerMenu"/>
     <addaction name="mAddLayerMenu"/>
@@ -214,9 +222,7 @@
     <addaction name="mActionPasteLayer"/>
     <addaction name="separator"/>
     <addaction name="mActionOpenTable"/>
-    <addaction name="mActionOpenTableSelected"/>
-    <addaction name="mActionOpenTableVisible"/>
-    <addaction name="mActionOpenTableEdited"/>
+    <addaction name="mMenuFilterTable"/>
     <addaction name="mActionToggleEditing"/>
     <addaction name="mActionSaveLayerEdits"/>
     <addaction name="mActionAllEdits"/>


### PR DESCRIPTION
(layer menu and attributes toolbar)

![Capture d’écran du 2021-06-05 09-06-48](https://user-images.githubusercontent.com/7983394/120883981-b2eaa380-c5e0-11eb-9859-332d79753c61.png)
I first add it directly in the Layer menu but thought a sub-menu might be appropriate if these filters are expected [to grow](https://github.com/qgis/QGIS/pull/42026#issuecomment-791045750). No strong opinion anyway.