### PR TITLE
fix mesh calculator IF operator

### DIFF
--- a/src/core/mesh/qgsmeshcalcnode.cpp
+++ b/src/core/mesh/qgsmeshcalcnode.cpp
@@ -241,6 +241,11 @@ bool QgsMeshCalcNode::isNonTemporal() const
 
   switch ( mOperator )
   {
+    case QgsMeshCalcNode::opIF:
+      return ( mLeft && mLeft->isNonTemporal() ) &&
+             ( mRight && mRight->isNonTemporal() &&
+               mCondition->isNonTemporal() );
+      break;
     case QgsMeshCalcNode::opPLUS:
     case QgsMeshCalcNode::opMINUS:
     case QgsMeshCalcNode::opMUL:
@@ -255,7 +260,6 @@ bool QgsMeshCalcNode::isNonTemporal() const
     case QgsMeshCalcNode::opAND:
     case QgsMeshCalcNode::opOR:
     case QgsMeshCalcNode::opNOT:
-    case QgsMeshCalcNode::opIF:
     case QgsMeshCalcNode::opSIGN:
     case QgsMeshCalcNode::opMIN:
     case QgsMeshCalcNode::opMAX:

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -395,7 +395,10 @@ void TestQgsMeshCalculator::test_dataset_group_dependency()
   formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + 2" ) );
   formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + \"virtual_0\"" ) );
   formulas.append( QStringLiteral( " \"virtual_0\" + max_aggr ( \"VertexScalarDataset\")  + 1" ) );
-  QVector<int> sizes{10, 10, 2, 1, 1, 10, 10};
+  formulas.append( QStringLiteral( "if ( \"FaceScalarDataset\" = \"VertexScalarDataset\" , 0 , 1 )" ) ); //temporal one, must have several datasets
+  formulas.append( QStringLiteral( "if ( 2 = 1 , 0 , 1 )" ) ); //dtatic one, must have one dataset
+  formulas.append( QStringLiteral( "if ( 2 = 1 , \"FaceScalarDataset\" , 1 )" ) ); //temporal one, must have several datasets
+  QVector<int> sizes{10, 10, 2, 1, 1, 10, 10, 2, 1, 2};
 
   std::vector<std::unique_ptr<QgsMeshVirtualDatasetGroup>> virtualDatasetGroups( formulas.count() );
 
@@ -407,7 +410,7 @@ void TestQgsMeshCalculator::test_dataset_group_dependency()
     mpMeshLayer->addDatasets( virtualDatasetGroups[i].release() );
   }
 
-  QCOMPARE( 24, mpMeshLayer->datasetGroupCount() );
+  QCOMPARE( 27, mpMeshLayer->datasetGroupCount() );
 
   QgsMeshDatasetGroupTreeItem *rootItem = mpMeshLayer->datasetGroupTreeRootItem();
 


### PR DESCRIPTION
when IF operator of mesh calculator has left member ans right member non temporal, the result is set to non temporal even the condition is temporal.
That leads to non temporal virtual dataset group when formula is, for example : if ('"Depth">1 , 2 , 3). Even is Depth is temporal, as "2" and "3" are not temporal the result is static, that is wrong.
This PR fixes this issue