### PR TITLE
Add QgsApplication::translation, also load qtbase translations

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -994,9 +994,18 @@ The maximum number of concurrent connections per connections pool.
 
     static void setTranslation( const QString &translation );
 %Docstring
-Set translation
+Set translation locale code
 
 .. versionadded:: 3.4
+%End
+
+    QString translation() const;
+%Docstring
+Returns the current application translation locale code
+
+.. seealso:: :py:func:`setTranslation`
+
+.. versionadded:: 3.22
 %End
 
     void collectTranslatableObjects( QgsTranslationContext *translationContext );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -206,6 +206,16 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
     {
       QgsDebugMsgLevel( QStringLiteral( "loading of qt translation failed %1/qt_%2" ).arg( QLibraryInfo::location( QLibraryInfo::TranslationsPath ), *sTranslation() ), 2 );
     }
+
+    mQtBaseTranslator = new QTranslator();
+    if ( mQtBaseTranslator->load( QStringLiteral( "qtbase_" ) + *sTranslation(), QLibraryInfo::location( QLibraryInfo::TranslationsPath ) ) )
+    {
+      installTranslator( mQtBaseTranslator );
+    }
+    else
+    {
+      QgsDebugMsg( QStringLiteral( "loading of qtbase translation failed %1/qtbase_%2" ).arg( QLibraryInfo::location( QLibraryInfo::TranslationsPath ), *sTranslation() ) );
+    }
   }
 
   mApplicationMembers = new ApplicationMembers();
@@ -417,6 +427,7 @@ QgsApplication::~QgsApplication()
   delete mApplicationMembers;
   delete mQgisTranslator;
   delete mQtTranslator;
+  delete mQtBaseTranslator;
 
   // we do this here as well as in exitQgis() -- it's safe to call as often as we want,
   // and there's just a *chance* that someone hasn't properly called exitQgis prior to

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1922,6 +1922,11 @@ void QgsApplication::setTranslation( const QString &translation )
   *sTranslation() = translation;
 }
 
+QString QgsApplication::translation() const
+{
+  return *sTranslation();
+}
+
 void QgsApplication::collectTranslatableObjects( QgsTranslationContext *translationContext )
 {
   emit requestForTranslatableObjects( translationContext );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -197,24 +197,30 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
      * the About, Preferences and Quit items to the Mac Application menu.
      * These items must be translated identically in both qt_ and qgis_ files.
      */
+    QString qtTranslationsPath = QLibraryInfo::location( QLibraryInfo::TranslationsPath );
+#ifdef __MINGW32__
+    QString prefix = QDir( QString( "%1/../" ).arg( QApplication::applicationDirPath() ) ).absolutePath();
+    qtTranslationsPath = prefix + qtTranslationsPath.mid( QLibraryInfo::location( QLibraryInfo::PrefixPath ).length() );
+#endif
+
     mQtTranslator = new QTranslator();
-    if ( mQtTranslator->load( QStringLiteral( "qt_" ) + *sTranslation(), QLibraryInfo::location( QLibraryInfo::TranslationsPath ) ) )
+    if ( mQtTranslator->load( QStringLiteral( "qt_" ) + *sTranslation(), qtTranslationsPath ) )
     {
       installTranslator( mQtTranslator );
     }
     else
     {
-      QgsDebugMsgLevel( QStringLiteral( "loading of qt translation failed %1/qt_%2" ).arg( QLibraryInfo::location( QLibraryInfo::TranslationsPath ), *sTranslation() ), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "loading of qt translation failed %1/qt_%2" ).arg( qtTranslationsPath, *sTranslation() ), 2 );
     }
 
     mQtBaseTranslator = new QTranslator();
-    if ( mQtBaseTranslator->load( QStringLiteral( "qtbase_" ) + *sTranslation(), QLibraryInfo::location( QLibraryInfo::TranslationsPath ) ) )
+    if ( mQtBaseTranslator->load( QStringLiteral( "qtbase_" ) + *sTranslation(), qtTranslationsPath ) )
     {
       installTranslator( mQtBaseTranslator );
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "loading of qtbase translation failed %1/qtbase_%2" ).arg( QLibraryInfo::location( QLibraryInfo::TranslationsPath ), *sTranslation() ) );
+      QgsDebugMsgLevel( QStringLiteral( "loading of qtbase translation failed %1/qt_%2" ).arg( qtTranslationsPath, *sTranslation() ), 2 );
     }
   }
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -1018,6 +1018,7 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     QTranslator *mQgisTranslator = nullptr;
     QTranslator *mQtTranslator = nullptr;
+    QTranslator *mQtBaseTranslator = nullptr;
 
     QgsDataItemProviderRegistry *mDataItemProviderRegistry = nullptr;
     QgsAuthManager *mAuthManager = nullptr;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -934,11 +934,18 @@ class CORE_EXPORT QgsApplication : public QApplication
     int maxConcurrentConnectionsPerPool() const;
 
     /**
-     * Set translation
+     * Set translation locale code
      *
      * \since QGIS 3.4
      */
     static void setTranslation( const QString &translation );
+
+    /**
+     * Returns the current application translation locale code
+     * \see setTranslation()
+     * \since QGIS 3.22
+     */
+    QString translation() const;
 
     /**
      * Emits the signal to collect all the strings of .qgs to be included in ts file


### PR DESCRIPTION
- Adds `QgsApplication::translation` as counterpart for `QgsApplication::setTranslation`
- Also makes qgis attempt to load qtbase translations, to translate buttons in dialog boxes etc.
- Fix loading the qt translations on MinGW by computing the translations dir relative to the binary dir