### PR TITLE
Amend sprite retrieval (qgis#43925)

### DIFF
--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -424,7 +424,10 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
 
       for ( int resolution = 2; resolution > 0; resolution-- )
       {
-        QNetworkRequest request = QNetworkRequest( QUrl( spriteUriBase + QStringLiteral( "%1.json" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) ) );
+        QUrl spriteUrl = QUrl( spriteUriBase );
+        spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.json" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
+        QNetworkRequest request = QNetworkRequest( spriteUrl );
+        
         QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
         QgsBlockingNetworkRequest networkRequest;
         switch ( networkRequest.get( request ) )
@@ -435,10 +438,11 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
             const QVariantMap spriteDefinition = QgsJsonUtils::parseJson( content.content() ).toMap();
 
             // retrieve sprite images
-            QNetworkRequest request = QNetworkRequest( QUrl( spriteUriBase + QStringLiteral( "%1.png" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) ) );
-
+            QUrl spriteUrl = QUrl( spriteUriBase );
+            spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.png" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
+            QNetworkRequest request = QNetworkRequest( spriteUrl );
+            
             QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
-
             QgsBlockingNetworkRequest networkRequest;
             switch ( networkRequest.get( request ) )
             {

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -427,7 +427,6 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
         QUrl spriteUrl = QUrl( spriteUriBase );
         spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.json" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
         QNetworkRequest request = QNetworkRequest( spriteUrl );
-        
         QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
         QgsBlockingNetworkRequest networkRequest;
         switch ( networkRequest.get( request ) )
@@ -441,7 +440,6 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
             QUrl spriteUrl = QUrl( spriteUriBase );
             spriteUrl.setPath( spriteUrl.path() + QStringLiteral( "%1.png" ).arg( resolution > 1 ? QStringLiteral( "@%1x" ).arg( resolution ) : QString() ) );
             QNetworkRequest request = QNetworkRequest( spriteUrl );
-            
             QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsVectorTileLayer" ) )
             QgsBlockingNetworkRequest networkRequest;
             switch ( networkRequest.get( request ) )


### PR DESCRIPTION
Update sprite url path with resolution and extension rather than simply appending to string

Fixes #43925
