### PR TITLE
Set up cache geometry if HTML widget needs it

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
@@ -48,6 +48,13 @@ Clears the content and makes new initialization
 Sets the HTML code to ``htmlCode``
 %End
 
+    bool needsGeometry() const;
+%Docstring
+Returns true if the widget needs feature geometry
+
+.. versionadded:: 3.20
+%End
+
   public slots:
     virtual void setFeature( const QgsFeature &feature );
 

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -319,9 +319,14 @@ have filter expressions that depend on the parent form scope.
 .. versionadded:: 3.14
 %End
 
+    bool needsGeometry() const;
+%Docstring
+Returns ``True`` if any of the form widgets need feature geometry
+
+.. versionadded:: 3.20
+%End
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -69,7 +69,7 @@ void QgsVectorLayerCache::setCacheGeometry( bool cacheGeometry )
   mCacheGeometry = shouldCacheGeometry;
   if ( cacheGeometry )
   {
-    connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayerCache::geometryChanged );
+    connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayerCache::geometryChanged, Qt::UniqueConnection );
   }
   else
   {

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -130,7 +130,14 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   mLayer = layer;
   mEditorContext = context;
 
-  initLayerCache( !( request.flags() & QgsFeatureRequest::NoGeometry ) || !request.filterRect().isNull() );
+  // create an empty form to find out if it needs geometry or not
+  QgsAttributeForm emptyForm( mLayer, QgsFeature(), mEditorContext );
+
+  const bool needsGeometry = !( request.flags() & QgsFeatureRequest::NoGeometry )
+                             || !request.filterRect().isNull()
+                             || emptyForm.needsGeometry();
+
+  initLayerCache( needsGeometry );
   initModels( mapCanvas, request, loadFeatures );
 
   mConditionalFormatWidget->setLayer( mLayer );

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
@@ -53,6 +53,12 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
     //! Sets the HTML code to \a htmlCode
     void setHtmlCode( const QString &htmlCode );
 
+    /**
+     * Returns true if the widget needs feature geometry
+     * \since QGIS 3.20
+     */
+    bool needsGeometry() const;
+
   public slots:
     void setFeature( const QgsFeature &feature ) override;
 
@@ -64,9 +70,16 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
 #endif
 
   private:
+
+    //! checks if HTML contains geometry related expression
+    void checkGeometryNeeds();
+
     QString mHtmlCode;
     QgsWebView *mWidget = nullptr;
     QgsFeature mFeature;
+    bool mNeedsGeometry = false;
+
+    friend class TestQgsHtmlWidgetWrapper;
 };
 
 
@@ -94,6 +107,34 @@ class HtmlExpression : public QObject
   private:
     QgsExpressionContext mExpressionContext;
 };
+
+/**
+ * \ingroup gui
+ * Evaluate expression when rendering the html content to determine whether we need feature
+ * geometry or not for later evaluation
+ * \since QGIS 3.20
+ */
+class NeedsGeometryEvaluator : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    //! Returns true if the widget needs feature geometry
+    bool needsGeometry() const { return mNeedsGeometry; }
+
+    //! set context use when evaluating expression
+    void setExpressionContext( const QgsExpressionContext &context );
+
+    //! evaluates the value regarding the \a expression and the context
+    Q_INVOKABLE void evaluate( const QString &expression );
+
+  private:
+    bool mNeedsGeometry = false;
+    QgsExpressionContext mExpressionContext;
+};
+
+
 ///@endcond
 #endif //SIP_RUN
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1332,6 +1332,11 @@ void QgsAttributeForm::parentFormValueChanged( const QString &attribute, const Q
   }
 }
 
+bool QgsAttributeForm::needsGeometry() const
+{
+  return mNeedsGeometry;
+}
+
 void QgsAttributeForm::synchronizeState()
 {
   bool isEditable = ( mFeature.isValid()
@@ -1396,6 +1401,7 @@ void QgsAttributeForm::init()
 
   // Cleanup of any previously shown widget, we start from scratch
   QWidget *formWidget = nullptr;
+  mNeedsGeometry = false;
 
   bool buttonBoxVisible = true;
   // Cleanup button box but preserve visibility
@@ -2234,6 +2240,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       newWidgetInfo.labelText = elementDef->name();
       newWidgetInfo.labelOnTop = true;
       newWidgetInfo.showLabel = widgetDef->showLabel();
+      mNeedsGeometry |= htmlWrapper->needsGeometry();
       break;
     }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -331,6 +331,11 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
 
+    /**
+     * Returns TRUE if any of the form widgets need feature geometry
+     * \since QGIS 3.20
+     */
+    bool needsGeometry() const;
 
   private slots:
     void onAttributeChanged( const QVariant &value, const QVariantList &additionalFieldValues );
@@ -516,9 +521,10 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;
 
+    bool mNeedsGeometry = false;
+
     friend class TestQgsDualView;
     friend class TestQgsAttributeForm;
 };
 
 #endif // QGSATTRIBUTEFORM_H
-

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TESTS
   testqgsfieldexpressionwidget.cpp
   testqgsfilewidget.cpp
   testqgsfocuswatcher.cpp
+  testqgshtmlwidgetwrapper.cpp
   testqgsmapcanvas.cpp
   testqgsmessagebar.cpp
   testprojectionissues.cpp

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -19,6 +19,7 @@
 #include <editorwidgets/core/qgseditorwidgetregistry.h>
 #include <attributetable/qgsattributetableview.h>
 #include <attributetable/qgsdualview.h>
+#include <editform/qgsattributeeditorhtmlelement.h>
 #include "qgsattributeform.h"
 #include <qgsapplication.h>
 #include "qgsfeatureiterator.h"
@@ -56,6 +57,9 @@ class TestQgsDualView : public QObject
 
     void testAttributeFormSharedValueScanning();
     void testNoGeom();
+
+    void testHtmlWidget_data();
+    void testHtmlWidget();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
@@ -338,6 +342,50 @@ void TestQgsDualView::testNoGeom()
   model = dv->masterModel();
   QVERIFY( !model->layerCache()->cacheGeometry() );
   QVERIFY( ( model->request().flags() & QgsFeatureRequest::NoGeometry ) );
+}
+
+void TestQgsDualView::testHtmlWidget_data()
+{
+  QTest::addColumn<QString>( "expression" );
+  QTest::addColumn<bool>( "expectedCacheGeometry" );
+
+  QTest::newRow( "with-geometry" ) << "geom_to_wkt($geometry)" << true;
+  QTest::newRow( "without-geometry" ) << "2+pk" << false;
+}
+
+void TestQgsDualView::testHtmlWidget()
+{
+  // check that HTML widget set cache geometry when needed
+
+  QFETCH( QString, expression );
+  QFETCH( bool, expectedCacheGeometry );
+
+  QgsVectorLayer layer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int" ), QStringLiteral( "layer" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( &layer, false, false );
+  QgsFeature f( layer.fields() );
+  f.setAttribute( QStringLiteral( "pk" ), 1 );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT(0.5 0.5)" ) ) );
+  QVERIFY( f.isValid() );
+  QVERIFY( f.geometry().isGeosValid() );
+  QVERIFY( layer.dataProvider()->addFeature( f ) );
+
+  QgsEditFormConfig editFormConfig = layer.editFormConfig();
+  editFormConfig.clearTabs();
+  QgsAttributeEditorHtmlElement *htmlElement = new QgsAttributeEditorHtmlElement( "HtmlWidget", nullptr );
+  htmlElement->setHtmlCode( QStringLiteral( "The text is '<script>document.write(expression.evaluate(\"%1\"));</script>'" ).arg( expression ) );
+  editFormConfig.addTab( htmlElement );
+  editFormConfig.setLayout( QgsEditFormConfig::TabLayout );
+  layer.setEditFormConfig( editFormConfig );
+
+  QgsFeatureRequest request;
+  request.setFlags( QgsFeatureRequest::NoGeometry );
+
+  QgsDualView dualView;
+  dualView.setView( QgsDualView::AttributeEditor );
+  dualView.init( &layer, mCanvas, request );
+  QCOMPARE( dualView.mLayerCache->cacheGeometry(), expectedCacheGeometry );
+
+  QgsProject::instance()->removeMapLayer( &layer );
 }
 
 QGSTEST_MAIN( TestQgsDualView )

--- a/tests/src/gui/testqgshtmlwidgetwrapper.cpp
+++ b/tests/src/gui/testqgshtmlwidgetwrapper.cpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+    testqgshtmlwidgetwrapper.cpp
+     --------------------------------------
+    Date                 : September 2020
+    Copyright            : (C) 2020 Julien Cabieces
+    Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QWebFrame>
+
+#include "qgstest.h"
+
+#include "editorwidgets/core/qgseditorwidgetregistry.h"
+#include "qgsapplication.h"
+#include "qgshtmlwidgetwrapper.h"
+#include "qgsgui.h"
+
+class TestQgsHtmlWidgetWrapper : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsHtmlWidgetWrapper() = default;
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+    void testExpressionEvaluate_data();
+    void testExpressionEvaluate();
+};
+
+void TestQgsHtmlWidgetWrapper::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
+}
+
+void TestQgsHtmlWidgetWrapper::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsHtmlWidgetWrapper::init()
+{
+}
+
+void TestQgsHtmlWidgetWrapper::cleanup()
+{
+}
+
+void TestQgsHtmlWidgetWrapper::testExpressionEvaluate_data()
+{
+  QTest::addColumn<QString>( "expression" );
+  QTest::addColumn<bool>( "needsGeometry" );
+  QTest::addColumn<QString>( "expectedText" );
+
+  QTest::newRow( "with-geometry" ) << "geom_to_wkt($geometry)" << true << "The text is 'Point (0.5 0.5)'";
+  QTest::newRow( "without-geometry" ) << "2+pk" << false << "The text is '3'";
+}
+
+void TestQgsHtmlWidgetWrapper::testExpressionEvaluate()
+{
+  QFETCH( QString, expression );
+  QFETCH( bool, needsGeometry );
+  QFETCH( QString, expectedText );
+
+  QgsVectorLayer layer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int" ), QStringLiteral( "layer" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( &layer, false, false );
+  QgsFeature f( layer.fields() );
+  f.setAttribute( QStringLiteral( "pk" ), 1 );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT(0.5 0.5)" ) ) );
+  QVERIFY( f.isValid() );
+  QVERIFY( f.geometry().isGeosValid() );
+  QVERIFY( layer.dataProvider()->addFeature( f ) );
+
+  QgsHtmlWidgetWrapper *htmlWrapper = new QgsHtmlWidgetWrapper( &layer, nullptr, nullptr );
+  htmlWrapper->setHtmlCode( QStringLiteral( "The text is '<script>document.write(expression.evaluate(\"%1\"));</script>'" ).arg( expression ) );
+
+  QgsWebView *webView = qobject_cast<QgsWebView *>( htmlWrapper->widget() );
+  Q_ASSERT( webView );
+  QCOMPARE( htmlWrapper->needsGeometry(), needsGeometry );
+
+  htmlWrapper->setFeature( f );
+
+  QCOMPARE( webView->page()->mainFrame()->toPlainText(), expectedText );
+
+  QgsProject::instance()->removeMapLayer( &layer );
+}
+
+QGSTEST_MAIN( TestQgsHtmlWidgetWrapper )
+#include "testqgshtmlwidgetwrapper.moc"


### PR DESCRIPTION
Supersedes #39041 and fixes #34791

It's possible to define a geometry based expression in HTML widget, but if the vector layer cache doesn't require geometry the expression will fail. This PR propose to run an html rendering to guess if the expression needs the geometry and then set up the cache geometry option on the vector layer cache.