### PR TITLE
Fix deadlocks

### DIFF
--- a/python/core/auto_generated/qgsaggregatecalculator.sip.in
+++ b/python/core/auto_generated/qgsaggregatecalculator.sip.in
@@ -141,7 +141,8 @@ Calculates the value of an aggregate.
                           If an expression is used, then the context parameter must be set.
 :param context: expression context for evaluating expressions
 :param ok: if specified, will be set to ``True`` if aggregate calculation was successful
-:param feedback: optional feedback argument for early cancellation (since QGIS 3.22)
+:param feedback: optional feedback argument for early cancellation (since QGIS 3.22). If set, this will take precedence over any feedback object
+                 set on the expression ``context``.
 
 :return: calculated aggregate value
 %End

--- a/python/core/auto_generated/qgsaggregatecalculator.sip.in
+++ b/python/core/auto_generated/qgsaggregatecalculator.sip.in
@@ -132,7 +132,7 @@ Returns the delimiter used for joining values with the StringConcatenate aggrega
 %End
 
     QVariant calculate( Aggregate aggregate, const QString &fieldOrExpression,
-                        QgsExpressionContext *context = 0, bool *ok = 0 ) const;
+                        QgsExpressionContext *context = 0, bool *ok = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Calculates the value of an aggregate.
 
@@ -141,6 +141,7 @@ Calculates the value of an aggregate.
                           If an expression is used, then the context parameter must be set.
 :param context: expression context for evaluating expressions
 :param ok: if specified, will be set to ``True`` if aggregate calculation was successful
+:param feedback: optional feedback argument for early cancellation (since QGIS 3.22)
 
 :return: calculated aggregate value
 %End

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -785,6 +785,29 @@ Clears all cached values from the context.
 .. versionadded:: 2.16
 %End
 
+    void setFeedback( QgsFeedback *feedback );
+%Docstring
+Attach a ``feedback`` object that can be queried regularly by the expression engine to check
+if expression evaluation should be canceled.
+
+Ownership of ``feedback`` is NOT transferred, and the caller must take care that it exists
+for the lifetime of the expression context.
+
+.. seealso:: :py:func:`feedback`
+
+.. versionadded:: 3.20
+%End
+
+    QgsFeedback *feedback() const;
+%Docstring
+Returns the feedback object that can be queried regularly by the expression to check
+if evaluation should be canceled, if set.
+
+.. seealso:: :py:func:`setFeedback`
+
+.. versionadded:: 3.20
+%End
+
     static const QString EXPR_FIELDS;
     static const QString EXPR_ORIGINAL_VALUE;
     static const QString EXPR_SYMBOL_COLOR;

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -746,6 +746,29 @@ expression function.
 .. versionadded:: 3.4
 %End
 
+    void setFeedback( QgsFeedback *feedback );
+%Docstring
+Attach a ``feedback`` object that can be queried regularly by the iterator to check
+if it should be canceled.
+
+Ownership of ``feedback`` is NOT transferred, and the caller must take care that it exists
+for the lifetime of the feature request and feature iterators.
+
+.. seealso:: :py:func:`feedback`
+
+.. versionadded:: 3.20
+%End
+
+    QgsFeedback *feedback() const;
+%Docstring
+Returns the feedback object that can be queried regularly by the iterator to check
+if it should be canceled, if set.
+
+.. seealso:: :py:func:`setFeedback`
+
+.. versionadded:: 3.20
+%End
+
   protected:
 };
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -2458,7 +2458,8 @@ and maximum values are required.
                         const QgsAggregateCalculator::AggregateParameters &parameters = QgsAggregateCalculator::AggregateParameters(),
                         QgsExpressionContext *context = 0,
                         bool *ok = 0,
-                        QgsFeatureIds *fids = 0 ) const;
+                        QgsFeatureIds *fids = 0,
+                        QgsFeedback *feedback = 0 ) const;
 %Docstring
 Calculates an aggregated value from the layer's features.
 Currently any filtering expression provided will override filters in the FeatureRequest.
@@ -2469,6 +2470,7 @@ Currently any filtering expression provided will override filters in the Feature
 :param context: expression context for expressions and filters
 :param ok: if specified, will be set to ``True`` if aggregate calculation was successful
 :param fids: list of fids to filter, otherwise will use all fids
+:param feedback: optional feedback argument for early cancellation (since QGIS 3.22)
 
 :return: calculated aggregate value
 

--- a/python/core/auto_generated/vector/qgsvectorlayerfeaturecounter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeaturecounter.sip.in
@@ -32,13 +32,16 @@ Create a new feature counter for ``layer``.
 :param context: Specific :py:class:`QgsExpressionContext` to use during the rendering step.
 :param storeSymbolFids: If ``True`` will store the feature ids (fids), otherwise will only count the number of features per symbol. Default ``False``.
 %End
-
+    ~QgsVectorLayerFeatureCounter();
 
     virtual bool run();
 
 %Docstring
 Calculates the feature count and Ids per symbol
 %End
+
+    virtual void cancel();
+
 
 
     long long featureCount( const QString &legendKey ) const;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -685,13 +685,13 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
     QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
     subScope->setVariable( QStringLiteral( "parent" ), context->feature() );
     subContext.appendScope( subScope );
-    result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok );
+    result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok, nullptr, context ? context->feedback() : nullptr );
 
     context->setCachedValue( cacheKey, result );
   }
   else
   {
-    result = vl->aggregate( aggregate, subExpression, parameters, nullptr, &ok );
+    result = vl->aggregate( aggregate, subExpression, parameters, nullptr, &ok, nullptr, context ? context->feedback() : nullptr );
   }
   if ( !ok )
   {
@@ -807,7 +807,7 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
 
 
   QgsExpressionContext subContext( *context );
-  result = childLayer->aggregate( aggregate, subExpression, parameters, &subContext, &ok );
+  result = childLayer->aggregate( aggregate, subExpression, parameters, &subContext, &ok, nullptr, context->feedback() );
 
   if ( !ok )
   {
@@ -931,7 +931,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
   subScope->setVariable( QStringLiteral( "parent" ), context->feature() );
   subContext.appendScope( subScope );
-  result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok );
+  result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok, nullptr, context->feedback() );
 
   if ( !ok )
   {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6073,8 +6073,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QgsFeatureRequest request;
   request.setTimeout( 10000 );
   request.setRequestMayBeNested( true );
-  if ( context )
-    request.setFeedback( context->feedback() );
+  request.setFeedback( context->feedback() );
 
   // First parameter is the overlay layer
   QgsExpressionNode *node = QgsExpressionUtils::getNode( values.at( 0 ), parent );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4979,7 +4979,7 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
 }
 
 
-static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant result;
   QgsVectorLayer *vl = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
@@ -4991,6 +4991,8 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
     req.setFilterFid( fid );
     req.setTimeout( 10000 );
     req.setRequestMayBeNested( true );
+    if ( context )
+      req.setFeedback( context->feedback() );
     QgsFeatureIterator fIt = vl->getFeatures( req );
 
     QgsFeature fet;
@@ -5034,6 +5036,8 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   req.setLimit( 1 );
   req.setTimeout( 10000 );
   req.setRequestMayBeNested( true );
+  if ( context )
+    req.setFeedback( context->feedback() );
   if ( !parent->needsGeometry() )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );
@@ -6069,6 +6073,8 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QgsFeatureRequest request;
   request.setTimeout( 10000 );
   request.setRequestMayBeNested( true );
+  if ( context )
+    request.setFeedback( context->feedback() );
 
   // First parameter is the overlay layer
   QgsExpressionNode *node = QgsExpressionUtils::getNode( values.at( 0 ), parent );
@@ -6282,6 +6288,8 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QgsFeature feat2;
   QgsFeatureRequest request2;
   request2.setLimit( limit );
+  if ( context )
+    request2.setFeedback( context->feedback() );
   QgsFeatureIterator fi = targetLayer->getFeatures( request2 );
   while ( fi.nextFeature( feat2 ) )
   {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -676,7 +676,7 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
       cacheKey = QStringLiteral( "aggfcn:%1:%2:%3:%4:%5" ).arg( vl->id(), QString::number( aggregate ), subExpression, parameters.filter, orderBy );
     }
 
-    if ( context && context->hasCachedValue( cacheKey ) )
+    if ( context->hasCachedValue( cacheKey ) )
     {
       return context->cachedValue( cacheKey );
     }
@@ -685,13 +685,13 @@ static QVariant fcnAggregate( const QVariantList &values, const QgsExpressionCon
     QgsExpressionContextScope *subScope = new QgsExpressionContextScope();
     subScope->setVariable( QStringLiteral( "parent" ), context->feature() );
     subContext.appendScope( subScope );
-    result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok, nullptr, context ? context->feedback() : nullptr );
+    result = vl->aggregate( aggregate, subExpression, parameters, &subContext, &ok, nullptr, context->feedback() );
 
     context->setCachedValue( cacheKey, result );
   }
   else
   {
-    result = vl->aggregate( aggregate, subExpression, parameters, nullptr, &ok, nullptr, context ? context->feedback() : nullptr );
+    result = vl->aggregate( aggregate, subExpression, parameters, nullptr, &ok );
   }
   if ( !ok )
   {

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -83,9 +83,13 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   else
   {
     //QgsDebugMsg( "Feature iterator of " + mSource->mLayerName + ": acquiring connection");
-    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource, mSource->mShareSameDatasetAmongLayers ), mRequest.timeout(), mRequest.requestMayBeNested() );
+    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource, mSource->mShareSameDatasetAmongLayers ),
+            mRequest.timeout(),
+            mRequest.requestMayBeNested(),
+            mRequest.feedback() );
     if ( !mConn || !mConn->ds )
     {
+      iteratorClosed();
       return;
     }
 

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -49,7 +49,7 @@ void QgsAggregateCalculator::setFidsFilter( const QgsFeatureIds &fids )
 }
 
 QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate aggregate,
-    const QString &fieldOrExpression, QgsExpressionContext *context, bool *ok ) const
+    const QString &fieldOrExpression, QgsExpressionContext *context, bool *ok, QgsFeedback *feedback ) const
 {
   if ( ok )
     *ok = false;
@@ -98,6 +98,9 @@ QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate ag
     request.setFilterExpression( mFilterExpression );
   if ( context )
     request.setExpressionContext( *context );
+
+  request.setFeedback( feedback ? feedback : ( context ? context->feedback() : nullptr ) );
+
   //determine result type
   QVariant::Type resultType = QVariant::Double;
   if ( attrNum == -1 )

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -171,10 +171,11 @@ class CORE_EXPORT QgsAggregateCalculator
      * If an expression is used, then the context parameter must be set.
      * \param context expression context for evaluating expressions
      * \param ok if specified, will be set to TRUE if aggregate calculation was successful
+     * \param feedback optional feedback argument for early cancellation (since QGIS 3.22)
      * \returns calculated aggregate value
      */
     QVariant calculate( Aggregate aggregate, const QString &fieldOrExpression,
-                        QgsExpressionContext *context = nullptr, bool *ok = nullptr ) const;
+                        QgsExpressionContext *context = nullptr, bool *ok = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Converts a string to a aggregate type.

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -171,7 +171,8 @@ class CORE_EXPORT QgsAggregateCalculator
      * If an expression is used, then the context parameter must be set.
      * \param context expression context for evaluating expressions
      * \param ok if specified, will be set to TRUE if aggregate calculation was successful
-     * \param feedback optional feedback argument for early cancellation (since QGIS 3.22)
+     * \param feedback optional feedback argument for early cancellation (since QGIS 3.22). If set, this will take precedence over any feedback object
+     * set on the expression \a context.
      * \returns calculated aggregate value
      */
     QVariant calculate( Aggregate aggregate, const QString &fieldOrExpression,

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -30,7 +30,7 @@
 #include <QTime>
 #include <QTimer>
 #include <QThread>
-
+#include <QElapsedTimer>
 
 #define CONN_POOL_EXPIRATION_TIME           60    // in seconds
 #define CONN_POOL_SPARE_CONNECTIONS          2    // number of spare connections in case all the base connections are used but we have a nested request with the risk of a deadlock

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -20,6 +20,8 @@
 
 #include "qgis.h"
 #include "qgsapplication.h"
+#include "qgsfeedback.h"
+
 #include <QCoreApplication>
 #include <QMap>
 #include <QMutex>
@@ -288,9 +290,12 @@ class QgsConnectionPool
      * If \a timeout is a negative value the calling thread will be blocked
      * until a connection becomes available. This is the default behavior.
      *
+     * The optional \a feedback argument can be used to cancel the request
+     * before the connection is acquired.
+     *
      * \returns initialized connection or NULLPTR if unsuccessful
      */
-    T acquireConnection( const QString &connInfo, int timeout = -1, bool requestMayBeNested = false )
+    T acquireConnection( const QString &connInfo, int timeout = -1, bool requestMayBeNested = false, QgsFeedback *feedback = nullptr )
     {
       mMutex.lock();
       typename T_Groups::iterator it = mGroups.find( connInfo );
@@ -301,7 +306,25 @@ class QgsConnectionPool
       T_Group *group = *it;
       mMutex.unlock();
 
-      return group->acquire( timeout, requestMayBeNested );
+      if ( feedback )
+      {
+        QElapsedTimer timer;
+        timer.start();
+
+        while ( !feedback->isCanceled() )
+        {
+          if ( T conn = group->acquire( 300, requestMayBeNested ) )
+            return conn;
+
+          if ( timeout > 0 && timer.elapsed() >= timeout )
+            return nullptr;
+        }
+        return nullptr;
+      }
+      else
+      {
+        return group->acquire( timeout, requestMayBeNested );
+      }
     }
 
     //! Release an existing connection so it will get back into the pool and can be reused

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -592,3 +592,13 @@ void QgsExpressionContext::clearCachedValues() const
 {
   mCachedValues.clear();
 }
+
+void QgsExpressionContext::setFeedback( QgsFeedback *feedback )
+{
+  mFeedback = feedback;
+}
+
+QgsFeedback *QgsExpressionContext::feedback() const
+{
+  return mFeedback;
+}

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -715,6 +715,29 @@ class CORE_EXPORT QgsExpressionContext
      */
     void clearCachedValues() const;
 
+    /**
+     * Attach a \a feedback object that can be queried regularly by the expression engine to check
+     * if expression evaluation should be canceled.
+     *
+     * Ownership of \a feedback is NOT transferred, and the caller must take care that it exists
+     * for the lifetime of the expression context.
+     *
+     * \see feedback()
+     *
+     * \since QGIS 3.20
+     */
+    void setFeedback( QgsFeedback *feedback );
+
+    /**
+     * Returns the feedback object that can be queried regularly by the expression to check
+     * if evaluation should be canceled, if set.
+     *
+     * \see setFeedback()
+     *
+     * \since QGIS 3.20
+     */
+    QgsFeedback *feedback() const;
+
     //! Inbuilt variable name for fields storage
     static const QString EXPR_FIELDS;
     //! Inbuilt variable name for value original value variable
@@ -747,6 +770,8 @@ class CORE_EXPORT QgsExpressionContext
     QList< QgsExpressionContextScope * > mStack;
     QStringList mHighlightedVariables;
     QStringList mHighlightedFunctions;
+
+    QgsFeedback *mFeedback = nullptr;
 
     // Cache is mutable because we want to be able to add cached values to const contexts
     mutable QMap< QString, QVariant > mCachedValues;

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -18,6 +18,7 @@
 #include "qgssimplifymethod.h"
 #include "qgsexception.h"
 #include "qgsexpressionsorter.h"
+#include "qgsfeedback.h"
 
 QgsAbstractFeatureIterator::QgsAbstractFeatureIterator( const QgsFeatureRequest &request )
   : mRequest( request )
@@ -31,6 +32,9 @@ bool QgsAbstractFeatureIterator::nextFeature( QgsFeature &f )
   {
     return false;
   }
+
+  if ( mRequest.feedback() && mRequest.feedback()->isCanceled() )
+    return false;
 
   if ( mUseCachedFeatures )
   {

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -340,7 +340,7 @@ void QgsFeatureRequest::setFeedback( QgsFeedback *feedback )
   mFeedback = feedback;
 }
 
-QgsFeedback *QgsFeatureRequest::feedback()
+QgsFeedback *QgsFeatureRequest::feedback() const
 {
   return mFeedback;
 }

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -86,6 +86,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mTransformErrorCallback = rh.mTransformErrorCallback;
   mTimeout = rh.mTimeout;
   mRequestMayBeNested = rh.mRequestMayBeNested;
+  mFeedback = rh.mFeedback;
   return *this;
 }
 
@@ -332,6 +333,16 @@ QgsFeatureRequest &QgsFeatureRequest::setRequestMayBeNested( bool requestMayBeNe
 {
   mRequestMayBeNested = requestMayBeNested;
   return *this;
+}
+
+void QgsFeatureRequest::setFeedback( QgsFeedback *feedback )
+{
+  mFeedback = feedback;
+}
+
+QgsFeedback *QgsFeatureRequest::feedback()
+{
+  return mFeedback;
 }
 
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -714,6 +714,29 @@ class CORE_EXPORT QgsFeatureRequest
      */
     QgsFeatureRequest &setRequestMayBeNested( bool requestMayBeNested );
 
+    /**
+     * Attach a \a feedback object that can be queried regularly by the iterator to check
+     * if it should be canceled.
+     *
+     * Ownership of \a feedback is NOT transferred, and the caller must take care that it exists
+     * for the lifetime of the feature request and feature iterators.
+     *
+     * \see feedback()
+     *
+     * \since QGIS 3.20
+     */
+    void setFeedback( QgsFeedback *feedback );
+
+    /**
+     * Returns the feedback object that can be queried regularly by the iterator to check
+     * if it should be canceled, if set.
+     *
+     * \see setFeedback()
+     *
+     * \since QGIS 3.20
+     */
+    QgsFeedback *feedback() const;
+
   protected:
     FilterType mFilter = FilterNone;
     QgsRectangle mFilterRect;
@@ -733,6 +756,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsCoordinateTransformContext mTransformContext;
     int mTimeout = -1;
     int mRequestMayBeNested = false;
+    QgsFeedback *mFeedback = nullptr;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -4428,7 +4428,7 @@ void QgsVectorLayer::minimumOrMaximumValue( int index, QVariant *minimum, QVaria
 
 QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate, const QString &fieldOrExpression,
                                     const QgsAggregateCalculator::AggregateParameters &parameters, QgsExpressionContext *context,
-                                    bool *ok, QgsFeatureIds *fids ) const
+                                    bool *ok, QgsFeatureIds *fids, QgsFeedback *feedback ) const
 {
   if ( ok )
     *ok = false;
@@ -4464,7 +4464,7 @@ QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate,
   if ( fids )
     c.setFidsFilter( *fids );
   c.setParameters( parameters );
-  return c.calculate( aggregate, fieldOrExpression, context, ok );
+  return c.calculate( aggregate, fieldOrExpression, context, ok, feedback );
 }
 
 void QgsVectorLayer::setFeatureBlendMode( QPainter::CompositionMode featureBlendMode )

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2272,6 +2272,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param context expression context for expressions and filters
      * \param ok if specified, will be set to TRUE if aggregate calculation was successful
      * \param fids list of fids to filter, otherwise will use all fids
+     * \param feedback optional feedback argument for early cancellation (since QGIS 3.22)
      * \returns calculated aggregate value
      * \since QGIS 2.16
      */
@@ -2280,7 +2281,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
                         const QgsAggregateCalculator::AggregateParameters &parameters = QgsAggregateCalculator::AggregateParameters(),
                         QgsExpressionContext *context = nullptr,
                         bool *ok = nullptr,
-                        QgsFeatureIds *fids = nullptr ) const;
+                        QgsFeatureIds *fids = nullptr,
+                        QgsFeedback *feedback = nullptr ) const;
 
     //! Sets the blending mode used for rendering each feature
     void setFeatureBlendMode( QPainter::CompositionMode blendMode );

--- a/src/core/vector/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.cpp
@@ -97,6 +97,7 @@ bool QgsVectorLayerFeatureCounter::run()
       if ( isCanceled() )
       {
         mRenderer->stopRender( renderContext );
+        mExpressionContext.setFeedback( nullptr );
         mFeedback.reset();
         return false;
       }

--- a/src/core/vector/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.cpp
@@ -118,7 +118,7 @@ void QgsVectorLayerFeatureCounter::cancel()
   QgsTask::cancel();
 }
 
-QHash<QString, long> QgsVectorLayerFeatureCounter::symbolFeatureCountMap() const
+QHash<QString, long long> QgsVectorLayerFeatureCounter::symbolFeatureCountMap() const
 {
   return mSymbolFeatureCountMap;
 }

--- a/src/core/vector/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.cpp
@@ -16,6 +16,7 @@
 #include "qgsvectorlayerfeaturecounter.h"
 #include "qgsvectorlayer.h"
 #include "qgsfeatureid.h"
+#include "qgsfeedback.h"
 
 QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context, bool storeSymbolFids )
   : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel )
@@ -30,6 +31,8 @@ QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *laye
     mExpressionContext = layer->createExpressionContext();
   }
 }
+
+QgsVectorLayerFeatureCounter::~QgsVectorLayerFeatureCounter() = default;
 
 bool QgsVectorLayerFeatureCounter::run()
 {
@@ -48,6 +51,8 @@ bool QgsVectorLayerFeatureCounter::run()
   // If there are no features to be counted, we can spare us the trouble
   if ( mFeatureCount > 0 )
   {
+    mFeedback = std::make_unique< QgsFeedback >();
+
     int featuresCounted = 0;
 
     // Renderer (rule based) may depend on context scale, with scale is ignored if 0
@@ -59,10 +64,11 @@ bool QgsVectorLayerFeatureCounter::run()
     if ( !mRenderer->filterNeedsGeometry() )
       request.setFlags( QgsFeatureRequest::NoGeometry );
     request.setSubsetOfAttributes( mRenderer->usedAttributes( renderContext ), mSource->fields() );
-    QgsFeatureIterator fit = mSource->getFeatures( request );
 
-    // TODO: replace QgsInterruptionChecker with QgsFeedback
-    // fit.setInterruptionChecker( mFeedback );
+    request.setFeedback( mFeedback.get() );
+    mExpressionContext.setFeedback( mFeedback.get() );
+
+    QgsFeatureIterator fit = mSource->getFeatures( request );
 
     mRenderer->startRender( renderContext, mSource->fields() );
 
@@ -91,17 +97,27 @@ bool QgsVectorLayerFeatureCounter::run()
       if ( isCanceled() )
       {
         mRenderer->stopRender( renderContext );
+        mFeedback.reset();
         return false;
       }
     }
     mRenderer->stopRender( renderContext );
+    mExpressionContext.setFeedback( nullptr );
+    mFeedback.reset();
   }
   setProgress( 100 );
   emit symbolsCounted();
   return true;
 }
 
-QHash<QString, long long> QgsVectorLayerFeatureCounter::symbolFeatureCountMap() const
+void QgsVectorLayerFeatureCounter::cancel()
+{
+  if ( mFeedback )
+    mFeedback->cancel();
+  QgsTask::cancel();
+}
+
+QHash<QString, long> QgsVectorLayerFeatureCounter::symbolFeatureCountMap() const
 {
   return mSymbolFeatureCountMap;
 }

--- a/src/core/vector/qgsvectorlayerfeaturecounter.h
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.h
@@ -43,12 +43,14 @@ class CORE_EXPORT QgsVectorLayerFeatureCounter : public QgsTask
      * \param storeSymbolFids If TRUE will store the feature ids (fids), otherwise will only count the number of features per symbol. Default FALSE.
      */
     QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), bool storeSymbolFids = false );
-
+    ~QgsVectorLayerFeatureCounter() override;
 
     /**
      * Calculates the feature count and Ids per symbol
      */
     bool run() override;
+
+    void cancel() override;
 
     /**
      * Returns the count for each symbol. Only valid after the symbolsCounted()
@@ -95,8 +97,9 @@ class CORE_EXPORT QgsVectorLayerFeatureCounter : public QgsTask
     QgsExpressionContext mExpressionContext;
     QHash<QString, long long> mSymbolFeatureCountMap;
     QHash<QString, QgsFeatureIds> mSymbolFeatureIdMap;
+    std::unique_ptr< QgsFeedback > mFeedback;
     bool mWithFids = false;
-    int mFeatureCount;
+    long mFeatureCount = 0;
 
 };
 

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -122,7 +122,6 @@ QString QgsVectorLayerFeatureSource::id() const
 QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsVectorLayerFeatureSource>( source, ownSource, request )
   , mFetchedFid( false )
-
 {
   if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
   {
@@ -1222,6 +1221,7 @@ void QgsVectorLayerFeatureIterator::createExpressionContext()
   mExpressionContext->appendScope( QgsExpressionContextUtils::globalScope() );
   mExpressionContext->appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) );
   mExpressionContext->appendScope( new QgsExpressionContextScope( mSource->mLayerScope ) );
+  mExpressionContext->setFeedback( mRequest.feedback() );
 }
 
 bool QgsVectorLayerFeatureIterator::prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys )

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -393,6 +393,9 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
   }
 
   featureRequest.setFeedback( mInterruptionChecker.get() );
+  // also set the interruption checker for the expression context, in case the renderer uses some complex expression
+  // which could benefit from early exit paths...
+  context.expressionContext().setFeedback( mInterruptionChecker.get() );
 
   QgsFeatureIterator fit = mSource->getFeatures( featureRequest );
   // Attach an interruption checker so that iterators that have potentially
@@ -416,6 +419,7 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
     renderer->paintEffect()->end( context );
   }
 
+  context.expressionContext().setFeedback( nullptr );
   mInterruptionChecker.reset();
   return true;
 }

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -392,6 +392,8 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
     context.setVectorSimplifyMethod( vectorMethod );
   }
 
+  featureRequest.setFeedback( mInterruptionChecker.get() );
+
   QgsFeatureIterator fit = mSource->getFeatures( featureRequest );
   // Attach an interruption checker so that iterators that have potentially
   // slow fetchFeature() implementations, such as in the WFS provider, can


### PR DESCRIPTION
Aimed at fixing #43572 (although the script referenced in that issue also needs fixes, which I'll comment in that ticket).

This PR adds a QgsFeedback argument to QgsFeatureRequest, so that we can abort feature iteration early in the situation that the results are no longer required (e.g. when a layer renderer is canceled).

While we already have QgsFeatureIterator::setInterruptionChecker which is designed to handle a similar situation, we can't use that particular API to fix the deadlock from #43572. Specifically, we need the feedback set on the request so that we can handle cancelation requests which occur during the construction of QgsFeatureIterators, rather than only those which occur after the iterator is created. In this particular situation the deadlock happens while acquiring a connection to the ogr layer, so I've add a  QgsFeedback argument to QgsConnectionPool::acquireConnection -- if set, this causes the acquisition to be attempted every 300 ms until either the connection is acquired, the feedback is canceled, OR the overall timeout length is reached.

That partially helps #43572, but to solve #43572 properly we also need a way to cancel unwanted expression evaluation for costly expressions (such as the custom expression function attached to that ticket). To handle this I've introduced a QgsFeedback object to QgsExpressionContext also, so that potentially expensive expression functions have a means to test if the result is no longer wanted and abort the evaluation early. (I've added checks here for some potentially expensive functions, specifically those which directly iterate features during evaluation. There's more scope to add this optimisation in other expression functions, e.g. ~~the aggregate functions~~ done!). 

With these two changes combined we now have a proper means to abort the vector layer feature counter early and avoid the unkillable tasks described in #43572.

This fix is too risky to merge for 3.20, so targeting it for >= 3.22 only.