### PR TITLE
Try to fix `404  Not Found` when installing python3-virtualenv in OGC workflow

### DIFF
--- a/.ci/ogc/Dockerfile
+++ b/.ci/ogc/Dockerfile
@@ -6,6 +6,7 @@ ENV  DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
+  ccache \
   cmake \
   ninja-build \
   clang \

--- a/.ci/ogc/build.sh
+++ b/.ci/ogc/build.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
+set -e
+
 mkdir /usr/src/qgis/build
 cd /usr/src/qgis/build || exit 1
 
+export CCACHE_TEMPDIR=/tmp
+# Github workflow cache max size is 2.0, but ccache data get compressed (roughly 1/5?)
+ccache -M 2.0G
+
+# Temporarily uncomment to debug ccache issues
+# export CCACHE_LOGFILE=/tmp/cache.debug
+ccache -z
+
 cmake -GNinja \
+ -DUSE_CCACHE=ON \
  -DWITH_QUICK=OFF \
  -DWITH_3D=OFF \
  -DWITH_STAGED_PLUGINS=OFF \
@@ -31,3 +42,6 @@ cmake -GNinja \
  ..
 
 ninja
+
+echo "ccache statistics"
+ccache -s

--- a/.ci/ogc/docker-compose.yml
+++ b/.ci/ogc/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - qgis-server
 
   qgis-server:
-    image: qgis_server_deps
+    image: ${DOCKER_IMAGE}
     container_name: qgis_server_deps
     volumes:
       - ./../../:/usr/src/qgis/

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -19,17 +19,52 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Setup build dependencies
-        run: |
-          docker build -t qgis_server_deps -f .ci/ogc/Dockerfile .ci/ogc/
+      - name: Prepare build cache for pull request
+        uses: pat-s/always-upload-cache@v2.1.5
+        if: github.event_name == 'pull_request'
+        with:
+          path: /home/runner/QGIS/.ccache
+          key: build-ccache-ogc-${{ github.actor }}-${{ github.head_ref }}-${{ github.sha }}
+          # The head_ref or source branch of the pull request in a workflow run.
+          # The base_ref or target branch of the pull request in a workflow run.
+          restore-keys: |
+            build-ccache-ogc-${{ github.actor }}-${{ github.head_ref }}-
+            build-ccache-ogc-refs/heads/${{ github.base_ref }}-
+            build-ccache-ogc-refs/heads/master-
+      - name: Prepare build cache for branch/tag
+        # use a fork of actions/cache@v2 to upload cache even when the build or test failed
+        uses: pat-s/always-upload-cache@v2.1.5
+        if: github.event_name != 'pull_request'
+        with:
+          path: /home/runner/QGIS/.ccache
+          # The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>
+          key: build-ccache-ogc-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            build-ccache-ogc-${{ github.ref }}-
+            build-ccache-ogc-refs/heads/master-
+      - name: Build Docker Container with Build Environment
+        id: docker-build
+        uses: whoan/docker-build-with-cache-action@v5
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          image_name: qgis-deps-ogc
+          context: .ci/ogc
+          dockerfile: Dockerfile
+          push_git_tag: true
+          push_image_and_stages: on:push
+          pull_image_and_stages: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Run build
         run: |
-          docker run -v $(pwd):/usr/src/qgis qgis_server_deps /usr/src/qgis/.ci/ogc/build.sh
+          docker run -v $(pwd):/usr/src/qgis -v /home/runner/QGIS/.ccache:/root/.ccache ${DOCKER_IMAGE} /usr/src/qgis/.ci/ogc/build.sh
+        env:
+          DOCKER_IMAGE: ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }}
 
       - name: Install pyogctest
         run: |
-          sudo apt-get install python3-virtualenv virtualenv git
+          sudo apt-get update && sudo apt-get install python3-virtualenv virtualenv git
           git clone https://github.com/pblottiere/pyogctest
           cd pyogctest && git checkout 1.0.4 && cd -
           virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install -e pyogctest/
@@ -42,3 +77,5 @@ jobs:
         run: |
           docker-compose -f .ci/ogc/docker-compose.yml up -d
           source venv/bin/activate && ./pyogctest/pyogctest.py -n ogc_qgis -s wms130 -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver
+        env:
+          DOCKER_IMAGE: ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }}


### PR DESCRIPTION
## Description

 Lately, there's strange errors on some backports when trying to install `python3-virtualenv` in GitHub actions:

``` bash
The following NEW packages will be installed:
  python3-appdirs python3-distlib python3-filelock python3-virtualenv
  virtualenv
0 upgraded, 5 newly installed, 0 to remove and 13 not upgraded.
Need to get 199 kB of archives.
After this operation, 1056 kB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 python3-appdirs all 1.4.3-2.1 [10.8 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 python3-distlib all 0.3.0-1 [116 kB]Get:3 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 python3-filelock all 3.0.12-2 [7948 B]
Err:4 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 python3-virtualenv all 20.0.17-1ubuntu0.3
  404  Not Found [IP: 52.147.219.192 80]
Err:5 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 virtualenv all 20.0.17-1ubuntu0.3
  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/p/python-virtualenv/python3-virtualenv_20.0.17-1ubuntu0.3_all.deb  404  Not Found [IP: 52.147.219.192 80]
Fetched 135 kB in 0s (490 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/p/python-virtualenv/virtualenv_20.0.17-1ubuntu0.3_all.deb  404  Not Found [IP: 52.147.219.192 80]
``` 

I'm not sure how we could improve the situation though (I'll try to install `virtualenv` thanks to `pip3`).