### PR TITLE
fix project dirtiness when changing layout name, FIX #44035

### DIFF
--- a/src/core/layout/qgsprintlayout.cpp
+++ b/src/core/layout/qgsprintlayout.cpp
@@ -64,6 +64,7 @@ void QgsPrintLayout::setName( const QString &name )
 {
   mName = name;
   emit nameChanged( name );
+  layoutProject()->setDirty( true );
 }
 
 QDomElement QgsPrintLayout::writeXml( QDomDocument &document, const QgsReadWriteContext &context ) const

--- a/tests/src/core/testqgslayout.cpp
+++ b/tests/src/core/testqgslayout.cpp
@@ -174,6 +174,7 @@ void TestQgsLayout::name()
   QString layoutName = QStringLiteral( "test name" );
   layout.setName( layoutName );
   QCOMPARE( layout.name(), layoutName );
+  QVERIFY( p.isDirty() );
 }
 
 void TestQgsLayout::customProperties()


### PR DESCRIPTION
## Description

FIX #44035

When changing layout name, the project is not set as "dirty". This PR add this behavior. 

I also added `QVERIFY( p.isDirty() );` in testqgslayout.cpp to check that the project is dirty after setName function.