### PR TITLE
Load the default relation editor if the relation editor type setting is not set

### DIFF
--- a/python/gui/auto_generated/qgsrelationwidgetregistry.sip.in
+++ b/python/gui/auto_generated/qgsrelationwidgetregistry.sip.in
@@ -70,6 +70,23 @@ Creates a configuration widget
 :param parent: The parent widget for the created widget
 %End
 
+
+    void setDefaultWidgetType( const QString &widgetType );
+%Docstring
+Sets the default editor widget type. Does nothing if the provided widget type is not present.
+
+:param widgetType: The widget type to be used by default.
+
+.. versionadded:: 3.20
+%End
+
+    QString defaultWidgetType() const;
+%Docstring
+Returns the default editor widget type.
+
+.. versionadded:: 3.20
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -16,7 +16,6 @@
 #include "qgsattributewidgetedit.h"
 #include "qgsattributesformproperties.h"
 #include "qgsrelationwidgetregistry.h"
-#include "qgsrelationeditorwidget.h"
 
 
 QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *parent )
@@ -127,23 +126,9 @@ void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const
   }
 
   int widgetTypeIdx = mWidgetTypeComboBox->findData( config.mRelationWidgetType );
-
-  if ( widgetTypeIdx == -1 )
-  {
-    QMap factories = QgsGui::relationWidgetRegistry()->factories();
-    const QStringList factoryNames = factories.keys();
-
-    for ( int i = 0, l = factoryNames.length(); i < l; i++ )
-    {
-      if ( dynamic_cast<QgsRelationEditorWidgetFactory *>( factories[factoryNames[i]] ) )
-      {
-        widgetTypeIdx = i;
-        break;
-      }
-    }
-  }
-
-  mWidgetTypeComboBox->setCurrentIndex( widgetTypeIdx );
+  mWidgetTypeComboBox->setCurrentIndex( widgetTypeIdx >= 0
+                                        ? widgetTypeIdx
+                                        : mWidgetTypeComboBox->findData( QgsGui::relationWidgetRegistry()->defaultWidgetType() ) );
 
   const QString widgetType = mWidgetTypeComboBox->currentData().toString();
   mConfigWidget = QgsGui::relationWidgetRegistry()->createConfigWidget( widgetType, relation, this );

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -16,6 +16,7 @@
 #include "qgsattributewidgetedit.h"
 #include "qgsattributesformproperties.h"
 #include "qgsrelationwidgetregistry.h"
+#include "qgsrelationeditorwidget.h"
 
 
 QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *parent )
@@ -126,7 +127,23 @@ void QgsAttributeWidgetRelationEditWidget::setRelationEditorConfiguration( const
   }
 
   int widgetTypeIdx = mWidgetTypeComboBox->findData( config.mRelationWidgetType );
-  mWidgetTypeComboBox->setCurrentIndex( widgetTypeIdx >= 0 ? widgetTypeIdx : 0 );
+
+  if ( widgetTypeIdx == -1 )
+  {
+    QMap factories = QgsGui::relationWidgetRegistry()->factories();
+    const QStringList factoryNames = factories.keys();
+
+    for ( int i = 0, l = factoryNames.length(); i < l; i++ )
+    {
+      if ( dynamic_cast<QgsRelationEditorWidgetFactory *>( factories[factoryNames[i]] ) )
+      {
+        widgetTypeIdx = i;
+        break;
+      }
+    }
+  }
+
+  mWidgetTypeComboBox->setCurrentIndex( widgetTypeIdx );
 
   const QString widgetType = mWidgetTypeComboBox->currentData().toString();
   mConfigWidget = QgsGui::relationWidgetRegistry()->createConfigWidget( widgetType, relation, this );

--- a/src/gui/qgsrelationwidgetregistry.cpp
+++ b/src/gui/qgsrelationwidgetregistry.cpp
@@ -20,7 +20,9 @@
 
 QgsRelationWidgetRegistry::QgsRelationWidgetRegistry()
 {
-  addRelationWidget( new QgsRelationEditorWidgetFactory() );
+  QgsRelationEditorWidgetFactory *factory = new QgsRelationEditorWidgetFactory();
+  addRelationWidget( factory );
+  setDefaultWidgetType( factory->type() );
 }
 
 QgsRelationWidgetRegistry::~QgsRelationWidgetRegistry()
@@ -42,8 +44,8 @@ void QgsRelationWidgetRegistry::addRelationWidget( QgsAbstractRelationEditorWidg
 
 void QgsRelationWidgetRegistry::removeRelationWidget( const QString &widgetType )
 {
-  // protect the relation editor widget from removing, so the user has at least one relation widget type
-  if ( dynamic_cast<QgsRelationEditorWidgetFactory *>( mRelationWidgetFactories.value( widgetType ) ) )
+  // protect the default relation editor widget from removing, so the user has at least one relation widget type
+  if ( widgetType == mDefaultWidgetType )
     return;
 
   mRelationWidgetFactories.remove( widgetType );
@@ -52,6 +54,19 @@ void QgsRelationWidgetRegistry::removeRelationWidget( const QString &widgetType 
 QStringList QgsRelationWidgetRegistry::relationWidgetNames()
 {
   return mRelationWidgetFactories.keys();
+}
+
+void QgsRelationWidgetRegistry::setDefaultWidgetType( const QString &defaultWidgetType )
+{
+  if ( !mRelationWidgetFactories.contains( defaultWidgetType ) )
+    return;
+
+  mDefaultWidgetType = defaultWidgetType;
+}
+
+QString QgsRelationWidgetRegistry::defaultWidgetType() const
+{
+  return mDefaultWidgetType;
 }
 
 QMap<QString, QgsAbstractRelationEditorWidgetFactory *> QgsRelationWidgetRegistry::factories() const

--- a/src/gui/qgsrelationwidgetregistry.h
+++ b/src/gui/qgsrelationwidgetregistry.h
@@ -79,9 +79,25 @@ class GUI_EXPORT QgsRelationWidgetRegistry
      */
     QgsAbstractRelationEditorConfigWidget *createConfigWidget( const QString &widgetType, const QgsRelation &relation, QWidget *parent = nullptr ) const SIP_TRANSFERBACK;
 
+
+    /**
+     * Sets the default editor widget type. Does nothing if the provided widget type is not present.
+     * \param widgetType The widget type to be used by default.
+     * \since QGIS 3.20
+     */
+    void setDefaultWidgetType( const QString &widgetType );
+
+    /**
+     * Returns the default editor widget type.
+     * \since QGIS 3.20
+     */
+    QString defaultWidgetType() const;
+
   private:
 
     QMap<QString, QgsAbstractRelationEditorWidgetFactory *> mRelationWidgetFactories;
+
+    QString mDefaultWidgetType;
 };
 
 #endif // QGSRELATIONWIDGETREGISTRY_H


### PR DESCRIPTION
The "widget type" from the screenshot above is automatically set to the first relation editor widget in the list, if the type was not explicitly selected before. This this is quite confusing. Now it shows the correct editor, even if the setting is missing.

![image (3)](https://user-images.githubusercontent.com/2820439/121032106-a36f8400-c7b3-11eb-96a9-3296ae200a37.png)
