### PR TITLE
Allow specifying default WMS image format in settings

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -45,6 +45,9 @@ connections-xyz\OpenStreetMap\username=
 connections-xyz\OpenStreetMap\zmax=19
 connections-xyz\OpenStreetMap\zmin=0
 
+# The image format selected by default when adding a WMS, i.e. image/png. If empty, the first available format is used
+WMSDefaultFormat=""
+
 # application stylesheet
 
 # Padding (in pixels) to add to toolbar icons, if blank then default padding will be used

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -291,6 +291,8 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
   const QVector<QgsWmsLayerProperty> layers = capabilities.supportedLayers();
   mLayerProperties = layers;
 
+  QString defaultEncoding = QgsSettings().value( "qgis/WMSDefaultFormat", "" ).toString();
+
   bool first = true;
   QSet<QString> alreadyAddedLabels;
   const auto supportedImageEncodings = capabilities.supportedImageEncodings();
@@ -311,7 +313,7 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
     alreadyAddedLabels.insert( mFormats[id].label );
 
     mImageFormatGroup->button( id )->setVisible( true );
-    if ( first )
+    if ( first || encoding == defaultEncoding )
     {
       mImageFormatGroup->button( id )->setChecked( true );
       first = false;


### PR DESCRIPTION
Rather than just picking the first available image encoding format by default, attempt to pick a default format optionally configured in the qgis settings ini file.