### PR TITLE
[memory] Fix parsing of field name of 'text' type

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -120,7 +120,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
   {
     QList<QgsField> attributes;
     QRegExp reFieldDef( "\\:"
-                        "(int|integer|long|int8|real|double|string|date|time|datetime|binary|bool|boolean)" // type
+                        "(int|integer|long|int8|real|double|string|text|date|time|datetime|binary|bool|boolean)" // type
                         "(?:\\((\\-?\\d+)"                // length
                         "(?:\\,(\\-?\\d+))?"                  // precision
                         "\\))?(\\[\\])?"                  // array

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -803,6 +803,16 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         vl.dataProvider().createSpatialIndex()
         self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexPresent)
 
+    def testStringTextField(self):
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=f1:text(0,0)&field=f2:string(100,0)',
+            'test', 'memory')
+        self.assertEqual(vl.fields.size(), 2)
+        self.assertEqual(vl.fields().at(0).name(), 'f1')
+        self.assertEqual(vl.fields().at(0).type(), QVariant.String)
+        self.assertEqual(vl.fields().at(1).name(), 'f2')
+        self.assertEqual(vl.fields().at(1).type(), QVariant.String)
+
     def testTypeValidation(self):
         """Test that incompatible types in attributes raise errors"""
 


### PR DESCRIPTION
## Description

This PR fixes #44087 by adding a missing 'text' bit in the regular expression to extract field information from URI strings.