### PR TITLE
Allow building qgis_native as static library

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 #############################################################
 # qgis_native library
 
-add_library(qgis_native SHARED ${QGIS_NATIVE_SRCS} ${QGIS_NATIVE_HDRS})
+add_library(qgis_native ${LIBRARY_TYPE} ${QGIS_NATIVE_SRCS} ${QGIS_NATIVE_HDRS})
 set_property(TARGET qgis_native PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # require c++17


### PR DESCRIPTION
@PeterPetrik was there a reason to introduce `${LIBRARY_TYPE}` and `FORCE_STATIC_LIBS` instead of using standard `BUILD_SHARED_LIBS` https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html?