### PR TITLE
Feature: Annotation item inline html

### DIFF
--- a/python/core/auto_generated/annotations/qgshtmlannotation.sip.in
+++ b/python/core/auto_generated/annotations/qgshtmlannotation.sip.in
@@ -50,6 +50,18 @@ Returns the file path for the source HTML file.
 .. seealso:: :py:func:`setSourceFile`
 %End
 
+    void setHtmlSource( const QString &htmlSource );
+%Docstring
+Sets the html source directly (not coming from a file)
+
+:param htmlSource:
+%End
+
+    QString htmlSource() const;
+%Docstring
+Returns html source text
+%End
+
     virtual void writeXml( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &itemElem, const QgsReadWriteContext &context );

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -42,7 +42,17 @@ QgsHtmlAnnotationDialog::QgsHtmlAnnotationDialog( QgsMapCanvasAnnotationItem *it
   if ( item && item->annotation() )
   {
     QgsHtmlAnnotation *annotation = static_cast< QgsHtmlAnnotation * >( item->annotation() );
-    mFileLineEdit->setText( annotation->sourceFile() );
+    QString file = annotation->sourceFile();
+    if ( !file.isEmpty() )
+    {
+      mFileLineEdit->setText( file );
+      mFileRadioButton->setChecked( true );
+    }
+    else
+    {
+      mHtmlSourceTextEdit->setPlainText( annotation->htmlSource() );
+      mSourceRadioButton->setChecked( true );
+    }
   }
 
   QObject::connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsHtmlAnnotationDialog::applySettingsToItem );
@@ -65,7 +75,15 @@ void QgsHtmlAnnotationDialog::applySettingsToItem()
   if ( mItem && mItem->annotation() )
   {
     QgsHtmlAnnotation *annotation = static_cast< QgsHtmlAnnotation * >( mItem->annotation() );
-    annotation->setSourceFile( mFileLineEdit->text() );
+    QString file = mFileLineEdit->text();
+    if ( mFileRadioButton->isChecked() )
+    {
+      annotation->setSourceFile( mFileLineEdit->text() );
+    }
+    else
+    {
+      annotation->setHtmlSource( mHtmlSourceTextEdit->toPlainText() );
+    }
     mItem->update();
   }
 }
@@ -84,6 +102,16 @@ void QgsHtmlAnnotationDialog::mBrowseToolButton_clicked()
   }
   QString filename = QFileDialog::getOpenFileName( nullptr, tr( "html" ), directory, QStringLiteral( "HTML (*.html *.htm);;All files (*.*)" ) );
   mFileLineEdit->setText( filename );
+}
+
+void QgsHtmlAnnotationDialog::on_mFileRadioButton_toggled( bool checked )
+{
+  mFileLineEdit->setEnabled( checked );
+}
+
+void QgsHtmlAnnotationDialog::on_mSourceRadioButton_toggled( bool checked )
+{
+  mHtmlSourceTextEdit->setEnabled( checked );
 }
 
 void QgsHtmlAnnotationDialog::deleteItem()

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -50,7 +50,7 @@ QgsHtmlAnnotationDialog::QgsHtmlAnnotationDialog( QgsMapCanvasAnnotationItem *it
     }
     else
     {
-      mHtmlSourceTextEdit->setPlainText( annotation->htmlSource() );
+      mHtmlSourceTextEdit->setText( annotation->htmlSource() );
       mSourceRadioButton->setChecked( true );
     }
   }
@@ -82,7 +82,7 @@ void QgsHtmlAnnotationDialog::applySettingsToItem()
     }
     else
     {
-      annotation->setHtmlSource( mHtmlSourceTextEdit->toPlainText() );
+      annotation->setHtmlSource( mHtmlSourceTextEdit->text() );
     }
     mItem->update();
   }

--- a/src/app/qgshtmlannotationdialog.h
+++ b/src/app/qgshtmlannotationdialog.h
@@ -36,6 +36,8 @@ class APP_EXPORT QgsHtmlAnnotationDialog: public QDialog, private Ui::QgsFormAnn
     void mBrowseToolButton_clicked();
     void deleteItem();
     void mButtonBox_clicked( QAbstractButton *button );
+    void on_mFileRadioButton_toggled( bool checked );
+    void on_mSourceRadioButton_toggled( bool checked );
     void showHelp();
 };
 

--- a/src/core/annotations/qgshtmlannotation.cpp
+++ b/src/core/annotations/qgshtmlannotation.cpp
@@ -78,6 +78,14 @@ void QgsHtmlAnnotation::setSourceFile( const QString &htmlFile )
   emit appearanceChanged();
 }
 
+void QgsHtmlAnnotation::setHtmlSource( const QString &htmlSource )
+{
+  mHtmlFile.clear();
+  mHtmlSource = htmlSource;
+  setAssociatedFeature( associatedFeature() );
+  emit appearanceChanged();
+}
+
 void QgsHtmlAnnotation::renderAnnotation( QgsRenderContext &context, QSizeF size ) const
 {
   if ( !context.painter() )
@@ -112,7 +120,14 @@ QSizeF QgsHtmlAnnotation::minimumFrameSize() const
 void QgsHtmlAnnotation::writeXml( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const
 {
   QDomElement formAnnotationElem = doc.createElement( QStringLiteral( "HtmlAnnotationItem" ) );
-  formAnnotationElem.setAttribute( QStringLiteral( "htmlfile" ), sourceFile() );
+  if ( !mHtmlFile.isEmpty() )
+  {
+    formAnnotationElem.setAttribute( QStringLiteral( "htmlfile" ), sourceFile() );
+  }
+  else
+  {
+    formAnnotationElem.setAttribute( QStringLiteral( "htmlsource" ), mHtmlSource );
+  }
 
   _writeXml( formAnnotationElem, doc, context );
   elem.appendChild( formAnnotationElem );
@@ -120,7 +135,6 @@ void QgsHtmlAnnotation::writeXml( QDomElement &elem, QDomDocument &doc, const Qg
 
 void QgsHtmlAnnotation::readXml( const QDomElement &itemElem, const QgsReadWriteContext &context )
 {
-  mHtmlFile = itemElem.attribute( QStringLiteral( "htmlfile" ), QString() );
   QDomElement annotationElem = itemElem.firstChildElement( QStringLiteral( "AnnotationItem" ) );
   if ( !annotationElem.isNull() )
   {
@@ -135,7 +149,15 @@ void QgsHtmlAnnotation::readXml( const QDomElement &itemElem, const QgsReadWrite
 
   if ( mWebPage )
   {
-    setSourceFile( mHtmlFile );
+    mHtmlFile = itemElem.attribute( QStringLiteral( "htmlfile" ), QString() );
+    if ( !mHtmlFile.isEmpty() )
+    {
+      setSourceFile( mHtmlFile );
+    }
+    else
+    {
+      setHtmlSource( itemElem.attribute( QStringLiteral( "htmlsource" ), QString() ) );
+    }
   }
 }
 

--- a/src/core/annotations/qgshtmlannotation.h
+++ b/src/core/annotations/qgshtmlannotation.h
@@ -58,6 +58,17 @@ class CORE_EXPORT QgsHtmlAnnotation: public QgsAnnotation
      */
     QString sourceFile() const { return mHtmlFile; }
 
+    /**
+     * Sets the html source directly (not coming from a file)
+     * \param htmlSource
+     */
+    void setHtmlSource( const QString &htmlSource );
+
+    /**
+     * Returns html source text
+     */
+    QString htmlSource() const { return mHtmlSource; }
+
     void writeXml( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &itemElem, const QgsReadWriteContext &context ) override;
 

--- a/src/ui/qgsformannotationdialogbase.ui
+++ b/src/ui/qgsformannotationdialogbase.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QPlainTextEdit" name="mHtmlSourceTextEdit"/>
+    <widget class="QgsCodeEditorHTML" name="mHtmlSourceTextEdit"/>
    </item>
    <item row="1" column="0">
     <widget class="QRadioButton" name="mSourceRadioButton">
@@ -101,4 +101,11 @@
    </hints>
   </connection>
  </connections>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCodeEditorHTML</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorhtml.h</header>
+  </customwidget>
+</customwidgets>
 </ui>

--- a/src/ui/qgsformannotationdialogbase.ui
+++ b/src/ui/qgsformannotationdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>298</width>
-    <height>134</height>
+    <width>433</width>
+    <height>246</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,16 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="mFileRadioButton">
+       <property name="text">
+        <string>File</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QLineEdit" name="mFileLineEdit"/>
      </item>
@@ -28,19 +38,29 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
+   <item row="3" column="0">
     <widget class="QStackedWidget" name="mStackedWidget">
      <widget class="QWidget" name="page"/>
      <widget class="QWidget" name="page_2"/>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="4" column="0">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QPlainTextEdit" name="mHtmlSourceTextEdit"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="mSourceRadioButton">
+     <property name="text">
+      <string>Source</string>
      </property>
     </widget>
    </item>

--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -135,6 +135,19 @@ class TestQgsAnnotation(unittest.TestCase):
         im = self.renderAnnotation(clone, QPointF(20, 30))
         self.assertTrue(self.imageCheck('html_annotation', 'html_annotation', im))
 
+    def testHtmlAnnotationSetHtmlSource(self):
+        """ test rendering html annotation where the html is set directly (not from file)"""
+        a = QgsHtmlAnnotation()
+        a.fillSymbol().symbolLayer(0).setStrokeColor(QColor(0, 0, 0))
+        a.markerSymbol().symbolLayer(0).setStrokeColor(QColor(0, 0, 0))
+        a.setFrameSizeMm(QSizeF(400 / 3.7795275, 250 / 3.7795275))
+        a.setFrameOffsetFromReferencePointMm(QPointF(70 / 3.7795275, 90 / 3.7795275))
+        htmlFile = open( TEST_DATA_DIR + "/test_html.html" )
+        htmlText = htmlFile.read()
+        a.setHtmlSource( htmlText )
+        im = self.renderAnnotation(a, QPointF(20, 30))
+        self.assertTrue(self.imageCheck('html_annotation_html_source', 'html_annotation', im))
+
     def testHtmlAnnotationInLayout(self):
         """ test rendering a svg annotation"""
         a = QgsHtmlAnnotation()
@@ -145,6 +158,7 @@ class TestQgsAnnotation(unittest.TestCase):
         html = TEST_DATA_DIR + "/test_html.html"
         a.setSourceFile(html)
         self.assertTrue(self.renderAnnotationInLayout('html_annotation_in_layout', a))
+
 
     def testHtmlAnnotationWithFeature(self):
         """ test rendering a html annotation with a feature"""

--- a/tests/src/python/test_qgsannotation.py
+++ b/tests/src/python/test_qgsannotation.py
@@ -142,9 +142,9 @@ class TestQgsAnnotation(unittest.TestCase):
         a.markerSymbol().symbolLayer(0).setStrokeColor(QColor(0, 0, 0))
         a.setFrameSizeMm(QSizeF(400 / 3.7795275, 250 / 3.7795275))
         a.setFrameOffsetFromReferencePointMm(QPointF(70 / 3.7795275, 90 / 3.7795275))
-        htmlFile = open( TEST_DATA_DIR + "/test_html.html" )
+        htmlFile = open(TEST_DATA_DIR + "/test_html.html")
         htmlText = htmlFile.read()
-        a.setHtmlSource( htmlText )
+        a.setHtmlSource(htmlText)
         im = self.renderAnnotation(a, QPointF(20, 30))
         self.assertTrue(self.imageCheck('html_annotation_html_source', 'html_annotation', im))
 
@@ -158,7 +158,6 @@ class TestQgsAnnotation(unittest.TestCase):
         html = TEST_DATA_DIR + "/test_html.html"
         a.setSourceFile(html)
         self.assertTrue(self.renderAnnotationInLayout('html_annotation_in_layout', a))
-
 
     def testHtmlAnnotationWithFeature(self):
         """ test rendering a html annotation with a feature"""


### PR DESCRIPTION
In the html annotation item dialog, it is possible to select an html file. For the use in QGIS Server, it would be nice to have the possibility to insert the html text directly and to store the html text in the project file. This PR adds this feature.

![annotation_inline_html](https://user-images.githubusercontent.com/278939/124386039-95d8eb80-dcd8-11eb-9267-8ae8c7cd16b1.jpg)
