### PR TITLE
Coordinate formatter localization

### DIFF
--- a/python/core/auto_generated/qgscoordinateformatter.sip.in
+++ b/python/core/auto_generated/qgscoordinateformatter.sip.in
@@ -93,7 +93,8 @@ of decimal places to include).
 %Docstring
 Returns the character used as X/Y separator, this is a `,` on locales that do not use
 `,` as decimal separator, it is a space otherwise.
-\from QGIS 3.20
+
+.. versionadded:: 3.20
 %End
 
 };

--- a/python/core/auto_generated/qgscoordinateformatter.sip.in
+++ b/python/core/auto_generated/qgscoordinateformatter.sip.in
@@ -89,6 +89,15 @@ Formats coordinates as an "``x``,``y``" pair, with optional decimal ``precision`
 of decimal places to include).
 %End
 
+    static QChar separator( );
+%Docstring
+Returns the charachter used as X/Y separator, this is a `,` on locales that do not use
+`,` as decimal separator, it is a space otherwise.
+
+.. seealso:: :py:func:`splitPair`
+\from QGIS 3.22
+%End
+
 };
 
 QFlags<QgsCoordinateFormatter::FormatFlag> operator|(QgsCoordinateFormatter::FormatFlag f1, QFlags<QgsCoordinateFormatter::FormatFlag> f2);

--- a/python/core/auto_generated/qgscoordinateformatter.sip.in
+++ b/python/core/auto_generated/qgscoordinateformatter.sip.in
@@ -91,10 +91,8 @@ of decimal places to include).
 
     static QChar separator( );
 %Docstring
-Returns the charachter used as X/Y separator, this is a `,` on locales that do not use
+Returns the character used as X/Y separator, this is a `,` on locales that do not use
 `,` as decimal separator, it is a space otherwise.
-
-.. seealso:: :py:func:`splitPair`
 \from QGIS 3.22
 %End
 

--- a/python/core/auto_generated/qgscoordinateformatter.sip.in
+++ b/python/core/auto_generated/qgscoordinateformatter.sip.in
@@ -93,7 +93,7 @@ of decimal places to include).
 %Docstring
 Returns the character used as X/Y separator, this is a `,` on locales that do not use
 `,` as decimal separator, it is a space otherwise.
-\from QGIS 3.22
+\from QGIS 3.20
 %End
 
 };

--- a/src/core/qgscoordinateformatter.cpp
+++ b/src/core/qgscoordinateformatter.cpp
@@ -19,6 +19,7 @@
 #include "qgis.h"
 
 #include <QObject> // for tr()
+#include <QLocale>
 
 QString QgsCoordinateFormatter::formatX( double x, QgsCoordinateFormatter::Format format, int precision, FormatFlags flags )
 {
@@ -60,21 +61,27 @@ QString QgsCoordinateFormatter::formatY( double y, QgsCoordinateFormatter::Forma
 
 QString QgsCoordinateFormatter::format( const QgsPointXY &point, QgsCoordinateFormatter::Format format, int precision, FormatFlags flags )
 {
-  return QStringLiteral( "%1,%2" ).arg( formatX( point.x(), format, precision, flags ),
-                                        formatY( point.y(), format, precision, flags ) );
+  return QStringLiteral( "%1%2%3" ).arg( formatX( point.x(), format, precision, flags ),
+                                         QgsCoordinateFormatter::separator(),
+                                         formatY( point.y(), format, precision, flags ) );
 }
 
 QString QgsCoordinateFormatter::asPair( double x, double y, int precision )
 {
   QString s = formatAsPair( x, precision );
-  s += ',';
+  s += QgsCoordinateFormatter::separator();
   s += formatAsPair( y, precision );
   return s;
 }
 
+QChar QgsCoordinateFormatter::separator()
+{
+  return QLocale().decimalPoint() == QLatin1Char( ',' ) ? QLatin1Char( ' ' ) : QLatin1Char( ',' );
+}
+
 QString QgsCoordinateFormatter::formatAsPair( double val, int precision )
 {
-  return std::isfinite( val ) ? QString::number( val, 'f', precision ) : QObject::tr( "infinite" );
+  return std::isfinite( val ) ? QLocale().toString( val, 'f', precision ) : QObject::tr( "infinite" );
 }
 
 QString QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds( double val, int precision, FormatFlags flags )
@@ -120,7 +127,7 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds( double val, int 
   {
     if ( wrappedX < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -143,17 +150,17 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutesSeconds( double val, int 
   //pad with leading digits if required
   if ( flags.testFlag( FlagDegreesPadMinutesSeconds ) )
   {
-    minutesX = QString( "%1" ).arg( intMinutesX, 2, 10, QChar( '0' ) );
+    minutesX = QString( "%L1" ).arg( intMinutesX, 2, 10, QChar( '0' ) );
     int digits = 2 + ( precision == 0 ? 0 : 1 + precision ); //1 for decimal place if required
-    strSecondsX = QString( "%1" ).arg( secondsX, digits, 'f', precision, QChar( '0' ) );
+    strSecondsX = QString( "%L1" ).arg( secondsX, digits, 'f', precision, QChar( '0' ) );
   }
   else
   {
-    minutesX =  QString::number( intMinutesX );
-    strSecondsX = QString::number( secondsX, 'f', precision );
+    minutesX = QLocale().toString( intMinutesX );
+    strSecondsX = QLocale().toString( secondsX, 'f', precision );
   }
 
-  return sign + QString::number( degreesX ) + QChar( 176 ) +
+  return sign + QLocale().toString( degreesX ) + QChar( 176 ) +
          minutesX + QChar( 0x2032 ) +
          strSecondsX + QChar( 0x2033 ) +
          hemisphere;
@@ -202,7 +209,7 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutesSeconds( double val, int 
   {
     if ( wrappedY < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -219,17 +226,17 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutesSeconds( double val, int 
   //pad with leading digits if required
   if ( flags.testFlag( FlagDegreesPadMinutesSeconds ) )
   {
-    strMinutesY = QString( "%1" ).arg( intMinutesY, 2, 10, QChar( '0' ) );
+    strMinutesY = QString( "%L1" ).arg( intMinutesY, 2, 10, QChar( '0' ) );
     int digits = 2 + ( precision == 0 ? 0 : 1 + precision ); //1 for decimal place if required
-    strSecondsY = QString( "%1" ).arg( secondsY, digits, 'f', precision, QChar( '0' ) );
+    strSecondsY = QString( "%L1" ).arg( secondsY, digits, 'f', precision, QChar( '0' ) );
   }
   else
   {
-    strMinutesY = QString::number( intMinutesY );
-    strSecondsY = QString::number( secondsY, 'f', precision );
+    strMinutesY = QLocale().toString( intMinutesY );
+    strSecondsY = QLocale().toString( secondsY, 'f', precision );
   }
 
-  return sign + QString::number( degreesY ) + QChar( 176 ) +
+  return sign + QLocale().toString( degreesY ) + QChar( 176 ) +
          strMinutesY + QChar( 0x2032 ) +
          strSecondsY + QChar( 0x2033 ) +
          hemisphere;
@@ -271,7 +278,7 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutes( double val, int precisi
   {
     if ( wrappedX < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -291,9 +298,9 @@ QString QgsCoordinateFormatter::formatXAsDegreesMinutes( double val, int precisi
   //pad minutes with leading digits if required
   int digits = 2 + ( precision == 0 ? 0 : 1 + precision ); //1 for decimal place if required
   QString strMinutesX = flags.testFlag( FlagDegreesPadMinutesSeconds ) ? QString( "%1" ).arg( floatMinutesX, digits, 'f', precision, QChar( '0' ) )
-                        : QString::number( floatMinutesX, 'f', precision );
+                        : QLocale().toString( floatMinutesX, 'f', precision );
 
-  return sign + QString::number( degreesX ) + QChar( 176 ) +
+  return sign + QLocale().toString( degreesX ) + QChar( 176 ) +
          strMinutesX + QChar( 0x2032 ) +
          hemisphere;
 }
@@ -334,7 +341,7 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutes( double val, int precisi
   {
     if ( wrappedY < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -349,9 +356,9 @@ QString QgsCoordinateFormatter::formatYAsDegreesMinutes( double val, int precisi
   //pad minutes with leading digits if required
   int digits = 2 + ( precision == 0 ? 0 : 1 + precision ); //1 for decimal place if required
   QString strMinutesY = flags.testFlag( FlagDegreesPadMinutesSeconds ) ? QString( "%1" ).arg( floatMinutesY, digits, 'f', precision, QChar( '0' ) )
-                        : QString::number( floatMinutesY, 'f', precision );
+                        : QLocale().toString( floatMinutesY, 'f', precision );
 
-  return sign + QString::number( degreesY ) + QChar( 176 ) +
+  return sign + QLocale().toString( degreesY ) + QChar( 176 ) +
          strMinutesY + QChar( 0x2032 ) +
          hemisphere;
 }
@@ -384,7 +391,7 @@ QString QgsCoordinateFormatter::formatXAsDegrees( double val, int precision, For
   {
     if ( wrappedX < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -402,7 +409,7 @@ QString QgsCoordinateFormatter::formatXAsDegrees( double val, int precision, For
     hemisphere.clear();
   }
 
-  return sign + QString::number( absX, 'f', precision ) + QChar( 176 ) + hemisphere;
+  return sign + QLocale().toString( absX, 'f', precision ) + QChar( 176 ) + hemisphere;
 }
 
 QString QgsCoordinateFormatter::formatYAsDegrees( double val, int precision, FormatFlags flags )
@@ -433,7 +440,7 @@ QString QgsCoordinateFormatter::formatYAsDegrees( double val, int precision, For
   {
     if ( wrappedY < 0 )
     {
-      sign = QObject::tr( "-" );
+      sign = QLocale().negativeSign();
     }
   }
   //check if coordinate is all zeros for the specified precision, and if so,
@@ -444,5 +451,5 @@ QString QgsCoordinateFormatter::formatYAsDegrees( double val, int precision, For
     hemisphere.clear();
   }
 
-  return sign + QString::number( absY, 'f', precision ) + QChar( 176 ) + hemisphere;
+  return sign + QLocale().toString( absY, 'f', precision ) + QChar( 176 ) + hemisphere;
 }

--- a/src/core/qgscoordinateformatter.h
+++ b/src/core/qgscoordinateformatter.h
@@ -108,7 +108,7 @@ class CORE_EXPORT QgsCoordinateFormatter
     /**
      * Returns the character used as X/Y separator, this is a `,` on locales that do not use
      * `,` as decimal separator, it is a space otherwise.
-     * \from QGIS 3.20
+     * \since QGIS 3.20
      */
     static QChar separator( );
 

--- a/src/core/qgscoordinateformatter.h
+++ b/src/core/qgscoordinateformatter.h
@@ -105,6 +105,14 @@ class CORE_EXPORT QgsCoordinateFormatter
      */
     static QString asPair( double x, double y, int precision = 12 );
 
+    /**
+     * Returns the charachter used as X/Y separator, this is a `,` on locales that do not use
+     * `,` as decimal separator, it is a space otherwise.
+     * \see splitPair( )
+     * \from QGIS 3.22
+     */
+    static QChar separator( );
+
   private:
 
     static QString formatAsPair( double val, int precision );

--- a/src/core/qgscoordinateformatter.h
+++ b/src/core/qgscoordinateformatter.h
@@ -106,9 +106,8 @@ class CORE_EXPORT QgsCoordinateFormatter
     static QString asPair( double x, double y, int precision = 12 );
 
     /**
-     * Returns the charachter used as X/Y separator, this is a `,` on locales that do not use
+     * Returns the character used as X/Y separator, this is a `,` on locales that do not use
      * `,` as decimal separator, it is a space otherwise.
-     * \see splitPair( )
      * \from QGIS 3.22
      */
     static QChar separator( );

--- a/src/core/qgscoordinateformatter.h
+++ b/src/core/qgscoordinateformatter.h
@@ -108,7 +108,7 @@ class CORE_EXPORT QgsCoordinateFormatter
     /**
      * Returns the character used as X/Y separator, this is a `,` on locales that do not use
      * `,` as decimal separator, it is a space otherwise.
-     * \from QGIS 3.22
+     * \from QGIS 3.20
      */
     static QChar separator( );
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsapplication.h"
+#include "qgscoordinateformatter.h"
 #include "qgsdistancearea.h"
 #include "qgsfeature.h"
 #include "qgsfeatureiterator.h"
@@ -748,13 +749,13 @@ QString QgsMapToolIdentify::formatCoordinate( const QgsPointXY &canvasPoint ) co
 QString QgsMapToolIdentify::formatXCoordinate( const QgsPointXY &canvasPoint ) const
 {
   QString coordinate = formatCoordinate( canvasPoint );
-  return coordinate.split( ',' ).at( 0 );
+  return coordinate.split( QgsCoordinateFormatter::separator() ).at( 0 );
 }
 
 QString QgsMapToolIdentify::formatYCoordinate( const QgsPointXY &canvasPoint ) const
 {
   QString coordinate = formatCoordinate( canvasPoint );
-  return coordinate.split( ',' ).at( 1 );
+  return coordinate.split( QgsCoordinateFormatter::separator() ).at( 1 );
 }
 
 QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const QgsFeature &feature, QgsMapLayer *layer, const QgsPointXY &layerPoint )

--- a/tests/src/python/test_qgscoordinateformatter.py
+++ b/tests/src/python/test_qgscoordinateformatter.py
@@ -13,9 +13,14 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 import qgis
 from qgis.testing import unittest
 from qgis.core import QgsCoordinateFormatter, QgsPointXY
+from qgis.PyQt.QtCore import QLocale
 
 
 class TestQgsCoordinateFormatter(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        QLocale.setDefault(QLocale(QLocale.English))
 
     def testFormatXPair(self):
         """Test formatting x as pair"""
@@ -54,302 +59,335 @@ class TestQgsCoordinateFormatter(unittest.TestCase):
     def testFormatXFormatDegreesMinutesSeconds(self):
         """Test formatting x as DMS"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"80°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "80°0′0.00″E")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), u"80°0′0.0000″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), u"80°7′24.4444″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), u"80°7′24″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "80°0′0.0000″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "80°7′24.4444″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), "80°7′24″E")
 
         # check if longitudes > 180 or <-180 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"10°0′0.00″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"10°0′0.00″W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"179°0′0.00″W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"179°0′0.00″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"1°0′0.00″W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"1°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "179°0′0.00″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "179°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "1°0′0.00″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "1°0′0.00″E")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"0°0′0.00360″W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"0°0′0.00360″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "0°0′0.00360″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "0°0′0.00360″E")
 
         # should be no directional suffixes for 180 degree longitudes
-        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"180°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"180°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"179°59′59.99640″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"180°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"179°59′59.99640″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "180°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "180°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "179°59′59.99640″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "180°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "179°59′59.99640″W")
 
         # test rounding does not create seconds >= 60
-        self.assertEqual(QgsCoordinateFormatter.formatX(99.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"100°0′0.00″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(89.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"90°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(99.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "100°0′0.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(89.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "90°0′0.00″E")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"80°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "80°0′0.00″")
 
         # test 0 longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
         # test near zero longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
         # should be no "-" prefix for near-zero longitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00360″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), u"-0°0′0.00360″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00360″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), "-0°0′0.00360″")
 
         # test with padding
         padding_and_suffix = QgsCoordinateFormatter.FormatFlags(QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds | QgsCoordinateFormatter.FlagDegreesUseStringSuffix)
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"80°00′00.00″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(85.44, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"85°26′24.00″E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), u"0°00′00.00360″W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), u"0°00′00.00360″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "80°00′00.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(85.44, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "85°26′24.00″E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), "0°00′00.00360″W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), "0°00′00.00360″E")
 
     def testFormatYFormatDegreesMinutesSeconds(self):
         """Test formatting y as DMS"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"20°0′0.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "20°0′0.00″N")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), u"20°0′0.0000″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), u"20°7′24.4444″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), u"20°7′24″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°0′0.0000″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°7′24.4444″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 0), "20°7′24″N")
 
         # check if latitudes > 90 or <-90 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"10°0′0.00″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"10°0′0.00″S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"89°0′0.00″S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"89°0′0.00″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"1°0′0.00″S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"1°0′0.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "10°0′0.00″S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "89°0′0.00″S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "89°0′0.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "1°0′0.00″S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "1°0′0.00″N")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"0°0′0.00360″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), u"0°0′0.00360″S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "0°0′0.00360″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5), "0°0′0.00360″S")
 
         # test rounding does not create seconds >= 60
-        self.assertEqual(QgsCoordinateFormatter.formatY(89.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), u"90°0′0.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(89.999999, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), "90°0′0.00″N")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"20°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "20°0′0.00″")
 
         # test 0 latitude
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
         # test near zero lat/long
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
         # should be no "-" prefix for near-zero latitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), u"0°0′0.00360″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), u"-0°0′0.00360″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), "0°0′0.00360″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, QgsCoordinateFormatter.FormatFlags()), "-0°0′0.00360″")
 
         # test with padding
         padding_and_suffix = QgsCoordinateFormatter.FormatFlags(QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds | QgsCoordinateFormatter.FlagDegreesUseStringSuffix)
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"20°00′00.00″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(85.44, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"85°26′24.00″N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), u"0°00′00.00″")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), u"0°00′00.00360″S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), u"0°00′00.00360″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "20°00′00.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(85.44, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "85°26′24.00″N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, padding_and_suffix), "0°00′00.00″")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), "0°00′00.00360″S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 5, padding_and_suffix), "0°00′00.00360″N")
 
     def testFormatXDegreesMinutes(self):
         """Test formatting x as DM"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"80°0.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "80°0.00′E")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 4), u"80°0.0000′E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 4), u"80°7.4074′E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 0), u"80°7′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 4), "80°0.0000′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 4), "80°7.4074′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 0), "80°7′E")
 
         # check if longitudes > 180 or <-180 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"10°0.00′E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"10°0.00′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"179°0.00′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"179°0.00′E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"1°0.00′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"1°0.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "10°0.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "10°0.00′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "179°0.00′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "179°0.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "1°0.00′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "1°0.00′E")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"0°0.00006′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"0°0.00006′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "0°0.00006′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "0°0.00006′E")
 
         # test rounding does not create minutes >= 60
-        self.assertEqual(QgsCoordinateFormatter.formatX(99.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"100°0.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(99.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "100°0.00′E")
 
         # should be no directional suffixes for 180 degree longitudes
-        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"180°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "180°0.00′")
 
         # should also be no directional suffix for 180 degree longitudes within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"180°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"180°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"179°59.99994′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"179°59.99994′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "180°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "180°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "179°59.99994′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "179°59.99994′E")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"80°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "80°0.00′")
         # test 0 longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
         # test near zero longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
         # should be no "-" prefix for near-zero longitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), u"0°0.00006′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), u"-0°0.00006′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), "0°0.00006′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), "-0°0.00006′")
 
         # test with padding
         padding_and_suffix = QgsCoordinateFormatter.FormatFlags(QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds | QgsCoordinateFormatter.FlagDegreesUseStringSuffix)
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"80°00.00′E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), u"0°00.00006′W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), u"0°00.00006′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "80°00.00′E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), "0°00.00006′W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), "0°00.00006′E")
 
     def testFormatYDegreesMinutes(self):
         """Test formatting y as DM"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"20°0.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "20°0.00′N")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 4), u"20°0.0000′N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 4), u"20°7.4074′N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 0), u"20°7′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 4), "20°0.0000′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 4), "20°7.4074′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutes, 0), "20°7′N")
 
         # check if latitudes > 90 or <-90 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"10°0.00′N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"10°0.00′S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"89°0.00′S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"89°0.00′N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"1°0.00′S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"1°0.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "10°0.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "10°0.00′S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "89°0.00′S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "89°0.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "1°0.00′S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "1°0.00′N")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"0°0.00006′S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), u"0°0.00006′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "0°0.00006′S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5), "0°0.00006′N")
 
         # test rounding does not create minutes >= 60
-        self.assertEqual(QgsCoordinateFormatter.formatY(79.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), u"80°0.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(79.999999, QgsCoordinateFormatter.FormatDegreesMinutes, 2), "80°0.00′N")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"20°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "20°0.00′")
         # test 0 latitude
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
         # test near zero latitude
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
         # should be no "-" prefix for near-zero latitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), u"0°0.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), u"0°0.00006′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), u"-0°0.00006′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, QgsCoordinateFormatter.FormatFlags()), "0°0.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), "0°0.00006′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, QgsCoordinateFormatter.FormatFlags()), "-0°0.00006′")
 
         # test with padding
         padding_and_suffix = QgsCoordinateFormatter.FormatFlags(QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds | QgsCoordinateFormatter.FlagDegreesUseStringSuffix)
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"20°00.00′N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), u"0°00.00′")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), u"0°00.00006′S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), u"0°00.00006′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "20°00.00′N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 2, padding_and_suffix), "0°00.00′")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), "0°00.00006′S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDegreesMinutes, 5, padding_and_suffix), "0°00.00006′N")
 
     def testFormatXDegrees(self):
         """Test formatting x as decimal degrees"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"80.00°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "80.00°E")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 4), u"80.0000°E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 4), u"80.1235°E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 0), u"80°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 4), "80.0000°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 4), "80.1235°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 0), "80°E")
 
         # check if longitudes > 180 or <-180 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"10.00°E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"10.00°W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"179.00°W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"179.00°E")
-        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"1.00°W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"1.00°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(370, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "10.00°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-370, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "10.00°W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(181, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "179.00°W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-181, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "179.00°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(359, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "1.00°W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-359, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "1.00°E")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), u"0.00001°W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), u"0.00001°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), "0.00001°W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), "0.00001°E")
 
         # should be no directional suffixes for 180 degree longitudes
-        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"180.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "180.00°")
 
         # should also be no directional suffix for 180 degree longitudes within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"180.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"180.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6), u"179.999999°W")
-        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDecimalDegrees, 6), u"179.999999°E")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "180.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "180.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(180.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6), "179.999999°W")
+        self.assertEqual(QgsCoordinateFormatter.formatX(179.999999, QgsCoordinateFormatter.FormatDecimalDegrees, 6), "179.999999°E")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"80.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "80.00°")
         # test 0 longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
         # test near zero longitude
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
         # should be no "-" prefix for near-zero longitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), u"0.000001°")
-        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), u"-0.000001°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), "0.000001°")
+        self.assertEqual(QgsCoordinateFormatter.formatX(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), "-0.000001°")
 
     def testFormatYDegrees(self):
         """Test formatting y as decimal degrees"""
 
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"20.00°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "20.00°N")
 
         # check precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDecimalDegrees, 4), u"20.0000°N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 4), u"20.1235°N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 0), u"20°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDecimalDegrees, 4), "20.0000°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 4), "20.1235°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDecimalDegrees, 0), "20°N")
 
         # check if latitudes > 90 or <-90 wrap around
-        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"10.00°N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"10.00°S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"89.00°S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"89.00°N")
-        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"1.00°S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"1.00°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(190, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "10.00°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-190, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "10.00°S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(91, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "89.00°S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-91, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "89.00°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(179, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "1.00°S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-179, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "1.00°N")
 
         # should be no directional suffixes for 0 degree coordinates
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
         # should also be no directional suffix for 0 degree coordinates within specified precision
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), u"0.00001°S")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), u"0.00001°N")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), "0.00001°S")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.00001, QgsCoordinateFormatter.FormatDecimalDegrees, 5), "0.00001°N")
 
         # test without direction suffix
-        self.assertEqual(QgsCoordinateFormatter.formatY(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"80.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(80, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "80.00°")
         # test 0 longitude
-        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
         # test near zero latitude
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
         # should be no "-" prefix for near-zero latitude when rounding to 2 decimal places
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), u"0.00°")
-        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), u"0.000001°")
-        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), u"-0.000001°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 2, QgsCoordinateFormatter.FormatFlags()), "0.00°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), "0.000001°")
+        self.assertEqual(QgsCoordinateFormatter.formatY(-0.000001, QgsCoordinateFormatter.FormatDecimalDegrees, 6, QgsCoordinateFormatter.FormatFlags()), "-0.000001°")
+
+    def testFormatLocale(self):
+        """Test formatting with locales that use comma as decimal separator"""
+
+        QLocale.setDefault(QLocale(QLocale.Italian))
+
+        self.assertEqual(QgsCoordinateFormatter.formatY(20, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "20,00°N")
+        self.assertEqual(QgsCoordinateFormatter.formatX(20, QgsCoordinateFormatter.FormatDecimalDegrees, 2), "20,00°E")
+
+        self.assertEqual(QgsCoordinateFormatter.formatY(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°7′24,4444″N")
+        self.assertEqual(QgsCoordinateFormatter.formatX(20.12345678, QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 4), "20°7′24,4444″E")
+
+        # formatting x/y as pair
+        self.assertEqual(QgsCoordinateFormatter.asPair(20, 30, 0), '20 30')
+        self.assertEqual(QgsCoordinateFormatter.asPair(20, -30, 0), '20 -30')
+        self.assertEqual(QgsCoordinateFormatter.asPair(20.111, 10.999, 0), '20 11')
+        self.assertEqual(QgsCoordinateFormatter.asPair(20.111, 10.999, 2), '20,11 11,00')
+        self.assertEqual(QgsCoordinateFormatter.asPair(20, 10, 2), '20,00 10,00')
+        self.assertEqual(QgsCoordinateFormatter.asPair(20, -10, 2), '20,00 -10,00')
+
+        self.assertEqual(QgsCoordinateFormatter.format(QgsPointXY(20.1111, 30.2111), QgsCoordinateFormatter.FormatPair, 2), '20,11 30,21')
+        self.assertEqual(QgsCoordinateFormatter.format(QgsPointXY(20.111, 30.211), QgsCoordinateFormatter.FormatPair, 2), '20,11 30,21')
+        self.assertEqual(QgsCoordinateFormatter.format(QgsPointXY(20.111, 30.211), QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2), '20°6′39,60″E 30°12′39,60″N')
+
+        self.assertEqual(QgsCoordinateFormatter.format(QgsPointXY(20.1111, 30.2111), QgsCoordinateFormatter.FormatDegreesMinutesSeconds, 2, QgsCoordinateFormatter.FlagDegreesUseStringSuffix | QgsCoordinateFormatter.FlagDegreesPadMinutesSeconds), '20°06′39,96″E 30°12′39,96″N')
+
+    def testSeparator(self):
+        """Test X/Y separator with different locales"""
+
+        self.assertEqual(QgsCoordinateFormatter.separator(), ',')
+
+        QLocale.setDefault(QLocale(QLocale.Italian))
+        self.assertEqual(QgsCoordinateFormatter.separator(), ' ')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Italian locale (comma as decimal separator, dot as thousands separator)

![immagine](https://user-images.githubusercontent.com/142164/122187883-bf4be780-ce8f-11eb-836b-dad0ce0e481c.png)

![immagine](https://user-images.githubusercontent.com/142164/122188068-e73b4b00-ce8f-11eb-97ba-93b6aef16473.png)

English locale (no changes):

![immagine](https://user-images.githubusercontent.com/142164/122188391-31bcc780-ce90-11eb-9bcc-1ee2d2568c5d.png)

![immagine](https://user-images.githubusercontent.com/142164/122188341-26699c00-ce90-11eb-847d-d55d551323c0.png)

