### PR TITLE
GUI localization tweaks

### DIFF
--- a/python/gui/auto_generated/qgsdoublevalidator.sip.in
+++ b/python/gui/auto_generated/qgsdoublevalidator.sip.in
@@ -50,21 +50,21 @@ Constructor for QgsDoubleValidator.
 :param parent: parent object
 %End
 
-    QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent );
+    QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent );
 %Docstring
 Constructor for QgsDoubleValidator.
 
 :param bottom: the minimal range limit accepted by the validator
 :param top: the maximal range limit accepted by the validator
-:param decimals: the number of decimals accepted by the validator
+:param decimal: the number of decimals accepted by the validator
 :param parent: parent object
 %End
 
-    QgsDoubleValidator( int decimals, QObject *parent );
+    QgsDoubleValidator( int decimal, QObject *parent );
 %Docstring
 Constructor for QgsDoubleValidator.
 
-:param decimals: the number of decimals accepted by the validator
+:param decimal: the number of decimals accepted by the validator
 :param parent: parent object
 
 .. versionadded:: 3.16
@@ -76,7 +76,7 @@ Sets the number of decimals accepted by the validator to ``maxDecimals``.
 
 .. warning::
 
-   setting decimals overrides any custom regular expression that was previosly set
+   setting decimals overrides any custom regular expression that was previously set
 
 .. versionadded:: 3.22
 %End

--- a/python/gui/auto_generated/qgsdoublevalidator.sip.in
+++ b/python/gui/auto_generated/qgsdoublevalidator.sip.in
@@ -50,25 +50,37 @@ Constructor for QgsDoubleValidator.
 :param parent: parent object
 %End
 
-    QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent );
+    QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent );
 %Docstring
 Constructor for QgsDoubleValidator.
 
 :param bottom: the minimal range limit accepted by the validator
 :param top: the maximal range limit accepted by the validator
-:param decimal: the number of decimals accepted by the validator
+:param decimals: the number of decimals accepted by the validator
 :param parent: parent object
 %End
 
-    QgsDoubleValidator( int decimal, QObject *parent );
+    QgsDoubleValidator( int decimals, QObject *parent );
 %Docstring
 Constructor for QgsDoubleValidator.
 
-:param decimal: the number of decimals accepted by the validator
+:param decimals: the number of decimals accepted by the validator
 :param parent: parent object
 
 .. versionadded:: 3.16
 %End
+
+    void setMaxDecimals( int maxDecimals );
+%Docstring
+Sets the number of decimals accepted by the validator to ``maxDecimals``.
+
+.. warning::
+
+   setting decimals overrides any custom regular expression that was previosly set
+
+.. versionadded:: 3.22
+%End
+
 
 
     QValidator::State validate( QString &input ) const;

--- a/src/app/decorations/qgsdecorationgriddialog.cpp
+++ b/src/app/decorations/qgsdecorationgriddialog.cpp
@@ -29,6 +29,7 @@
 #include "qgsgui.h"
 #include "qgslinesymbol.h"
 #include "qgsmarkersymbol.h"
+#include "qgsdoublevalidator.h"
 
 QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidget *parent )
   : QDialog( parent )
@@ -85,14 +86,13 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
 
 void QgsDecorationGridDialog::updateGuiElements()
 {
-  // blockAllSignals( true );
 
   grpEnable->setChecked( mDeco.enabled() );
 
-  mIntervalXEdit->setText( QString::number( mDeco.gridIntervalX() ) );
-  mIntervalYEdit->setText( QString::number( mDeco.gridIntervalY() ) );
-  mOffsetXEdit->setText( QString::number( mDeco.gridOffsetX() ) );
-  mOffsetYEdit->setText( QString::number( mDeco.gridOffsetY() ) );
+  mIntervalXEdit->setValue( mDeco.gridIntervalX() );
+  mIntervalYEdit->setValue( mDeco.gridIntervalY() );
+  mOffsetXEdit->setValue( mDeco.gridOffsetX() );
+  mOffsetYEdit->setValue( mDeco.gridOffsetY() );
 
   mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findData( mDeco.gridStyle() ) );
   mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
@@ -121,10 +121,10 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   mDeco.setDirty( false );
   mDeco.setEnabled( grpEnable->isChecked() );
 
-  mDeco.setGridIntervalX( mIntervalXEdit->text().toDouble() );
-  mDeco.setGridIntervalY( mIntervalYEdit->text().toDouble() );
-  mDeco.setGridOffsetX( mOffsetXEdit->text().toDouble() );
-  mDeco.setGridOffsetY( mOffsetYEdit->text().toDouble() );
+  mDeco.setGridIntervalX( mIntervalXEdit->value() );
+  mDeco.setGridIntervalY( mIntervalYEdit->value() );
+  mDeco.setGridOffsetX( mOffsetXEdit->value() );
+  mDeco.setGridOffsetY( mOffsetYEdit->value() );
   mDeco.setGridStyle( static_cast< QgsDecorationGrid::GridStyle >( mGridTypeComboBox->currentData().toInt() ) );
 
   mDeco.setTextFormat( mAnnotationFontButton->textFormat() );
@@ -213,10 +213,10 @@ void QgsDecorationGridDialog::mPbtnUpdateFromLayer_clicked()
   double values[4];
   if ( mDeco.getIntervalFromCurrentLayer( values ) )
   {
-    mIntervalXEdit->setText( QString::number( values[0] ) );
-    mIntervalYEdit->setText( QString::number( values[1] ) );
-    mOffsetXEdit->setText( QString::number( values[2] ) );
-    mOffsetYEdit->setText( QString::number( values[3] ) );
+    mIntervalXEdit->setValue( values[0] );
+    mIntervalYEdit->setValue( values[1] );
+    mOffsetXEdit->setValue( values[2] );
+    mOffsetYEdit->setValue( values[3] );
     if ( values[0] >= 1 )
       mCoordinatePrecisionSpinBox->setValue( 0 );
     else
@@ -231,10 +231,10 @@ void QgsDecorationGridDialog::updateInterval( bool force )
     double values[4];
     if ( mDeco.getIntervalFromExtent( values, true ) )
     {
-      mIntervalXEdit->setText( QString::number( values[0] ) );
-      mIntervalYEdit->setText( QString::number( values[1] ) );
-      mOffsetXEdit->setText( QString::number( values[2] ) );
-      mOffsetYEdit->setText( QString::number( values[3] ) );
+      mIntervalXEdit->setValue( values[0] );
+      mIntervalYEdit->setValue( values[1] );
+      mOffsetXEdit->setValue( values[2] );
+      mOffsetYEdit->setValue( values[3] );
       // also update coord. precision
       // if interval >= 1, set precision=0 because we have a rounded value
       // else set it to previous default of 3

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17049,11 +17049,11 @@ QgsFeature QgisApp::duplicateFeatures( QgsMapLayer *mlayer, const QgsFeature &fe
     const auto duplicatedFeatureContextLayers = duplicateFeatureContext.layers();
     for ( QgsVectorLayer *chl : duplicatedFeatureContextLayers )
     {
-      childrenInfo += ( tr( "%1 children on layer %2 duplicated" ).arg( QString::number( duplicateFeatureContext.duplicatedFeatures( chl ).size() ), chl->name() ) );
+      childrenInfo += ( tr( "%1 children on layer %2 duplicated" ).arg( QLocale().toString( duplicateFeatureContext.duplicatedFeatures( chl ).size() ), chl->name() ) );
     }
   }
 
-  visibleMessageBar()->pushMessage( tr( "%1 features on layer %2 duplicated\n%3" ).arg( QString::number( featureCount ), layer->name(), childrenInfo ), Qgis::MessageLevel::Success );
+  visibleMessageBar()->pushMessage( tr( "%1 features on layer %2 duplicated\n%3" ).arg( QLocale().toString( featureCount ), layer->name(), childrenInfo ), Qgis::MessageLevel::Success );
 
   return QgsFeature();
 }

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -581,7 +581,7 @@ void QgsHandleBadLayers::autoFind()
     progressDialog.setValue( i );
     QChar sentenceEnd = ( name.length() > 15 ) ? QChar( 0x2026 ) : '.';
     progressDialog.setLabelText( QObject::tr( "Searching for file: %1 \n [ %2 of %3 ] " ).arg( name.left( 15 ) + sentenceEnd,
-                                 QString::number( i + 1 ), QString::number( layersToFind.size() ) ) );
+                                 QLocale().toString( i + 1 ), QLocale().toString( layersToFind.size() ) ) );
     progressDialog.open();
 
     QVariantMap providerMap = QgsProviderRegistry::instance()->decodeUri( provider, dataInfo.absoluteFilePath() );

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -570,7 +570,7 @@ QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseAll( qi
   if ( featureCount < 0 )
     featureCountText = tr( "Searching…" );
   else
-    featureCountText = QString::number( featureCount );
+    featureCountText = QLocale().toString( featureCount );
 
   switch ( mBehavior )
   {

--- a/src/app/qgspointrotationitem.cpp
+++ b/src/app/qgspointrotationitem.cpp
@@ -15,6 +15,7 @@
 
 #include "qgspointrotationitem.h"
 #include <QPainter>
+#include <QLocale>
 #include <cmath>
 #include "qgsguiutils.h"
 
@@ -77,7 +78,7 @@ void QgsPointRotationItem::paint( QPainter *painter )
   bufferPen.setWidthF( QgsGuiUtils::scaleIconSize( 4 ) );
   QFontMetricsF fm( mFont );
   QPainterPath label;
-  label.addText( mPixmap.width(), mPixmap.height() / 2.0 + fm.height() / 2.0, mFont, QString::number( mRotation ) );
+  label.addText( mPixmap.width(), mPixmap.height() / 2.0 + fm.height() / 2.0, mFont, QLocale().toString( mRotation ) );
   painter->setPen( bufferPen );
   painter->setBrush( Qt::NoBrush );
   painter->drawPath( label );

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -626,7 +626,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        return QString::number( ls.tolerance() );
+        return QLocale().toString( ls.tolerance() );
       }
 
       if ( role == Qt::UserRole )
@@ -683,7 +683,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
         }
         else
         {
-          return QString::number( ls.minimumScale() );
+          return QLocale().toString( ls.minimumScale() );
         }
       }
 
@@ -703,7 +703,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
         }
         else
         {
-          return QString::number( ls.maximumScale() );
+          return QLocale().toString( ls.maximumScale() );
         }
       }
 

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -264,7 +264,7 @@ void QgsStatisticalSummaryDockWidget::updateNumericStatistics()
   {
     double val = stats.statistic( stat );
     addRow( row, QgsStatisticalSummary::displayName( stat ),
-            std::isnan( val ) ? QString() : QString::number( val ),
+            std::isnan( val ) ? QString() : QLocale().toString( val ),
             stats.count() != 0 );
     row++;
   }
@@ -272,7 +272,7 @@ void QgsStatisticalSummaryDockWidget::updateNumericStatistics()
   if ( mStatsActions.value( MISSING_VALUES )->isChecked() )
   {
     addRow( row, tr( "Missing (null) values" ),
-            QString::number( missingValues ),
+            QLocale().toString( missingValues ),
             stats.count() != 0 || missingValues != 0 );
     row++;
   }

--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -533,11 +533,11 @@ QgsDirectoryParamWidget::QgsDirectoryParamWidget( const QString &path, QWidget *
     QString size;
     if ( fi.size() > 1024 )
     {
-      size = QStringLiteral( "%1 KiB" ).arg( QString::number( fi.size() / 1024.0, 'f', 1 ) );
+      size = QStringLiteral( "%1 KiB" ).arg( QLocale().toString( fi.size() / 1024.0, 'f', 1 ) );
     }
     else if ( fi.size() > 1.048576e6 )
     {
-      size = QStringLiteral( "%1 MiB" ).arg( QString::number( fi.size() / 1.048576e6, 'f', 1 ) );
+      size = QStringLiteral( "%1 MiB" ).arg( QLocale().toString( fi.size() / 1.048576e6, 'f', 1 ) );
     }
     else
     {

--- a/src/core/classification/qgsclassificationlogarithmic.cpp
+++ b/src/core/classification/qgsclassificationlogarithmic.cpp
@@ -111,7 +111,7 @@ QString QgsClassificationLogarithmic::valueToLabel( double value ) const
 {
   if ( value <= 0 )
   {
-    return QString::number( value );
+    return QLocale().toString( value );
   }
   else
   {

--- a/src/core/classification/qgsclassificationstandarddeviation.cpp
+++ b/src/core/classification/qgsclassificationstandarddeviation.cpp
@@ -121,7 +121,7 @@ QString QgsClassificationStandardDeviation::labelForRange( const double lowerVal
 QString QgsClassificationStandardDeviation::valueToLabel( const double value ) const
 {
   double normalized = ( value - mEffectiveSymmetryPoint ) / mStdDev;
-  return QObject::tr( " %1 Std Dev" ).arg( QString::number( normalized, 'f', 2 ) );
+  return QObject::tr( " %1 Std Dev" ).arg( QLocale().toString( normalized, 'f', 2 ) );
 }
 
 

--- a/src/gui/layout/qgslayoutruler.cpp
+++ b/src/gui/layout/qgslayoutruler.cpp
@@ -137,7 +137,7 @@ void QgsLayoutRuler::paintEvent( QPaintEvent *event )
 
         //draw large division and text
         p.drawLine( pixelCoord, 0, pixelCoord, mRulerMinSize );
-        p.drawText( QPointF( pixelCoord + mPixelsBetweenLineAndText, mTextBaseline ), QString::number( markerPos ) );
+        p.drawText( QPointF( pixelCoord + mPixelsBetweenLineAndText, mTextBaseline ), QLocale().toString( markerPos ) );
 
         //draw small divisions
         drawSmallDivisions( &p, markerPos, numSmallDivisions, mmDisplay, endX );
@@ -186,7 +186,7 @@ void QgsLayoutRuler::paintEvent( QPaintEvent *event )
           double pixelCoord = mTransform.map( QPointF( 0, beforePageCoord ) ).y();
           p.drawLine( 0, pixelCoord, mRulerMinSize, pixelCoord );
           //calc size of label
-          QString label = QString::number( beforePageCoord );
+          QString label = QLocale().toString( beforePageCoord );
           int labelSize = mRulerFontMetrics->boundingRect( label ).width();
 
           //draw label only if it fits in before start of next page
@@ -234,7 +234,7 @@ void QgsLayoutRuler::paintEvent( QPaintEvent *event )
           double pixelCoord = mTransform.map( QPointF( 0, totalCoord ) ).y();
           p.drawLine( 0, pixelCoord, mRulerMinSize, pixelCoord );
           //calc size of label
-          QString label = QString::number( pageCoord );
+          QString label = QLocale().toString( pageCoord );
           int labelSize = mRulerFontMetrics->boundingRect( label ).width();
 
           //draw label only if it fits in before start of next page

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -51,8 +51,6 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
   connect( mScalarRecalculateMinMaxButton, &QPushButton::clicked, this, &QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked );
   connect( mScalarMinSpinBox, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [ = ]( double ) { minMaxChanged(); } );
   connect( mScalarMaxSpinBox, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [ = ]( double ) { minMaxChanged(); } );
-  connect( mScalarMinSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
-  connect( mScalarMaxSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
   connect( mScalarEdgeStrokeWidthVariableRadioButton, &QRadioButton::toggled, this, &QgsMeshRendererScalarSettingsWidget::onEdgeStrokeWidthMethodChanged );
 
   connect( mScalarColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsMeshRendererScalarSettingsWidget::widgetChanged );
@@ -165,13 +163,6 @@ double QgsMeshRendererScalarSettingsWidget::spinBoxValue( const QgsDoubleSpinBox
 }
 
 void QgsMeshRendererScalarSettingsWidget::minMaxChanged()
-{
-  const double min = spinBoxValue( mScalarMinSpinBox );
-  const double max = spinBoxValue( mScalarMaxSpinBox );
-  mScalarColorRampShaderWidget->setMinimumMaximum( min, max );
-}
-
-void QgsMeshRendererScalarSettingsWidget::minMaxEdited()
 {
   const double min = spinBoxValue( mScalarMinSpinBox );
   const double max = spinBoxValue( mScalarMaxSpinBox );

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -31,6 +31,11 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
 {
   setupUi( this );
 
+  mScalarMinSpinBox->setClearValueMode( QgsDoubleSpinBox::ClearValueMode::MinimumValue );
+  mScalarMinSpinBox->setSpecialValueText( QString( ) );
+  mScalarMaxSpinBox->setClearValueMode( QgsDoubleSpinBox::ClearValueMode::MinimumValue );
+  mScalarMaxSpinBox->setSpecialValueText( QString( ) );
+
   // add items to data interpolation combo box
   mScalarInterpolationTypeComboBox->addItem( tr( "None" ), QgsMeshRendererScalarSettings::None );
   mScalarInterpolationTypeComboBox->addItem( tr( "Neighbour Average" ), QgsMeshRendererScalarSettings::NeighbourAverage );
@@ -44,10 +49,10 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
 
   // connect
   connect( mScalarRecalculateMinMaxButton, &QPushButton::clicked, this, &QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked );
-  connect( mScalarMinLineEdit, &QLineEdit::textChanged, this, &QgsMeshRendererScalarSettingsWidget::minMaxChanged );
-  connect( mScalarMaxLineEdit, &QLineEdit::textChanged, this, &QgsMeshRendererScalarSettingsWidget::minMaxChanged );
-  connect( mScalarMinLineEdit, &QLineEdit::textEdited, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
-  connect( mScalarMaxLineEdit, &QLineEdit::textEdited, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
+  connect( mScalarMinSpinBox, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [ = ]( double ) { minMaxChanged(); } );
+  connect( mScalarMaxSpinBox, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [ = ]( double ) { minMaxChanged(); } );
+  connect( mScalarMinSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
+  connect( mScalarMaxSpinBox, &QgsDoubleSpinBox::editingFinished, this, &QgsMeshRendererScalarSettingsWidget::minMaxEdited );
   connect( mScalarEdgeStrokeWidthVariableRadioButton, &QRadioButton::toggled, this, &QgsMeshRendererScalarSettingsWidget::onEdgeStrokeWidthMethodChanged );
 
   connect( mScalarColorRampShaderWidget, &QgsColorRampShaderWidget::widgetChanged, this, &QgsMeshRendererScalarSettingsWidget::widgetChanged );
@@ -80,7 +85,7 @@ QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() co
 {
   QgsMeshRendererScalarSettings settings;
   settings.setColorRampShader( mScalarColorRampShaderWidget->shader() );
-  settings.setClassificationMinimumMaximum( lineEditValue( mScalarMinLineEdit ), lineEditValue( mScalarMaxLineEdit ) );
+  settings.setClassificationMinimumMaximum( spinBoxValue( mScalarMinSpinBox ), spinBoxValue( mScalarMaxSpinBox ) );
   settings.setOpacity( mOpacityWidget->opacity() );
   settings.setDataResamplingMethod( dataIntepolationMethod() );
 
@@ -113,8 +118,8 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
   const double min = settings.classificationMinimum();
   const double max = settings.classificationMaximum();
 
-  whileBlocking( mScalarMinLineEdit )->setText( QString::number( min ) );
-  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( max ) );
+  whileBlocking( mScalarMinSpinBox )->setValue( min );
+  whileBlocking( mScalarMaxSpinBox )->setValue( max );
   whileBlocking( mScalarColorRampShaderWidget )->setFromShader( shader );
   whileBlocking( mScalarColorRampShaderWidget )->setMinimumMaximum( min, max );
   whileBlocking( mOpacityWidget )->setOpacity( settings.opacity() );
@@ -149,27 +154,27 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
   onEdgeStrokeWidthMethodChanged();
 }
 
-double QgsMeshRendererScalarSettingsWidget::lineEditValue( const QLineEdit *lineEdit ) const
+double QgsMeshRendererScalarSettingsWidget::spinBoxValue( const QgsDoubleSpinBox *spinBox ) const
 {
-  if ( lineEdit->text().isEmpty() )
+  if ( spinBox->value() == spinBox->clearValue() )
   {
     return std::numeric_limits<double>::quiet_NaN();
   }
 
-  return lineEdit->text().toDouble();
+  return spinBox->value();
 }
 
 void QgsMeshRendererScalarSettingsWidget::minMaxChanged()
 {
-  double min = lineEditValue( mScalarMinLineEdit );
-  double max = lineEditValue( mScalarMaxLineEdit );
+  const double min = spinBoxValue( mScalarMinSpinBox );
+  const double max = spinBoxValue( mScalarMaxSpinBox );
   mScalarColorRampShaderWidget->setMinimumMaximum( min, max );
 }
 
 void QgsMeshRendererScalarSettingsWidget::minMaxEdited()
 {
-  double min = lineEditValue( mScalarMinLineEdit );
-  double max = lineEditValue( mScalarMaxLineEdit );
+  const double min = spinBoxValue( mScalarMinSpinBox );
+  const double max = spinBoxValue( mScalarMaxSpinBox );
   mScalarColorRampShaderWidget->setMinimumMaximumAndClassify( min, max );
 }
 
@@ -178,8 +183,8 @@ void QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked()
   const QgsMeshDatasetGroupMetadata metadata = mMeshLayer->datasetGroupMetadata( mActiveDatasetGroup );
   double min = metadata.minimum();
   double max = metadata.maximum();
-  whileBlocking( mScalarMinLineEdit )->setText( QString::number( min ) );
-  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( max ) );
+  whileBlocking( mScalarMinSpinBox )->setValue( min );
+  whileBlocking( mScalarMaxSpinBox )->setValue( max );
   mScalarColorRampShaderWidget->setMinimumMaximumAndClassify( min, max );
 }
 

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.h
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.h
@@ -67,7 +67,7 @@ class QgsMeshRendererScalarSettingsWidget : public QWidget, private Ui::QgsMeshR
     void onEdgeStrokeWidthMethodChanged();
 
   private:
-    double lineEditValue( const QLineEdit *lineEdit ) const;
+    double spinBoxValue( const QgsDoubleSpinBox *spinBox ) const;
     QgsMeshRendererScalarSettings::DataResamplingMethod dataIntepolationMethod() const;
 
     bool dataIsDefinedOnFaces() const;

--- a/src/gui/mesh/qgsmeshrendererscalarsettingswidget.h
+++ b/src/gui/mesh/qgsmeshrendererscalarsettingswidget.h
@@ -62,7 +62,6 @@ class QgsMeshRendererScalarSettingsWidget : public QWidget, private Ui::QgsMeshR
 
   private slots:
     void minMaxChanged();
-    void minMaxEdited();
     void recalculateMinMaxButtonClicked();
     void onEdgeStrokeWidthMethodChanged();
 

--- a/src/gui/mesh/qgsmeshrenderervectorsettingswidget.h
+++ b/src/gui/mesh/qgsmeshrenderervectorsettingswidget.h
@@ -72,10 +72,10 @@ class QgsMeshRendererVectorSettingsWidget : public QWidget, private Ui::QgsMeshR
   private:
 
     /**
-     * convert text to double, return err_val if
-     * text is not possible to convert or the value is negative
+     * Returns the value of the spin box, returns err_val if the
+     * value is equal to the clear value.
      */
-    double filterValue( const QString &text, double errVal ) const;
+    double filterValue( const QgsDoubleSpinBox *spinBox, double err_val ) const;
 
     QgsMeshLayer *mMeshLayer = nullptr; //not owned
     int mActiveDatasetGroup = -1;

--- a/src/gui/mesh/qgsmeshvariablestrokewidthwidget.h
+++ b/src/gui/mesh/qgsmeshvariablestrokewidthwidget.h
@@ -81,7 +81,7 @@ class QgsMeshVariableStrokeWidthWidget: public QgsPanelWidget, public Ui::QgsMes
     double mDefaultMinimumValue = 0;
     double mDefaultMaximumValue = 0;
 
-    double lineEditValue( const QLineEdit *lineEdit ) const;
+    double lineEditValue( const QgsDoubleSpinBox *lineEdit ) const;
 };
 
 #endif // QGSMESHVARIABLESTROKEWIDTHWIDGET_H

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -402,7 +402,7 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Warning );
         msgBox.setWindowTitle( tr( "Overwrite File" ) );
-        msgBox.setText( tr( "This file contains %1 layers that will be lost!\n" ).arg( QString::number( layerList.length() ) ) );
+        msgBox.setText( tr( "This file contains %1 layers that will be lost!\n" ).arg( QLocale().toString( layerList.length() ) ) );
         msgBox.setDetailedText( tr( "The following layers will be permanently lost:\n\n%1" ).arg( layerList.join( "\n" ) ) );
         msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Cancel );
         if ( msgBox.exec() == QMessageBox::Cancel )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1342,7 +1342,7 @@ QgsProcessingParameterDefinition *QgsProcessingRangeParameterDefinitionWidget::c
   else
   {
     bool ok;
-    defaultValue = QgsDoubleValidator::toDouble( mMinLineEdit->text(), &ok );
+    defaultValue = QString::number( QgsDoubleValidator::toDouble( mMinLineEdit->text(), &ok ) );
     if ( ! ok )
     {
       defaultValue = QStringLiteral( "None" );

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -306,7 +306,7 @@ void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids 
 
       if ( deletedFeaturesPks.size() == 1 && relatedLinkingFeaturesCount > 1 )
       {
-        QMessageBox messageBox( QMessageBox::Question, tr( "Really delete entry?" ), tr( "The entry on %1 is still linked to %2 features on %3. Do you want to delete it?" ).arg( mNmRelation.referencedLayer()->name(), QString::number( relatedLinkingFeaturesCount ), mRelation.referencedLayer()->name() ), QMessageBox::NoButton, this );
+        QMessageBox messageBox( QMessageBox::Question, tr( "Really delete entry?" ), tr( "The entry on %1 is still linked to %2 features on %3. Do you want to delete it?" ).arg( mNmRelation.referencedLayer()->name(), QLocale().toString( relatedLinkingFeaturesCount ), mRelation.referencedLayer()->name() ), QMessageBox::NoButton, this );
         messageBox.addButton( QMessageBox::Cancel );
         QAbstractButton *deleteButton = messageBox.addButton( tr( "Delete" ),  QMessageBox::AcceptRole );
 
@@ -316,7 +316,7 @@ void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids 
       }
       else if ( deletedFeaturesPks.size() > 1 && relatedLinkingFeaturesCount > deletedFeaturesPks.size() )
       {
-        QMessageBox messageBox( QMessageBox::Question, tr( "Really delete entries?" ), tr( "The %1 entries on %2 are still linked to %3 features on %4. Do you want to delete them?" ).arg( QString::number( deletedFeaturesPks.size() ), mNmRelation.referencedLayer()->name(), QString::number( relatedLinkingFeaturesCount ), mRelation.referencedLayer()->name() ), QMessageBox::NoButton, this );
+        QMessageBox messageBox( QMessageBox::Question, tr( "Really delete entries?" ), tr( "The %1 entries on %2 are still linked to %3 features on %4. Do you want to delete them?" ).arg( QLocale().toString( deletedFeaturesPks.size() ), mNmRelation.referencedLayer()->name(), QLocale().toString( relatedLinkingFeaturesCount ), mRelation.referencedLayer()->name() ), QMessageBox::NoButton, this );
         messageBox.addButton( QMessageBox::Cancel );
         QAbstractButton *deleteButton = messageBox.addButton( tr( "Delete" ), QMessageBox::AcceptRole );
 

--- a/src/gui/qgscoordinateoperationwidget.cpp
+++ b/src/gui/qgscoordinateoperationwidget.cpp
@@ -301,7 +301,7 @@ void QgsCoordinateOperationWidget::loadAvailableOperations()
 
     item = std::make_unique< QTableWidgetItem >();
     item->setFlags( item->flags() & ~Qt::ItemIsEditable );
-    item->setText( transform.accuracy >= 0 ? QString::number( transform.accuracy ) : tr( "Unknown" ) );
+    item->setText( transform.accuracy >= 0 ? QLocale().toString( transform.accuracy ) : tr( "Unknown" ) );
     item->setToolTip( toolTipString );
     if ( !transform.isAvailable )
     {

--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -55,23 +55,29 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, QObject *pare
   setRegularExpression( reg );
 }
 
-QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent )
+QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent )
   : QRegularExpressionValidator( parent )
   , mMinimum( bottom )
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
+  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimals ) ) );
   setRegularExpression( reg );
 }
 
-QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
+QgsDoubleValidator::QgsDoubleValidator( int decimals, QObject *parent )
   : QRegularExpressionValidator( parent )
   , mMinimum( std::numeric_limits<qreal>::lowest() )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
+  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimals ) ) );
+  setRegularExpression( reg );
+}
+
+void QgsDoubleValidator::setMaxDecimals( int maxDecimals )
+{
+  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( maxDecimals ) ) );
   setRegularExpression( reg );
 }
 

--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -55,23 +55,23 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, QObject *pare
   setRegularExpression( reg );
 }
 
-QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent )
+QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent )
   : QRegularExpressionValidator( parent )
   , mMinimum( bottom )
   , mMaximum( top )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimals ) ) );
+  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
   setRegularExpression( reg );
 }
 
-QgsDoubleValidator::QgsDoubleValidator( int decimals, QObject *parent )
+QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
   : QRegularExpressionValidator( parent )
   , mMinimum( std::numeric_limits<qreal>::lowest() )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimals ) ) );
+  QRegularExpression reg( PERMISSIVE_DOUBLE.arg( locale().decimalPoint() ).arg( QString::number( decimal ) ) );
   setRegularExpression( reg );
 }
 

--- a/src/gui/qgsdoublevalidator.h
+++ b/src/gui/qgsdoublevalidator.h
@@ -72,23 +72,23 @@ class GUI_EXPORT QgsDoubleValidator : public QRegularExpressionValidator
      *
      * \param bottom the minimal range limit accepted by the validator
      * \param top the maximal range limit accepted by the validator
-     * \param decimals the number of decimals accepted by the validator
+     * \param decimal the number of decimals accepted by the validator
      * \param parent parent object
      */
-    QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent );
+    QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent );
 
     /**
      * Constructor for QgsDoubleValidator.
      *
-     * \param decimals the number of decimals accepted by the validator
+     * \param decimal the number of decimals accepted by the validator
      * \param parent parent object
      * \since QGIS 3.16
      */
-    QgsDoubleValidator( int decimals, QObject *parent );
+    QgsDoubleValidator( int decimal, QObject *parent );
 
     /**
      * Sets the number of decimals accepted by the validator to \a maxDecimals.
-     * \warning setting decimals overrides any custom regular expression that was previosly set
+     * \warning setting decimals overrides any custom regular expression that was previously set
      * \since QGIS 3.22
      */
     void setMaxDecimals( int maxDecimals );

--- a/src/gui/qgsdoublevalidator.h
+++ b/src/gui/qgsdoublevalidator.h
@@ -72,19 +72,27 @@ class GUI_EXPORT QgsDoubleValidator : public QRegularExpressionValidator
      *
      * \param bottom the minimal range limit accepted by the validator
      * \param top the maximal range limit accepted by the validator
-     * \param decimal the number of decimals accepted by the validator
+     * \param decimals the number of decimals accepted by the validator
      * \param parent parent object
      */
-    QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent );
+    QgsDoubleValidator( double bottom, double top, int decimals, QObject *parent );
 
     /**
      * Constructor for QgsDoubleValidator.
      *
-     * \param decimal the number of decimals accepted by the validator
+     * \param decimals the number of decimals accepted by the validator
      * \param parent parent object
      * \since QGIS 3.16
      */
-    QgsDoubleValidator( int decimal, QObject *parent );
+    QgsDoubleValidator( int decimals, QObject *parent );
+
+    /**
+     * Sets the number of decimals accepted by the validator to \a maxDecimals.
+     * \warning setting decimals overrides any custom regular expression that was previosly set
+     * \since QGIS 3.22
+     */
+    void setMaxDecimals( int maxDecimals );
+
 
     QValidator::State validate( QString &input, int & ) const override SIP_SKIP;
 

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -241,10 +241,11 @@ void QgsExtentWidget::setOutputExtentFromCondensedLineEdit()
     const QRegularExpressionMatch match = mCondensedRe.match( text );
     if ( match.hasMatch() )
     {
-      whileBlocking( mXMinLineEdit )->setText( match.captured( 1 ) );
-      whileBlocking( mXMaxLineEdit )->setText( match.captured( 2 ) );
-      whileBlocking( mYMinLineEdit )->setText( match.captured( 3 ) );
-      whileBlocking( mYMaxLineEdit )->setText( match.captured( 4 ) );
+      // Localization
+      whileBlocking( mXMinLineEdit )->setText( QLocale().toString( match.captured( 1 ).toDouble() ) );
+      whileBlocking( mXMaxLineEdit )->setText( QLocale().toString( match.captured( 2 ).toDouble() ) );
+      whileBlocking( mYMinLineEdit )->setText( QLocale().toString( match.captured( 3 ).toDouble() ) );
+      whileBlocking( mYMaxLineEdit )->setText( QLocale().toString( match.captured( 4 ).toDouble() ) );
       if ( !match.captured( 5 ).isEmpty() )
       {
         mOutputCrs = QgsCoordinateReferenceSystem( match.captured( 5 ) );

--- a/src/gui/qgshistogramwidget.cpp
+++ b/src/gui/qgshistogramwidget.cpp
@@ -254,7 +254,7 @@ void QgsHistogramWidget::drawHistogram()
     rangeMarker->attach( mpPlot );
     rangeMarker->setLineStyle( QwtPlotMarker::VLine );
     rangeMarker->setXValue( range.upperValue() );
-    rangeMarker->setLabel( QString::number( range.upperValue() ) );
+    rangeMarker->setLabel( QLocale().toString( range.upperValue() ) );
     rangeMarker->setLabelOrientation( Qt::Vertical );
     rangeMarker->setLabelAlignment( Qt::AlignLeft | Qt::AlignTop );
     rangeMarker->show();

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -319,7 +319,7 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     {
       const QgsMeshDatasetValue scalarValue = layer->datasetValue( index, point, searchRadius );
       const double scalar = scalarValue.scalar();
-      attribute.insert( tr( "Scalar Value" ), std::isnan( scalar ) ? tr( "no data" ) : QString::number( scalar ) );
+      attribute.insert( tr( "Scalar Value" ), std::isnan( scalar ) ? tr( "no data" ) : QLocale().toString( scalar ) );
     }
 
     if ( groupMeta.isVector() )
@@ -331,9 +331,9 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
         attribute.insert( tr( "Vector Value" ), tr( "no data" ) );
       else
       {
-        attribute.insert( tr( "Vector Magnitude" ), QString::number( vectorValue.scalar() ) );
-        derivedAttributes.insert( tr( "Vector x-component" ), QString::number( vectorY ) );
-        derivedAttributes.insert( tr( "Vector y-component" ), QString::number( vectorX ) );
+        attribute.insert( tr( "Vector Magnitude" ), QLocale().toString( vectorValue.scalar() ) );
+        derivedAttributes.insert( tr( "Vector x-component" ), QLocale().toString( vectorY ) );
+        derivedAttributes.insert( tr( "Vector y-component" ), QLocale().toString( vectorX ) );
       }
     }
 
@@ -360,22 +360,22 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
   QgsPointXY vertexPoint = layer->snapOnElement( QgsMesh::Vertex, point, searchRadius );
   if ( !vertexPoint.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Snapped Vertex Position X" ), QString::number( vertexPoint.x() ) );
-    derivedGeometry.insert( tr( "Snapped Vertex Position Y" ), QString::number( vertexPoint.y() ) );
+    derivedGeometry.insert( tr( "Snapped Vertex Position X" ), QLocale().toString( vertexPoint.x() ) );
+    derivedGeometry.insert( tr( "Snapped Vertex Position Y" ), QLocale().toString( vertexPoint.y() ) );
   }
 
   QgsPointXY faceCentroid = layer->snapOnElement( QgsMesh::Face, point, searchRadius );
   if ( !faceCentroid.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Face Centroid X" ), QString::number( faceCentroid.x() ) );
-    derivedGeometry.insert( tr( "Face Centroid Y" ), QString::number( faceCentroid.y() ) );
+    derivedGeometry.insert( tr( "Face Centroid X" ), QLocale().toString( faceCentroid.x() ) );
+    derivedGeometry.insert( tr( "Face Centroid Y" ), QLocale().toString( faceCentroid.y() ) );
   }
 
   QgsPointXY pointOnEdge = layer->snapOnElement( QgsMesh::Edge, point, searchRadius );
   if ( !pointOnEdge.isEmpty() )
   {
-    derivedGeometry.insert( tr( "Point on Edge X" ), QString::number( pointOnEdge.x() ) );
-    derivedGeometry.insert( tr( "Point on Edge Y" ), QString::number( pointOnEdge.y() ) );
+    derivedGeometry.insert( tr( "Point on Edge X" ), QLocale().toString( pointOnEdge.x() ) );
+    derivedGeometry.insert( tr( "Point on Edge Y" ), QLocale().toString( pointOnEdge.y() ) );
   }
 
   const IdentifyResult result( layer,
@@ -532,7 +532,7 @@ QMap<QString, QString> QgsMapToolIdentify::derivedAttributesForPoint( const QgsP
   derivedAttributes.insert( tr( "(clicked coordinate X)" ), formatXCoordinate( point ) );
   derivedAttributes.insert( tr( "(clicked coordinate Y)" ), formatYCoordinate( point ) );
   if ( point.is3D() )
-    derivedAttributes.insert( tr( "(clicked coordinate Z)" ), QString::number( point.z(), 'f' ) );
+    derivedAttributes.insert( tr( "(clicked coordinate Z)" ), QLocale().toString( point.z(), 'f' ) );
   return derivedAttributes;
 }
 

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -230,7 +230,7 @@ void QgsPropertyAssistantWidget::updatePreview()
     const QSize minSize( node->minimumIconSize() );
     node->setIconSize( minSize );
     widthMax = std::max( minSize.width(), widthMax );
-    QStandardItem *item = new QStandardItem( node->data( Qt::DecorationRole ).value<QPixmap>(), QString::number( breaks[i] ) );
+    QStandardItem *item = new QStandardItem( node->data( Qt::DecorationRole ).value<QPixmap>(), QLocale().toString( breaks[i] ) );
     item->setEditable( false );
     mPreviewList.appendRow( item );
     delete node;

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -1065,7 +1065,7 @@ QString findClosestTickVal( double target, const QwtScaleDiv *scale, int div = 1
   }
 
   // QgsDebugMsg( QStringLiteral( "target=%1 div=%2 closest=%3" ).arg( target ).arg( div ).arg( closest ) );
-  return QString::number( closest );
+  return QLocale().toString( closest );
 }
 
 void QgsRasterHistogramWidget::histoPickerSelected( QPointF pos )
@@ -1224,9 +1224,9 @@ QPair< QString, QString > QgsRasterHistogramWidget::rendererMinMax( int bandNo )
 
   // if we get an empty result, fill with default value (histo min/max)
   if ( myMinMax.first.isEmpty() )
-    myMinMax.first = QString::number( mHistoMin );
+    myMinMax.first = QLocale().toString( mHistoMin );
   if ( myMinMax.second.isEmpty() )
-    myMinMax.second = QString::number( mHistoMax );
+    myMinMax.second = QLocale().toString( mHistoMax );
 
   QgsDebugMsg( QStringLiteral( "bandNo %1 got min/max [%2] [%3]" ).arg( bandNo ).arg( myMinMax.first, myMinMax.second ) );
 

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -356,20 +356,20 @@ void QgsRendererRasterPropertiesWidget::refreshAfterStyleChanged()
       const QgsContrastEnhancement *redCe = mbcr->redContrastEnhancement();
       if ( redCe )
       {
-        mRendererWidget->setMin( QString::number( redCe->minimumValue() ), 0 );
-        mRendererWidget->setMax( QString::number( redCe->maximumValue() ), 0 );
+        mRendererWidget->setMin( QLocale().toString( redCe->minimumValue() ), 0 );
+        mRendererWidget->setMax( QLocale().toString( redCe->maximumValue() ), 0 );
       }
       const QgsContrastEnhancement *greenCe = mbcr->greenContrastEnhancement();
       if ( greenCe )
       {
-        mRendererWidget->setMin( QString::number( greenCe->minimumValue() ), 1 );
-        mRendererWidget->setMax( QString::number( greenCe->maximumValue() ), 1 );
+        mRendererWidget->setMin( QLocale().toString( greenCe->minimumValue() ), 1 );
+        mRendererWidget->setMax( QLocale().toString( greenCe->maximumValue() ), 1 );
       }
       const QgsContrastEnhancement *blueCe = mbcr->blueContrastEnhancement();
       if ( blueCe )
       {
-        mRendererWidget->setMin( QString::number( blueCe->minimumValue() ), 2 );
-        mRendererWidget->setMax( QString::number( blueCe->maximumValue() ), 2 );
+        mRendererWidget->setMin( QLocale().toString( blueCe->minimumValue() ), 2 );
+        mRendererWidget->setMax( QLocale().toString( blueCe->maximumValue() ), 2 );
       }
     }
     else if ( QgsSingleBandGrayRenderer *sbgr = dynamic_cast<QgsSingleBandGrayRenderer *>( renderer ) )
@@ -377,8 +377,8 @@ void QgsRendererRasterPropertiesWidget::refreshAfterStyleChanged()
       const QgsContrastEnhancement *ce = sbgr->contrastEnhancement();
       if ( ce )
       {
-        mRendererWidget->setMin( QString::number( ce->minimumValue() ) );
-        mRendererWidget->setMax( QString::number( ce->maximumValue() ) );
+        mRendererWidget->setMin( QLocale().toString( ce->minimumValue() ) );
+        mRendererWidget->setMax( QLocale().toString( ce->maximumValue() ) );
       }
     }
   }

--- a/src/gui/symbology/qgsdashspacedialog.cpp
+++ b/src/gui/symbology/qgsdashspacedialog.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsdashspacedialog.h"
+#include "qgsdoublevalidator.h"
 #include "qgsapplication.h"
 
 #include <QDialogButtonBox>
@@ -35,8 +36,8 @@ QgsDashSpaceWidget::QgsDashSpaceWidget( const QVector<qreal> &vectorPattern, QWi
     space = vectorPattern.at( i );
     QTreeWidgetItem *entry = new QTreeWidgetItem();
     entry->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled );
-    entry->setText( 0, QString::number( dash ) );
-    entry->setText( 1, QString::number( space ) );
+    entry->setText( 0, QLocale().toString( dash ) );
+    entry->setText( 1, QLocale().toString( space ) );
     mDashSpaceTreeWidget->addTopLevelItem( entry );
   }
 
@@ -76,7 +77,7 @@ QVector<qreal> QgsDashSpaceWidget::dashDotVector() const
     QTreeWidgetItem *currentItem = mDashSpaceTreeWidget->topLevelItem( i );
     if ( currentItem )
     {
-      dashVector << currentItem->text( 0 ).toDouble() << currentItem->text( 1 ).toDouble();
+      dashVector << QgsDoubleValidator::toDouble( currentItem->text( 0 ) ) << QgsDoubleValidator::toDouble( currentItem->text( 1 ) );
     }
   }
   return dashVector;

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -29,6 +29,7 @@
 #include "qgssymbolselectordialog.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsdoublevalidator.h"
 #include "qgsmarkersymbol.h"
 #include "qgslinesymbol.h"
 
@@ -94,7 +95,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
     const auto constClasses = ddsLegend->classes();
     for ( const QgsDataDefinedSizeLegend::SizeClass &sc : constClasses )
     {
-      QStandardItem *item = new QStandardItem( QString::number( sc.size ) );
+      QStandardItem *item = new QStandardItem( QLocale().toString( sc.size ) );
       item->setData( sc.size );
       QStandardItem *itemLabel = new QStandardItem( sc.label );
       mSizeClassesModel->appendRow( QList<QStandardItem *>() << item << itemLabel );
@@ -158,8 +159,8 @@ QgsDataDefinedSizeLegend *QgsDataDefinedSizeLegendWidget::dataDefinedSizeLegend(
     QList<QgsDataDefinedSizeLegend::SizeClass> classes;
     for ( int i = 0; i < mSizeClassesModel->rowCount(); ++i )
     {
-      double value = mSizeClassesModel->item( i, 0 )->data().toDouble();
-      QString label = mSizeClassesModel->item( i, 1 )->text();
+      const double value = mSizeClassesModel->item( i, 0 )->data().toDouble();
+      const QString label = mSizeClassesModel->item( i, 1 )->text();
       classes << QgsDataDefinedSizeLegend::SizeClass( value, label );
     }
     ddsLegend->setClasses( classes );
@@ -223,9 +224,9 @@ void QgsDataDefinedSizeLegendWidget::addSizeClass()
   if ( !ok )
     return;
 
-  QStandardItem *item = new QStandardItem( QString::number( v ) );
+  QStandardItem *item = new QStandardItem( QLocale().toString( v ) );
   item->setData( v );
-  QStandardItem *itemLabel = new QStandardItem( QString::number( v ) );
+  QStandardItem *itemLabel = new QStandardItem( QLocale().toString( v ) );
   mSizeClassesModel->appendRow( QList<QStandardItem *>() << item << itemLabel );
   mSizeClassesModel->sort( 0 );
   emit widgetChanged();
@@ -246,7 +247,7 @@ void QgsDataDefinedSizeLegendWidget::onSizeClassesChanged()
   for ( int row = 0; row < mSizeClassesModel->rowCount(); ++row )
   {
     QStandardItem *item = mSizeClassesModel->item( row, 0 );
-    item->setData( item->text().toDouble() );
+    item->setData( QgsDoubleValidator::toDouble( item->text() ) );
   }
 
   mSizeClassesModel->sort( 0 );

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
@@ -23,6 +23,7 @@
 #include "ui_qgsdatadefinedsizelegendwidget.h"
 
 #include "qgspanelwidget.h"
+#include "qgsdoublevalidator.h"
 #include "qgsproperty.h"
 #include <QStyledItemDelegate>
 
@@ -98,7 +99,7 @@ class SizeClassDelegate : public QStyledItemDelegate
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &, const QModelIndex & ) const override
     {
       QLineEdit *lineEdit = new QLineEdit( parent );
-      QDoubleValidator *validator = new QDoubleValidator( 0, 1e6, 1, lineEdit );
+      QgsDoubleValidator *validator = new QgsDoubleValidator( 0, 1e6, 1, lineEdit );
       lineEdit->setValidator( validator );
       return lineEdit;
     }

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -464,7 +464,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   // setup user interface
   setupUi( this );
 
-  mSymmetryPointValidator = new QDoubleValidator( this );
+  mSymmetryPointValidator = new QgsDoubleValidator( this );
   cboSymmetryPoint->setEditable( true );
   cboSymmetryPoint->setValidator( mSymmetryPointValidator );
 
@@ -693,7 +693,7 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
   while ( cboSymmetryPoint->count() )
     cboSymmetryPoint->removeItem( 0 );
   for ( int i = 0; i < ranges.count() - 1; i++ )
-    cboSymmetryPoint->addItem( QString::number( ranges.at( i ).upperValue(), 'f', precision ), ranges.at( i ).upperValue() );
+    cboSymmetryPoint->addItem( QLocale().toString( ranges.at( i ).upperValue(), 'f', precision ), ranges.at( i ).upperValue() );
 
   if ( method )
   {
@@ -1022,7 +1022,7 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
   double maximum = maxVal.toDouble();
   mSymmetryPointValidator->setBottom( minimum );
   mSymmetryPointValidator->setTop( maximum );
-  mSymmetryPointValidator->setDecimals( spinPrecision->value() );
+  mSymmetryPointValidator->setMaxDecimals( spinPrecision->value() );
 
   if ( method->id() == QgsClassificationEqualInterval::METHOD_ID ||
        method->id() == QgsClassificationStandardDeviation::METHOD_ID )

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -24,6 +24,7 @@
 #include "qgsrendererwidget.h"
 #include "qgsproxystyle.h"
 #include "qgsprocessingwidgetwrapper.h"
+#include "qgsdoublevalidator.h"
 
 #include "ui_qgsgraduatedsymbolrendererwidget.h"
 
@@ -197,7 +198,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
 
     QgsRangeList mCopyBuffer;
 
-    QDoubleValidator *mSymmetryPointValidator = nullptr;
+    QgsDoubleValidator *mSymmetryPointValidator = nullptr;
     QAction *mActionLevels = nullptr;
     std::vector< std::unique_ptr< QgsAbstractProcessingParameterWidgetWrapper >> mParameterWidgetWrappers;
 };

--- a/src/gui/symbology/qgsinterpolatedlinesymbollayerwidget.cpp
+++ b/src/gui/symbology/qgsinterpolatedlinesymbollayerwidget.cpp
@@ -389,6 +389,6 @@ void QgsInterpolatedLineSymbolLayerWidget::setLineEditValue( QLineEdit *lineEdit
 {
   QString strValue;
   if ( !std::isnan( value ) )
-    strValue = QString::number( value );
+    strValue = QLocale().toString( value );
   whileBlocking( lineEdit )->setText( strValue );
 }

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1590,7 +1590,7 @@ void QgsVectorLayerProperties::addJoinToTreeWidget( const QgsVectorLayerJoinInfo
   childFields->setText( 0, tr( "Joined fields" ) );
   const QStringList *list = join.joinFieldNamesSubset();
   if ( list )
-    childFields->setText( 1, QString::number( list->count() ) );
+    childFields->setText( 1, QLocale().toString( list->count() ) );
   else
     childFields->setText( 1, tr( "all" ) );
   joinItem->addChild( childFields );
@@ -1915,8 +1915,8 @@ void QgsVectorLayerProperties::updateAuxiliaryStoragePage()
     mAuxiliaryStorageKeyLineEdit->setText( alayer->joinInfo().targetFieldName() );
 
     // update feature count
-    long features = alayer->featureCount();
-    mAuxiliaryStorageFeaturesLineEdit->setText( QString::number( features ) );
+    const qlonglong features = alayer->featureCount();
+    mAuxiliaryStorageFeaturesLineEdit->setText( QLocale().toString( features ) );
 
     // update actions
     mAuxiliaryLayerActionClear->setEnabled( true );
@@ -1928,7 +1928,7 @@ void QgsVectorLayerProperties::updateAuxiliaryStoragePage()
     if ( alayer )
     {
       const int fields = alayer->auxiliaryFields().count();
-      mAuxiliaryStorageFieldsLineEdit->setText( QString::number( fields ) );
+      mAuxiliaryStorageFieldsLineEdit->setText( QLocale().toString( fields ) );
 
       // add fields
       mAuxiliaryStorageFieldsTree->clear();

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -247,6 +247,9 @@
   <tabstop>mScalarEdgeStrokeWidthVariableRadioButton</tabstop>
   <tabstop>mScalarEdgeStrokeWidthSpinBox</tabstop>
   <tabstop>mScalarEdgeStrokeWidthVariablePushButton</tabstop>
+  <tabstop>mScalarEdgeStrokeWidthUnitSelectionWidget</tabstop>
+  <tabstop>mScalarMinSpinBox</tabstop>
+  <tabstop>mScalarMaxSpinBox</tabstop>
   <tabstop>mScalarRecalculateMinMaxButton</tabstop>
   <tabstop>mScalarInterpolationTypeComboBox</tabstop>
  </tabstops>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
+    <width>381</width>
     <height>206</height>
    </rect>
   </property>
@@ -136,9 +136,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="mScalarMinLineEdit">
-       <property name="text">
-        <string>0</string>
+      <widget class="QgsDoubleSpinBox" name="mScalarMinSpinBox">
+       <property name="minimum">
+        <double>-10000000000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000000000.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -150,9 +153,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="mScalarMaxLineEdit">
-       <property name="text">
-        <string>1</string>
+      <widget class="QgsDoubleSpinBox" name="mScalarMaxSpinBox">
+       <property name="minimum">
+        <double>-10000000000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000000000.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -241,8 +247,6 @@
   <tabstop>mScalarEdgeStrokeWidthVariableRadioButton</tabstop>
   <tabstop>mScalarEdgeStrokeWidthSpinBox</tabstop>
   <tabstop>mScalarEdgeStrokeWidthVariablePushButton</tabstop>
-  <tabstop>mScalarMinLineEdit</tabstop>
-  <tabstop>mScalarMaxLineEdit</tabstop>
   <tabstop>mScalarRecalculateMinMaxButton</tabstop>
   <tabstop>mScalarInterpolationTypeComboBox</tabstop>
  </tabstops>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -667,6 +667,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -681,12 +687,6 @@
    <class>QgsColorRampShaderWidget</class>
    <extends>QWidget</extends>
    <header>raster/qgscolorrampshaderwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -706,18 +706,28 @@
   <tabstop>mLineWidthSpinBox</tabstop>
   <tabstop>mColoringMethodComboBox</tabstop>
   <tabstop>mColorWidget</tabstop>
+  <tabstop>mColorRampShaderMinimumSpinBox</tabstop>
+  <tabstop>mColorRampShaderMaximumSpinBox</tabstop>
   <tabstop>mColorRampShaderLoadButton</tabstop>
+  <tabstop>mMinMagSpinBox</tabstop>
+  <tabstop>mMaxMagSpinBox</tabstop>
   <tabstop>mDisplayVectorsOnGridGroupBox</tabstop>
   <tabstop>mXSpacingSpinBox</tabstop>
   <tabstop>mYSpacingSpinBox</tabstop>
+  <tabstop>mHeadWidthSpinBox</tabstop>
+  <tabstop>mHeadLengthSpinBox</tabstop>
   <tabstop>mShaftLengthComboBox</tabstop>
+  <tabstop>mMinimumShaftSpinBox</tabstop>
+  <tabstop>mMaximumShaftSpinBox</tabstop>
   <tabstop>mStreamlinesSeedingMethodComboBox</tabstop>
   <tabstop>mStreamlinesDensitySpinBox</tabstop>
   <tabstop>mTracesParticlesCountSpinBox</tabstop>
   <tabstop>mTracesMaxLengthSpinBox</tabstop>
-  <tabstop>mTracesTailLengthMapUnitWidget</tabstop>
+  <tabstop>mScaleShaftByFactorOfSpinBox</tabstop>
+  <tabstop>mShaftLengthSpinBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -128,7 +128,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QgsUnitSelectionWidget" name="mTracesTailLengthMapUnitWidget"/>
+         <widget class="QgsUnitSelectionWidget" name="mTracesTailLengthMapUnitWidget" native="true"/>
         </item>
        </layout>
       </item>
@@ -141,6 +141,13 @@
       <string>Color Ramp Shader</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Max</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="4">
        <widget class="QPushButton" name="mColorRampShaderLoadButton">
         <property name="text">
@@ -149,6 +156,16 @@
         <property name="icon">
          <iconset resource="../../../images/images.qrc">
           <normaloff>:/images/themes/default/mActionRefresh.svg</normaloff>:/images/themes/default/mActionRefresh.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="5">
+       <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -165,15 +182,21 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Max</string>
+      <item row="0" column="3">
+       <widget class="QgsDoubleSpinBox" name="mColorRampShaderMaximumSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000.000000000000000</double>
         </property>
        </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLineEdit" name="mColorRampShaderMaximumEditLine"/>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
@@ -183,15 +206,18 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="mColorRampShaderMinimumEditLine"/>
-      </item>
-      <item row="2" column="0" colspan="5">
-       <widget class="QgsColorRampShaderWidget" name="mColorRampShaderWidget" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
+       <widget class="QgsDoubleSpinBox" name="mColorRampShaderMinimumSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -244,10 +270,10 @@
    </item>
    <item row="7" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="1">
-      <widget class="QLabel" name="minimumMagLabel">
+     <item row="0" column="0" rowspan="2">
+      <widget class="QLabel" name="filterByMagnitudeLabel">
        <property name="text">
-        <string>Min</string>
+        <string>Filter by magnitude</string>
        </property>
       </widget>
      </item>
@@ -259,15 +285,35 @@
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QLineEdit" name="mMaxMagLineEdit"/>
+      <widget class="QgsDoubleSpinBox" name="mMaxMagSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimum">
+        <double>-1000000000000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000000000000000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="minimumMagLabel">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLineEdit" name="mMinMagLineEdit"/>
-     </item>
-     <item row="0" column="0" rowspan="2">
-      <widget class="QLabel" name="filterByMagnitudeLabel">
-       <property name="text">
-        <string>Filter by magnitude</string>
+      <widget class="QgsDoubleSpinBox" name="mMinMagSpinBox">
+       <property name="minimum">
+        <double>-1000000000000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000000000000000.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -410,15 +456,32 @@
       <string>Head Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="headWidthLabel">
+      <item row="1" column="2">
+       <widget class="QLabel" name="percShaftLenLabel_2">
         <property name="text">
-         <string>Width</string>
+         <string>% of shaft length</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="mHeadWidthLineEdit"/>
+       <widget class="QgsDoubleSpinBox" name="mHeadWidthSpinBox">
+        <property name="maximum">
+         <double>100.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mHeadLengthSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximum">
+         <double>100.000000000000000</double>
+        </property>
+       </widget>
       </item>
       <item row="0" column="2">
        <widget class="QLabel" name="percShaftLenLabel">
@@ -434,13 +497,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="mHeadLengthLineEdit"/>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="percShaftLenLabel_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="headWidthLabel">
         <property name="text">
-         <string>% of shaft length</string>
+         <string>Width</string>
         </property>
        </widget>
       </item>
@@ -517,25 +577,25 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="minimumShaftLabel">
             <property name="text">
              <string>Minimum</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="mMinimumShaftLineEdit"/>
-          </item>
-          <item row="1" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="maximumShaftLabel">
             <property name="text">
              <string>Maximum</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="mMaximumShaftLineEdit"/>
+          <item row="2" column="1">
+           <widget class="QgsDoubleSpinBox" name="mMinimumShaftSpinBox"/>
+          </item>
+          <item row="4" column="1">
+           <widget class="QgsDoubleSpinBox" name="mMaximumShaftSpinBox"/>
           </item>
          </layout>
         </widget>
@@ -553,15 +613,22 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
+          <item row="0" column="1">
+           <widget class="QgsDoubleSpinBox" name="mScaleShaftByFactorOfSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="scaleByFactorOfLabel">
             <property name="text">
              <string>Scale by a factor of</string>
             </property>
            </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="mScaleShaftByFactorOfLineEdit"/>
           </item>
          </layout>
         </widget>
@@ -579,15 +646,15 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
+          <item row="0" column="1">
+           <widget class="QgsDoubleSpinBox" name="mShaftLengthSpinBox"/>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="LengthLabel">
             <property name="text">
              <string>Length</string>
             </property>
            </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="mShaftLengthLineEdit"/>
           </item>
          </layout>
         </widget>
@@ -605,15 +672,9 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -623,9 +684,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QComboBox</extends>
-   <header>qgsunitselectionwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -639,26 +706,16 @@
   <tabstop>mLineWidthSpinBox</tabstop>
   <tabstop>mColoringMethodComboBox</tabstop>
   <tabstop>mColorWidget</tabstop>
-  <tabstop>mColorRampShaderMinimumEditLine</tabstop>
-  <tabstop>mColorRampShaderMaximumEditLine</tabstop>
   <tabstop>mColorRampShaderLoadButton</tabstop>
-  <tabstop>mMinMagLineEdit</tabstop>
-  <tabstop>mMaxMagLineEdit</tabstop>
   <tabstop>mDisplayVectorsOnGridGroupBox</tabstop>
   <tabstop>mXSpacingSpinBox</tabstop>
   <tabstop>mYSpacingSpinBox</tabstop>
-  <tabstop>mHeadWidthLineEdit</tabstop>
-  <tabstop>mHeadLengthLineEdit</tabstop>
   <tabstop>mShaftLengthComboBox</tabstop>
-  <tabstop>mMinimumShaftLineEdit</tabstop>
-  <tabstop>mMaximumShaftLineEdit</tabstop>
   <tabstop>mStreamlinesSeedingMethodComboBox</tabstop>
   <tabstop>mStreamlinesDensitySpinBox</tabstop>
   <tabstop>mTracesParticlesCountSpinBox</tabstop>
   <tabstop>mTracesMaxLengthSpinBox</tabstop>
   <tabstop>mTracesTailLengthMapUnitWidget</tabstop>
-  <tabstop>mShaftLengthLineEdit</tabstop>
-  <tabstop>mScaleShaftByFactorOfLineEdit</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -163,6 +163,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mValueMinimumSpinBox</tabstop>
+  <tabstop>mValueMaximumSpinBox</tabstop>
   <tabstop>mDefaultMinMaxButton</tabstop>
   <tabstop>mIgnoreOutOfRangecheckBox</tabstop>
   <tabstop>mUseAbsoluteValueCheckBox</tabstop>

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -110,8 +110,8 @@
        <height>0</height>
       </size>
      </property>
-     <property name="text">
-      <string/>
+     <property name="toolTip">
+      <string>Load</string>
      </property>
      <property name="icon">
       <iconset resource="../../../images/images.qrc">

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -14,6 +14,20 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Min Value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Max Value</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -21,15 +35,53 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QgsDoubleSpinBox" name="mWidthMinimumSpinBox">
-     <property name="value">
-      <double>1.000000000000000</double>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Min Width</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="mValueMinimumLineEdit"/>
+   <item row="3" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="mIgnoreOutOfRangecheckBox">
+       <property name="text">
+        <string>Ignore Out of Range Values</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mUseAbsoluteValueCheckBox">
+       <property name="text">
+        <string>Use Absolute Value</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Max Width</string>
+     </property>
+    </widget>
    </item>
    <item row="9" column="0">
     <spacer name="verticalSpacer">
@@ -44,10 +96,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="mValueMaximumLineEdit"/>
-   </item>
-   <item row="1" column="2" rowspan="2">
+   <item row="1" column="3" rowspan="2">
     <widget class="QPushButton" name="mDefaultMinMaxButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -70,74 +119,39 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Min Width</string>
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsDoubleSpinBox" name="mValueMaximumSpinBox">
+     <property name="minimum">
+      <double>-1000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Max Width</string>
+   <item row="1" column="1" colspan="2">
+    <widget class="QgsDoubleSpinBox" name="mValueMinimumSpinBox">
+     <property name="minimum">
+      <double>-1000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="7" column="1" colspan="2">
+    <widget class="QgsDoubleSpinBox" name="mWidthMinimumSpinBox">
+     <property name="value">
+      <double>1.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Max Value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Min Value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
+   <item row="8" column="1" colspan="2">
     <widget class="QgsDoubleSpinBox" name="mWidthMaximumSpinBox">
      <property name="value">
       <double>5.000000000000000</double>
      </property>
     </widget>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="mIgnoreOutOfRangecheckBox">
-       <property name="text">
-        <string>Ignore Out of Range Values</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mUseAbsoluteValueCheckBox">
-       <property name="text">
-        <string>Use Absolute Value</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>
@@ -149,8 +163,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mValueMinimumLineEdit</tabstop>
-  <tabstop>mValueMaximumLineEdit</tabstop>
   <tabstop>mDefaultMinMaxButton</tabstop>
   <tabstop>mIgnoreOutOfRangecheckBox</tabstop>
   <tabstop>mUseAbsoluteValueCheckBox</tabstop>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -29,13 +29,55 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="3" column="1">
-       <widget class="QLabel" name="label_2">
+      <item row="10" column="1">
+       <widget class="QLabel" name="mOffsetYLabel">
         <property name="text">
-         <string>X</string>
+         <string>Y</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" rowspan="2">
+       <widget class="QLabel" name="mOffsetXLabel">
+        <property name="text">
+         <string>Offset</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="2">
+       <widget class="QgsDoubleSpinBox" name="mOffsetYEdit">
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QgsSymbolButton" name="mMarkerSymbolButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>
@@ -61,7 +103,7 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="0" colspan="3">
+      <item row="13" column="0" colspan="3">
        <layout class="QGridLayout" name="gridLayout_4">
         <property name="leftMargin">
          <number>9</number>
@@ -91,146 +133,14 @@
         </item>
        </layout>
       </item>
-      <item row="7" column="1">
-       <widget class="QLabel" name="mOffsetYLabel">
-        <property name="text">
-         <string>Y</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QLineEdit" name="mIntervalYEdit"/>
-      </item>
-      <item row="3" column="2">
-       <widget class="QLineEdit" name="mIntervalXEdit"/>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="mIntervalYLabel">
-        <property name="text">
-         <string>Y</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="mGridTypeLabel">
-        <property name="accessibleName">
-         <string extracomment="Hello translotor"/>
-        </property>
-        <property name="text">
-         <string>Grid type</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>X</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QComboBox" name="mGridTypeComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QLabel" name="mLineSymbolLabel">
-        <property name="text">
-         <string>Line symbol</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="2">
-       <widget class="QLineEdit" name="mOffsetYEdit"/>
-      </item>
-      <item row="6" column="2">
-       <widget class="QLineEdit" name="mOffsetXEdit"/>
-      </item>
-      <item row="2" column="2">
-       <widget class="QgsSymbolButton" name="mMarkerSymbolButton">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
+       <widget class="QgsDoubleSpinBox" name="mIntervalYEdit">
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" rowspan="2">
-       <widget class="QLabel" name="mIntervalXLabel">
-        <property name="text">
-         <string>Interval</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="mMarkerSymbolLabel">
-        <property name="text">
-         <string>Marker symbol</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" rowspan="2">
-       <widget class="QLabel" name="mOffsetXLabel">
-        <property name="text">
-         <string>Offset</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="18" column="0" colspan="3">
+      <item row="22" column="0" colspan="3">
        <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
         <property name="title">
          <string>Draw Annotation</string>
@@ -313,7 +223,80 @@
         </layout>
        </widget>
       </item>
-      <item row="19" column="0" colspan="3">
+      <item row="9" column="2">
+       <widget class="QgsDoubleSpinBox" name="mOffsetXEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0" colspan="3">
+       <widget class="QLabel" name="mUpdateIntervalOffsetLabel">
+        <property name="text">
+         <string>Update Interval / Offset from</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="mLineSymbolLabel">
+        <property name="text">
+         <string>Line symbol</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="mGridTypeLabel">
+        <property name="accessibleName">
+         <string extracomment="Hello translotor"/>
+        </property>
+        <property name="text">
+         <string>Grid type</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QgsDoubleSpinBox" name="mIntervalXEdit">
+        <property name="maximum">
+         <double>10000000000000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" rowspan="4">
+       <widget class="QLabel" name="mIntervalXLabel">
+        <property name="text">
+         <string>Interval</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="mIntervalYLabel">
+        <property name="text">
+         <string>Y</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="23" column="0" colspan="3">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -326,10 +309,49 @@
         </property>
        </spacer>
       </item>
-      <item row="8" column="0" colspan="3">
-       <widget class="QLabel" name="mUpdateIntervalOffsetLabel">
+      <item row="0" column="2">
+       <widget class="QComboBox" name="mGridTypeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="mMarkerSymbolLabel">
         <property name="text">
-         <string>Update Interval / Offset from</string>
+         <string>Marker symbol</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>X</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>X</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -375,10 +397,6 @@
   <tabstop>mGridTypeComboBox</tabstop>
   <tabstop>mLineSymbolButton</tabstop>
   <tabstop>mMarkerSymbolButton</tabstop>
-  <tabstop>mIntervalXEdit</tabstop>
-  <tabstop>mIntervalYEdit</tabstop>
-  <tabstop>mOffsetXEdit</tabstop>
-  <tabstop>mOffsetYEdit</tabstop>
   <tabstop>mPbtnUpdateFromExtents</tabstop>
   <tabstop>mPbtnUpdateFromLayer</tabstop>
   <tabstop>mDrawAnnotationCheckBox</tabstop>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -397,6 +397,10 @@
   <tabstop>mGridTypeComboBox</tabstop>
   <tabstop>mLineSymbolButton</tabstop>
   <tabstop>mMarkerSymbolButton</tabstop>
+  <tabstop>mIntervalXEdit</tabstop>
+  <tabstop>mIntervalYEdit</tabstop>
+  <tabstop>mOffsetXEdit</tabstop>
+  <tabstop>mOffsetYEdit</tabstop>
   <tabstop>mPbtnUpdateFromExtents</tabstop>
   <tabstop>mPbtnUpdateFromLayer</tabstop>
   <tabstop>mDrawAnnotationCheckBox</tabstop>


### PR DESCRIPTION
Part of QEP https://github.com/qgis/QGIS-Enhancement-Proposals/issues/210

Locale support for numeric input and display: revision and enhancements

Grant proposal 2021

Affected widgets/classes:

    - QgisApp
    - QgsDecorationGridDialog
    - QgsHandleBadLayers
    - QgsPointRotationItem
    - QgsSnappingLayerTreeModel
    - QgsStatisticalSummaryDockWidget
    - QgsDirectoryParamWidget
    - QgsClassificationStandardDeviation
    - QgsLayoutRuler
    - QgsMeshRendererScalarSettingsWidget
    - QgsMeshRendererVectorSettingsWidget
    - QgsMeshVariableStrokeWidthWidget
    - QgsVectorLayerSaveAsDialog
    - QgsProcessingNumberParameterDefinitionWidget
    - QgsProcessingRangeParameterDefinitionWidget
    - QgsProcessingDistanceParameterDefinitionWidget
    - QgsAbstractRelationEditorWidget
    - QgsCoordinateOperationWidget
    - QgsDoubleValidator (added ::setMaxDecimals( int decimals ) )
    - QgsExtentWidget
    - QgsMapToolIdentify
    - QgsPropertyAssistantWidget
    - QgsRasterHistogramWidget
    - QgsRendererRasterPropertiesWidget
    - QgsDashSpaceWidget
    - QgsDataDefinedSizeLegendWidget
    - QgsGraduatedSymbolRendererWidget
    - QgsGraduatedSymbolRendererWidget

