### PR TITLE
[mssql] use unique constraint info from db to set field ConstraintUnique

### DIFF
--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -708,6 +708,42 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(fields.at(3).constraints().constraints()
                          & QgsFieldConstraints.ConstraintNotNull)
 
+    def testUniqueConstraint(self):
+        vl = QgsVectorLayer('%s table="qgis_test"."constraints" sql=' %
+                            (self.dbconn), "testdatetimes", "mssql")
+        self.assertTrue(vl.isValid())
+        self.assertEqual(len(vl.fields()), 4)
+
+        # test some bad field indexes
+        self.assertEqual(vl.dataProvider().fieldConstraints(-1),
+                         QgsFieldConstraints.Constraints())
+        self.assertEqual(vl.dataProvider().fieldConstraints(
+            1001), QgsFieldConstraints.Constraints())
+
+        self.assertTrue(vl.dataProvider().fieldConstraints(0)
+                        & QgsFieldConstraints.ConstraintUnique)
+        self.assertTrue(vl.dataProvider().fieldConstraints(1)
+                        & QgsFieldConstraints.ConstraintUnique)
+        self.assertFalse(vl.dataProvider().fieldConstraints(2)
+                         & QgsFieldConstraints.ConstraintUnique)
+        self.assertFalse(vl.dataProvider().fieldConstraints(3)
+                         & QgsFieldConstraints.ConstraintUnique)
+
+        # test that constraints have been saved to fields correctly
+        fields = vl.fields()
+        self.assertTrue(fields.at(0).constraints().constraints()
+                        & QgsFieldConstraints.ConstraintUnique)
+        self.assertEqual(fields.at(0).constraints().constraintOrigin(QgsFieldConstraints.ConstraintUnique),
+                         QgsFieldConstraints.ConstraintOriginProvider)
+        self.assertTrue(fields.at(1).constraints().constraints()
+                        & QgsFieldConstraints.ConstraintUnique)
+        self.assertEqual(fields.at(1).constraints().constraintOrigin(QgsFieldConstraints.ConstraintUnique),
+                         QgsFieldConstraints.ConstraintOriginProvider)
+        self.assertFalse(fields.at(2).constraints().constraints()
+                         & QgsFieldConstraints.ConstraintUnique)
+        self.assertFalse(fields.at(3).constraints().constraints()
+                         & QgsFieldConstraints.ConstraintUnique)
+
     def getSubsetString(self):
         return '[cnt] > 100 and [cnt] < 410'
 

--- a/tests/testdata/provider/testdata_mssql.sql
+++ b/tests/testdata/provider/testdata_mssql.sql
@@ -295,6 +295,8 @@ CREATE TABLE [qgis_test].[constraints]
   gid integer PRIMARY KEY,
   val int,
   name text NOT NULL,
-  description text
+  description text,
+  CONSTRAINT constraint_val UNIQUE (val)
 );
 GO
+


### PR DESCRIPTION
Set ConstraintUnique also for other fields than primary key according to informations from sql server

I ran the test `PyQgsMssqlProvider` locally. Some unrelated tests where failing already before my changes. Do someone now if this tests (or the functionality in QGIS) are broken? 
- testExtentFromGeometryTable
- testPktComposite
- testPktCompositeFloat
