### PR TITLE
create new mesh layer

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -921,6 +921,7 @@
         <file>themes/default/mIconFolderLinkParams.svg</file>
         <file>themes/default/mIconFolderHomeParams.svg</file>
         <file>themes/default/mActionMeasureBearing.svg</file>
+        <file>themes/default/mActionNewMeshLayer.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mActionNewMeshLayer.svg
+++ b/images/themes/default/mActionNewMeshLayer.svg
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg889"
+   sodipodi:docname="mActionNewMeshLayer.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata895">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs893">
+    <linearGradient
+       id="g"
+       gradientUnits="userSpaceOnUse"
+       x1="4.5300002"
+       x2="4.4580002"
+       y1="22.364"
+       y2="25.132999">
+      <stop
+         offset="0"
+         stop-color="#e7eff5"
+         id="stop1039" />
+      <stop
+         offset="1"
+         stop-color="#6e97c4"
+         id="stop1041" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       id="b"
+       gradientUnits="userSpaceOnUse"
+       x1="7.3730001"
+       x2="7.4489999"
+       xlink:href="#a"
+       y1="10"
+       y2="15" />
+    <linearGradient
+       id="a">
+      <stop
+         offset="0"
+         stop-color="#6e97c4"
+         id="stop1021" />
+      <stop
+         offset="1"
+         stop-color="#aec7e2"
+         id="stop1023" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       id="c"
+       gradientUnits="userSpaceOnUse"
+       x1="1.729"
+       x2="7"
+       xlink:href="#a"
+       y1="15.458"
+       y2="15.458" />
+    <linearGradient
+       id="linearGradient1659"
+       gradientUnits="userSpaceOnUse"
+       x1="1.729"
+       x2="7"
+       xlink:href="#a"
+       y1="15.458"
+       y2="15.458" />
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       id="d"
+       gradientUnits="userSpaceOnUse"
+       x1="18"
+       x2="16"
+       xlink:href="#a"
+       y1="14.322"
+       y2="13" />
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       id="e"
+       gradientUnits="userSpaceOnUse"
+       x1="18"
+       x2="15.288"
+       y1="14.322"
+       y2="12">
+      <stop
+         offset="0"
+         stop-color="#6e97c4"
+         id="stop1029" />
+      <stop
+         offset="1"
+         stop-color="#e7eff5"
+         id="stop1031" />
+    </linearGradient>
+    <linearGradient
+       id="f"
+       gradientUnits="userSpaceOnUse"
+       x1="4.5300002"
+       x2="4.4580002"
+       y1="22.364"
+       y2="25.132999">
+      <stop
+         offset="0"
+         stop-color="#aec7e2"
+         id="stop1034" />
+      <stop
+         offset="1"
+         stop-color="#6e97c4"
+         id="stop1036" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       y2="25.132999"
+       x2="4.4580002"
+       y1="22.364"
+       x1="4.5300002"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1704"
+       xlink:href="#f"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       y2="25.132999"
+       x2="4.4580002"
+       y1="22.364"
+       x1="4.5300002"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1710"
+       xlink:href="#g"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient1808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       x1="4.5300002"
+       y1="22.364"
+       x2="4.4580002"
+       y2="25.132999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1810"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       x1="1.729"
+       y1="15.458"
+       x2="7"
+       y2="15.458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient1812"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.7496244e-7,-7.9999999)"
+       x1="4.5300002"
+       y1="22.364"
+       x2="4.4580002"
+       y2="25.132999" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     id="namedview891"
+     showgrid="false"
+     inkscape:zoom="6.2240128"
+     inkscape:cx="14.847229"
+     inkscape:cy="4.0612319"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg889" />
+  <g
+     transform="matrix(.6923 0 0 .6923 1.846 1.846)"
+     id="g881">
+    <rect
+       fill="#c4a000"
+       height="13"
+       rx="2.615"
+       width="13"
+       x="19"
+       y="19"
+       id="rect875" />
+    <path
+       d="m20.3 25.5h10.4v-2.6c0-2.6-.65-2.6-5.2-2.6s-5.2 0-5.2 2.6z"
+       fill="#fcffff"
+       fill-rule="evenodd"
+       opacity=".3"
+       id="path877" />
+    <path
+       d="m-6.457-5.813v.76c0 1.04-.16 1.76-.64 2.68-.72 1.56-.8 1.76-.8 2.36 0 1.16.88 2.12 1.92 2.12 1.08 0 1.92-.96 1.92-2.16 0-.4-.12-.92-.4-1.44-.92-1.96-1-2.28-1-3.56v-.76l.64.4c.84.48 1.48 1.04 2.04 1.84 1.32 1.8 1.76 2.16 2.84 2.16 1 0 1.8-.76 1.8-1.76 0-1.24-1.04-2.16-2.6-2.28-1.96-.12-2.32-.2-3.56-.88l-.64-.36.64-.36c.92-.52 1.6-.76 2.64-.8 1.6-.16 1.72-.16 2.2-.36.8-.4 1.32-1.12 1.32-1.96 0-1.04-.84-1.84-1.88-1.84-.88 0-1.6.44-2.24 1.4-1.12 1.68-1.36 1.92-2.56 2.64l-.64.4v-.76c0-1 .16-1.76.64-2.68.76-1.6.8-1.76.8-2.32 0-1.2-.88-2.16-1.96-2.16-1.04 0-1.92.96-1.92 2.12 0 .44.12.96.4 1.48.96 2 1.04 2.28 1.04 3.56v.76l-.64-.4c-.92-.52-1.44-1.04-2.04-1.88-.8-1.2-.8-1.2-1.12-1.52-.44-.4-1.08-.64-1.6-.64-1.08 0-1.92.84-1.92 1.84 0 1.24 1 2.12 2.56 2.24 2.04.12 2.36.2 3.6.88l.64.36-.64.4c-.84.48-1.64.72-2.64.8-1.56.08-1.68.12-2.2.32-.8.36-1.32 1.12-1.32 1.96 0 1 .84 1.84 1.88 1.84.88 0 1.64-.48 2.24-1.4 1.08-1.6 1.4-1.96 2.56-2.64z"
+       fill="#fff"
+       stroke="#fff"
+       stroke-width=".497"
+       transform="matrix(.60272 0 0 .60366 29.09 29.54)"
+       id="path879" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient1808)"
+     d="m 1.9972412,14.082448 v 3.569 h 5 v -3.569 z"
+     id="path1044" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient1704)"
+     d="m 7.9972412,14.082448 v 3.569 h 4.9999998 v -3.569 z"
+     id="path1046" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#e)"
+     d="M 21.997241,13.082448 V 2.0824484 l -8,10.9999996 z"
+     id="path1048" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#d)"
+     d="M 13.997241,2.0824484 V 13.082448 l 8,-10.9999996 z"
+     id="path1050" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient1810)"
+     d="m 12.997241,13.082448 -5.4789998,-5.4599996 -5.521,5.4599996 z"
+     id="path1052" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#c)"
+     d="m 1.7242412,13.082448 5.461,-5.4789996 -5.46,-5.521 z"
+     id="path1054" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#b)"
+     d="m 1.9972412,2.0824484 5.479,5.46 5.5209998,-5.46 z"
+     id="path1056" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#253e5b;stroke-linecap:round"
+     d="M 12.997241,2.0824484 1.9972412,13.082448 m 0,-10.9999996 L 12.997241,13.082448 M 1.4972412,1.5824484 H 13.497241 V 13.582448 H 1.4972412 Z"
+     id="path1068" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#aec7e2"
+     d="m 13.457241,2.0824484 -5.4619998,5.479 5.4619998,5.5209996 z"
+     id="path1070" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#253e5b;stroke-linecap:round"
+     d="m 13.497241,1.5824484 h 9 V 13.582448 h -9 z M 1.4972412,13.582448 H 13.497241 v 9 H 1.4972412 Z M 21.997241,2.0824484 l -8,10.9999996 m -6.4999998,1 v 8"
+     id="path1072" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient1812)"
+     d="m 1.9972412,18.513448 v 3.569 h 5 v -3.569 z"
+     id="path1074" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#253e5b;stroke-linecap:round"
+     d="M 12.997241,18.082448 H 1.9972412"
+     id="path1076" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient1710)"
+     d="m 7.9972412,18.513448 v 3.569 h 4.9999998 v -3.569 z"
+     id="path1078" />
+</svg>

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -49,7 +49,7 @@ Constructs default metadata without any capabilities
  QgsMeshDriverMetadata( const QString &name,
         const QString &description,
         const MeshDriverCapabilities &capabilities,
-        const QString &writeDatasetOnFileSuffix ); /Deprecated/;
+        const QString &writeDatasetOnFileSuffix ) /Deprecated/;
 %Docstring
 Constructs driver metadata with selected capabilities
 
@@ -57,8 +57,11 @@ Constructs driver metadata with selected capabilities
 :param description: short description of the driver
 :param capabilities: driver's capabilities
 :param writeDatasetOnFileSuffix: suffix used to write datasets on file
-:param writeMeshFrameOnFileSuffix: suffix used to write mesh frame on file
+
+.. deprecated::
+   QGIS 3.22
 %End
+
     QgsMeshDriverMetadata( const QString &name,
                            const QString &description,
                            const MeshDriverCapabilities &capabilities,

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -46,10 +46,10 @@ Holds metadata about mesh driver
 Constructs default metadata without any capabilities
 %End
 
-    QgsMeshDriverMetadata( const QString &name,
-                           const QString &description,
-                           const MeshDriverCapabilities &capabilities,
-                           const QString &writeDatasetOnFileSuffix );
+ QgsMeshDriverMetadata( const QString &name,
+        const QString &description,
+        const MeshDriverCapabilities &capabilities,
+        const QString &writeDatasetOnFileSuffix ); /Deprecated/;
 %Docstring
 Constructs driver metadata with selected capabilities
 
@@ -57,6 +57,23 @@ Constructs driver metadata with selected capabilities
 :param description: short description of the driver
 :param capabilities: driver's capabilities
 :param writeDatasetOnFileSuffix: suffix used to write datasets on file
+:param writeMeshFrameOnFileSuffix: suffix used to write mesh frame on file
+%End
+    QgsMeshDriverMetadata( const QString &name,
+                           const QString &description,
+                           const MeshDriverCapabilities &capabilities,
+                           const QString &writeDatasetOnFileSuffix,
+                           const QString &writeMeshFrameOnFileSuffix );
+%Docstring
+Constructs driver metadata with selected capabilities
+
+:param name: name/key of the driver
+:param description: short description of the driver
+:param capabilities: driver's capabilities
+:param writeDatasetOnFileSuffix: suffix used to write datasets on file
+:param writeMeshFrameOnFileSuffix: suffix used to write mesh frame on file
+
+.. versionadded:: 3.22
 %End
 
     MeshDriverCapabilities capabilities() const;
@@ -77,6 +94,13 @@ Returns the description for this driver.
     QString writeDatasetOnFileSuffix() const;
 %Docstring
 Returns the suffix used to write datasets on file
+%End
+
+    QString writeMeshFrameOnFileSuffix() const;
+%Docstring
+Returns the suffix used to write mesh on file
+
+.. versionadded:: 3.22
 %End
 
 };

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -244,6 +244,7 @@ set(QGIS_APP_SRCS
   qgscrashhandler.cpp
 
   mesh/qgsmeshcalculatordialog.cpp
+  mesh/qgsnewmeshlayerdialog.cpp
 )
 
 if (WITH_SPATIALITE)

--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -43,12 +43,12 @@ QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags f
   for ( const QgsMeshDriverMetadata &driverMeta : driverList )
     if ( driverMeta.capabilities() & QgsMeshDriverMetadata::CanWriteMeshData )
     {
-      QString descritpion = driverMeta.description();
+      QString description = driverMeta.description();
       QString driverName = driverMeta.name();
       QString suffix = driverMeta.writeMeshFrameOnFileSuffix();
-      mFormatComboBox->addItem( descritpion, driverName );
+      mFormatComboBox->addItem( description, driverName );
       mDriverSuffixes.insert( driverMeta.name(), suffix );
-      mDriverFileFilters.insert( driverMeta.name(), tr( "%1 files" ).arg( descritpion ) + QStringLiteral( " (*." ) + suffix + ')' );
+      mDriverFileFilters.insert( driverMeta.name(), tr( "%1 files" ).arg( description ) + QStringLiteral( " (*." ) + suffix + ')' );
     }
 
   QStringList filters = mDriverFileFilters.values();

--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -1,0 +1,200 @@
+/***************************************************************************
+  qgsnewmeshlayerdialog.cpp - QgsNewMeshLayerDialog
+
+ ---------------------
+ begin                : 22.6.2021
+ copyright            : (C) 2021 by Vincent Cloarec
+ email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsnewmeshlayerdialog.h"
+
+#include <QPushButton>
+#include <QMessageBox>
+
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
+#include "qgsmeshdataprovider.h"
+#include "qgsproject.h"
+#include "qgsmeshlayer.h"
+#include "qgsapplication.h"
+
+
+QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags fl ) : QDialog( parent, fl )
+{
+  QgsProviderMetadata *meta = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "mdal" ) );
+
+  if ( !meta )
+  {
+    setLayout( new QVBoxLayout );
+    layout()->addWidget( new QLabel( tr( "MDAL not available, unable to create a new mesh layer" ) ) );
+    return;
+  }
+
+  setupUi( this );
+  const QList<QgsMeshDriverMetadata> driverList = meta->meshDriversMetadata();
+
+  for ( const QgsMeshDriverMetadata &driverMeta : driverList )
+    if ( driverMeta.capabilities() & QgsMeshDriverMetadata::CanWriteMeshData )
+    {
+      mFormatComboBox->addItem( driverMeta.description(), driverMeta.name() );
+    }
+
+  mFormatComboBox->setCurrentIndex( -1 );
+  mFileWidget->setStorageMode( QgsFileWidget::SaveFile );
+  mMeshProjectComboBox->setFilters( QgsMapLayerProxyModel::MeshLayer );
+
+  connect( mFormatComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewMeshLayerDialog::updateDialog );
+  connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsNewMeshLayerDialog::updateDialog );
+  connect( mEmptyMeshRadioButton, &QRadioButton::toggled, this, &QgsNewMeshLayerDialog::updateDialog );
+  connect( mMeshFileRadioButton, &QRadioButton::toggled, this, &QgsNewMeshLayerDialog::updateDialog );
+  connect( mMeshFromFileWidget, &QgsFileWidget::fileChanged, this, &QgsNewMeshLayerDialog::updateDialog );
+  connect( mMeshProjectComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsNewMeshLayerDialog::updateDialog );
+
+  updateDialog();
+
+}
+
+void QgsNewMeshLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  mProjectionSelectionWidget->setCrs( crs );
+}
+
+void QgsNewMeshLayerDialog::setSourceMeshLayer( QgsMeshLayer *meshLayer )
+{
+  mMeshProjectComboBox->setLayer( meshLayer );
+  mMeshProjectRadioButton->setChecked( true );
+}
+
+void QgsNewMeshLayerDialog::accept()
+{
+  if ( apply() )
+    QDialog::accept();
+}
+
+void QgsNewMeshLayerDialog::updateDialog()
+{
+  updateSourceMeshframe();
+
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled(
+    ! mFileWidget->filePath().isEmpty() &&
+    mFormatComboBox->currentIndex() != -1 &&
+    mSourceMeshFrameReady );
+}
+
+void QgsNewMeshLayerDialog::updateSourceMeshframe()
+{
+  mMeshProjectComboBox->setEnabled( false );
+  mMeshFromFileWidget->setEnabled( false );
+  if ( mEmptyMeshRadioButton->isChecked() )
+  {
+    mSourceMeshFromFile.reset();
+    mSourceMeshFrameReady = true;
+    mProjectionSelectionWidget->setEnabled( true );
+  }
+  else if ( mMeshProjectRadioButton->isChecked() )
+  {
+    mMeshProjectComboBox->setEnabled( true );
+    mSourceMeshFromFile.reset();
+    mSourceMeshFrameReady = mMeshProjectComboBox->currentLayer() != nullptr;
+    mProjectionSelectionWidget->setEnabled( false );
+  }
+  else if ( mMeshFileRadioButton->isChecked() )
+  {
+    mMeshFromFileWidget->setEnabled( true );
+    if ( !mSourceMeshFromFile || mSourceMeshFromFile->source() != mMeshFromFileWidget->filePath() )
+    {
+      QgsApplication::setOverrideCursor( Qt::WaitCursor );
+      if ( !mMeshFromFileWidget->filePath().isEmpty() )
+        mSourceMeshFromFile.reset( new QgsMeshLayer( mMeshFromFileWidget->filePath(), QString(), QStringLiteral( "mdal" ) ) );
+
+      if ( mSourceMeshFromFile && !mSourceMeshFromFile->isValid() )
+        mSourceMeshFromFile.reset();
+
+      mProjectionSelectionWidget->setEnabled( false );
+
+      mSourceMeshFrameReady = mSourceMeshFromFile != nullptr;
+
+      QgsApplication::restoreOverrideCursor();
+    }
+  }
+
+  updateSourceMeshInformation();
+}
+
+void QgsNewMeshLayerDialog::updateSourceMeshInformation()
+{
+  QString myStyle = QgsApplication::reportStyleSheet();
+  myStyle.append( QStringLiteral( "body { margin: 10px; }\n " ) );
+
+  mInformationTextBrowser->clear();
+  mInformationTextBrowser->document()->setDefaultStyleSheet( myStyle );
+  if ( mMeshProjectRadioButton->isChecked() )
+  {
+    if ( mMeshProjectComboBox->currentLayer() )
+      mInformationTextBrowser->setHtml( mMeshProjectComboBox->currentLayer()->htmlMetadata() );
+  }
+
+  if ( mMeshFileRadioButton->isChecked() )
+  {
+    if ( mSourceMeshFromFile )
+      mInformationTextBrowser->setHtml( mSourceMeshFromFile->htmlMetadata() );
+  }
+
+  mInformationTextBrowser->setOpenLinks( false );
+};
+
+bool QgsNewMeshLayerDialog::apply()
+{
+  bool result = false;
+  QString fileName = mFileWidget->filePath();
+  QString format = mFormatComboBox->currentData().toString();
+
+  QgsMesh mesh;
+  QgsCoordinateReferenceSystem crs;
+
+  QgsMeshLayer *source = nullptr;
+
+  if ( mEmptyMeshRadioButton->isChecked() )
+  {
+    crs = mProjectionSelectionWidget->crs();
+  }
+  else if ( mMeshProjectRadioButton->isChecked() )
+  {
+    source = qobject_cast<QgsMeshLayer *>( mMeshProjectComboBox->currentLayer() );
+  }
+  else if ( mMeshFromFileWidget )
+  {
+    source = mSourceMeshFromFile.get();
+  }
+
+  if ( source )
+  {
+    crs = source->crs();
+    source->dataProvider()->populateMesh( &mesh );
+  }
+
+  const QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "mdal" ) );
+  if ( providerMetadata )
+  {
+    result = providerMetadata->createMeshData( mesh, fileName, format, crs );
+    if ( result )
+    {
+      std::unique_ptr<QgsMeshLayer> newMeshLayer = std::make_unique<QgsMeshLayer>( fileName, mLayerNameLineEdit->text(), QStringLiteral( "mdal" ) );
+
+      if ( newMeshLayer->isValid() )
+        QgsProject::instance()->addMapLayer( newMeshLayer.release(), true, true );
+      return true;
+    }
+  }
+
+  QMessageBox::warning( this, windowTitle(), tr( "Unable to create a new mesh layer" ) );
+  return false;
+}
+

--- a/src/app/mesh/qgsnewmeshlayerdialog.h
+++ b/src/app/mesh/qgsnewmeshlayerdialog.h
@@ -23,7 +23,9 @@
 #include "qgis_app.h"
 
 /**
- * @brief A Dialog Widget that is used to create and load in the project a new Mesh Layer from scratch or derived from another mesh
+ * \brief A Dialog Widget that is used to create and load in the project a new Mesh Layer from scratch or derived from another mesh
+ *
+ * \since QGIS 3.22
  */
 class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshLayerDialogBase
 {

--- a/src/app/mesh/qgsnewmeshlayerdialog.h
+++ b/src/app/mesh/qgsnewmeshlayerdialog.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgsnewmeshlayerdialog.h - QgsNewMeshLayerDialog
+
+ ---------------------
+ begin                : 22.6.2021
+ copyright            : (C) 2021 by Vincent Cloarec
+ email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSNEWMESHLAYERDIALOG_H
+#define QGSNEWMESHLAYERDIALOG_H
+
+#include "ui_qgsnewmeshlayerdialogbase.h"
+
+#include "qgsguiutils.h"
+#include "qgsmeshlayer.h"
+#include "qgis_app.h"
+
+/**
+ * @brief A Dialog Widget that is used to create and load in the project a new Mesh Layer from scratch or derived from another mesh
+ */
+class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshLayerDialogBase
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsNewMeshLayerDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+
+    void accept() override;
+
+    //! Sets the default CRS of the widget
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
+    //! Sets a mesh layer that could be used as base for the new mesh
+    void setSourceMeshLayer( QgsMeshLayer *meshLayer );
+
+  private slots:
+    void updateDialog();
+    void updateSourceMeshframe();
+
+    void updateSourceMeshInformation();
+
+  private:
+    bool apply();
+
+    std::unique_ptr<QgsMeshLayer> mSourceMeshFromFile;
+    bool mSourceMeshFrameReady;
+};
+
+#endif // QGSNEWMESHLAYERDIALOG_H

--- a/src/app/mesh/qgsnewmeshlayerdialog.h
+++ b/src/app/mesh/qgsnewmeshlayerdialog.h
@@ -46,7 +46,8 @@ class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshL
   private slots:
     void updateDialog();
     void updateSourceMeshframe();
-
+    void onFormatChanged();
+    void onFilePathChanged();
     void updateSourceMeshInformation();
 
   private:
@@ -54,6 +55,8 @@ class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshL
 
     std::unique_ptr<QgsMeshLayer> mSourceMeshFromFile;
     bool mSourceMeshFrameReady;
+    QMap<QString, QString> mDriverSuffixes;
+    QMap<QString, QString> mDriverFileFilters;
 };
 
 #endif // QGSNEWMESHLAYERDIALOG_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -310,6 +310,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsnativealgorithms.h"
 #include "qgsnewvectorlayerdialog.h"
 #include "qgsnewmemorylayerdialog.h"
+#include "qgsnewmeshlayerdialog.h"
 #include "options/qgsoptions.h"
 #include "qgspluginlayer.h"
 #include "qgspluginlayerregistry.h"
@@ -2672,6 +2673,7 @@ void QgisApp::createActions()
 #endif
   connect( mActionNewGeoPackageLayer, &QAction::triggered, this, &QgisApp::newGeoPackageLayer );
   connect( mActionNewMemoryLayer, &QAction::triggered, this, &QgisApp::newMemoryLayer );
+  connect( mActionNewMeshLayer, &QAction::triggered, this, &QgisApp::newMeshLayer );
   connect( mActionNewVirtualLayer, &QAction::triggered, this, &QgisApp::addVirtualLayer );
   connect( mActionShowRasterCalculator, &QAction::triggered, this, &QgisApp::showRasterCalculator );
   connect( mActionShowMeshCalculator, &QAction::triggered, this, &QgisApp::showMeshCalculator );
@@ -6808,6 +6810,13 @@ void QgisApp::newSpatialiteLayer()
 void QgisApp::newGeoPackageLayer()
 {
   QgsNewGeoPackageLayerDialog dialog( this );
+  dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+  dialog.exec();
+}
+
+void QgisApp::newMeshLayer()
+{
+  QgsNewMeshLayerDialog dialog( this );
   dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
   dialog.exec();
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1578,6 +1578,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Create a new empty GeoPackage layer
     void newGeoPackageLayer();
 
+    //! Create a new empty mesh layer
+    void newMeshLayer();
+
     //! Create a new print layout
     void newPrintLayout();
 

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -339,8 +339,27 @@ QMap<QString, T *> QgsProviderMetadata::connections( bool cached )
 
 QgsMeshDriverMetadata::QgsMeshDriverMetadata() = default;
 
-QgsMeshDriverMetadata::QgsMeshDriverMetadata( const QString &name, const QString &description, const MeshDriverCapabilities &capabilities, const QString &writeDatasetOnfileSuffix )
-  : mName( name ), mDescription( description ), mCapabilities( capabilities ), mWriteDatasetOnFileSuffix( writeDatasetOnfileSuffix )
+QgsMeshDriverMetadata::QgsMeshDriverMetadata( const QString &name,
+    const QString &description,
+    const MeshDriverCapabilities &capabilities,
+    const QString &writeDatasetOnfileSuffix )
+  : mName( name )
+  , mDescription( description )
+  , mCapabilities( capabilities )
+  , mWriteDatasetOnFileSuffix( writeDatasetOnfileSuffix )
+{
+}
+
+QgsMeshDriverMetadata::QgsMeshDriverMetadata( const QString &name,
+    const QString &description,
+    const MeshDriverCapabilities &capabilities,
+    const QString &writeDatasetOnfileSuffix,
+    const QString &writeMeshFrameOnFileSuffix )
+  : mName( name )
+  , mDescription( description )
+  , mCapabilities( capabilities )
+  , mWriteDatasetOnFileSuffix( writeDatasetOnfileSuffix )
+  , mWriteMeshFrameOnFileSuffix( ( writeMeshFrameOnFileSuffix ) )
 {
 }
 
@@ -362,4 +381,9 @@ QString QgsMeshDriverMetadata::description() const
 QString QgsMeshDriverMetadata::writeDatasetOnFileSuffix() const
 {
   return mWriteDatasetOnFileSuffix;
+}
+
+QString QgsMeshDriverMetadata::writeMeshFrameOnFileSuffix() const
+{
+  return mWriteMeshFrameOnFileSuffix;
 }

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -85,11 +85,29 @@ class CORE_EXPORT QgsMeshDriverMetadata
      * \param description short description of the driver
      * \param capabilities driver's capabilities
      * \param writeDatasetOnFileSuffix suffix used to write datasets on file
+     * \param writeMeshFrameOnFileSuffix suffix used to write mesh frame on file
+     */
+    Q_DECL_DEPRECATED QgsMeshDriverMetadata( const QString &name,
+        const QString &description,
+        const MeshDriverCapabilities &capabilities,
+        const QString &writeDatasetOnFileSuffix ); SIP_DEPRECATED
+
+    /**
+     * Constructs driver metadata with selected capabilities
+     *
+     * \param name name/key of the driver
+     * \param description short description of the driver
+     * \param capabilities driver's capabilities
+     * \param writeDatasetOnFileSuffix suffix used to write datasets on file
+     * \param writeMeshFrameOnFileSuffix suffix used to write mesh frame on file
+     *
+     * \since QGIS 3.22
      */
     QgsMeshDriverMetadata( const QString &name,
                            const QString &description,
                            const MeshDriverCapabilities &capabilities,
-                           const QString &writeDatasetOnFileSuffix );
+                           const QString &writeDatasetOnFileSuffix,
+                           const QString &writeMeshFrameOnFileSuffix );
 
     /**
      * Returns the capabilities for this driver.
@@ -111,11 +129,19 @@ class CORE_EXPORT QgsMeshDriverMetadata
      */
     QString writeDatasetOnFileSuffix() const;
 
+    /**
+     * Returns the suffix used to write mesh on file
+     *
+     * \since QGIS 3.22
+     */
+    QString writeMeshFrameOnFileSuffix() const;
+
   private:
     QString mName;
     QString mDescription;
     MeshDriverCapabilities mCapabilities;
     QString mWriteDatasetOnFileSuffix;
+    QString mWriteMeshFrameOnFileSuffix;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMeshDriverMetadata::MeshDriverCapabilities )

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -85,12 +85,13 @@ class CORE_EXPORT QgsMeshDriverMetadata
      * \param description short description of the driver
      * \param capabilities driver's capabilities
      * \param writeDatasetOnFileSuffix suffix used to write datasets on file
-     * \param writeMeshFrameOnFileSuffix suffix used to write mesh frame on file
+     *
+     * \deprecated QGIS 3.22
      */
     Q_DECL_DEPRECATED QgsMeshDriverMetadata( const QString &name,
         const QString &description,
         const MeshDriverCapabilities &capabilities,
-        const QString &writeDatasetOnFileSuffix ); SIP_DEPRECATED
+        const QString &writeDatasetOnFileSuffix ) SIP_DEPRECATED;
 
     /**
      * Constructs driver metadata with selected capabilities

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -230,6 +230,7 @@ QgsMeshDriverMetadata QgsMdalProvider::driverMetadata() const
   MDAL_DriverH mdalDriver = MDAL_driverFromName( name.toStdString().c_str() );
   QString longName = MDAL_DR_longName( mdalDriver );
   QString writeDatasetSuffix = MDAL_DR_writeDatasetsSuffix( mdalDriver );
+  QString writeMeshFrameSuffix = MDAL_DR_saveMeshSuffix( mdalDriver );
 
   QgsMeshDriverMetadata::MeshDriverCapabilities capabilities;
   bool hasSaveFaceDatasetsCapability = MDAL_DR_writeDatasetsCapability( mdalDriver, MDAL_DataLocation::DataOnFaces );
@@ -244,7 +245,7 @@ QgsMeshDriverMetadata QgsMdalProvider::driverMetadata() const
   bool hasMeshSaveCapability = MDAL_DR_saveMeshCapability( mdalDriver );
   if ( hasMeshSaveCapability )
     capabilities |= QgsMeshDriverMetadata::CanWriteMeshData;
-  const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix );
+  const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix );
 
   return meta;
 }
@@ -1140,6 +1141,7 @@ QList<QgsMeshDriverMetadata> QgsMdalProviderMetadata::meshDriversMetadata()
     QString name = MDAL_DR_name( mdalDriver );
     QString longName = MDAL_DR_longName( mdalDriver );
     QString writeDatasetSuffix = MDAL_DR_writeDatasetsSuffix( mdalDriver );
+    QString writeMeshFrameSuffix = MDAL_DR_saveMeshSuffix( mdalDriver );
 
     QgsMeshDriverMetadata::MeshDriverCapabilities capabilities;
     bool hasSaveFaceDatasetsCapability = MDAL_DR_writeDatasetsCapability( mdalDriver, MDAL_DataLocation::DataOnFaces );
@@ -1154,7 +1156,7 @@ QList<QgsMeshDriverMetadata> QgsMdalProviderMetadata::meshDriversMetadata()
     bool hasMeshSaveCapability = MDAL_DR_saveMeshCapability( mdalDriver );
     if ( hasMeshSaveCapability )
       capabilities |= QgsMeshDriverMetadata::CanWriteMeshData;
-    const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix );
+    const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix );
     ret.push_back( meta );
   }
   return ret;

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsNewMeshLayerDialogBase</class>
+ <widget class="QDialog" name="QgsNewMeshLayerDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>477</width>
+    <height>479</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>New Mesh Layer</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Layer Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mLayerNameLineEdit">
+     <property name="text">
+      <string>New Mesh Layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>File Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>File Format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="mFormatComboBox"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsProjectionSelectionWidget" name="mProjectionSelectionWidget" native="true"/>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Frame of the New Mesh</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="mMeshFileRadioButton">
+        <property name="text">
+         <string>Mesh from file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="mMeshProjectRadioButton">
+        <property name="text">
+         <string>From a mesh of the current project</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="mEmptyMeshRadioButton">
+        <property name="text">
+         <string>Empty mesh</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsFileWidget" name="mMeshFromFileWidget" native="true"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsMapLayerComboBox" name="mMeshProjectComboBox"/>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QTextBrowser" name="mInformationTextBrowser"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsNewMeshLayerDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsNewMeshLayerDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -17,21 +17,21 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Layer Name</string>
+      <string>Layer name</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
     <widget class="QLineEdit" name="mLayerNameLineEdit">
      <property name="text">
-      <string>New Mesh Layer</string>
+      <string>New mesh layer</string>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>File Name</string>
+      <string>File name</string>
      </property>
     </widget>
    </item>
@@ -41,7 +41,7 @@
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>File Format</string>
+      <string>File format</string>
      </property>
     </widget>
    </item>

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -54,7 +54,7 @@
    <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Frame of the New Mesh</string>
+      <string>Initialize Mesh Using</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -175,6 +175,7 @@
      <addaction name="mActionNewVectorLayer"/>
      <addaction name="mActionNewSpatiaLiteLayer"/>
      <addaction name="mActionNewMemoryLayer"/>
+     <addaction name="mActionNewMeshLayer"/>
      <addaction name="separator"/>
      <addaction name="mActionNewVirtualLayer"/>
     </widget>
@@ -746,6 +747,7 @@
    <addaction name="mActionNewVectorLayer"/>
    <addaction name="mActionNewSpatiaLiteLayer"/>
    <addaction name="mActionNewMemoryLayer"/>
+   <addaction name="mActionNewMeshLayer"/>
    <addaction name="separator"/>
    <addaction name="mActionNewVirtualLayer"/>
    <addaction name="separator"/>
@@ -3548,10 +3550,19 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
     <string>Measure Bearing</string>
    </property>
   </action>
+  <action name="mActionNewMeshLayer">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/images/themes/default/mActionNewMeshLayer.svg</normaloff>:/images/themes/default/mActionNewMeshLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>New Mesh Layer</string>
+   </property>
+   <property name="toolTip">
+    <string>New Mesh Layer</string>
+   </property>
+  </action>
  </widget>
- <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
In the scope of mesh layer editing (https://github.com/qgis/QGIS-Enhancement-Proposals/issues/228), the aim of this PR is to allow the user to create new frame of mesh layer.
From the dialog, the user can create:
* an empty mesh layer
* a frame based on an existing mesh in the project
* a frame based on a existing mesh from a file

To work fine, this new functionality needs few changes in MDAL that are coming...

![createNewMesh_1](https://user-images.githubusercontent.com/7416892/123103562-232c5e00-d404-11eb-8e65-2795d6226bbe.gif)

![createNewMesh_2](https://user-images.githubusercontent.com/7416892/123103582-2889a880-d404-11eb-8096-21a03e97d7b9.gif)

![createNewMesh_3](https://user-images.githubusercontent.com/7416892/123103599-2c1d2f80-d404-11eb-85a2-f8539f4f75ed.gif)
