### PR TITLE
MemoryProvider fix strange fieldName suffix in cloned layer

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,8 +8,6 @@ ignore =
 	E501,
 	# do not use variables named ‘l’, ‘O’, or ‘I’
 	E741,
-	# redefinition of unused name from line N
-	F811,
 	# local variable name is assigned to but never used
 	F841,
 	# class names should use CapWords convention

--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,8 @@ ignore =
 	E501,
 	# do not use variables named ‘l’, ‘O’, or ‘I’
 	E741,
+	# redefinition of unused name from line N
+	F811,
 	# local variable name is assigned to but never used
 	F841,
 	# class names should use CapWords convention

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -103,7 +103,6 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
                   << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
 
                   // boolean
-                  << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool )
                   << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "boolean" ), QVariant::Bool )
 
                   // blob

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -104,6 +104,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
 
                   // boolean
                   << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool )
+                  << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "boolean" ), QVariant::Bool )
 
                   // blob
                   << QgsVectorDataProvider::NativeType( tr( "Binary object (BLOB)" ), QStringLiteral( "binary" ), QVariant::ByteArray )
@@ -556,28 +557,39 @@ bool QgsMemoryProvider::deleteFeatures( const QgsFeatureIds &id )
 
 bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
 {
-  for ( QList<QgsField>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
+  for ( QgsField field : attributes )
   {
-    switch ( it->type() )
+    if ( !supportedType( field ) )
+      continue;
+
+    // Make sure added attributes typeName correspond to a native type name
+    bool isNativeTypeName = false;
+    NativeType nativeTypeCandidate( QString(), QString(), QVariant::Invalid );
+    for ( const NativeType &nativeType : nativeTypes() )
     {
-      case QVariant::Int:
-      case QVariant::Double:
-      case QVariant::String:
-      case QVariant::Date:
-      case QVariant::Time:
-      case QVariant::DateTime:
-      case QVariant::LongLong:
-      case QVariant::StringList:
-      case QVariant::List:
-      case QVariant::Bool:
-      case QVariant::ByteArray:
+      if ( nativeType.mTypeName.toLower() == field.typeName().toLower() )
+      {
+        isNativeTypeName = true;
         break;
-      default:
-        QgsDebugMsg( "Field type not supported: " + it->typeName() );
-        continue;
+      }
+
+      if ( nativeType.mType == field.type()
+           && nativeTypeCandidate.mType == QVariant::Invalid )
+        nativeTypeCandidate = nativeType;
     }
+    if ( !isNativeTypeName )
+    {
+      if ( nativeTypeCandidate.mType == QVariant::Invalid )
+      {
+        QgsDebugMsg( "Field type not supported: " + field.typeName() );
+        continue;
+      }
+
+      field.setTypeName( nativeTypeCandidate.mTypeName );
+    }
+
     // add new field as a last one
-    mFields.append( *it );
+    mFields.append( field );
 
     for ( QgsFeatureMap::iterator fit = mFeatures.begin(); fit != mFeatures.end(); ++fit )
     {

--- a/tests/src/python/test_qgsauxiliarystorage.py
+++ b/tests/src/python/test_qgsauxiliarystorage.py
@@ -551,7 +551,7 @@ class TestQgsAuxiliaryStorage(unittest.TestCase):
 
         # create auxiliary storage based on the invalid field
         s = QgsAuxiliaryStorage()
-        pkf = vl.fields().field(vl.fields().indexOf('invalid_pk'))
+        pkf = field
         al = s.createAuxiliaryLayer(pkf, vl)
 
         self.assertEqual(al, None)


### PR DESCRIPTION
If fields added with `QgsMemoryProvider::addAttributes` have an empty typeName, the URI returned by `vl.publicSource()` misses the type information for fields.

This are the steps to reproduce the bug:
``` python
vl = QgsVectorLayer("Point", "temporary_points", "memory")
pr = vl.dataProvider()
pr.addAttributes([QgsField("name", QVariant.String)])
vl.updateFields()
vl2 = vl.clone()
vl2.fields()[0].name() # Resulting field name: 'name:(0,0)'
```