### PR TITLE
Fix massive performance regression in attribute table

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayercache.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsVectorLayerCache : QObject
 {
 %Docstring(signature="appended")

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -53,7 +53,7 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
       break;
 
     default:
-      mFeatureIds = mVectorLayerCache->mCacheOrderedKeys;
+      mFeatureIds = QList( mVectorLayerCache->mCacheOrderedKeys.begin(), mVectorLayerCache->mCacheOrderedKeys.end() );
       break;
   }
 

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -53,7 +53,14 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
       break;
 
     default:
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+      mFeatureIds.clear();
+      mFeatureIds.reserve( static_cast< int >( mVectorLayerCache->mCacheOrderedKeys.size() ) );
+      for ( auto it = mVectorLayerCache->mCacheOrderedKeys.begin(); it != mVectorLayerCache->mCacheOrderedKeys.end(); ++it )
+        mFeatureIds << *it;
+#else
       mFeatureIds = QList( mVectorLayerCache->mCacheOrderedKeys.begin(), mVectorLayerCache->mCacheOrderedKeys.end() );
+#endif
       break;
   }
 

--- a/src/core/vector/qgsvectorlayercache.h
+++ b/src/core/vector/qgsvectorlayercache.h
@@ -24,7 +24,8 @@
 #include "qgsfield.h"
 #include "qgsfeaturerequest.h"
 #include "qgsfeatureiterator.h"
-
+#include <unordered_set>
+#include <deque>
 #include <QCache>
 
 class QgsVectorLayer;
@@ -393,13 +394,21 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     {
       QgsCachedFeature *cachedFeature = new QgsCachedFeature( feat, this );
       mCache.insert( feat.id(), cachedFeature );
-      if ( !mCacheOrderedKeys.contains( feat.id() ) )
-        mCacheOrderedKeys << feat.id();
+      if ( mCacheUnorderedKeys.find( feat.id() ) == mCacheUnorderedKeys.end() )
+      {
+        mCacheUnorderedKeys.insert( feat.id() );
+        mCacheOrderedKeys.emplace_back( feat.id() );
+      }
     }
 
     QgsVectorLayer *mLayer = nullptr;
     QCache< QgsFeatureId, QgsCachedFeature > mCache;
-    QList< QgsFeatureId > mCacheOrderedKeys;
+
+    // we need two containers here. One is used for efficient tracking of the IDs which have been added to the cache, the other
+    // is used to store the order of the incoming feature ids, so that we can correctly iterate through features in the original order.
+    // the ordered list alone is far too slow to handle this -- searching for existing items in a list is magnitudes slower than the unordered_set
+    std::unordered_set< QgsFeatureId > mCacheUnorderedKeys;
+    std::deque< QgsFeatureId > mCacheOrderedKeys;
 
     bool mCacheGeometry = true;
     bool mFullCache = false;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -28,6 +28,7 @@
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsapplication.h"
+#include "qgsvectorlayercache.h"
 
 //////////////////
 // Filter Model //

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -27,13 +27,13 @@
 
 #include "qgsconditionalstyle.h"
 #include "qgsattributeeditorcontext.h"
-#include "qgsvectorlayercache.h"
 #include "qgis_gui.h"
 
 class QgsMapCanvas;
 class QgsMapLayerAction;
 class QgsEditorWidgetFactory;
 class QgsFieldFormatter;
+class QgsVectorLayerCache;
 
 /**
  * \ingroup gui
@@ -165,7 +165,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     /**
      * Returns the layer this model uses as backend. Retrieved from the layer cache.
      */
-    inline QgsVectorLayer *layer() const { return mLayerCache ? mLayerCache->layer() : nullptr; }
+    inline QgsVectorLayer *layer() const { return mLayer; }
 
     /**
      * Returns the layer cache this model uses as backend.
@@ -329,6 +329,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     virtual void fieldFormatterRemoved( QgsFieldFormatter *fieldFormatter );
 
   private:
+    QgsVectorLayer *mLayer = nullptr;
     QgsVectorLayerCache *mLayerCache = nullptr;
     int mFieldCount = 0;
 

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsattributetablefiltermodel.h"
 #include "qgsapplication.h"
+#include "qgsvectorlayercache.h"
 
 #include <QItemSelection>
 #include <QSettings>

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -31,6 +31,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerselectionmanager.h"
+#include "qgsvectorlayercache.h"
 
 QgsFeatureListView::QgsFeatureListView( QWidget *parent )
   : QListView( parent )

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -29,8 +29,7 @@
 #include "qgsvectorfilewriter.h"
 #include "qgsfeaturelistmodel.h"
 #include "qgsclipboard.h"
-
-#include "qgstest.h"
+#include "qgsvectorlayercache.h"
 
 /**
  * \ingroup UnitTests

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -27,7 +27,7 @@
 #include <qgsmapcanvas.h>
 #include <qgsfeature.h>
 #include "qgsgui.h"
-
+#include "qgsvectorlayercache.h"
 #include "qgstest.h"
 
 class TestQgsDualView : public QObject


### PR DESCRIPTION
Follow up 56f7812

This commit fixed the ordering of features coming from the
vector layer cache for the attribute table, but came with a massive
speed impact due to the repeated calls QList::contains for
every feature fetched. For any moderately sized table or above
these calls stacked up into multiple minute delays in opening
the table.

Avoid this by tracking the added feature ids in a separate
unordered set, so that we don't need to check through the
ordered list for existing features at all.

Eg a 500k feature gpkg was taking 10 minutes to open the table.
With this optimization that's back down to 20 seconds.