### PR TITLE
Fix compilation when WITH_QTWEBKIT=FALSE

### DIFF
--- a/tests/src/gui/testqgshtmlwidgetwrapper.cpp
+++ b/tests/src/gui/testqgshtmlwidgetwrapper.cpp
@@ -13,7 +13,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifdef WITH_QTWEBKIT
 #include <QWebFrame>
+#endif
 
 #include "qgstest.h"
 
@@ -91,7 +93,9 @@ void TestQgsHtmlWidgetWrapper::testExpressionEvaluate()
 
   htmlWrapper->setFeature( f );
 
+#ifdef WITH_QTWEBKIT
   QCOMPARE( webView->page()->mainFrame()->toPlainText(), expectedText );
+#endif
 
   QgsProject::instance()->removeMapLayer( &layer );
 }


### PR DESCRIPTION
Follows #43617 which breaks build when QtWebkit is disabled

cc @elpaso