### PR TITLE
Improve "create new mesh layer" dialog

### DIFF
--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmeshlayer.h"
 #include "qgsapplication.h"
+#include "qgsgui.h"
 
 
 QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags fl ) : QDialog( parent, fl )
@@ -38,6 +39,7 @@ QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags f
   }
 
   setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
   const QList<QgsMeshDriverMetadata> driverList = meta->meshDriversMetadata();
 
   for ( const QgsMeshDriverMetadata &driverMeta : driverList )

--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -51,7 +51,7 @@ QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags f
       QString suffix = driverMeta.writeMeshFrameOnFileSuffix();
       mFormatComboBox->addItem( description, driverName );
       mDriverSuffixes.insert( driverMeta.name(), suffix );
-      mDriverFileFilters.insert( driverMeta.name(), tr( "%1 files" ).arg( description ) + QStringLiteral( " (*." ) + suffix + ')' );
+      mDriverFileFilters.insert( driverMeta.name(), tr( "%1" ).arg( description ) + QStringLiteral( " (*." ) + suffix + ')' );
     }
 
   QStringList filters = mDriverFileFilters.values();

--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmeshlayer.h"
 #include "qgsapplication.h"
+#include "qgshelp.h"
 #include "qgsgui.h"
 
 
@@ -66,6 +67,11 @@ QgsNewMeshLayerDialog::QgsNewMeshLayerDialog( QWidget *parent, Qt::WindowFlags f
   connect( mMeshFileRadioButton, &QRadioButton::toggled, this, &QgsNewMeshLayerDialog::updateDialog );
   connect( mMeshFromFileWidget, &QgsFileWidget::fileChanged, this, &QgsNewMeshLayerDialog::updateDialog );
   connect( mMeshProjectComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsNewMeshLayerDialog::updateDialog );
+
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#creating-a-new-mesh-layer" ) );
+  } );
 
   updateDialog();
 }

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -117,7 +117,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -85,7 +85,7 @@
       <item row="1" column="0">
        <widget class="QRadioButton" name="mMeshProjectRadioButton">
         <property name="text">
-         <string>Mesh of the current project</string>
+         <string>Mesh from the current project</string>
         </property>
        </widget>
       </item>

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -85,7 +85,7 @@
       <item row="1" column="0">
        <widget class="QRadioButton" name="mMeshProjectRadioButton">
         <property name="text">
-         <string>From a mesh of the current project</string>
+         <string>Mesh of the current project</string>
         </property>
        </widget>
       </item>
@@ -142,6 +142,15 @@
    <header location="global">qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mLayerNameLineEdit</tabstop>
+  <tabstop>mFormatComboBox</tabstop>
+  <tabstop>mEmptyMeshRadioButton</tabstop>
+  <tabstop>mMeshProjectRadioButton</tabstop>
+  <tabstop>mMeshProjectComboBox</tabstop>
+  <tabstop>mMeshFileRadioButton</tabstop>
+  <tabstop>mInformationTextBrowser</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
+++ b/src/ui/mesh/qgsnewmeshlayerdialogbase.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>477</width>
-    <height>479</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>New Mesh Layer</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
+  <layout class="QGridLayout" name="gridLayout1">
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -53,6 +53,12 @@
    </item>
    <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Initialize Mesh Using</string>
      </property>
@@ -105,7 +111,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="5" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -114,19 +120,6 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item row="5" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -3554,7 +3554,7 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
      <normaloff>:/images/themes/default/mActionNewMeshLayer.svg</normaloff>:/images/themes/default/mActionNewMeshLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>New Mesh Layer</string>
+    <string>New Mesh Layer…</string>
    </property>
    <property name="toolTip">
     <string>New Mesh Layer</string>


### PR DESCRIPTION
 Ensure New Mesh layer GUI behaves correctly when it's resized and remembers latest geometry
before: ![image](https://user-images.githubusercontent.com/7983394/126069853-cc085986-438a-482c-a0ed-c839be941b36.png)

Pull request: ![image](https://user-images.githubusercontent.com/7983394/126065341-3d60c81c-e1ad-49cc-a8a4-9bc4c4dba58d.png)

Connect to online documentation: the docs is not yet available online but the PR will strongly welcome review (https://github.com/qgis/QGIS-Documentation/pull/6816)
Fix strings in GUI and the tabstop order
I think there are more inconsistencies (with respect to other "create layer" dialogs) that need to be fixed but require more coding --> #44226