### PR TITLE
Standardize UX for measure tool/measure angle tools with other map tools

### DIFF
--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -86,6 +86,13 @@ void QgsMapToolMeasureAngle::canvasMoveEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolMeasureAngle::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
+  // if we clicked the right button we cancel the operation, unless it's the "final" click
+  if ( e->button() == Qt::RightButton && mAnglePoints.size() != 2 )
+  {
+    stopMeasuring();
+    return;
+  }
+
   //add points until we have three
   if ( mAnglePoints.size() == 3 )
   {
@@ -109,6 +116,34 @@ void QgsMapToolMeasureAngle::canvasReleaseEvent( QgsMapMouseEvent *e )
     QgsPointXY newPoint = e->snapPoint();
     mAnglePoints.push_back( newPoint );
     mRubberBand->addPoint( newPoint );
+  }
+}
+
+void QgsMapToolMeasureAngle::keyPressEvent( QKeyEvent *e )
+{
+  if ( e->key() == Qt::Key_Escape )
+  {
+    stopMeasuring();
+  }
+  else if ( ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete ) )
+  {
+    if ( !mAnglePoints.empty() && mRubberBand )
+    {
+      if ( mAnglePoints.size() == 1 )
+      {
+        //removing first point, so restart everything
+        stopMeasuring();
+      }
+      else
+      {
+        //remove second last point from line band, and last point from points band
+        mRubberBand->removePoint( -2, true );
+        mAnglePoints.removeLast();
+      }
+    }
+
+    // Override default shortcut management in MapCanvas
+    e->ignore();
   }
 }
 

--- a/src/app/qgsmaptoolmeasureangle.h
+++ b/src/app/qgsmaptoolmeasureangle.h
@@ -34,17 +34,10 @@ class APP_EXPORT QgsMapToolMeasureAngle: public QgsMapTool
     ~QgsMapToolMeasureAngle() override;
 
     Flags flags() const override { return QgsMapTool::AllowZoomRect; }
-
-    //! Mouse move event for overriding
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-
-    //! Mouse release event for overriding
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
-
-    //! called when set as currently active map tool
+    void keyPressEvent( QKeyEvent *e ) override;
     void activate() override;
-
-    //! called when map tool is being deactivated
     void deactivate() override;
 
   private:

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -252,7 +252,11 @@ void QgsMeasureTool::undo()
 
 void QgsMeasureTool::keyPressEvent( QKeyEvent *e )
 {
-  if ( ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete ) )
+  if ( e->key() == Qt::Key_Escape )
+  {
+    mDialog->restart();
+  }
+  else if ( ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete ) )
   {
     if ( !mDone )
     {


### PR DESCRIPTION
I got sick of these tools not behaving like the rest of QGIS, so...

- Measure tool: pressing "escape" cancels the measure
- Measure angle tool: right click cancels the measure, unless its the
  final point in which case the angle is locked in (like
digitizing/measure distance tools)
- Measure angle tool: backspace/del removes last point
- Measure angle tool: escape cancels the measure

(I don't think documentation updates are required here -- this is just making these tools follow the same pattern as is used elsewhere in qgis)