### PR TITLE
ArcGIS MapServer: Allow disabling tiled rendering

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -251,6 +251,10 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
   mLayerMetadata.setCrs( mCrs );
 
   mTiled = mServiceInfo.value( QStringLiteral( "singleFusedMapCache" ) ).toBool() && mCrs.mapUnits() == QgsUnitTypes::DistanceMeters;
+  if ( dataSource.param( QStringLiteral( "tiled" ) ).toLower() == "false" || dataSource.param( QStringLiteral( "tiled" ) ) == "0" )
+  {
+    mTiled = false;
+  }
 
   if ( mServiceInfo.contains( QStringLiteral( "maxImageWidth" ) ) )
     mMaxImageWidth = mServiceInfo.value( QStringLiteral( "maxImageWidth" ) ).toInt();


### PR DESCRIPTION
Support a data source param to force non-tiled rendering of arcgis mapserver layers.