### PR TITLE
Improve QgsRasterPipe docs, promote enums to enum class in Qgis namespace

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -338,3 +338,43 @@ Qgis.SublayerQueryFlag.CountFeatures.__doc__ = "Count features in vector sublaye
 Qgis.SublayerQueryFlag.__doc__ = 'Flags which control how data providers will scan for sublayers in a dataset.\n\n.. versionadded:: 3.22\n\n' + '* ``FastScan``: ' + Qgis.SublayerQueryFlag.FastScan.__doc__ + '\n' + '* ``ResolveGeometryType``: ' + Qgis.SublayerQueryFlag.ResolveGeometryType.__doc__ + '\n' + '* ``CountFeatures``: ' + Qgis.SublayerQueryFlag.CountFeatures.__doc__
 # --
 Qgis.SublayerQueryFlag.baseClass = Qgis
+QgsRasterPipe.Role = Qgis.RasterPipeInterfaceRole
+# monkey patching scoped based enum
+QgsRasterPipe.UnknownRole = Qgis.RasterPipeInterfaceRole.Unknown
+QgsRasterPipe.UnknownRole.is_monkey_patched = True
+QgsRasterPipe.UnknownRole.__doc__ = "Unknown role"
+QgsRasterPipe.ProviderRole = Qgis.RasterPipeInterfaceRole.Provider
+QgsRasterPipe.ProviderRole.is_monkey_patched = True
+QgsRasterPipe.ProviderRole.__doc__ = "Data provider role"
+QgsRasterPipe.RendererRole = Qgis.RasterPipeInterfaceRole.Renderer
+QgsRasterPipe.RendererRole.is_monkey_patched = True
+QgsRasterPipe.RendererRole.__doc__ = "Raster renderer role"
+QgsRasterPipe.BrightnessRole = Qgis.RasterPipeInterfaceRole.Brightness
+QgsRasterPipe.BrightnessRole.is_monkey_patched = True
+QgsRasterPipe.BrightnessRole.__doc__ = "Brightness filter role"
+QgsRasterPipe.ResamplerRole = Qgis.RasterPipeInterfaceRole.Resampler
+QgsRasterPipe.ResamplerRole.is_monkey_patched = True
+QgsRasterPipe.ResamplerRole.__doc__ = "Resampler role"
+QgsRasterPipe.ProjectorRole = Qgis.RasterPipeInterfaceRole.Projector
+QgsRasterPipe.ProjectorRole.is_monkey_patched = True
+QgsRasterPipe.ProjectorRole.__doc__ = "Projector role"
+QgsRasterPipe.NullerRole = Qgis.RasterPipeInterfaceRole.Nuller
+QgsRasterPipe.NullerRole.is_monkey_patched = True
+QgsRasterPipe.NullerRole.__doc__ = "Raster nuller role"
+QgsRasterPipe.HueSaturationRole = Qgis.RasterPipeInterfaceRole.HueSaturation
+QgsRasterPipe.HueSaturationRole.is_monkey_patched = True
+QgsRasterPipe.HueSaturationRole.__doc__ = "Hue/saturation filter role"
+Qgis.RasterPipeInterfaceRole.__doc__ = 'Raster pipe interface roles.\n\n.. versionadded:: 3.22\n\n' + '* ``UnknownRole``: ' + Qgis.RasterPipeInterfaceRole.Unknown.__doc__ + '\n' + '* ``ProviderRole``: ' + Qgis.RasterPipeInterfaceRole.Provider.__doc__ + '\n' + '* ``RendererRole``: ' + Qgis.RasterPipeInterfaceRole.Renderer.__doc__ + '\n' + '* ``BrightnessRole``: ' + Qgis.RasterPipeInterfaceRole.Brightness.__doc__ + '\n' + '* ``ResamplerRole``: ' + Qgis.RasterPipeInterfaceRole.Resampler.__doc__ + '\n' + '* ``ProjectorRole``: ' + Qgis.RasterPipeInterfaceRole.Projector.__doc__ + '\n' + '* ``NullerRole``: ' + Qgis.RasterPipeInterfaceRole.Nuller.__doc__ + '\n' + '* ``HueSaturationRole``: ' + Qgis.RasterPipeInterfaceRole.HueSaturation.__doc__
+# --
+Qgis.RasterPipeInterfaceRole.baseClass = Qgis
+QgsRasterPipe.ResamplingStage = Qgis.RasterResamplingStage
+# monkey patching scoped based enum
+QgsRasterPipe.ResampleFilter = Qgis.RasterResamplingStage.ResampleFilter
+QgsRasterPipe.ResampleFilter.is_monkey_patched = True
+QgsRasterPipe.ResampleFilter.__doc__ = ""
+QgsRasterPipe.Provider = Qgis.RasterResamplingStage.Provider
+QgsRasterPipe.Provider.is_monkey_patched = True
+QgsRasterPipe.Provider.__doc__ = ""
+Qgis.RasterResamplingStage.__doc__ = 'Stage at which raster resampling occurs.\n\n.. versionadded:: 3.22\n\n' + '* ``ResampleFilter``: ' + Qgis.RasterResamplingStage.ResampleFilter.__doc__ + '\n' + '* ``Provider``: ' + Qgis.RasterResamplingStage.Provider.__doc__
+# --
+Qgis.RasterResamplingStage.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -363,7 +363,7 @@ QgsRasterPipe.NullerRole.is_monkey_patched = True
 QgsRasterPipe.NullerRole.__doc__ = "Raster nuller role"
 QgsRasterPipe.HueSaturationRole = Qgis.RasterPipeInterfaceRole.HueSaturation
 QgsRasterPipe.HueSaturationRole.is_monkey_patched = True
-QgsRasterPipe.HueSaturationRole.__doc__ = "Hue/saturation filter role"
+QgsRasterPipe.HueSaturationRole.__doc__ = "Hue/saturation filter role (also applies grayscale/color inversion)"
 Qgis.RasterPipeInterfaceRole.__doc__ = 'Raster pipe interface roles.\n\n.. versionadded:: 3.22\n\n' + '* ``UnknownRole``: ' + Qgis.RasterPipeInterfaceRole.Unknown.__doc__ + '\n' + '* ``ProviderRole``: ' + Qgis.RasterPipeInterfaceRole.Provider.__doc__ + '\n' + '* ``RendererRole``: ' + Qgis.RasterPipeInterfaceRole.Renderer.__doc__ + '\n' + '* ``BrightnessRole``: ' + Qgis.RasterPipeInterfaceRole.Brightness.__doc__ + '\n' + '* ``ResamplerRole``: ' + Qgis.RasterPipeInterfaceRole.Resampler.__doc__ + '\n' + '* ``ProjectorRole``: ' + Qgis.RasterPipeInterfaceRole.Projector.__doc__ + '\n' + '* ``NullerRole``: ' + Qgis.RasterPipeInterfaceRole.Nuller.__doc__ + '\n' + '* ``HueSaturationRole``: ' + Qgis.RasterPipeInterfaceRole.HueSaturation.__doc__
 # --
 Qgis.RasterPipeInterfaceRole.baseClass = Qgis

--- a/python/core/auto_additions/qgsrasterpipe.py
+++ b/python/core/auto_additions/qgsrasterpipe.py
@@ -1,6 +1,0 @@
-# The following has been generated automatically from src/core/raster/qgsrasterpipe.h
-# monkey patching scoped based enum
-QgsRasterPipe.ResamplingStage.ResampleFilter.__doc__ = ""
-QgsRasterPipe.ResamplingStage.Provider.__doc__ = ""
-QgsRasterPipe.ResamplingStage.__doc__ = 'Stage at which resampling occurs.\n\n.. versionadded:: 3.16\n\n' + '* ``ResampleFilter``: ' + QgsRasterPipe.ResamplingStage.ResampleFilter.__doc__ + '\n' + '* ``Provider``: ' + QgsRasterPipe.ResamplingStage.Provider.__doc__
-# --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -251,6 +251,26 @@ The development version
     typedef QFlags<Qgis::SublayerQueryFlag> SublayerQueryFlags;
 
 
+    enum class RasterPipeInterfaceRole
+      {
+      Unknown,
+      Provider,
+      Renderer,
+      Brightness,
+      Resampler,
+      Projector,
+      Nuller,
+      HueSaturation,
+    };
+
+    enum class RasterResamplingStage
+      {
+      //! Resampling occurs in ResamplingFilter
+      ResampleFilter,
+      //! Resampling occurs in Provider
+      Provider
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsRasterFileWriterTask : QgsTask
 {
 %Docstring(signature="appended")
@@ -56,6 +57,8 @@ coordinate ``transformContext`` .
 Ownership of the ``pipe`` is transferred to the writer task, and will
 be deleted when the task completes.
 %End
+
+    ~QgsRasterFileWriterTask();
 
     virtual void cancel();
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -204,7 +204,7 @@ Returns the raster's hue/saturation filter.
 .. seealso:: :py:func:`brightnessFilter`
 %End
 
-    void setResamplingStage( QgsRasterPipe::ResamplingStage stage );
+    void setResamplingStage( Qgis::RasterResamplingStage stage );
 %Docstring
 Select which stage of the pipe should apply resampling.
 
@@ -213,7 +213,7 @@ Select which stage of the pipe should apply resampling.
 .. versionadded:: 3.16
 %End
 
-    QgsRasterPipe::ResamplingStage resamplingStage() const;
+    Qgis::RasterResamplingStage resamplingStage() const;
 %Docstring
 Returns which stage of the pipe should apply resampling.
 

--- a/python/core/auto_generated/raster/qgsrasterpipe.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterpipe.sip.in
@@ -14,13 +14,14 @@
 class QgsRasterPipe
 {
 %Docstring(signature="appended")
-Base class for processing modules.
+Contains a pipeline of raster interfaces for sequential raster processing.
 %End
 
 %TypeHeaderCode
 #include "qgsrasterpipe.h"
 %End
   public:
+
     enum Role
     {
       UnknownRole,
@@ -35,7 +36,7 @@ Base class for processing modules.
 
     QgsRasterPipe();
 %Docstring
-Constructor for QgsRasterPipe.
+Constructor for an empty QgsRasterPipe.
 %End
 
 
@@ -44,8 +45,12 @@ Constructor for QgsRasterPipe.
 
     bool insert( int idx, QgsRasterInterface *interface /Transfer/ );
 %Docstring
-Try to insert interface at specified index and connect
+Attempts to insert interface at specified index and connect
 if connection would fail, the interface is not inserted and ``False`` is returned
+
+.. seealso:: :py:func:`set`
+
+.. seealso:: :py:func:`replace`
 %End
 %MethodCode
     sipRes = sipCpp->insert( a0, a1 );
@@ -60,51 +65,115 @@ if connection would fail, the interface is not inserted and ``False`` is returne
 
     bool replace( int idx, QgsRasterInterface *interface /Transfer/ );
 %Docstring
-Try to replace interface at specified index and connect
-if connection would fail, the interface is not inserted and ``False`` is returned
+Attempts to replace the interface at specified index and reconnect the pipe.
+
+If the connection would fail, the interface is not inserted and ``False`` is returned.
+
+.. seealso:: :py:func:`insert`
+
+.. seealso:: :py:func:`set`
 %End
 
     bool set( QgsRasterInterface *interface /Transfer/ );
 %Docstring
-Insert a new known interface in default place or replace interface of the same
-role if it already exists. Known interfaces are: :py:class:`QgsRasterDataProvider`,
-:py:class:`QgsRasterRenderer`, :py:class:`QgsRasterResampleFilter`, :py:class:`QgsRasterProjector` and their
-subclasses. For unknown interfaces it mus be explicitly specified position
-where it should be inserted using :py:func:`~QgsRasterPipe.insert` method.
+Inserts a new known interface in default place or replace interface of the same
+role if it already exists.
+
+Known interfaces are:
+
+- :py:class:`QgsRasterDataProvider`,
+- :py:class:`QgsRasterRenderer`
+- :py:class:`QgsRasterResampleFilter`
+- :py:class:`QgsRasterProjector`
+- :py:class:`QgsHueSaturationFilter`
+- :py:class:`QgsBrightnessContrastFilter`
+
+(and their subclasses).
+
+For other interfaces the position of the interface in the pipe must be explicitly
+specified using the :py:func:`~QgsRasterPipe.insert` method.
+
+.. seealso:: :py:func:`insert`
+
+.. seealso:: :py:func:`replace`
 %End
 
     bool remove( int idx );
 %Docstring
-Remove and delete interface at given index if possible
+Removes and deletes the interface at given index (if possible).
+
+Returns ``True`` if the interface was successfully removed.
 %End
 
     bool remove( QgsRasterInterface *interface );
 %Docstring
-Remove and delete interface from pipe if possible
+Removes and deletes interface from pipe (if possible).
+
+Returns ``True`` if the interface was successfully removed.
 %End
 
     int size() const;
+%Docstring
+Returns the size of the pipe (the number of interfaces contained in the pipe).
+%End
+
     QgsRasterInterface *at( int idx ) const;
+%Docstring
+Returns the interface at the specified index.
+%End
+
     QgsRasterInterface *last() const;
+%Docstring
+Returns last interface in the pipe.
+%End
 
     bool setOn( int idx, bool on );
 %Docstring
-Set interface at index on/off
-Returns ``True`` on success
+Set whether the interface at the specified index is enabled.
+
+Returns ``True`` on success.
 %End
 
     bool canSetOn( int idx, bool on );
 %Docstring
-Test if interface at index may be switched on/off
+Returns ``True`` if the interface at the specified index may be switched on or off.
 %End
 
+
     QgsRasterDataProvider *provider() const;
+%Docstring
+Returns the data provider interface, or ``None`` if no data provider is present in the pipe.
+%End
+
     QgsRasterRenderer *renderer() const;
+%Docstring
+Returns the raster renderer interface, or ``None`` if no raster renderer is present in the pipe.
+%End
+
     QgsRasterResampleFilter *resampleFilter() const;
+%Docstring
+Returns the resample filter interface, or ``None`` if no resample filter is present in the pipe.
+%End
+
     QgsBrightnessContrastFilter *brightnessFilter() const;
+%Docstring
+Returns the brightness filter interface, or ``None`` if no brightness filter is present in the pipe.
+%End
+
     QgsHueSaturationFilter *hueSaturationFilter() const;
+%Docstring
+Returns the hue/saturation interface, or ``None`` if no hue/saturation filter is present in the pipe.
+%End
+
     QgsRasterProjector *projector() const;
+%Docstring
+Returns the projector interface, or ``None`` if no projector is present in the pipe.
+%End
+
     QgsRasterNuller *nuller() const;
+%Docstring
+Returns the raster nuller interface, or ``None`` if no raster nuller is present in the pipe.
+%End
 
     enum class ResamplingStage
     {
@@ -116,10 +185,12 @@ Test if interface at index may be switched on/off
 
     void setResamplingStage( ResamplingStage stage );
 %Docstring
-Select which stage of the pipe should apply resampling.
+Sets which stage of the pipe should apply resampling.
 
 Provider resampling is only supported if provider sets
 ProviderHintCanPerformProviderResampling in :py:func:`~QgsRasterPipe.providerCapabilities`.
+
+.. seealso:: :py:func:`resamplingStage`
 
 .. versionadded:: 3.16
 %End
@@ -127,6 +198,8 @@ ProviderHintCanPerformProviderResampling in :py:func:`~QgsRasterPipe.providerCap
     ResamplingStage resamplingStage() const;
 %Docstring
 Returns which stage of the pipe should apply resampling
+
+.. seealso:: :py:func:`setResamplingStage`
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/raster/qgsrasterpipe.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterpipe.sip.in
@@ -22,18 +22,6 @@ Contains a pipeline of raster interfaces for sequential raster processing.
 %End
   public:
 
-    enum Role
-    {
-      UnknownRole,
-      ProviderRole,
-      RendererRole,
-      BrightnessRole,
-      ResamplerRole,
-      ProjectorRole,
-      NullerRole,
-      HueSaturationRole,
-    };
-
     QgsRasterPipe();
 %Docstring
 Constructor for an empty QgsRasterPipe.
@@ -175,15 +163,7 @@ Returns the projector interface, or ``None`` if no projector is present in the p
 Returns the raster nuller interface, or ``None`` if no raster nuller is present in the pipe.
 %End
 
-    enum class ResamplingStage
-    {
-      //! Resampling occurs in ResamplingFilter
-      ResampleFilter,
-      //! Resampling occurs in Provider
-      Provider
-    };
-
-    void setResamplingStage( ResamplingStage stage );
+    void setResamplingStage( Qgis::RasterResamplingStage stage );
 %Docstring
 Sets which stage of the pipe should apply resampling.
 
@@ -195,7 +175,7 @@ ProviderHintCanPerformProviderResampling in :py:func:`~QgsRasterPipe.providerCap
 .. versionadded:: 3.16
 %End
 
-    ResamplingStage resamplingStage() const;
+    Qgis::RasterResamplingStage resamplingStage() const;
 %Docstring
 Returns which stage of the pipe should apply resampling
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -259,6 +259,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewnocrsindicator.h"
 #include "qgslayertreeviewtemporalindicator.h"
 #include "qgslayertreeviewofflineindicator.h"
+#include "qgsrasterpipe.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
 #include "qgslayoutcustomdrophandler.h"

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -385,7 +385,7 @@ class CORE_EXPORT Qgis
       Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
       Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
       Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
-      HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role
+      HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role (also applies grayscale/color inversion)
     };
     Q_ENUM( RasterPipeInterfaceRole )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -372,6 +372,37 @@ class CORE_EXPORT Qgis
     Q_ENUM( SublayerQueryFlag )
 
     /**
+     * Raster pipe interface roles.
+     *
+     * \since QGIS 3.22
+     */
+    enum class RasterPipeInterfaceRole SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, Role ) : int
+      {
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownRole ) = 0, //!< Unknown role
+      Provider SIP_MONKEYPATCH_COMPAT_NAME( ProviderRole ) = 1, //!< Data provider role
+      Renderer SIP_MONKEYPATCH_COMPAT_NAME( RendererRole ) = 2, //!< Raster renderer role
+      Brightness SIP_MONKEYPATCH_COMPAT_NAME( BrightnessRole ) = 3, //!< Brightness filter role
+      Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
+      Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
+      Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
+      HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role
+    };
+    Q_ENUM( RasterPipeInterfaceRole )
+
+    /**
+     * Stage at which raster resampling occurs.
+     * \since QGIS 3.22
+     */
+    enum class RasterResamplingStage SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, ResamplingStage ) : int
+      {
+      //! Resampling occurs in ResamplingFilter
+      ResampleFilter,
+      //! Resampling occurs in Provider
+      Provider
+    };
+    Q_ENUM( RasterResamplingStage )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -25,6 +25,7 @@
 #include "qgsrasterdataprovider.h"
 #include "qgsrasternuller.h"
 #include "qgsreadwritelocker.h"
+#include "qgsrasterpipe.h"
 
 #include <QCoreApplication>
 #include <QProgressDialog>

--- a/src/core/raster/qgsrasterfilewritertask.cpp
+++ b/src/core/raster/qgsrasterfilewritertask.cpp
@@ -18,6 +18,7 @@
 #include "qgsrasterfilewritertask.h"
 #include "qgsrasterinterface.h"
 #include "qgsrasterdataprovider.h"
+#include "qgsrasterpipe.h"
 
 // Deprecated!
 QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe, int columns, int rows,
@@ -42,6 +43,8 @@ QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &wri
   , mTransformContext( transformContext )
 {
 }
+
+QgsRasterFileWriterTask::~QgsRasterFileWriterTask() = default;
 
 void QgsRasterFileWriterTask::cancel()
 {

--- a/src/core/raster/qgsrasterfilewritertask.h
+++ b/src/core/raster/qgsrasterfilewritertask.h
@@ -23,7 +23,8 @@
 #include "qgsrasterfilewriter.h"
 #include "qgscoordinatetransformcontext.h"
 #include "qgsrasterinterface.h"
-#include "qgsrasterpipe.h"
+
+class QgsRasterPipe;
 
 /**
  * \class QgsRasterFileWriterTask
@@ -67,6 +68,8 @@ class CORE_EXPORT QgsRasterFileWriterTask : public QgsTask
                              const QgsCoordinateReferenceSystem &crs,
                              const QgsCoordinateTransformContext &transformContext
                            );
+
+    ~QgsRasterFileWriterTask() override;
 
     void cancel() override;
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -57,6 +57,7 @@ email                : tim at linfiniti.com
 #include "qgsrasterlayertemporalproperties.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsmaplayerfactory.h"
+#include "qgsrasterpipe.h"
 
 #include <cmath>
 #include <cstdio>
@@ -105,6 +106,7 @@ QgsRasterLayer::QgsRasterLayer()
   , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
   , TRSTRING_NOT_SET( tr( "Not Set" ) )
   , mTemporalProperties( new QgsRasterLayerTemporalProperties( this ) )
+  , mPipe( std::make_unique< QgsRasterPipe >() )
 
 {
   init();
@@ -120,6 +122,7 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
   , TRSTRING_NOT_SET( tr( "Not Set" ) )
   , mTemporalProperties( new QgsRasterLayerTemporalProperties( this ) )
+  , mPipe( std::make_unique< QgsRasterPipe >() )
 {
   mShouldValidateCrs = !options.skipCrsValidation;
 
@@ -160,10 +163,10 @@ QgsRasterLayer *QgsRasterLayer::clone() const
   QgsMapLayer::clone( layer );
 
   // do not clone data provider which is the first element in pipe
-  for ( int i = 1; i < mPipe.size(); i++ )
+  for ( int i = 1; i < mPipe->size(); i++ )
   {
-    if ( mPipe.at( i ) )
-      layer->pipe()->set( mPipe.at( i )->clone() );
+    if ( mPipe->at( i ) )
+      layer->pipe()->set( mPipe->at( i )->clone() );
   }
 
   return layer;
@@ -274,9 +277,9 @@ void QgsRasterLayer::draw( QPainter *theQPainter,
   // procedure to use :
   //
 
-  QgsRasterProjector *projector = mPipe.projector();
+  QgsRasterProjector *projector = mPipe->projector();
   bool restoreOldResamplingStage = false;
-  QgsRasterPipe::ResamplingStage oldResamplingState = resamplingStage();
+  Qgis::RasterResamplingStage oldResamplingState = resamplingStage();
   // TODO add a method to interface to get provider and get provider
   // params in QgsRasterProjector
 
@@ -286,16 +289,16 @@ void QgsRasterLayer::draw( QPainter *theQPainter,
     if ( mDataProvider != nullptr &&
          ( mDataProvider->providerCapabilities() & QgsRasterDataProvider::ProviderHintCanPerformProviderResampling ) &&
          rasterViewPort->mSrcCRS != rasterViewPort->mDestCRS &&
-         oldResamplingState != QgsRasterPipe::ResamplingStage::Provider )
+         oldResamplingState != Qgis::RasterResamplingStage::Provider )
     {
       restoreOldResamplingStage = true;
-      setResamplingStage( QgsRasterPipe::ResamplingStage::Provider );
+      setResamplingStage( Qgis::RasterResamplingStage::Provider );
     }
     projector->setCrs( rasterViewPort->mSrcCRS, rasterViewPort->mDestCRS, rasterViewPort->mTransformContext );
   }
 
   // Drawer to pipe?
-  QgsRasterIterator iterator( mPipe.last() );
+  QgsRasterIterator iterator( mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( theQPainter, rasterViewPort, qgsMapToPixel );
 
@@ -309,7 +312,7 @@ void QgsRasterLayer::draw( QPainter *theQPainter,
 
 QgsLegendColorList QgsRasterLayer::legendSymbologyItems() const
 {
-  QgsRasterRenderer *renderer = mPipe.renderer();
+  QgsRasterRenderer *renderer = mPipe->renderer();
   return renderer ? renderer->legendSymbologyItems() : QList< QPair< QString, QColor > >();;
 }
 
@@ -593,17 +596,17 @@ double QgsRasterLayer::rasterUnitsPerPixelY() const
 
 void QgsRasterLayer::setOpacity( double opacity )
 {
-  if ( !mPipe.renderer() || mPipe.renderer()->opacity() == opacity )
+  if ( !mPipe->renderer() || mPipe->renderer()->opacity() == opacity )
     return;
 
-  mPipe.renderer()->setOpacity( opacity );
+  mPipe->renderer()->setOpacity( opacity );
   emit opacityChanged( opacity );
   emitStyleChanged();
 }
 
 double QgsRasterLayer::opacity() const
 {
-  return mPipe.renderer() ? mPipe.renderer()->opacity() : 1.0;
+  return mPipe->renderer() ? mPipe->renderer()->opacity() : 1.0;
 }
 
 void QgsRasterLayer::init()
@@ -624,7 +627,7 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   setValid( false ); // assume the layer is invalid until we determine otherwise
 
-  mPipe.remove( mDataProvider ); // deletes if exists
+  mPipe->remove( mDataProvider ); // deletes if exists
   mDataProvider = nullptr;
 
   // XXX should I check for and possibly delete any pre-existing providers?
@@ -654,7 +657,7 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   mDataProvider->setParent( this );
 
   // Set data provider into pipe even if not valid so that it is deleted with pipe (with layer)
-  mPipe.set( mDataProvider );
+  mPipe->set( mDataProvider );
   if ( !mDataProvider->isValid() )
   {
     setError( mDataProvider->error() );
@@ -776,7 +779,7 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   {
     if ( mDataProvider->colorInterpretation( bandNo ) == QgsRaster::AlphaBand )
     {
-      if ( auto *lRenderer = mPipe.renderer() )
+      if ( auto *lRenderer = mPipe->renderer() )
       {
         lRenderer->setAlphaBand( bandNo );
       }
@@ -786,15 +789,15 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
 
   // brightness filter
   QgsBrightnessContrastFilter *brightnessFilter = new QgsBrightnessContrastFilter();
-  mPipe.set( brightnessFilter );
+  mPipe->set( brightnessFilter );
 
   // hue/saturation filter
   QgsHueSaturationFilter *hueSaturationFilter = new QgsHueSaturationFilter();
-  mPipe.set( hueSaturationFilter );
+  mPipe->set( hueSaturationFilter );
 
   // resampler (must be after renderer)
   QgsRasterResampleFilter *resampleFilter = new QgsRasterResampleFilter();
-  mPipe.set( resampleFilter );
+  mPipe->set( resampleFilter );
 
   if ( mDataProvider->providerCapabilities() & QgsRasterDataProvider::ProviderHintBenefitsFromResampling )
   {
@@ -824,17 +827,17 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
     if ( ( mDataProvider->providerCapabilities() & QgsRasterDataProvider::ProviderHintCanPerformProviderResampling ) &&
          settings.value( QStringLiteral( "/Raster/defaultEarlyResampling" ), false ).toBool() )
     {
-      setResamplingStage( QgsRasterPipe::ResamplingStage::Provider );
+      setResamplingStage( Qgis::RasterResamplingStage::Provider );
     }
     else
     {
-      setResamplingStage( QgsRasterPipe::ResamplingStage::ResampleFilter );
+      setResamplingStage( Qgis::RasterResamplingStage::ResampleFilter );
     }
   }
 
   // projector (may be anywhere in pipe)
   QgsRasterProjector *projector = new QgsRasterProjector;
-  mPipe.set( projector );
+  mPipe->set( projector );
 
   // Set default identify format - use the richest format available
   int capabilities = mDataProvider->capabilities();
@@ -923,9 +926,9 @@ void QgsRasterLayer::setDataSourcePrivate( const QString &dataSource, const QStr
 
   init();
 
-  for ( int i = mPipe.size() - 1; i >= 0; --i )
+  for ( int i = mPipe->size() - 1; i >= 0; --i )
   {
-    mPipe.remove( i );
+    mPipe->remove( i );
   }
 
   mDataSource = dataSource;
@@ -974,7 +977,7 @@ void QgsRasterLayer::setDataSourcePrivate( const QString &dataSource, const QStr
 void QgsRasterLayer::closeDataProvider()
 {
   setValid( false );
-  mPipe.remove( mDataProvider );
+  mPipe->remove( mDataProvider );
   mDataProvider = nullptr;
 }
 
@@ -1092,7 +1095,7 @@ void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnh
                           extent,
                           sampleSize,
                           generateLookupTableFlag,
-                          mPipe.renderer() );
+                          mPipe->renderer() );
 }
 
 void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm,
@@ -1521,7 +1524,7 @@ QDateTime QgsRasterLayer::timestamp() const
 
 bool QgsRasterLayer::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
-  if ( auto *lRenderer = mPipe.renderer() )
+  if ( auto *lRenderer = mPipe->renderer() )
   {
     if ( !lRenderer->accept( visitor ) )
       return false;
@@ -1609,7 +1612,7 @@ bool QgsRasterLayer::writeSld( QDomNode &node, QDomDocument &doc, QString &error
     }
 
     // export renderer dependent tags
-    mPipe.renderer()->toSld( doc, typeStyleRuleElem, localProps );
+    mPipe->renderer()->toSld( doc, typeStyleRuleElem, localProps );
 
     // inject raster layer parameters in RasterSymbolizer tag because
     // they belongs to rasterlayer and not to the renderer => avoid to
@@ -1746,9 +1749,29 @@ void QgsRasterLayer::setRenderer( QgsRasterRenderer *renderer )
     return;
   }
 
-  mPipe.set( renderer );
+  mPipe->set( renderer );
   emit rendererChanged();
   emitStyleChanged();
+}
+
+QgsRasterRenderer *QgsRasterLayer::renderer() const
+{
+  return mPipe->renderer();
+}
+
+QgsRasterResampleFilter *QgsRasterLayer::resampleFilter() const
+{
+  return mPipe->resampleFilter();
+}
+
+QgsBrightnessContrastFilter *QgsRasterLayer::brightnessFilter() const
+{
+  return mPipe->brightnessFilter();
+}
+
+QgsHueSaturationFilter *QgsRasterLayer::hueSaturationFilter() const
+{
+  return mPipe->hueSaturationFilter();
 }
 
 void QgsRasterLayer::showStatusMessage( QString const &message )
@@ -1890,13 +1913,13 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     if ( QgsApplication::rasterRendererRegistry()->rendererData( rendererType, rendererEntry ) )
     {
       QgsRasterRenderer *renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, dataProvider() );
-      mPipe.set( renderer );
+      mPipe->set( renderer );
     }
   }
 
   //brightness
   QgsBrightnessContrastFilter *brightnessFilter = new QgsBrightnessContrastFilter();
-  mPipe.set( brightnessFilter );
+  mPipe->set( brightnessFilter );
 
   //brightness coefficient
   QDomElement brightnessElem = pipeNode.firstChildElement( QStringLiteral( "brightnesscontrast" ) );
@@ -1907,7 +1930,7 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
 
   //hue/saturation
   QgsHueSaturationFilter *hueSaturationFilter = new QgsHueSaturationFilter();
-  mPipe.set( hueSaturationFilter );
+  mPipe->set( hueSaturationFilter );
 
   //saturation coefficient
   QDomElement hueSaturationElem = pipeNode.firstChildElement( QStringLiteral( "huesaturation" ) );
@@ -1918,7 +1941,7 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
 
   //resampler
   QgsRasterResampleFilter *resampleFilter = new QgsRasterResampleFilter();
-  mPipe.set( resampleFilter );
+  mPipe->set( resampleFilter );
 
   //max oversampling
   QDomElement resampleElem = pipeNode.firstChildElement( QStringLiteral( "rasterresampler" ) );
@@ -1943,9 +1966,9 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
   {
     QDomElement e = resamplingStageElement.toElement();
     if ( e.text() == QLatin1String( "provider" ) )
-      setResamplingStage( QgsRasterPipe::ResamplingStage::Provider );
+      setResamplingStage( Qgis::RasterResamplingStage::Provider );
     else if ( e.text() == QLatin1String( "resamplingFilter" ) )
-      setResamplingStage( QgsRasterPipe::ResamplingStage::ResampleFilter );
+      setResamplingStage( Qgis::RasterResamplingStage::ResampleFilter );
   }
 
   // get and set the blend mode if it exists
@@ -2151,15 +2174,15 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
   // possible to add custom filters into the pipe
   QDomElement pipeElement  = document.createElement( QStringLiteral( "pipe" ) );
 
-  for ( int i = 0; i < mPipe.size(); i++ )
+  for ( int i = 0; i < mPipe->size(); i++ )
   {
-    QgsRasterInterface *interface = mPipe.at( i );
+    QgsRasterInterface *interface = mPipe->at( i );
     if ( !interface ) continue;
     interface->writeXml( document, pipeElement );
   }
 
   QDomElement resamplingStageElement = document.createElement( QStringLiteral( "resamplingStage" ) );
-  QDomText resamplingStageText = document.createTextNode( resamplingStage() == QgsRasterPipe::ResamplingStage::Provider ? QStringLiteral( "provider" ) : QStringLiteral( "resamplingFilter" ) );
+  QDomText resamplingStageText = document.createTextNode( resamplingStage() == Qgis::RasterResamplingStage::Provider ? QStringLiteral( "provider" ) : QStringLiteral( "resamplingFilter" ) );
   resamplingStageElement.appendChild( resamplingStageText );
   pipeElement.appendChild( resamplingStageElement );
 
@@ -2559,9 +2582,14 @@ int QgsRasterLayer::height() const
   return mDataProvider->ySize();
 }
 
-void QgsRasterLayer::setResamplingStage( QgsRasterPipe::ResamplingStage stage )
+void QgsRasterLayer::setResamplingStage( Qgis::RasterResamplingStage stage )
 {
-  mPipe.setResamplingStage( stage );
+  mPipe->setResamplingStage( stage );
+}
+
+Qgis::RasterResamplingStage QgsRasterLayer::resamplingStage() const
+{
+  return mPipe->resamplingStage();
 }
 
 //////////////////////////////////////////////////////////

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -31,10 +31,10 @@
 #include <QVector>
 
 #include "qgis_sip.h"
+#include "qgis.h"
 #include "qgsmaplayer.h"
 #include "qgsraster.h"
 #include "qgsrasterdataprovider.h"
-#include "qgsrasterpipe.h"
 #include "qgsrasterviewport.h"
 #include "qgsrasterminmaxorigin.h"
 #include "qgscontrastenhancement.h"
@@ -43,6 +43,10 @@ class QgsMapToPixel;
 class QgsRasterRenderer;
 class QgsRectangle;
 class QgsRasterLayerTemporalProperties;
+class QgsRasterPipe;
+class QgsRasterResampleFilter;
+class QgsBrightnessContrastFilter;
+class QgsHueSaturationFilter;
 
 class QImage;
 class QPixmap;
@@ -237,7 +241,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * \see setRenderer()
      */
-    QgsRasterRenderer *renderer() const { return mPipe.renderer(); }
+    QgsRasterRenderer *renderer() const;
 
     /**
      * Returns the raster's resample filter.
@@ -245,7 +249,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      * \see brightnessFilter()
      * \see hueSaturationFilter()
      */
-    QgsRasterResampleFilter *resampleFilter() const { return mPipe.resampleFilter(); }
+    QgsRasterResampleFilter *resampleFilter() const;
 
     /**
      * Returns the raster's brightness/contrast filter.
@@ -253,7 +257,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      * \see resampleFilter()
      * \see hueSaturationFilter()
      */
-    QgsBrightnessContrastFilter *brightnessFilter() const { return mPipe.brightnessFilter(); }
+    QgsBrightnessContrastFilter *brightnessFilter() const;
 
     /**
      * Returns the raster's hue/saturation filter.
@@ -261,7 +265,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      * \see resampleFilter()
      * \see brightnessFilter()
      */
-    QgsHueSaturationFilter *hueSaturationFilter() const { return mPipe.hueSaturationFilter(); }
+    QgsHueSaturationFilter *hueSaturationFilter() const;
 
     /**
      * Select which stage of the pipe should apply resampling.
@@ -270,7 +274,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * \since QGIS 3.16
      */
-    void setResamplingStage( QgsRasterPipe::ResamplingStage stage );
+    void setResamplingStage( Qgis::RasterResamplingStage stage );
 
     /**
      * Returns which stage of the pipe should apply resampling.
@@ -279,12 +283,12 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * \since QGIS 3.16
      */
-    QgsRasterPipe::ResamplingStage resamplingStage() const { return mPipe.resamplingStage(); }
+    Qgis::RasterResamplingStage resamplingStage() const;
 
     /**
      * Returns the raster pipe.
      */
-    QgsRasterPipe *pipe() { return &mPipe; }
+    QgsRasterPipe *pipe() { return mPipe.get(); }
 
     /**
      * Returns the width of the (unclipped) raster.
@@ -554,7 +558,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     LayerType mRasterType;
 
-    QgsRasterPipe mPipe;
+    std::unique_ptr< QgsRasterPipe > mPipe;
 
     //! To save computations and possible infinite cycle of notifications
     QgsRectangle mLastRectangleUsedByRefreshContrastEnhancementIfNeeded;

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -26,6 +26,7 @@
 #include "qgsexception.h"
 #include "qgsrasterlayertemporalproperties.h"
 #include "qgsmapclippingutils.h"
+#include "qgsrasterpipe.h"
 
 #include <QElapsedTimer>
 #include <QPointer>
@@ -316,7 +317,7 @@ bool QgsRasterLayerRenderer::render()
 
   QgsRasterProjector *projector = mPipe->projector();
   bool restoreOldResamplingStage = false;
-  QgsRasterPipe::ResamplingStage oldResamplingState = mPipe->resamplingStage();
+  Qgis::RasterResamplingStage oldResamplingState = mPipe->resamplingStage();
 
   // TODO add a method to interface to get provider and get provider
   // params in QgsRasterProjector
@@ -325,10 +326,10 @@ bool QgsRasterLayerRenderer::render()
     // Force provider resampling if reprojection is needed
     if ( ( mPipe->provider()->providerCapabilities() & QgsRasterDataProvider::ProviderHintCanPerformProviderResampling ) &&
          mRasterViewPort->mSrcCRS != mRasterViewPort->mDestCRS &&
-         oldResamplingState != QgsRasterPipe::ResamplingStage::Provider )
+         oldResamplingState != Qgis::RasterResamplingStage::Provider )
     {
       restoreOldResamplingStage = true;
-      mPipe->setResamplingStage( QgsRasterPipe::ResamplingStage::Provider );
+      mPipe->setResamplingStage( Qgis::RasterResamplingStage::Provider );
     }
     projector->setCrs( mRasterViewPort->mSrcCRS, mRasterViewPort->mDestCRS, mRasterViewPort->mTransformContext );
   }

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -36,14 +36,14 @@ QgsRasterPipe::QgsRasterPipe( const QgsRasterPipe &pipe )
     QgsRasterInterface *interface = pipe.at( i );
     QgsRasterInterface *clone = interface->clone();
 
-    Role role = interfaceRole( clone );
-    QgsDebugMsgLevel( QStringLiteral( "cloned interface with role %1" ).arg( role ), 4 );
+    Qgis::RasterPipeInterfaceRole role = interfaceRole( clone );
+    QgsDebugMsgLevel( QStringLiteral( "cloned interface with role %1" ).arg( qgsEnumValueToKey( role ) ), 4 );
     if ( i > 0 )
     {
       clone->setInput( mInterfaces.at( i - 1 ) );
     }
     mInterfaces.append( clone );
-    if ( role != UnknownRole )
+    if ( role != Qgis::RasterPipeInterfaceRole::Unknown )
     {
       mRoleMap.insert( role, i );
     }
@@ -131,44 +131,57 @@ bool QgsRasterPipe::replace( int idx, QgsRasterInterface *interface )
   return success;
 }
 
-QgsRasterPipe::Role QgsRasterPipe::interfaceRole( QgsRasterInterface *interface ) const
+Qgis::RasterPipeInterfaceRole QgsRasterPipe::interfaceRole( QgsRasterInterface *interface ) const
 {
-  Role role = UnknownRole;
-  if ( dynamic_cast<QgsRasterDataProvider *>( interface ) ) role = ProviderRole;
-  else if ( dynamic_cast<QgsRasterRenderer *>( interface ) ) role = RendererRole;
-  else if ( dynamic_cast<QgsRasterResampleFilter *>( interface ) ) role = ResamplerRole;
-  else if ( dynamic_cast<QgsBrightnessContrastFilter *>( interface ) ) role = BrightnessRole;
-  else if ( dynamic_cast<QgsHueSaturationFilter *>( interface ) ) role = HueSaturationRole;
-  else if ( dynamic_cast<QgsRasterProjector *>( interface ) ) role = ProjectorRole;
-  else if ( dynamic_cast<QgsRasterNuller *>( interface ) ) role = NullerRole;
+  Qgis::RasterPipeInterfaceRole role = Qgis::RasterPipeInterfaceRole::Unknown;
+  if ( dynamic_cast<QgsRasterDataProvider *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Provider;
+  else if ( dynamic_cast<QgsRasterRenderer *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Renderer;
+  else if ( dynamic_cast<QgsRasterResampleFilter *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Resampler;
+  else if ( dynamic_cast<QgsBrightnessContrastFilter *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Brightness;
+  else if ( dynamic_cast<QgsHueSaturationFilter *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::HueSaturation;
+  else if ( dynamic_cast<QgsRasterProjector *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Projector;
+  else if ( dynamic_cast<QgsRasterNuller *>( interface ) )
+    role = Qgis::RasterPipeInterfaceRole::Nuller;
 
-  QgsDebugMsgLevel( QStringLiteral( "%1 role = %2" ).arg( typeid( *interface ).name() ).arg( role ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "%1 role = %2" ).arg( typeid( *interface ).name() ).arg( qgsEnumValueToKey( role ) ), 4 );
   return role;
 }
 
 void QgsRasterPipe::setRole( QgsRasterInterface *interface, int idx )
 {
-  Role role = interfaceRole( interface );
-  if ( role == UnknownRole ) return;
+  Qgis::RasterPipeInterfaceRole role = interfaceRole( interface );
+  if ( role == Qgis::RasterPipeInterfaceRole::Unknown )
+    return;
+
   mRoleMap.insert( role, idx );
 }
 
 void QgsRasterPipe::unsetRole( QgsRasterInterface *interface )
 {
-  Role role = interfaceRole( interface );
-  if ( role == UnknownRole ) return;
+  Qgis::RasterPipeInterfaceRole role = interfaceRole( interface );
+  if ( role == Qgis::RasterPipeInterfaceRole::Unknown )
+    return;
+
   mRoleMap.remove( role );
 }
 
 bool QgsRasterPipe::set( QgsRasterInterface *interface )
 {
-  if ( !interface ) return false;
+  if ( !interface )
+    return false;
 
   QgsDebugMsgLevel( typeid( *interface ).name(), 4 );
-  Role role = interfaceRole( interface );
+  Qgis::RasterPipeInterfaceRole role = interfaceRole( interface );
 
   // We don't know where to place unknown interface
-  if ( role == UnknownRole ) return false;
+  if ( role == Qgis::RasterPipeInterfaceRole::Unknown )
+    return false;
 
   //if ( mInterfacesMap.value ( role ) )
   if ( mRoleMap.contains( role ) )
@@ -186,33 +199,33 @@ bool QgsRasterPipe::set( QgsRasterInterface *interface )
   //   QgsRasterResampler     - ResamplerRole
   //   QgsRasterProjector     - ProjectorRole
 
-  int providerIdx = mRoleMap.value( ProviderRole, -1 );
-  int rendererIdx = mRoleMap.value( RendererRole, -1 );
-  int resamplerIdx = mRoleMap.value( ResamplerRole, -1 );
-  int brightnessIdx = mRoleMap.value( BrightnessRole, -1 );
-  int hueSaturationIdx = mRoleMap.value( HueSaturationRole, -1 );
+  int providerIdx = mRoleMap.value( Qgis::RasterPipeInterfaceRole::Provider, -1 );
+  int rendererIdx = mRoleMap.value( Qgis::RasterPipeInterfaceRole::Renderer, -1 );
+  int resamplerIdx = mRoleMap.value( Qgis::RasterPipeInterfaceRole::Resampler, -1 );
+  int brightnessIdx = mRoleMap.value( Qgis::RasterPipeInterfaceRole::Brightness, -1 );
+  int hueSaturationIdx = mRoleMap.value( Qgis::RasterPipeInterfaceRole::HueSaturation, -1 );
 
-  if ( role == ProviderRole )
+  if ( role == Qgis::RasterPipeInterfaceRole::Provider )
   {
     idx = 0;
   }
-  else if ( role == RendererRole )
+  else if ( role == Qgis::RasterPipeInterfaceRole::Renderer )
   {
     idx = providerIdx + 1;
   }
-  else if ( role == BrightnessRole )
+  else if ( role == Qgis::RasterPipeInterfaceRole::Brightness )
   {
     idx = std::max( providerIdx, rendererIdx ) + 1;
   }
-  else if ( role == HueSaturationRole )
+  else if ( role == Qgis::RasterPipeInterfaceRole::HueSaturation )
   {
     idx = std::max( std::max( providerIdx, rendererIdx ), brightnessIdx ) + 1;
   }
-  else if ( role == ResamplerRole )
+  else if ( role == Qgis::RasterPipeInterfaceRole::Resampler )
   {
     idx = std::max( std::max( std::max( providerIdx, rendererIdx ), brightnessIdx ), hueSaturationIdx ) + 1;
   }
-  else if ( role == ProjectorRole )
+  else if ( role == Qgis::RasterPipeInterfaceRole::Projector )
   {
     idx = std::max( std::max( std::max( std::max( providerIdx, rendererIdx ), brightnessIdx ), hueSaturationIdx ), resamplerIdx )  + 1;
   }
@@ -220,9 +233,9 @@ bool QgsRasterPipe::set( QgsRasterInterface *interface )
   return insert( idx, interface );  // insert may still fail and return false
 }
 
-QgsRasterInterface *QgsRasterPipe::interface( Role role ) const
+QgsRasterInterface *QgsRasterPipe::interface( Qgis::RasterPipeInterfaceRole role ) const
 {
-  QgsDebugMsgLevel( QStringLiteral( "role = %1" ).arg( role ), 4 );
+  QgsDebugMsgLevel( QStringLiteral( "role = %1" ).arg( qgsEnumValueToKey( role ) ), 4 );
   if ( mRoleMap.contains( role ) )
   {
     return mInterfaces.value( mRoleMap.value( role ) );
@@ -232,37 +245,37 @@ QgsRasterInterface *QgsRasterPipe::interface( Role role ) const
 
 QgsRasterDataProvider *QgsRasterPipe::provider() const
 {
-  return dynamic_cast<QgsRasterDataProvider *>( interface( ProviderRole ) );
+  return dynamic_cast<QgsRasterDataProvider *>( interface( Qgis::RasterPipeInterfaceRole::Provider ) );
 }
 
 QgsRasterRenderer *QgsRasterPipe::renderer() const
 {
-  return dynamic_cast<QgsRasterRenderer *>( interface( RendererRole ) );
+  return dynamic_cast<QgsRasterRenderer *>( interface( Qgis::RasterPipeInterfaceRole::Renderer ) );
 }
 
 QgsRasterResampleFilter *QgsRasterPipe::resampleFilter() const
 {
-  return dynamic_cast<QgsRasterResampleFilter *>( interface( ResamplerRole ) );
+  return dynamic_cast<QgsRasterResampleFilter *>( interface( Qgis::RasterPipeInterfaceRole::Resampler ) );
 }
 
 QgsBrightnessContrastFilter *QgsRasterPipe::brightnessFilter() const
 {
-  return dynamic_cast<QgsBrightnessContrastFilter *>( interface( BrightnessRole ) );
+  return dynamic_cast<QgsBrightnessContrastFilter *>( interface( Qgis::RasterPipeInterfaceRole::Brightness ) );
 }
 
 QgsHueSaturationFilter *QgsRasterPipe::hueSaturationFilter() const
 {
-  return dynamic_cast<QgsHueSaturationFilter *>( interface( HueSaturationRole ) );
+  return dynamic_cast<QgsHueSaturationFilter *>( interface( Qgis::RasterPipeInterfaceRole::HueSaturation ) );
 }
 
 QgsRasterProjector *QgsRasterPipe::projector() const
 {
-  return dynamic_cast<QgsRasterProjector *>( interface( ProjectorRole ) );
+  return dynamic_cast<QgsRasterProjector *>( interface( Qgis::RasterPipeInterfaceRole::Projector ) );
 }
 
 QgsRasterNuller *QgsRasterPipe::nuller() const
 {
-  return dynamic_cast<QgsRasterNuller *>( interface( NullerRole ) );
+  return dynamic_cast<QgsRasterNuller *>( interface( Qgis::RasterPipeInterfaceRole::Nuller ) );
 }
 
 bool QgsRasterPipe::remove( int idx )
@@ -302,13 +315,15 @@ bool QgsRasterPipe::remove( QgsRasterInterface *interface )
 bool QgsRasterPipe::canSetOn( int idx, bool on )
 {
   QgsDebugMsgLevel( QStringLiteral( "idx = %1 on = %2" ).arg( idx ).arg( on ), 4 );
-  if ( !checkBounds( idx ) ) return false;
+  if ( !checkBounds( idx ) )
+    return false;
 
   // Because setting interface on/off may change its output we must check if
   // connection is OK after such switch
   bool onOrig = mInterfaces.at( idx )->on();
 
-  if ( onOrig == on ) return true;
+  if ( onOrig == on )
+    return true;
 
   mInterfaces.at( idx )->setOn( on );
 
@@ -322,15 +337,18 @@ bool QgsRasterPipe::canSetOn( int idx, bool on )
 bool QgsRasterPipe::setOn( int idx, bool on )
 {
   QgsDebugMsgLevel( QStringLiteral( "idx = %1 on = %2" ).arg( idx ).arg( on ), 4 );
-  if ( !checkBounds( idx ) ) return false;
+  if ( !checkBounds( idx ) )
+    return false;
 
   bool onOrig = mInterfaces.at( idx )->on();
 
-  if ( onOrig == on ) return true;
+  if ( onOrig == on )
+    return true;
 
   mInterfaces.at( idx )->setOn( on );
 
-  if ( connect( mInterfaces ) ) return true;
+  if ( connect( mInterfaces ) )
+    return true;
 
   mInterfaces.at( idx )->setOn( onOrig );
   connect( mInterfaces );
@@ -343,7 +361,7 @@ bool QgsRasterPipe::checkBounds( int idx ) const
   return !( idx < 0 || idx >= mInterfaces.size() );
 }
 
-void QgsRasterPipe::setResamplingStage( ResamplingStage stage )
+void QgsRasterPipe::setResamplingStage( Qgis::RasterResamplingStage stage )
 {
   mResamplingStage = stage;
   setOn( ResamplerRole, stage == ResamplingStage::ResampleFilter );

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -364,10 +364,20 @@ bool QgsRasterPipe::checkBounds( int idx ) const
 void QgsRasterPipe::setResamplingStage( Qgis::RasterResamplingStage stage )
 {
   mResamplingStage = stage;
-  setOn( ResamplerRole, stage == ResamplingStage::ResampleFilter );
-  QgsRasterDataProvider *l_provider = provider();
-  if ( l_provider )
+
+  int resamplerIndex = 0;
+  for ( QgsRasterInterface *interface : std::as_const( mInterfaces ) )
   {
-    l_provider->enableProviderResampling( stage == ResamplingStage::Provider );
+    if ( interfaceRole( interface ) == Qgis::RasterPipeInterfaceRole::Resampler )
+    {
+      setOn( resamplerIndex, stage == Qgis::RasterResamplingStage::ResampleFilter );
+      break;
+    }
+    resamplerIndex ++;
+  }
+
+  if ( QgsRasterDataProvider *l_provider = provider() )
+  {
+    l_provider->enableProviderResampling( stage == Qgis::RasterResamplingStage::Provider );
   }
 }

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -269,7 +269,8 @@ bool QgsRasterPipe::remove( int idx )
 {
   QgsDebugMsgLevel( QStringLiteral( "remove at %1" ).arg( idx ), 4 );
 
-  if ( !checkBounds( idx ) ) return false;
+  if ( !checkBounds( idx ) )
+    return false;
 
   // make a copy of pipe to test connection, we test the connections
   // of the whole pipe, because the types and band numbers may change

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgis.h"
 #include <QImage>
 #include <QMap>
 #include <QObject>
@@ -46,19 +47,6 @@ class QgsRasterDataProvider;
 class CORE_EXPORT QgsRasterPipe
 {
   public:
-
-    //! Roles of known interfaces
-    enum Role
-    {
-      UnknownRole = 0, //!< Unknown role
-      ProviderRole = 1, //!< Data provider role
-      RendererRole = 2, //!< Raster renderer role
-      BrightnessRole = 3, //!< Brightness filter role
-      ResamplerRole = 4, //!< Resampler role
-      ProjectorRole = 5, //!< Projector role
-      NullerRole = 6, //!< Raster nuller role
-      HueSaturationRole = 7, //!< Hue/saturation filter role
-    };
 
     /**
      * Constructor for an empty QgsRasterPipe.
@@ -207,18 +195,6 @@ class CORE_EXPORT QgsRasterPipe
     QgsRasterNuller *nuller() const;
 
     /**
-     * Stage at which resampling occurs.
-     * \since QGIS 3.16
-     */
-    enum class ResamplingStage
-    {
-      //! Resampling occurs in ResamplingFilter
-      ResampleFilter,
-      //! Resampling occurs in Provider
-      Provider
-    };
-
-    /**
      * Sets which stage of the pipe should apply resampling.
      *
      * Provider resampling is only supported if provider sets
@@ -227,7 +203,7 @@ class CORE_EXPORT QgsRasterPipe
      * \see resamplingStage()
      * \since QGIS 3.16
      */
-    void setResamplingStage( ResamplingStage stage );
+    void setResamplingStage( Qgis::RasterResamplingStage stage );
 
     /**
      * Returns which stage of the pipe should apply resampling
@@ -235,7 +211,7 @@ class CORE_EXPORT QgsRasterPipe
      * \see setResamplingStage()
      * \since QGIS 3.16
      */
-    ResamplingStage resamplingStage() const { return mResamplingStage; }
+    Qgis::RasterResamplingStage resamplingStage() const { return mResamplingStage; }
 
   private:
 #ifdef SIP_RUN
@@ -243,12 +219,12 @@ class CORE_EXPORT QgsRasterPipe
 #endif
 
     //! Gets known parent type_info of interface parent
-    Role interfaceRole( QgsRasterInterface *iface ) const;
+    Qgis::RasterPipeInterfaceRole interfaceRole( QgsRasterInterface *iface ) const;
 
     // Interfaces in pipe, the first is always provider
     QVector<QgsRasterInterface *> mInterfaces;
 
-    QMap<Role, int> mRoleMap;
+    QMap<Qgis::RasterPipeInterfaceRole, int> mRoleMap;
 
     // Set role in mRoleMap
     void setRole( QgsRasterInterface *interface, int idx );
@@ -260,7 +236,7 @@ class CORE_EXPORT QgsRasterPipe
     bool checkBounds( int idx ) const;
 
     //! Gets known interface by role
-    QgsRasterInterface *interface( Role role ) const;
+    QgsRasterInterface *interface( Qgis::RasterPipeInterfaceRole role ) const;
 
     /**
      * \brief Try to connect interfaces in pipe and to the provider at beginning.
@@ -268,7 +244,7 @@ class CORE_EXPORT QgsRasterPipe
     */
     bool connect( QVector<QgsRasterInterface *> interfaces );
 
-    ResamplingStage mResamplingStage = ResamplingStage::ResampleFilter;
+    Qgis::RasterResamplingStage mResamplingStage = Qgis::RasterResamplingStage::ResampleFilter;
 };
 
 #endif

--- a/src/gui/raster/qgsresamplingutils.cpp
+++ b/src/gui/raster/qgsresamplingutils.cpp
@@ -70,19 +70,19 @@ void QgsResamplingUtils::refreshWidgetsFromLayer()
   QgsRasterDataProvider *provider = mRasterLayer->dataProvider();
   mCbEarlyResampling->setVisible(
     provider && ( provider->providerCapabilities() & QgsRasterDataProvider::ProviderHintCanPerformProviderResampling ) );
-  mCbEarlyResampling->setChecked( mRasterLayer->resamplingStage() == QgsRasterPipe::ResamplingStage::Provider );
+  mCbEarlyResampling->setChecked( mRasterLayer->resamplingStage() == Qgis::RasterResamplingStage::Provider );
 
   switch ( mRasterLayer->resamplingStage() )
   {
-    case QgsRasterPipe::ResamplingStage::ResampleFilter:
+    case Qgis::RasterResamplingStage::ResampleFilter:
       removeExtraEarlyResamplingMethodsFromCombos();
       break;
-    case QgsRasterPipe::ResamplingStage::Provider:
+    case Qgis::RasterResamplingStage::Provider:
       addExtraEarlyResamplingMethodsToCombos();
       break;
   }
 
-  if ( provider && mRasterLayer->resamplingStage() == QgsRasterPipe::ResamplingStage::Provider )
+  if ( provider && mRasterLayer->resamplingStage() == Qgis::RasterResamplingStage::Provider )
   {
     mZoomedInResamplingComboBox->setCurrentIndex( mZoomedInResamplingComboBox->findData( static_cast<int>( provider->zoomedInResamplingMethod() ) ) );
     mZoomedOutResamplingComboBox->setCurrentIndex( mZoomedOutResamplingComboBox->findData( static_cast<int>( provider->zoomedOutResamplingMethod() ) ) );
@@ -143,7 +143,7 @@ void QgsResamplingUtils::refreshLayerFromWidgets()
     static_cast< QgsRasterDataProvider::ResamplingMethod >(
       mZoomedOutResamplingComboBox->itemData( mZoomedOutResamplingComboBox->currentIndex() ).toInt() );
 
-  mRasterLayer->setResamplingStage( mCbEarlyResampling->isChecked() ? QgsRasterPipe::ResamplingStage::Provider : QgsRasterPipe::ResamplingStage::ResampleFilter );
+  mRasterLayer->setResamplingStage( mCbEarlyResampling->isChecked() ? Qgis::RasterResamplingStage::Provider : Qgis::RasterResamplingStage::ResampleFilter );
   QgsRasterDataProvider *provider = mRasterLayer->dataProvider();
   if ( provider )
   {

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -27,13 +27,14 @@
 #include "cpl_conv.h"
 
 //qgis includes...
-#include <qgsrasterchecker.h>
+#include "qgsrasterchecker.h"
 #include "qgsrasterdataprovider.h"
-#include <qgsrasterlayer.h>
-#include <qgsrasterfilewriter.h>
-#include <qgsrasternuller.h>
+#include "qgsrasterlayer.h"
+#include "qgsrasterfilewriter.h"
+#include "qgsrasternuller.h"
 #include "qgsrasterprojector.h"
-#include <qgsapplication.h>
+#include "qgsapplication.h"
+#include "qgsrasterpipe.h"
 
 /**
  * \ingroup UnitTests

--- a/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
+++ b/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
@@ -23,7 +23,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
 #include "qgsrasterfilewriter.h"
-
+#include "qgsrasterpipe.h"
 #include "qgsgui.h"
 
 class TestQgsRasterLayerSaveAsDialog : public QObject


### PR DESCRIPTION
And fix incorrect use of QgsRasterPipie::setOn when changing raster pipe resampling stage (this needs backporting)