### PR TITLE
Fix massive performance regression in attribute table

### DIFF
--- a/python/core/auto_generated/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/qgsvectorlayercache.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsVectorLayerCache : QObject
 {
 %Docstring


### PR DESCRIPTION
Follow up 56f7812ca1e

This commit fixed the ordering of features coming from the
vector layer cache for the attribute table, but came with a massive
speed impact due to the repeated calls QList::contains for
every feature fetched. For any moderately sized table or above
these calls stacked up into multiple minute delays in opening
the table.

Avoid this by tracking the added feature ids in a separate
unordered set, so that we don't need to check through the
ordered list for existing features at all.

Eg a 500k feature gpkg was taking 10 minutes to open the table.
With this optimization that's back down to 20 seconds.

Manual backport of https://github.com/qgis/QGIS/pull/43606