### PR TITLE
Localization for table layout items

### DIFF
--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -29,6 +29,7 @@
 #include "qgsvectorlayer.h"
 
 #include <QThread>
+#include <QLocale>
 
 #define ENSURE_NO_EVAL_ERROR   {  if ( parent->hasEvalError() ) return QVariant(); }
 #define SET_EVAL_ERROR(x)   { parent->setEvalErrorString( x ); return QVariant(); }

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -429,6 +429,61 @@ class QgsExpressionUtils
         return QVariantMap();
       }
     }
+
+    /**
+     * Returns the localized string representation of a QVariant, converting numbers according to locale settings.
+     * \param value the QVariant to convert.
+     * \returns the string representation of the value.
+     * \since QGIS 3.20
+     */
+    static QString toLocalizedString( const QVariant &value )
+    {
+      if ( value.type() == QVariant::Int || value.type() == QVariant::UInt || value.type() == QVariant::LongLong || value.type() == QVariant::ULongLong )
+      {
+        bool ok;
+        QString res;
+
+        if ( value.type() == QVariant::ULongLong )
+        {
+          res = QLocale().toString( value.toULongLong( &ok ) );
+        }
+        else
+        {
+          res = QLocale().toString( value.toLongLong( &ok ) );
+        }
+
+        if ( ok )
+        {
+          return res;
+        }
+        else
+        {
+          return value.toString();
+        }
+      }
+      // Qt madness with QMetaType::Float :/
+      else if ( value.type() == QVariant::Double || value.type() == static_cast<QVariant::Type>( QMetaType::Float ) )
+      {
+        bool ok;
+        const QString strVal { value.toString() };
+        const int dotPosition { strVal.indexOf( '.' ) };
+        const int precision { dotPosition > 0 ? strVal.length() - dotPosition - 1 : 0 };
+        const QString res { QLocale().toString( value.toDouble( &ok ), 'f', precision ) };
+
+        if ( ok )
+        {
+          return res;
+        }
+        else
+        {
+          return value.toString();
+        }
+      }
+      else
+      {
+        return value.toString();
+      }
+    }
 };
 
 /// @endcond

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -35,6 +35,7 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsexpressionutils.h"
 #include <geos_c.h>
 
 static void _parseAndEvalExpr( int arg )
@@ -4442,6 +4443,41 @@ class TestQgsExpression: public QObject
       QCOMPARE( qgis::down_cast< const QgsExpressionNodeColumnRef * >( exp.rootNode()->effectiveNode() )->name(), QStringLiteral( "second_field" ) );
       QCOMPARE( exp.evaluate( &context ).toInt(), 20 );
     }
+
+    void testExpressionUtilsToLocalizedString()
+    {
+      const QVariant t_int( 12346 );
+      QVariant t_uint( QVariant::UInt );
+      t_uint = 12346;
+      QVariant t_long( QVariant::LongLong );
+      t_long = 12346;
+      QVariant t_ulong( QVariant::ULongLong );
+      t_ulong = 12346;
+      const QVariant t_double( 123456.801 );
+
+      QLocale().setDefault( QLocale::English );
+
+      qDebug() << QVariant( 123456.801 ).toString();
+
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_int ), QStringLiteral( "12,346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_uint ), QStringLiteral( "12,346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_long ), QStringLiteral( "12,346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_ulong ), QStringLiteral( "12,346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_double ), QStringLiteral( "123,456.801" ) );
+
+      QLocale().setDefault( QLocale::Italian );
+
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_int ), QStringLiteral( "12.346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_uint ), QStringLiteral( "12.346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_long ), QStringLiteral( "12.346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_ulong ), QStringLiteral( "12.346" ) );
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( t_double ), QStringLiteral( "123.456,801" ) );
+
+      QLocale().setDefault( QLocale::English );
+
+      QCOMPARE( QgsExpressionUtils::toLocalizedString( QString( "hello world" ) ), QStringLiteral( "hello world" ) );
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsExpression )


### PR DESCRIPTION
Fixes #43678

Note: there is some overlapping with https://github.com/qgis/QGIS/pull/43699 I will refactor that one later and use `QgsExpressionUtils::toLocalizedString` inside `QgsExpression::formatPreviewString`.

The method is generic and not necessarily bound to expressions, if anyone has a better idea about where to place it I'm happy to move it, must be in `core` rather than in `gui` though. 
