### PR TITLE
Additional test for postgres

### DIFF
--- a/.docker/docker-compose-testing-postgres.yml
+++ b/.docker/docker-compose-testing-postgres.yml
@@ -20,3 +20,5 @@ services:
       - postgres
     env_file:
       - docker-variables.env
+    cap_add:
+      - NET_ADMIN

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -377,6 +377,7 @@ if (ENABLE_PGTEST)
   ADD_PYTHON_TEST(PyQgsVectorFileWriterPostgres test_qgsvectorfilewriter_postgres.py)
   ADD_PYTHON_TEST(PyQgsVectorLayerUtilsPostgres test_qgsvectorlayerutils_postgres.py)
   ADD_PYTHON_TEST(PyQgsPostgresProvider test_provider_postgres.py)
+  ADD_PYTHON_TEST(PyQgsPostgresProviderRemote test_provider_postgres_remote.py TEST_TIMEOUT=600)
   ADD_PYTHON_TEST(PyQgsPostgresRasterProvider test_provider_postgresraster.py)
   ADD_PYTHON_TEST(PyQgsPostgresDomain test_qgspostgresdomain.py)
   ADD_PYTHON_TEST(PyQgsPostgresTransaction test_qgspostgrestransaction.py)
@@ -407,6 +408,7 @@ if (ENABLE_PGTEST)
     PyQgsDbManagerPostgis PyQgsDatabaseSchemaModel PyQgsDatabaseTableModel PyQgsDatabaseSchemaComboBox PyQgsDatabaseTableComboBox
     PyQgsProviderConnectionPostgres
     PROPERTIES LABELS "POSTGRES")
+  SET_TESTS_PROPERTIES(PyQgsPostgresProviderRemote PROPERTIES LABELS "POSTGRESREMOTE")
 endif()
 
 if (ENABLE_MSSQLTEST)

--- a/tests/src/python/test_provider_postgres_remote.py
+++ b/tests/src/python/test_provider_postgres_remote.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for the remote PostgreSQL server.
+
+Note: The test makes sense if the network latency
+between QGIS and the PG server is 100ms.
+
+Run with ctest -V -R PyQgsPostgresProviderRemote
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+"""
+from builtins import next
+
+__author__ = 'Daryna Dyka'
+__date__ = '2021-06-02'
+__copyright__ = 'Copyright 2021, The QGIS Project'
+
+import qgis  # NOQA
+import psycopg2
+
+import os
+import time
+
+from qgis.core import QgsVectorLayer, QgsFeatureRequest
+from qgis.testing import start_app, unittest
+
+QGISAPP = start_app()
+
+
+class TestPyQgsPostgresProviderRemote(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        cls.dbconn = 'service=qgis_test'
+        if 'QGIS_PGTEST_DB' in os.environ:
+            cls.dbconn = os.environ['QGIS_PGTEST_DB']
+        cls.con = psycopg2.connect(cls.dbconn)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+
+    def execSQLCommand(self, sql):
+        self.assertTrue(self.con)
+        cur = self.con.cursor()
+        self.assertTrue(cur)
+        cur.execute(sql)
+        cur.close()
+        self.con.commit()
+
+    def testSaveChangedGeometryToDB(self):
+        """Test Save geometries to remote DB"""
+
+        self.execSQLCommand('''
+          DROP TABLE IF EXISTS qgis_test.speed_test_remote_db CASCADE;
+          CREATE TABLE qgis_test.speed_test_remote_db (
+            id_serial serial NOT NULL,
+            geom geometry(Polygon,3857),
+            CONSTRAINT speed_test_remote_db_pk PRIMARY KEY (id_serial) );
+          INSERT INTO qgis_test.speed_test_remote_db(geom)
+            SELECT
+              ST_Translate(
+                ST_GeomFromText(\'POLYGON((3396900.0 6521800.0,3396900.0 6521870.0,
+                    3396830.0 6521870.0,3396830.0 6521800.0,3396900.0 6521800.0))\', 3857 ),
+                100.0 * dx,
+                100.0 * dy )
+            FROM generate_series(1,42) dx, generate_series(1,42) dy;''')
+
+        set_new_layer = ' sslmode=disable key=\'id_serial\' srid=3857 type=POLYGON table="qgis_test"."speed_test_remote_db" (geom) sql='
+        error_string = 'Save geoms to remote DB : expected < 10s, got {}s'
+
+        vl = QgsVectorLayer(self.dbconn + set_new_layer, 'test_vl_remote_save', 'postgres')
+        # fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(1000))]
+        fids = [f.id() for f in vl.getFeatures(QgsFeatureRequest().setLimit(50))]
+        self.assertTrue(vl.startEditing())
+        for f in vl.getFeatures(fids):
+            self.assertTrue(vl.changeGeometry(f.id(), f.geometry()))
+
+        start_time = time.time()
+        self.assertTrue(vl.commitChanges())
+        duration = round(abs(time.time() - start_time), 1)
+        self.assertTrue(duration < 10, error_string.format(duration))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some optimisations are aimed at reducing the number of queries to the geospatial database. Unfortunately, there are no tests that can prevent these improvements from degrading. This PR introduces a new class of tests for PostGIS.
Practically, two docker containers are used for the LABELS "POSTGRES" tests:
- qgis-deps, the container in which the test script is executed
- postgres, container with deployed PostgreSQL database

So, it is proposed to make further modifications:
After passing all the "POSTGRES" tests, changes are made to the qgis-deps container that add a delay of 100ms for all outgoing packets.
Then the tests marked as LABELS "POSTGRESREMOTE" are executed again. For these tests, in a zero approximation, we can assume that each request to the database is converted into 100ms of test execution time. Test execution time is fairly easy to control within the test itself.