### PR TITLE
Add QgsProject::dirtySet signal

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1808,7 +1808,7 @@ Emitted when setDirty(true) is called.
    As opposed to :py:func:`~QgsProject.isDirtyChanged`, this signal is invoked every time setDirty(true)
    is called, regardless of whether the project was already dirty.
 
-.. versionadded:: 3.22
+.. versionadded:: 3.20
 %End
 
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1799,6 +1799,18 @@ Emitted when the project dirty status changes.
 .. versionadded:: 3.2
 %End
 
+    void dirtySet();
+%Docstring
+Emitted when setDirty(true) is called.
+
+.. note::
+
+   As opposed to :py:func:`~QgsProject.isDirtyChanged`, this signal is invoked every time setDirty(true)
+   is called, regardless of whether the project was already dirty.
+
+.. versionadded:: 3.22
+%End
+
 
  void mapScalesChanged() /Deprecated/;
 %Docstring

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -520,6 +520,9 @@ void QgsProject::setDirty( const bool dirty )
   if ( dirty && mDirtyBlockCount > 0 )
     return;
 
+  if ( dirty )
+    emit dirtySet();
+
   if ( mDirty == dirty )
     return;
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1829,7 +1829,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note As opposed to isDirtyChanged(), this signal is invoked every time setDirty(true)
      * is called, regardless of whether the project was already dirty.
      *
-     * \since QGIS 3.22
+     * \since QGIS 3.20
      */
     void dirtySet();
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1825,6 +1825,15 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void isDirtyChanged( bool dirty );
 
     /**
+     * Emitted when setDirty(true) is called.
+     * \note As opposed to isDirtyChanged(), this signal is invoked every time setDirty(true)
+     * is called, regardless of whether the project was already dirty.
+     *
+     * \since QGIS 3.22
+     */
+    void dirtySet();
+
+    /**
      * Emitted whenever the project is saved to a qgz file.
      * This can be used to package additional files into the qgz file by modifying the \a files map.
      *

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -39,6 +39,7 @@ class TestQgsProject : public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
 
+    void testDirtySet();
     void testReadPath();
     void testPathResolver();
     void testPathResolverSvg();
@@ -83,6 +84,15 @@ void TestQgsProject::cleanupTestCase()
 {
   // Runs once after all tests are run
   QgsApplication::exitQgis();
+}
+
+void TestQgsProject::testDirtySet()
+{
+  QgsProject p;
+  bool dirtySet = false;
+  connect( &p, &QgsProject::dirtySet, [&] { dirtySet = true; } );
+  p.setDirty( true );
+  QVERIFY( dirtySet );
 }
 
 void TestQgsProject::testReadPath()


### PR DESCRIPTION
Adds a QgsProject::dirtySet signal, emitted when QgsProject::setDirty(true) is invoked.