### PR TITLE
Fix incorrect frame duration in last frame in animation mode 

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -113,10 +113,7 @@ QgsDateTimeRange QgsTemporalNavigationObject::dateTimeRangeForFrameNumber( long 
   if ( mCumulativeTemporalRange )
     frameStart = start;
 
-  if ( end <= mTemporalExtents.end() )
-    return QgsDateTimeRange( frameStart, end, true, false );
-
-  return QgsDateTimeRange( frameStart, mTemporalExtents.end(), true, false );
+  return QgsDateTimeRange( frameStart, end, true, false );
 }
 
 void QgsTemporalNavigationObject::setNavigationMode( const NavigationMode mode )
@@ -322,7 +319,7 @@ long long QgsTemporalNavigationObject::totalFrameCount() const
   else
   {
     QgsInterval totalAnimationLength = mTemporalExtents.end() - mTemporalExtents.begin();
-    return std::floor( totalAnimationLength.seconds() / mFrameDuration.seconds() ) + 1;
+    return static_cast< long long >( std::ceil( totalAnimationLength.seconds() / mFrameDuration.seconds() ) );
   }
 }
 

--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -156,7 +156,7 @@ void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &te
   {
     case Animated:
     {
-      int currentFrameNumber = mCurrentFrameNumber;
+      long long currentFrameNumber = mCurrentFrameNumber;
 
       // Force to emit signal if the current frame number doesn't change
       if ( currentFrameNumber == mCurrentFrameNumber && !mBlockUpdateTemporalRangeSignal )
@@ -235,7 +235,7 @@ void QgsTemporalNavigationObject::setFramesPerSecond( double framesPerSeconds )
   if ( framesPerSeconds > 0 )
   {
     mFramesPerSecond = framesPerSeconds;
-    mNewFrameTimer->setInterval( ( 1.0 / mFramesPerSecond ) * 1000 );
+    mNewFrameTimer->setInterval( static_cast< int >( ( 1.0 / mFramesPerSecond ) * 1000 ) );
   }
 }
 
@@ -256,7 +256,7 @@ bool QgsTemporalNavigationObject::temporalRangeCumulative() const
 
 void QgsTemporalNavigationObject::play()
 {
-  mNewFrameTimer->start( ( 1.0 / mFramesPerSecond ) * 1000 );
+  mNewFrameTimer->start( static_cast< int >( ( 1.0 / mFramesPerSecond ) * 1000 ) );
 }
 
 void QgsTemporalNavigationObject::pause()
@@ -367,7 +367,7 @@ long long QgsTemporalNavigationObject::findBestFrameNumberForFrameStart( const Q
       // We tend to receive a framestart of 'now()' upon startup for example
       if ( mTemporalExtents.contains( frameStart ) )
       {
-        roughFrameStart = std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() );
+        roughFrameStart = static_cast< long long >( std::floor( ( frameStart - mTemporalExtents.begin() ).seconds() / mFrameDuration.seconds() ) );
       }
       roughFrameEnd = roughFrameStart + 100; // just in case we miss the guess
     }

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -482,10 +482,17 @@ void QgsTemporalControllerWidget::onProjectCleared()
   mNavigationObject->setNavigationMode( QgsTemporalNavigationObject::NavigationOff );
   setWidgetStateFromNavigationMode( QgsTemporalNavigationObject::NavigationOff );
 
-  whileBlocking( mStartDateTime )->setDateTime( QDateTime( QDate::currentDate(), QTime( 0, 0, 0 ), Qt::UTC ) );
-  whileBlocking( mEndDateTime )->setDateTime( mStartDateTime->dateTime() );
-  whileBlocking( mFixedRangeStartDateTime )->setDateTime( QDateTime( QDate::currentDate(), QTime( 0, 0, 0 ), Qt::UTC ) );
-  whileBlocking( mFixedRangeEndDateTime )->setDateTime( mStartDateTime->dateTime() );
+  // default to showing the last 24 hours, ending at the current date's hour, in one hour blocks...
+  // it's COMPLETELY arbitrary, but better than starting with a "zero length" duration!
+  const QTime startOfCurrentHour = QTime( QTime::currentTime().hour(), 0, 0 );
+  const QDateTime end = QDateTime( QDate::currentDate(), startOfCurrentHour, Qt::UTC );
+  const QDateTime start = end.addSecs( -24 * 60 * 60 );
+
+  whileBlocking( mStartDateTime )->setDateTime( start );
+  whileBlocking( mEndDateTime )->setDateTime( end );
+  whileBlocking( mFixedRangeStartDateTime )->setDateTime( start );
+  whileBlocking( mFixedRangeEndDateTime )->setDateTime( end );
+
   updateTemporalExtent();
   mTimeStepsComboBox->setCurrentIndex( mTimeStepsComboBox->findData( QgsUnitTypes::TemporalHours ) );
   mStepSpinBox->setValue( 1 );


### PR DESCRIPTION
The final frame must always have the same duration as other frames,
even if this means we go past the end of the animation range. Also
avoid showing a "zero length" frame at the end of the animation
if the frame duration fits exactly into the overall animation
range.

Fixes #40777