### PR TITLE
Misc changes to mesh (mainly) dialog

### DIFF
--- a/src/app/3d/qgsmeshlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsmeshlayer3drendererwidget.cpp
@@ -18,7 +18,7 @@
 #include "qgsmesh3dsymbol.h"
 #include "qgsmesh3dsymbolwidget.h"
 #include "qgsmeshlayer3drenderer.h"
-
+#include "qgsvscrollarea.h"
 #include "qgsmeshlayer.h"
 
 #include <QBoxLayout>
@@ -29,8 +29,20 @@ QgsMeshLayer3DRendererWidget::QgsMeshLayer3DRendererWidget( QgsMeshLayer *layer,
 {
   setPanelTitle( tr( "3D View" ) );
 
-  QVBoxLayout *layout = new QVBoxLayout( this );
+  QgsVScrollArea *scrollArea = new QgsVScrollArea( this );
+  scrollArea->setFrameShape( QFrame::NoFrame );
+  scrollArea->setFrameShadow( QFrame::Plain );
+  scrollArea->setWidgetResizable( true );
+  QVBoxLayout *scrollLayout = new QVBoxLayout( this );
+  scrollLayout->setContentsMargins( 0, 0, 0, 0 );
+  scrollLayout->addWidget( scrollArea );
+
+  QVBoxLayout *layout = new QVBoxLayout;
   layout->setContentsMargins( 0, 0, 0, 0 );
+  QWidget *widget = new QWidget;
+  widget->setLayout( layout );
+  scrollArea->setWidget( widget );
+
   mChkEnabled = new QCheckBox( tr( "Enable 3D Renderer" ), this );
   layout->addWidget( mChkEnabled );
 

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -416,7 +416,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -89,6 +89,12 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
           </widget>
          </item>
         </layout>
@@ -322,6 +328,12 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
            </property>
            <property name="text">
             <string/>

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -129,14 +129,14 @@
       <string>Vertical Settings</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Vertical scale</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="2" column="1">
        <widget class="QgsDoubleSpinBox" name="mSpinBoxVerticaleScale">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
@@ -152,14 +152,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Dataset group for vertical value</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="QComboBox" name="mComboBoxDatasetVertical">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
@@ -169,7 +169,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="mCheckBoxVerticalMagnitudeRelative">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">

--- a/src/ui/3d/qgsmesh3dpropswidget.ui
+++ b/src/ui/3d/qgsmesh3dpropswidget.ui
@@ -254,8 +254,8 @@
              <height>24</height>
             </size>
            </property>
-           <property name="text">
-            <string/>
+           <property name="toolTip">
+            <string>Load</string>
            </property>
            <property name="icon">
             <iconset resource="../../../images/images.qrc">

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -435,7 +435,7 @@ border-radius: 2px;</string>
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>20</width>
-                   <height>40</height>
+                   <height>0</height>
                   </size>
                  </property>
                 </spacer>
@@ -579,7 +579,7 @@ border-radius: 2px;</string>
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>40</height>
+               <height>0</height>
               </size>
              </property>
             </spacer>
@@ -762,7 +762,7 @@ border-radius: 2px;</string>
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>40</height>
+               <height>0</height>
               </size>
              </property>
             </spacer>

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -158,8 +158,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="mScalarRecalculateMinMaxButton">
-       <property name="text">
+       <property name="toolTip">
         <string>Load</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionRefresh.svg</normaloff>:/images/themes/default/mActionRefresh.svg</iconset>
        </property>
       </widget>
      </item>
@@ -246,6 +250,8 @@
   <tabstop>mScalarRecalculateMinMaxButton</tabstop>
   <tabstop>mScalarInterpolationTypeComboBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -150,8 +150,8 @@
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="4">
        <widget class="QPushButton" name="mColorRampShaderLoadButton">
-        <property name="text">
-         <string/>
+        <property name="toolTip">
+         <string>Load</string>
         </property>
         <property name="icon">
          <iconset resource="../../../images/images.qrc">

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -47,7 +47,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -27,7 +27,14 @@
     <number>0</number>
    </property>
    <item row="5" column="1">
-    <widget class="QgsColorButton" name="mColorWidget"/>
+    <widget class="QgsColorButton" name="mColorWidget">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
    </item>
    <item row="4" column="1">
     <widget class="QComboBox" name="mColoringMethodComboBox"/>

--- a/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshvariablestrokewidthwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>395</width>
-    <height>220</height>
+    <height>219</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,7 +39,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -41,7 +41,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="iconSize">
       <size>

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -66,6 +66,9 @@
       <attribute name="title">
        <string/>
       </attribute>
+      <attribute name="toolTip">
+       <string>Datasets</string>
+      </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_11">
        <property name="leftMargin">
         <number>0</number>
@@ -138,6 +141,9 @@
       <attribute name="title">
        <string/>
       </attribute>
+      <attribute name="toolTip">
+       <string>Contours</string>
+      </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <property name="leftMargin">
         <number>0</number>
@@ -201,6 +207,9 @@
       <attribute name="title">
        <string/>
       </attribute>
+      <attribute name="toolTip">
+       <string>Vectors</string>
+      </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="leftMargin">
         <number>0</number>
@@ -258,6 +267,9 @@
       </attribute>
       <attribute name="title">
        <string/>
+      </attribute>
+      <attribute name="toolTip">
+       <string>Rendering</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_12">
        <property name="leftMargin">

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -360,7 +360,7 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-536</y>
+                <y>0</y>
                 <width>856</width>
                 <height>1223</height>
                </rect>
@@ -6348,6 +6348,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mLayerDeleteConfirmationChkBx</tabstop>
   <tabstop>chbWarnOldProjectVersion</tabstop>
   <tabstop>mEnableMacrosComboBox</tabstop>
+  <tabstop>mDefaultPathsComboBox</tabstop>
   <tabstop>mFileFormatQgzButton</tabstop>
   <tabstop>mFileFormatQgsButton</tabstop>
   <tabstop>mOptionsScrollArea_03</tabstop>
@@ -6378,6 +6379,8 @@ p, li { white-space: pre-wrap; }
   <tabstop>radPromptForProjection</tabstop>
   <tabstop>radUseProjectProjection</tabstop>
   <tabstop>radUseGlobalProjection</tabstop>
+  <tabstop>mCrsAccuracySpin</tabstop>
+  <tabstop>mCrsAccuracyIndicatorCheck</tabstop>
   <tabstop>mPlanimetricMeasurementsComboBox</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mShowDatumTransformDialogCheckBox</tabstop>
@@ -6421,6 +6424,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mZoomedInResamplingComboBox</tabstop>
   <tabstop>mZoomedOutResamplingComboBox</tabstop>
   <tabstop>spnOversampling</tabstop>
+  <tabstop>mCbEarlyResampling</tabstop>
   <tabstop>cboxContrastEnhancementAlgorithmSingleBand</tabstop>
   <tabstop>cboxContrastEnhancementLimitsSingleBand</tabstop>
   <tabstop>cboxContrastEnhancementAlgorithmMultiBandSingleByte</tabstop>
@@ -6437,7 +6441,10 @@ p, li { white-space: pre-wrap; }
   <tabstop>cmbLegendDoubleClickAction</tabstop>
   <tabstop>cbxLegendClassifiers</tabstop>
   <tabstop>mLegendGraphicResolutionSpinBox</tabstop>
+  <tabstop>mLegendSymbolMinimumSizeSpinBox</tabstop>
+  <tabstop>mLegendSymbolMaximumSizeSpinBox</tabstop>
   <tabstop>mMapTipsDelaySpinBox</tabstop>
+  <tabstop>mRespectScreenDpiCheckBox</tabstop>
   <tabstop>mOptionsScrollArea_05</tabstop>
   <tabstop>spinBoxIdentifyValue</tabstop>
   <tabstop>mIdentifyHighlightColorButton</tabstop>
@@ -6472,6 +6479,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>chkReuseLastValues</tabstop>
   <tabstop>mValidateGeometries</tabstop>
   <tabstop>mDefaultZValueSpinBox</tabstop>
+  <tabstop>mDefaultMValueSpinBox</tabstop>
   <tabstop>mLineWidthSpinBox</tabstop>
   <tabstop>mLineColorToolButton</tabstop>
   <tabstop>mFillColorToolButton</tabstop>
@@ -6537,12 +6545,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mGPUEnableCheckBox</tabstop>
   <tabstop>mOpenClDevicesCombo</tabstop>
   <tabstop>mGPUInfoTextBrowser</tabstop>
-  <tabstop>mCbEarlyResampling</tabstop>
-  <tabstop>mCrsAccuracySpin</tabstop>
-  <tabstop>mCrsAccuracyIndicatorCheck</tabstop>
-  <tabstop>mLegendSymbolMinimumSizeSpinBox</tabstop>
-  <tabstop>mLegendSymbolMaximumSizeSpinBox</tabstop>
-  <tabstop>mDefaultMValueSpinBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
* Allow the 3D Map view in mesh properties to resize
* Add a tooltip to mesh symbology tabs (there's no way to identify them when trying to write documentation - fixes #29450). The last tab, I don't know how it could be named - and I'm not sure whether suggested names are the correct ones
![image](https://user-images.githubusercontent.com/7983394/126037457-97dc3a8b-d6ec-43c6-b68d-264800abbf39.png)
* Harmonize Min and Max values load button in mesh properties in "Contours" / "vectors" / "color ramp shader": they now all display the refresh icon with a tooltip instead of name in one case, icon in the others
![image](https://user-images.githubusercontent.com/7983394/126037279-e64f5fc6-b054-4d7c-893a-bd257afe32c6.png)
* Reorder 3D vertical settings: I'd expect people to select the dataset they want to use, whether it's relative and then scae factor, and not first choose the scale factor before "knowing" which dataset they would use
![image](https://user-images.githubusercontent.com/7983394/126037375-64bc1cfd-a105-495e-a9c3-f49a55c58160.png)
* Fix some tab stops and dialog size