### PR TITLE
Do not set initial attr values for default clause

### DIFF
--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -187,7 +187,10 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
     }
     else if ( ( reuseAllLastValues || mLayer->editFormConfig().reuseLastValue( idx ) ) && sLastUsedValues()->contains( mLayer ) && ( *sLastUsedValues() )[ mLayer ].contains( idx ) )
     {
-      initialAttributeValues.insert( idx, ( *sLastUsedValues() )[ mLayer ][idx] );
+      // Only set initial attribute value if it's different from the default clause or we may trigger
+      // unique constraint checks for no reason, see https://github.com/qgis/QGIS/issues/42909
+      if ( mLayer->dataProvider()->defaultValueClause( idx ) != ( *sLastUsedValues() )[ mLayer ][idx] )
+        initialAttributeValues.insert( idx, ( *sLastUsedValues() )[ mLayer ][idx] );
     }
   }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -189,7 +189,7 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
     {
       // Only set initial attribute value if it's different from the default clause or we may trigger
       // unique constraint checks for no reason, see https://github.com/qgis/QGIS/issues/42909
-      if ( mLayer->dataProvider()->defaultValueClause( idx ) != ( *sLastUsedValues() )[ mLayer ][idx] )
+      if ( mLayer->dataProvider() && mLayer->dataProvider()->defaultValueClause( idx ) != ( *sLastUsedValues() )[ mLayer ][idx] )
         initialAttributeValues.insert( idx, ( *sLastUsedValues() )[ mLayer ][idx] );
     }
   }
@@ -318,4 +318,3 @@ QgsFeature QgsFeatureAction::feature() const
 {
   return mFeature ? *mFeature : QgsFeature();
 }
-


### PR DESCRIPTION
Fixes #42909

Setting intial values from previously entered values when
they are equal to the default was pointless anyway because
QgsVectorLayerUtils::createFeature will do that a few lines
below.

Setting the default value for unique constraints
was triggering unique checks for no reason and slowing down
the feature creation up to the point that for large layers
QGIS froze.
