### PR TITLE
Backport [processing][grass] Fix r.proj in Windows to release 3.16

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,7 +85,7 @@ jobs:
           popd
 
       - name: Push deps image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.repository_owner == 'qgis' && github.event_name != 'pull_request' }}
         run: |
           docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
           docker push "qgis/qgis3-build-deps:${DOCKER_TAG}"

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -18,6 +18,8 @@ This page tries to maintain a list with incompatible changes that happened in pr
 
 
 
+- QgsVectorLayerFeatureIterator::FetchJoinInfo::joinLayer was removed. This layer pointer was dangerous and not safe to access in any situation. 
+
 QGIS 3.4        {#qgis_api_break_3_4}
 ========
 

--- a/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
@@ -111,7 +111,7 @@ end of iterating: free the resources / lock
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
 
- QgsVectorLayer *joinLayer /Deprecated/;
+      QgsVectorLayer *joinLayer /Deprecated/;
 
 
       QgsFields joinLayerFields;

--- a/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
@@ -104,12 +104,18 @@ end of iterating: free the resources / lock
 %End
 
 
+
     struct FetchJoinInfo
     {
       const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
-      QgsVectorLayer *joinLayer;        //!< Resolved pointer to the joined layer
+
+ QgsVectorLayer *joinLayer /Deprecated/;
+
+
+      QgsFields joinLayerFields;
+
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
 

--- a/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
@@ -104,17 +104,12 @@ end of iterating: free the resources / lock
 %End
 
 
-
     struct FetchJoinInfo
     {
       const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
 
-      QgsVectorLayer *joinLayer /Deprecated/;
-
-
-      QgsFields joinLayerFields;
 
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
@@ -122,7 +117,6 @@ end of iterating: free the resources / lock
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
-
 
     virtual bool isValid() const;
 

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -104,6 +104,13 @@ Returns a vector of indices for use in join based on field names from the layer
 .. versionadded:: 2.6
 %End
 
+    static QVector<int> joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset );
+%Docstring
+Returns a vector of indices for use in join based on field names from the join layer's fields.
+
+.. versionadded:: 3.20
+%End
+
     QList<const QgsVectorLayerJoinInfo *> joinsWhereFieldIsId( const QgsField &field ) const;
 %Docstring
 Returns joins where the field of a target layer is considered as an id.

--- a/python/plugins/processing/algs/grass7/ext/r_proj.py
+++ b/python/plugins/processing/algs/grass7/ext/r_proj.py
@@ -69,7 +69,7 @@ def processInputs(alg, parameters, context, feedback):
     if isWindows():
         # TODO: make some tests under a non POSIX shell
         alg.commands.append('set regVar=')
-        alg.commands.append('for /f "delims=" %%a in (\'r.proj -g input="{}" location="{}"\') do @set theValue=%%a'.format(
+        alg.commands.append('for /f "delims=" %%a in (\'r.proj -g input^="{}" location^="{}"\') do @set regVar=%%a'.format(
             grassName, newLocation))
         alg.commands.append('g.region -a %regVar%')
     else:

--- a/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests2.yaml
@@ -806,3 +806,21 @@ tests:
         type: regex
         rules:
           - '1.0|0.0|1.0|1.0|1|2'
+
+  - algorithm: grass7:r.proj
+    name: GRASS7 r.proj
+    params:
+      -n: false
+      GRASS_RASTER_FORMAT_META: ''
+      GRASS_RASTER_FORMAT_OPT: ''
+      GRASS_REGION_CELLSIZE_PARAMETER: 0.0
+      crs: EPSG:32634
+      input:
+        name: dem.tif
+        type: raster
+      memory: 300
+      method: 0
+    results:
+      output:
+        hash: caa4870e0f0f1a42583cd562c26f0ad6b7795116961c7f6053f1ccde
+        type: rasterhash

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -2105,7 +2105,7 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
       d->mEllipsoidAcronym = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "geographicflag" ) );
-      d->mIsGeographic = node.toElement().text().compare( QLatin1String( "true" ) );
+      d->mIsGeographic = node.toElement().text() == QLatin1String( "true" );
 
       d->mWktPreferred.clear();
 

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -703,9 +703,6 @@ void QgsVectorLayerFeatureIterator::prepareJoin( int fieldIdx )
   {
     FetchJoinInfo info;
     info.joinInfo = joinInfo;
-    Q_NOWARN_DEPRECATED_PUSH
-    info.joinLayer = joinLayer;
-    Q_NOWARN_DEPRECATED_POP
     info.joinSource = std::make_shared< QgsVectorLayerFeatureSource >( joinLayer );
     info.indexOffset = mSource->mJoinBuffer->joinedFieldsOffset( joinInfo, mSource->mFields );
     info.targetField = mSource->mFields.indexFromName( joinInfo->targetFieldName() );

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -703,10 +703,14 @@ void QgsVectorLayerFeatureIterator::prepareJoin( int fieldIdx )
   {
     FetchJoinInfo info;
     info.joinInfo = joinInfo;
+    Q_NOWARN_DEPRECATED_PUSH
     info.joinLayer = joinLayer;
+    Q_NOWARN_DEPRECATED_POP
+    info.joinSource = std::make_shared< QgsVectorLayerFeatureSource >( joinLayer );
     info.indexOffset = mSource->mJoinBuffer->joinedFieldsOffset( joinInfo, mSource->mFields );
     info.targetField = mSource->mFields.indexFromName( joinInfo->targetFieldName() );
     info.joinField = joinLayer->fields().indexFromName( joinInfo->joinFieldName() );
+    info.joinLayerFields = joinLayer->fields();
 
     // for joined fields, we always need to request the targetField from the provider too
     if ( !mPreparedFields.contains( info.targetField ) && !mFieldsToPrepare.contains( info.targetField ) )
@@ -1043,11 +1047,13 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesCached( Qg
 
 void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const
 {
+#if 0 // this is not thread safe -- we cannot access the layer here as this will be called from non-main threads.
   // Shortcut
   if ( joinLayer && ! joinLayer->hasFeatures() )
   {
     return;
   }
+#endif
 
   // no memory cache, query the joined values by setting substring
   QString subsetString;
@@ -1085,7 +1091,7 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( Qg
   if ( joinInfo->hasSubset() )
   {
     const QStringList subsetNames = QgsVectorLayerJoinInfo::joinFieldNamesSubset( *joinInfo );
-    subsetIndices = QgsVectorLayerJoinBuffer::joinSubsetIndices( joinLayer, subsetNames );
+    subsetIndices = QgsVectorLayerJoinBuffer::joinSubsetIndices( joinLayerFields, subsetNames );
   }
 
   // select (no geometry)
@@ -1094,7 +1100,7 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( Qg
   request.setSubsetOfAttributes( attributes );
   request.setFilterExpression( subsetString );
   request.setLimit( 1 );
-  QgsFeatureIterator fi = joinLayer->getFeatures( request );
+  QgsFeatureIterator fi = joinSource->getFeatures( request );
 
   // get first feature
   QgsFeature fet;

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -140,6 +140,8 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     void setInterruptionChecker( QgsFeedback *interruptionChecker ) override SIP_SKIP;
 
+    Q_NOWARN_DEPRECATED_PUSH
+
     /**
      * Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
      * Created in the select() method of QgsVectorLayerJoinBuffer for the joins that contain fetched attributes
@@ -149,13 +151,32 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
-      QgsVectorLayer *joinLayer;        //!< Resolved pointer to the joined layer
+
+      /**
+       * Resolved pointer to the joined layer
+       * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
+       */
+      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer SIP_DEPRECATED = nullptr;
+
+      /**
+       * Feature source for join
+       */
+      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource SIP_SKIP;
+
+      /**
+       * Fields from joined layer.
+       *
+       * \since QGIS 3.20
+       */
+      QgsFields joinLayerFields;
+
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
 
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
+    Q_NOWARN_DEPRECATED_POP
 
 
     bool isValid() const override;

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -156,7 +156,11 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
        * Resolved pointer to the joined layer
        * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
        */
-      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer SIP_DEPRECATED = nullptr;
+#ifndef SIP_RUN
+      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer = nullptr;
+#else
+      QgsVectorLayer *joinLayer SIP_DEPRECATED;
+#endif
 
       /**
        * Feature source for join

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -140,8 +140,6 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     void setInterruptionChecker( QgsFeedback *interruptionChecker ) override SIP_SKIP;
 
-    Q_NOWARN_DEPRECATED_PUSH
-
     /**
      * Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
      * Created in the select() method of QgsVectorLayerJoinBuffer for the joins that contain fetched attributes
@@ -152,27 +150,24 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       QgsAttributeList attributes;      //!< Attributes to fetch
       int indexOffset;                  //!< At what position the joined fields start
 
-      /**
-       * Resolved pointer to the joined layer
-       * \deprecated Do NOT use. This is not thread safe, and should never be accessed from a background thread.
-       */
 #ifndef SIP_RUN
-      Q_DECL_DEPRECATED QgsVectorLayer *joinLayer = nullptr;
-#else
-      QgsVectorLayer *joinLayer SIP_DEPRECATED;
-#endif
 
       /**
        * Feature source for join
+       *
+       * \note Not available in Python bindings
+       * \since QGIS 3.20
        */
-      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource SIP_SKIP;
+      std::shared_ptr< QgsVectorLayerFeatureSource > joinSource;
 
       /**
        * Fields from joined layer.
        *
+       * \note Not available in Python bindings
        * \since QGIS 3.20
        */
       QgsFields joinLayerFields;
+#endif
 
       int targetField;                  //!< Index of field (of this layer) that drives the join
       int joinField;                    //!< Index of field (of the joined layer) must have equal value
@@ -180,8 +175,6 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;
     };
-    Q_NOWARN_DEPRECATED_POP
-
 
     bool isValid() const override;
 

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -182,12 +182,16 @@ void QgsVectorLayerJoinBuffer::cacheJoinLayer( QgsVectorLayerJoinInfo &joinInfo 
 
 QVector<int> QgsVectorLayerJoinBuffer::joinSubsetIndices( QgsVectorLayer *joinLayer, const QStringList &joinFieldsSubset )
 {
+  return joinSubsetIndices( joinLayer->fields(), joinFieldsSubset );
+}
+
+QVector<int> QgsVectorLayerJoinBuffer::joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset )
+{
   QVector<int> subsetIndices;
-  const QgsFields &fields = joinLayer->fields();
   for ( int i = 0; i < joinFieldsSubset.count(); ++i )
   {
     QString joinedFieldName = joinFieldsSubset.at( i );
-    int index = fields.lookupField( joinedFieldName );
+    int index = joinLayerFields.lookupField( joinedFieldName );
     if ( index != -1 )
     {
       subsetIndices.append( index );

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -104,6 +104,12 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
     static QVector<int> joinSubsetIndices( QgsVectorLayer *joinLayer, const QStringList &joinFieldsSubset );
 
     /**
+     * Returns a vector of indices for use in join based on field names from the join layer's fields.
+     * \since QGIS 3.20
+     */
+    static QVector<int> joinSubsetIndices( const QgsFields &joinLayerFields, const QStringList &joinFieldsSubset );
+
+    /**
      * Returns joins where the field of a target layer is considered as an id.
      * \param field the field of a target layer
      * \returns a list of vector joins

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -190,6 +190,9 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
 {
   QgsDebugMsg( QStringLiteral( "theBandNo = %1 min = %2 max = %3" ).arg( bandNo ).arg( min ).arg( max ) );
 
+  const QString oldMinTextvalue = mMinLineEdit->text();
+  const QString oldMaxTextvalue = mMaxLineEdit->text();
+
   if ( std::isnan( min ) )
   {
     whileBlocking( mMinLineEdit )->clear();
@@ -211,7 +214,7 @@ void QgsSingleBandPseudoColorRendererWidget::loadMinMax( int bandNo, double min,
   // We compare old min and new min as text because QString::number keeps a fixed number of significant
   // digits (default 6) and so loaded min/max will always differ from current one, which triggers a
   // classification, and wipe out every user modification (see https://github.com/qgis/QGIS/issues/36172)
-  if ( mMinLineEdit->text() != displayValueWithMaxPrecision( min ) || mMaxLineEdit->text() != displayValueWithMaxPrecision( max ) )
+  if ( mMinLineEdit->text() != oldMinTextvalue || mMaxLineEdit->text() != oldMaxTextvalue )
   {
     whileBlocking( mColorRampShaderWidget )->setRasterBand( bandNo );
     whileBlocking( mColorRampShaderWidget )->setMinimumMaximumAndClassify( min, max );

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -84,6 +84,7 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     // Convert min/max to localized display value with maximum precision for the current data type
     QString displayValueWithMaxPrecision( const double value );
 
+    friend class TestQgsSingleBandPseudoColorRendererWidget;
 };
 
 #endif // QGSSINGLEBANDCOLORRENDERERWIDGET_H

--- a/src/server/qgsserverapiutils.cpp
+++ b/src/server/qgsserverapiutils.cpp
@@ -115,13 +115,13 @@ template<typename T, class T2> T QgsServerApiUtils::parseTemporalInterval( const
   const QStringList parts { interval.split( '/' ) };
   if ( parts.length() != 2 )
   {
-    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval." ).arg( interval ), QStringLiteral( "Server" ), Qgis::Critical );
+    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval." ).arg( interval ), QStringLiteral( "Server" ) );
   }
   T result { parseDate( parts[0] ), parseDate( parts[1] ) };
   // Check validity
   if ( result.isEmpty() )
   {
-    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval (empty)." ).arg( interval ), QStringLiteral( "Server" ), Qgis::Critical );
+    throw QgsServerApiBadRequestException( QStringLiteral( "%1 is not a valid datetime interval (empty)." ).arg( interval ), QStringLiteral( "Server" ) );
   }
   return result;
 }

--- a/tests/src/gui/testqgssinglebandpseudocolorrendererwidget.cpp
+++ b/tests/src/gui/testqgssinglebandpseudocolorrendererwidget.cpp
@@ -112,6 +112,21 @@ void TestQgsSingleBandPseudoColorRendererWidget::testEditLabel()
 
   QList<QgsColorRampShader::ColorRampItem> newColorRampItems = newColorRampShader->colorRampItemList();
   QCOMPARE( newColorRampItems.at( 0 ).label, QStringLiteral( "zero" ) );
+
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->minimum() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->maximum() ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().minimumValue() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().maximumValue() ) );
+
+  // change the min/max
+  widget.loadMinMax( 1, min + 1.0, max - 1.0 );
+
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( min + 1.0 ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( max - 1.0 ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->minimum() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->maximum() ) );
+  QCOMPARE( widget.mMinLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().minimumValue() ) );
+  QCOMPARE( widget.mMaxLineEdit->text(), widget.displayValueWithMaxPrecision( widget.mColorRampShaderWidget->shader().maximumValue() ) );
 }
 
 


### PR DESCRIPTION
## Description

Fixes the GRASS r.proj processing tool in Windows by escaping the equal signs in the for `/f` command and by fixing a typo in the variable name used to store the results from `r.proj -g` and to pass it to `g.region -a`.

Manual backport of #43546 to 3.16 branch.