### PR TITLE
[qt6][spatialite] Fix compilation against qt6

### DIFF
--- a/src/core/qgsinterval.h
+++ b/src/core/qgsinterval.h
@@ -380,7 +380,7 @@ QgsInterval CORE_EXPORT operator-( QTime time1, QTime time2 );
 QDateTime CORE_EXPORT operator+( const QDateTime &start, const QgsInterval &interval );
 
 //! Debug string representation of interval
-QDebug operator<<( QDebug dbg, const QgsInterval &interval );
+QDebug CORE_EXPORT operator<<( QDebug dbg, const QgsInterval &interval );
 \
 #endif
 

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -961,8 +961,8 @@ void QgsSpatiaLiteProvider::fetchConstraints()
         const QChar delimiter { field.at( 0 ) };
         if ( delimiter == '"' || delimiter == '`' )
         {
-          const int start {  field.indexOf( delimiter ) + 1};
-          const int end { field.indexOf( delimiter, start ) };
+          const int start = field.indexOf( delimiter ) + 1;
+          const int end = field.indexOf( delimiter, start );
           fieldName = field.mid( start, end - start );
           definition = field.mid( end + 1 );
         }


### PR DESCRIPTION
Interesting, this little exercise reveal we were missing a CORE_EXPORT in qgsinterval.h (which didn´t seem to bother compilers and qt5 :) )