### PR TITLE
 Allow to resize the vector 3D Map view properties tab

### DIFF
--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgsapplication.h"
 #include "qgs3dsymbolregistry.h"
 #include "qgsabstractmaterialsettings.h"
+#include "qgsvscrollarea.h"
 
 #include <QBoxLayout>
 #include <QCheckBox>
@@ -40,9 +41,18 @@ QgsSingleSymbol3DRendererWidget::QgsSingleSymbol3DRendererWidget( QgsVectorLayer
 {
   widgetSymbol = new QgsSymbol3DWidget( mLayer, this );
 
+  QgsVScrollArea *scrollArea = new QgsVScrollArea( this );
+  scrollArea->setFrameShape( QFrame::NoFrame );
+  scrollArea->setFrameShadow( QFrame::Plain );
+  scrollArea->setWidgetResizable( true );
+  QVBoxLayout *scrollLayout = new QVBoxLayout( this );
+  scrollLayout->setContentsMargins( 0, 0, 0, 0 );
+  scrollLayout->addWidget( scrollArea );
+
   QVBoxLayout *layout = new QVBoxLayout( this );
   layout->setContentsMargins( 0, 0, 0, 0 );
-  layout->addWidget( widgetSymbol );
+  widgetSymbol->setLayout( layout );
+  scrollArea->setWidget( widgetSymbol );
 
   connect( widgetSymbol, &QgsSymbol3DWidget::widgetChanged, this, &QgsSingleSymbol3DRendererWidget::widgetChanged );
 }

--- a/src/ui/3d/line3dsymbolwidget.ui
+++ b/src/ui/3d/line3dsymbolwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>382</width>
-    <height>264</height>
+    <height>229</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -133,8 +133,8 @@
        <widget class="QgsMaterialWidget" name="widgetMaterial" native="true">
         <property name="minimumSize">
          <size>
-          <width>10</width>
-          <height>10</height>
+          <width>0</width>
+          <height>0</height>
          </size>
         </property>
        </widget>

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>457</width>
-    <height>587</height>
+    <height>562</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -210,8 +210,8 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>10</width>
-          <height>10</height>
+          <width>0</width>
+          <height>0</height>
          </size>
         </property>
        </widget>


### PR DESCRIPTION
adding a scrollbar to single symbol widget to control its height (this resurrects #38345 --the first option-- but with a fix for the shading group shrinking)
Fixes #38134
![image](https://user-images.githubusercontent.com/7983394/126036543-52b07a8b-7a94-4829-82c5-9dbafc037782.png)
