### PR TITLE
Fix "force layer to render as raster" setting wasn't correctly copied with cloned renderers

### DIFF
--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -501,7 +501,6 @@ QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::clone() const
   {
     r->setSourceColorRamp( mSourceColorRamp->clone() );
   }
-  r->setUsingSymbolLevels( usingSymbolLevels() );
   r->setDataDefinedSizeLegend( mDataDefinedSizeLegend ? new QgsDataDefinedSizeLegend( *mDataDefinedSizeLegend ) : nullptr );
 
   copyRendererData( r );

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -316,7 +316,6 @@ QgsGraduatedSymbolRenderer *QgsGraduatedSymbolRenderer::clone() const
   {
     r->setSourceColorRamp( mSourceColorRamp->clone() );
   }
-  r->setUsingSymbolLevels( usingSymbolLevels() );
   r->setDataDefinedSizeLegend( mDataDefinedSizeLegend ? new QgsDataDefinedSizeLegend( *mDataDefinedSizeLegend ) : nullptr );
   r->setGraduatedMethod( graduatedMethod() );
   copyRendererData( r );

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -52,17 +52,15 @@ void QgsFeatureRenderer::copyRendererData( QgsFeatureRenderer *destRenderer ) co
     return;
 
   destRenderer->setPaintEffect( mPaintEffect->clone() );
+  destRenderer->setForceRasterRender( mForceRaster );
+  destRenderer->setUsingSymbolLevels( mUsingSymbolLevels );
   destRenderer->mOrderBy = mOrderBy;
   destRenderer->mOrderByEnabled = mOrderByEnabled;
 }
 
 QgsFeatureRenderer::QgsFeatureRenderer( const QString &type )
   : mType( type )
-  , mUsingSymbolLevels( false )
   , mCurrentVertexMarkerType( QgsVectorLayer::Cross )
-  , mCurrentVertexMarkerSize( 2 )
-  , mForceRaster( false )
-  , mOrderByEnabled( false )
 {
   mPaintEffect = QgsPaintEffectRegistry::defaultStack();
   mPaintEffect->setEnabled( false );

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -519,16 +519,16 @@ class CORE_EXPORT QgsFeatureRenderer
 
     QString mType;
 
-    bool mUsingSymbolLevels;
+    bool mUsingSymbolLevels = false;
 
     //! The current type of editing marker
     int mCurrentVertexMarkerType;
     //! The current size of editing marker
-    double mCurrentVertexMarkerSize;
+    double mCurrentVertexMarkerSize = 2;
 
     QgsPaintEffect *mPaintEffect = nullptr;
 
-    bool mForceRaster;
+    bool mForceRaster = false;
 
     /**
      * \note this function is used to convert old sizeScale expressions to symbol
@@ -544,7 +544,7 @@ class CORE_EXPORT QgsFeatureRenderer
 
     QgsFeatureRequest::OrderBy mOrderBy;
 
-    bool mOrderByEnabled;
+    bool mOrderByEnabled = false;
 
   private:
 #ifdef SIP_RUN

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1055,7 +1055,6 @@ QgsRuleBasedRenderer *QgsRuleBasedRenderer::clone() const
 
   QgsRuleBasedRenderer *r = new QgsRuleBasedRenderer( clonedRoot );
 
-  r->setUsingSymbolLevels( usingSymbolLevels() );
   copyRendererData( r );
   return r;
 }

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -112,7 +112,6 @@ QString QgsSingleSymbolRenderer::dump() const
 QgsSingleSymbolRenderer *QgsSingleSymbolRenderer::clone() const
 {
   QgsSingleSymbolRenderer *r = new QgsSingleSymbolRenderer( mSymbol->clone() );
-  r->setUsingSymbolLevels( usingSymbolLevels() );
   r->setDataDefinedSizeLegend( mDataDefinedSizeLegend ? new QgsDataDefinedSizeLegend( *mDataDefinedSizeLegend ) : nullptr );
   copyRendererData( r );
   return r;


### PR DESCRIPTION
And move more common code to QgsFeatureRenderer::copyRendererData

Fixes #43535
Manual backport of https://github.com/qgis/QGIS/pull/43612