### PR TITLE
Fix #43539 Bad edit button states in relation editor widget for n:m relations

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -281,7 +281,7 @@ void QgsRelationEditorWidget::updateButtons()
 
   if ( mRelation.isValid() )
   {
-    toggleEditingButtonEnabled = mRelation.referencingLayer()->supportsEditing() && !mRelation.referencingLayer()->readOnly();
+    toggleEditingButtonEnabled = mRelation.referencingLayer()->supportsEditing();
     editable = mRelation.referencingLayer()->isEditable();
     linkable = mRelation.referencingLayer()->isEditable();
     spatial = mRelation.referencingLayer()->isSpatial();
@@ -289,7 +289,7 @@ void QgsRelationEditorWidget::updateButtons()
 
   if ( mNmRelation.isValid() )
   {
-    toggleEditingButtonEnabled = toggleEditingButtonEnabled && mNmRelation.referencedLayer()->supportsEditing() && !mNmRelation.referencedLayer()->readOnly();
+    toggleEditingButtonEnabled |= mNmRelation.referencedLayer()->supportsEditing();
     editable = mNmRelation.referencedLayer()->isEditable();
     spatial = mNmRelation.referencedLayer()->isSpatial();
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -281,7 +281,7 @@ void QgsRelationEditorWidget::updateButtons()
 
   if ( mRelation.isValid() )
   {
-    toggleEditingButtonEnabled = mRelation.referencingLayer()->supportsEditing();
+    toggleEditingButtonEnabled = mRelation.referencingLayer()->supportsEditing() && !mRelation.referencingLayer()->readOnly();
     editable = mRelation.referencingLayer()->isEditable();
     linkable = mRelation.referencingLayer()->isEditable();
     spatial = mRelation.referencingLayer()->isSpatial();
@@ -289,8 +289,8 @@ void QgsRelationEditorWidget::updateButtons()
 
   if ( mNmRelation.isValid() )
   {
-    toggleEditingButtonEnabled = mNmRelation.referencedLayer()->supportsEditing() && mRelation.referencingLayer()->supportsEditing();
-    editable = mNmRelation.referencedLayer()->isEditable() && mRelation.referencingLayer()->isEditable();
+    toggleEditingButtonEnabled = toggleEditingButtonEnabled && mNmRelation.referencedLayer()->supportsEditing() && !mNmRelation.referencedLayer()->readOnly();
+    editable = mNmRelation.referencedLayer()->isEditable();
     spatial = mNmRelation.referencedLayer()->isSpatial();
   }
 


### PR DESCRIPTION
Use QgsVectorLayer::supportsEditing() instead of QgsVectorLayer::Capability::ChangeAttributeValues

Additional fix: "Link" and "Save edit" buttons enabled/disabled correctly
when only the final or only the middle table are editable