### PR TITLE
Avoid including QgsWebView from installed header

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -105,6 +105,10 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mRGBMinimumMaximumEstimated = true;
 
   setupUi( this );
+
+  mMetadataViewer = new QgsWebView( this );
+  mOptsPage_Information->layout()->addWidget( mMetadataViewer );
+
   connect( mLayerOrigNameLineEd, &QLineEdit::textEdited, this, &QgsRasterLayerProperties::mLayerOrigNameLineEd_textEdited );
   connect( buttonBuildPyramids, &QPushButton::clicked, this, &QgsRasterLayerProperties::buttonBuildPyramids_clicked );
   connect( pbnAddValuesFromDisplay, &QToolButton::clicked, this, &QgsRasterLayerProperties::pbnAddValuesFromDisplay_clicked );

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -275,6 +275,8 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     QgsProviderSourceWidget *mSourceWidget = nullptr;
 
+    QgsWebView *mMetadataViewer = nullptr;
+
     friend class QgsAppScreenShots;
 };
 #endif

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -270,9 +270,6 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QgsWebView" name="mMetadataViewer" native="true"/>
-           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="mOptsPage_Source">
@@ -2265,12 +2262,6 @@ p, li { white-space: pre-wrap; }
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsWebView</class>
-   <extends>QWidget</extends>
-   <header>qgswebview.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
`qgswebview.h` has a preprocessor conditional on `WITH_QTWEBKIT`, but this define is only set as a compiler flag when building QGIS. External applications including this headers won't be able to determine whether  `WITH_QTWEBKIT` was set or unset when QGIS was built.

This PR avoids `qgsrasterlayerproperties.h` from including  `qgswebview.h`. AFAICS, no other public headers include `qgswebview.h`.