### PR TITLE
Disable empty menus or action not working in context

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14776,10 +14776,10 @@ void QgisApp::activateDeactivateMultipleLayersRelatedActions()
   // these actions are enabled whenever ANY selected layer is spatial
   const bool hasSpatial = selectedLayersHaveSpatial();
   mActionZoomToLayers->setEnabled( hasSpatial );
-  mActionPanToSelected->setEnabled( hasSpatial );
 
   // this action is enabled whenever ANY selected layer has a selection
   const bool hasSelection = selectedLayersHaveSelection();
+  mActionPanToSelected->setEnabled( hasSelection );
   mActionZoomToSelected->setEnabled( hasSelection );
 }
 
@@ -14865,6 +14865,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionRegularPolygon2Points->setEnabled( false );
     mActionRegularPolygonCenterPoint->setEnabled( false );
     mActionRegularPolygonCenterCorner->setEnabled( false );
+    mMenuEditGeometry->setEnabled( false );
     mActionMoveFeature->setEnabled( false );
     mActionMoveFeatureCopy->setEnabled( false );
     mActionRotateFeature->setEnabled( false );
@@ -14897,6 +14898,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionSplitFeatures->setEnabled( false );
     mActionSplitParts->setEnabled( false );
     mActionMergeFeatures->setEnabled( false );
+    mMenuEditAttributes->setEnabled( false );
     mActionMergeFeatureAttributes->setEnabled( false );
     mActionMultiEditAttributes->setEnabled( false );
     mActionRotatePointSymbols->setEnabled( false );
@@ -14920,7 +14922,9 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionDecreaseContrast->setEnabled( false );
     mActionIncreaseGamma->setEnabled( false );
     mActionDecreaseGamma->setEnabled( false );
+    mActionPanToSelected->setEnabled( false );
     mActionZoomActualSize->setEnabled( false );
+    mActionZoomToSelected->setEnabled( false );
     mActionZoomToLayers->setEnabled( false );
     mActionZoomToLayer->setEnabled( false );
 
@@ -14933,6 +14937,8 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
 
   mActionLayerProperties->setEnabled( QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() );
   mActionAddToOverview->setEnabled( true );
+  mActionPanToSelected->setEnabled( true );
+  mActionZoomToSelected->setEnabled( true );
   mActionZoomToLayers->setEnabled( true );
   mActionZoomToLayer->setEnabled( true );
 
@@ -15013,6 +15019,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
         mUndoDock->widget()->setEnabled( canSupportEditing && isEditable );
         mActionUndo->setEnabled( canSupportEditing );
         mActionRedo->setEnabled( canSupportEditing );
+        mMenuEditGeometry->setEnabled( canSupportEditing && isEditable );
 
         //start editing/stop editing
         if ( canSupportEditing )
@@ -15060,12 +15067,14 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
         if ( isEditable && canChangeAttributes )
         {
           mActionMergeFeatures->setEnabled( layerHasSelection && canDeleteFeatures && canAddFeatures );
+          mMenuEditAttributes->setEnabled( layerHasSelection );
           mActionMergeFeatureAttributes->setEnabled( layerHasSelection );
           mActionMultiEditAttributes->setEnabled( layerHasSelection );
         }
         else
         {
           mActionMergeFeatures->setEnabled( false );
+          mMenuEditAttributes->setEnabled( false );
           mActionMergeFeatureAttributes->setEnabled( false );
           mActionMultiEditAttributes->setEnabled( false );
         }
@@ -15266,6 +15275,8 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionRegularPolygon2Points->setEnabled( false );
       mActionRegularPolygonCenterPoint->setEnabled( false );
       mActionRegularPolygonCenterCorner->setEnabled( false );
+      mMenuEditAttributes->setEnabled( false );
+      mMenuEditGeometry->setEnabled( false );
       mActionReverseLine->setEnabled( false );
       mActionTrimExtendFeature->setEnabled( false );
       mActionDeleteSelected->setEnabled( false );
@@ -16694,7 +16705,7 @@ void QgisApp::eraseAuthenticationDatabase()
     }
   }
 
-  // TODO: Check is Browser panel is also still loading?
+  // TODO: Check if Browser panel is also still loading?
   //       It has auto-connections in parallel (if tree item is expanded), though
   //       such connections with possible master password requests *should* be ignored
   //       when there is an authentication db erase scheduled.


### PR DESCRIPTION
Unlike eg the "Add shape" menus, The "Edit geometry" and "Edit attributes" menu are enabled while none of their items is available. This PR disables them also. note that it does not cover #43738
It also aligns the "Pan map to selection" tool with "zoom map to selection", ie enable if there is a selection.