### PR TITLE
Attempt to fallback to project CRS if no defaultCRS specified in QgsOWSSourceSelect

### DIFF
--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -451,7 +451,7 @@ void QgsOWSSourceSelect::populateCrs()
 
     if ( it == mSelectedLayersCRSs.constEnd() )
     {
-      if ( mSelectedLayersCRSs.find( QgsProject::instance()->crs().authid() ) != mSelectedLayersCRSs.end() )
+      if ( mSelectedLayersCRSs.constFind( QgsProject::instance()->crs().authid() ) != mSelectedLayersCRSs.constEnd() )
       {
         mSelectedCRS = QgsProject::instance()->crs().authid();
       }

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -451,8 +451,15 @@ void QgsOWSSourceSelect::populateCrs()
 
     if ( it == mSelectedLayersCRSs.constEnd() )
     {
-      // not found
-      mSelectedCRS = defaultCRS;
+      if ( mSelectedLayersCRSs.find( QgsProject::instance()->crs().authid() ) != mSelectedLayersCRSs.end() )
+      {
+        mSelectedCRS = QgsProject::instance()->crs().authid();
+      }
+      else
+      {
+        // not found
+        mSelectedCRS = defaultCRS;
+      }
     }
     mSelectedCRSLabel->setText( descriptionForAuthId( mSelectedCRS ) );
     mChangeCRSButton->setEnabled( true );


### PR DESCRIPTION
If the selected CRS is not supported by the OWS service, also attempt to use the project CRS, if supported by the OWS service, rather than just falling back to the first supported CRS.