### PR TITLE
fix updating disabled scalar dataset group for mesh layer

### DIFF
--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -214,7 +214,7 @@ void QgsMeshLayerProperties::syncToLayer()
     mDatasetGroupTreeWidget->syncToLayer( mMeshLayer );
 
   QgsDebugMsgLevel( QStringLiteral( "populate config tab" ), 4 );
-  for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
+  for ( QgsMapLayerConfigWidget *w : std::as_const( mConfigWidgets ) )
     w->syncToLayer( mMeshLayer );
 
   QgsDebugMsgLevel( QStringLiteral( "populate rendering tab" ), 4 );
@@ -362,7 +362,7 @@ void QgsMeshLayerProperties::apply()
 
   QgsDebugMsgLevel( QStringLiteral( "processing config tabs" ), 4 );
 
-  for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
+  for ( QgsMapLayerConfigWidget *w : std::as_const( mConfigWidgets ) )
     w->apply();
 
   QgsDebugMsgLevel( QStringLiteral( "processing rendering tab" ), 4 );
@@ -410,7 +410,8 @@ void QgsMeshLayerProperties::apply()
 
   // Resync what have to be resync (widget that can be changed by other properties part)
   mStaticDatasetWidget->syncToLayer();
-  mRendererMeshPropertiesWidget->syncToLayer();
+  for ( QgsMapLayerConfigWidget *w : std::as_const( mConfigWidgets ) )
+    w->syncToLayer( mMeshLayer );
 }
 
 void QgsMeshLayerProperties::changeCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/mesh/qgsmeshstaticdatasetwidget.cpp
+++ b/src/gui/mesh/qgsmeshstaticdatasetwidget.cpp
@@ -48,8 +48,22 @@ void QgsMeshStaticDatasetWidget::apply()
   if ( !mLayer )
     return;
 
-  mLayer->setStaticScalarDatasetIndex( QgsMeshDatasetIndex( mScalarDatasetGroup, mScalarDatasetComboBox->currentIndex() - 1 ) );
-  mLayer->setStaticVectorDatasetIndex( QgsMeshDatasetIndex( mVectorDatasetGroup, mVectorDatasetComboBox->currentIndex() - 1 ) );
+  int scalarIndex;
+  // if only one item, there is no active dataset group.
+  // Set to 0 instead of -1 to avoid none dataset (item 0) when the group is reactivate
+  if ( mScalarDatasetComboBox->count() == 1 )
+    scalarIndex = 0;
+  else
+    scalarIndex = mScalarDatasetComboBox->currentIndex() - 1;
+  int vectorIndex;
+  // Same as scalar
+  if ( mVectorDatasetComboBox->count() == 1 )
+    vectorIndex = 0;
+  else
+    vectorIndex = mVectorDatasetComboBox->currentIndex() - 1;
+
+  mLayer->setStaticScalarDatasetIndex( QgsMeshDatasetIndex( mScalarDatasetGroup, scalarIndex ) );
+  mLayer->setStaticVectorDatasetIndex( QgsMeshDatasetIndex( mVectorDatasetGroup, vectorIndex ) );
 }
 
 void QgsMeshStaticDatasetWidget::setScalarDatasetGroup( int index )


### PR DESCRIPTION
This PR fixes two bugs:
- In mesh layer properties, when the scalar rendering is disabled, using the 3D tab leads to crash. That is due to the dataset group combo box that is not updated when.
- Still in mesh layer properties and when scalar rendering is disabled, re-enable does not lead to display again directly the dataset group. The user needs to reactivate it by going to the static dataset widget in the source tab.
-