### PR TITLE
Add the nominatim locator filter in the list of core filters to support default '>' prefix

### DIFF
--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -30,7 +30,8 @@ const QList<QString> QgsLocator::CORE_FILTERS = QList<QString>() << QStringLiter
     <<  QStringLiteral( "bookmarks" )
     <<  QStringLiteral( "optionpages" )
     <<  QStringLiteral( "edit_features" )
-    <<  QStringLiteral( "goto" );
+    <<  QStringLiteral( "goto" )
+    <<  QStringLiteral( "nominatimgeocoder" ) ;
 
 QgsLocator::QgsLocator( QObject *parent )
   : QObject( parent )


### PR DESCRIPTION
## Description

When editing a QGIS 3.20 changelog entry reveal a bug, fix it! :) 

If we don't add the nominatim locator filter as a core filter, we're prevented from using the default prefix we settled on (i.e.'>').