### PR TITLE
Don't disable JsonEditWidget by readonly layer

### DIFF
--- a/src/gui/editorwidgets/qgsjsoneditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwrapper.cpp
@@ -79,7 +79,7 @@ void QgsJsonEditWrapper::updateValues( const QVariant &value, const QVariantList
 
 void QgsJsonEditWrapper::setEnabled( bool enabled )
 {
-  if ( mJsonEditWidget )
-    mJsonEditWidget->setEnabled( enabled );
+  // No need to disable JsonEditWidget as it is already read only
+  Q_UNUSED( enabled )
 }
 


### PR DESCRIPTION
QGsJsonEditWidget is always read only, so there is no need to disable it completely when a layer is not editable.