### PR TITLE
Fix QgsDistanceArea.bearing()

### DIFF
--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -859,7 +859,7 @@ double QgsDistanceArea::bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) co
     double distance = 0;
     double azimuth1 = 0;
     double azimuth2 = 0;
-    geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.x(), pp2.y(), &distance, &azimuth1, &azimuth2 );
+    geod_inverse( mGeod.get(), pp1.y(), pp1.x(), pp2.y(), pp2.x(), &distance, &azimuth1, &azimuth2 );
 
     bearing = DEG2RAD( azimuth1 );
   }

--- a/tests/src/python/test_qgsdistancearea.py
+++ b/tests/src/python/test_qgsdistancearea.py
@@ -63,6 +63,20 @@ class TestQgsDistanceArea(unittest.TestCase):
                      (4, length))
         assert length == 4, myMessage
 
+    def testBearing(self):
+        """
+        Test bearing calculation
+        """
+        da = QgsDistanceArea()
+        self.assertAlmostEqual(da.bearing(QgsPointXY(145.047, -37.578), QgsPointXY(168.38, -16.95)), 0.84685, 5)
+        self.assertAlmostEqual(da.bearing(QgsPointXY(-19.57, 65.12), QgsPointXY(-2.63, 54.97)), 2.11060792, 5)
+
+        da.setSourceCrs(QgsCoordinateReferenceSystem('EPSG:3857'), QgsProject.instance().transformContext())
+        da.setEllipsoid(da.sourceCrs().ellipsoidAcronym())
+        self.assertTrue(da.willUseEllipsoid())
+        self.assertAlmostEqual(da.bearing(QgsPointXY(16198544, -4534850), QgsPointXY(18736872, -1877769)), 0.8723168079, 5)
+        self.assertAlmostEqual(da.bearing(QgsPointXY(-2074453, 9559553), QgsPointXY(-55665, 6828252)), 2.35691008, 5)
+
     def testMeasureLineProjected(self):
         #   +-+
         #   | |


### PR DESCRIPTION
This method had absolutely NO unit tests, and has been returning NaN! ARGHHhhhhhhhh
