### PR TITLE
Set default absolute/relative paths for new projects 

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -50,6 +50,9 @@ connections-xyz\OpenStreetMap\zmin=0
 # Padding (in pixels) to add to toolbar icons, if blank then default padding will be used
 stylesheet\toolbarSpacing=
 
+# If true, new projects are using relative paths. If false, new projects default to absolute paths.
+defaultProjectPathsRelative=true
+
 [app]
 
 # Whether the user should be asked to save a layer in case of one or more MemoryLayers

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -826,6 +826,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   Qgis::PythonMacroMode pyMacroMode = mSettings->enumValue( QStringLiteral( "/qgis/enableMacros" ), Qgis::PythonMacroMode::Ask );
   mEnableMacrosComboBox->setCurrentIndex( mEnableMacrosComboBox->findData( QVariant::fromValue( pyMacroMode ) ) );
 
+  mDefaultPathsComboBox->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), QVariant( true ) ).toBool() ? 0 : 1 );
+
   QgsProject::FileFormat defaultProjectFileFormat = mSettings->enumValue( QStringLiteral( "/qgis/defaultProjectFileFormat" ), QgsProject::FileFormat::Qgz );
   mFileFormatQgzButton->setChecked( defaultProjectFileFormat == QgsProject::FileFormat::Qgz );
   mFileFormatQgsButton->setChecked( defaultProjectFileFormat == QgsProject::FileFormat::Qgs );
@@ -1652,6 +1654,8 @@ void QgsOptions::saveOptions()
     QgisApp::instance()->updateProjectFromTemplates();
   }
   mSettings->setEnumValue( QStringLiteral( "/qgis/enableMacros" ), mEnableMacrosComboBox->currentData().value<Qgis::PythonMacroMode>() );
+
+  mSettings->setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), mDefaultPathsComboBox->currentIndex() == 0 );
 
   mSettings->setEnumValue( QStringLiteral( "/qgis/defaultProjectFileFormat" ), mFileFormatQgsButton->isChecked() ? QgsProject::FileFormat::Qgs : QgsProject::FileFormat::Qgz );
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -844,8 +844,7 @@ void QgsProject::clear()
   writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ), true );
   writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 2 );
 
-  QSettings s;
-  bool defaultRelativePaths = s.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true ).toBool();
+  bool defaultRelativePaths = mSettings.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true ).toBool();
   writeEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), !defaultRelativePaths );
 
   //copy default units to project

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -843,7 +843,10 @@ void QgsProject::clear()
   // XXX THESE SHOULD BE MOVED TO STATUSBAR RELATED SOURCE
   writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ), true );
   writeEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 2 );
-  writeEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
+
+  QSettings s;
+  bool defaultRelativePaths = s.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true ).toBool();
+  writeEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), !defaultRelativePaths );
 
   //copy default units to project
   writeEntry( QStringLiteral( "Measurement" ), QStringLiteral( "/DistanceUnits" ), mSettings.value( QStringLiteral( "/qgis/measure/displayunits" ) ).toString() );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -360,9 +360,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>843</width>
-                <height>959</height>
+                <y>-536</y>
+                <width>856</width>
+                <height>1223</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -772,8 +772,8 @@
                  <property name="title">
                   <string>Project Files</string>
                  </property>
-                 <layout class="QVBoxLayout">
-                  <item>
+                 <layout class="QGridLayout" name="gridLayout_38">
+                  <item row="0" column="0">
                    <layout class="QGridLayout" name="gridLayout_4">
                     <item row="0" column="2" colspan="2">
                      <widget class="QComboBox" name="mProjectOnLaunchCmbBx">
@@ -882,14 +882,14 @@
                     </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="1" column="0">
                    <widget class="QCheckBox" name="cbxProjectDefaultNew">
                     <property name="text">
                      <string>Create new project from default project</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="2" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_16">
                     <item>
                      <spacer name="horizontalSpacer_22">
@@ -936,7 +936,7 @@
                     </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="3" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_15">
                     <item>
                      <widget class="QLabel" name="label_31">
@@ -982,28 +982,28 @@
                     </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="4" column="0">
                    <widget class="QCheckBox" name="chbAskToSaveProjectChanges">
                     <property name="text">
                      <string>Prompt to save project and data source changes when required</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="5" column="0">
                    <widget class="QCheckBox" name="mLayerDeleteConfirmationChkBx">
                     <property name="text">
                      <string>Prompt for confirmation when a layer is to be removed</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="6" column="0">
                    <widget class="QCheckBox" name="chbWarnOldProjectVersion">
                     <property name="text">
                      <string>Warn when opening a project file saved with an older version of QGIS</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="7" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_21">
                     <item>
                      <widget class="QLabel" name="label_33">
@@ -1037,7 +1037,45 @@
                     </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="8" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="mDefaultPathsLabel">
+                      <property name="text">
+                       <string>Default paths</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="mDefaultPathsComboBox">
+                      <item>
+                       <property name="text">
+                        <string>relative</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>absolute</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_24">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="9" column="0">
                    <layout class="QGridLayout" name="gridLayout_31">
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_67">
@@ -1133,8 +1171,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1068</height>
+                <width>617</width>
+                <height>1135</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1672,8 +1710,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>695</height>
+                <width>673</width>
+                <height>575</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1916,8 +1954,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>596</width>
-                <height>105</height>
+                <width>648</width>
+                <height>118</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1999,8 +2037,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>637</width>
-                <height>717</height>
+                <width>702</width>
+                <height>895</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2398,8 +2436,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>719</width>
-                <height>1132</height>
+                <width>772</width>
+                <height>1396</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -3203,8 +3241,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>508</width>
-                <height>357</height>
+                <width>523</width>
+                <height>435</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3648,8 +3686,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>630</width>
-                <height>686</height>
+                <width>678</width>
+                <height>850</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -4165,8 +4203,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>147</width>
-                <height>251</height>
+                <width>155</width>
+                <height>320</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -4345,8 +4383,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>555</width>
-                <height>968</height>
+                <width>608</width>
+                <height>1229</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4424,7 +4462,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   </item>
                   <item row="3" column="2">
                    <widget class="QgsDoubleSpinBox" name="mDefaultZValueSpinBox">
-		    <property name="toolTip">
+                    <property name="toolTip">
                      <string>Default Z Value</string>
                     </property>
                     <property name="decimals">
@@ -4443,7 +4481,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   </item>
                   <item row="4" column="2">
                    <widget class="QgsDoubleSpinBox" name="mDefaultMValueSpinBox">
-		    <property name="toolTip">
+                    <property name="toolTip">
                      <string>Default Measure Value</string>
                     </property>
                     <property name="decimals">
@@ -5048,8 +5086,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>494</width>
-                <height>539</height>
+                <width>546</width>
+                <height>606</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -5329,8 +5367,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>457</width>
-                <height>419</height>
+                <width>498</width>
+                <height>455</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -5601,8 +5639,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>657</width>
-                <height>669</height>
+                <width>712</width>
+                <height>828</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -6082,8 +6120,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1050,12 +1050,12 @@
                      <widget class="QComboBox" name="mDefaultPathsComboBox">
                       <item>
                        <property name="text">
-                        <string>relative</string>
+                        <string>Relative</string>
                        </property>
                       </item>
                       <item>
                        <property name="text">
-                        <string>absolute</string>
+                        <string>Absolute</string>
                        </property>
                       </item>
                      </widget>

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -708,15 +708,14 @@ void TestQgsProject::testDefaultRelativePaths()
   s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true );
   QgsProject p1;
   bool p1PathsAbsolute = p1.readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
-
   s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), false );
-  QgsProject p2;
-  bool p2PathsAbsolute = p2.readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
+  p1.clear();
+  bool p1PathsAbsolute_2 = p1.readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
 
   s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), bk_defaultRelativePaths );
 
   QCOMPARE( p1PathsAbsolute, false );
-  QCOMPARE( p2PathsAbsolute, true );
+  QCOMPARE( p1PathsAbsolute_2, true );
 }
 
 QGSTEST_MAIN( TestQgsProject )

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -54,6 +54,7 @@ class TestQgsProject : public QObject
     void projectSaveUser();
     void testCrsExpressions();
     void testCrsValidAfterReadingProjectFile();
+    void testDefaultRelativePaths();
 };
 
 void TestQgsProject::init()
@@ -697,6 +698,25 @@ void TestQgsProject::testCrsExpressions()
   QgsExpression e9( QStringLiteral( "@project_crs_ellipsoid" ) );
   r = e9.evaluate( &c );
   QCOMPARE( r.toString(), QString( "EPSG:7030" ) );
+}
+
+void TestQgsProject::testDefaultRelativePaths()
+{
+  QgsSettings s;
+  bool bk_defaultRelativePaths = s.value( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), QVariant( true ) ).toBool();
+
+  s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), true );
+  QgsProject p1;
+  bool p1PathsAbsolute = p1.readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
+
+  s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), false );
+  QgsProject p2;
+  bool p2PathsAbsolute = p2.readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
+
+  s.setValue( QStringLiteral( "/qgis/defaultProjectPathsRelative" ), bk_defaultRelativePaths );
+
+  QCOMPARE( p1PathsAbsolute, false );
+  QCOMPARE( p2PathsAbsolute, true );
 }
 
 QGSTEST_MAIN( TestQgsProject )


### PR DESCRIPTION
Pathes in the QGIS project can be set to 'absolute' or 'relative'. It is however not possible to set a default for newly created projects (new projects are always with relative paths by default). This PR adds an option to set the default for new projects to absolute or relative paths. Like this, it is possible to set the default for new projects to absolute paths (e.g. for the use in organisations where they have geodata on network shares but move around the project files).
What are your thoughts about it?