### PR TITLE
Simplify "CASE WHEN..." expressions

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -287,7 +287,7 @@ after any compilation optimizations have been applied.
 
 Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
 be replaced entirely by a :py:class:`QgsExpressionNodeColumnRef` referencing the "some_field" field, as the
-CASE WHEN ... will ALWAYS evalute to "some_field".
+CASE WHEN ... will ALWAYS evaluate to "some_field".
 
 Returns a reference to the current object if no optimizations were applied.
 
@@ -299,6 +299,9 @@ Returns a reference to the current object if no optimizations were applied.
     QgsExpressionNode();
 
     QgsExpressionNode( const QgsExpressionNode &other );
+%Docstring
+Copy constructor
+%End
 
 
 

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -280,7 +280,25 @@ Returns the node's static cached value. Only valid if :py:func:`~QgsExpressionNo
 .. versionadded:: 3.18
 %End
 
+    const QgsExpressionNode *effectiveNode() const;
+%Docstring
+Returns a reference to the simplest node which represents this node,
+after any compilation optimizations have been applied.
+
+Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
+be replaced entirely by a :py:class:`QgsExpressionNodeColumnRef` referencing the "some_field" field, as the
+CASE WHEN ... will ALWAYS evalute to "some_field".
+
+Returns a reference to the current object if no optimizations were applied.
+
+.. versionadded:: 3.20
+%End
+
   protected:
+
+    QgsExpressionNode();
+
+    QgsExpressionNode( const QgsExpressionNode &other );
 
 
 

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -297,6 +297,9 @@ Returns a reference to the current object if no optimizations were applied.
   protected:
 
     QgsExpressionNode();
+%Docstring
+Constructor.
+%End
 
     QgsExpressionNode( const QgsExpressionNode &other );
 %Docstring

--- a/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -32,6 +32,12 @@ A node unary operator is modifying the value of ``operand`` by negating it with 
 %End
     ~QgsExpressionNodeUnaryOperator();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeUnaryOperator: %1>" ).arg( sipCpp->text() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     QgsExpressionNodeUnaryOperator::UnaryOperator op() const;
 %Docstring
 Returns the unary operator.
@@ -121,6 +127,12 @@ A binary expression operator, which operates on two values.
 Binary combination of the left and the right with op.
 %End
     ~QgsExpressionNodeBinaryOperator();
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeBinaryOperator: %1>" ).arg( sipCpp->text() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
 
     QgsExpressionNodeBinaryOperator::BinaryOperator op() const;
 %Docstring
@@ -311,6 +323,22 @@ a list of arguments that will be passed to it.
 
     ~QgsExpressionNodeFunction();
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString function;
+    if ( QgsExpressionFunction *fd = QgsExpression::QgsExpression::Functions()[sipCpp->fnIndex()] )
+    {
+      function = fd->name();
+    }
+    else
+    {
+      function = QString::number( sipCpp->fnIndex() );
+    }
+
+    QString str = QStringLiteral( "<QgsExpressionNodeFunction: %1>" ).arg( function );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     int fnIndex() const;
 %Docstring
 Returns the index of the node's function.
@@ -365,6 +393,12 @@ An expression node for literal values.
 Constructor for QgsExpressionNodeLiteral, with the specified literal ``value``.
 %End
 
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeLiteral: %1>" ).arg( sipCpp->valueAsString() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
     QVariant value() const;
 %Docstring
 The value of the literal.
@@ -391,6 +425,13 @@ The value of the literal.
     virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
 
 
+    QString valueAsString() const;
+%Docstring
+Returns a string representation of the node's literal value.
+
+.. versionadded:: 3.20
+%End
+
 };
 
 class QgsExpressionNodeColumnRef : QgsExpressionNode
@@ -408,6 +449,12 @@ An expression node which takes it value from a feature's field.
 %Docstring
 Constructor for QgsExpressionNodeColumnRef, referencing the column
 with the specified ``name``.
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeColumnRef: \"%1\">" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
     QString name() const;

--- a/src/app/labeling/qgslabelpropertydialog.h
+++ b/src/app/labeling/qgslabelpropertydialog.h
@@ -37,6 +37,7 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
                             const QString &labelText,
                             bool isPinned,
                             const QgsPalLayerSettings &layerSettings,
+                            QgsMapCanvas *canvas,
                             QWidget *parent = nullptr,
                             Qt::WindowFlags f = Qt::WindowFlags() );
 
@@ -89,6 +90,8 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     //! Block / unblock all input element signals
     void blockElementSignals( bool block );
 
+    int dataDefinedColumnIndex( QgsPalLayerSettings::Property p, const QgsVectorLayer *vlayer, const QgsExpressionContext &context ) const;
+
     void setDataDefinedValues( QgsVectorLayer *vlayer );
     void enableDataDefinedWidgets( QgsVectorLayer *vlayer );
 
@@ -107,8 +110,11 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
 
     void enableWidgetsForPinnedLabels();
 
+    QgsMapCanvas *mCanvas = nullptr;
+
     QgsAttributeMap mChangedProperties;
     QgsPropertyCollection mDataDefinedProperties;
+    QMap< int, int > mPropertyToFieldMap;
     QFont mLabelFont;
 
     QFontDatabase mFontDB;

--- a/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
@@ -111,6 +111,7 @@ void QgsMapToolChangeLabelProperties::canvasReleaseEvent( QgsMapMouseEvent *e )
                               labeltext,
                               mCurrentLabel.pos.isPinned,
                               mCurrentLabel.settings,
+                              mCanvas,
                               nullptr );
     d.setMapCanvas( canvas() );
 

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -35,6 +35,7 @@
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsstatusbar.h"
 #include "qgslabelingresults.h"
+#include "qgsexpressionnodeimpl.h"
 
 #include <QMouseEvent>
 
@@ -500,21 +501,50 @@ bool QgsMapToolLabel::hasDataDefinedColumn( QgsPalLayerSettings::DataDefinedProp
 }
 #endif
 
-QString QgsMapToolLabel::dataDefinedColumnName( QgsPalLayerSettings::Property p, const QgsPalLayerSettings &labelSettings ) const
+QString QgsMapToolLabel::dataDefinedColumnName( QgsPalLayerSettings::Property p, const QgsPalLayerSettings &labelSettings, const QgsVectorLayer *layer ) const
 {
   if ( !labelSettings.dataDefinedProperties().isActive( p ) )
     return QString();
 
-  QgsProperty prop = labelSettings.dataDefinedProperties().property( p );
-  if ( prop.propertyType() != QgsProperty::FieldBasedProperty )
-    return QString();
+  const QgsProperty property = labelSettings.dataDefinedProperties().property( p );
 
-  return prop.field();
+  switch ( property.propertyType() )
+  {
+    case QgsProperty::InvalidProperty:
+    case QgsProperty::StaticProperty:
+      break;
+
+    case QgsProperty::FieldBasedProperty:
+      return property.field();
+
+    case QgsProperty::ExpressionBasedProperty:
+    {
+      // an expression based property may still be a effectively a single field reference in the map canvas context.
+      // e.g. if it is a expression like '"some_field"', or 'case when @some_project_var = 'a' then "field_a" else "field_b" end'
+
+      QgsExpressionContext context = mCanvas->createExpressionContext();
+      context.appendScope( layer->createExpressionContextScope() );
+
+      QgsExpression expression( property.expressionString() );
+      if ( expression.prepare( &context ) )
+      {
+        const QgsExpressionNode *node = expression.rootNode()->effectiveNode();
+        if ( node->nodeType() == QgsExpressionNode::ntColumnRef )
+        {
+          const QgsExpressionNodeColumnRef *columnRef = qgis::down_cast<const QgsExpressionNodeColumnRef *>( node );
+          return columnRef->name();
+        }
+      }
+      break;
+    }
+  }
+
+  return QString();
 }
 
 int QgsMapToolLabel::dataDefinedColumnIndex( QgsPalLayerSettings::Property p, const QgsPalLayerSettings &labelSettings, const QgsVectorLayer *vlayer ) const
 {
-  QString fieldname = dataDefinedColumnName( p, labelSettings );
+  QString fieldname = dataDefinedColumnName( p, labelSettings, vlayer );
   if ( !fieldname.isEmpty() )
     return vlayer->fields().lookupField( fieldname );
   return -1;
@@ -595,7 +625,7 @@ bool QgsMapToolLabel::layerIsRotatable( QgsVectorLayer *vlayer, int &rotationCol
 
 bool QgsMapToolLabel::labelIsRotatable( QgsVectorLayer *layer, const QgsPalLayerSettings &settings, int &rotationCol ) const
 {
-  QString rColName = dataDefinedColumnName( QgsPalLayerSettings::LabelRotation, settings );
+  QString rColName = dataDefinedColumnName( QgsPalLayerSettings::LabelRotation, settings, layer );
   rotationCol = layer->fields().lookupField( rColName );
   return rotationCol != -1;
 }
@@ -717,8 +747,8 @@ bool QgsMapToolLabel::labelMoveable( QgsVectorLayer *vlayer, int &xCol, int &yCo
 
 bool QgsMapToolLabel::labelMoveable( QgsVectorLayer *vlayer, const QgsPalLayerSettings &settings, int &xCol, int &yCol ) const
 {
-  QString xColName = dataDefinedColumnName( QgsPalLayerSettings::PositionX, settings );
-  QString yColName = dataDefinedColumnName( QgsPalLayerSettings::PositionY, settings );
+  QString xColName = dataDefinedColumnName( QgsPalLayerSettings::PositionX, settings, vlayer );
+  QString yColName = dataDefinedColumnName( QgsPalLayerSettings::PositionY, settings, vlayer );
   //return !xColName.isEmpty() && !yColName.isEmpty();
   xCol = vlayer->fields().lookupField( xColName );
   yCol = vlayer->fields().lookupField( yColName );
@@ -743,7 +773,7 @@ bool QgsMapToolLabel::labelCanShowHide( QgsVectorLayer *vlayer, int &showCol ) c
   for ( const QString &providerId : constSubProviders )
   {
     QString fieldname = dataDefinedColumnName( QgsPalLayerSettings::Show,
-                        vlayer->labeling()->settings( providerId ) );
+                        vlayer->labeling()->settings( providerId ), vlayer );
     showCol = vlayer->fields().lookupField( fieldname );
     if ( showCol != -1 )
       return true;

--- a/src/app/labeling/qgsmaptoollabel.h
+++ b/src/app/labeling/qgsmaptoollabel.h
@@ -164,7 +164,7 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
     QFont currentLabelFont();
 
     //! Returns a data defined attribute column name for particular property or empty string if not defined
-    QString dataDefinedColumnName( QgsPalLayerSettings::Property p, const QgsPalLayerSettings &labelSettings ) const;
+    QString dataDefinedColumnName( QgsPalLayerSettings::Property p, const QgsPalLayerSettings &labelSettings, const QgsVectorLayer *layer ) const;
 
     /**
      * Returns a data defined attribute column index

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -345,6 +345,9 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
 
   protected:
 
+    /**
+     * Constructor.
+     */
     QgsExpressionNode() = default;
 
     //! Copy constructor

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -329,7 +329,26 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
      */
     QVariant cachedStaticValue() const { return mCachedStaticValue; }
 
+    /**
+     * Returns a reference to the simplest node which represents this node,
+     * after any compilation optimizations have been applied.
+     *
+     * Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
+     * be replaced entirely by a QgsExpressionNodeColumnRef referencing the "some_field" field, as the
+     * CASE WHEN ... will ALWAYS evalute to "some_field".
+     *
+     * Returns a reference to the current object if no optimizations were applied.
+     *
+     * \since QGIS 3.20
+     */
+    const QgsExpressionNode *effectiveNode() const { return mCompiledSimplifiedNode ? mCompiledSimplifiedNode.get() : this; }
+
   protected:
+
+    QgsExpressionNode() = default;
+
+    QgsExpressionNode( const QgsExpressionNode &other );
+    QgsExpressionNode &operator=( const QgsExpressionNode &other );
 
     /**
      * Copies the members of this node to the node provided in \a target.
@@ -357,6 +376,18 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
      * \since QGIS 3.20
      */
     mutable QVariant mCachedStaticValue;
+
+    /**
+     * Contains a compiled node which represents a simplified version of this node
+     * as a result of compilation optimizations.
+     *
+     * Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
+     * be replaced entirely by a QgsExpressionNodeColumnRef referencing the "some_field" field, as the
+     * CASE WHEN ... will ALWAYS evalute to "some_field".
+     *
+     * \since QGIS 3.20
+     */
+    mutable std::unique_ptr< QgsExpressionNode > mCompiledSimplifiedNode;
 #endif
 
   private:

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -335,7 +335,7 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
      *
      * Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
      * be replaced entirely by a QgsExpressionNodeColumnRef referencing the "some_field" field, as the
-     * CASE WHEN ... will ALWAYS evalute to "some_field".
+     * CASE WHEN ... will ALWAYS evaluate to "some_field".
      *
      * Returns a reference to the current object if no optimizations were applied.
      *
@@ -347,7 +347,9 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
 
     QgsExpressionNode() = default;
 
+    //! Copy constructor
     QgsExpressionNode( const QgsExpressionNode &other );
+    //! Assignment operator
     QgsExpressionNode &operator=( const QgsExpressionNode &other );
 
     /**
@@ -383,7 +385,7 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
      *
      * Eg. a node like "CASE WHEN true THEN "some_field" WHEN other condition THEN ... END" can effectively
      * be replaced entirely by a QgsExpressionNodeColumnRef referencing the "some_field" field, as the
-     * CASE WHEN ... will ALWAYS evalute to "some_field".
+     * CASE WHEN ... will ALWAYS evaluate to "some_field".
      *
      * \since QGIS 3.20
      */

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -1345,7 +1345,7 @@ bool QgsExpressionNodeLiteral::prepareNode( QgsExpression *parent, const QgsExpr
 }
 
 
-QString QgsExpressionNodeLiteral::dump() const
+QString QgsExpressionNodeLiteral::valueAsString() const
 {
   if ( mValue.isNull() )
     return QStringLiteral( "NULL" );
@@ -1365,6 +1365,11 @@ QString QgsExpressionNodeLiteral::dump() const
     default:
       return tr( "[unsupported type: %1; value: %2]" ).arg( mValue.typeName(), mValue.toString() );
   }
+}
+
+QString QgsExpressionNodeLiteral::dump() const
+{
+  return valueAsString();
 }
 
 QSet<QString> QgsExpressionNodeLiteral::referencedColumns() const

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -47,6 +47,14 @@ class CORE_EXPORT QgsExpressionNodeUnaryOperator : public QgsExpressionNode
     {}
     ~QgsExpressionNodeUnaryOperator() override { delete mOperand; }
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeUnaryOperator: %1>" ).arg( sipCpp->text() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns the unary operator.
      */
@@ -139,6 +147,14 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
       , mOpRight( opRight )
     {}
     ~QgsExpressionNodeBinaryOperator() override { delete mOpLeft; delete mOpRight; }
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeBinaryOperator: %1>" ).arg( sipCpp->text() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
     /**
      * Returns the binary operator.
@@ -325,6 +341,24 @@ class CORE_EXPORT QgsExpressionNodeFunction : public QgsExpressionNode
 
     ~QgsExpressionNodeFunction() override;
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString function;
+    if ( QgsExpressionFunction *fd = QgsExpression::QgsExpression::Functions()[sipCpp->fnIndex()] )
+    {
+      function = fd->name();
+    }
+    else
+    {
+      function = QString::number( sipCpp->fnIndex() );
+    }
+
+    QString str = QStringLiteral( "<QgsExpressionNodeFunction: %1>" ).arg( function );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     /**
      * Returns the index of the node's function.
      */
@@ -372,6 +406,14 @@ class CORE_EXPORT QgsExpressionNodeLiteral : public QgsExpressionNode
       : mValue( value )
     {}
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeLiteral: %1>" ).arg( sipCpp->valueAsString() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
     //! The value of the literal.
     inline QVariant value() const { return mValue; }
 
@@ -388,6 +430,13 @@ class CORE_EXPORT QgsExpressionNodeLiteral : public QgsExpressionNode
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
+
+    /**
+     * Returns a string representation of the node's literal value.
+     *
+     * \since QGIS 3.20
+     */
+    QString valueAsString() const;
 
   private:
     QVariant mValue;
@@ -409,6 +458,14 @@ class CORE_EXPORT QgsExpressionNodeColumnRef : public QgsExpressionNode
       : mName( name )
       , mIndex( -1 )
     {}
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsExpressionNodeColumnRef: \"%1\">" ).arg( sipCpp->name() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
 
     //! The name of the column.
     QString name() const { return mName; }

--- a/tests/src/app/testqgslabelpropertydialog.cpp
+++ b/tests/src/app/testqgslabelpropertydialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsauxiliarystorage.h"
 #include "qgslabelpropertydialog.h"
 #include "qgsvectorlayerlabeling.h"
+#include "qgsmapcanvas.h"
 
 class TestQgsLabelPropertyDialog : public QObject
 {
@@ -80,8 +81,10 @@ class TestQgsLabelPropertyDialog : public QObject
       QgsFeatureId fid = 0;
       QVariant val = vl->getFeature( fid ).attribute( propName );
 
+      std::unique_ptr< QgsMapCanvas > mapCanvas = std::make_unique< QgsMapCanvas >();
+
       // init label property dialog and togle buffer draw
-      QgsLabelPropertyDialog dialog( vl->id(), QString(), fid, QFont(), QString(), false, settings );
+      QgsLabelPropertyDialog dialog( vl->id(), QString(), fid, QFont(), QString(), false, settings, mapCanvas.get() );
       dialog.bufferDrawToggled( true );
 
       // apply changes


### PR DESCRIPTION
This PR has two (related) parts:

## Simplify "CASE WHEN..." expressions during preparation wherever possible

In many situations we are able to optimize a case when expression
and replace it with a simpler expression node during the preparation
stage. Specifically, if the WHEN conditions are known to be
static values (such as those coming from certain expression context
variables) then we can often replace the whole condition node
with the THEN node of the first static true condition.

E.g.

    CASE
        WHEN @variable=1 THEN "first_field"
        WHEN @variable=2 THEN "second_field"
        ELSE "third_field"
    END

If @variable is static and '1', then the whole expression node will ALWAYS
be identical to "first_field". Similiarly if @variable='2', then the
whole expression will ALWAYS be "second_field".

If we're able to apply this optimization, then we use the simplified
effective node which represents the whole node during evaluation
time and save a bunch of unnecessary work.

(TODO: If we use the effective node during expression compilation
for providers we would be able to handoff more expressions involving
QGIS-side variables and other components to the backend, resulting
in increased use of backend provider indices, etc....)

## Labeling tool fixes
Using the framework from the expression node changes, the interactive labeling tools have been fixed to work correctly with data defined properties which aren't bound to fields, but which are still effectively representing a single column name.

Eg.

    CASE WHEN @map_id = 'map 1' then "label_x_pos_map1" WHEN @map_id='map 2' then "label_x_pos_map2" END

The label tools now correctly recognize that this is a valid expression which simplifies down to a single column reference, and now store the results of the label edit in the correct linked column