### PR TITLE
Fix regression in getOperationAndEllipsoidFromProjString when used in QgsCoordinateReferenceSystem::syncDatabase()

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2122,8 +2122,7 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
 
   thread_local const QRegularExpression ellipseRegExp( QStringLiteral( "\\+(?:ellps|datum)=(\\S+)" ) );
   const QRegularExpressionMatch ellipseMatch = projRegExp.match( proj );
-  QString ellps;
-  if ( !ellipseMatch.hasMatch() )
+  if ( ellipseMatch.hasMatch() )
   {
     ellipsoid = ellipseMatch.captured( 1 );
   }
@@ -2134,7 +2133,7 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
     // and will result in oddities within other areas of QGIS (e.g. project ellipsoid won't be correctly
     // set for these CRSes). Better just hack around and make the constraint happy for now,
     // and hope that the definitions get corrected in future.
-    ellipsoid.clear();
+    ellipsoid = "";
   }
 }
 


### PR DESCRIPTION
## Description

Since https://github.com/qgis/QGIS/commit/9e0bf6df993a8548be3e21e274ee2857728e658d (https://github.com/qgis/QGIS/pull/40737), `QgsCoordinateReferenceSystem::syncDatabase()` doesn't properly insert [about 100 srs definitions](https://gist.github.com/agiudiceandrea/b4a9f191f0a4b4b7f5126868e6eac722) into tbl_srs because `getOperationAndEllipsoidFromProjString` fails to properly retrieve ellipsoid name from proj string and doesn't satisfy the NOT NULL constraint of ellipsoid_acronym field in tbl_srs.

This fixes [about 100 errors](https://gist.github.com/agiudiceandrea/b4a9f191f0a4b4b7f5126868e6eac722) like:

> After a 'make install' I received sevaral similar messages, please see a
> cut below:
> 
> 
> Could not execute: INSERT INTO tbl_srs(srs_id,
> description,projection_acronym,ellipsoid_acronym,parameters,srid,auth_name,auth_id,is_geo,deprecated)
> VALUES (63422, 'NAD27 (CRS27)','longlat',NULL,'+proj=longlat
> +datum=NAD27 +no_defs',520003422,'OGC','CRS27',1,0) [NOT NULL constraint
> failed: tbl_srs.ellipsoid_acronym/NOT NULL constraint failed:
> tbl_srs.ellipsoid_acronym]
> 
> Could not execute: INSERT INTO tbl_srs(srs_id,
> description,projection_acronym,ellipsoid_acronym,parameters,srid,auth_name,auth_id,is_geo,deprecated)
> VALUES (63423, 'NAD83 (CRS83)','longlat',NULL,'+proj=longlat
> +datum=NAD83 +no_defs',520003423,'OGC','CRS83',1,0) [NOT NULL constraint
> failed: tbl_srs.ellipsoid_acronym/NOT NULL constraint failed:
> tbl_srs.ellipsoid_acronym]
>
> ...
> ...
> ...

See https://lists.osgeo.org/pipermail/qgis-user/2021-June/049055.html

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
