### PR TITLE
Also read proxyFactories of main NAM

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -67,7 +67,13 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
       QgsNetworkAccessManager *nam = QgsNetworkAccessManager::instance();
 
       // iterate proxies factories and take first non empty list
-      const auto constProxyFactories = nam->proxyFactories();
+      QList<QNetworkProxyFactory *> proxyFactories = QgsNetworkAccessManager::sMainNAM->proxyFactories();
+      if ( nam != QgsNetworkAccessManager::sMainNAM )
+      {
+        proxyFactories.append( nam->proxyFactories() );
+      }
+      const auto constProxyFactories = proxyFactories;
+
       for ( QNetworkProxyFactory *f : constProxyFactories )
       {
         QList<QNetworkProxy> systemproxies = f->systemProxyForQuery( query );

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -795,6 +795,8 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;
 
   private:
+    friend class QgsNetworkProxyFactory;
+
 #ifndef QT_NO_SSL
     void unlockAfterSslErrorHandled();
     void afterSslErrorHandled( QNetworkReply *reply );


### PR DESCRIPTION
Perhaps I've missed something, but AFAICS any child NAMs will not inherit the manually inserted proxy factories of the main NAM. This PR makes the QgsNetworkProxyFactory also iterate the manually inserted proxy factories of the main NAM.