### PR TITLE
Restore forced rasterization of whole layout map item when a layer has opacity set for Qt < 5.15

### DIFF
--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -54,6 +54,13 @@ QStringList QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSettings &
       // if vector layer, check labels and feature blend mode
       if ( QgsVectorLayer *currentVectorLayer = qobject_cast<QgsVectorLayer *>( layer ) )
       {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+        // Qt < 5.15 does not correctly support layer level opacity in PDF exports -- see https://github.com/qgis/QGIS/issues/42698
+        if ( !qgsDoubleNear( currentVectorLayer->opacity(), 1.0 ) && !( flags & EffectsCheckFlag::IgnoreGeoPdfSupportedEffects ) )
+        {
+          layers << layer->name();
+        }
+#endif
         if ( currentVectorLayer->featureBlendMode() != QPainter::CompositionMode_SourceOver )
         {
           layers << layer->name();

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -96,7 +96,12 @@ void TestQgsMapSettingsUtils::containsAdvancedEffects()
   // changing an individual layer's opacity is OK -- we don't want to force the whole map to be rasterized just because of this setting!
   // (just let that one layer get exported as raster instead)
   layer->setOpacity( 0.5 );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  // this only works on Qt 5.15 or later -- see https://github.com/qgis/QGIS/issues/42698
   QCOMPARE( QgsMapSettingsUtils::containsAdvancedEffects( mapSettings ).size(), 0 );
+#else
+  QCOMPARE( QgsMapSettingsUtils::containsAdvancedEffects( mapSettings ).size(), 1 );
+#endif
   QCOMPARE( QgsMapSettingsUtils::containsAdvancedEffects( mapSettings, QgsMapSettingsUtils::EffectsCheckFlag::IgnoreGeoPdfSupportedEffects ).size(), 0 );
 }
 


### PR DESCRIPTION
Workarounds bugs in the PDF export for these earlier versions

Fixes #42698
