### PR TITLE
[qt6] Work around compiler complaining about std::min( long long, int )

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -259,7 +259,7 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
     if ( context.feedback() && context.feedback()->isCanceled() )
       break;
     // Async loading of nodes
-    const int currentGroupSize = std::min( std::max( nodes.size() - groupIndex, 0 ), groupSize );
+    const int currentGroupSize = std::min< size_t >( std::max< size_t >( nodes.size() - groupIndex, 0 ), groupSize );
     QVector<QgsPointCloudBlockRequest *> blockRequests( currentGroupSize, nullptr );
     QVector<bool> finishedLoadingBlock( currentGroupSize, false );
     QEventLoop loop;


### PR DESCRIPTION
(Breaking down little bits needed to insure /core/ compiles against Qt6)

For whomever else will help out insure our code is qt6-friendly, this one is good to know: since Qt6 .size(), .length(), etc. aren't returning integers anymore, it ends up breaking a bunch of std::{min,max} calls. 