### PR TITLE
Network request preprocessor

### DIFF
--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -338,11 +338,21 @@ The ``processor`` function takes the QNetworkRequest as its argument, and can mu
     PyObject *s = 0;
     Py_BEGIN_ALLOW_THREADS
     Py_XINCREF( a0 );
-    QString id = QgsNetworkAccessManager::setRequestPreprocessor( [a0]( QNetworkRequest *arg )
+    QString id = QgsNetworkAccessManager::setRequestPreprocessor( [a0]( QNetworkRequest *arg )->QString
     {
+      QString res;
       SIP_BLOCK_THREADS
-      Py_XDECREF( sipCallMethod( NULL, a0, "D", &arg, sipType_QNetworkRequest, NULL ) );
+      PyObject *s = sipCallMethod( NULL, a0, "D", arg, sipType_QNetworkRequest, NULL );
+      int state;
+      int sipIsError = 0;
+      QString *t1 = reinterpret_cast<QString *>( sipConvertToType( s, sipType_QString, 0, SIP_NOT_NONE, &state, &sipIsError ) );
+      if ( sipIsError == 0 )
+      {
+        res = QString( *t1 );
+      }
+      sipReleaseType( t1, sipType_QString, state );
       SIP_UNBLOCK_THREADS
+      return res;
     } );
 
     s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -405,6 +405,7 @@ Abort any outstanding external browser login request.
 
 
 
+    void preprocessRequest( QNetworkRequest *req ) const;
 
   signals:
 

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -416,6 +416,11 @@ Abort any outstanding external browser login request.
 
 
     void preprocessRequest( QNetworkRequest *req ) const;
+%Docstring
+Preprocesses request
+
+:param req: the request to preprocess
+%End
 
   signals:
 

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -332,7 +332,7 @@ The ``processor`` function takes the QNetworkRequest as its argument, and can mu
 
 .. seealso:: :py:func:`removeRequestPreprocessor`
 
-.. versionadded:: 3.12
+.. versionadded:: 3.22
 %End
 %MethodCode
     PyObject *s = 0;
@@ -370,7 +370,7 @@ Returns ``True`` if processor existed and was removed.
 
 .. seealso:: :py:func:`setRequestPreprocessor`
 
-.. versionadded:: 3.12
+.. versionadded:: 3.22
 %End
 %MethodCode
     if ( !QgsNetworkAccessManager::removeRequestPreprocessor( *a0 ) )
@@ -420,6 +420,8 @@ Abort any outstanding external browser login request.
 Preprocesses request
 
 :param req: the request to preprocess
+
+.. versionadded:: 3.22
 %End
 
   signals:

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -323,9 +323,9 @@ The contents of the reply will be returned after the request is completed or an 
 
     static QString setRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
 %Docstring
-Sets a request pre-processor function, which allows to manipulate a network request before it is processed.
+Sets a request pre-processor function, which allows manipulation of a network request before it is processed.
 
-The ``processor`` function takes the QNetworkRequest as its argument, and can mutate the request if neccessary.
+The ``processor`` function takes the QNetworkRequest as its argument, and can mutate the request if necessary.
 
 :return: An auto-generated string uniquely identifying the preprocessor, which can later be
          used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeRequestPreprocessor`).

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -321,6 +321,55 @@ The contents of the reply will be returned after the request is completed or an 
 .. versionadded:: 3.6
 %End
 
+    static QString setRequestPreprocessor( SIP_PYCALLABLE / AllowNone / );
+%Docstring
+Sets a request pre-processor function, which allows to manipulate a network request before it is processed.
+
+The ``processor`` function takes the QNetworkRequest as its argument, and can mutate the request if neccessary.
+
+:return: An auto-generated string uniquely identifying the preprocessor, which can later be
+         used to remove the preprocessor (via a call to :py:func:`~QgsNetworkAccessManager.removeRequestPreprocessor`).
+
+.. seealso:: :py:func:`removeRequestPreprocessor`
+
+.. versionadded:: 3.12
+%End
+%MethodCode
+    PyObject *s = 0;
+    Py_BEGIN_ALLOW_THREADS
+    Py_XINCREF( a0 );
+    QString id = QgsNetworkAccessManager::setRequestPreprocessor( [a0]( QNetworkRequest *arg )
+    {
+      SIP_BLOCK_THREADS
+      Py_XDECREF( sipCallMethod( NULL, a0, "D", &arg, sipType_QNetworkRequest, NULL ) );
+      SIP_UNBLOCK_THREADS
+    } );
+
+    s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );
+    Py_END_ALLOW_THREADS
+    return s;
+%End
+
+    static void removeRequestPreprocessor( const QString &id );
+%Docstring
+Removes the custom pre-processor function with matching ``id``.
+
+The ``id`` must correspond to a pre-processor previously added via a call to :py:func:`~QgsNetworkAccessManager.setRequestPreprocessor`.
+
+Returns ``True`` if processor existed and was removed.
+
+.. seealso:: :py:func:`setRequestPreprocessor`
+
+.. versionadded:: 3.12
+%End
+%MethodCode
+    if ( !QgsNetworkAccessManager::removeRequestPreprocessor( *a0 ) )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No processor with id %1 exists." ).arg( *a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+%End
+
     void requestAuthOpenBrowser( const QUrl &url ) const;
 %Docstring
 Forwards an external browser login ``url`` opening request to the authentication handler.

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -831,6 +831,14 @@ bool QgsNetworkAccessManager::removeRequestPreprocessor( const QString &id )
   return prevCount != sCustomPreprocessors.size();
 }
 
+void QgsNetworkAccessManager::preprocessRequest( QNetworkRequest *req ) const
+{
+  for ( const auto &preprocessor :  sCustomPreprocessors )
+  {
+    preprocessor.second( req );
+  }
+}
+
 
 //
 // QgsNetworkRequestParameters

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -54,7 +54,7 @@
 
 QgsNetworkAccessManager *QgsNetworkAccessManager::sMainNAM = nullptr;
 
-std::vector< std::pair< QString, std::function< void( QNetworkRequest * ) > > > QgsNetworkAccessManager::sCustomPreprocessors;
+static std::vector< std::pair< QString, std::function< void( QNetworkRequest * ) > > > sCustomPreprocessors;
 
 /// @cond PRIVATE
 class QgsNetworkProxyFactory : public QNetworkProxyFactory

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -43,6 +43,7 @@
 #include <QThreadStorage>
 #include <QAuthenticator>
 #include <QStandardPaths>
+#include <QUuid>
 
 #ifndef QT_NO_SSL
 #include <QSslConfiguration>
@@ -52,6 +53,8 @@
 #include "qgsauthmanager.h"
 
 QgsNetworkAccessManager *QgsNetworkAccessManager::sMainNAM = nullptr;
+
+std::vector< std::pair< QString, std::function< void( QNetworkRequest * ) > > > QgsNetworkAccessManager::sCustomPreprocessors;
 
 /// @cond PRIVATE
 class QgsNetworkProxyFactory : public QNetworkProxyFactory
@@ -335,6 +338,11 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
     // if caching is disabled then we override whatever the request actually has set!
     pReq->setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
     pReq->setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+  }
+
+  for ( const auto &preprocessor :  sCustomPreprocessors )
+  {
+    preprocessor.second( pReq );
   }
 
   static QAtomicInt sRequestId = 0;
@@ -804,6 +812,23 @@ QgsNetworkReplyContent QgsNetworkAccessManager::blockingPost( QNetworkRequest &r
   br.setAuthCfg( authCfg );
   br.post( request, data, forceRefresh, feedback );
   return br.reply();
+}
+
+QString QgsNetworkAccessManager::setRequestPreprocessor( const std::function<void ( QNetworkRequest * )> &processor )
+{
+  QString id = QUuid::createUuid().toString();
+  sCustomPreprocessors.emplace_back( std::make_pair( id, processor ) );
+  return id;
+}
+
+bool QgsNetworkAccessManager::removeRequestPreprocessor( const QString &id )
+{
+  const size_t prevCount = sCustomPreprocessors.size();
+  sCustomPreprocessors.erase( std::remove_if( sCustomPreprocessors.begin(), sCustomPreprocessors.end(), [id]( std::pair< QString, std::function< void( QNetworkRequest * ) > > &a )
+  {
+    return a.first == id;
+  } ), sCustomPreprocessors.end() );
+  return prevCount != sCustomPreprocessors.size();
 }
 
 

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -525,7 +525,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * used to remove the preprocessor (via a call to removeRequestPreprocessor()).
      *
      * \see removeRequestPreprocessor()
-     * \since QGIS 3.12
+     * \since QGIS 3.22
      */
 #ifndef SIP_RUN
     static QString setRequestPreprocessor( const std::function< void( QNetworkRequest *request )> &processor );
@@ -566,7 +566,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * Returns TRUE if processor existed and was removed.
      *
      * \see setRequestPreprocessor()
-     * \since QGIS 3.12
+     * \since QGIS 3.22
      */
 #ifndef SIP_RUN
     static bool removeRequestPreprocessor( const QString &id );
@@ -614,6 +614,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     /**
      * Preprocesses request
      * \param req the request to preprocess
+     * \since QGIS 3.22
      */
     void preprocessRequest( QNetworkRequest *req ) const;
 

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -517,9 +517,9 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     static QgsNetworkReplyContent blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = nullptr );
 
     /**
-     * Sets a request pre-processor function, which allows to manipulate a network request before it is processed.
+     * Sets a request pre-processor function, which allows manipulation of a network request before it is processed.
      *
-     * The \a processor function takes the QNetworkRequest as its argument, and can mutate the request if neccessary.
+     * The \a processor function takes the QNetworkRequest as its argument, and can mutate the request if necessary.
      *
      * \returns An auto-generated string uniquely identifying the preprocessor, which can later be
      * used to remove the preprocessor (via a call to removeRequestPreprocessor()).

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -823,9 +823,6 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QMutex mAuthRequestHandlerMutex;
     // only in use by worker threads, unused in main thread
     QWaitCondition mAuthRequestWaitCondition;
-
-    static std::vector< std::pair< QString, std::function< void( QNetworkRequest * ) > > > sCustomPreprocessors;
-
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -611,6 +611,10 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     static const inline QgsSettingsEntryInteger settingsNetworkTimeout = QgsSettingsEntryInteger( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QgsSettings::NoSection, 60000, QObject::tr( "Network timeout" ) );
 #endif
 
+    /**
+     * Preprocesses request
+     * \param req the request to preprocess
+     */
     void preprocessRequest( QNetworkRequest *req ) const;
 
   signals:

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -601,6 +601,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     static const inline QgsSettingsEntryInteger settingsNetworkTimeout = QgsSettingsEntryInteger( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QgsSettings::NoSection, 60000, QObject::tr( "Network timeout" ) );
 #endif
 
+    void preprocessRequest( QNetworkRequest *req ) const;
 
   signals:
 

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -535,11 +535,21 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     PyObject *s = 0;
     Py_BEGIN_ALLOW_THREADS
     Py_XINCREF( a0 );
-    QString id = QgsNetworkAccessManager::setRequestPreprocessor( [a0]( QNetworkRequest *arg )
+    QString id = QgsNetworkAccessManager::setRequestPreprocessor( [a0]( QNetworkRequest *arg )->QString
     {
+      QString res;
       SIP_BLOCK_THREADS
-      Py_XDECREF( sipCallMethod( NULL, a0, "D", &arg, sipType_QNetworkRequest, NULL ) );
+      PyObject *s = sipCallMethod( NULL, a0, "D", arg, sipType_QNetworkRequest, NULL );
+      int state;
+      int sipIsError = 0;
+      QString *t1 = reinterpret_cast<QString *>( sipConvertToType( s, sipType_QString, 0, SIP_NOT_NONE, &state, &sipIsError ) );
+      if ( sipIsError == 0 )
+      {
+        res = QString( *t1 );
+      }
+      sipReleaseType( t1, sipType_QString, state );
       SIP_UNBLOCK_THREADS
+      return res;
     } );
 
     s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );

--- a/src/core/qgstilecache.cpp
+++ b/src/core/qgstilecache.cpp
@@ -33,16 +33,20 @@ void QgsTileCache::insertTile( const QUrl &url, const QImage &image )
 
 bool QgsTileCache::tile( const QUrl &url, QImage &image )
 {
+  QNetworkRequest req( url );
+  QgsNetworkAccessManager::instance()->preprocessRequest( &req );
+  QUrl adjUrl = req.url();
+
   QMutexLocker locker( &sTileCacheMutex );
   bool success = false;
-  if ( QImage *i = sTileCache.object( url ) )
+  if ( QImage *i = sTileCache.object( adjUrl ) )
   {
     image = *i;
     success = true;
   }
-  else if ( QgsNetworkAccessManager::instance()->cache()->metaData( url ).isValid() )
+  else if ( QgsNetworkAccessManager::instance()->cache()->metaData( adjUrl ).isValid() )
   {
-    if ( QIODevice *data = QgsNetworkAccessManager::instance()->cache()->data( url ) )
+    if ( QIODevice *data = QgsNetworkAccessManager::instance()->cache()->data( adjUrl ) )
     {
       QByteArray imageData = data->readAll();
       delete data;
@@ -53,7 +57,7 @@ bool QgsTileCache::tile( const QUrl &url, QImage &image )
       // Check for null because it could be a redirect (see: https://github.com/qgis/QGIS/issues/24336 )
       if ( ! image.isNull( ) )
       {
-        sTileCache.insert( url, new QImage( image ) );
+        sTileCache.insert( adjUrl, new QImage( image ) );
         success = true;
       }
     }

--- a/src/core/qgstilecache.cpp
+++ b/src/core/qgstilecache.cpp
@@ -34,6 +34,7 @@ void QgsTileCache::insertTile( const QUrl &url, const QImage &image )
 bool QgsTileCache::tile( const QUrl &url, QImage &image )
 {
   QNetworkRequest req( url );
+  //Preprocessing might alter the url, so we need to make sure we store/retrieve the url after preprocessing
   QgsNetworkAccessManager::instance()->preprocessRequest( &req );
   QUrl adjUrl = req.url();
 

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -150,6 +150,7 @@ class TestQgsNetworkAccessManager : public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
+    void testRequestPreprocessor();
     void testProxyExcludeList();
     void fetchEmptyUrl(); //test fetching blank url
     void fetchBadUrl(); //test fetching bad url
@@ -1128,6 +1129,14 @@ void TestQgsNetworkAccessManager::testCookieManagement()
   evLoop.exec();
   QVERIFY( thread2.getResult() );
 
+void TestQgsNetworkAccessManager::testRequestPreprocessor()
+{
+  QString processorId = QgsNetworkAccessManager::instance()->setRequestPreprocessor( []( QNetworkRequest * request ) { request->setHeader( QNetworkRequest::UserAgentHeader, QStringLiteral( "QGIS" ) );} );
+  QNetworkRequest request;
+  QgsNetworkAccessManager::instance()->preprocessRequest( &request );
+  QString userAgent = request.header( QNetworkRequest::UserAgentHeader ).toString();
+  QCOMPARE( userAgent, "QGIS" );
+  QgsNetworkAccessManager::instance()->removeRequestPreprocessor( processorId );
 }
 
 QGSTEST_MAIN( TestQgsNetworkAccessManager )

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -1128,6 +1128,7 @@ void TestQgsNetworkAccessManager::testCookieManagement()
   thread2.start();
   evLoop.exec();
   QVERIFY( thread2.getResult() );
+};
 
 void TestQgsNetworkAccessManager::testRequestPreprocessor()
 {
@@ -1137,7 +1138,7 @@ void TestQgsNetworkAccessManager::testRequestPreprocessor()
   QString userAgent = request.header( QNetworkRequest::UserAgentHeader ).toString();
   QCOMPARE( userAgent, "QGIS" );
   QgsNetworkAccessManager::instance()->removeRequestPreprocessor( processorId );
-}
+};
 
 QGSTEST_MAIN( TestQgsNetworkAccessManager )
 #include "testqgsnetworkaccessmanager.moc"


### PR DESCRIPTION
This PR adds the possibility to register network request preprocessor functions to the network access manager. The functions are executed before a network request is sent and they can change the network request (e.g. to add security tokens to a request).