### PR TITLE
[processing] Fix file download alg stuck in infinit loop when network errors occur

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -78,9 +78,10 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   QEventLoop loop;
   QTimer timer;
   QUrl downloadedUrl;
+  QStringList errors;
   QgsFileDownloader *downloader = new QgsFileDownloader( QUrl( url ), outputFile, QString(), true );
   connect( mFeedback, &QgsFeedback::canceled, downloader, &QgsFileDownloader::cancelDownload );
-  connect( downloader, &QgsFileDownloader::downloadError, this, &QgsFileDownloaderAlgorithm::reportErrors );
+  connect( downloader, &QgsFileDownloader::downloadError, this, [&errors, &loop]( const QStringList & e ) { errors = e; loop.exit(); } );
   connect( downloader, &QgsFileDownloader::downloadProgress, this, &QgsFileDownloaderAlgorithm::receiveProgressFromDownloader );
   connect( downloader, &QgsFileDownloader::downloadCompleted, this, [&downloadedUrl]( const QUrl url ) { downloadedUrl = url; } );
   connect( downloader, &QgsFileDownloader::downloadExited, &loop, &QEventLoop::quit );
@@ -91,6 +92,9 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   loop.exec();
 
   timer.stop();
+  if ( errors.size() > 0 )
+    throw QgsProcessingException( errors.join( '\n' ) );
+
   bool exists = QFileInfo::exists( outputFile );
   if ( !feedback->isCanceled() && !exists )
     throw QgsProcessingException( tr( "Output file doesn't exist." ) );
@@ -115,11 +119,6 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), exists ? outputFile : QString() );
   return outputs;
-}
-
-void QgsFileDownloaderAlgorithm::reportErrors( const QStringList &errors )
-{
-  throw QgsProcessingException( errors.join( '\n' ) );
 }
 
 void QgsFileDownloaderAlgorithm::sendProgressFeedback()

--- a/src/analysis/processing/qgsalgorithmfiledownloader.h
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.h
@@ -55,7 +55,6 @@ class QgsFileDownloaderAlgorithm : public QObject, public QgsProcessingAlgorithm
     QString mReceived;
     QgsProcessingFeedback *mFeedback = nullptr;
     QString mLastReport;
-    void reportErrors( const QStringList &errors );
     void receiveProgressFromDownloader( qint64 bytesReceived, qint64 bytesTotal );
     void sendProgressFeedback();
 };


### PR DESCRIPTION
## Description

This PR fixes a bug whereas the file downloader algorithm gets stuck in an infinite loop when network errors occur. Long story short here: do not throw when inside an event loop and expect things will terminate properly :)