### PR TITLE
[cmake] use single macro QGIS_ADD_TEST and modernize cmake code

### DIFF
--- a/.ci/test_blocklist.txt
+++ b/.ci/test_blocklist.txt
@@ -15,13 +15,10 @@ PyQgsAuthManagerOgrPostgresTest
 PyQgsDbManagerPostgis
 
 # Needs an OpenCL device, the library is not enough
-qgis_openclutilstest
+test_core_openclutils
 
 # Relies on a broken/unreliable 3rd party service
-qgis_layerdefinition
+test_core_layerdefinition
 
 # MSSQL requires the MSSQL docker
 PyQgsProviderConnectionMssql
-
-
-

--- a/.ci/test_flaky.txt
+++ b/.ci/test_flaky.txt
@@ -1,8 +1,8 @@
 # flaky
-qgis_filedownloader
-qgis_wcsprovidertest
+test_gui_filedownloader
+test_provider_wcsprovider
 PyQgsWFSProviderGUI
-qgis_ziplayertest
+test_core_ziplayer
 
 # Flaky, the ms odbc driver crashes a lot on the ubuntu docker image. Retest when
 # the docker base image is upgraded

--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -32,39 +32,41 @@ set (WMS_HDRS
 ########################################################
 # Build
 
-add_library (wms MODULE ${WMS_SRCS} ${WMS_HDRS})
+set(_library_suffix_MODULE "")
+set(_library_suffix_STATIC "_static")
 
-# require c++17
-target_compile_features(wms PRIVATE cxx_std_17)
+foreach(_library_type MODULE STATIC)
+  set(_library_name "wms${_library_suffix_${_library_type}}")
 
-include_directories(SYSTEM
-  ${GDAL_INCLUDE_DIR}
-  ${POSTGRES_INCLUDE_DIR}
-)
+  add_library(${_library_name} ${_library_type} ${WMS_SRCS} ${WMS_HDRS})
 
-include_directories(
-  ${CMAKE_SOURCE_DIR}/src/server
-  ${CMAKE_SOURCE_DIR}/src/server/services
-  ${CMAKE_SOURCE_DIR}/src/server/services/wms
+  # require c++17
+  target_compile_features(${_library_name} PRIVATE cxx_std_17)
 
-  ${CMAKE_BINARY_DIR}/src/python
-  ${CMAKE_BINARY_DIR}/src/analysis
-  ${CMAKE_BINARY_DIR}/src/server
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
+  include_directories(${_library_name} SYSTEM PUBLIC
+    ${GDAL_INCLUDE_DIR}
+    ${POSTGRES_INCLUDE_DIR}
+  )
 
+  target_include_directories(${_library_name} PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/server
+    ${CMAKE_SOURCE_DIR}/src/server/services
+    ${CMAKE_SOURCE_DIR}/src/server/services/wms
 
-target_link_libraries(wms
-  qgis_core
-  qgis_server
-)
+    ${CMAKE_BINARY_DIR}/src/python
+    ${CMAKE_BINARY_DIR}/src/analysis
+    ${CMAKE_BINARY_DIR}/src/server
+    ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
+  target_link_libraries(${_library_name}
+    qgis_core
+    qgis_server
+  )
 
-########################################################
-# Install
-
-install(TARGETS wms
-    RUNTIME DESTINATION ${QGIS_SERVER_MODULE_DIR}
-    LIBRARY DESTINATION ${QGIS_SERVER_MODULE_DIR}
-)
+  install(TARGETS ${_library_name}
+      RUNTIME DESTINATION ${QGIS_SERVER_MODULE_DIR}
+      LIBRARY DESTINATION ${QGIS_SERVER_MODULE_DIR}
+  )
+endforeach()
 

--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -63,10 +63,11 @@ foreach(_library_type MODULE STATIC)
     qgis_core
     qgis_server
   )
-
-  install(TARGETS ${_library_name}
-      RUNTIME DESTINATION ${QGIS_SERVER_MODULE_DIR}
-      LIBRARY DESTINATION ${QGIS_SERVER_MODULE_DIR}
-  )
 endforeach()
+
+# only install module, static library is for testing only
+install(TARGETS ${_library_name}
+    RUNTIME DESTINATION ${QGIS_SERVER_MODULE_DIR}
+    LIBRARY DESTINATION ${QGIS_SERVER_MODULE_DIR}
+)
 

--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -66,7 +66,7 @@ foreach(_library_type MODULE STATIC)
 endforeach()
 
 # only install module, static library is for testing only
-install(TARGETS ${_library_name}
+install(TARGETS wms
     RUNTIME DESTINATION ${QGIS_SERVER_MODULE_DIR}
     LIBRARY DESTINATION ${QGIS_SERVER_MODULE_DIR}
 )

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Standard includes and utils to compile into all tests.
 set (util_SRCS)
 
-
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
@@ -18,48 +17,21 @@ include_directories(SYSTEM
   ${QT5_3DEXTRA_INCLUDE_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-#############################################################
-# Tests:
-
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  set(qgis_${testname}_MOC_CPPS ${testsrc})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  # require c++17
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  set_target_properties(qgis_${testname} PROPERTIES AUTORCC TRUE)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    qgis_core
-    qgis_3d
-    qgis_native)
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-  target_link_libraries(qgis_${testname} qgis_native)
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname})
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
 
 add_subdirectory(sandbox)
 
-ADD_QGIS_TEST(3dutilstest testqgs3dutils.cpp)
-ADD_QGIS_TEST(3drenderingtest testqgs3drendering.cpp)
-ADD_QGIS_TEST(layout3dmaptest testqgslayout3dmap.cpp)
-ADD_QGIS_TEST(materialregistrytest testqgsmaterialregistry.cpp)
-ADD_QGIS_TEST(3dmaterialtest testqgs3dmaterial.cpp)
-ADD_QGIS_TEST(tessellatortest testqgstessellator.cpp)
-ADD_QGIS_TEST(3dsymbolregistrytest testqgs3dsymbolregistry.cpp)
+set(TESTS
+  testqgs3dutils.cpp
+  testqgs3drendering.cpp
+  testqgslayout3dmap.cpp
+  testqgsmaterialregistry.cpp
+  testqgs3dmaterial.cpp
+  testqgstessellator.cpp
+  testqgs3dsymbolregistry.cpp
+)
+
+
+foreach(TESTSRC ${TESTS})
+  add_qgis_test(${TESTSRC} MODULE 3d LINKEDLIBRARIES qgis_3d)
+endforeach(TESTSRC)
 

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -1,4 +1,34 @@
 if (ENABLE_TESTS)
+
+
+  macro (add_qgis_test TESTSRC)
+    set(options OPTIONAL)
+    set(oneValueArgs MODULE LABELS)
+    set(multiValueArgs LINKEDLIBRARIES DEPENDENCIES)
+    cmake_parse_arguments(ARG_QGIS_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set (TESTNAME ${TESTSRC})
+    string(REPLACE "test" "" TESTNAME ${TESTNAME})
+    string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
+    string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
+    set (TESTNAME  "test_${ARG_QGIS_TEST_MODULE}_${TESTNAME}")
+    add_executable(${TESTNAME} ${TESTSRC} ${util_SRCS})
+    # add_custom_target(${TESTNAME}moc ALL DEPENDS ${${TESTNAME}_MOC_SRCS})
+    target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
+    set_target_properties(${TESTNAME} PROPERTIES AUTORCC TRUE)
+    target_link_libraries(${TESTNAME} ${ARG_QGIS_TEST_LINKEDLIBRARIES})
+    target_link_libraries(${TESTNAME} ${Qt5Test_LIBRARIES})
+    add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
+    if (DEFINED ARG_QGIS_TEST_DEPENDENCIES)
+      add_dependencies(${TESTNAME} ${ARG_QGIS_TEST_DEPENDENCIES})
+    endif()
+    if (DEFINED ARG_QGIS_TEST_LABELS)
+      set_tests_properties(${TESTNAME} PROPERTIES LABELS ${ARG_QGIS_TEST_LABELS})
+    endif()
+  endmacro()
+
+
+
   #############################################################
   # Compiler defines
 

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -5,7 +5,8 @@ set (util_SRCS)
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/test
 )
@@ -14,43 +15,11 @@ if(HAVE_OPENCL)
     include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
 endif()
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  set (TESTNAME  "qgis_${TESTNAME}test")
-
-  set(${TESTNAME}_SRCS ${TESTSRC} ${util_SRCS})
-  set(${TESTNAME}_MOC_CPPS ${TESTSRC})
-  add_executable(${TESTNAME} ${${TESTNAME}_SRCS})
-  # require c++17
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    qgis_analysis)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 set(TESTS
  testqgsgeometrysnapper.cpp
  testqgsinterpolator.cpp
- testqgsprocessing.cpp
  testqgsprocessingalgs.cpp
  testqgszonalstatistics.cpp
  testqgsrastercalculator.cpp
@@ -62,17 +31,11 @@ set(TESTS
  testqgsmeshcontours.cpp
  testqgstriangulation.cpp
 )
-
 if(HAVE_GSL)
-  set(TESTS
-    ${TESTS}
-    testqgsgcptransformer.cpp
-    )
+  set(TESTS ${TESTS} testqgsgcptransformer.cpp)
 endif()
 
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+    add_qgis_test(${TESTSRC} MODULE analysis LINKEDLIBRARIES qgis_analysis)
 endforeach(TESTSRC)
-
-SET_TESTS_PROPERTIES(qgis_processingtest
-  PROPERTIES LABELS "POSTGRES")
+add_qgis_test(testqgsprocessing.cpp MODULE analysis LINKEDLIBRARIES qgis_analysis LABELS "POSTGRES")

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -6,89 +6,50 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
 
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
 
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  add_custom_target(qgis_${testname}moc ALL DEPENDS ${qgis_${testname}_MOC_SRCS})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Sql_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${QWT_LIBRARY}
-    qgis_core
-    qgis_gui
-    qgis_analysis
-    qgis_app)
-  if(WITH_QWTPOLAR AND NOT WITH_INTERNAL_QWTPOLAR)
-    target_link_libraries(qgis_${testname} ${QWTPOLAR_LIBRARY})
-  endif()
-  if(WIN32)
-    add_definitions(-DQWT_DLL)
-    target_link_libraries(qgis_${testname} dbghelp)
-  endif()
-  if (APPLE)
-    target_link_libraries(qgis_${testname} ${APP_SERVICES_LIBRARY} )
-  endif()
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
-#############################################################
-# Tests:
-
+set(TESTS
+  testqgisapp.cpp
+  testqgsappbrowserproviders.cpp
+  testqgisappclipboard.cpp
+  testqgisappdockwidgets.cpp
+  testqgsattributetable.cpp
+  testqgsapplocatorfilters.cpp
+  testqgsdecorationscalebar.cpp
+  testqgsfieldcalculator.cpp
+  testqgsmaptoolidentifyaction.cpp
+  testqgsmaptoollabel.cpp
+  testqgsmaptoolselect.cpp
+  testqgsmaptoolreshape.cpp
+  testqgsmaptoolrotatefeature.cpp
+  testqgsmaptoolscalefeature.cpp
+  testqgsmaptoolcircularstring.cpp
+  testqgsmaptoolcircle.cpp
+  testqgsmaptoolmovefeature.cpp
+  testqgsmaptoolellipse.cpp
+  testqgsmaptoolrectangle.cpp
+  testqgsmaptoolregularpolygon.cpp
+  testqgsmaptoolsplitparts.cpp
+  testqgsmaptoolsplitfeatures.cpp
+  testqgsmeasuretool.cpp
+  testqgsmeasurebearingtool.cpp
+  testqgsvertextool.cpp
+  testqgsvectorlayersaveasdialog.cpp
+  testqgsmaptoolreverseline.cpp
+  testqgsmaptooltrimextendfeature.cpp
+  testqgsprojectproperties.cpp
+  testqgsapplayoutvaliditychecks.cpp
+  testqgsmeshcalculatordialog.cpp
+  testqgsgpsinformationwidget.cpp
+  testqgslabelpropertydialog.cpp
+)
 if (WITH_BINDINGS)
-ADD_QGIS_TEST(apppythontest testqgisapppython.cpp)
+  set(TESTS ${TESTS} testqgisapppython.cpp)
 endif()
-ADD_QGIS_TEST(qgisapp testqgisapp.cpp)
-ADD_QGIS_TEST(appbrowserproviders testqgsappbrowserproviders.cpp)
-ADD_QGIS_TEST(qgisappclipboard testqgisappclipboard.cpp)
-ADD_QGIS_TEST(appdockwidgets testqgisappdockwidgets.cpp)
-ADD_QGIS_TEST(attributetabletest testqgsattributetable.cpp)
-ADD_QGIS_TEST(applocatorfilters testqgsapplocatorfilters.cpp)
-ADD_QGIS_TEST(decorationscalebar testqgsdecorationscalebar.cpp)
-ADD_QGIS_TEST(fieldcalculatortest testqgsfieldcalculator.cpp)
-ADD_QGIS_TEST(maptoolidentifyaction testqgsmaptoolidentifyaction.cpp)
-ADD_QGIS_TEST(maptoollabel testqgsmaptoollabel.cpp)
-ADD_QGIS_TEST(maptoolselect testqgsmaptoolselect.cpp)
-ADD_QGIS_TEST(maptoolreshape testqgsmaptoolreshape.cpp)
-ADD_QGIS_TEST(maptoolrotatefeature testqgsmaptoolrotatefeature.cpp)
-ADD_QGIS_TEST(maptoolscalefeature testqgsmaptoolscalefeature.cpp)
-ADD_QGIS_TEST(maptoolcircularstringtest testqgsmaptoolcircularstring.cpp)
-ADD_QGIS_TEST(maptoolcircletest testqgsmaptoolcircle.cpp)
-ADD_QGIS_TEST(maptoolmovefeaturetest testqgsmaptoolmovefeature.cpp)
-ADD_QGIS_TEST(maptoolellipsetest testqgsmaptoolellipse.cpp)
-ADD_QGIS_TEST(maptoolrectangletest testqgsmaptoolrectangle.cpp)
-ADD_QGIS_TEST(maptoolregularpolygontest testqgsmaptoolregularpolygon.cpp)
-ADD_QGIS_TEST(maptoolsplitpartstest testqgsmaptoolsplitparts.cpp)
-ADD_QGIS_TEST(maptoolsplitfeaturestest testqgsmaptoolsplitfeatures.cpp)
-ADD_QGIS_TEST(measuretool testqgsmeasuretool.cpp)
-ADD_QGIS_TEST(measurebearingtool testqgsmeasurebearingtool.cpp)
-ADD_QGIS_TEST(vertextool testqgsvertextool.cpp)
-ADD_QGIS_TEST(vectorlayersaveasdialogtest testqgsvectorlayersaveasdialog.cpp)
-ADD_QGIS_TEST(maptoolreverselinetest testqgsmaptoolreverseline.cpp)
-ADD_QGIS_TEST(maptooltrimextendfeaturetest testqgsmaptooltrimextendfeature.cpp)
-ADD_QGIS_TEST(projectproperties testqgsprojectproperties.cpp)
-ADD_QGIS_TEST(layoutvaliditychecks testqgsapplayoutvaliditychecks.cpp)
-ADD_QGIS_TEST(meshcalculator testqgsmeshcalculatordialog.cpp)
-ADD_QGIS_TEST(gpsinformationwidget testqgsgpsinformationwidget.cpp)
-ADD_QGIS_TEST(labelpropertydialog testqgslabelpropertydialog.cpp)
+
+foreach(TESTSRC ${TESTS})
+  add_qgis_test(${TESTSRC} MODULE app LINKEDLIBRARIES qgis_app)
+endforeach(TESTSRC)
 
 add_subdirectory(maptooladdfeaturepoint)
 add_subdirectory(maptooladdfeatureline)

--- a/tests/src/app/maptooladdfeatureline/CMakeLists.txt
+++ b/tests/src/app/maptooladdfeatureline/CMakeLists.txt
@@ -10,42 +10,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "qgis_" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  add_executable(${TESTNAME} ${TESTSRC} ${util_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Sql_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${QWT_LIBRARY}
-    qgis_core
-    qgis_gui
-    qgis_analysis
-    qgis_app)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
@@ -57,5 +21,5 @@ set(TESTS
   )
 
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+  add_qgis_test(${TESTSRC} MODULE app LINKEDLIBRARIES qgis_app)
 endforeach(TESTSRC)

--- a/tests/src/app/maptooladdfeaturepoint/CMakeLists.txt
+++ b/tests/src/app/maptooladdfeaturepoint/CMakeLists.txt
@@ -10,42 +10,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "qgis_" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  add_executable(${TESTNAME} ${TESTSRC} ${util_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Sql_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${QWT_LIBRARY}
-    qgis_core
-    qgis_gui
-    qgis_analysis
-    qgis_app)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
@@ -57,5 +21,5 @@ set(TESTS
   )
 
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+  add_qgis_test(${TESTSRC} MODULE app LINKEDLIBRARIES qgis_app)
 endforeach(TESTSRC)

--- a/tests/src/auth/CMakeLists.txt
+++ b/tests/src/auth/CMakeLists.txt
@@ -7,15 +7,10 @@ set (util_SRCS)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_SOURCE_DIR}/src/auth/oauth2
-  ${CMAKE_SOURCE_DIR}/src/auth/oauth2/qjsonwrapper
+  ${CMAKE_SOURCE_DIR}/src/auth/oauth2/core
   ${CMAKE_SOURCE_DIR}/src/test
   ${CMAKE_BINARY_DIR}/src/gui/auth
   ${CMAKE_BINARY_DIR}/src/auth/oauth2
-)
-
-include_directories(SYSTEM
-  ${O2_INCLUDE_DIR}
 )
 
 # libraries
@@ -25,40 +20,18 @@ if (WIN32)
   set(PLATFORM_LIBRARIES wsock32)
 endif()
 
-macro (ADD_QGIS_TEST testname testsrc)
-  add_executable(qgis_${testname} ${testsrc} ${util_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  if(APPLE)
-    target_link_libraries(qgis_${testname} ${APP_SERVICES_LIBRARY})
-  endif()
-  target_link_libraries(qgis_${testname}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${OPTIONAL_QTWEBKIT}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    qgis_core
-    )
-    if(WITH_GUI)
-      target_link_libraries(qgis_${testname}
-        qgis_gui
-        )
-    endif()
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
 
 #############################################################
 # Tests:
 
+set(LINKEDLIBRARIES qgis_core authmethod_oauth2_static)
+if(WITH_GUI)
+  set(LINKEDLIBRARIES ${LINKEDLIBRARIES} qgis_gui)
+endif()
+if(APPLE)
+  set(LINKEDLIBRARIES ${LINKEDLIBRARIES} ${APP_SERVICES_LIBRARY})
+endif()
+
 if(WITH_OAUTH2_PLUGIN)
-  ADD_QGIS_TEST(authoauthmethodtest testqgsauthoauth2method.cpp)
-  add_dependencies(qgis_authoauthmethodtest authmethod_oauth2_static)
-  target_link_libraries(qgis_authoauthmethodtest authmethod_oauth2_static)
+  ADD_QGIS_TEST(testqgsauthoauth2method.cpp MODULE authmethod LINKEDLIBRARIES ${LINKEDLIBRARIES})
 endif()

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -1,7 +1,8 @@
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/external/kdbush/include
   ${CMAKE_SOURCE_DIR}/src/test
@@ -11,47 +12,19 @@ if(HAVE_OPENCL)
     include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
 endif()
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  set (TESTNAME  "qgis_${TESTNAME}test")
-  add_executable(${TESTNAME} ${TESTSRC} ${util_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${${QT_VERSION_BASE}Core_LIBRARIES}
-    ${${QT_VERSION_BASE}Xml_LIBRARIES}
-    ${${QT_VERSION_BASE}Svg_LIBRARIES}
-    ${${QT_VERSION_BASE}Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${SPATIALINDEX_LIBRARY}
-    qgis_core)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
 set(TESTS
+ testcontrastenhancements.cpp
+ testqgis.cpp
  testqgs25drenderer.cpp
  testqgsannotationitemregistry.cpp
  testqgsapplication.cpp
  testqgsarcgisrestutils.cpp
- testqgsauthcrypto.cpp
  testqgsauthcertutils.cpp
  testqgsauthconfig.cpp
+ testqgsauthcrypto.cpp
  testqgsauthmanager.cpp
  testqgsblendmodes.cpp
  testqgsbrowsermodel.cpp
@@ -59,13 +32,12 @@ set(TESTS
  testqgscadutils.cpp
  testqgscallout.cpp
  testqgscalloutregistry.cpp
+ testqgscentroidfillsymbol.cpp
  testqgsclipper.cpp
  testqgscolorscheme.cpp
  testqgscolorschemeregistry.cpp
  testqgscompositionconverter.cpp
  testqgsconnectionpool.cpp
- testcontrastenhancements.cpp
- testqgscoordinatereferencesystem.cpp
  testqgscoordinatereferencesystemregistry.cpp
  testqgscoordinatetransform.cpp
  testqgscredentials.cpp
@@ -77,24 +49,22 @@ set(TESTS
  testqgsdistancearea.cpp
  testqgsdxfexport.cpp
  testqgsellipsemarker.cpp
- testqgsexpressioncontext.cpp
- testqgssqliteexpressioncompiler.cpp
  testqgsexpression.cpp
- testqgsoverlayexpression.cpp
+ testqgsexpressioncontext.cpp
  testqgsfeature.cpp
- testqgsfields.cpp
  testqgsfield.cpp
+ testqgsfields.cpp
  testqgsfilledmarker.cpp
+ testqgsfontmarker.cpp
+ testqgsfontutils.cpp
  testqgsgdalprovider.cpp
  testqgsgdalutils.cpp
- testqgsvectorfilewriter.cpp
- testqgsfontmarker.cpp
  testqgsgenericspatialindex.cpp
- testqgsgeopdfexport.cpp
- testqgsgeometryimport.cpp
  testqgsgeometry.cpp
+ testqgsgeometryimport.cpp
  testqgsgeometryutils.cpp
  testqgsgeonodeconnection.cpp
+ testqgsgeopdfexport.cpp
  testqgsgml.cpp
  testqgsgradients.cpp
  testqgsgraduatedsymbolrenderer.cpp
@@ -106,15 +76,16 @@ set(TESTS
  testqgsinvertedpolygonrenderer.cpp
  testqgsjsonutils.cpp
  testqgslabelingengine.cpp
+ testqgslayerdefinition.cpp
  testqgslayertree.cpp
  testqgslayout.cpp
  testqgslayoutatlas.cpp
  testqgslayoutcontext.cpp
  testqgslayoutexporter.cpp
+ testqgslayoutgeopdfexport.cpp
  testqgslayouthtml.cpp
  testqgslayoutitem.cpp
  testqgslayoutitemgroup.cpp
- testqgslayoutgeopdfexport.cpp
  testqgslayoutlabel.cpp
  testqgslayoutmanualtable.cpp
  testqgslayoutmap.cpp
@@ -132,55 +103,57 @@ set(TESTS
  testqgslayoutunits.cpp
  testqgslayoututils.cpp
  testqgslegendrenderer.cpp
- testqgscentroidfillsymbol.cpp
  testqgslinefillsymbol.cpp
  testqgsmapdevicepixelratio.cpp
- testqgsmaplayerstylemanager.cpp
  testqgsmaplayer.cpp
- testqgsmaprendererjob.cpp
+ testqgsmaplayerstylemanager.cpp
  testqgsmaprenderercache.cpp
+ testqgsmaprendererjob.cpp
  testqgsmaprotation.cpp
  testqgsmapsettings.cpp
  testqgsmapsettingsutils.cpp
  testqgsmapthemecollection.cpp
- testqgsmaptopixelgeometrysimplifier.cpp
  testqgsmaptopixel.cpp
+ testqgsmaptopixelgeometrysimplifier.cpp
  testqgsmarkerlinesymbol.cpp
  testqgsmesh3daveraging.cpp
  testqgsmeshlayer.cpp
  testqgsmeshlayerinterpolator.cpp
  testqgsmeshlayerrenderer.cpp
+ testqgsmimedatautils.cpp
  testqgsnetworkaccessmanager.cpp
  testqgsnetworkcontentfetcher.cpp
  testqgsnewsfeedparser.cpp
+ testqgsofflineediting.cpp
  testqgsogcutils.cpp
  testqgsogrprovider.cpp
  testqgsogrutils.cpp
+ testqgsoverlayexpression.cpp
  testqgspagesizeregistry.cpp
- testqgspainteffectregistry.cpp
  testqgspainteffect.cpp
+ testqgspainteffectregistry.cpp
  testqgspallabeling.cpp
- testqgspointlocator.cpp
- testqgspointpatternfillsymbol.cpp
  testqgspoint.cpp
  testqgspointcloudattribute.cpp
  testqgspointcloudrendererregistry.cpp
+ testqgspointlocator.cpp
+ testqgspointpatternfillsymbol.cpp
+ testqgspostgresstringutils.cpp
  testqgsproject.cpp
  testqgsprojectstorage.cpp
  testqgsprojutils.cpp
  testqgsproperty.cpp
  testqgsprovidermetadata.cpp
- testqgis.cpp
  testqgsrange.cpp
- testqgsrasterfilewriter.cpp
- testqgsrasterfill.cpp
- testqgsrastermarker.cpp
- testqgsrasteriterator.cpp
  testqgsrasterblock.cpp
  testqgsrastercontourrenderer.cpp
  testqgsrasterdataprovidertemporalcapabilities.cpp
+ testqgsrasterfilewriter.cpp
+ testqgsrasterfill.cpp
+ testqgsrasteriterator.cpp
  testqgsrasterlayer.cpp
  testqgsrasterlayertemporalproperties.cpp
+ testqgsrastermarker.cpp
  testqgsrastersublayer.cpp
  testqgsrectangle.cpp
  testqgsrelationreferencefieldformatter.cpp
@@ -195,40 +168,37 @@ set(TESTS
  testqgssnappingutils.cpp
  testqgsspatialindex.cpp
  testqgsspatialindexkdbush.cpp
+ testqgssqliteexpressioncompiler.cpp
+ testqgssqliteutils.cpp
  testqgsstatisticalsummary.cpp
+ testqgsstoredexpressionmanager.cpp
  testqgsstringutils.cpp
  testqgsstyle.cpp
  testqgssvgcache.cpp
  testqgssvgmarker.cpp
  testqgssymbol.cpp
  testqgstaskmanager.cpp
+ testqgstemporalnavigationobject.cpp
  testqgstemporalproperty.cpp
  testqgstemporalrangeobject.cpp
- testqgstemporalnavigationobject.cpp
  testqgstiledownloadmanager.cpp
  testqgstracer.cpp
+ testqgstranslateproject.cpp
  testqgstriangularmesh.cpp
- testqgsfontutils.cpp
  testqgsvaluerelationfieldformatter.cpp
  testqgsvector.cpp
  testqgsvectordataprovider.cpp
+ testqgsvectorfilewriter.cpp
+ testqgsvectorlayer.cpp
  testqgsvectorlayercache.cpp
  testqgsvectorlayerjoinbuffer.cpp
- testqgsvectorlayer.cpp
  testqgsvectorlayerutils.cpp
  testqgsvectortilelayer.cpp
  testqgsvectortilewriter.cpp
- testqgsziputils.cpp
- testziplayer.cpp
- testqgslayerdefinition.cpp
- testqgssqliteutils.cpp
- testqgsmimedatautils.cpp
- testqgsofflineediting.cpp
- testqgstranslateproject.cpp
- testqobjectuniqueptr.cpp
- testqgspostgresstringutils.cpp
- testqgsstoredexpressionmanager.cpp
  testqgsweakrelation.cpp
+ testqgsziputils.cpp
+ testqobjectuniqueptr.cpp
+ testziplayer.cpp
 )
 
 if(WITH_QTWEBKIT)
@@ -241,13 +211,12 @@ if(HAVE_OPENCL)
      )
 endif()
 
-
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+    add_qgis_test( ${TESTSRC} MODULE core LINKEDLIBRARIES qgis_core)
 endforeach(TESTSRC)
 
-if (ENABLE_PGTEST)
-  SET_TESTS_PROPERTIES(qgis_vectorlayerjoinbuffertest PROPERTIES LABELS "POSTGRES")
-endif()
+add_qgis_test(testqgscoordinatereferencesystem.cpp MODULE core LINKEDLIBRARIES qgis_core DEPENDENCIES synccrsdb )
 
-add_dependencies(qgis_coordinatereferencesystemtest synccrsdb)
+if (ENABLE_PGTEST)
+  SET_TESTS_PROPERTIES(test_core_vectorlayerjoinbuffer PROPERTIES LABELS "POSTGRES")
+endif()

--- a/tests/src/geometry_checker/CMakeLists.txt
+++ b/tests/src/geometry_checker/CMakeLists.txt
@@ -3,7 +3,8 @@
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/test
   ${CMAKE_SOURCE_DIR}/src/plugins
@@ -14,38 +15,9 @@ include_directories(SYSTEM
   ${POSTGRES_INCLUDE_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  set (TESTNAME  "qgis_${TESTNAME}test")
-
-  set(${TESTNAME}_SRCS ${TESTSRC} ${util_SRCS})
-  set(${TESTNAME}_MOC_CPPS ${TESTSRC})
-  add_executable(${TESTNAME} ${${TESTNAME}_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    qgis_analysis)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
-ADD_QGIS_TEST(testqgsgeometrychecks.cpp)
-ADD_QGIS_TEST(testqgsvectorlayerfeaturepool.cpp)
+add_qgis_test(testqgsgeometrychecks.cpp MODULE geometry_checker LINKEDLIBRARIES qgis_analysis)
+add_qgis_test(testqgsvectorlayerfeaturepool.cpp MODULE geometry_checker LINKEDLIBRARIES qgis_analysis)
+

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Standard includes and utils to compile into all tests.
 set (util_SRCS)
 
-
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
@@ -16,122 +15,72 @@ if(ENABLE_MODELTEST)
   include_directories(${CMAKE_SOURCE_DIR}/tests/qt_modeltest)
 endif()
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-#############################################################
-# Tests:
-
-#
-# QgsQuickPrint test
-#
-#set(qgis_quickprinttest_SRCS testqgsquickprint.cpp ${util_SRCS})
-#set(qgis_quickprinttest_MOC_CPPS testqgsquickprint.cpp)
-#QT5_WRAP_CPP(qgis_quickprinttest_MOC_SRCS ${qgis_quickprinttest_MOC_CPPS})
-#add_custom_target(qgis_quickprinttestmoc ALL DEPENDS ${qgis_quickprinttest_MOC_SRCS})
-#add_executable(qgis_quickprinttest ${qgis_quickprinttest_SRCS})
-#add_dependencies(qgis_quickprinttest qgis_quickprinttestmoc)
-#target_link_libraries(qgis_quickprinttest ${QT_LIBRARIES} qgis_core qgis_gui)
-#set_target_properties(qgis_quickprinttest
-#  PROPERTIES INSTALL_RPATH ${QGIS_LIB_DIR}
-#  INSTALL_RPATH_USE_LINK_PATH true)
-#if (APPLE)
-#  # For Mac OS X, the executable must be at the root of the bundle's executable folder
-#  install(TARGETS qgis_quickprinttest RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})
-#  add_test(qgis_quickprinttest ${CMAKE_INSTALL_PREFIX}/qgis_quickprinttest)
-#else()
-#  install(TARGETS qgis_quickprinttest RUNTIME DESTINATION ${QGIS_BIN_DIR})
-#  add_test(qgis_quickprinttest ${CMAKE_INSTALL_PREFIX}/bin/qgis_quickprinttest)
-#endif()
-
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  set(qgis_${testname}_MOC_CPPS ${testsrc})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  set_target_properties(qgis_${testname} PROPERTIES AUTORCC TRUE)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${OPTIONAL_QTWEBKIT}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    ${QWT_LIBRARY}
-    qgis_analysis
-    qgis_core
-    qgis_gui
-    qgis_native)
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-  target_link_libraries(qgis_${testname} qgis_native)
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname})
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
-ADD_QGIS_TEST(zoomtest testqgsmaptoolzoom.cpp)
-ADD_QGIS_TEST(edittooltest testqgsmaptooledit.cpp)
-
 # a simple app for testing GUI of renderers
 # These tests are old and are never run so removed for now.
 #set(rendererv2gui_SRCS testrenderergui.cpp)
 #set(rendererv2gui_HDRS testrenderergui.h)
-#QT5_WRAP_CPP(rendererv2gui_MOC_SRCS ${rendererv2gui_HDRS})
 #add_executable(qgis_rendererv2gui ${rendererv2gui_SRCS} ${rendererv2gui_MOC_SRCS})
 
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
-ADD_QGIS_TEST(categorizedrendererwidget testqgscategorizedrendererwidget.cpp)
-ADD_QGIS_TEST(datumtransformdialog testqgsdatumtransformdialog.cpp)
-ADD_QGIS_TEST(doublespinbox testqgsdoublespinbox.cpp)
-ADD_QGIS_TEST(dualviewtest testqgsdualview.cpp)
-ADD_QGIS_TEST(attributeformtest testqgsattributeform.cpp)
-ADD_QGIS_TEST(datetimedittest testqgsdatetimeedit.cpp)
-ADD_QGIS_TEST(dockwidget testqgsdockwidget.cpp)
-ADD_QGIS_TEST(fieldexpressionwidget testqgsfieldexpressionwidget.cpp)
-ADD_QGIS_TEST(filewidget testqgsfilewidget.cpp)
-ADD_QGIS_TEST(focuswatcher testqgsfocuswatcher.cpp)
-ADD_QGIS_TEST(mapcanvastest testqgsmapcanvas.cpp)
-ADD_QGIS_TEST(messagebartest testqgsmessagebar.cpp)
-ADD_QGIS_TEST(projectionissues testprojectionissues.cpp)
-ADD_QGIS_TEST(qgsguitest testqgsgui.cpp)
-ADD_QGIS_TEST(processingguitest testprocessinggui.cpp)
-ADD_QGIS_TEST(processingmodeltest testqgsprocessingmodel.cpp)
-ADD_QGIS_TEST(rubberbandtest testqgsrubberband.cpp)
-ADD_QGIS_TEST(scalecombobox testqgsscalecombobox.cpp)
-ADD_QGIS_TEST(scalerangewidget testqgsscalerangewidget.cpp)
-ADD_QGIS_TEST(rangewidgetwrapper testqgsrangewidgetwrapper.cpp)
-ADD_QGIS_TEST(spinbox testqgsspinbox.cpp)
-ADD_QGIS_TEST(sqlcomposerdialog testqgssqlcomposerdialog.cpp)
-ADD_QGIS_TEST(editorwidgetregistrytest testqgseditorwidgetregistry.cpp)
-ADD_QGIS_TEST(keyvaluewidgettest testqgskeyvaluewidget.cpp)
-ADD_QGIS_TEST(listwidgettest testqgslistwidget.cpp)
-ADD_QGIS_TEST(filedownloader testqgsfiledownloader.cpp)
-ADD_QGIS_TEST(layoutgui testqgslayoutgui.cpp)
-ADD_QGIS_TEST(layoutview testqgslayoutview.cpp)
-ADD_QGIS_TEST(valuemapwidgetwrapper testqgsvaluemapwidgetwrapper.cpp)
-ADD_QGIS_TEST(rasterlayersaveasdialog testqgsrasterlayersaveasdialog.cpp)
-ADD_QGIS_TEST(valuerelationwidgetwrapper testqgsvaluerelationwidgetwrapper.cpp)
-ADD_QGIS_TEST(relationreferencewidget testqgsrelationreferencewidget.cpp)
-ADD_QGIS_TEST(featurelistcombobox testqgsfeaturelistcombobox.cpp)
-ADD_QGIS_TEST(texteditwrapper testqgstexteditwrapper.cpp)
-ADD_QGIS_TEST(tableeditorwidget testqgstableeditor.cpp)
-ADD_QGIS_TEST(newdatabasetablewidget testqgsnewdatabasetablewidget.cpp)
-ADD_QGIS_TEST(ogrproviderguitest testqgsogrprovidergui.cpp)
-ADD_QGIS_TEST(singlebandpseudocolorrendererwidget testqgssinglebandpseudocolorrendererwidget.cpp)
-ADD_QGIS_TEST(doublevalidator testqgsdoublevalidator.cpp)
-ADD_QGIS_TEST(meshlayerpropertiesdialog testqgsmeshlayerpropertiesdialog.cpp)
-ADD_QGIS_TEST(externalresourcewidgetwrapper testqgsexternalresourcewidgetwrapper.cpp)
-ADD_QGIS_TEST(querybuilder testqgsquerybuilder.cpp)
 
-SET_TESTS_PROPERTIES(qgis_listwidgettest PROPERTIES LABELS "POSTGRES")
+set(TESTS
+  testqgsmaptoolzoom.cpp
+  testqgsmaptooledit.cpp
+  testqgscategorizedrendererwidget.cpp
+  testqgsdatumtransformdialog.cpp
+  testqgsdoublespinbox.cpp
+  testqgsdualview.cpp
+  testqgsattributeform.cpp
+  testqgsdatetimeedit.cpp
+  testqgsdockwidget.cpp
+  testqgsfieldexpressionwidget.cpp
+  testqgsfilewidget.cpp
+  testqgsfocuswatcher.cpp
+  testqgsmapcanvas.cpp
+  testqgsmessagebar.cpp
+  testprojectionissues.cpp
+  testqgsgui.cpp
+  testprocessinggui.cpp
+  testqgsprocessingmodel.cpp
+  testqgsrubberband.cpp
+  testqgsscalecombobox.cpp
+  testqgsscalerangewidget.cpp
+  testqgsrangewidgetwrapper.cpp
+  testqgsspinbox.cpp
+  testqgssqlcomposerdialog.cpp
+  testqgseditorwidgetregistry.cpp
+  testqgskeyvaluewidget.cpp
+  testqgsfiledownloader.cpp
+  testqgslayoutgui.cpp
+  testqgslayoutview.cpp
+  testqgsvaluemapwidgetwrapper.cpp
+  testqgsvaluerelationwidgetwrapper.cpp
+  testqgsrelationreferencewidget.cpp
+  testqgsfeaturelistcombobox.cpp
+  testqgstexteditwrapper.cpp
+  testqgstableeditor.cpp
+  testqgsnewdatabasetablewidget.cpp
+  testqgsogrprovidergui.cpp
+  testqgssinglebandpseudocolorrendererwidget.cpp
+  testqgsdoublevalidator.cpp
+  testqgsmeshlayerpropertiesdialog.cpp
+  testqgsexternalresourcewidgetwrapper.cpp
+  testqgsquerybuilder.cpp
+)
+
+foreach(TESTSRC ${TESTS})
+  add_qgis_test( ${TESTSRC} MODULE gui LINKEDLIBRARIES qgis_gui qgis_analysis)
+endforeach(TESTSRC)
+
+add_qgis_test(testqgsrasterlayersaveasdialog.cpp MODULE gui LINKEDLIBRARIES qgis_gui qgis_analysis provider_postgres_gui_a)
+add_qgis_test(testqgslistwidget.cpp MODULE gui LINKEDLIBRARIES qgis_gui qgis_analysis LABELS "POSTGRES")
+
+
 if (ENABLE_PGTEST)
-  SET_TESTS_PROPERTIES(qgis_processingguitest qgis_valuerelationwidgetwrapper qgis_texteditwrapper
-    qgis_newdatabasetablewidget
+  SET_TESTS_PROPERTIES(
+    test_gui_processinggui
+    test_gui_valuerelationwidgetwrapper
+    test_gui_texteditwrapper
+    test_gui_newdatabasetablewidget
     PROPERTIES LABELS "POSTGRES")
 endif()

--- a/tests/src/native/CMakeLists.txt
+++ b/tests/src/native/CMakeLists.txt
@@ -40,37 +40,11 @@ if (APPLE)
 #  set (CMAKE_INSTALL_NAME_DIR @executable_path/../../../src/core)
 endif()
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  set(qgis_${testname}_MOC_CPPS ${testsrc})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    qgis_core
-    qgis_native
-  )
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-  #set_target_properties(qgis_${testname} PROPERTIES
-  #  INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${QGIS_LIB_DIR}
-  #  INSTALL_RPATH_USE_LINK_PATH true )
-endmacro (ADD_QGIS_TEST)
-
 
 
 #############################################################
 # Tests:
 
 if (APPLE)
-  ADD_QGIS_TEST(macnativetest testqgsmacnative.cpp)
+  add_qgis_test(testqgsmacnative.cpp MODULE native LINKEDLIBRARIES qgis_core qgis_native)
 endif()

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -3,7 +3,8 @@
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/providers/wms
   ${CMAKE_SOURCE_DIR}/src/providers/postgres
@@ -16,76 +17,39 @@ include_directories(SYSTEM
   ${POSTGRES_INCLUDE_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  add_custom_target(qgis_${testname}moc ALL DEPENDS ${qgis_${testname}_MOC_SRCS})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    qgis_core)
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
 
 #############################################################
 # Tests:
 
-ADD_QGIS_TEST(wcsprovidertest testqgswcsprovider.cpp)
+add_qgis_test(testqgswcsprovider.cpp MODULE provider LINKEDLIBRARIES qgis_core)
 # Temporarily set to old version until server is reconfigured
 #set(TEST_SERVER_URL "http://wcs.qgis.org/${COMPLETE_VERSION}")
 set(TEST_SERVER_URL "http://wcs.qgis.org/1.9.0")
 #add_definitions(-DTEST_SERVER_URL="${TEST_SERVER_URL}")
-set_target_properties(qgis_wcsprovidertest PROPERTIES
+set_target_properties(test_provider_wcsprovider PROPERTIES
   COMPILE_FLAGS "-DTEST_SERVER_URL=\\\"${TEST_SERVER_URL}\\\""
 )
 
-ADD_QGIS_TEST(wmscapabilitiestest testqgswmscapabilities.cpp)
-target_link_libraries(qgis_wmscapabilitiestest provider_wms_a qgis_core)
+add_qgis_test(testqgswmscapabilities.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
+add_qgis_test(testqgswmsccapabilities.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
+add_qgis_test(testqgswmsprovider.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
 
-ADD_QGIS_TEST(wmsccapabilitiestest testqgswmsccapabilities.cpp)
-target_link_libraries(qgis_wmsccapabilitiestest provider_wms_a qgis_core)
-
-ADD_QGIS_TEST(wmsprovidertest testqgswmsprovider.cpp)
-target_link_libraries(qgis_wmsprovidertest provider_wms_a qgis_core)
-
-ADD_QGIS_TEST(postgresprovidertest testqgspostgresprovider.cpp)
-target_link_libraries(qgis_postgresprovidertest provider_postgres_a qgis_core)
-
-ADD_QGIS_TEST(postgresconntest testqgspostgresconn.cpp)
-target_link_libraries(qgis_postgresconntest provider_postgres_a qgis_core)
-SET_TESTS_PROPERTIES(qgis_postgresconntest PROPERTIES LABELS "POSTGRES")
+add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
+add_qgis_test(testqgspostgresconn.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
 
 if (NOT FORCE_STATIC_PROVIDERS)
-  ADD_QGIS_TEST(mdalprovidertest testqgsmdalprovider.cpp)
+  add_qgis_test(testqgsmdalprovider.cpp MODULE provider LINKEDLIBRARIES qgis_core)
 endif()
 
 if (WITH_EPT)
-  include_directories(
-  )
-  ADD_QGIS_TEST(eptprovidertest testqgseptprovider.cpp)
+  add_qgis_test(testqgseptprovider.cpp MODULE provider LINKEDLIBRARIES qgis_core)
 endif()
 
 if (WITH_PDAL)
   include_directories(
     ${CMAKE_SOURCE_DIR}/src/providers/pdal
   )
-  ADD_QGIS_TEST(pdalprovidertest testqgspdalprovider.cpp)
-  target_link_libraries(qgis_pdalprovidertest provider_pdal_a qgis_core)
+  add_qgis_test(testqgspdalprovider.cpp MODULE provider LINKEDLIBRARIES provider_pdal_a qgis_core)
 endif()
 
 #############################################################

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -61,8 +61,8 @@ if(UNIX AND NOT ANDROID AND CMAKE_BUILD_TYPE MATCHES Debug)
         testqgswcspublicservers.cpp
   )
 
-  add_executable ( qgis_wcstest ${WCSTEST_SRCS} )
-  target_compile_features(qgis_wcstest PRIVATE cxx_std_17)
+  add_executable(test_provdider_wcs ${WCSTEST_SRCS} )
+  target_compile_features(test_provdider_wcs PRIVATE cxx_std_17)
 
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/core
@@ -70,7 +70,7 @@ if(UNIX AND NOT ANDROID AND CMAKE_BUILD_TYPE MATCHES Debug)
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/providers/wcs
   )
 
-  target_link_libraries(qgis_wcstest
+  target_link_libraries(test_provdider_wcs
     ${Qt5Core_LIBRARIES}
     ${Qt5Network_LIBRARIES}
     ${Qt5Svg_LIBRARIES}
@@ -79,7 +79,7 @@ if(UNIX AND NOT ANDROID AND CMAKE_BUILD_TYPE MATCHES Debug)
     qgis_core
   )
 
-  install (TARGETS qgis_wcstest
+  install (TARGETS test_provdider_wcs
     BUNDLE DESTINATION ${QGIS_BIN_DIR}
     RUNTIME DESTINATION ${QGIS_BIN_DIR}
   )

--- a/tests/src/quickgui/CMakeLists.txt
+++ b/tests/src/quickgui/CMakeLists.txt
@@ -28,39 +28,11 @@ include_directories(SYSTEM
     ${QTKEYCHAIN_INCLUDE_DIR}
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST testname testsrc)
-  set(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
-  add_custom_target(qgis_${testname}moc ALL DEPENDS ${qgis_${testname}_MOC_SRCS})
-  add_executable(qgis_${testname} ${qgis_${testname}_SRCS})
-  target_compile_features(qgis_${testname} PRIVATE cxx_std_17)
-  target_link_libraries(qgis_${testname}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    Qt5::Gui
-    Qt5::Qml
-    Qt5::Quick
-    Qt5::Xml
-    qgis_core
-    qgis_quick)
-
-  add_test(qgis_${testname} ${CMAKE_CURRENT_BINARY_DIR}/../../../output/bin/qgis_${testname} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
 
 #############################################################
 # Tests:
 
-ADD_QGIS_TEST(qgsquickutils testqgsquickutils.cpp)
+add_qgis_test(testqgsquickutils.cpp MODULE quick LINKEDLIBRARIES qgis_quick)
 
 #############################################################
 # Add also test application

--- a/tests/src/server/CMakeLists.txt
+++ b/tests/src/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT MSVC)
-add_subdirectory(wms)
+  add_subdirectory(wms)
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
@@ -10,30 +10,6 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/src/server
 )
 
-#note for tests we should not include the moc of our
-#qtests in the executable file list as the moc is
-#directly included in the sources
-#and should not be compiled twice. Trying to include
-#them in will cause an error at build time
-
-#No relinking and full RPATH for the install tree
-#See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
-
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  set (TESTNAME  "qgis_${TESTNAME}test")
-  add_executable(${TESTNAME} ${TESTSRC} ${util_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    qgis_server)
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
@@ -42,5 +18,5 @@ set(TESTS
 )
 
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+    add_qgis_test(${TESTSRC} MODULE server LINKEDLIBRARIES qgis_server)
 endforeach(TESTSRC)

--- a/tests/src/server/wms/CMakeLists.txt
+++ b/tests/src/server/wms/CMakeLists.txt
@@ -35,28 +35,6 @@ set(MODULE_WMS_HDRS
 
 QT5_WRAP_CPP(MODULE_WMS_MOC_SRCS ${MODULE_WMS_HDRS})
 
-macro (ADD_QGIS_TEST TESTSRC)
-  set (TESTNAME  ${TESTSRC})
-  string(REPLACE "test" "" TESTNAME ${TESTNAME})
-  string(REPLACE "qgs" "" TESTNAME ${TESTNAME})
-  string(REPLACE ".cpp" "" TESTNAME ${TESTNAME})
-  set (TESTNAME  "qgis_${TESTNAME}test")
-  add_executable(${TESTNAME} ${TESTSRC} ${MODULE_WMS_SRCS} ${MODULE_WMS_MOC_SRCS})
-  target_compile_features(${TESTNAME} PRIVATE cxx_std_17)
-  target_link_libraries(${TESTNAME}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Test_LIBRARIES}
-    ${PROJ_LIBRARY}
-    ${GEOS_LIBRARY}
-    ${GDAL_LIBRARY}
-    qgis_core
-    qgis_server
-  )
-  add_test(${TESTNAME} ${CMAKE_BINARY_DIR}/output/bin/${TESTNAME} -maxwarnings 10000)
-endmacro (ADD_QGIS_TEST)
-
 #############################################################
 # Tests:
 
@@ -69,5 +47,5 @@ set(TESTS
 )
 
 foreach(TESTSRC ${TESTS})
-    ADD_QGIS_TEST(${TESTSRC})
+    ADD_QGIS_TEST(${TESTSRC} MODULE server LINKEDLIBRARIES qgis_server wms_static)
 endforeach(TESTSRC)


### PR DESCRIPTION
all duplication of the macro have been removed
the test targets are now named test_[module]_[test-name] which helps to sort them in QGIS

