### PR TITLE
If statistics summary dock is NOT visible, then don't calculate statistics

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -567,7 +567,7 @@ QgsStatisticalSummaryDockWidget::DataType QgsStatisticalSummaryDockWidget::field
 }
 
 QgsStatisticsValueGatherer::QgsStatisticsValueGatherer( QgsVectorLayer *layer, const QgsFeatureIterator &fit, long featureCount, const QString &sourceFieldExp )
-  : QgsTask( tr( "Fetching statistic values" ) )
+  : QgsTask( tr( "Fetching statistic values" ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt )
   , mFeatureIterator( fit )
   , mFeatureCount( featureCount )
   , mFieldExpression( sourceFieldExp )

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -82,6 +82,12 @@ QgsStatisticalSummaryDockWidget::QgsStatisticalSummaryDockWidget( QWidget *paren
   mFieldType = DataType::Numeric;
   mPreviousFieldType = DataType::Numeric;
   refreshStatisticsMenu();
+
+  connect( this, &QgsDockWidget::visibilityChanged, this, [ = ]( bool visible )
+  {
+    if ( mPendingCalculate && visible )
+      refreshStatistics();
+  } );
 }
 
 QgsStatisticalSummaryDockWidget::~QgsStatisticalSummaryDockWidget()
@@ -136,6 +142,16 @@ void QgsStatisticalSummaryDockWidget::refreshStatistics()
     mStatisticsTable->setRowCount( 0 );
     return;
   }
+
+  if ( !isUserVisible() )
+  {
+    //defer calculation until dock is visible -- no point calculating stats if the user can't
+    //see them!
+    mPendingCalculate = true;
+    return;
+  }
+
+  mPendingCalculate = false;
 
   // determine field type
   mFieldType = DataType::Numeric;

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -132,6 +132,8 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     QString mExpression;
 
     QgsStatisticsValueGatherer *mGatherer = nullptr;
+
+    bool mPendingCalculate = false;
 };
 
 #endif // QGSSTATISTICALSUMMARYDOCKWIDGET_H

--- a/src/core/vector/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.cpp
@@ -19,7 +19,7 @@
 #include "qgsfeedback.h"
 
 QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context, bool storeSymbolFids )
-  : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel )
+  : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt )
   , mSource( new QgsVectorLayerFeatureSource( layer ) )
   , mRenderer( layer->renderer()->clone() )
   , mExpressionContext( context )


### PR DESCRIPTION
Instead defer their calculation until the dock is made visible. No point doing all that work when the results aren't wanted/visible!