### PR TITLE
quick fix qgis_tiledownloadmanagertest flapping

### DIFF
--- a/tests/src/core/testqgstiledownloadmanager.cpp
+++ b/tests/src/core/testqgstiledownloadmanager.cpp
@@ -29,7 +29,7 @@
 
 const QString url_1 = "https://www.qwant.com/maps/tiles/ozbasemap/0/0/0.pbf";
 const QString url_2 = "https://www.qwant.com/maps/tiles/ozbasemap/1/0/0.pbf";
-const QString url_bad = "http://www.example.com/download-manager-fail";
+const QString url_bad = "https://www.qwant.com/maps/tiles/ozbasemap/1/0/90913.pbf";
 
 
 class TestQgsTileDownloadManager : public QObject
@@ -185,12 +185,12 @@ void TestQgsTileDownloadManager::testOneRequestTwiceAndEarlyDelete()
   std::unique_ptr<QgsTileDownloadManagerReply> r2( manager.get( QNetworkRequest( url_1 ) ) );
 
   QVERIFY( manager.hasPendingRequests() );
+  QSignalSpy spy( r2.get(), &QgsTileDownloadManagerReply::finished );
 
   QThread::usleep( 1000 );  // sleep 1ms - enough time to start request but not enough to finish it
 
   r1.reset();
 
-  QSignalSpy spy( r2.get(), &QgsTileDownloadManagerReply::finished );
   spy.wait();
   QCOMPARE( spy.count(), 1 );
   QVERIFY( !r2->data().isEmpty() );


### PR DESCRIPTION
**working hypothesis:**
The response from the `http://www.example.com/download-manager-fail` comes back too quickly and the test fails.
https://github.com/qgis/QGIS/blob/e8efe8164200d03ec2ce7cd857512c7987977493/tests/src/core/testqgstiledownloadmanager.cpp#L224

**solution:**
For testing `url_bad`, use a request to a non-existent page on the `https://www.qwant.com/` server.
https://github.com/qgis/QGIS/blob/e8efe8164200d03ec2ce7cd857512c7987977493/tests/src/core/testqgstiledownloadmanager.cpp#L30-L32