### PR TITLE
QgsGeometryValidator Improves the error message when the Z differs and adds a location point

### DIFF
--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -60,6 +60,19 @@ Returns the end point of the curve.
     virtual bool isClosed() const /HoldGIL/;
 %Docstring
 Returns ``True`` if the curve is closed.
+
+.. seealso:: :py:func:`is2DClosed`
+%End
+
+    virtual bool is2DClosed() const /HoldGIL/;
+%Docstring
+Returns true if the curve is closed.
+
+Unlike isClosed. It looks only for XY coordinates.
+
+.. seealso:: :py:func:`isClosed`
+
+.. versionadded:: 3.20
 %End
 
     virtual bool isRing() const /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgscurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscurve.sip.in
@@ -61,10 +61,10 @@ Returns the end point of the curve.
 %Docstring
 Returns ``True`` if the curve is closed.
 
-.. seealso:: :py:func:`is2DClosed`
+.. seealso:: :py:func:`isClosed2D`
 %End
 
-    virtual bool is2DClosed() const /HoldGIL/;
+    virtual bool isClosed2D() const /HoldGIL/;
 %Docstring
 Returns true if the curve is closed.
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -591,7 +591,7 @@ segment in the line.
 
     virtual bool isClosed() const /HoldGIL/;
 
-    virtual bool is2DClosed() const /HoldGIL/;
+    virtual bool isClosed2D() const /HoldGIL/;
 
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -591,6 +591,8 @@ segment in the line.
 
     virtual bool isClosed() const /HoldGIL/;
 
+    virtual bool is2DClosed() const /HoldGIL/;
+
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
 

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -37,7 +37,7 @@ bool QgsCurve::operator!=( const QgsAbstractGeometry &other ) const
   return !operator==( other );
 }
 
-bool QgsCurve::is2DClosed() const
+bool QgsCurve::isClosed2D() const
 {
   if ( numPoints() == 0 )
     return false;
@@ -51,7 +51,7 @@ bool QgsCurve::is2DClosed() const
 }
 bool QgsCurve::isClosed() const
 {
-  bool closed = is2DClosed();
+  bool closed = isClosed2D();
   if ( is3D() && closed )
   {
     QgsPoint start = startPoint();

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -37,7 +37,7 @@ bool QgsCurve::operator!=( const QgsAbstractGeometry &other ) const
   return !operator==( other );
 }
 
-bool QgsCurve::isClosed() const
+bool QgsCurve::is2DClosed() const
 {
   if ( numPoints() == 0 )
     return false;
@@ -46,10 +46,18 @@ bool QgsCurve::isClosed() const
   QgsPoint start = startPoint();
   QgsPoint end = endPoint();
 
-  bool closed = qgsDoubleNear( start.x(), end.x() ) &&
-                qgsDoubleNear( start.y(), end.y() );
+  return qgsDoubleNear( start.x(), end.x() ) &&
+         qgsDoubleNear( start.y(), end.y() );
+}
+bool QgsCurve::isClosed() const
+{
+  bool closed = is2DClosed();
   if ( is3D() && closed )
+  {
+    QgsPoint start = startPoint();
+    QgsPoint end = endPoint();
     closed &= qgsDoubleNear( start.z(), end.z() ) || ( std::isnan( start.z() ) && std::isnan( end.z() ) );
+  }
   return closed;
 }
 

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -67,7 +67,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
     /**
      * Returns TRUE if the curve is closed.
      *
-     * \see is2DClosed()
+     * \see isClosed2D()
      */
     virtual bool isClosed() const SIP_HOLDGIL;
 
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
      *
      * \since QGIS 3.20
      */
-    virtual bool is2DClosed() const SIP_HOLDGIL;
+    virtual bool isClosed2D() const SIP_HOLDGIL;
 
     /**
      * Returns TRUE if the curve is a ring.

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -66,8 +66,21 @@ class CORE_EXPORT QgsCurve: public QgsAbstractGeometry SIP_ABSTRACT
 
     /**
      * Returns TRUE if the curve is closed.
+     *
+     * \see is2DClosed()
      */
     virtual bool isClosed() const SIP_HOLDGIL;
+
+    /**
+     * Returns true if the curve is closed.
+     *
+     * Unlike isClosed. It looks only for XY coordinates.
+     *
+     * \see isClosed()
+     *
+     * \since QGIS 3.20
+     */
+    virtual bool is2DClosed() const SIP_HOLDGIL;
 
     /**
      * Returns TRUE if the curve is a ring.

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -406,7 +406,7 @@ bool QgsLineString::removeDuplicateNodes( double epsilon, bool useZValues )
   return result;
 }
 
-bool QgsLineString::is2DClosed() const
+bool QgsLineString::isClosed2D() const
 {
   if ( mX.empty() )
     return false;
@@ -417,7 +417,7 @@ bool QgsLineString::is2DClosed() const
 
 bool QgsLineString::isClosed() const
 {
-  bool closed = is2DClosed();
+  bool closed = isClosed2D();
 
   if ( is3D() && closed )
     closed &= qgsDoubleNear( mZ.first(), mZ.last() ) || ( std::isnan( mZ.first() ) && std::isnan( mZ.last() ) );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -406,13 +406,19 @@ bool QgsLineString::removeDuplicateNodes( double epsilon, bool useZValues )
   return result;
 }
 
-bool QgsLineString::isClosed() const
+bool QgsLineString::is2DClosed() const
 {
   if ( mX.empty() )
     return false;
 
-  bool closed = qgsDoubleNear( mX.first(), mX.last() ) &&
-                qgsDoubleNear( mY.first(), mY.last() );
+  return qgsDoubleNear( mX.first(), mX.last() ) &&
+         qgsDoubleNear( mY.first(), mY.last() );
+}
+
+bool QgsLineString::isClosed() const
+{
+  bool closed = is2DClosed();
+
   if ( is3D() && closed )
     closed &= qgsDoubleNear( mZ.first(), mZ.last() ) || ( std::isnan( mZ.first() ) && std::isnan( mZ.last() ) );
   return closed;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -779,7 +779,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool isClosed() const override SIP_HOLDGIL;
-    bool is2DClosed() const override SIP_HOLDGIL;
+    bool isClosed2D() const override SIP_HOLDGIL;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
 
     /**

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -779,6 +779,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool isClosed() const override SIP_HOLDGIL;
+    bool is2DClosed() const override SIP_HOLDGIL;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
 
     /**

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -99,9 +99,17 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
 
     if ( !line->isClosed() )
     {
-      QString msg = QObject::tr( "ring %1 not closed" ).arg( i );
-      QgsDebugMsgLevel( msg, 2 );
-      emit errorFound( QgsGeometry::Error( msg ) );
+      QString msg;
+      if ( line->is3D() && line->is2DClosed() )
+      {
+        msg = QObject::tr( "ring %1 not closed, Z mismatch" ).arg( i );
+      }
+      else
+      {
+        msg = QObject::tr( "ring %1 not closed" ).arg( i );
+        QgsDebugMsgLevel( msg, 2 );
+      }
+      emit errorFound( QgsGeometry::Error( msg, QgsPointXY( line->startPoint().x(), line->startPoint().y() ) ) );
       mErrorCount++;
       return;
     }

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -102,7 +102,7 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
       QgsPoint startPoint = line->startPoint();
       QgsPoint endPoint = line->endPoint();
       QString msg;
-      if ( line->is3D() && line->is2DClosed() )
+      if ( line->is3D() && line->isClosed2D() )
       {
         msg = QObject::tr( "ring %1 not closed, Z mismatch: %2 vs %3" ).arg( i ).arg( startPoint.z() ).arg( endPoint.z() );
       }

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -99,17 +99,19 @@ void QgsGeometryValidator::validatePolyline( int i, const QgsLineString *line, b
 
     if ( !line->isClosed() )
     {
+      QgsPoint startPoint = line->startPoint();
+      QgsPoint endPoint = line->endPoint();
       QString msg;
       if ( line->is3D() && line->is2DClosed() )
       {
-        msg = QObject::tr( "ring %1 not closed, Z mismatch" ).arg( i );
+        msg = QObject::tr( "ring %1 not closed, Z mismatch: %2 vs %3" ).arg( i ).arg( startPoint.z() ).arg( endPoint.z() );
       }
       else
       {
         msg = QObject::tr( "ring %1 not closed" ).arg( i );
         QgsDebugMsgLevel( msg, 2 );
       }
-      emit errorFound( QgsGeometry::Error( msg, QgsPointXY( line->startPoint().x(), line->startPoint().y() ) ) );
+      emit errorFound( QgsGeometry::Error( msg, QgsPointXY( startPoint.x(), startPoint.y() ) ) );
       mErrorCount++;
       return;
     }

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -1805,13 +1805,13 @@ void TestQgsGeometry::circularString()
 
   //isClosed
   QgsCircularString l11;
-  QVERIFY( !l11.is2DClosed() );
+  QVERIFY( !l11.isClosed2D() );
   QVERIFY( !l11.isClosed() );
   l11.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
                  << QgsPoint( 11, 2 )
                  << QgsPoint( 11, 22 )
                  << QgsPoint( 1, 22 ) );
-  QVERIFY( !l11.is2DClosed() );
+  QVERIFY( !l11.isClosed2D() );
   QVERIFY( !l11.isClosed() );
   QCOMPARE( l11.numPoints(), 4 );
   QCOMPARE( l11.area(), 0.0 );
@@ -1822,17 +1822,17 @@ void TestQgsGeometry::circularString()
                  << QgsPoint( QgsWkbTypes::PointM, 11, 2, 0, 4 )
                  << QgsPoint( QgsWkbTypes::PointM, 11, 22, 0, 5 )
                  << QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 6 ) );
-  QVERIFY( l11.is2DClosed() );
+  QVERIFY( l11.isClosed2D() );
   QVERIFY( l11.isClosed() );
 
   // test with z
   l11.addZValue( 123.0 );
-  QVERIFY( l11.is2DClosed() );
+  QVERIFY( l11.isClosed2D() );
   QVERIFY( l11.isClosed() );
   QgsPoint pEnd = l11.endPoint();
   pEnd.setZ( 234.0 );
   l11.moveVertex( QgsVertexId( 0, 0, l11.numPoints() - 1 ), pEnd );
-  QVERIFY( l11.is2DClosed() );
+  QVERIFY( l11.isClosed2D() );
   QVERIFY( !l11.isClosed() );
 
   //polygonf

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -1805,11 +1805,13 @@ void TestQgsGeometry::circularString()
 
   //isClosed
   QgsCircularString l11;
+  QVERIFY( !l11.is2DClosed() );
   QVERIFY( !l11.isClosed() );
   l11.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
                  << QgsPoint( 11, 2 )
                  << QgsPoint( 11, 22 )
                  << QgsPoint( 1, 22 ) );
+  QVERIFY( !l11.is2DClosed() );
   QVERIFY( !l11.isClosed() );
   QCOMPARE( l11.numPoints(), 4 );
   QCOMPARE( l11.area(), 0.0 );
@@ -1820,7 +1822,18 @@ void TestQgsGeometry::circularString()
                  << QgsPoint( QgsWkbTypes::PointM, 11, 2, 0, 4 )
                  << QgsPoint( QgsWkbTypes::PointM, 11, 22, 0, 5 )
                  << QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 6 ) );
+  QVERIFY( l11.is2DClosed() );
   QVERIFY( l11.isClosed() );
+
+  // test with z
+  l11.addZValue( 123.0 );
+  QVERIFY( l11.is2DClosed() );
+  QVERIFY( l11.isClosed() );
+  QgsPoint pEnd = l11.endPoint();
+  pEnd.setZ( 234.0 );
+  l11.moveVertex( QgsVertexId( 0, 0, l11.numPoints() - 1 ), pEnd );
+  QVERIFY( l11.is2DClosed() );
+  QVERIFY( !l11.isClosed() );
 
   //polygonf
   QgsCircularString l13;

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -239,7 +239,7 @@ class TestQgsGeometryValidator(unittest.TestCase):
         validator.run()
         self.assertEqual(len(spy), 1)
 
-        self.assertEqual(spy[0][0].where(), QgsPointXY())
+        self.assertEqual(spy[0][0].where(), QgsPointXY(0, 0))
         self.assertEqual(spy[0][0].what(), 'ring 0 not closed')
 
         g = QgsGeometry.fromWkt("Polygon ((0 0, 10 0, 10 10, 0 0),(1 1, 2 1, 2 2, 1.1 1))")
@@ -249,7 +249,7 @@ class TestQgsGeometryValidator(unittest.TestCase):
         validator.run()
         self.assertEqual(len(spy), 1)
 
-        self.assertEqual(spy[0][0].where(), QgsPointXY())
+        self.assertEqual(spy[0][0].where(), QgsPointXY(1, 1))
         self.assertEqual(spy[0][0].what(), 'ring 1 not closed')
 
         g = QgsGeometry.fromWkt("Polygon ((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 2 1, 2 2, 1 1),(3 3, 3 4, 4 4, 3.1 3))")
@@ -259,8 +259,19 @@ class TestQgsGeometryValidator(unittest.TestCase):
         validator.run()
         self.assertEqual(len(spy), 1)
 
-        self.assertEqual(spy[0][0].where(), QgsPointXY())
+        self.assertEqual(spy[0][0].where(), QgsPointXY(3, 3))
         self.assertEqual(spy[0][0].what(), 'ring 2 not closed')
+
+        # not closed but 2d close
+        g = QgsGeometry.fromWkt("POLYGONZ((1 1 0, 1 2 1, 2 2 2, 2 1 3, 1 1 4))")
+
+        validator = QgsGeometryValidator(g)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 1)
+
+        self.assertEqual(spy[0][0].where(), QgsPointXY(1, 1))
+        self.assertEqual(spy[0][0].what(), 'ring 0 not closed, Z mismatch: 0 vs 4')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -262,7 +262,7 @@ class TestQgsGeometryValidator(unittest.TestCase):
         self.assertEqual(spy[0][0].where(), QgsPointXY(3, 3))
         self.assertEqual(spy[0][0].what(), 'ring 2 not closed')
 
-        # not closed but 2d close
+        # not closed but 2d closed
         g = QgsGeometry.fromWkt("POLYGONZ((1 1 0, 1 2 1, 2 2 2, 2 1 3, 1 1 4))")
 
         validator = QgsGeometryValidator(g)


### PR DESCRIPTION
## Description

As stated in #43582, it is surprising not to have the information on the point that is not closed. This PR fixes this problem.

On the other hand, in the case of a 3D geometry we may need the information if the geometry is closed in 2D and if it is the Zs that are different. I added a method for this with tests and I reuse it in the validator.