### PR TITLE
[feature][exiftools] Implement tags reading, allow for individual tag value read

### DIFF
--- a/python/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/core/auto_generated/raster/qgsexiftools.sip.in
@@ -26,8 +26,18 @@ Contains utilities for working with EXIF tags in images.
   public:
 
     static QVariantMap readTags( const QString &imagePath );
+%Docstring
+Returns a map object containing all exif tags stored in the image at ``imagePath``.
+
+.. versionadded:: 3.22
+%End
 
     static QVariant readTag( const QString &imagePath, const QString &key );
+%Docstring
+Returns the value of of an exif tag ``key`` stored in the image at ``imagePath``.
+
+.. versionadded:: 3.22
+%End
 
     static QgsPoint getGeoTag( const QString &imagePath, bool &ok /Out/ );
 %Docstring

--- a/python/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/core/auto_generated/raster/qgsexiftools.sip.in
@@ -25,6 +25,9 @@ Contains utilities for working with EXIF tags in images.
 
   public:
 
+    static QVariantMap readTags( const QString &imagePath );
+
+    static QVariant readTag( const QString &imagePath, const QString &key );
 
     static QgsPoint getGeoTag( const QString &imagePath, bool &ok /Out/ );
 %Docstring
@@ -75,6 +78,7 @@ Returns ``True`` if writing was successful.
 
 .. seealso:: :py:func:`getGeoTag`
 %End
+
 };
 
 /************************************************************************

--- a/src/core/raster/qgsexiftools.h
+++ b/src/core/raster/qgsexiftools.h
@@ -35,8 +35,16 @@ class CORE_EXPORT QgsExifTools
 
   public:
 
+    /**
+     * Returns a map object containing all exif tags stored in the image at \a imagePath.
+     * \since QGIS 3.22
+     */
     static QVariantMap readTags( const QString &imagePath );
 
+    /**
+     * Returns the value of of an exif tag \a key stored in the image at \a imagePath.
+     * \since QGIS 3.22
+     */
     static QVariant readTag( const QString &imagePath, const QString &key );
 
     /**

--- a/src/core/raster/qgsexiftools.h
+++ b/src/core/raster/qgsexiftools.h
@@ -35,9 +35,9 @@ class CORE_EXPORT QgsExifTools
 
   public:
 
-#if 0
     static QVariantMap readTags( const QString &imagePath );
-#endif
+
+    static QVariant readTag( const QString &imagePath, const QString &key );
 
     /**
      * Returns the geotagged coordinate stored in the image at \a imagePath.
@@ -90,6 +90,7 @@ class CORE_EXPORT QgsExifTools
      * \see getGeoTag()
      */
     static bool geoTagImage( const QString &imagePath, const QgsPointXY &location, const GeoTagDetails &details = QgsExifTools::GeoTagDetails() );
+
 };
 
 #endif // QGSEXIFTOOLS_H

--- a/tests/src/python/test_qgsexiftools.py
+++ b/tests/src/python/test_qgsexiftools.py
@@ -13,7 +13,7 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 import qgis  # NOQA switch sip api
 import os
 import shutil
-from qgis.PyQt.QtCore import QTemporaryFile
+from qgis.PyQt.QtCore import QTemporaryFile, QDateTime
 from qgis.core import QgsPointXY, QgsExifTools
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -24,6 +24,17 @@ start_app()
 
 
 class TestQgsExifUtils(unittest.TestCase):
+
+    def testReadTags(self):
+        photos_folder = os.path.join(TEST_DATA_DIR, 'photos')
+
+        # test a convnerted rational value
+        elevation = QgsExifTools.readTag(os.path.join(photos_folder, '0997.JPG'), 'Exif.GPSInfo.GPSAltitude')
+        self.assertEqual(elevation, 422.19101123595505)
+
+        # test a converted datetime value
+        dt = QgsExifTools.readTag(os.path.join(photos_folder, '0997.JPG'), 'Exif.Image.DateTime')
+        self.assertEqual(dt, QDateTime(2018, 3, 16, 12, 19, 19))
 
     def testGeoTags(self):
         photos_folder = os.path.join(TEST_DATA_DIR, 'photos')


### PR DESCRIPTION
## Description

This PR finishes the tags reading exif conversion implementation, and adds a function to read an individual tag to the QgsExifTools class. 

E.g.: `QgsExifTools.readTag('/my/photo/0997.JPG'), 'Exif.Image.DateTime')`

Implementation note: known exif date/time/datetime are converted to Q{Date,Time,DateTime} objects. This makes working with tags much nicer, and will come in handy in expression contexts too.