### PR TITLE
Add QgsMapTool::canvasToolTipEvent

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -1303,6 +1303,8 @@ Can be used to extend the context menu.
 
     virtual void dragEnterEvent( QDragEnterEvent *e );
 
+    virtual bool viewportEvent( QEvent *event );
+
 
     void moveCanvasContents( bool reset = false );
 %Docstring

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -110,6 +110,14 @@ Key event for overriding. Default implementation does nothing.
 gesture event for overriding. Default implementation does nothing.
 %End
 
+    virtual bool canvasToolTipEvent( QHelpEvent *e );
+%Docstring
+Tooltip event for overriding. Default implementation does nothing.
+Returns whether the event was handled by the tool and should not be propagated further.
+
+.. versionadded:: 3.22
+%End
+
     void setAction( QAction *action );
 %Docstring
 Use this to associate a QAction to this maptool. Then when the setMapTool

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2796,6 +2796,15 @@ void QgsMapCanvas::dragEnterEvent( QDragEnterEvent *event )
   }
 }
 
+bool QgsMapCanvas::viewportEvent( QEvent *event )
+{
+  if ( event->type() == QEvent::ToolTip && mMapTool && mMapTool->canvasToolTipEvent( qgis::down_cast<QHelpEvent *>( event ) ) )
+  {
+    return true;
+  }
+  return QGraphicsView::viewportEvent( event );
+}
+
 void QgsMapCanvas::mapToolDestroyed()
 {
   QgsDebugMsgLevel( QStringLiteral( "maptool destroyed" ), 2 );

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1174,6 +1174,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     void resizeEvent( QResizeEvent *e ) override;
     void paintEvent( QPaintEvent *e ) override;
     void dragEnterEvent( QDragEnterEvent *e ) override;
+    bool viewportEvent( QEvent *event ) override;
 
     //! called when panning is in action, reset indicates end of panning
     void moveCanvasContents( bool reset = false );

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -192,6 +192,12 @@ bool QgsMapTool::gestureEvent( QGestureEvent *e )
   return true;
 }
 
+bool QgsMapTool::canvasToolTipEvent( QHelpEvent *e )
+{
+  Q_UNUSED( e )
+  return false;
+}
+
 QgsMapCanvas *QgsMapTool::canvas() const
 {
   return mCanvas;

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -134,6 +134,13 @@ class GUI_EXPORT QgsMapTool : public QObject
     virtual bool gestureEvent( QGestureEvent *e );
 
     /**
+     * Tooltip event for overriding. Default implementation does nothing.
+     * Returns whether the event was handled by the tool and should not be propagated further.
+     * \since QGIS 3.22
+     */
+    virtual bool canvasToolTipEvent( QHelpEvent *e );
+
+    /**
      * Use this to associate a QAction to this maptool. Then when the setMapTool
      * method of mapcanvas is called the action state will be set to on.
      * Usually this will cause e.g. a toolbutton to appear pressed in and

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -42,6 +42,20 @@ class QgsMapToolTest : public QgsMapTool // clazy:exclude=missing-qobject-macro
   public:
     QgsMapToolTest( QgsMapCanvas *canvas ) : QgsMapTool( canvas ) {}
 
+    bool canvasToolTipEvent( QHelpEvent *e ) override
+    {
+      Q_UNUSED( e );
+      mGotTooltipEvent = true;
+      return true;
+    }
+    bool gotTooltipEvent() const
+    {
+      return mGotTooltipEvent;
+    }
+
+  private:
+    bool mGotTooltipEvent = false;
+
 };
 
 class TestQgsMapCanvas : public QObject
@@ -64,6 +78,7 @@ class TestQgsMapCanvas : public QObject
     void testShiftZoom();
     void testDragDrop();
     void testZoomResolutions();
+    void testTooltipEvent();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
@@ -536,6 +551,18 @@ void TestQgsMapCanvas::testZoomResolutions()
   QGSCOMPARENEAR( mCanvas->mapSettings().mapUnitsPerPixel(), resolutions[0], 0.0001 );
 
   QCOMPARE( mCanvas->zoomResolutions(), resolutions );
+}
+
+void TestQgsMapCanvas::testTooltipEvent()
+{
+  QgsMapToolTest mapTool( mCanvas );
+  mCanvas->setMapTool( &mapTool );
+
+  QHelpEvent helpEvent( QEvent::ToolTip, QPoint( 10, 10 ), QPoint( 10, 10 ) );
+
+  QApplication::sendEvent( mCanvas->viewport(), &helpEvent );
+
+  QVERIFY( mapTool.gotTooltipEvent() );
 }
 
 QGSTEST_MAIN( TestQgsMapCanvas )


### PR DESCRIPTION
Adds QgsMapTool::canvasToolTipEvent to allow tools to display context sensitive help tooltips.