### PR TITLE
Fix WMS layer crash when the project is closed faster than GetCapabilities response

### DIFF
--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
@@ -46,6 +46,10 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
   mTimer->setSingleShot( true );
   mTimer->setInterval( 100 );
   connect( mTimer, &QTimer::timeout, this, &QgsLayerTreeOpacityWidget::updateOpacityFromSlider );
+  connect( mLayer, &QgsMapLayer::destroyed, this, [ = ]()
+  {
+    mTimer->stop();
+  } );
 
   connect( mSlider, &QAbstractSlider::valueChanged, this, &QgsLayerTreeOpacityWidget::sliderValueChanged );
 


### PR DESCRIPTION
Since `GetCapabilities` for WMS layer is done in another event loop and there is a timer to set the opacity, if the project is closed in the meanwhile the `QgsLayerTreeOpacityWidget::mLayer` might be destroyed which causes a crash. :boom: 
