### PR TITLE
Add "Open attribute table (edited or new features)" to main GUI

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditbuffer.sip.in
@@ -118,6 +118,14 @@ Returns a map of new features which are not committed.
 .. seealso:: :py:func:`isFeatureAdded`
 %End
 
+    QgsFeatureIds allAddedOrEditedFeatures() const;
+%Docstring
+Returns a list of the features IDs for all newly added or edited features
+in the buffer.
+
+.. versionadded:: 3.20
+%End
+
     bool isFeatureAdded( QgsFeatureId id ) const;
 %Docstring
 Returns ``True`` if the specified feature ID has been added but not committed.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2710,6 +2710,10 @@ void QgisApp::createActions()
   {
     attributeTable( QgsAttributeTableFilterModel::ShowVisible );
   } );
+  connect( mActionOpenTableEdited, &QAction::triggered, this, [ = ]
+  {
+    attributeTable( QgsAttributeTableFilterModel::ShowEdited );
+  } );
   connect( mActionOpenFieldCalc, &QAction::triggered, this, &QgisApp::fieldCalculator );
   connect( mActionToggleEditing, &QAction::triggered, this, [ = ] { toggleEditing(); } );
   connect( mActionSaveLayerEdits, &QAction::triggered, this, &QgisApp::saveActiveLayerEdits );
@@ -3359,6 +3363,7 @@ void QgisApp::createToolBars()
   bt->addAction( mActionOpenTable );
   bt->addAction( mActionOpenTableSelected );
   bt->addAction( mActionOpenTableVisible );
+  bt->addAction( mActionOpenTableEdited );
 
   QAction *defOpenTableAction = mActionOpenTable;
   switch ( settings.value( QStringLiteral( "UI/openTableTool" ), 0 ).toInt() )
@@ -3371,6 +3376,9 @@ void QgisApp::createToolBars()
       break;
     case 2:
       defOpenTableAction = mActionOpenTableVisible;
+      break;
+    case 3:
+      defOpenTableAction = mActionOpenTableEdited;
       break;
   }
   bt->setDefaultAction( defOpenTableAction );
@@ -4063,6 +4071,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionOpenTable->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTable.svg" ) ) );
   mActionOpenTableSelected->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableSelected.svg" ) ) );
   mActionOpenTableVisible->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableVisible.svg" ) ) );
+  mActionOpenTableEdited->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTableEdited.svg" ) ) );
   mActionOpenFieldCalc->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCalculateField.svg" ) ) );
   mActionMeasure->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasure.svg" ) ) );
   mActionMeasureArea->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasureArea.svg" ) ) );
@@ -14815,6 +14824,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionOpenTable->setEnabled( false );
     mActionOpenTableSelected->setEnabled( false );
     mActionOpenTableVisible->setEnabled( false );
+    mActionOpenTableEdited->setEnabled( false );
     mActionSelectAll->setEnabled( false );
     mActionReselect->setEnabled( false );
     mActionInvertSelection->setEnabled( false );
@@ -14967,6 +14977,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( true );
       mActionOpenTableSelected->setEnabled( true );
       mActionOpenTableVisible->setEnabled( true );
+      mActionOpenTableEdited->setEnabled( true );
       mActionSelectAll->setEnabled( true );
       mActionReselect->setEnabled( true );
       mActionInvertSelection->setEnabled( true );
@@ -15211,6 +15222,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15324,6 +15336,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15391,6 +15404,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -15458,6 +15472,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionOpenTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
       mActionSelectAll->setEnabled( false );
       mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
@@ -16733,6 +16748,8 @@ void QgisApp::toolButtonActionTriggered( QAction *action )
     settings.setValue( QStringLiteral( "UI/openTableTool" ), 1 );
   else if ( action == mActionOpenTableVisible )
     settings.setValue( QStringLiteral( "UI/openTableTool" ), 2 );
+  else if ( action == mActionOpenTableEdited )
+    settings.setValue( QStringLiteral( "UI/openTableTool" ), 3 );
   else if ( action == mActionMeasure )
     settings.setValue( QStringLiteral( "UI/measureTool" ), 0 );
   else if ( action == mActionMeasureArea )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14822,6 +14822,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionSelectByForm->setEnabled( false );
     mActionLabeling->setEnabled( false );
     mActionOpenTable->setEnabled( false );
+    mMenuFilterTable->setEnabled( false );
     mActionOpenTableSelected->setEnabled( false );
     mActionOpenTableVisible->setEnabled( false );
     mActionOpenTableEdited->setEnabled( false );
@@ -14975,6 +14976,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectByExpression->setEnabled( true );
       mActionSelectByForm->setEnabled( true );
       mActionOpenTable->setEnabled( true );
+      mMenuFilterTable->setEnabled( true );
       mActionOpenTableSelected->setEnabled( true );
       mActionOpenTableVisible->setEnabled( true );
       mActionOpenTableEdited->setEnabled( true );
@@ -15220,6 +15222,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( true );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15334,6 +15337,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15402,6 +15406,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );
@@ -15470,6 +15475,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomActualSize->setEnabled( false );
       mActionZoomToLayer->setEnabled( true );
       mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
       mActionOpenTableSelected->setEnabled( false );
       mActionOpenTableVisible->setEnabled( false );
       mActionOpenTableEdited->setEnabled( false );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -56,6 +56,7 @@
 #include "qgsproxyprogresstask.h"
 #include "qgisapp.h"
 #include "qgsorganizetablecolumnsdialog.h"
+#include "qgsvectorlayereditbuffer.h"
 
 QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 {
@@ -192,6 +193,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   else if ( initialMode == QgsAttributeTableFilterModel::ShowSelected )
   {
     r.setFilterFids( layer->selectedFeatureIds() );
+  }
+  else if ( initialMode == QgsAttributeTableFilterModel::ShowEdited )
+  {
+    r.setFilterFids( layer->editBuffer() ? layer->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );
   }
   if ( !needsGeom )
     r.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -315,6 +315,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
       mFeatureFilterWidget->filterSelected();
       break;
 
+    case QgsAttributeTableFilterModel::ShowEdited:
+      mFeatureFilterWidget->filterEdited();
+      break;
+
     case QgsAttributeTableFilterModel::ShowAll:
     default:
       mFeatureFilterWidget->filterShowAll();

--- a/src/core/vector/qgsvectorlayereditbuffer.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffer.cpp
@@ -711,6 +711,11 @@ void QgsVectorLayerEditBuffer::rollBack()
   Q_ASSERT( mAddedFeatures.isEmpty() );
 }
 
+QgsFeatureIds QgsVectorLayerEditBuffer::allAddedOrEditedFeatures() const
+{
+  return qgis::listToSet( mAddedFeatures.keys() ).unite( qgis::listToSet( mChangedAttributeValues.keys() ) ).unite( qgis::listToSet( mChangedGeometries.keys() ) );
+}
+
 #if 0
 QString QgsVectorLayerEditBuffer::dumpEditBuffer()
 {

--- a/src/core/vector/qgsvectorlayereditbuffer.h
+++ b/src/core/vector/qgsvectorlayereditbuffer.h
@@ -115,6 +115,14 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     QgsFeatureMap addedFeatures() const { return mAddedFeatures; }
 
     /**
+     * Returns a list of the features IDs for all newly added or edited features
+     * in the buffer.
+     *
+     * \since QGIS 3.20
+     */
+    QgsFeatureIds allAddedOrEditedFeatures() const;
+
+    /**
      * Returns TRUE if the specified feature ID has been added but not committed.
      * \param id feature ID
      * \see addedFeatures()

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -358,6 +358,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void onSortColumnChanged();
 
     void updateSelectedFeatures();
+    void updateEditedAddedFeatures();
 
     void extentChanged();
 

--- a/src/gui/attributetable/qgsfeaturefilterwidget_p.h
+++ b/src/gui/attributetable/qgsfeaturefilterwidget_p.h
@@ -70,6 +70,7 @@ class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeature
     void filterShowAll();
     void filterSelected();
     void filterVisible();
+    void filterEdited();
 
 
   private slots:
@@ -83,7 +84,6 @@ class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeature
     void storeExpressionButtonInit();
 
     void filterExpressionBuilder();
-    void filterEdited();
     void filterQueryChanged( const QString &query );
     void filterQueryAccepted();
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -216,6 +216,7 @@
     <addaction name="mActionOpenTable"/>
     <addaction name="mActionOpenTableSelected"/>
     <addaction name="mActionOpenTableVisible"/>
+    <addaction name="mActionOpenTableEdited"/>
     <addaction name="mActionToggleEditing"/>
     <addaction name="mActionSaveLayerEdits"/>
     <addaction name="mActionAllEdits"/>
@@ -1705,6 +1706,15 @@ Shift+R to enable range selection.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+F6</string>
+   </property>
+  </action>
+  <action name="mActionOpenTableEdited">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionOpenTableEdited.svg</normaloff>:/images/themes/default/mActionOpenTableEdited.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Open Attribute Table (Edited and New Features)</string>
    </property>
   </action>
   <action name="mActionToggleEditing">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -201,6 +201,14 @@
      <addaction name="mActionAddVectorTileLayer"/>
      <addaction name="mActionAddPointCloudLayer"/>
     </widget>
+    <widget class="QMenu" name="mMenuFilterTable">
+     <property name="title">
+      <string>Filter Attribute Table</string>
+     </property>
+     <addaction name="mActionOpenTableSelected"/>
+     <addaction name="mActionOpenTableVisible"/>
+     <addaction name="mActionOpenTableEdited"/>
+    </widget>
     <addaction name="mActionDataSourceManager"/>
     <addaction name="mNewLayerMenu"/>
     <addaction name="mAddLayerMenu"/>
@@ -214,9 +222,7 @@
     <addaction name="mActionPasteLayer"/>
     <addaction name="separator"/>
     <addaction name="mActionOpenTable"/>
-    <addaction name="mActionOpenTableSelected"/>
-    <addaction name="mActionOpenTableVisible"/>
-    <addaction name="mActionOpenTableEdited"/>
+    <addaction name="mMenuFilterTable"/>
     <addaction name="mActionToggleEditing"/>
     <addaction name="mActionSaveLayerEdits"/>
     <addaction name="mActionAllEdits"/>

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -61,6 +61,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertTrue(layer.startEditing())
 
         self.assertEqual(layer.editBuffer().addedFeatures(), {})
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
         self.assertFalse(layer.editBuffer().isFeatureAdded(1))
         self.assertFalse(layer.editBuffer().isFeatureAdded(3))
 
@@ -86,6 +87,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
 
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[0]))
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[1]))
+        self.assertCountEqual(layer.editBuffer().allAddedOrEditedFeatures(), [new_feature_ids[0], new_feature_ids[1]])
 
         # check if error in case adding not adaptable geometry
         # eg. a Multiline in a Line
@@ -95,6 +97,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().addedFeatures(), {})
         self.assertFalse(layer.editBuffer().isFeatureAdded(1))
         self.assertFalse(layer.editBuffer().isFeatureAdded(3))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         # add a features with a multi line geometry of not touched lines =>
         # cannot be forced to be linestring
@@ -114,6 +117,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertTrue(layer.startEditing())
 
         self.assertEqual(layer.editBuffer().addedFeatures(), {})
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
         self.assertFalse(layer.editBuffer().isFeatureAdded(1))
         self.assertFalse(layer.editBuffer().isFeatureAdded(3))
 
@@ -137,6 +141,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
 
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[0]))
         self.assertTrue(layer.editBuffer().isFeatureAdded(new_feature_ids[1]))
+        self.assertCountEqual(layer.editBuffer().allAddedOrEditedFeatures(), [new_feature_ids[0], new_feature_ids[1]])
 
     def testDeleteFeatures(self):
         # test deleting features from an edit buffer
@@ -218,6 +223,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         # make a layer with two features
         layer = createEmptyLayer()
         self.assertTrue(layer.startEditing())
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         # add two features
         f1 = QgsFeature(layer.fields(), 1)
@@ -236,6 +242,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().changedAttributeValues(), {})
         self.assertFalse(layer.editBuffer().isFeatureAttributesChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureAttributesChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         # change attribute values
         layer.changeAttributeValue(1, 0, 'a')
@@ -245,6 +252,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().changedAttributeValues()[1], {0: 'a'})
         self.assertTrue(layer.editBuffer().isFeatureAttributesChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureAttributesChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1])
 
         layer.changeAttributeValue(2, 1, 5)
 
@@ -254,6 +262,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().changedAttributeValues()[2], {1: 5})
         self.assertTrue(layer.editBuffer().isFeatureAttributesChanged(1))
         self.assertTrue(layer.editBuffer().isFeatureAttributesChanged(2))
+        self.assertCountEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1, 2])
 
     def testChangeGeometry(self):
         # test changing geometries values from an edit buffer
@@ -261,6 +270,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         # make a layer with two features
         layer = createEmptyLayer()
         self.assertTrue(layer.startEditing())
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         # add two features
         f1 = QgsFeature(layer.fields(), 1)
@@ -279,6 +289,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().changedGeometries(), {})
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         # change geometry
         layer.changeGeometry(1, QgsGeometry.fromPointXY(QgsPointXY(10, 20)))
@@ -289,6 +300,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
         self.assertEqual(layer.undoStack().count(), 1)
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 10)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 2)
@@ -304,6 +316,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
         self.assertEqual(layer.undoStack().count(), 2)
+        self.assertCountEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 100)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 2)
@@ -317,6 +330,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(2))
         self.assertEqual(layer.undoStack().count(), 3)
+        self.assertCountEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1, 2])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 100)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 20)
@@ -327,6 +341,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(layer.editBuffer().changedGeometries()[1].constGet().x(), 100)
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 100)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 2)
@@ -335,6 +350,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(list(layer.editBuffer().changedGeometries().keys()), [1])
         self.assertTrue(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [1])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 10)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 2)
@@ -343,6 +359,7 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
         self.assertEqual(list(layer.editBuffer().changedGeometries().keys()), [])
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(1))
         self.assertFalse(layer.editBuffer().isFeatureGeometryChanged(2))
+        self.assertEqual(layer.editBuffer().allAddedOrEditedFeatures(), [])
 
         self.assertEqual(layer.getFeature(1).geometry().constGet().x(), 1)
         self.assertEqual(layer.getFeature(2).geometry().constGet().x(), 2)


### PR DESCRIPTION
Includes https://github.com/qgis/QGIS/pull/43567, but fixes the underlying performance issue associated with using the attribute table in the "edited or added" features filter mode.