### PR TITLE
[qt6] Move string utils and {vector,raster} layer class away from QRegExp

### DIFF
--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsStringReplacement
 {
 %Docstring(signature="appended")

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -14,12 +14,13 @@
  ***************************************************************************/
 
 #include "qgis_core.h"
+#include "qgis.h"
+
 #include <QString>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QList>
 #include <QDomDocument>
 #include <QFont> // for enum values
-#include "qgis.h"
 
 #ifndef QGSSTRINGUTILS_H
 #define QGSSTRINGUTILS_H
@@ -101,7 +102,7 @@ class CORE_EXPORT QgsStringReplacement
 
     bool mWholeWordOnly;
 
-    QRegExp mRx;
+    QRegularExpression mRx;
 };
 
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -79,7 +79,7 @@ email                : tim at linfiniti.com
 #include <QList>
 #include <QPainter>
 #include <QPixmap>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSlider>
 #include <QUrl>
 
@@ -2321,13 +2321,14 @@ QString QgsRasterLayer::encodedSource( const QString &source, const QgsReadWrite
     {
       // NETCDF:filename:variable
       // filename can be quoted with " as it can contain colons
-      QRegExp r( "NETCDF:(.+):([^:]+)" );
-      if ( r.exactMatch( src ) )
+      const QRegularExpression netcdfEncodedRegExp( QRegularExpression::anchoredPattern( "NETCDF:(.+):([^:]+)" ) );
+      const QRegularExpressionMatch match = netcdfEncodedRegExp.match( src );
+      if ( match.hasMatch() )
       {
-        QString filename = r.cap( 1 );
+        QString filename = match.captured( 1 );
         if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
           filename = filename.mid( 1, filename.length() - 2 );
-        src = "NETCDF:\"" + context.pathResolver().writePath( filename ) + "\":" + r.cap( 2 );
+        src = "NETCDF:\"" + context.pathResolver().writePath( filename ) + "\":" + match.captured( 2 );
         handled = true;
       }
     }
@@ -2346,13 +2347,14 @@ QString QgsRasterLayer::encodedSource( const QString &source, const QgsReadWrite
     {
       // HDF4_SDS:subdataset_type:file_name:subdataset_index
       // filename can be quoted with " as it can contain colons
-      QRegExp r( "HDF4_SDS:([^:]+):(.+):([^:]+)" );
-      if ( r.exactMatch( src ) )
+      const QRegularExpression hdf4EncodedRegExp( QRegularExpression::anchoredPattern( "HDF4_SDS:([^:]+):(.+):([^:]+)" ) );
+      const QRegularExpressionMatch match = hdf4EncodedRegExp.match( src );
+      if ( match.hasMatch() )
       {
-        QString filename = r.cap( 2 );
+        QString filename = match.captured( 2 );
         if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
           filename = filename.mid( 1, filename.length() - 2 );
-        src = "HDF4_SDS:" + r.cap( 1 ) + ":\"" + context.pathResolver().writePath( filename ) + "\":" + r.cap( 3 );
+        src = "HDF4_SDS:" + match.captured( 1 ) + ":\"" + context.pathResolver().writePath( filename ) + "\":" + match.captured( 3 );
         handled = true;
       }
     }
@@ -2360,24 +2362,26 @@ QString QgsRasterLayer::encodedSource( const QString &source, const QgsReadWrite
     {
       // HDF5:file_name:subdataset
       // filename can be quoted with " as it can contain colons
-      QRegExp r( "HDF5:(.+):([^:]+)" );
-      if ( r.exactMatch( src ) )
+      const QRegularExpression hdf5EncodedRegExp( QRegularExpression::anchoredPattern( "HDF5:(.+):([^:]+)" ) );
+      const QRegularExpressionMatch match = hdf5EncodedRegExp.match( src );
+      if ( match.hasMatch() )
       {
-        QString filename = r.cap( 1 );
+        QString filename = match.captured( 1 );
         if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
           filename = filename.mid( 1, filename.length() - 2 );
-        src = "HDF5:\"" + context.pathResolver().writePath( filename ) + "\":" + r.cap( 2 );
+        src = "HDF5:\"" + context.pathResolver().writePath( filename ) + "\":" + match.captured( 2 );
         handled = true;
       }
     }
-    else if ( src.contains( QRegExp( "^(NITF_IM|RADARSAT_2_CALIB):" ) ) )
+    else if ( src.contains( QRegularExpression( "^(NITF_IM|RADARSAT_2_CALIB):" ) ) )
     {
       // NITF_IM:0:filename
       // RADARSAT_2_CALIB:?:filename
-      QRegExp r( "([^:]+):([^:]+):(.+)" );
-      if ( r.exactMatch( src ) )
+      const QRegularExpression nitfRadarsatEncodedRegExp( QRegularExpression::anchoredPattern( "([^:]+):([^:]+):(.+)" ) );
+      const QRegularExpressionMatch match = nitfRadarsatEncodedRegExp.match( src );
+      if ( match.hasMatch() )
       {
-        src = r.cap( 1 ) + ':' + r.cap( 2 ) + ':' + context.pathResolver().writePath( r.cap( 3 ) );
+        src = match.captured( 1 ) + ':' + match.captured( 2 ) + ':' + context.pathResolver().writePath( match.captured( 3 ) );
         handled = true;
       }
     }
@@ -2510,13 +2514,14 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
       {
         // NETCDF:filename:variable
         // filename can be quoted with " as it can contain colons
-        QRegExp r( "NETCDF:(.+):([^:]+)" );
-        if ( r.exactMatch( src ) )
+        const QRegularExpression netcdfDecodedRegExp( QRegularExpression::anchoredPattern( "NETCDF:(.+):([^:]+)" ) );
+        const QRegularExpressionMatch match = netcdfDecodedRegExp.match( src );
+        if ( match.hasMatch() )
         {
-          QString filename = r.cap( 1 );
+          QString filename = match.captured( 1 );
           if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
             filename = filename.mid( 1, filename.length() - 2 );
-          src = "NETCDF:\"" + context.pathResolver().readPath( filename ) + "\":" + r.cap( 2 );
+          src = "NETCDF:\"" + context.pathResolver().readPath( filename ) + "\":" + match.captured( 2 );
           handled = true;
         }
       }
@@ -2535,13 +2540,14 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
       {
         // HDF4_SDS:subdataset_type:file_name:subdataset_index
         // filename can be quoted with " as it can contain colons
-        QRegExp r( "HDF4_SDS:([^:]+):(.+):([^:]+)" );
-        if ( r.exactMatch( src ) )
+        const QRegularExpression hdf4DecodedRegExp( QRegularExpression::anchoredPattern( "HDF4_SDS:([^:]+):(.+):([^:]+)" ) );
+        const QRegularExpressionMatch match = hdf4DecodedRegExp.match( src );
+        if ( match.hasMatch() )
         {
-          QString filename = r.cap( 2 );
+          QString filename = match.captured( 2 );
           if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
             filename = filename.mid( 1, filename.length() - 2 );
-          src = "HDF4_SDS:" + r.cap( 1 ) + ":\"" + context.pathResolver().readPath( filename ) + "\":" + r.cap( 3 );
+          src = "HDF4_SDS:" + match.captured( 1 ) + ":\"" + context.pathResolver().readPath( filename ) + "\":" + match.captured( 3 );
           handled = true;
         }
       }
@@ -2549,24 +2555,26 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
       {
         // HDF5:file_name:subdataset
         // filename can be quoted with " as it can contain colons
-        QRegExp r( "HDF5:(.+):([^:]+)" );
-        if ( r.exactMatch( src ) )
+        const QRegularExpression hdf5DecodedRegExp( QRegularExpression::anchoredPattern( "HDF5:(.+):([^:]+)" ) );
+        const QRegularExpressionMatch match = hdf5DecodedRegExp.match( src );
+        if ( match.hasMatch() )
         {
-          QString filename = r.cap( 1 );
+          QString filename = match.captured( 1 );
           if ( filename.startsWith( '"' ) && filename.endsWith( '"' ) )
             filename = filename.mid( 1, filename.length() - 2 );
-          src = "HDF5:\"" + context.pathResolver().readPath( filename ) + "\":" + r.cap( 2 );
+          src = "HDF5:\"" + context.pathResolver().readPath( filename ) + "\":" + match.captured( 2 );
           handled = true;
         }
       }
-      else if ( src.contains( QRegExp( "^(NITF_IM|RADARSAT_2_CALIB):" ) ) )
+      else if ( src.contains( QRegularExpression( "^(NITF_IM|RADARSAT_2_CALIB):" ) ) )
       {
         // NITF_IM:0:filename
         // RADARSAT_2_CALIB:?:filename
-        QRegExp r( "([^:]+):([^:]+):(.+)" );
-        if ( r.exactMatch( src ) )
+        const QRegularExpression niftRadarsatDecodedRegExp( QRegularExpression::anchoredPattern( "([^:]+):([^:]+):(.+)" ) );
+        const QRegularExpressionMatch match = niftRadarsatDecodedRegExp.match( src );
+        if ( match.hasMatch() )
         {
-          src = r.cap( 1 ) + ':' + r.cap( 2 ) + ':' + context.pathResolver().readPath( r.cap( 3 ) );
+          src = match.captured( 1 ) + ':' + match.captured( 2 ) + ':' + context.pathResolver().readPath( match.captured( 3 ) );
           handled = true;
         }
       }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -21,28 +21,10 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <limits>
-
-#include <QDir>
-#include <QFile>
-#include <QImage>
-#include <QPainter>
-#include <QPainterPath>
-#include <QPolygonF>
-#include <QProgressDialog>
-#include <QString>
-#include <QDomNode>
-#include <QVector>
-#include <QStringBuilder>
-#include <QUrl>
-#include <QUndoCommand>
-#include <QUrlQuery>
-#include <QUuid>
-
+#include "qgis.h" //for globals
 #include "qgssettings.h"
 #include "qgsvectorlayer.h"
 #include "qgsactionmanager.h"
-#include "qgis.h" //for globals
 #include "qgsapplication.h"
 #include "qgsclipper.h"
 #include "qgsconditionalstyle.h"
@@ -107,6 +89,25 @@
 #include "qgsvectorlayerutils.h"
 
 #include "diagram/qgsdiagram.h"
+
+#include <QDir>
+#include <QFile>
+#include <QImage>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPolygonF>
+#include <QProgressDialog>
+#include <QString>
+#include <QDomNode>
+#include <QVector>
+#include <QStringBuilder>
+#include <QUrl>
+#include <QUndoCommand>
+#include <QUrlQuery>
+#include <QUuid>
+#include <QRegularExpression>
+
+#include <limits>
 
 #ifdef TESTPROVIDERLIB
 #include <dlfcn.h>
@@ -1835,10 +1836,11 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     QgsDebugMsgLevel( QStringLiteral( "Beautifying layer name %1" ).arg( name() ), 3 );
 
     // adjust the display name for postgres layers
-    QRegExp reg( R"lit("[^"]+"\."([^"] + )"( \([^)]+\))?)lit" );
-    if ( reg.indexIn( name() ) >= 0 )
+    const QRegularExpression reg( R"lit("[^"]+"\."([^"] + )"( \([^)]+\))?)lit" );
+    const QRegularExpressionMatch match = reg.match( name() );
+    if ( match.hasMatch() )
     {
-      QStringList stuff = reg.capturedTexts();
+      QStringList stuff = match.capturedTexts();
       QString lName = stuff[1];
 
       const QMap<QString, QgsMapLayer *> &layers = QgsProject::instance()->mapLayers();

--- a/tests/src/core/testqgspallabeling.cpp
+++ b/tests/src/core/testqgspallabeling.cpp
@@ -85,7 +85,7 @@ void TestQgsPalLabeling::wrapChar()
   QCOMPARE( QgsPalLabeling::splitToLines( "with auto wrap", QString(), 6, false ), QStringList() << "with auto" << "wrap" );
 
   // manual wrap character should take precedence
-  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with" << "auto" << "wrap and" << "manual" << "wrap" );
   QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 6, false ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
 }
 


### PR DESCRIPTION
## Description

The string utils one was a bit more involved. Vector and raster layer class straightforward. 