### PR TITLE
[qt6] QMap::unite is gone in Qt6, use QMultiMap

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -668,7 +668,7 @@ Returns the provider key.
 .. versionadded:: 3.16
 %End
 
-    virtual QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary();
+    virtual QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary();
 %Docstring
 Returns a dictionary of SQL keywords supported by the provider.
 The default implementation returns an list of common reserved words under the

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -714,7 +714,7 @@ QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const 
   return fieldList;
 }
 
-QMap<Qgis::SqlKeywordCategory, QStringList> QgsGeoPackageProviderConnection::sqlDictionary()
+QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsGeoPackageProviderConnection::sqlDictionary()
 {
   /*
    * last_insert_rowid + list from: http://www.gaia-gis.it/gaia-sins/spatialite-sql-4.2.0.html

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -81,7 +81,7 @@ class QgsGeoPackageProviderConnection : public QgsAbstractDatabaseProviderConnec
     QIcon icon() const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QgsFields fields( const QString &schema, const QString &table ) const override;
-    QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
+    QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
 
   private:
 

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -74,7 +74,7 @@ QString QgsAbstractDatabaseProviderConnection::providerKey() const
 ///@endcond
 
 
-QMap<Qgis::SqlKeywordCategory, QStringList> QgsAbstractDatabaseProviderConnection::sqlDictionary()
+QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsAbstractDatabaseProviderConnection::sqlDictionary()
 {
   return
   {

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -788,7 +788,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     *
     * \since QGIS 3.22
     */
-    virtual QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary();
+    virtual QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary();
 
   protected:
 

--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -322,7 +322,7 @@ QList<QgsVectorDataProvider::NativeType> QgsOracleProviderConnection::nativeType
   return types;
 }
 
-QMap<Qgis::SqlKeywordCategory, QStringList> QgsOracleProviderConnection::sqlDictionary()
+QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsOracleProviderConnection::sqlDictionary()
 {
   return
   {

--- a/src/providers/oracle/qgsoracleproviderconnection.h
+++ b/src/providers/oracle/qgsoracleproviderconnection.h
@@ -72,7 +72,7 @@ class QgsOracleProviderConnection : public QgsAbstractDatabaseProviderConnection
     void remove( const QString &name ) const override;
     QIcon icon() const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
-    QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
+    QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
 
   private:

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -807,7 +807,7 @@ QgsVectorLayer *QgsPostgresProviderConnection::createSqlVectorLayer( const SqlVe
   return new QgsVectorLayer{ tUri.uri(), options.layerName.isEmpty() ? QStringLiteral( "QueryLayer" ) : options.layerName, providerKey(), vectorLayerOptions };
 }
 
-QMap<Qgis::SqlKeywordCategory, QStringList> QgsPostgresProviderConnection::sqlDictionary()
+QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsPostgresProviderConnection::sqlDictionary()
 {
   return QgsAbstractDatabaseProviderConnection::sqlDictionary().unite(
   {

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -77,7 +77,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     QIcon icon() const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
-    QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
+    QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
 
   private:
 

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -668,7 +668,7 @@ QString QgsSpatiaLiteProviderConnection::pathFromUri() const
   return dsUri.database();
 }
 
-QMap<Qgis::SqlKeywordCategory, QStringList> QgsSpatiaLiteProviderConnection::sqlDictionary()
+QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsSpatiaLiteProviderConnection::sqlDictionary()
 {
   /*
    * List from: http://www.gaia-gis.it/gaia-sins/spatialite-sql-4.2.0.html

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.h
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.h
@@ -79,7 +79,7 @@ class QgsSpatiaLiteProviderConnection : public QgsAbstractDatabaseProviderConnec
     QIcon icon() const override;
     void deleteField( const QString &fieldName, const QString &schema, const QString &tableName, bool force ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
-    QMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
+    QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
 
   private:
 


### PR DESCRIPTION
(Breaking down little bits needed to insure /core/ compiles against Qt6)