### PR TITLE
Add 'update' tag to find GeometryByExpression alg easier

### DIFF
--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -32,7 +32,7 @@ QString QgsGeometryByExpressionAlgorithm::displayName() const
 
 QStringList QgsGeometryByExpressionAlgorithm::tags() const
 {
-  return QObject::tr( "geometry,expression,create,modify" ).split( ',' );
+  return QObject::tr( "geometry,expression,create,modify,update" ).split( ',' );
 }
 
 QString QgsGeometryByExpressionAlgorithm::group() const


### PR DESCRIPTION
The algorithm help starts with "This algorithm updates existing geometries", but is missing the update tag to find it easier in the toolbox.