### PR TITLE
PostgreSQL provider: use bounding box column to compute extent

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3744,7 +3744,7 @@ QgsRectangle QgsPostgresProvider::extent() const
     {
       sql = QStringLiteral( "SELECT %1(%2%3) FROM %4%5" )
             .arg( connectionRO()->majorVersion() < 2 ? "extent" : "st_extent",
-                  quotedIdentifier( mGeometryColumn ),
+                  quotedIdentifier( mBoundingBoxColumn ),
                   mSpatialColType == SctPcPatch ? "::geometry" : "",
                   mQuery,
                   filterWhereClause() );


### PR DESCRIPTION
Speeds up extent computation when custom indexed bbox column is
given. References #43835
