### PR TITLE
OGR/SQLite/GPKG pragma-defer_foreign_keys=ON

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.h
+++ b/src/core/providers/ogr/qgsogrproviderutils.h
@@ -270,6 +270,7 @@ class CORE_EXPORT QgsOgrProviderUtils
 class QgsOgrDataset
 {
     friend class QgsOgrProviderUtils;
+    friend class QgsOgrTransaction;
     QgsOgrProviderUtils::DatasetIdentification mIdent;
     QgsOgrProviderUtils::DatasetWithLayers *mDs;
 

--- a/src/core/providers/ogr/qgsogrtransaction.cpp
+++ b/src/core/providers/ogr/qgsogrtransaction.cpp
@@ -31,6 +31,16 @@ QgsOgrTransaction::QgsOgrTransaction( const QString &connString, QgsOgrDatasetSh
 
 bool QgsOgrTransaction::beginTransaction( QString &error, int /* statementTimeout */ )
 {
+  GDALDriverH hDriver = GDALGetDatasetDriver( mSharedDS.get()->mDs->hDS );
+  const QString driverName = GDALGetDriverShortName( hDriver );
+  if ( driverName == QLatin1String( "GPKG" ) || driverName == QLatin1String( "SQLite" ) )
+  {
+    QString fkDeferError;
+    if ( ! executeSql( QStringLiteral( "PRAGMA defer_foreign_keys = ON" ), fkDeferError ) )
+    {
+      QgsDebugMsg( QStringLiteral( "Error setting PRAGMA defer_foreign_keys = ON: %1" ).arg( fkDeferError ) );
+    }
+  }
   return executeSql( QStringLiteral( "BEGIN" ), error );
 }
 


### PR DESCRIPTION
When in transaction forces defer FK evaluation.

While debugging #43959 , I tested this approach which makes the relations work also when the FK constraint is not `DEFERRABLE`.

I'm not really sure how common is this case in the real world, feel free to close if you think this is not useful.