### PR TITLE
[ept] Fix point cloud loading hang/crash

### DIFF
--- a/src/core/pointcloud/qgseptdecoder.cpp
+++ b/src/core/pointcloud/qgseptdecoder.cpp
@@ -287,7 +287,9 @@ QgsPointCloudBlock *__decompressLaz( FileType &file, const QgsPointCloudAttribut
   const size_t count = f.get_header().point_count;
   QgsVector3D scale( f.get_header().scale.x, f.get_header().scale.y, f.get_header().scale.z );
   QgsVector3D offset( f.get_header().offset.x, f.get_header().offset.y, f.get_header().offset.z );
-  char buf[sizeof( laszip::formats::las::point10 ) + sizeof( laszip::formats::las::gpstime ) + sizeof( laszip::formats::las::rgb ) ]; // a buffer large enough to hold our point
+
+  QByteArray bufArray( f.get_header().point_record_length, 0 );
+  char *buf = bufArray.data();
 
   const size_t requestedPointRecordSize = requestedAttributes.pointRecordSize();
   QByteArray data;


### PR DESCRIPTION
The fixed buffer of 34 bytes may not be large enough. There could be some extra fields in the input LAZ files. For example, the failing dataset I got hold of was having point length of 80 bytes due to a couple of extra fields. Checked with laz-perf devs and this should be the right approach to get appropriately sized buffer to read points.

Fixes #42696