### PR TITLE
Change prototypes of extern functions of C++ plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,7 +618,7 @@ if (PEDANTIC)
     # add_definitions( -fstrict-aliasing -Wstrict-aliasing=1 -Wredundant-decls )
 
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type-c-linkage -Woverloaded-virtual -Wimplicit-fallthrough")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wreturn-type-c-linkage -Woverloaded-virtual -Wimplicit-fallthrough")
     endif()
 
     # add any extra CXXFLAGS flags set by user. can be -D CXX_EXTRA_FLAGS or environment variable

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -441,7 +441,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       // show the values (or lack of) for each function
       if ( pName )
       {
-        QgsDebugMsgLevel( "Plugin name: " + pName(), 2 );
+        QgsDebugMsgLevel( "Plugin name: " + *pName(), 2 );
       }
       else
       {
@@ -449,7 +449,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pDesc )
       {
-        QgsDebugMsgLevel( "Plugin description: " + pDesc(), 2 );
+        QgsDebugMsgLevel( "Plugin description: " + *pDesc(), 2 );
       }
       else
       {
@@ -457,7 +457,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pCat )
       {
-        QgsDebugMsgLevel( "Plugin category: " + pCat(), 2 );
+        QgsDebugMsgLevel( "Plugin category: " + *pCat(), 2 );
       }
       else
       {
@@ -465,7 +465,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pVersion )
       {
-        QgsDebugMsgLevel( "Plugin version: " + pVersion(), 2 );
+        QgsDebugMsgLevel( "Plugin version: " + *pVersion(), 2 );
       }
       else
       {
@@ -473,7 +473,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pIcon )
       {
-        QgsDebugMsgLevel( "Plugin icon: " + pIcon(), 2 );
+        QgsDebugMsgLevel( "Plugin icon: " + *pIcon(), 2 );
       }
       else
       {
@@ -481,7 +481,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pCreateDate )
       {
-        QgsDebugMsgLevel( "Plugin create date: " + pCreateDate(), 2 );
+        QgsDebugMsgLevel( "Plugin create date: " + *pCreateDate(), 2 );
       }
       else
       {
@@ -489,7 +489,7 @@ void QgsPluginManager::getCppPluginsMetadata()
       }
       if ( pUpdateDate )
       {
-        QgsDebugMsgLevel( "Plugin update date: " + pUpdateDate(), 2 );
+        QgsDebugMsgLevel( "Plugin update date: " + *pUpdateDate(), 2 );
       }
       else
       {
@@ -508,19 +508,19 @@ void QgsPluginManager::getCppPluginsMetadata()
 
       QMap<QString, QString> metadata;
       metadata[QStringLiteral( "id" )] = baseName;
-      metadata[QStringLiteral( "name" )] = pName();
-      metadata[QStringLiteral( "description" )] = pDesc();
-      metadata[QStringLiteral( "category" )] = ( pCat ? pCat() : tr( "Plugins" ) );
-      metadata[QStringLiteral( "version_installed" )] = pVersion();
-      metadata[QStringLiteral( "icon" )] = ( pIcon ? pIcon() : QString() );
+      metadata[QStringLiteral( "name" )] = *pName();
+      metadata[QStringLiteral( "description" )] = *pDesc();
+      metadata[QStringLiteral( "category" )] = ( pCat ? *pCat() : tr( "Plugins" ) );
+      metadata[QStringLiteral( "version_installed" )] = *pVersion();
+      metadata[QStringLiteral( "icon" )] = ( pIcon ? *pIcon() : QString() );
       metadata[QStringLiteral( "library" )] = myLib->fileName();
       metadata[QStringLiteral( "pythonic" )] = QStringLiteral( "false" );
       metadata[QStringLiteral( "installed" )] = QStringLiteral( "true" );
       metadata[QStringLiteral( "readonly" )] = QStringLiteral( "true" );
       metadata[QStringLiteral( "status" )] = QStringLiteral( "orphan" );
-      metadata[QStringLiteral( "experimental" )] = ( pExperimental ? pExperimental() : QString() );
-      metadata[QStringLiteral( "create_date" )] = ( pCreateDate ? pCreateDate() : QString() );
-      metadata[QStringLiteral( "update_date" )] = ( pUpdateDate ? pUpdateDate() : QString() );
+      metadata[QStringLiteral( "experimental" )] = ( pExperimental ? *pExperimental() : QString() );
+      metadata[QStringLiteral( "create_date" )] = ( pCreateDate ? *pCreateDate() : QString() );
+      metadata[QStringLiteral( "update_date" )] = ( pUpdateDate ? *pUpdateDate() : QString() );
       mPlugins.insert( baseName, metadata );
 
       delete myLib;

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -41,9 +41,9 @@
 
 /* typedefs for plugins */
 typedef QgisPlugin *create_ui( QgisInterface *qI );
-typedef QString name_t();
-typedef QString description_t();
-typedef QString category_t();
+typedef const QString *name_t();
+typedef const QString *description_t();
+typedef const QString *category_t();
 typedef int type_t();
 
 
@@ -372,10 +372,10 @@ void QgsPluginRegistry::loadCppPlugin( const QString &fullPathName )
         {
           pl->initGui();
           // add it to the plugin registry
-          addPlugin( baseName, QgsPluginMetadata( myLib.fileName(), pName(), pl ) );
+          addPlugin( baseName, QgsPluginMetadata( myLib.fileName(), *pName(), pl ) );
           //add it to the qsettings file [ts]
           settings.setValue( "/Plugins/" + baseName, true );
-          QgsMessageLog::logMessage( QObject::tr( "Loaded %1 (Path: %2)" ).arg( pName(), myLib.fileName() ), QObject::tr( "Plugins" ), Qgis::MessageLevel::Info );
+          QgsMessageLog::logMessage( QObject::tr( "Loaded %1 (Path: %2)" ).arg( *pName(), myLib.fileName() ), QObject::tr( "Plugins" ), Qgis::MessageLevel::Info );
 
           QObject *o = dynamic_cast<QObject *>( pl );
           if ( o )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1147,10 +1147,6 @@ typedef unsigned long long qgssize;
 #ifndef QGISEXTERN
 #ifdef Q_OS_WIN
 #  define QGISEXTERN extern "C" __declspec( dllexport )
-#  ifdef _MSC_VER
-// do not warn about C bindings returning QString
-#    pragma warning(disable:4190)
-#  endif
 #else
 #  if defined(__GNUC__) || defined(__clang__)
 #    define QGISEXTERN extern "C" __attribute__ ((visibility ("default")))

--- a/src/core/qgsfeaturefilterprovider.h
+++ b/src/core/qgsfeaturefilterprovider.h
@@ -23,10 +23,10 @@
 #include "qgis_sip.h"
 
 #include "qgis_core.h"
+#include "qgsfeaturerequest.h"
 
 class QString;
 class QgsVectorLayer;
-class QgsFeatureRequest;
 
 
 /**

--- a/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
@@ -68,21 +68,21 @@ QGISEXTERN QgisPlugin *classFactory( QgisInterface *qgisInterfacePointer )
 }
 // Return the name of the plugin - note that we do not user class members as
 // the class may not yet be insantiated when this method is called.
-QGISEXTERN QString name()
+QGISEXTERN const QString *name()
 {
-  return sName;
+  return &sName;
 }
 
 // Return the description
-QGISEXTERN QString description()
+QGISEXTERN const QString *description()
 {
-  return sDescription;
+  return &sDescription;
 }
 
 // Return the category
-QGISEXTERN QString category()
+QGISEXTERN const QString *category()
 {
-  return sCategory;
+  return &sCategory;
 }
 
 // Return the type (either UI or MapLayer plugin)
@@ -92,14 +92,14 @@ QGISEXTERN int type()
 }
 
 // Return the version number for the plugin
-QGISEXTERN QString version()
+QGISEXTERN const QString *version()
 {
-  return sPluginVersion;
+  return &sPluginVersion;
 }
 
-QGISEXTERN QString icon()
+QGISEXTERN const QString *icon()
 {
-  return sPluginIcon;
+  return &sPluginIcon;
 }
 
 // Delete ourself

--- a/src/plugins/gps_importer/qgsgpsplugin.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugin.cpp
@@ -704,21 +704,21 @@ QGISEXTERN QgisPlugin *classFactory( QgisInterface *qgisInterfacePointer )
 
 // Return the name of the plugin - note that we do not user class members as
 // the class may not yet be insantiated when this method is called.
-QGISEXTERN QString name()
+QGISEXTERN const QString *name()
 {
-  return name_;
+  return &name_;
 }
 
 // Return the description
-QGISEXTERN QString description()
+QGISEXTERN const QString *description()
 {
-  return description_;
+  return &description_;
 }
 
 // Return the category
-QGISEXTERN QString category()
+QGISEXTERN const QString *category()
 {
-  return category_;
+  return &category_;
 }
 
 // Return the type (either UI or MapLayer plugin)
@@ -728,14 +728,14 @@ QGISEXTERN int type()
 }
 
 // Return the version number for the plugin
-QGISEXTERN QString version()
+QGISEXTERN const QString *version()
 {
-  return version_;
+  return &version_;
 }
 
-QGISEXTERN QString icon()
+QGISEXTERN const QString *icon()
 {
-  return icon_;
+  return &icon_;
 }
 
 // Delete ourself

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -907,21 +907,21 @@ QGISEXTERN QgisPlugin *classFactory( QgisInterface *qgisInterfacePointer )
 
 // Return the name of the plugin - note that we do not user class members as
 // the class may not yet be insantiated when this method is called.
-QGISEXTERN QString name()
+QGISEXTERN const QString *name()
 {
-  return pluginName;
+  return &pluginName;
 }
 
 // Return the description
-QGISEXTERN QString description()
+QGISEXTERN const QString *description()
 {
-  return pluginDescription;
+  return &pluginDescription;
 }
 
 // Return the category
-QGISEXTERN QString category()
+QGISEXTERN const QString *category()
 {
-  return pluginCategory;
+  return &pluginCategory;
 }
 
 // Return the type (either UI or MapLayer plugin)
@@ -931,14 +931,14 @@ QGISEXTERN int type()
 }
 
 // Return the version number for the plugin
-QGISEXTERN QString version()
+QGISEXTERN const QString *version()
 {
-  return pluginVersion;
+  return &pluginVersion;
 }
 
-QGISEXTERN QString icon()
+QGISEXTERN const QString *icon()
 {
-  return pluginIcon;
+  return &pluginIcon;
 }
 
 // Delete ourself

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -217,21 +217,21 @@ QGISEXTERN QgisPlugin *classFactory( QgisInterface *qgisInterfacePointer )
 
 // Return the name of the plugin - note that we do not user class members as
 // the class may not yet be insantiated when this method is called.
-QGISEXTERN QString name()
+QGISEXTERN const QString *name()
 {
-  return sName;
+  return &sName;
 }
 
 // Return the description
-QGISEXTERN QString description()
+QGISEXTERN const QString *description()
 {
-  return sDescription;
+  return &sDescription;
 }
 
 // Return the category
-QGISEXTERN QString category()
+QGISEXTERN const QString *category()
 {
-  return sCategory;
+  return &sCategory;
 }
 
 // Return the type (either UI or MapLayer plugin)
@@ -241,14 +241,14 @@ QGISEXTERN int type()
 }
 
 // Return the version number for the plugin
-QGISEXTERN QString version()
+QGISEXTERN const QString *version()
 {
-  return sPluginVersion;
+  return &sPluginVersion;
 }
 
-QGISEXTERN QString icon()
+QGISEXTERN const QString *icon()
 {
-  return sPluginIcon;
+  return &sPluginIcon;
 }
 
 // Delete ourself

--- a/src/plugins/qgisplugin.h
+++ b/src/plugins/qgisplugin.h
@@ -195,30 +195,30 @@ typedef QgisPlugin *create_t( QgisInterface * );
 typedef void unload_t( QgisPlugin * );
 
 //! Typedef for getting the name of the plugin without instantiating it
-typedef QString name_t();
+typedef const QString *name_t();
 
 //! Typedef for getting the description without instantiating the plugin
-typedef QString description_t();
+typedef const QString *description_t();
 
 //! Typedef for getting the category without instantiating the plugin
-typedef QString category_t();
+typedef const QString *category_t();
 
 //! Typedef for getting the plugin type without instantiating the plugin
 typedef int type_t();
 
 //! Typedef for getting the plugin version without instantiating the plugin
-typedef QString version_t();
+typedef const QString *version_t();
 
 //! Typedef for getting the plugin icon file name without instantiating the plugin
-typedef QString icon_t();
+typedef const QString *icon_t();
 
 //! Typedef for getting the experimental status without instantiating the plugin
-typedef QString experimental_t();
+typedef const QString *experimental_t();
 
 //! Typedef for getting the create date without instantiating the plugin
-typedef QString create_date_t();
+typedef const QString *create_date_t();
 
 //! Typedef for getting the update date status without instantiating the plugin
-typedef QString update_date_t();
+typedef const QString *update_date_t();
 
 #endif // QGISPLUGIN_H

--- a/src/plugins/topology/topol.cpp
+++ b/src/plugins/topology/topol.cpp
@@ -141,15 +141,15 @@ QGISEXTERN QgisPlugin *classFactory( QgisInterface *qgisInterfacePointer )
 }
 // Return the name of the plugin - note that we do not user class members as
 // the class may not yet be insantiated when this method is called.
-QGISEXTERN QString name()
+QGISEXTERN const QString *name()
 {
-  return sName;
+  return &sName;
 }
 
 // Return the description
-QGISEXTERN QString description()
+QGISEXTERN const QString *description()
 {
-  return sDescription;
+  return &sDescription;
 }
 
 // Return the type (either UI or MapLayer plugin)
@@ -159,20 +159,20 @@ QGISEXTERN int type()
 }
 
 // Return the category
-QGISEXTERN QString category()
+QGISEXTERN const QString *category()
 {
-  return sCategory;
+  return &sCategory;
 }
 
 // Return the version number for the plugin
-QGISEXTERN QString version()
+QGISEXTERN const QString *version()
 {
-  return sPluginVersion;
+  return &sPluginVersion;
 }
 
-QGISEXTERN QString icon()
+QGISEXTERN const QString *icon()
 {
-  return sPluginIcon;
+  return &sPluginIcon;
 }
 
 // Delete ourself


### PR DESCRIPTION
... to fix the -Wreturn-type-c-linkage warnings.

The methods that returned a QString now return a const QString*.

This is a breakage for out-of-tree native plugins.

I was considering changing the names of the methods, for example "namePtr" instead of "name", to detect more easily mismatches. I'm happy to do it if needed