### PR TITLE
Fix incorrect symbol size units shown when first showing the symbol widget

### DIFF
--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -104,15 +104,15 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbol *symbol, QgsStyle *style, 
 
   stackedWidget->setCurrentIndex( 0 );
 
+  mSymbolUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMetersInMapUnits << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
+                               << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
+
   if ( mSymbol )
   {
     updateSymbolInfo();
   }
 
   connect( mSymbolUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsSymbolsListWidget::mSymbolUnitWidget_changed );
-  mSymbolUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMetersInMapUnits << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
-                               << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
-
   connect( mSymbolColorButton, &QgsColorButton::colorChanged, this, &QgsSymbolsListWidget::setSymbolColor );
 
   registerSymbolDataDefinedButton( opacityDDBtn, QgsSymbol::PropertyOpacity );


### PR DESCRIPTION
We need to populate the combo box with all valid size units before trying
to set the unit for the combo

Fixes #44070
