### PR TITLE
fix crash with 3D mesh terrain

### DIFF
--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -86,18 +86,13 @@ void QgsMeshTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) c
 
 void QgsMeshTerrainGenerator::resolveReferences( const QgsProject &project )
 {
-  mLayer = QgsMapLayerRef( project.mapLayer( mLayer.layerId ) );
-  updateTriangularMesh();
+  setLayer( qobject_cast<QgsMeshLayer *>( project.mapLayer( mLayer.layerId ) ) );
 }
 
 void QgsMeshTerrainGenerator::setLayer( QgsMeshLayer *layer )
 {
   mLayer = QgsMapLayerRef( layer );
   mIsValid = layer != nullptr;
-
-  if ( layer )
-    mTerrainTilingScheme = QgsTilingScheme( layer->extent(), layer->crs() );
-
   updateTriangularMesh();
 }
 
@@ -185,7 +180,10 @@ void QgsMeshTerrainGenerator::updateTriangularMesh()
     QgsCoordinateTransform transform( mCrs, meshLayer()->crs(), mTransformContext );
     meshLayer()->updateTriangularMesh( transform );
     mTriangularMesh = *meshLayer()->triangularMeshByLodIndex( mSymbol->levelOfDetailIndex() );
+    mTerrainTilingScheme = QgsTilingScheme( mTriangularMesh.extent(), mCrs );
   }
+  else
+    mTerrainTilingScheme = QgsTilingScheme();
 }
 
 QgsMesh3DSymbol *QgsMeshTerrainGenerator::symbol() const

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -43,7 +43,6 @@ int QgsTerrainTextureGenerator::render( const QgsRectangle &extent, QgsChunkNode
 
   QgsMapRendererSequentialJob *job = new QgsMapRendererSequentialJob( mapSettings );
   connect( job, &QgsMapRendererJob::finished, this, &QgsTerrainTextureGenerator::onRenderingFinished );
-  job->start();
 
   JobData jobData;
   jobData.jobId = ++mLastJobId;
@@ -52,7 +51,9 @@ int QgsTerrainTextureGenerator::render( const QgsRectangle &extent, QgsChunkNode
   jobData.extent = extent;
   jobData.debugText = debugText;
 
-  mJobs.insert( job, jobData );
+  mJobs.insert( job, jobData ); //store job data just before launching the job
+  job->start();
+
   // QgsDebugMsgLevel( QStringLiteral("added job: %1 .... in queue: %2").arg( jobData.jobId ).arg( jobs.count() ), 2);
   return jobData.jobId;
 }


### PR DESCRIPTION
following this fix https://github.com/qgis/QGIS/pull/43376, 3D view with mesh terrain make QGIS crashes.
Two reasons:
- bad handling of unused but necessary QgsTilingScheme for mesh terrain
- texture terrain generator start rendering before being added to the job container, if the rendering does not really start (invalid map settings), the job is attempted to be removed from the container before be added.

This PR fixes this issue.
