### PR TITLE
Add method for PyQGIS QgsMapTool subclasses to set the tool name

### DIFF
--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -170,6 +170,8 @@ returns pointer to the tool's map canvas
 %Docstring
 Emit map tool changed with the old tool
 
+.. seealso:: :py:func:`setToolName`
+
 .. versionadded:: 2.3
 %End
 
@@ -303,6 +305,15 @@ Transforms a ``rect`` from map coordinates to ``layer`` coordinates.
     QPoint toCanvasCoordinates( const QgsPointXY &point ) const;
 %Docstring
 Transforms a ``point`` from map coordinates to screen coordinates.
+%End
+
+    void setToolName( const QString &name );
+%Docstring
+Sets the tool's ``name``.
+
+.. seealso:: :py:func:`toolName`
+
+.. versionadded:: 3.20
 %End
 
 

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -76,6 +76,10 @@ QPoint QgsMapTool::toCanvasCoordinates( const QgsPointXY &point ) const
   return QPoint( std::round( x ), std::round( y ) );
 }
 
+void QgsMapTool::setToolName( const QString &name )
+{
+  mToolName = name;
+}
 
 void QgsMapTool::activate()
 {

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -176,6 +176,7 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     /**
      * Emit map tool changed with the old tool
+     * \see setToolName()
      * \since QGIS 2.3
      */
     QString toolName() { return mToolName; }
@@ -283,6 +284,14 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     //! Transforms a \a point from map coordinates to screen coordinates.
     QPoint toCanvasCoordinates( const QgsPointXY &point ) const;
+
+    /**
+     * Sets the tool's \a name.
+     *
+     * \see toolName()
+     * \since QGIS 3.20
+     */
+    void setToolName( const QString &name );
 
     //! The pointer to the map canvas
     QgsMapCanvas *mCanvas = nullptr;


### PR DESCRIPTION
Since PyQGIS can't access protected member variables, we need an explicit setter for this variable.
