### PR TITLE
[bugfix] Fix scalebar decoration in rotated map (Fix #44011)

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -497,7 +497,7 @@ Check whether the map settings are valid and can be used for rendering
 %End
     QgsRectangle visibleExtent() const;
 %Docstring
-Returns the actual extent derived from requested extent that takes takes output image size into account
+Returns the actual extent derived from requested extent that takes output image size into account
 %End
 
     QPolygonF visiblePolygon() const;

--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -212,7 +212,9 @@ void QgsDecorationScaleBar::setupScaleBar()
 
 double QgsDecorationScaleBar::mapWidth( const QgsMapSettings &settings ) const
 {
-  const QgsRectangle mapExtent = settings.visibleExtent();
+  QgsMapSettings ms = settings;
+  ms.setRotation( 0 );
+  const QgsRectangle mapExtent = ms.visibleExtent();
   if ( mSettings.units() == QgsUnitTypes::DistanceUnknownUnit )
   {
     return mapExtent.width();

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -459,7 +459,7 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
 
     //! Check whether the map settings are valid and can be used for rendering
     bool hasValidSettings() const;
-    //! Returns the actual extent derived from requested extent that takes takes output image size into account
+    //! Returns the actual extent derived from requested extent that takes output image size into account
     QgsRectangle visibleExtent() const;
 
     /**


### PR DESCRIPTION
## Description

Resets the map rotation before calculating the map width from QgsMapSettings::visibleExtent().

Fixes #44011.

Also fixes a typo in QgsMapSettings::visibleExtent() documentation.

This PR needs to be backported.

Ref: https://github.com/qgis/QGIS/pull/37084, https://github.com/qgis/QGIS/pull/41056.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
