### PR TITLE
Don't restrict adding crs selections to list of recent CRSes to only a few select dialogs

### DIFF
--- a/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
@@ -147,9 +147,12 @@ by the given Coordinate Reference Systems.
    This function's behavior is undefined if it is called after the widget is shown.
 %End
 
-    void pushProjectionToFront();
+ void pushProjectionToFront() /Deprecated/;
 %Docstring
 Marks the current selected projection for push to front of recent projections list.
+
+.. deprecated::
+   Has no effect since QGIS 3.20
 %End
 
   signals:

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1072,9 +1072,6 @@ void QgsProjectProperties::apply()
     {
       QgsDebugMsgLevel( QStringLiteral( "CRS set to no projection!" ), 4 );
     }
-
-    // mark selected projection for push to front
-    projectionSelector->pushProjectionToFront();
   }
 
   mMetadataWidget->acceptMetadata();

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -51,12 +51,6 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
 
   mAreaCanvas->setVisible( mShowMap );
 
-  if ( QDialog *dlg = qobject_cast<QDialog *>( parent ) )
-  {
-    // mark selected projection for push to front if parent dialog is accepted
-    connect( dlg, &QDialog::accepted, this, &QgsProjectionSelectionTreeWidget::pushProjectionToFront );
-  }
-
   // Get the full path name to the sqlite3 spatial reference database.
   mSrsDatabaseFileName = QgsApplication::srsDatabaseFilePath();
 
@@ -100,20 +94,13 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
 
 QgsProjectionSelectionTreeWidget::~QgsProjectionSelectionTreeWidget()
 {
-  if ( !mPushProjectionToFront )
-  {
-    return;
-  }
-
-  // Push current projection to front, only if set
-  long crsId = selectedCrsId();
-  if ( crsId == 0 )
-    return;
-
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Windows/ProjectionSelector/splitterState" ), mSplitter->saveState() );
 
-  QgsCoordinateReferenceSystem::pushRecentCoordinateReferenceSystem( crs() );
+  // Push current projection to front, only if set
+  const QgsCoordinateReferenceSystem selectedCrs = crs();
+  if ( selectedCrs.isValid() )
+    QgsCoordinateReferenceSystem::pushRecentCoordinateReferenceSystem( selectedCrs );
 }
 
 void QgsProjectionSelectionTreeWidget::resizeEvent( QResizeEvent *event )
@@ -850,13 +837,9 @@ void QgsProjectionSelectionTreeWidget::updateFilter()
   filterTreeWidget( lstCoordinateSystems );
 }
 
-
 void QgsProjectionSelectionTreeWidget::pushProjectionToFront()
 {
-  // set flag to push selected projection to front in destructor
-  mPushProjectionToFront = true;
 }
-
 
 long QgsProjectionSelectionTreeWidget::getLargestCrsIdMatch( const QString &sql )
 {

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -140,8 +140,10 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
 
     /**
      * Marks the current selected projection for push to front of recent projections list.
+     *
+     * \deprecated Has no effect since QGIS 3.20
      */
-    void pushProjectionToFront();
+    Q_DECL_DEPRECATED void pushProjectionToFront() SIP_DEPRECATED;
 
   signals:
 
@@ -291,8 +293,6 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     enum Columns { NameColumn, AuthidColumn, QgisCrsIdColumn, None };
     int mSearchColumn = QgsProjectionSelectionTreeWidget::None;
     QString mSearchValue;
-
-    bool mPushProjectionToFront = false;
 
     //! The set of OGC WMS CRSs that want to be applied to this widget
     QSet<QString> mCrsFilter;


### PR DESCRIPTION
If the user has gone to the trouble of picking a CRS from the dialog,
it should ALWAYS be pushed to the list of recently used CRS, regardless
of whether they've done it from project properties, layer properties,
some processing algorithm, etc...
