### PR TITLE
Add cookie management logic

### DIFF
--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -502,6 +502,14 @@ Emitted when external browser logins are to be aborted.
 .. versionadded:: 3.20
 %End
 
+
+    void cookiesChanged( const QList<QNetworkCookie> &cookies );
+%Docstring
+Emitted when the cookies changed.
+
+.. versionadded:: 3.22
+%End
+
   protected:
     virtual QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = 0 );
 

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -23,6 +23,8 @@
 #include "qgis_sip.h"
 #include <QStringList>
 #include <QNetworkAccessManager>
+#include <QNetworkCookie>
+#include <QNetworkCookieJar>
 #include <QNetworkProxy>
 #include <QNetworkRequest>
 #include <QMutex>
@@ -694,6 +696,13 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      */
     void authBrowserAborted();
 
+    /**
+     * Emitted when the cookies changed.
+     * \since QGIS 3.22
+     */
+
+    void cookiesChanged( const QList<QNetworkCookie> &cookies );
+
   private slots:
     void abortRequest();
 
@@ -708,6 +717,8 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     void onAuthRequired( QNetworkReply *reply, QAuthenticator *auth );
     void handleAuthRequest( QNetworkReply *reply, QAuthenticator *auth );
+
+    void syncCookies( const QList<QNetworkCookie> &cookies );
 
   protected:
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;


### PR DESCRIPTION
Keeps the cookie jar synchronized between all running QgsNetworkAccessManager instances.