### PR TITLE
Migrate remaining(*) uses of QRegExp in src/providers and tests/

### DIFF
--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -30,6 +30,7 @@
 #include <QListWidgetItem>
 #include <QMessageBox>
 #include <QFileDialog>
+#include <QRegularExpression>
 
 enum
 {
@@ -351,10 +352,8 @@ void QgsGeoNodeSourceSelect::loadGeonodeConnection()
 
 void QgsGeoNodeSourceSelect::filterChanged( const QString &text )
 {
-  QRegExp::PatternSyntax mySyntax = QRegExp::PatternSyntax( QRegExp::RegExp );
-  Qt::CaseSensitivity myCaseSensitivity = Qt::CaseInsensitive;
-  QRegExp myRegExp( text, myCaseSensitivity, mySyntax );
-  mModelProxy->setFilterRegExp( myRegExp );
+  QRegularExpression regExp( text, QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( regExp );
   mModelProxy->sort( mModelProxy->sortColumn(), mModelProxy->sortOrder() );
 }
 

--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -62,7 +62,7 @@
 #include <qvariant.h>
 #include <qdatetime.h>
 #include <qmetatype.h>
-#include <qregexp.h>
+#include <qregularexpression.h>
 #include <qshareddata.h>
 #include <qsqlerror.h>
 #include <qsqlfield.h>
@@ -3903,9 +3903,10 @@ bool QOCISpatialDriver::open( const QString &db,
   {
     QString versionStr;
     versionStr = QString( reinterpret_cast<const QChar *>( vertxt ) );
-    QRegExp vers( QLatin1String( "([0-9]+)\\.[0-9\\.]+[0-9]" ) );
-    if ( vers.indexIn( versionStr ) >= 0 )
-      d->serverVersion = vers.cap( 1 ).toInt();
+    QRegularExpression vers( QLatin1String( "([0-9]+)\\.[0-9\\.]+[0-9]" ) );
+    QRegularExpressionMatch match = vers.match( versionStr );
+    if ( match.hasMatch() )
+      d->serverVersion = match.captured( 1 ).toInt();
     if ( d->serverVersion == 0 )
       d->serverVersion = -1;
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -26,10 +26,6 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsxmlutils.h"
 #include "qgsvectorlayer.h"
-
-#include <QMessageBox>
-#include <QRegularExpression>
-
 #include "qgsvectorlayerexporter.h"
 #include "qgspostgresprovider.h"
 #include "qgspostgresconn.h"
@@ -43,12 +39,15 @@
 #include "qgslogger.h"
 #include "qgsfeedback.h"
 #include "qgssettings.h"
+#include "qgsstringutils.h"
 #include "qgsjsonutils.h"
 
 #include "qgspostgresprovider.h"
 #include "qgsprovidermetadata.h"
 #include "qgspostgresproviderconnection.h"
 
+#include <QMessageBox>
+#include <QRegularExpression>
 
 const QString QgsPostgresProvider::POSTGRES_KEY = QStringLiteral( "postgres" );
 const QString QgsPostgresProvider::POSTGRES_DESCRIPTION = QStringLiteral( "PostgreSQL/PostGIS data provider" );
@@ -1463,13 +1462,13 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     // get a new alias for the subquery
     int index = 0;
     QString alias;
-    QRegExp regex;
+    QRegularExpression regex;
     do
     {
       alias = QStringLiteral( "subQuery_%1" ).arg( QString::number( index++ ) );
-      QString pattern = QStringLiteral( "(\\\"?)%1\\1" ).arg( QRegExp::escape( alias ) );
+      QString pattern = QStringLiteral( "(\\\"?)%1\\1" ).arg( QgsStringUtils::qRegExpEscape( alias ) );
       regex.setPattern( pattern );
-      regex.setCaseSensitivity( Qt::CaseInsensitive );
+      regex.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
     }
     while ( mQuery.contains( regex ) );
 
@@ -2057,8 +2056,8 @@ bool QgsPostgresProvider::parseDomainCheckConstraint( QStringList &enumValues, c
       //we assume that the constraint is of the following form:
       //(VALUE = ANY (ARRAY['a'::text, 'b'::text, 'c'::text, 'd'::text]))
       //normally, PostgreSQL creates that if the constraint has been specified as 'VALUE in ('a', 'b', 'c', 'd')
-
-      int anyPos = checkDefinition.indexOf( QRegExp( "VALUE\\s*=\\s*ANY\\s*\\(\\s*ARRAY\\s*\\[" ) );
+      const thread_local QRegularExpression definitionRegExp( "VALUE\\s*=\\s*ANY\\s*\\(\\s*ARRAY\\s*\\[" );
+      int anyPos = checkDefinition.indexOf( definitionRegExp );
       int arrayPosition = checkDefinition.lastIndexOf( QLatin1String( "ARRAY[" ) );
       int closingBracketPos = checkDefinition.indexOf( ']', arrayPosition + 6 );
 
@@ -4758,13 +4757,14 @@ QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QS
   jumpSpace( txt, i );
   if ( i < txt.length() && txt.at( i ) == '"' )
   {
-    QRegExp stringRe( "^\"((?:\\\\.|[^\"\\\\])*)\".*" );
-    if ( !stringRe.exactMatch( txt.mid( i ) ) )
+    const thread_local QRegularExpression stringRe( QRegularExpression::anchoredPattern( "^\"((?:\\\\.|[^\"\\\\])*)\".*" ) );
+    const QRegularExpressionMatch match = stringRe.match( txt.mid( i ) );
+    if ( !match.hasMatch() )
     {
       QgsMessageLog::logMessage( tr( "Cannot find end of double quoted string: %1" ).arg( txt ), tr( "PostGIS" ) );
       return QString();
     }
-    i += stringRe.cap( 1 ).length() + 2;
+    i += match.captured( 1 ).length() + 2;
     jumpSpace( txt, i );
     if ( !QStringView{txt}.mid( i ).startsWith( sep ) && i < txt.length() )
     {
@@ -4772,7 +4772,7 @@ QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QS
       return QString();
     }
     i += sep.length();
-    return stringRe.cap( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ), QLatin1String( "\\" ) );
+    return match.captured( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ), QLatin1String( "\\" ) );
   }
   else
   {

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -42,6 +42,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QPainter>
+#include <QRegularExpression>
 
 enum
 {
@@ -751,10 +752,8 @@ void QgsWFSSourceSelect::buildQueryButtonClicked()
 void QgsWFSSourceSelect::filterChanged( const QString &text )
 {
   QgsDebugMsgLevel( "WFS FeatureType filter changed to :" + text, 2 );
-  QRegExp::PatternSyntax mySyntax = QRegExp::PatternSyntax( QRegExp::RegExp );
-  Qt::CaseSensitivity myCaseSensitivity = Qt::CaseInsensitive;
-  QRegExp myRegExp( text, myCaseSensitivity, mySyntax );
-  mModelProxy->setFilterRegExp( myRegExp );
+  QRegularExpression regExp( text, QRegularExpression::CaseInsensitiveOption );
+  mModelProxy->setFilterRegularExpression( regExp );
   mModelProxy->sort( mModelProxy->sortColumn(), mModelProxy->sortOrder() );
 }
 

--- a/tests/qt_modeltest/tst_modeltest.cpp
+++ b/tests/qt_modeltest/tst_modeltest.cpp
@@ -52,6 +52,7 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QStandardItemModel>
+#include <QRegularExpression>
 
 #include "modeltest.h"
 #include "dynamictreemodel.h"
@@ -116,7 +117,7 @@ void tst_ModelTest::stringListModel()
   model.setStringList( QStringList() << "a" << "e" << "plop" << "b" << "c" );
 
   proxy.setDynamicSortFilter( true );
-  proxy.setFilterRegExp( QRegExp( "[^b]" ) );
+  proxy.setFilterRegularExpression( QRegularExpression( "[^b]" ) );
 }
 
 void tst_ModelTest::treeWidgetModel()

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -19,6 +19,7 @@
 #include <QSplashScreen>
 #include <QString>
 #include <QStringList>
+#include <QRegularExpression>
 
 #include "qgisapp.h"
 #include "qgsapplication.h"
@@ -179,9 +180,9 @@ void TestQgisAppClipboard::copyToText()
 
   // just test coordinates as integers - that's enough to verify that reprojection has occurred
   // and helps avoid rounding issues
-  QRegExp regex( "\\[([-\\d.]+),([-\\d.]+)\\]" );
-  ( void )regex.indexIn( result );
-  QStringList list = regex.capturedTexts();
+  QRegularExpression regex( "\\[([-\\d.]+),([-\\d.]+)\\]" );
+  QRegularExpressionMatch  match = regex.match( result );
+  QStringList list = match.capturedTexts();
   QCOMPARE( list.count(), 3 );
 
   int x = std::round( list.at( 1 ).toDouble() );

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -23,6 +23,8 @@
 #include "qgsapplication.h"
 #include "qgsvectorlayer.h"
 
+#include <QRegularExpression>
+
 /**
  * \ingroup UnitTests
  * This is a unit test for OGC utilities
@@ -103,9 +105,9 @@ void TestQgsOgcUtils::testGeometryFromGML()
 static bool compareElements( QDomElement &element1, QDomElement &element2 )
 {
   QString tag1 = element1.tagName();
-  tag1.replace( QRegExp( ".*:" ), QString() );
+  tag1.replace( QRegularExpression( ".*:" ), QString() );
   QString tag2 = element2.tagName();
-  tag2.replace( QRegExp( ".*:" ), QString() );
+  tag2.replace( QRegularExpression( ".*:" ), QString() );
   if ( tag1 != tag2 )
   {
     qDebug( "Different tag names: %s, %s", tag1.toLatin1().data(), tag2.toLatin1().data() );

--- a/tests/src/providers/testqgswcspublicservers.cpp
+++ b/tests/src/providers/testqgswcspublicservers.cpp
@@ -21,6 +21,7 @@
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
+#include <QRegularExpression>
 
 #include "qgsapplication.h"
 #include "qgsdatasourceuri.h"
@@ -272,8 +273,8 @@ void TestQgsWcsPublicServers::test()
     QStringList myServerLog;
     myServerLog << "server:" + serverUrl;
     QString myServerDirName = serverUrl;
-    myServerDirName.replace( QRegExp( "[:/]+" ), QStringLiteral( "." ) );
-    myServerDirName.remove( QRegExp( "\\.$" ) );
+    myServerDirName.replace( QRegularExpression( "[:/]+" ), QStringLiteral( "." ) );
+    myServerDirName.remove( QRegularExpression( "\\.$" ) );
     QgsDebugMsg( "myServerDirName = " + myServerDirName );
 
     QDir myServerDir( mCacheDir.absolutePath() + '/' + myServerDirName );


### PR DESCRIPTION
## Description

This PR migrates the remaining(*) uses of QRegExp in src/providers to QRegularExpression.

For those keeping track of the score, QRegExp is gone from:
- src/core (pending #44170)
- src/providers (pending this)
- src/auth
- src/analysis

_(*) the stagnant GRASS provider hasn't been ported, no interest on my side._