### PR TITLE
Fix formatting of exception blocks in PyQGIS docs

### DIFF
--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -95,7 +95,7 @@ Returns the curve polygon's exterior ring.
 %Docstring
 Retrieves an interior ring from the curve polygon. The first interior ring has index 0.
 
-An IndexError will be raised if no interior ring with the specified index exists.
+:raises IndexError: if no interior ring with the specified index exists.
 
 .. seealso:: :py:func:`numInteriorRings`
 
@@ -151,7 +151,7 @@ Removes an interior ring from the polygon. The first interior ring has index 0.
 The corresponding ring is removed from the polygon and deleted.
 It is not possible to remove the exterior ring using this method.
 
-An IndexError will be raised if no interior ring with the specified index exists.
+:raises IndexError: if no interior ring with the specified index exists.
 
 .. seealso:: :py:func:`removeInteriorRings`
 %End

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -95,7 +95,7 @@ Returns the curve polygon's exterior ring.
 %Docstring
 Retrieves an interior ring from the curve polygon. The first interior ring has index 0.
 
-:raises IndexError: if no interior ring with the specified index exists.
+:raises `IndexError` if no interior ring with the specified index exists.
 
 .. seealso:: :py:func:`numInteriorRings`
 
@@ -151,7 +151,7 @@ Removes an interior ring from the polygon. The first interior ring has index 0.
 The corresponding ring is removed from the polygon and deleted.
 It is not possible to remove the exterior ring using this method.
 
-:raises IndexError: if no interior ring with the specified index exists.
+:raises `IndexError` if no interior ring with the specified index exists.
 
 .. seealso:: :py:func:`removeInteriorRings`
 %End

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1694,9 +1694,11 @@ Returns a list of ``count`` random points generated inside a (multi)polygon geom
 Optionally, a specific random ``seed`` can be used when generating points. If ``seed``
 is 0, then a completely random sequence of points will be generated.
 
-This method works only with (multi)polygon geometry types. If the geometry
-is not a polygon type, a TypeError will be raised. If the geometry
-is null, a ValueError will be raised.
+This method works only with (multi)polygon geometry types.
+
+:raises TypeError: if the geometry is not a polygon type
+
+:raises ValueError: if the geometry is null
 
 .. versionadded:: 3.10
 %End
@@ -1823,9 +1825,11 @@ Returns the contents of the geometry as a 2-dimensional point.
 
 Any z or m values present in the geometry will be discarded.
 
-This method works only with single-point geometry types. If the geometry
-is not a single-point type, a TypeError will be raised. If the geometry
-is null, a ValueError will be raised.
+This method works only with single-point geometry types.
+
+:raises TypeError: if the geometry is not a single-point type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1853,9 +1857,11 @@ Returns the contents of the geometry as a polyline.
 Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
 (such as a CircularString), it will be automatically segmentized.
 
-This method works only with single-line (or single-curve) geometry types. If the geometry
-is not a single-line type, a TypeError will be raised. If the geometry is null, a ValueError
-will be raised.
+This method works only with single-line (or single-curve).
+
+:raises TypeError: if the geometry is not a single-line type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1884,9 +1890,11 @@ Returns the contents of the geometry as a polygon.
 Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
 (such as a CurvePolygon), it will be automatically segmentized.
 
-This method works only with single-polygon (or single-curve polygon) geometry types. If the geometry
-is not a single-polygon type, a TypeError will be raised. If the geometry is null, a ValueError
-will be raised.
+This method works only with single-polygon (or single-curve polygon) geometry types.
+
+:raises TypeError: if the geometry is not a single-polygon type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1914,9 +1922,11 @@ Returns the contents of the geometry as a multi-point.
 
 Any z or m values present in the geometry will be discarded.
 
-This method works only with multi-point geometry types. If the geometry
-is not a multi-point type, a TypeError will be raised. If the geometry is null, a ValueError
-will be raised.
+This method works only with multi-point geometry types.
+
+:raises TypeError: if the geometry is not a multi-point type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1945,9 +1955,11 @@ Returns the contents of the geometry as a multi-linestring.
 Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
 (such as a MultiCurve), it will be automatically segmentized.
 
-This method works only with multi-linestring (or multi-curve) geometry types. If the geometry
-is not a multi-linestring type, a TypeError will be raised. If the geometry is null, a ValueError
-will be raised.
+This method works only with multi-linestring (or multi-curve) geometry types.
+
+:raises TypeError: if the geometry is not a multi-linestring type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1976,9 +1988,11 @@ Returns the contents of the geometry as a multi-polygon.
 Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
 (such as a MultiSurface), it will be automatically segmentized.
 
-This method works only with multi-polygon (or multi-curve polygon) geometry types. If the geometry
-is not a multi-polygon type, a TypeError will be raised. If the geometry is null, a ValueError
-will be raised.
+This method works only with multi-polygon (or multi-curve polygon) geometry types.
+
+:raises TypeError: if the geometry is not a multi-polygon type
+
+:raises ValueError: if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -577,7 +577,7 @@ In case of error -1 will be returned.
 
 This method requires a QGIS build based on GEOS 3.7 or later.
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
 
 .. seealso:: :py:func:`frechetDistanceDensify`
 
@@ -603,7 +603,7 @@ distance returned approach the true Fréchet distance for the geometries.
 
 This method requires a QGIS build based on GEOS 3.7 or later.
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.6 or earlier.
 
 .. seealso:: :py:func:`frechetDistance`
 
@@ -1415,7 +1415,7 @@ This method requires QGIS builds based on GEOS 3.9 or later.
 
    the ``tolerance`` value must be a value greater than 0, or the algorithm may never converge on a solution
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.8 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.8 or earlier.
 
 
 .. versionadded:: 3.20
@@ -1432,7 +1432,7 @@ can be moved through, with a single rotation.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 
 .. versionadded:: 3.20
 %End
@@ -1455,7 +1455,7 @@ If an error occurs while calculating the clearance NaN will be returned.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 
 .. versionadded:: 3.20
 %End
@@ -1468,7 +1468,7 @@ If the geometry has no minimum clearance, an empty LineString will be returned.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on GEOS 3.5 or earlier.
 
 .. versionadded:: 3.20
 %End
@@ -1696,9 +1696,9 @@ is 0, then a completely random sequence of points will be generated.
 
 This method works only with (multi)polygon geometry types.
 
-:raises TypeError: if the geometry is not a polygon type
+:raises `TypeError` if the geometry is not a polygon type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 
 .. versionadded:: 3.10
 %End
@@ -1827,9 +1827,9 @@ Any z or m values present in the geometry will be discarded.
 
 This method works only with single-point geometry types.
 
-:raises TypeError: if the geometry is not a single-point type
+:raises `TypeError` if the geometry is not a single-point type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1859,9 +1859,9 @@ Any z or m values present in the geometry will be discarded. If the geometry is 
 
 This method works only with single-line (or single-curve).
 
-:raises TypeError: if the geometry is not a single-line type
+:raises `TypeError` if the geometry is not a single-line type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1892,9 +1892,9 @@ Any z or m values present in the geometry will be discarded. If the geometry is 
 
 This method works only with single-polygon (or single-curve polygon) geometry types.
 
-:raises TypeError: if the geometry is not a single-polygon type
+:raises `TypeError` if the geometry is not a single-polygon type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1924,9 +1924,9 @@ Any z or m values present in the geometry will be discarded.
 
 This method works only with multi-point geometry types.
 
-:raises TypeError: if the geometry is not a multi-point type
+:raises `TypeError` if the geometry is not a multi-point type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1957,9 +1957,9 @@ Any z or m values present in the geometry will be discarded. If the geometry is 
 
 This method works only with multi-linestring (or multi-curve) geometry types.
 
-:raises TypeError: if the geometry is not a multi-linestring type
+:raises `TypeError` if the geometry is not a multi-linestring type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();
@@ -1990,9 +1990,9 @@ Any z or m values present in the geometry will be discarded. If the geometry is 
 
 This method works only with multi-polygon (or multi-curve polygon) geometry types.
 
-:raises TypeError: if the geometry is not a multi-polygon type
+:raises `TypeError` if the geometry is not a multi-polygon type
 
-:raises ValueError: if the geometry is null
+:raises `ValueError` if the geometry is null
 %End
 %MethodCode
     const QgsWkbTypes::Type type = sipCpp->wkbType();

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -69,7 +69,9 @@ Returns the number of geometries within the collection.
 %Docstring
 Returns a geometry from within the collection.
 
-:param n: index of geometry to return. An IndexError will be raised if no geometry with the specified index exists.
+:param n: index of geometry to return.
+
+:raises IndexError: if no geometry with the specified index exists.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
@@ -133,9 +135,9 @@ Inserts a geometry before a specified index and takes ownership. Returns ``True`
 %Docstring
 Removes a geometry from the collection by index.
 
-An IndexError will be raised if no geometry with the specified index exists.
-
 :return: ``True`` if removal was successful.
+
+:raises IndexError: if no geometry with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numGeometries();
@@ -256,10 +258,12 @@ Returns a geometry without curves. Caller takes ownership
 
     SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsAbstractGeometry"/;
 %Docstring
-Returns the geometry at the specified ``index``. An IndexError will be raised if no geometry with the specified ``index`` exists.
+Returns the geometry at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to geometries from the end of the collect. E.g. an index of -1
 corresponds to the last geometry in the collection.
+
+:raises IndexError: if no geometry with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -282,10 +286,12 @@ corresponds to the last geometry in the collection.
 
     void __delitem__( int index );
 %Docstring
-Deletes the geometry at the specified ``index``. A geometry at the ``index`` must already exist or an IndexError will be raised.
+Deletes the geometry at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to geometries from the end of the collection. E.g. an index of -1
 corresponds to the last geometry in the collection.
+
+:raises IndexError: if no geometry at the ``index`` exists
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -71,7 +71,7 @@ Returns a geometry from within the collection.
 
 :param n: index of geometry to return.
 
-:raises IndexError: if no geometry with the specified index exists.
+:raises `IndexError` if no geometry with the specified index exists.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
@@ -137,7 +137,7 @@ Removes a geometry from the collection by index.
 
 :return: ``True`` if removal was successful.
 
-:raises IndexError: if no geometry with the specified index exists.
+:raises `IndexError` if no geometry with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numGeometries();
@@ -263,7 +263,7 @@ Returns the geometry at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to geometries from the end of the collect. E.g. an index of -1
 corresponds to the last geometry in the collection.
 
-:raises IndexError: if no geometry with the specified ``index`` exists.
+:raises `IndexError` if no geometry with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -291,7 +291,7 @@ Deletes the geometry at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to geometries from the end of the collection. E.g. an index of -1
 corresponds to the last geometry in the collection.
 
-:raises IndexError: if no geometry at the ``index`` exists
+:raises `IndexError` if no geometry at the ``index`` exists
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -279,7 +279,7 @@ Returns the point at the specified index.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -308,7 +308,7 @@ Returns the x-coordinate of the specified node in the line string.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -335,7 +335,7 @@ Returns the y-coordinate of the specified node in the line string.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -367,7 +367,7 @@ If the LineString does not have a z-dimension then ``nan`` will be returned.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -395,7 +395,7 @@ If the LineString does not have a m-dimension then ``nan`` will be returned.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -422,7 +422,7 @@ The corresponding node must already exist in line string.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 
 .. seealso:: :py:func:`xAt`
 %End
@@ -451,7 +451,7 @@ The corresponding node must already exist in line string.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 
 .. seealso:: :py:func:`yAt`
 %End
@@ -480,7 +480,7 @@ The corresponding node must already exist in line string and the line string mus
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 
 .. seealso:: :py:func:`zAt`
 %End
@@ -509,7 +509,7 @@ The corresponding node must already exist in line string and the line string mus
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 
 .. seealso:: :py:func:`mAt`
 %End
@@ -743,7 +743,7 @@ Returns the point at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified ``index`` exists.
+:raises `IndexError` if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -772,7 +772,7 @@ Sets the point at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified ``index`` exists.
+:raises `IndexError` if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -804,7 +804,7 @@ Deletes the vertex at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
 
-:raises IndexError: if no point with the specified ``index`` exists.
+:raises `IndexError` if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -274,10 +274,12 @@ Returns a new linestring from a QPolygonF ``polygon`` input.
 
     SIP_PYOBJECT pointN( int i ) const /TypeHint="QgsPoint"/;
 %Docstring
-Returns the point at the specified index. An IndexError will be raised if no point with the specified index exists.
+Returns the point at the specified index.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -303,10 +305,10 @@ corresponds to the last point in the line.
 %Docstring
 Returns the x-coordinate of the specified node in the line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -330,10 +332,10 @@ corresponds to the last point in the line.
 %Docstring
 Returns the y-coordinate of the specified node in the line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -360,12 +362,12 @@ corresponds to the last point in the line.
 %Docstring
 Returns the z-coordinate of the specified node in the line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 If the LineString does not have a z-dimension then ``nan`` will be returned.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -388,12 +390,12 @@ corresponds to the last point in the line.
 %Docstring
 Returns the m-coordinate of the specified node in the line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 If the LineString does not have a m-dimension then ``nan`` will be returned.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 %End
 %MethodCode
     const int count = sipCpp->numPoints();
@@ -417,10 +419,10 @@ corresponds to the last point in the line.
 Sets the x-coordinate of the specified node in the line string.
 The corresponding node must already exist in line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 
 .. seealso:: :py:func:`xAt`
 %End
@@ -446,10 +448,10 @@ corresponds to the last point in the line.
 Sets the y-coordinate of the specified node in the line string.
 The corresponding node must already exist in line string.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 
 .. seealso:: :py:func:`yAt`
 %End
@@ -475,10 +477,10 @@ corresponds to the last point in the line.
 Sets the z-coordinate of the specified node in the line string.
 The corresponding node must already exist in line string and the line string must have z-dimension.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 
 .. seealso:: :py:func:`zAt`
 %End
@@ -504,10 +506,10 @@ corresponds to the last point in the line.
 Sets the m-coordinate of the specified node in the line string.
 The corresponding node must already exist in line string and the line string must have m-dimension.
 
-An IndexError will be raised if no point with the specified index exists.
-
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified index exists.
 
 .. seealso:: :py:func:`mAt`
 %End
@@ -736,10 +738,12 @@ of the curve.
 
     SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsPoint"/;
 %Docstring
-Returns the point at the specified ``index``. An IndexError will be raised if no point with the specified ``index`` exists.
+Returns the point at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -763,10 +767,12 @@ corresponds to the last point in the line.
 
     void __setitem__( int index, const QgsPoint &point );
 %Docstring
-Sets the point at the specified ``index``. A point at the ``index`` must already exist or an IndexError will be raised.
+Sets the point at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End
@@ -793,10 +799,12 @@ corresponds to the last point in the line.
 
     void __delitem__( int index );
 %Docstring
-Deletes the vertex at the specified ``index``. A point at the ``index`` must already exist or an IndexError will be raised.
+Deletes the vertex at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
 corresponds to the last point in the line.
+
+:raises IndexError: if no point with the specified ``index`` exists.
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/geometry/qgsmulticurve.sip.in
+++ b/python/core/auto_generated/geometry/qgsmulticurve.sip.in
@@ -28,7 +28,7 @@ Multi curve geometry collection.
 %Docstring
 Returns the curve with the specified ``index``.
 
-An IndexError will be raised if no curve with the specified index exists.
+:raises IndexError: if no curve with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmulticurve.sip.in
+++ b/python/core/auto_generated/geometry/qgsmulticurve.sip.in
@@ -28,7 +28,7 @@ Multi curve geometry collection.
 %Docstring
 Returns the curve with the specified ``index``.
 
-:raises IndexError: if no curve with the specified index exists.
+:raises `IndexError` if no curve with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multilinestring geometry.
 %Docstring
 Returns the line string with the specified ``index``.
 
-An IndexError will be raised if no line string with the specified index exists.
+:raises IndexError: if no line string with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multilinestring geometry.
 %Docstring
 Returns the line string with the specified ``index``.
 
-:raises IndexError: if no line string with the specified index exists.
+:raises `IndexError` if no line string with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultipoint.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipoint.sip.in
@@ -31,7 +31,7 @@ Constructor for an empty multipoint geometry.
 %Docstring
 Returns the point with the specified ``index``.
 
-An IndexError will be raised if no point with the specified index exists.
+:raises IndexError: if no point with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultipoint.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipoint.sip.in
@@ -31,7 +31,7 @@ Constructor for an empty multipoint geometry.
 %Docstring
 Returns the point with the specified ``index``.
 
-:raises IndexError: if no point with the specified index exists.
+:raises `IndexError` if no point with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multipolygon geometry.
 %Docstring
 Returns the polygon with the specified ``index``.
 
-An IndexError will be raised if no polygon with the specified index exists.
+:raises IndexError: if no polygon with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multipolygon geometry.
 %Docstring
 Returns the polygon with the specified ``index``.
 
-:raises IndexError: if no polygon with the specified index exists.
+:raises `IndexError` if no polygon with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultisurface.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultisurface.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multisurface geometry.
 %Docstring
 Returns the surface with the specified ``index``.
 
-An IndexError will be raised if no surface with the specified index exists.
+:raises IndexError: if no surface with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/geometry/qgsmultisurface.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultisurface.sip.in
@@ -33,7 +33,7 @@ Constructor for an empty multisurface geometry.
 %Docstring
 Returns the surface with the specified ``index``.
 
-:raises IndexError: if no surface with the specified index exists.
+:raises `IndexError` if no surface with the specified index exists.
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -178,7 +178,7 @@ This method will not perform any statistical calculations, rather it will return
 statistics which are included in the data source's metadata. Not all data sources include this information
 in the metadata, and even for sources with statistical metadata only some ``statistic`` values may be available.
 
-:raises ValueError: if no matching precalculated statistic is available for the attribute.
+:raises `ValueError` if no matching precalculated statistic is available for the attribute.
 %End
 %MethodCode
     {
@@ -216,7 +216,7 @@ This method will not perform any statistical calculations, rather it will return
 statistics which are included in the data source's metadata. Not all data sources include this information
 in the metadata, and even for sources with statistical metadata only some ``statistic`` values may be available.
 
-:raises ValueError: if no matching precalculated statistic is available for the attribute.
+:raises `ValueError` if no matching precalculated statistic is available for the attribute.
 %End
 %MethodCode
     {

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -701,7 +701,7 @@ The ``datasourceOptions`` and ``layerOptions`` arguments is used to pass on GDAL
 
 This function creates a new object and the caller takes responsibility for deleting the returned object.
 
-:raises :: py:class:`QgsProcessingException`
+:raises `QgsProcessingException` 
 %End
 
     QgsProcessingFeatureSource *parameterAsSource( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const /Factory/;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1007,7 +1007,7 @@ The ``datasourceOptions`` and ``layerOptions`` arguments is used to pass on GDAL
 
 This function creates a new object and the caller takes responsibility for deleting the returned object.
 
-:raises :: py:class:`QgsProcessingException`
+:raises `QgsProcessingException` 
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -818,7 +818,7 @@ be returned.
 
    This method requires PROJ 8.0 or later
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 7 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on PROJ 7 or earlier.
 
 
 .. versionadded:: 3.20
@@ -832,7 +832,7 @@ Attempts to retrieve the name of the celestial body associated with the CRS (e.g
 
    This method requires PROJ 8.1 or later
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
 
 
 .. versionadded:: 3.20

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -130,7 +130,7 @@ Returns a list of all known celestial bodies.
 
    This method requires PROJ 8.1 or later
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
 
 
 .. versionadded:: 3.20

--- a/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
+++ b/python/core/auto_generated/proj/qgsellipsoidutils.sip.in
@@ -81,7 +81,7 @@ Returns a list of all known celestial bodies.
    This method requires PROJ 8.1 or later
 
 
-:raises :: py:class:`QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
+:raises `QgsNotSupportedException` on QGIS builds based on PROJ 8.0 or earlier.
 
 
 .. versionadded:: 3.20

--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -364,7 +364,7 @@ Returns connection geomerty column capabilities (Z, M, SinglePart, Curves)
 Returns the URI string for the given ``table`` and ``schema``.
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.12
 %End
@@ -374,7 +374,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 Creates an empty table with ``name`` in the given ``schema`` (schema is ignored if not supported by the backend).
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual bool tableExists( const QString &schema, const QString &name ) const throw( QgsProviderConnectionException );
@@ -382,7 +382,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 Checks whether a table ``name`` exists in the given ``schema``.
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void dropVectorTable( const QString &schema, const QString &name ) const throw( QgsProviderConnectionException );
@@ -394,7 +394,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void dropRasterTable( const QString &schema, const QString &name ) const throw( QgsProviderConnectionException );
@@ -406,7 +406,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const throw( QgsProviderConnectionException );
@@ -418,7 +418,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void renameRasterTable( const QString &schema, const QString &name, const QString &newName ) const throw( QgsProviderConnectionException );
@@ -430,14 +430,14 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void createSchema( const QString &name ) const throw( QgsProviderConnectionException );
 %Docstring
 Creates a new schema with the specified ``name``
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void dropSchema( const QString &name, bool force = false ) const throw( QgsProviderConnectionException );
@@ -452,7 +452,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual void deleteField( const QString &fieldName, const QString &schema, const QString &tableName, bool force = false ) const throw( QgsProviderConnectionException );
@@ -469,7 +469,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.16
 %End
@@ -487,7 +487,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.16
 %End
@@ -502,7 +502,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
    it is responsibility of the caller to handle open layers and registry entries.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual QList<QList<QVariant>> executeSql( const QString &sql, QgsFeedback *feedback = 0 ) const throw( QgsProviderConnectionException );
@@ -512,7 +512,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
 .. seealso:: :py:func:`execSql`
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual QueryResult execSql( const QString &sql, QgsFeedback *feedback = 0 ) const throw( QgsProviderConnectionException );
@@ -522,7 +522,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
 .. seealso:: :py:func:`executeSql`
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.18
 %End
@@ -532,7 +532,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 Vacuum the database table with given ``schema`` and ``name`` (schema is ignored if not supported by the backend).
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     struct SpatialIndexOptions
@@ -548,7 +548,7 @@ The ``options`` argument can be used to provide extra options controlling the sp
 
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.14
 %End
@@ -560,7 +560,7 @@ ignored if not supported by the backend).
 
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.14
 %End
@@ -572,7 +572,7 @@ ignored if not supported by the backend).
 
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.14
 %End
@@ -583,7 +583,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 Returns information on a ``table`` in the given ``schema``.
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered or if the table does not exist.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. note::
 
@@ -600,7 +600,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 :param schema: name of the schema (ignored if not supported by the backend)
 :param flags: filter tables by flags, this option completely overrides search options stored in the connection
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
 
@@ -610,7 +610,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 Returns information about the existing schemas.
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
     virtual QgsFields fields( const QString &schema, const QString &table ) const throw( QgsProviderConnectionException );
@@ -623,7 +623,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
    the default implementation creates a temporary vector layer, providers may
    choose to override this method for a greater efficiency.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.16
 %End
@@ -632,7 +632,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 %Docstring
 Returns a list of native types supported by the connection.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.16
 %End
@@ -651,7 +651,7 @@ Returns the provider key
 %Docstring
 Checks if ``capability`` is supported and throws and exception if it's not
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
 

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -437,7 +437,7 @@ Saves ``metadata`` to the layer corresponding to the specified ``uri``.
          - errorMessage: descriptive string of error if encountered
 
 
-:raises :: py:class:`QgsNotSupportedException` if the provider does not support saving layer metadata for the
+:raises `QgsNotSupportedException` if the provider does not support saving layer metadata for the
    specified ``uri``.
 
 
@@ -467,7 +467,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
 :param cached: if ``False`` connections will be re-read from the settings
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.10
 %End
@@ -481,7 +481,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 
 :param cached: if ``False`` connections will be re-read from the settings
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.10
 %End
@@ -495,7 +495,7 @@ Raises a :py:class:`QgsProviderConnectionException` if any errors are encountere
 :param name: the connection name
 :param cached: if ``False`` connections will be re-read from the settings
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.10
 %End
@@ -508,7 +508,7 @@ the newly created connection is not automatically stored in the settings, call
 :py:func:`~QgsProviderMetadata.saveConnection` to save it.
 Ownership is transferred to the caller.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. seealso:: :py:func:`saveConnection`
 
@@ -520,7 +520,7 @@ Ownership is transferred to the caller.
 Creates a new connection by loading the connection with the given ``name`` from the settings.
 Ownership is transferred to the caller.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. seealso:: :py:func:`findConnection`
 %End
@@ -530,7 +530,7 @@ Ownership is transferred to the caller.
 Removes the connection with the given ``name`` from the settings.
 Raises a :py:class:`QgsProviderConnectionException` if any errors are encountered.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.10
 %End
@@ -542,7 +542,7 @@ Stores the connection in the settings
 :param connection: the connection to be stored in the settings
 :param name: the name under which the connection will be stored
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -245,7 +245,7 @@ Saves ``metadata`` to the layer corresponding to the specified ``uri``.
          - errorMessage: descriptive string of error if encountered
 
 
-:raises :: py:class:`QgsNotSupportedException` if the provider does not support saving layer metadata for the
+:raises `QgsNotSupportedException` if the provider does not support saving layer metadata for the
    specified ``uri``.
 
 

--- a/python/core/auto_generated/qgsconnectionregistry.sip.in
+++ b/python/core/auto_generated/qgsconnectionregistry.sip.in
@@ -43,7 +43,7 @@ the PostgreSQL connection saved as "my_connection".
 
 Ownership is transferred to the caller.
 
-:raises :: py:class:`QgsProviderConnectionException`
+:raises `QgsProviderConnectionException` 
 %End
 
   private:

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -218,6 +218,7 @@ The number of provided attributes need to exactly match the number of the featur
 .. seealso:: :py:func:`attributes`
 %End
 
+
     bool setAttribute( int field, const QVariant &attr /GetWrapper/ );
 %Docstring
 Sets an attribute's value by field index.
@@ -292,6 +293,7 @@ Resizes the attributes attached to this feature by appending the specified ``cou
 
 .. versionadded:: 3.18
 %End
+
 
     void deleteAttribute( int field );
 %Docstring
@@ -439,6 +441,7 @@ Returns the field map associated with the feature.
 .. seealso:: :py:func:`setFields`
 %End
 
+
     void setAttribute( const QString &name, const QVariant &value /GetWrapper/ );
 %Docstring
 Insert a value into attribute, by field ``name``.
@@ -511,6 +514,7 @@ Field map must be associated using setFields()before this method can be used.
       sipRes = true;
     }
 %End
+
 
     SIP_PYOBJECT attribute( const QString &name ) const;
 %Docstring

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -228,7 +228,7 @@ The feature will be valid if it was successful.
 :param field: the index of the field to set
 :param attr: the value of the attribute
 
-:raises KeyError: if the field index does not exist
+:raises `KeyError` if the field index does not exist
 
 .. note::
 
@@ -301,7 +301,7 @@ Deletes an attribute and its value.
 
 .. seealso:: :py:func:`setAttribute`
 
-:raises KeyError: if the field is not found
+:raises `KeyError` if the field is not found
 
 .. note::
 
@@ -445,7 +445,7 @@ The feature will be valid if it was successful
 :param name: The name of the field to set
 :param value: The value to set
 
-:raises KeyError: if the attribute name could not be converted to an index
+:raises `KeyError` if the attribute name could not be converted to an index
 
 .. note::
 
@@ -481,7 +481,7 @@ before this method can be used.
 
 :param name: The name of the field to delete
 
-:raises KeyError: if attribute name could not be converted to index
+:raises `KeyError` if attribute name could not be converted to index
 
 .. note::
 
@@ -512,7 +512,7 @@ before this method can be used.
 
 :param name: The name of the attribute to get
 
-:raises KeyError: if the field is not found
+:raises `KeyError` if the field is not found
 
 .. note::
 
@@ -542,7 +542,7 @@ before this method can be used.
 
 :param fieldIdx: The index of the attribute to get
 
-:raises KeyError: if the field is not found
+:raises `KeyError` if the field is not found
 
 .. note::
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -219,6 +219,7 @@ number of the feature's fields.
    provider.
 %End
 
+
     bool setAttribute( int field, const QVariant &attr /GetWrapper/ );
 %Docstring
 Set an attribute's value by field index.
@@ -227,11 +228,7 @@ The feature will be valid if it was successful.
 :param field: the index of the field to set
 :param attr: the value of the attribute
 
-:return: ``False``, if the field index does not exist
-
-.. note::
-
-   For Python: raises a KeyError exception instead of returning ``False``
+:raises KeyError: if the field index does not exist
 
 .. note::
 
@@ -295,6 +292,7 @@ Resizes the attributes attached to this feature by appending the specified ``cou
 .. versionadded:: 3.18
 %End
 
+
     void deleteAttribute( int field );
 %Docstring
 Deletes an attribute and its value.
@@ -303,9 +301,7 @@ Deletes an attribute and its value.
 
 .. seealso:: :py:func:`setAttribute`
 
-.. note::
-
-   For Python: raises a KeyError exception if the field is not found
+:raises KeyError: if the field is not found
 
 .. note::
 
@@ -439,6 +435,7 @@ Returns the field map associated with the feature.
 .. seealso:: :py:func:`setFields`
 %End
 
+
     void setAttribute( const QString &name, const QVariant &value /GetWrapper/ );
 %Docstring
 Insert a value into attribute. Returns ``False`` if attribute name could not be converted to index.
@@ -448,11 +445,7 @@ The feature will be valid if it was successful
 :param name: The name of the field to set
 :param value: The value to set
 
-:return: ``False`` if attribute name could not be converted to index (C++ only)
-
-.. note::
-
-   For Python: raises a KeyError exception instead of returning ``False``
+:raises KeyError: if the attribute name could not be converted to an index
 
 .. note::
 
@@ -480,6 +473,7 @@ The feature will be valid if it was successful
     }
 %End
 
+
     bool deleteAttribute( const QString &name );
 %Docstring
 Removes an attribute value by field name. Field map must be associated using :py:func:`~QgsFeature.setFields`
@@ -487,11 +481,7 @@ before this method can be used.
 
 :param name: The name of the field to delete
 
-:return: ``False`` if attribute name could not be converted to index (C++ only)
-
-.. note::
-
-   For Python: raises a KeyError exception instead of returning ``False``
+:raises KeyError: if attribute name could not be converted to index
 
 .. note::
 
@@ -514,6 +504,7 @@ before this method can be used.
     }
 %End
 
+
     SIP_PYOBJECT attribute( const QString &name ) const;
 %Docstring
 Lookup attribute value from attribute name. Field map must be associated using :py:func:`~QgsFeature.setFields`
@@ -521,11 +512,7 @@ before this method can be used.
 
 :param name: The name of the attribute to get
 
-:return: The value of the attribute (C++: Invalid variant if no such name exists )
-
-.. note::
-
-   For Python: raises a KeyError exception if the field is not found
+:raises KeyError: if the field is not found
 
 .. note::
 
@@ -547,6 +534,7 @@ before this method can be used.
     }
 %End
 
+
     SIP_PYOBJECT attribute( int fieldIdx ) const;
 %Docstring
 Lookup attribute value from its index. Field map must be associated using :py:func:`~QgsFeature.setFields`
@@ -554,11 +542,7 @@ before this method can be used.
 
 :param fieldIdx: The index of the attribute to get
 
-:return: The value of the attribute (C++: Invalid variant if no such index exists )
-
-.. note::
-
-   For Python: raises a KeyError exception if the field is not found
+:raises KeyError: if the field is not found
 
 .. note::
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -15,7 +15,7 @@
 class QgsFeature
 {
 %Docstring(signature="appended")
-The feature class encapsulates a single feature including its id,
+The feature class encapsulates a single feature including its unique ID,
 geometry and a list of field/values attributes.
 
 .. note::
@@ -139,7 +139,7 @@ geometry and a list of field/values attributes.
 %Docstring
 Constructor for QgsFeature
 
-:param id: feature id
+:param id: unique feature ID
 %End
 
     QgsFeature( const QgsFields &fields, qint64 id = FID_NULL );
@@ -147,7 +147,7 @@ Constructor for QgsFeature
 Constructor for QgsFeature
 
 :param fields: feature's fields
-:param id: feature id
+:param id: unique feature ID
 %End
 
     QgsFeature( const QgsFeature &rhs );
@@ -162,16 +162,14 @@ Copy constructor
 
     QgsFeatureId id() const;
 %Docstring
-Gets the feature ID for this feature.
-
-:return: feature ID
+Returns the feature ID for this feature.
 
 .. seealso:: :py:func:`setId`
 %End
 
     void setId( QgsFeatureId id );
 %Docstring
-Sets the feature ID for this feature.
+Sets the feature ``id`` for this feature.
 
 :param id: feature id
 
@@ -181,8 +179,6 @@ Sets the feature ID for this feature.
     QgsAttributes attributes() const;
 %Docstring
 Returns the feature's attributes.
-
-:return: list of feature's attributes
 
 .. seealso:: :py:func:`setAttributes`
 
@@ -203,27 +199,30 @@ Returns the number of attributes attached to the feature.
     void setAttributes( const QgsAttributes &attrs );
 %Docstring
 Sets the feature's attributes.
-The feature will be valid after. The number of provided attributes need to match exactly the
-number of the feature's fields.
+
+Calling this method will automatically set the feature as valid (see :py:func:`~QgsFeature.isValid`).
+
+The number of provided attributes need to exactly match the number of the feature's fields.
 
 :param attrs: List of attribute values
+
+.. warning::
+
+   If the number of provided attributes does not exactly match
+   the number of the feature's fields then it will not be possible to add this feature to the corresponding data
+   provider.
+
 
 .. seealso:: :py:func:`setAttribute`
 
 .. seealso:: :py:func:`attributes`
-
-.. warning::
-
-   Method will return false if the number of provided attributes does not exactly match
-   the number of the feature's fields and it will not be possible to add this feature to the data
-   provider.
 %End
-
 
     bool setAttribute( int field, const QVariant &attr /GetWrapper/ );
 %Docstring
-Set an attribute's value by field index.
-The feature will be valid if it was successful.
+Sets an attribute's value by field index.
+
+If the attribute was successfully set then the feature will be automatically marked as valid (see :py:func:`~QgsFeature.isValid`).
 
 :param field: the index of the field to set
 :param attr: the value of the attribute
@@ -259,7 +258,9 @@ The feature will be valid if it was successful.
 
     void initAttributes( int fieldCount );
 %Docstring
-Initialize this feature with the given number of fields. Discard any previously set attribute data.
+Initialize this feature with the given number of fields.
+
+Discards any previously set attribute data.
 
 :param fieldCount: Number of fields to initialize
 
@@ -292,20 +293,19 @@ Resizes the attributes attached to this feature by appending the specified ``cou
 .. versionadded:: 3.18
 %End
 
-
     void deleteAttribute( int field );
 %Docstring
 Deletes an attribute and its value.
 
 :param field: the index of the field
 
-.. seealso:: :py:func:`setAttribute`
-
 :raises `KeyError` if the field is not found
 
 .. note::
 
    Alternatively in Python: @code del feature[field] @endcode
+
+.. seealso:: :py:func:`setAttribute`
 %End
 %MethodCode
     if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
@@ -319,8 +319,9 @@ Deletes an attribute and its value.
 
     bool isValid() const;
 %Docstring
-Returns the validity of this feature. This is normally set by
-the provider to indicate some problem that makes the feature
+Returns the validity of this feature.
+
+This is normally set by the provider to indicate some problem that makes the feature
 invalid or to indicate a null feature.
 
 .. seealso:: :py:func:`setValid`
@@ -356,7 +357,9 @@ an empty :py:class:`QgsGeometry` object will be returned.
 
     void setGeometry( const QgsGeometry &geometry );
 %Docstring
-Set the feature's geometry. The feature will be valid after.
+Set the feature's geometry.
+
+Calling this method will automatically set the feature as valid (see :py:func:`~QgsFeature.isValid`).
 
 :param geometry: new feature geometry
 
@@ -367,8 +370,11 @@ Set the feature's geometry. The feature will be valid after.
 
     void setGeometry( QgsAbstractGeometry *geometry /Transfer/ );
 %Docstring
-Set the feature's ``geometry``. Ownership of the geometry is transferred to the feature.
-The feature will be made valid after calling this method.
+Set the feature's ``geometry``.
+
+Ownership of the geometry is transferred to the feature.
+
+Calling this method will automatically set the feature as valid (see :py:func:`~QgsFeature.isValid`).
 
 This method is a shortcut for calling:
 
@@ -416,12 +422,10 @@ Removes any geometry associated with the feature.
 
     void setFields( const QgsFields &fields, bool initAttributes = true  );
 %Docstring
-Assign a field map with the feature to allow attribute access by attribute name.
+Assigns a field map with the feature to allow attribute access by attribute name.
 
 :param fields: The attribute fields which this feature holds
 :param initAttributes: If ``True``, attributes are initialized. Clears any data previously assigned.
-                       C++: Defaults to ``False``
-                       Python: Defaults to ``True``
 
 .. seealso:: :py:func:`fields`
 
@@ -435,12 +439,15 @@ Returns the field map associated with the feature.
 .. seealso:: :py:func:`setFields`
 %End
 
-
     void setAttribute( const QString &name, const QVariant &value /GetWrapper/ );
 %Docstring
-Insert a value into attribute. Returns ``False`` if attribute name could not be converted to index.
+Insert a value into attribute, by field ``name``.
+
+Returns ``False`` if field ``name`` could not be matched.
+
 Field map must be associated using :py:func:`~QgsFeature.setFields` before this method can be used.
-The feature will be valid if it was successful
+
+Calling this method will automatically set the feature as valid (see :py:func:`~QgsFeature.isValid`).
 
 :param name: The name of the field to set
 :param value: The value to set
@@ -476,8 +483,9 @@ The feature will be valid if it was successful
 
     bool deleteAttribute( const QString &name );
 %Docstring
-Removes an attribute value by field name. Field map must be associated using :py:func:`~QgsFeature.setFields`
-before this method can be used.
+Removes an attribute value by field ``name``.
+
+Field map must be associated using setFields()before this method can be used.
 
 :param name: The name of the field to delete
 
@@ -504,13 +512,15 @@ before this method can be used.
     }
 %End
 
-
     SIP_PYOBJECT attribute( const QString &name ) const;
 %Docstring
-Lookup attribute value from attribute name. Field map must be associated using :py:func:`~QgsFeature.setFields`
-before this method can be used.
+Lookup attribute value by attribute ``name``.
+
+Field map must be associated using :py:func:`~QgsFeature.setFields` before this method can be used.
 
 :param name: The name of the attribute to get
+
+:return: The value of the attribute
 
 :raises `KeyError` if the field is not found
 
@@ -537,10 +547,13 @@ before this method can be used.
 
     SIP_PYOBJECT attribute( int fieldIdx ) const;
 %Docstring
-Lookup attribute value from its index. Field map must be associated using :py:func:`~QgsFeature.setFields`
-before this method can be used.
+Lookup attribute value from its index.
+
+Field map must be associated using :py:func:`~QgsFeature.setFields` before this method can be used.
 
 :param fieldIdx: The index of the attribute to get
+
+:return: The value of the attribute
 
 :raises `KeyError` if the field is not found
 
@@ -583,8 +596,9 @@ Ownership of ``symbol`` is transferred to the feature.
 
     int fieldNameIndex( const QString &fieldName ) const;
 %Docstring
-Utility method to get attribute index from name. Field map must be associated using :py:func:`~QgsFeature.setFields`
-before this method can be used.
+Utility method to get attribute index from name.
+
+Field map must be associated using :py:func:`~QgsFeature.setFields` before this method can be used.
 
 :param fieldName: name of field to get attribute index of
 

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -300,7 +300,7 @@ Converts the provided variant to a compatible format
 
 :param v: The value to convert
 
-:return: ``True`` if the conversion was successful
+:raises ValueError: if the value could not be converted to a compatible format
 %End
 %MethodCode
     PyObject *sipParseErr = NULL;

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -300,7 +300,7 @@ Converts the provided variant to a compatible format
 
 :param v: The value to convert
 
-:raises ValueError: if the value could not be converted to a compatible format
+:raises `ValueError` if the value could not be converted to a compatible format
 %End
 %MethodCode
     PyObject *sipParseErr = NULL;

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -80,7 +80,7 @@ Appends an expression field. The field must have unique name, otherwise it is re
 %Docstring
 Removes the field with the given index.
 
-:raises KeyError: if no field with the specified index exists
+:raises `KeyError` if no field with the specified index exists
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -156,7 +156,7 @@ Returns if a field index is valid
 %Docstring
 Returns the field at particular index (must be in range 0..N-1).
 
-:raises KeyError: if no field exists at the specified index
+:raises `KeyError` if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -175,7 +175,7 @@ Returns the field at particular index (must be in range 0..N-1).
 %Docstring
 Returns the field at particular index (must be in range 0..N-1).
 
-:raises KeyError: if no field exists at the specified index
+:raises `KeyError` if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -194,7 +194,7 @@ Returns the field at particular index (must be in range 0..N-1).
 %Docstring
 Returns the field with matching name.
 
-:raises KeyError: if no matching field was found.
+:raises `KeyError` if no matching field was found.
 %End
 %MethodCode
     int fieldIdx = sipCpp->indexFromName( *a0 );
@@ -214,7 +214,7 @@ Returns the field with matching name.
 %Docstring
 Returns the field's origin (value from an enumeration).
 
-:raises KeyError: if no field exists at the specified index
+:raises `KeyError` if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -233,7 +233,7 @@ Returns the field's origin (value from an enumeration).
 %Docstring
 Returns the field's origin index (its meaning is specific to each type of origin).
 
-:raises KeyError: if no field exists at the specified index
+:raises `KeyError` if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -317,7 +317,7 @@ Returns an icon corresponding to a field index, based on the field's type and so
 :param fieldIdx: the field index
 :param considerOrigin: if ``True`` the icon will the origin of the field
 
-:raises KeyError: if no field exists at the specified index
+:raises `KeyError` if no field exists at the specified index
 
 .. versionadded:: 2.14
 %End

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -151,7 +151,6 @@ Returns if a field index is valid
       sipRes = new QgsField( sipCpp->operator[]( idx ) );
 %End
 
-
     QgsField at( int i ) const /Factory/;
 %Docstring
 Returns the field at particular index (must be in range 0..N-1).
@@ -169,7 +168,6 @@ Returns the field at particular index (must be in range 0..N-1).
       sipRes = new QgsField( sipCpp->at( a0 ) );
     }
 %End
-
 
     QgsField field( int fieldIdx ) const /Factory/;
 %Docstring
@@ -209,7 +207,6 @@ Returns the field with matching name.
     }
 %End
 
-
     FieldOrigin fieldOrigin( int fieldIdx ) const;
 %Docstring
 Returns the field's origin (value from an enumeration).
@@ -227,7 +224,6 @@ Returns the field's origin (value from an enumeration).
       sipRes = sipCpp->fieldOrigin( a0 );
     }
 %End
-
 
     int fieldOriginIndex( int fieldIdx ) const;
 %Docstring
@@ -250,8 +246,10 @@ Returns the field's origin index (its meaning is specific to each type of origin
     int indexFromName( const QString &fieldName ) const;
 %Docstring
 Gets the field index from the field name.
+
 This method is case sensitive and only matches the data source
 name of the field.
+
 Alias for indexOf
 
 :param fieldName: The name of the field.
@@ -264,6 +262,7 @@ Alias for indexOf
     int indexOf( const QString &fieldName ) const;
 %Docstring
 Gets the field index from the field name.
+
 This method is case sensitive and only matches the data source
 name of the field.
 
@@ -309,7 +308,6 @@ Utility function to return a list of :py:class:`QgsField` instances
     bool operator==( const QgsFields &other ) const;
     bool operator!=( const QgsFields &other ) const;
 
-
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const /Factory/;
 %Docstring
 Returns an icon corresponding to a field index, based on the field's type and source
@@ -332,7 +330,6 @@ Returns an icon corresponding to a field index, based on the field's type and so
       sipRes = new QIcon( sipCpp->iconForField( a0 ) );
     }
 %End
-
 
     static QIcon iconForFieldType( const QVariant::Type &type ) /Factory/;
 %Docstring

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -151,6 +151,7 @@ Returns if a field index is valid
       sipRes = new QgsField( sipCpp->operator[]( idx ) );
 %End
 
+
     QgsField at( int i ) const /Factory/;
 %Docstring
 Returns the field at particular index (must be in range 0..N-1).
@@ -168,6 +169,7 @@ Returns the field at particular index (must be in range 0..N-1).
       sipRes = new QgsField( sipCpp->at( a0 ) );
     }
 %End
+
 
     QgsField field( int fieldIdx ) const /Factory/;
 %Docstring
@@ -207,6 +209,7 @@ Returns the field with matching name.
     }
 %End
 
+
     FieldOrigin fieldOrigin( int fieldIdx ) const;
 %Docstring
 Returns the field's origin (value from an enumeration).
@@ -224,6 +227,7 @@ Returns the field's origin (value from an enumeration).
       sipRes = sipCpp->fieldOrigin( a0 );
     }
 %End
+
 
     int fieldOriginIndex( int fieldIdx ) const;
 %Docstring
@@ -307,6 +311,7 @@ Utility function to return a list of :py:class:`QgsField` instances
 
     bool operator==( const QgsFields &other ) const;
     bool operator!=( const QgsFields &other ) const;
+
 
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const /Factory/;
 %Docstring

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -75,9 +75,12 @@ Renames a name of field. The field must have unique name, otherwise change is re
 Appends an expression field. The field must have unique name, otherwise it is rejected (returns ``False``)
 %End
 
+
     void remove( int fieldIdx );
 %Docstring
-Removes a field with the given index
+Removes the field with the given index.
+
+:raises KeyError: if no field with the specified index exists
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -148,9 +151,12 @@ Returns if a field index is valid
       sipRes = new QgsField( sipCpp->operator[]( idx ) );
 %End
 
+
     QgsField at( int i ) const /Factory/;
 %Docstring
-Gets field at particular index (must be in range 0..N-1)
+Returns the field at particular index (must be in range 0..N-1).
+
+:raises KeyError: if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -164,9 +170,12 @@ Gets field at particular index (must be in range 0..N-1)
     }
 %End
 
+
     QgsField field( int fieldIdx ) const /Factory/;
 %Docstring
-Gets field at particular index (must be in range 0..N-1)
+Returns the field at particular index (must be in range 0..N-1).
+
+:raises KeyError: if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -180,9 +189,12 @@ Gets field at particular index (must be in range 0..N-1)
     }
 %End
 
+
     QgsField field( const QString &name ) const /Factory/;
 %Docstring
-Gets field with matching name
+Returns the field with matching name.
+
+:raises KeyError: if no matching field was found.
 %End
 %MethodCode
     int fieldIdx = sipCpp->indexFromName( *a0 );
@@ -197,9 +209,12 @@ Gets field with matching name
     }
 %End
 
+
     FieldOrigin fieldOrigin( int fieldIdx ) const;
 %Docstring
-Gets field's origin (value from an enumeration)
+Returns the field's origin (value from an enumeration).
+
+:raises KeyError: if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -213,9 +228,12 @@ Gets field's origin (value from an enumeration)
     }
 %End
 
+
     int fieldOriginIndex( int fieldIdx ) const;
 %Docstring
-Gets field's origin index (its meaning is specific to each type of origin)
+Returns the field's origin index (its meaning is specific to each type of origin).
+
+:raises KeyError: if no field exists at the specified index
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -291,12 +309,15 @@ Utility function to return a list of :py:class:`QgsField` instances
     bool operator==( const QgsFields &other ) const;
     bool operator!=( const QgsFields &other ) const;
 
+
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const /Factory/;
 %Docstring
 Returns an icon corresponding to a field index, based on the field's type and source
 
 :param fieldIdx: the field index
 :param considerOrigin: if ``True`` the icon will the origin of the field
+
+:raises KeyError: if no field exists at the specified index
 
 .. versionadded:: 2.14
 %End

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -122,7 +122,7 @@ Will check ``basepath`` in an outward spiral up to ``maxClimbs`` levels to check
 %Docstring
 Returns the drive type for the given ``path``.
 
-:raises :: py:class:`QgsNotSupportedException` if determining the drive type is not supported on the current platform.
+:raises `QgsNotSupportedException` if determining the drive type is not supported on the current platform.
 
 .. versionadded:: 3.20
 %End

--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -123,7 +123,7 @@ Removes the custom pre-processor function with matching ``id``.
 
 The ``id`` must correspond to a pre-processor previously added via a call to :py:func:`~QgsPathResolver.setPathPreprocessor`.
 
-:raises KeyError: if no processor with the specified ``id`` exists.
+:raises `KeyError` if no processor with the specified ``id`` exists.
 
 .. seealso:: :py:func:`setPathPreprocessor`
 

--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -122,7 +122,8 @@ Example - replace stored database credentials with new ones:
 Removes the custom pre-processor function with matching ``id``.
 
 The ``id`` must correspond to a pre-processor previously added via a call to :py:func:`~QgsPathResolver.setPathPreprocessor`.
-An KeyError will be raised if no processor with the specified ``id`` exists.
+
+:raises KeyError: if no processor with the specified ``id`` exists.
 
 .. seealso:: :py:func:`setPathPreprocessor`
 

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -33,10 +33,7 @@ Some valid use cases for :py:class:`QgsPointXY` include:
 
 Use cases for which :py:class:`QgsPointXY` is NOT a valid choice include:
 
-- Storage of coordinates for a geometry. Since :py:class:`QgsPointXY` is strictly 2-dimensional
-
-it should never be used to store coordinates for vector geometries, as this will involve
-a loss of any z or m values present in the geometry.
+- Storage of coordinates for a geometry. Since :py:class:`QgsPointXY` is strictly 2-dimensional it should never be used to store coordinates for vector geometries, as this will involve a loss of any z or m values present in the geometry.
 
 .. seealso:: :py:class:`QgsPoint`
 

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -195,10 +195,11 @@ number of returned feature IDs may exceed ``neighbors``.
 
     SIP_PYOBJECT geometry( QgsFeatureId id ) const /TypeHint="QgsGeometry"/;
 %Docstring
-Returns the stored geometry for the indexed feature with matching ``id``. A KeyError will be raised if no
-geometry with the specified feature id exists in the index.
+Returns the stored geometry for the indexed feature with matching ``id``.
 
 Geometry is only stored if the QgsSpatialIndex was created with the FlagStoreFeatureGeometries flag.
+
+:raises KeyError: if no geometry with the specified feature id exists in the index.
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -199,7 +199,7 @@ Returns the stored geometry for the indexed feature with matching ``id``.
 
 Geometry is only stored if the QgsSpatialIndex was created with the FlagStoreFeatureGeometries flag.
 
-:raises KeyError: if no geometry with the specified feature id exists in the index.
+:raises `KeyError` if no geometry with the specified feature id exists in the index.
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/qgsvector.sip.in
+++ b/python/core/auto_generated/qgsvector.sip.in
@@ -113,7 +113,7 @@ Rotates the vector by a specified angle.
 %Docstring
 Returns the vector's normalized (or "unit") vector (ie same angle but length of 1.0).
 
-:raises :: py:class:`QgsException` if called on a vector with length of 0.
+:raises `QgsException` if called on a vector with length of 0.
 %End
 
     bool operator==( QgsVector other ) const /HoldGIL/;

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -89,7 +89,9 @@ Returns the list of symbol layers contained in the symbol.
 
     SIP_PYOBJECT symbolLayer( int layer ) /TypeHint="QgsSymbolLayer"/;
 %Docstring
-Returns the symbol layer at the specified index. An IndexError will be raised if no layer with the specified index exists.
+Returns the symbol layer at the specified index.
+
+:raises IndexError: if no layer with the specified index exists.
 
 .. seealso:: :py:func:`symbolLayers`
 
@@ -140,10 +142,12 @@ Returns the number of symbol layers contained in the symbol.
 
     SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsSymbolLayer"/;
 %Docstring
-Returns the symbol layer at the specified ``index``. An IndexError will be raised if no layer with the specified ``index`` exists.
+Returns the symbol layer at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
 corresponds to the last layer in the symbol.
+
+:raises IndexError: if no layer with the specified ``index`` exists.
 
 .. versionadded:: 3.10
 %End
@@ -166,10 +170,12 @@ corresponds to the last layer in the symbol.
 
     void __delitem__( int index );
 %Docstring
-Deletes the layer at the specified ``index``. A layer at the ``index`` must already exist or an IndexError will be raised.
+Deletes the layer at the specified ``index``.
 
 Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
 corresponds to the last layer in the symbol.
+
+:raises IndexError: if no layer at the specified ``index`` exists
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -91,7 +91,7 @@ Returns the list of symbol layers contained in the symbol.
 %Docstring
 Returns the symbol layer at the specified index.
 
-:raises IndexError: if no layer with the specified index exists.
+:raises `IndexError` if no layer with the specified index exists.
 
 .. seealso:: :py:func:`symbolLayers`
 
@@ -147,7 +147,7 @@ Returns the symbol layer at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
 corresponds to the last layer in the symbol.
 
-:raises IndexError: if no layer with the specified ``index`` exists.
+:raises `IndexError` if no layer with the specified ``index`` exists.
 
 .. versionadded:: 3.10
 %End
@@ -175,7 +175,7 @@ Deletes the layer at the specified ``index``.
 Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
 corresponds to the last layer in the symbol.
 
-:raises IndexError: if no layer at the specified ``index`` exists
+:raises `IndexError` if no layer at the specified ``index`` exists
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/textrenderer/qgstextblock.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextblock.sip.in
@@ -76,9 +76,12 @@ Applies a ``capitalization`` style to the block's text.
     sipRes = sipCpp->size();
 %End
 
+
     const QgsTextFragment &at( int index ) const /Factory/;
 %Docstring
 Returns the fragment at the specified ``index``.
+
+:raises KeyError: if no fragment exists at the specified index.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/python/core/auto_generated/textrenderer/qgstextblock.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextblock.sip.in
@@ -76,7 +76,6 @@ Applies a ``capitalization`` style to the block's text.
     sipRes = sipCpp->size();
 %End
 
-
     const QgsTextFragment &at( int index ) const /Factory/;
 %Docstring
 Returns the fragment at the specified ``index``.

--- a/python/core/auto_generated/textrenderer/qgstextblock.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextblock.sip.in
@@ -76,6 +76,7 @@ Applies a ``capitalization`` style to the block's text.
     sipRes = sipCpp->size();
 %End
 
+
     const QgsTextFragment &at( int index ) const /Factory/;
 %Docstring
 Returns the fragment at the specified ``index``.

--- a/python/core/auto_generated/textrenderer/qgstextblock.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextblock.sip.in
@@ -81,7 +81,7 @@ Applies a ``capitalization`` style to the block's text.
 %Docstring
 Returns the fragment at the specified ``index``.
 
-:raises KeyError: if no fragment exists at the specified index.
+:raises `KeyError` if no fragment exists at the specified index.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
@@ -62,9 +62,12 @@ Appends a ``block`` to the document.
 Reserves the specified ``count`` of blocks for optimised block appending.
 %End
 
+
     const QgsTextBlock &at( int index ) const /Factory/;
 %Docstring
 Returns the block at the specified ``index``.
+
+:raises KeyError: if no block exists at the specified index.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
@@ -67,7 +67,7 @@ Reserves the specified ``count`` of blocks for optimised block appending.
 %Docstring
 Returns the block at the specified ``index``.
 
-:raises KeyError: if no block exists at the specified index.
+:raises `KeyError` if no block exists at the specified index.
 %End
 %MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
@@ -62,6 +62,7 @@ Appends a ``block`` to the document.
 Reserves the specified ``count`` of blocks for optimised block appending.
 %End
 
+
     const QgsTextBlock &at( int index ) const /Factory/;
 %Docstring
 Returns the block at the specified ``index``.

--- a/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextdocument.sip.in
@@ -62,7 +62,6 @@ Appends a ``block`` to the document.
 Reserves the specified ``count`` of blocks for optimised block appending.
 %End
 
-
     const QgsTextBlock &at( int index ) const /Factory/;
 %Docstring
 Returns the block at the specified ``index``.

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -234,7 +234,7 @@ Sets the canvas to the specified ``extent``.
 
 :return: ``True`` if the zoom was successful.
 
-:raises :: py:class:`QgsCsException` if a transformation error occurred.
+:raises `QgsCsException` if a transformation error occurred.
 
 .. versionadded:: 3.10
 %End

--- a/python/server/auto_generated/qgsserverapiutils.sip.in
+++ b/python/server/auto_generated/qgsserverapiutils.sip.in
@@ -46,7 +46,7 @@ Returns a list of temporal dimensions information for the given ``layer`` (eithe
 %Docstring
 Parses a date ``interval`` and returns a :py:class:`QgsDateRange`
 
-:raises :: py:class:`QgsServerApiBadRequestException` if interval cannot be parsed
+:raises `QgsServerApiBadRequestException` if interval cannot be parsed
 
 .. versionadded:: 3.12
 %End
@@ -55,7 +55,7 @@ Parses a date ``interval`` and returns a :py:class:`QgsDateRange`
 %Docstring
 Parses a datetime ``interval`` and returns a :py:class:`QgsDateTimeRange`
 
-:raises :: py:class:`QgsServerApiBadRequestException` if interval cannot be parsed
+:raises `QgsServerApiBadRequestException` if interval cannot be parsed
 
 .. versionadded:: 3.12
 %End

--- a/python/server/auto_generated/qgsserverogcapihandler.sip.in
+++ b/python/server/auto_generated/qgsserverogcapihandler.sip.in
@@ -149,7 +149,7 @@ Handles the request within its ``context``
 Subclasses must implement this methods, and call :py:func:`~QgsServerOgcApiHandler.validate` to
 extract validated parameters from the request.
 
-:raises :: py:class:`QgsServerApiBadRequestError` if the method encounters any error
+:raises `QgsServerApiBadRequestError` if the method encounters any error
 %End
 
     virtual QVariantMap values( const QgsServerApiContext &context ) const throw( QgsServerApiBadRequestException );
@@ -172,7 +172,7 @@ the parameters map.
 
 .. seealso:: :py:func:`parameters`
 
-:raises :: py:class:`QgsServerApiBadRequestError` if validation fails
+:raises `QgsServerApiBadRequestError` if validation fails
 %End
 
     QString contentTypeForAccept( const QString &accept ) const;
@@ -238,7 +238,7 @@ The path file extension is examined first and checked for known mime types,
 the "Accept" HTTP header is examined next.
 Fallback to the default content type of the handler if none of the above matches.
 
-:raises QgsServerApiBadRequestError: if the content type of the request is not compatible with the handler (:py:func:`contentTypes` member)
+:raises `QgsServerApiBadRequestError` if the content type of the request is not compatible with the handler (:py:func:`contentTypes` member)
 %End
 
     static QString parentLink( const QUrl &url, int levels = 1 );
@@ -250,7 +250,7 @@ Returns a link to the parent page up to ``levels`` in the HTML hierarchy from th
 %Docstring
 Returns a vector layer from the ``collectionId`` in the given ``context``.
 
-:raises :: py:class:`QgsServerApiNotFoundError` if the layer could not be found.
+:raises `QgsServerApiNotFoundError` if the layer could not be found.
 %End
 
 

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -170,7 +170,7 @@ Raises an exception in case of an invalid parameters.
 
 :param msg: The message describing the exception
 
-:raises :: py:class:`QgsBadRequestException` Invalid parameter exception
+:raises `QgsBadRequestException` Invalid parameter exception
 %End
 
     QVariant::Type mType;
@@ -218,7 +218,7 @@ Constructor for QgsServerParameter.
 %Docstring
 Raises an error in case of an invalid conversion.
 
-:raises :: py:class:`QgsBadRequestException` Invalid parameter exception
+:raises `QgsBadRequestException` Invalid parameter exception
 %End
 
     static QString name( const QgsServerParameter::Name name );

--- a/python/server/auto_generated/qgsserverquerystringparameter.sip.in
+++ b/python/server/auto_generated/qgsserverquerystringparameter.sip.in
@@ -76,7 +76,7 @@ Validation steps:
 
 :return: the parameter value or an invalid QVariant if not found (and not required)
 
-:raises :: py:class:`QgsServerApiBadRequestError` if validation fails
+:raises `QgsServerApiBadRequestError` if validation fails
 %End
 
 

--- a/scripts/astyle_all.sh
+++ b/scripts/astyle_all.sh
@@ -34,7 +34,7 @@ find python src tests -type f -print | while read -r f; do
         fi
 
 	echo -ne "Reformatting $f $elcr"
-	astyle.sh "$f" || true &
+	astyle.sh "$f" || true
 done
 
 remove_temporary_files.sh

--- a/scripts/astyle_all.sh
+++ b/scripts/astyle_all.sh
@@ -34,7 +34,7 @@ find python src tests -type f -print | while read -r f; do
         fi
 
 	echo -ne "Reformatting $f $elcr"
-	astyle.sh "$f" || true
+	astyle.sh "$f" || true &
 done
 
 remove_temporary_files.sh

--- a/scripts/doxygen_space.pl
+++ b/scripts/doxygen_space.pl
@@ -49,7 +49,10 @@ while ($LINE_IDX < $LINE_COUNT){
     my $new_line = $INPUT_LINES[$LINE_IDX];
     my $is_blank_line = ( $new_line =~ m/^\s*$/ ) ? 1 : 0;
 
-    if ( $new_line =~ m/^(\s*)\/\/!\s*(.*?)$/ ){
+    if ( $new_line =~ m/^(\s*)(?:#ifdef|#ifndef|#else|#endif)/ ){
+      print $out_handle $new_line."\n";
+    }
+    elsif ( $new_line =~ m/^(\s*)\/\/!\s*(.*?)$/ ){
        #found a //! comment
        my $indentation = $1;
        my $comment = $2;
@@ -134,7 +137,7 @@ while ($LINE_IDX < $LINE_COUNT){
           $BUFFERED_LINE = "";
         }
 
-        if ($new_line !~ m/^\s*\*/ && $new_line =~ m/^(\s*?)(\s?)(.+?)$/ )
+        if ($new_line !~ m/^\s*[#\*]/ && $new_line =~ m/^(\s*?)(\s?)(.+?)$/ )
         {
           $new_line = "$1* $3";
         }

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -344,9 +344,9 @@ sub processDoxygenLine {
             }
         }
     }
-    else
-    {
+    elsif ( $line !~ m/\\throws.*/ ) {
         # create links in plain text too (less performant)
+        # we don't do this for "throws" lines, as Sphinx does not format these correctly
         $line = create_class_links($line)
     }
 
@@ -366,7 +366,7 @@ sub processDoxygenLine {
         $PREV_INDENT = $INDENT;
         $INDENT = '';
         $COMMENT_LAST_LINE_NOTE_WARNING = 1;
-        return "\n:raises $1: $2\n";
+        return "\n:raises `$1` $2\n";
     }
 
     if ( $line !~ m/^\s*$/ ){

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -75,7 +75,7 @@ my $LINE_IDX = 0;
 my $LINE;
 my @OUTPUT = ();
 my @OUTPUT_PYTHON = ();
-
+my $DOXY_INSIDE_SIP_RUN = 0;
 
 sub read_line {
     my $new_line = $INPUT_LINES[$LINE_IDX];
@@ -182,6 +182,27 @@ sub create_class_links {
 
 sub processDoxygenLine {
     my $line = $_[0];
+
+    if ( $line =~ m/\s*#ifdef SIP_RUN/ ) {
+      $DOXY_INSIDE_SIP_RUN = 1;
+      return "";
+    }
+    elsif ( $line =~ m/\s*#ifndef SIP_RUN/ ) {
+      $DOXY_INSIDE_SIP_RUN = 2;
+      return "";
+    }
+    elsif ($DOXY_INSIDE_SIP_RUN != 0 && $line =~ m/\s*#else/ ) {
+      $DOXY_INSIDE_SIP_RUN = $DOXY_INSIDE_SIP_RUN == 1 ? 2 : 1;
+      return "";
+    }
+    elsif ($DOXY_INSIDE_SIP_RUN != 0 && $line =~ m/\s*#endif/ ) {
+      $DOXY_INSIDE_SIP_RUN = 0;
+      return "";
+    }
+
+    if ($DOXY_INSIDE_SIP_RUN == 2) {
+      return "";
+    }
 
     # detect code snippet
     if ( $line =~ m/\\code(\{\.?(\w+)\})?/ ) {

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     /**
      * Retrieves an interior ring from the curve polygon. The first interior ring has index 0.
      *
-     * An IndexError will be raised if no interior ring with the specified index exists.
+     * \throws IndexError if no interior ring with the specified index exists.
      *
      * \see numInteriorRings()
      * \see exteriorRing()
@@ -170,7 +170,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
      * The corresponding ring is removed from the polygon and deleted.
      * It is not possible to remove the exterior ring using this method.
      *
-     * An IndexError will be raised if no interior ring with the specified index exists.
+     * \throws IndexError if no interior ring with the specified index exists.
      *
      * \see removeInteriorRings()
      */

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1712,9 +1712,10 @@ class CORE_EXPORT QgsGeometry
      * Optionally, a specific random \a seed can be used when generating points. If \a seed
      * is 0, then a completely random sequence of points will be generated.
      *
-     * This method works only with (multi)polygon geometry types. If the geometry
-     * is not a polygon type, a TypeError will be raised. If the geometry
-     * is null, a ValueError will be raised.
+     * This method works only with (multi)polygon geometry types.
+     *
+     * \throws TypeError if the geometry is not a polygon type
+     * \throws ValueError if the geometry is null
      *
      * \since QGIS 3.10
      */
@@ -1853,9 +1854,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Any z or m values present in the geometry will be discarded.
      *
-     * This method works only with single-point geometry types. If the geometry
-     * is not a single-point type, a TypeError will be raised. If the geometry
-     * is null, a ValueError will be raised.
+     * This method works only with single-point geometry types.
+     *
+     * \throws TypeError if the geometry is not a single-point type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asPoint() const SIP_TYPEHINT( QgsPointXY );
     % MethodCode
@@ -1896,9 +1898,10 @@ class CORE_EXPORT QgsGeometry
      * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
      * (such as a CircularString), it will be automatically segmentized.
      *
-     * This method works only with single-line (or single-curve) geometry types. If the geometry
-     * is not a single-line type, a TypeError will be raised. If the geometry is null, a ValueError
-     * will be raised.
+     * This method works only with single-line (or single-curve).
+     *
+     * \throws TypeError if the geometry is not a single-line type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asPolyline() const SIP_TYPEHINT( QgsPolylineXY );
     % MethodCode
@@ -1940,9 +1943,10 @@ class CORE_EXPORT QgsGeometry
      * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
      * (such as a CurvePolygon), it will be automatically segmentized.
      *
-     * This method works only with single-polygon (or single-curve polygon) geometry types. If the geometry
-     * is not a single-polygon type, a TypeError will be raised. If the geometry is null, a ValueError
-     * will be raised.
+     * This method works only with single-polygon (or single-curve polygon) geometry types.
+     *
+     * \throws TypeError if the geometry is not a single-polygon type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asPolygon() const SIP_TYPEHINT( QgsPolygonXY );
     % MethodCode
@@ -1982,9 +1986,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Any z or m values present in the geometry will be discarded.
      *
-     * This method works only with multi-point geometry types. If the geometry
-     * is not a multi-point type, a TypeError will be raised. If the geometry is null, a ValueError
-     * will be raised.
+     * This method works only with multi-point geometry types.
+     *
+     * \throws TypeError if the geometry is not a multi-point type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asMultiPoint() const SIP_TYPEHINT( QgsMultiPointXY );
     % MethodCode
@@ -2026,9 +2031,10 @@ class CORE_EXPORT QgsGeometry
      * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
      * (such as a MultiCurve), it will be automatically segmentized.
      *
-     * This method works only with multi-linestring (or multi-curve) geometry types. If the geometry
-     * is not a multi-linestring type, a TypeError will be raised. If the geometry is null, a ValueError
-     * will be raised.
+     * This method works only with multi-linestring (or multi-curve) geometry types.
+     *
+     * \throws TypeError if the geometry is not a multi-linestring type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asMultiPolyline() const SIP_TYPEHINT( QgsMultiPolylineXY );
     % MethodCode
@@ -2070,9 +2076,10 @@ class CORE_EXPORT QgsGeometry
      * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
      * (such as a MultiSurface), it will be automatically segmentized.
      *
-     * This method works only with multi-polygon (or multi-curve polygon) geometry types. If the geometry
-     * is not a multi-polygon type, a TypeError will be raised. If the geometry is null, a ValueError
-     * will be raised.
+     * This method works only with multi-polygon (or multi-curve polygon) geometry types.
+     *
+     * \throws TypeError if the geometry is not a multi-polygon type
+     * \throws ValueError if the geometry is null
      */
     SIP_PYOBJECT asMultiPolygon() const SIP_TYPEHINT( QgsMultiPolygonXY );
     % MethodCode

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -98,7 +98,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 
     /**
      * Returns a geometry from within the collection.
-     * \param n index of geometry to return. An IndexError will be raised if no geometry with the specified index exists.
+     * \param n index of geometry to return.
+     * \throws IndexError if no geometry with the specified index exists.
      */
     SIP_PYOBJECT geometryN( int n ) SIP_TYPEHINT( QgsAbstractGeometry );
     % MethodCode
@@ -160,9 +161,8 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     /**
      * Removes a geometry from the collection by index.
      *
-     * An IndexError will be raised if no geometry with the specified index exists.
-     *
      * \returns TRUE if removal was successful.
+     * \throws IndexError if no geometry with the specified index exists.
      */
     virtual bool removeGeometry( int nr );
     % MethodCode
@@ -264,10 +264,12 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 #ifdef SIP_RUN
 
     /**
-    * Returns the geometry at the specified ``index``. An IndexError will be raised if no geometry with the specified ``index`` exists.
+    * Returns the geometry at the specified ``index``.
     *
     * Indexes can be less than 0, in which case they correspond to geometries from the end of the collect. E.g. an index of -1
     * corresponds to the last geometry in the collection.
+    *
+    * \throws IndexError if no geometry with the specified ``index`` exists.
     *
     * \since QGIS 3.6
     */
@@ -290,10 +292,12 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     % End
 
     /**
-     * Deletes the geometry at the specified ``index``. A geometry at the ``index`` must already exist or an IndexError will be raised.
+     * Deletes the geometry at the specified ``index``.
      *
      * Indexes can be less than 0, in which case they correspond to geometries from the end of the collection. E.g. an index of -1
      * corresponds to the last geometry in the collection.
+     *
+     * \throws IndexError if no geometry at the ``index`` exists
      *
      * \since QGIS 3.6
      */

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -316,10 +316,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #else
 
     /**
-     * Returns the point at the specified index. An IndexError will be raised if no point with the specified index exists.
+     * Returns the point at the specified index.
      *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
      */
     SIP_PYOBJECT pointN( int i ) const SIP_TYPEHINT( QgsPoint );
     % MethodCode
@@ -348,10 +350,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Returns the x-coordinate of the specified node in the line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
     */
     double xAt( int index ) const override;
     % MethodCode
@@ -378,10 +380,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Returns the y-coordinate of the specified node in the line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
     */
     double yAt( int index ) const override;
     % MethodCode
@@ -476,12 +478,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Returns the z-coordinate of the specified node in the line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * If the LineString does not have a z-dimension then ``nan`` will be returned.
      *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
     */
     double zAt( int index ) const;
     % MethodCode
@@ -522,12 +524,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Returns the m-coordinate of the specified node in the line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * If the LineString does not have a m-dimension then ``nan`` will be returned.
      *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
     */
     double mAt( int index ) const;
     % MethodCode
@@ -563,10 +565,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Sets the x-coordinate of the specified node in the line string.
      * The corresponding node must already exist in line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
      *
      * \see xAt()
      */
@@ -604,10 +606,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Sets the y-coordinate of the specified node in the line string.
      * The corresponding node must already exist in line string.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
+     *
+     * \throws IndexError if no point with the specified index exists.
      *
      * \see yAt()
      */
@@ -649,11 +651,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Sets the z-coordinate of the specified node in the line string.
      * The corresponding node must already exist in line string and the line string must have z-dimension.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
      *
+     * \throws IndexError if no point with the specified index exists.
      * \see zAt()
      */
     void setZAt( int index, double z );
@@ -694,11 +695,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Sets the m-coordinate of the specified node in the line string.
      * The corresponding node must already exist in line string and the line string must have m-dimension.
      *
-     * An IndexError will be raised if no point with the specified index exists.
-     *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
      *
+     * \throws IndexError if no point with the specified index exists.
      * \see mAt()
      */
     void setMAt( int index, double m );
@@ -901,11 +901,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     % End
 
     /**
-    * Returns the point at the specified ``index``. An IndexError will be raised if no point with the specified ``index`` exists.
+    * Returns the point at the specified ``index``.
     *
     * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
     * corresponds to the last point in the line.
     *
+    * \throws IndexError if no point with the specified ``index`` exists.
     * \since QGIS 3.6
     */
     SIP_PYOBJECT __getitem__( int index ) SIP_TYPEHINT( QgsPoint );
@@ -928,11 +929,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     % End
 
     /**
-    * Sets the point at the specified ``index``. A point at the ``index`` must already exist or an IndexError will be raised.
+    * Sets the point at the specified ``index``.
     *
     * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
     * corresponds to the last point in the line.
     *
+    * \throws IndexError if no point with the specified ``index`` exists.
     * \since QGIS 3.6
     */
     void __setitem__( int index, const QgsPoint &point );
@@ -958,11 +960,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
 
     /**
-     * Deletes the vertex at the specified ``index``. A point at the ``index`` must already exist or an IndexError will be raised.
+     * Deletes the vertex at the specified ``index``.
      *
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
      *
+     * \throws IndexError if no point with the specified ``index`` exists.
      * \since QGIS 3.6
      */
     void __delitem__( int index );

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsMultiCurve: public QgsGeometryCollection
     /**
      * Returns the curve with the specified \a index.
      *
-     * An IndexError will be raised if no curve with the specified index exists.
+     * \throws IndexError if no curve with the specified index exists.
      *
      * \since QGIS 3.16
      */

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsMultiLineString: public QgsMultiCurve
     /**
      * Returns the line string with the specified \a index.
      *
-     * An IndexError will be raised if no line string with the specified index exists.
+     * \throws IndexError if no line string with the specified index exists.
      *
      * \since QGIS 3.16
      */

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
     /**
      * Returns the point with the specified \a index.
      *
-     * An IndexError will be raised if no point with the specified index exists.
+     * \throws IndexError if no point with the specified index exists.
      *
      * \since QGIS 3.16
      */

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsMultiPolygon: public QgsMultiSurface
     /**
      * Returns the polygon with the specified \a index.
      *
-     * An IndexError will be raised if no polygon with the specified index exists.
+     * \throws IndexError if no polygon with the specified index exists.
      *
      * \since QGIS 3.16
      */

--- a/src/core/geometry/qgsmultisurface.h
+++ b/src/core/geometry/qgsmultisurface.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsMultiSurface: public QgsGeometryCollection
     /**
      * Returns the surface with the specified \a index.
      *
-     * An IndexError will be raised if no surface with the specified index exists.
+     * \throws IndexError if no surface with the specified index exists.
      *
      * \since QGIS 3.16
      */

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -48,7 +48,7 @@ class QgsSymbol;
 
 /**
  * \ingroup core
- * \brief The feature class encapsulates a single feature including its id,
+ * \brief The feature class encapsulates a single feature including its unique ID,
  * geometry and a list of field/values attributes.
  * \note QgsFeature objects are implicitly shared.
  */
@@ -173,7 +173,7 @@ class CORE_EXPORT QgsFeature
 
     /**
      * Constructor for QgsFeature
-     * \param id feature id
+     * \param id unique feature ID
      */
 #ifndef SIP_RUN
     QgsFeature( QgsFeatureId id = FID_NULL );
@@ -184,7 +184,7 @@ class CORE_EXPORT QgsFeature
     /**
      * Constructor for QgsFeature
      * \param fields feature's fields
-     * \param id feature id
+     * \param id unique feature ID
      */
 #ifndef SIP_RUN
     QgsFeature( const QgsFields &fields, QgsFeatureId id = FID_NULL );
@@ -215,22 +215,20 @@ class CORE_EXPORT QgsFeature
     virtual ~QgsFeature();
 
     /**
-     * Gets the feature ID for this feature.
-     * \returns feature ID
+     * Returns the feature ID for this feature.
      * \see setId()
      */
     QgsFeatureId id() const;
 
     /**
-     * Sets the feature ID for this feature.
+     * Sets the feature \a id for this feature.
      * \param id feature id
-     * \see id
+     * \see id()
      */
     void setId( QgsFeatureId id );
 
     /**
      * Returns the feature's attributes.
-     * \returns list of feature's attributes
      * \see setAttributes
      * \note Alternatively in Python: iterate feature, eg. @code [attr for attr in feature] @endcode
      * \since QGIS 2.9
@@ -245,39 +243,40 @@ class CORE_EXPORT QgsFeature
 
     /**
      * Sets the feature's attributes.
-     * The feature will be valid after. The number of provided attributes need to match exactly the
-     * number of the feature's fields.
+     *
+     * Calling this method will automatically set the feature as valid (see isValid()).
+     *
+     * The number of provided attributes need to exactly match the number of the feature's fields.
+     *
      * \param attrs List of attribute values
-     * \see setAttribute
-     * \see attributes
-     * \warning Method will return false if the number of provided attributes does not exactly match
-     * the number of the feature's fields and it will not be possible to add this feature to the data
+     *
+     * \warning If the number of provided attributes does not exactly match
+     * the number of the feature's fields then it will not be possible to add this feature to the corresponding data
      * provider.
+     *
+     * \see setAttribute()
+     * \see attributes()
      */
     void setAttributes( const QgsAttributes &attrs );
 
-#ifndef SIP_RUN
-
     /**
-     * Set an attribute's value by field index.
-     * The feature will be valid if it was successful.
+     * Sets an attribute's value by field index.
+     *
+     * If the attribute was successfully set then the feature will be automatically marked as valid (see isValid()).
+     *
      * \param field the index of the field to set
      * \param attr the value of the attribute
+    #ifndef SIP_RUN
      * \returns FALSE, if the field index does not exist
-     * \see setAttributes
-     */
-    bool setAttribute( int field, const QVariant &attr );
-#else
-
-    /**
-     * Set an attribute's value by field index.
-     * The feature will be valid if it was successful.
-     * \param field the index of the field to set
-     * \param attr the value of the attribute
+    #else
      * \throws KeyError if the field index does not exist
      * \note Alternatively in Python: @code feature[field] = attr @endcode
-     * \see setAttributes
+    #endif
+     * \see setAttributes()
      */
+#ifndef SIP_RUN
+    bool setAttribute( int field, const QVariant &attr );
+#else
     bool setAttribute( int field, const QVariant &attr / GetWrapper / );
     % MethodCode
     bool rv;
@@ -302,7 +301,10 @@ class CORE_EXPORT QgsFeature
 #endif
 
     /**
-     * Initialize this feature with the given number of fields. Discard any previously set attribute data.
+     * Initialize this feature with the given number of fields.
+     *
+     * Discards any previously set attribute data.
+     *
      * \param fieldCount Number of fields to initialize
      *
      * \see resizeAttributes()
@@ -332,24 +334,19 @@ class CORE_EXPORT QgsFeature
      */
     void padAttributes( int count );
 
-#ifndef SIP_RUN
-
     /**
      * Deletes an attribute and its value.
+     *
      * \param field the index of the field
-     * \see setAttribute
-     */
-    void deleteAttribute( int field );
-#else
-
-    /**
-     * Deletes an attribute and its value.
-     * \param field the index of the field
-     * \see setAttribute
+     *
+    #ifdef SIP_RUN
      * \throws KeyError if the field is not found
      * \note Alternatively in Python: @code del feature[field] @endcode
+    #endif
+     * \see setAttribute()
      */
     void deleteAttribute( int field );
+#ifdef SIP_RUN
     % MethodCode
     if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
       sipCpp->deleteAttribute( a0 );
@@ -362,17 +359,21 @@ class CORE_EXPORT QgsFeature
 #endif
 
     /**
-     * Returns the validity of this feature. This is normally set by
-     * the provider to indicate some problem that makes the feature
+     * Returns the validity of this feature.
+     *
+     * This is normally set by the provider to indicate some problem that makes the feature
      * invalid or to indicate a null feature.
-     * \see setValid
+     *
+     * \see setValid()
      */
     bool isValid() const;
 
     /**
      * Sets the validity of the feature.
+     *
      * \param validity set to TRUE if feature is valid
-     * \see isValid
+     *
+     * \see isValid()
      */
     void setValid( bool validity );
 
@@ -392,7 +393,10 @@ class CORE_EXPORT QgsFeature
     QgsGeometry geometry() const;
 
     /**
-     * Set the feature's geometry. The feature will be valid after.
+     * Set the feature's geometry.
+     *
+     * Calling this method will automatically set the feature as valid (see isValid()).
+     *
      * \param geometry new feature geometry
      * \see geometry()
      * \see clearGeometry()
@@ -400,8 +404,11 @@ class CORE_EXPORT QgsFeature
     void setGeometry( const QgsGeometry &geometry );
 
     /**
-     * Set the feature's \a geometry. Ownership of the geometry is transferred to the feature.
-     * The feature will be made valid after calling this method.
+     * Set the feature's \a geometry.
+     *
+     * Ownership of the geometry is transferred to the feature.
+     *
+     * Calling this method will automatically set the feature as valid (see isValid()).
      *
      * This method is a shortcut for calling:
      * \code{.py}
@@ -444,46 +451,42 @@ class CORE_EXPORT QgsFeature
     void clearGeometry();
 
     /**
-     * Assign a field map with the feature to allow attribute access by attribute name.
-     *  \param fields The attribute fields which this feature holds
-     *  \param initAttributes If TRUE, attributes are initialized. Clears any data previously assigned.
-     *                        C++: Defaults to FALSE
-     *                        Python: Defaults to TRUE
-     * \see fields
+     * Assigns a field map with the feature to allow attribute access by attribute name.
+     * \param fields The attribute fields which this feature holds
+     * \param initAttributes If TRUE, attributes are initialized. Clears any data previously assigned.
+     * \see fields()
      * \since QGIS 2.9
      */
     void setFields( const QgsFields &fields, bool initAttributes = false SIP_PYARGDEFAULT( true ) );
 
     /**
      * Returns the field map associated with the feature.
-     * \see setFields
+     * \see setFields()
      */
     QgsFields fields() const;
 
-#ifndef SIP_RUN
-
     /**
-     * Insert a value into attribute. Returns FALSE if attribute name could not be converted to index.
-     *  Field map must be associated using setFields() before this method can be used.
-     *  The feature will be valid if it was successful
-     *  \param name The name of the field to set
-     *  \param value The value to set
-     *  \returns FALSE if attribute name could not be converted to index (C++ only)
-     *  \see setFields
-     */
-    bool setAttribute( const QString &name, const QVariant &value );
-#else
-
-    /**
-     * Insert a value into attribute. Returns FALSE if attribute name could not be converted to index.
-     *  Field map must be associated using setFields() before this method can be used.
-     *  The feature will be valid if it was successful
-     *  \param name The name of the field to set
-     *  \param value The value to set
+     * Insert a value into attribute, by field \a name.
+     *
+     * Returns FALSE if field \a name could not be matched.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * Calling this method will automatically set the feature as valid (see isValid()).
+     *
+     * \param name The name of the field to set
+     * \param value The value to set
+     #ifndef SIP_RUN
+     * \returns FALSE if attribute name could not be converted to index
+     #else
      *  \throws KeyError if the attribute name could not be converted to an index
      *  \note Alternatively in Python: @code feature[name] = attr @endcode
-     *  \see setFields
+     #endif
+     * \see setFields()
      */
+#ifndef SIP_RUN
+    bool setAttribute( const QString &name, const QVariant &value );
+#else
     void setAttribute( const QString &name, const QVariant &value / GetWrapper / );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -506,27 +509,23 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
-#ifndef SIP_RUN
 
     /**
-     * Removes an attribute value by field name. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param name The name of the field to delete
-     *  \returns FALSE if attribute name could not be converted to index (C++ only)
-     *  \see setFields
-     */
-    bool deleteAttribute( const QString &name );
-#else
-
-    /**
-     * Removes an attribute value by field name. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param name The name of the field to delete
+     * Removes an attribute value by field \a name.
+     *
+     * Field map must be associated using setFields()before this method can be used.
+     *
+     * \param name The name of the field to delete
+     #ifndef SIP_RUN
+     * \returns FALSE if attribute name could not be converted to index
+     #else
      *  \throws KeyError if attribute name could not be converted to index
      *  \note Alternatively in Python: @code del feature[name] @endcode
-     *  \see setFields
+     #endif
+     * \see setFields()
      */
     bool deleteAttribute( const QString &name );
+#ifdef SIP_RUN
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -543,26 +542,24 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
-#ifndef SIP_RUN
-
     /**
-     * Lookup attribute value from attribute name. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param name The name of the attribute to get
-     *  \returns The value of the attribute (C++: Invalid variant if no such name exists )
-     *  \see setFields
+     * Lookup attribute value by attribute \a name.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * \param name The name of the attribute to get
+     #ifndef SIP_RUN
+     * \returns The value of the attribute, or an invalid/null variant if no such name exists
+     #else
+     * \returns The value of the attribute
+     * \throws KeyError if the field is not found
+     * \note Alternatively in Python: @code feature[name] @endcode
+     #endif
+     * \see setFields
      */
+#ifndef SIP_RUN
     QVariant attribute( const QString &name ) const;
 #else
-
-    /**
-     * Lookup attribute value from attribute name. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param name The name of the attribute to get
-     *  \throws KeyError if the field is not found
-     *  \note Alternatively in Python: @code feature[name] @endcode
-     *  \see setFields
-     */
     SIP_PYOBJECT attribute( const QString &name ) const;
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -579,26 +576,25 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
-#ifndef SIP_RUN
 
     /**
-     * Lookup attribute value from its index. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param fieldIdx The index of the attribute to get
-     *  \returns The value of the attribute (C++: Invalid variant if no such index exists )
-     *  \see setFields
+     * Lookup attribute value from its index.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * \param fieldIdx The index of the attribute to get
+     #ifndef SIP_RUN
+     * \returns The value of the attribute, or an invalid/null variant if no such name exists
+     #else
+     * \returns The value of the attribute
+     * \throws KeyError if the field is not found
+     * \note Alternatively in Python: @code feature[fieldIdx] @endcode
+     #endif
+     * \see setFields()
      */
+#ifndef SIP_RUN
     QVariant attribute( int fieldIdx ) const;
 #else
-
-    /**
-     * Lookup attribute value from its index. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param fieldIdx The index of the attribute to get
-     *  \throws KeyError if the field is not found
-     *  \note Alternatively in Python: @code feature[fieldIdx] @endcode
-     *  \see setFields
-     */
     SIP_PYOBJECT attribute( int fieldIdx ) const;
     % MethodCode
     {
@@ -633,11 +629,13 @@ class CORE_EXPORT QgsFeature
     void setEmbeddedSymbol( QgsSymbol *symbol SIP_TRANSFER );
 
     /**
-     * Utility method to get attribute index from name. Field map must be associated using setFields()
-     *  before this method can be used.
-     *  \param fieldName name of field to get attribute index of
-     *  \returns -1 if field does not exist or field map is not associated.
-     *  \see setFields
+     * Utility method to get attribute index from name.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * \param fieldName name of field to get attribute index of
+     * \returns -1 if field does not exist or field map is not associated.
+     * \see setFields()
      */
     int fieldNameIndex( const QString &fieldName ) const;
 

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -256,19 +256,28 @@ class CORE_EXPORT QgsFeature
      */
     void setAttributes( const QgsAttributes &attrs );
 
+#ifndef SIP_RUN
+
     /**
      * Set an attribute's value by field index.
      * The feature will be valid if it was successful.
      * \param field the index of the field to set
      * \param attr the value of the attribute
      * \returns FALSE, if the field index does not exist
-     * \note For Python: raises a KeyError exception instead of returning FALSE
+     * \see setAttributes
+     */
+    bool setAttribute( int field, const QVariant &attr );
+#else
+
+    /**
+     * Set an attribute's value by field index.
+     * The feature will be valid if it was successful.
+     * \param field the index of the field to set
+     * \param attr the value of the attribute
+     * \throws KeyError if the field index does not exist
      * \note Alternatively in Python: @code feature[field] = attr @endcode
      * \see setAttributes
      */
-#ifndef SIP_RUN
-    bool setAttribute( int field, const QVariant &attr );
-#else
     bool setAttribute( int field, const QVariant &attr / GetWrapper / );
     % MethodCode
     bool rv;
@@ -323,15 +332,24 @@ class CORE_EXPORT QgsFeature
      */
     void padAttributes( int count );
 
+#ifndef SIP_RUN
+
     /**
      * Deletes an attribute and its value.
      * \param field the index of the field
      * \see setAttribute
-     * \note For Python: raises a KeyError exception if the field is not found
+     */
+    void deleteAttribute( int field );
+#else
+
+    /**
+     * Deletes an attribute and its value.
+     * \param field the index of the field
+     * \see setAttribute
+     * \throws KeyError if the field is not found
      * \note Alternatively in Python: @code del feature[field] @endcode
      */
     void deleteAttribute( int field );
-#ifdef SIP_RUN
     % MethodCode
     if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
       sipCpp->deleteAttribute( a0 );
@@ -442,6 +460,8 @@ class CORE_EXPORT QgsFeature
      */
     QgsFields fields() const;
 
+#ifndef SIP_RUN
+
     /**
      * Insert a value into attribute. Returns FALSE if attribute name could not be converted to index.
      *  Field map must be associated using setFields() before this method can be used.
@@ -449,13 +469,21 @@ class CORE_EXPORT QgsFeature
      *  \param name The name of the field to set
      *  \param value The value to set
      *  \returns FALSE if attribute name could not be converted to index (C++ only)
-     *  \note For Python: raises a KeyError exception instead of returning FALSE
+     *  \see setFields
+     */
+    bool setAttribute( const QString &name, const QVariant &value );
+#else
+
+    /**
+     * Insert a value into attribute. Returns FALSE if attribute name could not be converted to index.
+     *  Field map must be associated using setFields() before this method can be used.
+     *  The feature will be valid if it was successful
+     *  \param name The name of the field to set
+     *  \param value The value to set
+     *  \throws KeyError if the attribute name could not be converted to an index
      *  \note Alternatively in Python: @code feature[name] = attr @endcode
      *  \see setFields
      */
-#ifndef SIP_RUN
-    bool setAttribute( const QString &name, const QVariant &value );
-#else
     void setAttribute( const QString &name, const QVariant &value / GetWrapper / );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -478,17 +506,27 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Removes an attribute value by field name. Field map must be associated using setFields()
      *  before this method can be used.
      *  \param name The name of the field to delete
      *  \returns FALSE if attribute name could not be converted to index (C++ only)
-     *  \note For Python: raises a KeyError exception instead of returning FALSE
+     *  \see setFields
+     */
+    bool deleteAttribute( const QString &name );
+#else
+
+    /**
+     * Removes an attribute value by field name. Field map must be associated using setFields()
+     *  before this method can be used.
+     *  \param name The name of the field to delete
+     *  \throws KeyError if attribute name could not be converted to index
      *  \note Alternatively in Python: @code del feature[name] @endcode
      *  \see setFields
      */
     bool deleteAttribute( const QString &name );
-#ifdef SIP_RUN
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -505,18 +543,26 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Lookup attribute value from attribute name. Field map must be associated using setFields()
      *  before this method can be used.
      *  \param name The name of the attribute to get
      *  \returns The value of the attribute (C++: Invalid variant if no such name exists )
-     *  \note For Python: raises a KeyError exception if the field is not found
+     *  \see setFields
+     */
+    QVariant attribute( const QString &name ) const;
+#else
+
+    /**
+     * Lookup attribute value from attribute name. Field map must be associated using setFields()
+     *  before this method can be used.
+     *  \param name The name of the attribute to get
+     *  \throws KeyError if the field is not found
      *  \note Alternatively in Python: @code feature[name] @endcode
      *  \see setFields
      */
-#ifndef SIP_RUN
-    QVariant attribute( const QString &name ) const;
-#else
     SIP_PYOBJECT attribute( const QString &name ) const;
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -533,18 +579,26 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Lookup attribute value from its index. Field map must be associated using setFields()
      *  before this method can be used.
      *  \param fieldIdx The index of the attribute to get
      *  \returns The value of the attribute (C++: Invalid variant if no such index exists )
-     *  \note For Python: raises a KeyError exception if the field is not found
+     *  \see setFields
+     */
+    QVariant attribute( int fieldIdx ) const;
+#else
+
+    /**
+     * Lookup attribute value from its index. Field map must be associated using setFields()
+     *  before this method can be used.
+     *  \param fieldIdx The index of the attribute to get
+     *  \throws KeyError if the field is not found
      *  \note Alternatively in Python: @code feature[fieldIdx] @endcode
      *  \see setFields
      */
-#ifndef SIP_RUN
-    QVariant attribute( int fieldIdx ) const;
-#else
     SIP_PYOBJECT attribute( int fieldIdx ) const;
     % MethodCode
     {

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -259,6 +259,8 @@ class CORE_EXPORT QgsFeature
      */
     void setAttributes( const QgsAttributes &attrs );
 
+#ifndef SIP_RUN
+
     /**
      * Sets an attribute's value by field index.
      *
@@ -266,17 +268,23 @@ class CORE_EXPORT QgsFeature
      *
      * \param field the index of the field to set
      * \param attr the value of the attribute
-    #ifndef SIP_RUN
      * \returns FALSE, if the field index does not exist
-    #else
-     * \throws KeyError if the field index does not exist
-     * \note Alternatively in Python: @code feature[field] = attr @endcode
-    #endif
      * \see setAttributes()
      */
-#ifndef SIP_RUN
     bool setAttribute( int field, const QVariant &attr );
 #else
+
+    /**
+     * Sets an attribute's value by field index.
+     *
+     * If the attribute was successfully set then the feature will be automatically marked as valid (see isValid()).
+     *
+     * \param field the index of the field to set
+     * \param attr the value of the attribute
+     * \throws KeyError if the field index does not exist
+     * \note Alternatively in Python: @code feature[field] = attr @endcode
+     * \see setAttributes()
+     */
     bool setAttribute( int field, const QVariant &attr / GetWrapper / );
     % MethodCode
     bool rv;
@@ -334,19 +342,28 @@ class CORE_EXPORT QgsFeature
      */
     void padAttributes( int count );
 
+#ifndef SIP_RUN
+
     /**
      * Deletes an attribute and its value.
      *
      * \param field the index of the field
      *
-    #ifdef SIP_RUN
-     * \throws KeyError if the field is not found
-     * \note Alternatively in Python: @code del feature[field] @endcode
-    #endif
      * \see setAttribute()
      */
     void deleteAttribute( int field );
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Deletes an attribute and its value.
+     *
+     * \param field the index of the field
+     *
+     * \throws KeyError if the field is not found
+     * \note Alternatively in Python: @code del feature[field] @endcode
+     * \see setAttribute()
+     */
+    void deleteAttribute( int field );
     % MethodCode
     if ( a0 >= 0 && a0 < sipCpp->attributes().count() )
       sipCpp->deleteAttribute( a0 );
@@ -465,6 +482,8 @@ class CORE_EXPORT QgsFeature
      */
     QgsFields fields() const;
 
+#ifndef SIP_RUN
+
     /**
      * Insert a value into attribute, by field \a name.
      *
@@ -476,17 +495,27 @@ class CORE_EXPORT QgsFeature
      *
      * \param name The name of the field to set
      * \param value The value to set
-     #ifndef SIP_RUN
      * \returns FALSE if attribute name could not be converted to index
-     #else
-     *  \throws KeyError if the attribute name could not be converted to an index
-     *  \note Alternatively in Python: @code feature[name] = attr @endcode
-     #endif
      * \see setFields()
      */
-#ifndef SIP_RUN
     bool setAttribute( const QString &name, const QVariant &value );
 #else
+
+    /**
+     * Insert a value into attribute, by field \a name.
+     *
+     * Returns FALSE if field \a name could not be matched.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * Calling this method will automatically set the feature as valid (see isValid()).
+     *
+     * \param name The name of the field to set
+     * \param value The value to set
+     *  \throws KeyError if the attribute name could not be converted to an index
+     *  \note Alternatively in Python: @code feature[name] = attr @endcode
+     * \see setFields()
+     */
     void setAttribute( const QString &name, const QVariant &value / GetWrapper / );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -509,6 +538,7 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
 
     /**
      * Removes an attribute value by field \a name.
@@ -516,16 +546,23 @@ class CORE_EXPORT QgsFeature
      * Field map must be associated using setFields()before this method can be used.
      *
      * \param name The name of the field to delete
-     #ifndef SIP_RUN
      * \returns FALSE if attribute name could not be converted to index
-     #else
-     *  \throws KeyError if attribute name could not be converted to index
-     *  \note Alternatively in Python: @code del feature[name] @endcode
-     #endif
      * \see setFields()
      */
     bool deleteAttribute( const QString &name );
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Removes an attribute value by field \a name.
+     *
+     * Field map must be associated using setFields()before this method can be used.
+     *
+     * \param name The name of the field to delete
+     * \throws KeyError if attribute name could not be converted to index
+     * \note Alternatively in Python: @code del feature[name] @endcode
+     * \see setFields()
+     */
+    bool deleteAttribute( const QString &name );
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
     if ( fieldIdx == -1 )
@@ -542,24 +579,31 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Lookup attribute value by attribute \a name.
      *
      * Field map must be associated using setFields() before this method can be used.
      *
      * \param name The name of the attribute to get
-     #ifndef SIP_RUN
      * \returns The value of the attribute, or an invalid/null variant if no such name exists
-     #else
+     * \see setFields
+     */
+    QVariant attribute( const QString &name ) const;
+#else
+
+    /**
+     * Lookup attribute value by attribute \a name.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * \param name The name of the attribute to get
      * \returns The value of the attribute
      * \throws KeyError if the field is not found
      * \note Alternatively in Python: @code feature[name] @endcode
-     #endif
      * \see setFields
      */
-#ifndef SIP_RUN
-    QVariant attribute( const QString &name ) const;
-#else
     SIP_PYOBJECT attribute( const QString &name ) const;
     % MethodCode
     int fieldIdx = sipCpp->fieldNameIndex( *a0 );
@@ -576,6 +620,7 @@ class CORE_EXPORT QgsFeature
     % End
 #endif
 
+#ifndef SIP_RUN
 
     /**
      * Lookup attribute value from its index.
@@ -583,18 +628,23 @@ class CORE_EXPORT QgsFeature
      * Field map must be associated using setFields() before this method can be used.
      *
      * \param fieldIdx The index of the attribute to get
-     #ifndef SIP_RUN
      * \returns The value of the attribute, or an invalid/null variant if no such name exists
-     #else
+     * \see setFields()
+     */
+    QVariant attribute( int fieldIdx ) const;
+#else
+
+    /**
+     * Lookup attribute value from its index.
+     *
+     * Field map must be associated using setFields() before this method can be used.
+     *
+     * \param fieldIdx The index of the attribute to get
      * \returns The value of the attribute
      * \throws KeyError if the field is not found
      * \note Alternatively in Python: @code feature[fieldIdx] @endcode
-     #endif
      * \see setFields()
      */
-#ifndef SIP_RUN
-    QVariant attribute( int fieldIdx ) const;
-#else
     SIP_PYOBJECT attribute( int fieldIdx ) const;
     % MethodCode
     {

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -346,7 +346,7 @@ class CORE_EXPORT QgsField
      *
      * \param v  The value to convert
      *
-     * \returns   TRUE if the conversion was successful
+     * \throws ValueError if the value could not be converted to a compatible format
      */
     bool convertCompatible( QVariant &v ) const;
     % MethodCode

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -111,17 +111,19 @@ class CORE_EXPORT  QgsFields
     //! Appends an expression field. The field must have unique name, otherwise it is rejected (returns FALSE)
     bool appendExpressionField( const QgsField &field, int originIndex );
 
+#ifndef SIP_RUN
 
     /**
      * Removes the field with the given index.
-     #ifdef SIP_RUN
-     *
-     * \throws KeyError if no field with the specified index exists
-     #endif
      */
-#ifndef SIP_RUN
     void remove( int fieldIdx );
 #else
+
+    /**
+     * Removes the field with the given index.
+     *
+     * \throws KeyError if no field with the specified index exists
+     */
     void remove( int fieldIdx );
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -191,15 +193,18 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Returns the field at particular index (must be in range 0..N-1).
-     #ifdef SIP_RUN
-     * \throws KeyError if no field exists at the specified index
-     #endif
      */
-#ifndef SIP_RUN
     QgsField at( int i ) const SIP_FACTORY;
 #else
+
+    /**
+     * Returns the field at particular index (must be in range 0..N-1).
+     * \throws KeyError if no field exists at the specified index
+     */
     QgsField at( int i ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -214,15 +219,18 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Returns the field at particular index (must be in range 0..N-1).
-     #ifdef SIP_RUN
-     * \throws KeyError if no field exists at the specified index
-     #endif
      */
-#ifndef SIP_RUN
     QgsField field( int fieldIdx ) const SIP_FACTORY;
 #else
+
+    /**
+     * Returns the field at particular index (must be in range 0..N-1).
+     * \throws KeyError if no field exists at the specified index
+     */
     QgsField field( int fieldIdx ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -237,16 +245,18 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Returns the field with matching name.
-     #ifdef SIP_RUN
-     * \throws KeyError if no matching field was found.
-     #endif
      */
-#ifndef SIP_RUN
     QgsField field( const QString &name ) const SIP_FACTORY;
 #else
 
+    /**
+     * Returns the field with matching name.
+     * \throws KeyError if no matching field was found.
+     */
     QgsField field( const QString &name ) const SIP_FACTORY;
     % MethodCode
     int fieldIdx = sipCpp->indexFromName( *a0 );
@@ -262,16 +272,19 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
+
+    /**
+     * Returns the field's origin (value from an enumeration).
+     */
+    FieldOrigin fieldOrigin( int fieldIdx ) const;
+#else
+
     /**
      * Returns the field's origin (value from an enumeration).
      *
-     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
-     #endif
      */
-#ifndef SIP_RUN
-    FieldOrigin fieldOrigin( int fieldIdx ) const;
-#else
     FieldOrigin fieldOrigin( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -286,16 +299,19 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
+
+    /**
+     * Returns the field's origin index (its meaning is specific to each type of origin).
+     */
+    int fieldOriginIndex( int fieldIdx ) const;
+#else
+
     /**
      * Returns the field's origin index (its meaning is specific to each type of origin).
      *
-     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
-     #endif
      */
-#ifndef SIP_RUN
-    int fieldOriginIndex( int fieldIdx ) const;
-#else
     int fieldOriginIndex( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -369,18 +385,24 @@ class CORE_EXPORT  QgsFields
     //! \since QGIS 2.6
     bool operator!=( const QgsFields &other ) const { return !( *this == other ); }
 
+#ifndef SIP_RUN
+
     /**
      * Returns an icon corresponding to a field index, based on the field's type and source
      * \param fieldIdx the field index
      * \param considerOrigin if TRUE the icon will the origin of the field
-     #ifdef SIP_RUN
-     * \throws KeyError if no field exists at the specified index
-     #endif
      * \since QGIS 2.14
      */
-#ifndef SIP_RUN
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
 #else
+
+    /**
+     * Returns an icon corresponding to a field index, based on the field's type and source
+     * \param fieldIdx the field index
+     * \param considerOrigin if TRUE the icon will the origin of the field
+     * \throws KeyError if no field exists at the specified index
+     * \since QGIS 2.14
+     */
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -111,9 +111,20 @@ class CORE_EXPORT  QgsFields
     //! Appends an expression field. The field must have unique name, otherwise it is rejected (returns FALSE)
     bool appendExpressionField( const QgsField &field, int originIndex );
 
-    //! Removes a field with the given index
+#ifndef SIP_RUN
+
+    /**
+     * Removes the field with the given index.
+     */
     void remove( int fieldIdx );
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Removes the field with the given index.
+     *
+     * \throws KeyError if no field with the specified index exists
+     */
+    void remove( int fieldIdx );
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {
@@ -182,9 +193,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
-    //! Gets field at particular index (must be in range 0..N-1)
+#ifndef SIP_RUN
+    //! Returns the field at particular index (must be in range 0..N-1)
     QgsField at( int i ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the field at particular index (must be in range 0..N-1).
+     * \throws KeyError if no field exists at the specified index
+     */
+    QgsField at( int i ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {
@@ -198,9 +216,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
     //! Gets field at particular index (must be in range 0..N-1)
     QgsField field( int fieldIdx ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the field at particular index (must be in range 0..N-1).
+     * \throws KeyError if no field exists at the specified index
+     */
+    QgsField field( int fieldIdx ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {
@@ -214,9 +239,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
     //! Gets field with matching name
     QgsField field( const QString &name ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the field with matching name.
+     * \throws KeyError if no matching field was found.
+     */
+    QgsField field( const QString &name ) const SIP_FACTORY;
     % MethodCode
     int fieldIdx = sipCpp->indexFromName( *a0 );
     if ( fieldIdx == -1 )
@@ -231,9 +263,17 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
     //! Gets field's origin (value from an enumeration)
     FieldOrigin fieldOrigin( int fieldIdx ) const;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the field's origin (value from an enumeration).
+     *
+     * \throws KeyError if no field exists at the specified index
+     */
+    FieldOrigin fieldOrigin( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {
@@ -247,9 +287,17 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifndef SIP_RUN
     //! Gets field's origin index (its meaning is specific to each type of origin)
     int fieldOriginIndex( int fieldIdx ) const;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the field's origin index (its meaning is specific to each type of origin).
+     *
+     * \throws KeyError if no field exists at the specified index
+     */
+    int fieldOriginIndex( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {
@@ -319,6 +367,8 @@ class CORE_EXPORT  QgsFields
     //! \since QGIS 2.6
     bool operator!=( const QgsFields &other ) const { return !( *this == other ); }
 
+#ifndef SIP_RUN
+
     /**
      * Returns an icon corresponding to a field index, based on the field's type and source
      * \param fieldIdx the field index
@@ -326,7 +376,16 @@ class CORE_EXPORT  QgsFields
      * \since QGIS 2.14
      */
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns an icon corresponding to a field index, based on the field's type and source
+     * \param fieldIdx the field index
+     * \param considerOrigin if TRUE the icon will the origin of the field
+     * \throws KeyError if no field exists at the specified index
+     * \since QGIS 2.14
+     */
+    QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
     {

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -111,19 +111,17 @@ class CORE_EXPORT  QgsFields
     //! Appends an expression field. The field must have unique name, otherwise it is rejected (returns FALSE)
     bool appendExpressionField( const QgsField &field, int originIndex );
 
-#ifndef SIP_RUN
 
     /**
      * Removes the field with the given index.
-     */
-    void remove( int fieldIdx );
-#else
-
-    /**
-     * Removes the field with the given index.
+     #ifdef SIP_RUN
      *
      * \throws KeyError if no field with the specified index exists
+     #endif
      */
+#ifndef SIP_RUN
+    void remove( int fieldIdx );
+#else
     void remove( int fieldIdx );
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -193,15 +191,15 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
-#ifndef SIP_RUN
-    //! Returns the field at particular index (must be in range 0..N-1)
-    QgsField at( int i ) const SIP_FACTORY;
-#else
-
     /**
      * Returns the field at particular index (must be in range 0..N-1).
+     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
+     #endif
      */
+#ifndef SIP_RUN
+    QgsField at( int i ) const SIP_FACTORY;
+#else
     QgsField at( int i ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -216,15 +214,15 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
-#ifndef SIP_RUN
-    //! Gets field at particular index (must be in range 0..N-1)
-    QgsField field( int fieldIdx ) const SIP_FACTORY;
-#else
-
     /**
      * Returns the field at particular index (must be in range 0..N-1).
+     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
+     #endif
      */
+#ifndef SIP_RUN
+    QgsField field( int fieldIdx ) const SIP_FACTORY;
+#else
     QgsField field( int fieldIdx ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -239,15 +237,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+    /**
+     * Returns the field with matching name.
+     #ifdef SIP_RUN
+     * \throws KeyError if no matching field was found.
+     #endif
+     */
 #ifndef SIP_RUN
-    //! Gets field with matching name
     QgsField field( const QString &name ) const SIP_FACTORY;
 #else
 
-    /**
-     * Returns the field with matching name.
-     * \throws KeyError if no matching field was found.
-     */
     QgsField field( const QString &name ) const SIP_FACTORY;
     % MethodCode
     int fieldIdx = sipCpp->indexFromName( *a0 );
@@ -263,16 +262,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
-#ifndef SIP_RUN
-    //! Gets field's origin (value from an enumeration)
-    FieldOrigin fieldOrigin( int fieldIdx ) const;
-#else
-
     /**
      * Returns the field's origin (value from an enumeration).
      *
+     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
+     #endif
      */
+#ifndef SIP_RUN
+    FieldOrigin fieldOrigin( int fieldIdx ) const;
+#else
     FieldOrigin fieldOrigin( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -287,16 +286,16 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
-#ifndef SIP_RUN
-    //! Gets field's origin index (its meaning is specific to each type of origin)
-    int fieldOriginIndex( int fieldIdx ) const;
-#else
-
     /**
      * Returns the field's origin index (its meaning is specific to each type of origin).
      *
+     #ifdef SIP_RUN
      * \throws KeyError if no field exists at the specified index
+     #endif
      */
+#ifndef SIP_RUN
+    int fieldOriginIndex( int fieldIdx ) const;
+#else
     int fieldOriginIndex( int fieldIdx ) const;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -313,8 +312,10 @@ class CORE_EXPORT  QgsFields
 
     /**
      * Gets the field index from the field name.
+     *
      * This method is case sensitive and only matches the data source
      * name of the field.
+     *
      * Alias for indexOf
      *
      * \param fieldName The name of the field.
@@ -326,6 +327,7 @@ class CORE_EXPORT  QgsFields
 
     /**
      * Gets the field index from the field name.
+     *
      * This method is case sensitive and only matches the data source
      * name of the field.
      *
@@ -367,24 +369,18 @@ class CORE_EXPORT  QgsFields
     //! \since QGIS 2.6
     bool operator!=( const QgsFields &other ) const { return !( *this == other ); }
 
-#ifndef SIP_RUN
-
     /**
      * Returns an icon corresponding to a field index, based on the field's type and source
      * \param fieldIdx the field index
      * \param considerOrigin if TRUE the icon will the origin of the field
+     #ifdef SIP_RUN
+     * \throws KeyError if no field exists at the specified index
+     #endif
      * \since QGIS 2.14
      */
+#ifndef SIP_RUN
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
 #else
-
-    /**
-     * Returns an icon corresponding to a field index, based on the field's type and source
-     * \param fieldIdx the field index
-     * \param considerOrigin if TRUE the icon will the origin of the field
-     * \throws KeyError if no field exists at the specified index
-     * \since QGIS 2.14
-     */
     QIcon iconForField( int fieldIdx, bool considerOrigin = false ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->count() )
@@ -398,7 +394,6 @@ class CORE_EXPORT  QgsFields
     }
     % End
 #endif
-
 
     /**
      * Returns an icon corresponding to a field \a type

--- a/src/core/qgspathresolver.h
+++ b/src/core/qgspathresolver.h
@@ -156,7 +156,8 @@ class CORE_EXPORT QgsPathResolver
      * Removes the custom pre-processor function with matching \a id.
      *
      * The \a id must correspond to a pre-processor previously added via a call to setPathPreprocessor().
-     * An KeyError will be raised if no processor with the specified \a id exists.
+     *
+     * \throws KeyError if no processor with the specified \a id exists.
      *
      * \see setPathPreprocessor()
      * \since QGIS 3.10

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -50,10 +50,7 @@ class QgsPoint;
  *
  * Use cases for which QgsPointXY is NOT a valid choice include:
  *
- * - Storage of coordinates for a geometry. Since QgsPointXY is strictly 2-dimensional
- *
- * it should never be used to store coordinates for vector geometries, as this will involve
- * a loss of any z or m values present in the geometry.
+ * - Storage of coordinates for a geometry. Since QgsPointXY is strictly 2-dimensional it should never be used to store coordinates for vector geometries, as this will involve a loss of any z or m values present in the geometry.
  *
  * \see QgsPoint
  * \since QGIS 3.0

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -243,10 +243,11 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
 #else
 
     /**
-     * Returns the stored geometry for the indexed feature with matching \a id. A KeyError will be raised if no
-     * geometry with the specified feature id exists in the index.
+     * Returns the stored geometry for the indexed feature with matching \a id.
      *
      * Geometry is only stored if the QgsSpatialIndex was created with the FlagStoreFeatureGeometries flag.
+     *
+     * \throws KeyError if no geometry with the specified feature id exists in the index.
      *
      * \since QGIS 3.6
      */

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -127,7 +127,9 @@ class CORE_EXPORT QgsSymbol
 #else
 
     /**
-     * Returns the symbol layer at the specified index. An IndexError will be raised if no layer with the specified index exists.
+     * Returns the symbol layer at the specified index.
+     *
+     * \throws IndexError if no layer with the specified index exists.
      *
      * \see symbolLayers
      * \see symbolLayerCount
@@ -174,10 +176,12 @@ class CORE_EXPORT QgsSymbol
     % End
 
     /**
-    * Returns the symbol layer at the specified ``index``. An IndexError will be raised if no layer with the specified ``index`` exists.
+    * Returns the symbol layer at the specified ``index``.
     *
     * Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
     * corresponds to the last layer in the symbol.
+    *
+    * \throws IndexError if no layer with the specified ``index`` exists.
     *
     * \since QGIS 3.10
     */
@@ -200,10 +204,12 @@ class CORE_EXPORT QgsSymbol
     % End
 
     /**
-     * Deletes the layer at the specified ``index``. A layer at the ``index`` must already exist or an IndexError will be raised.
+     * Deletes the layer at the specified ``index``.
      *
      * Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
      * corresponds to the last layer in the symbol.
+     *
+     * \throws IndexError if no layer at the specified ``index`` exists
      *
      * \since QGIS 3.10
      */

--- a/src/core/textrenderer/qgstextblock.h
+++ b/src/core/textrenderer/qgstextblock.h
@@ -93,11 +93,20 @@ class CORE_EXPORT QgsTextBlock
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Returns the fragment at the specified \a index.
      */
     const QgsTextFragment &at( int index ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the fragment at the specified \a index.
+     *
+     * \throws KeyError if no fragment exists at the specified index.
+     */
+    const QgsTextFragment &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )
     {

--- a/src/core/textrenderer/qgstextblock.h
+++ b/src/core/textrenderer/qgstextblock.h
@@ -93,16 +93,19 @@ class CORE_EXPORT QgsTextBlock
     % End
 #endif
 
+#ifndef SIP_RUN
+
     /**
      * Returns the fragment at the specified \a index.
-     #ifdef SIP_RUN
-     *
-     * \throws KeyError if no fragment exists at the specified index.
-     #endif
      */
-#ifndef SIP_RUN
     const QgsTextFragment &at( int index ) const SIP_FACTORY;
 #else
+
+    /**
+     * Returns the fragment at the specified \a index.
+     *
+     * \throws KeyError if no fragment exists at the specified index.
+     */
     const QgsTextFragment &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/src/core/textrenderer/qgstextblock.h
+++ b/src/core/textrenderer/qgstextblock.h
@@ -93,19 +93,16 @@ class CORE_EXPORT QgsTextBlock
     % End
 #endif
 
-#ifndef SIP_RUN
-
     /**
      * Returns the fragment at the specified \a index.
-     */
-    const QgsTextFragment &at( int index ) const SIP_FACTORY;
-#else
-
-    /**
-     * Returns the fragment at the specified \a index.
+     #ifdef SIP_RUN
      *
      * \throws KeyError if no fragment exists at the specified index.
+     #endif
      */
+#ifndef SIP_RUN
+    const QgsTextFragment &at( int index ) const SIP_FACTORY;
+#else
     const QgsTextFragment &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/src/core/textrenderer/qgstextdocument.h
+++ b/src/core/textrenderer/qgstextdocument.h
@@ -78,11 +78,20 @@ class CORE_EXPORT QgsTextDocument
      */
     void reserve( int count );
 
+#ifndef SIP_RUN
+
     /**
      * Returns the block at the specified \a index.
      */
     const QgsTextBlock &at( int index ) const SIP_FACTORY;
-#ifdef SIP_RUN
+#else
+
+    /**
+     * Returns the block at the specified \a index.
+     *
+     * \throws KeyError if no block exists at the specified index.
+     */
+    const QgsTextBlock &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )
     {

--- a/src/core/textrenderer/qgstextdocument.h
+++ b/src/core/textrenderer/qgstextdocument.h
@@ -78,16 +78,19 @@ class CORE_EXPORT QgsTextDocument
      */
     void reserve( int count );
 
+#ifndef SIP_RUN
+
     /**
      * Returns the block at the specified \a index.
-     #ifdef SIP_RUN
-     *
-     * \throws KeyError if no block exists at the specified index.
-     #endif
      */
-#ifndef SIP_RUN
     const QgsTextBlock &at( int index ) const SIP_FACTORY;
 #else
+
+    /**
+     * Returns the block at the specified \a index.
+     *
+     * \throws KeyError if no block exists at the specified index.
+     */
     const QgsTextBlock &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )

--- a/src/core/textrenderer/qgstextdocument.h
+++ b/src/core/textrenderer/qgstextdocument.h
@@ -78,19 +78,16 @@ class CORE_EXPORT QgsTextDocument
      */
     void reserve( int count );
 
-#ifndef SIP_RUN
-
     /**
      * Returns the block at the specified \a index.
-     */
-    const QgsTextBlock &at( int index ) const SIP_FACTORY;
-#else
-
-    /**
-     * Returns the block at the specified \a index.
+     #ifdef SIP_RUN
      *
      * \throws KeyError if no block exists at the specified index.
+     #endif
      */
+#ifndef SIP_RUN
+    const QgsTextBlock &at( int index ) const SIP_FACTORY;
+#else
     const QgsTextBlock &at( int index ) const SIP_FACTORY;
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->size() )


### PR DESCRIPTION
Fixes this formatting issue in the PyQGIS docs:

![image](https://user-images.githubusercontent.com/1829991/121290933-ca03fb00-c92a-11eb-82f6-52299c6801fc.png)
