### PR TITLE
Move enums from QgsVectorLayer to Qgis and promote to enum classes

### DIFF
--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -73,6 +73,17 @@ QgsMarkerLineSymbolLayer.FirstVertex = QgsTemplatedLineSymbolLayerBase.FirstVert
 QgsMarkerLineSymbolLayer.CentralPoint = QgsTemplatedLineSymbolLayerBase.CentralPoint
 QgsMarkerLineSymbolLayer.CurvePoint = QgsTemplatedLineSymbolLayerBase.CurvePoint
 
+QgsVectorLayer.VertexMarkerType = Qgis.VertexMarkerType
+QgsVectorLayer.SemiTransparentCircle = Qgis.VertexMarkerType.SemiTransparentCircle
+QgsVectorLayer.SemiTransparentCircle.is_monkey_patched = True
+QgsVectorLayer.SemiTransparentCircle.__doc__ = "Semi-transparent circle marker"
+QgsVectorLayer.Cross = Qgis.VertexMarkerType.Cross
+QgsVectorLayer.Cross.is_monkey_patched = True
+QgsVectorLayer.Cross.__doc__ = "Cross marker"
+QgsVectorLayer.NoMarker = Qgis.VertexMarkerType.NoMarker
+QgsVectorLayer.NoMarker.is_monkey_patched = True
+QgsVectorLayer.NoMarker.__doc__ = "No marker"
+
 # Monkey patch static const "QgsDataProvider.SUBLAYER_SEPARATOR" which was removed for QGIS 3.12
 QgsDataProvider.SUBLAYER_SEPARATOR = QgsDataProvider.sublayerSeparator()
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -423,3 +423,54 @@ Qgis.SublayerPromptMode.NeverAskLoadAll.__doc__ = "Never ask users to select sub
 Qgis.SublayerPromptMode.__doc__ = 'Specifies how to handle layer sources with multiple sublayers.\n\n.. versionadded:: 3.22\n\n' + '* ``AlwaysAsk``: ' + Qgis.SublayerPromptMode.AlwaysAsk.__doc__ + '\n' + '* ``AskExcludingRasterBands``: ' + Qgis.SublayerPromptMode.AskExcludingRasterBands.__doc__ + '\n' + '* ``NeverAskSkip``: ' + Qgis.SublayerPromptMode.NeverAskSkip.__doc__ + '\n' + '* ``NeverAskLoadAll``: ' + Qgis.SublayerPromptMode.NeverAskLoadAll.__doc__
 # --
 Qgis.SublayerPromptMode.baseClass = Qgis
+QgsVectorLayer.SelectBehavior = Qgis.SelectBehavior
+# monkey patching scoped based enum
+QgsVectorLayer.SetSelection = Qgis.SelectBehavior.SetSelection
+QgsVectorLayer.SetSelection.is_monkey_patched = True
+QgsVectorLayer.SetSelection.__doc__ = "Set selection, removing any existing selection"
+QgsVectorLayer.AddToSelection = Qgis.SelectBehavior.AddToSelection
+QgsVectorLayer.AddToSelection.is_monkey_patched = True
+QgsVectorLayer.AddToSelection.__doc__ = "Add selection to current selection"
+QgsVectorLayer.IntersectSelection = Qgis.SelectBehavior.IntersectSelection
+QgsVectorLayer.IntersectSelection.is_monkey_patched = True
+QgsVectorLayer.IntersectSelection.__doc__ = "Modify current selection to include only select features which match"
+QgsVectorLayer.RemoveFromSelection = Qgis.SelectBehavior.RemoveFromSelection
+QgsVectorLayer.RemoveFromSelection.is_monkey_patched = True
+QgsVectorLayer.RemoveFromSelection.__doc__ = "Remove from current selection"
+Qgis.SelectBehavior.__doc__ = 'Specifies how a selection should be applied.\n\n.. versionadded:: 3.22\n\n' + '* ``SetSelection``: ' + Qgis.SelectBehavior.SetSelection.__doc__ + '\n' + '* ``AddToSelection``: ' + Qgis.SelectBehavior.AddToSelection.__doc__ + '\n' + '* ``IntersectSelection``: ' + Qgis.SelectBehavior.IntersectSelection.__doc__ + '\n' + '* ``RemoveFromSelection``: ' + Qgis.SelectBehavior.RemoveFromSelection.__doc__
+# --
+Qgis.SelectBehavior.baseClass = Qgis
+QgsVectorLayer.EditResult = Qgis.VectorEditResult
+# monkey patching scoped based enum
+QgsVectorLayer.Success = Qgis.VectorEditResult.Success
+QgsVectorLayer.Success.is_monkey_patched = True
+QgsVectorLayer.Success.__doc__ = "Edit operation was successful"
+QgsVectorLayer.EmptyGeometry = Qgis.VectorEditResult.EmptyGeometry
+QgsVectorLayer.EmptyGeometry.is_monkey_patched = True
+QgsVectorLayer.EmptyGeometry.__doc__ = "Edit operation resulted in an empty geometry"
+QgsVectorLayer.EditFailed = Qgis.VectorEditResult.EditFailed
+QgsVectorLayer.EditFailed.is_monkey_patched = True
+QgsVectorLayer.EditFailed.__doc__ = "Edit operation failed"
+QgsVectorLayer.FetchFeatureFailed = Qgis.VectorEditResult.FetchFeatureFailed
+QgsVectorLayer.FetchFeatureFailed.is_monkey_patched = True
+QgsVectorLayer.FetchFeatureFailed.__doc__ = "Unable to fetch requested feature"
+QgsVectorLayer.InvalidLayer = Qgis.VectorEditResult.InvalidLayer
+QgsVectorLayer.InvalidLayer.is_monkey_patched = True
+QgsVectorLayer.InvalidLayer.__doc__ = "Edit failed due to invalid layer"
+Qgis.VectorEditResult.__doc__ = 'Specifies the result of a vector layer edit operation\n\n.. versionadded:: 3.22\n\n' + '* ``Success``: ' + Qgis.VectorEditResult.Success.__doc__ + '\n' + '* ``EmptyGeometry``: ' + Qgis.VectorEditResult.EmptyGeometry.__doc__ + '\n' + '* ``EditFailed``: ' + Qgis.VectorEditResult.EditFailed.__doc__ + '\n' + '* ``FetchFeatureFailed``: ' + Qgis.VectorEditResult.FetchFeatureFailed.__doc__ + '\n' + '* ``InvalidLayer``: ' + Qgis.VectorEditResult.InvalidLayer.__doc__
+# --
+Qgis.VectorEditResult.baseClass = Qgis
+QgsSymbolLayerUtils.VertexMarkerType = Qgis.VertexMarkerType
+# monkey patching scoped based enum
+QgsSymbolLayerUtils.SemiTransparentCircle = Qgis.VertexMarkerType.SemiTransparentCircle
+QgsSymbolLayerUtils.SemiTransparentCircle.is_monkey_patched = True
+QgsSymbolLayerUtils.SemiTransparentCircle.__doc__ = "Semi-transparent circle marker"
+QgsSymbolLayerUtils.Cross = Qgis.VertexMarkerType.Cross
+QgsSymbolLayerUtils.Cross.is_monkey_patched = True
+QgsSymbolLayerUtils.Cross.__doc__ = "Cross marker"
+QgsSymbolLayerUtils.NoMarker = Qgis.VertexMarkerType.NoMarker
+QgsSymbolLayerUtils.NoMarker.is_monkey_patched = True
+QgsSymbolLayerUtils.NoMarker.__doc__ = "No marker"
+Qgis.VertexMarkerType.__doc__ = 'Editing vertex markers, used for showing vertices during a edit operation.\n\n.. versionadded:: 3.22\n\n' + '* ``SemiTransparentCircle``: ' + Qgis.VertexMarkerType.SemiTransparentCircle.__doc__ + '\n' + '* ``Cross``: ' + Qgis.VertexMarkerType.Cross.__doc__ + '\n' + '* ``NoMarker``: ' + Qgis.VertexMarkerType.NoMarker.__doc__
+# --
+Qgis.VertexMarkerType.baseClass = Qgis

--- a/python/core/auto_additions/qgsvectorlayer.py
+++ b/python/core/auto_additions/qgsvectorlayer.py
@@ -1,3 +1,0 @@
-# The following has been generated automatically from src/core/vector/qgsvectorlayer.h
-QgsVectorLayer.EditResult.baseClass = QgsVectorLayer
-QgsVectorLayer.SelectBehavior.baseClass = QgsVectorLayer

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -319,6 +319,30 @@ The development version
       NeverAskLoadAll,
     };
 
+    enum class SelectBehavior
+      {
+      SetSelection,
+      AddToSelection,
+      IntersectSelection,
+      RemoveFromSelection,
+    };
+
+    enum class VectorEditResult
+      {
+      Success,
+      EmptyGeometry,
+      EditFailed,
+      FetchFeatureFailed,
+      InvalidLayer,
+    };
+
+    enum class VertexMarkerType
+      {
+      SemiTransparentCircle,
+      Cross,
+      NoMarker,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -337,7 +337,7 @@ If supported by the renderer, return classification attribute for the use in leg
 .. versionadded:: 2.6
 %End
 
-    void setVertexMarkerAppearance( int type, double size );
+    void setVertexMarkerAppearance( Qgis::VertexMarkerType type, double size );
 %Docstring
 Sets type and size of editing vertex markers for subsequent rendering
 %End
@@ -596,6 +596,7 @@ to store all common base class properties in the DOM ``element``.
 
 .. versionadded:: 3.22
 %End
+
 
 
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -602,7 +602,7 @@ and returns ``True`` if any of the layers returned ``True``.
    Will be removed in QGIS 4.0
 %End
 
-    void renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false, int currentVertexMarkerType = 0, double currentVertexMarkerSize = 0.0 ) throw( QgsCsException );
+    void renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false, Qgis::VertexMarkerType currentVertexMarkerType = Qgis::VertexMarkerType::SemiTransparentCircle, double currentVertexMarkerSize = 0.0 ) throw( QgsCsException );
 %Docstring
 Render a feature. Before calling this the :py:func:`~QgsSymbol.startRender` method should be called to initialize
 the rendering process. After rendering all features :py:func:`~QgsSymbol.stopRender` must be called.
@@ -688,7 +688,7 @@ This is required for layers that generate their own geometry from other
 information in the rendering context.
 %End
 
-    void renderVertexMarker( QPointF pt, QgsRenderContext &context, int currentVertexMarkerType, double currentVertexMarkerSize );
+    void renderVertexMarker( QPointF pt, QgsRenderContext &context, Qgis::VertexMarkerType currentVertexMarkerType, double currentVertexMarkerSize );
 %Docstring
 Render editing vertex marker at specified point
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -23,13 +23,6 @@ class QgsSymbolLayerUtils
 %End
   public:
 
-    enum VertexMarkerType
-    {
-      SemiTransparentCircle,
-      Cross,
-      NoMarker
-    };
-
     static QString encodeColor( const QColor &color );
     static QColor decodeColor( const QString &str );
 
@@ -317,7 +310,7 @@ Returns a pixmap preview for a color ramp.
 
     static void drawStippledBackground( QPainter *painter, QRect rect );
 
-    static void drawVertexMarker( double x, double y, QPainter &p, QgsSymbolLayerUtils::VertexMarkerType type, int markerSize );
+    static void drawVertexMarker( double x, double y, QPainter &p, Qgis::VertexMarkerType type, int markerSize );
 %Docstring
 Draws a vertex symbol at (painter) coordinates x, y. (Useful to assist vertex editing.)
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -341,23 +341,6 @@ Provider to display vector data in a GRASS GIS layer.
 %End
   public:
 
-    enum EditResult
-    {
-      Success,
-      EmptyGeometry,
-      EditFailed,
-      FetchFeatureFailed,
-      InvalidLayer,
-    };
-
-    enum SelectBehavior
-    {
-      SetSelection,
-      AddToSelection,
-      IntersectSelection,
-      RemoveFromSelection,
-    };
-
     struct LayerOptions
     {
 
@@ -647,7 +630,7 @@ Returns the number of features that are selected in this layer.
 .. seealso:: :py:func:`selectedFeatureIds`
 %End
 
-    void selectByRect( QgsRectangle &rect, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 %Docstring
 Selects features found within the search rectangle (in layer's coordinates)
 
@@ -662,7 +645,7 @@ Selects features found within the search rectangle (in layer's coordinates)
 .. seealso:: :py:func:`selectByIds`
 %End
 
-    void selectByExpression( const QString &expression, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    void selectByExpression( const QString &expression, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 %Docstring
 Selects matching features using an expression.
 
@@ -677,7 +660,7 @@ Selects matching features using an expression.
 .. versionadded:: 2.16
 %End
 
-    void selectByIds( const QgsFeatureIds &ids, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 %Docstring
 Selects matching features using a list of feature IDs. Will emit the
 :py:func:`~QgsVectorLayer.selectionChanged` signal with the clearAndSelect flag set.
@@ -1262,7 +1245,7 @@ to the given coordinates.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
-    EditResult deleteVertex( QgsFeatureId featureId, int vertex );
+    Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 %Docstring
 Deletes a vertex from a feature.
 
@@ -2186,14 +2169,7 @@ Finish edit command and add it to undo/redo stack
 Destroy active command and reverts all changes in it
 %End
 
-    enum VertexMarkerType
-    {
-      SemiTransparentCircle,
-      Cross,
-      NoMarker
-    };
-
- static void drawVertexMarker( double x, double y, QPainter &p, QgsVectorLayer::VertexMarkerType type, int vertexSize );
+ static void drawVertexMarker( double x, double y, QPainter &p, Qgis::VertexMarkerType type, int vertexSize );
 %Docstring
 Draws a vertex symbol at (screen) coordinates x, y. (Useful to assist vertex editing.)
 

--- a/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -50,7 +50,7 @@ to the given coordinates
    available in Python bindings as moveVertexV2
 %End
 
-    QgsVectorLayer::EditResult deleteVertex( QgsFeatureId featureId, int vertex );
+    Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 %Docstring
 Deletes a vertex from a feature.
 

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -413,7 +413,7 @@ QVariantMap QgsSelectByLocationAlgorithm::processAlgorithm( const QVariantMap &p
   if ( !selectLayer )
     throw QgsProcessingException( QObject::tr( "Could not load source layer for INPUT" ) );
 
-  QgsVectorLayer::SelectBehavior method = static_cast< QgsVectorLayer::SelectBehavior >( parameterAsEnum( parameters, QStringLiteral( "METHOD" ), context ) );
+  Qgis::SelectBehavior method = static_cast< Qgis::SelectBehavior >( parameterAsEnum( parameters, QStringLiteral( "METHOD" ), context ) );
   std::unique_ptr< QgsFeatureSource > intersectSource( parameterAsSource( parameters, QStringLiteral( "INTERSECT" ), context ) );
   if ( !intersectSource )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INTERSECT" ) ) );

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -158,13 +158,13 @@ bool QgsMapToolSelect::populateContextMenuWithEvent( QMenu *menu, QgsMapMouseEve
     modifiers = event->modifiers();
     mapPoint = event->mapPoint();
   }
-  QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection;
+  Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection;
   if ( modifiers & Qt::ShiftModifier && modifiers & Qt::ControlModifier )
-    behavior = QgsVectorLayer::IntersectSelection;
+    behavior = Qgis::SelectBehavior::IntersectSelection;
   else if ( modifiers & Qt::ShiftModifier )
-    behavior = QgsVectorLayer::AddToSelection;
+    behavior = Qgis::SelectBehavior::AddToSelection;
   else if ( modifiers & Qt::ControlModifier )
-    behavior = QgsVectorLayer::RemoveFromSelection;
+    behavior = Qgis::SelectBehavior::RemoveFromSelection;
 
   QgsRectangle r = QgsMapToolSelectUtils::expandSelectRectangle( mapPoint, mCanvas, vlayer );
 

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -95,13 +95,13 @@ QgsRectangle QgsMapToolSelectUtils::expandSelectRectangle( QgsPointXY mapPoint, 
 
 void QgsMapToolSelectUtils::selectMultipleFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry, Qt::KeyboardModifiers modifiers )
 {
-  QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection;
+  Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection;
   if ( modifiers & Qt::ShiftModifier && modifiers & Qt::ControlModifier )
-    behavior = QgsVectorLayer::IntersectSelection;
+    behavior = Qgis::SelectBehavior::IntersectSelection;
   else if ( modifiers & Qt::ShiftModifier )
-    behavior = QgsVectorLayer::AddToSelection;
+    behavior = Qgis::SelectBehavior::AddToSelection;
   else if ( modifiers & Qt::ControlModifier )
-    behavior = QgsVectorLayer::RemoveFromSelection;
+    behavior = Qgis::SelectBehavior::RemoveFromSelection;
 
   bool doContains = modifiers & Qt::AltModifier;
   setSelectedFeatures( canvas, selectGeometry, behavior, doContains );
@@ -130,7 +130,7 @@ void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const Qgs
     return;
   }
 
-  QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection;
+  Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection;
 
   //either shift or control modifier switches to "toggle" selection mode
   if ( modifiers & Qt::ShiftModifier || modifiers & Qt::ControlModifier )
@@ -138,9 +138,9 @@ void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const Qgs
     QgsFeatureId selectId = *selectedFeatures.constBegin();
     QgsFeatureIds layerSelectedFeatures = vlayer->selectedFeatureIds();
     if ( layerSelectedFeatures.contains( selectId ) )
-      behavior = QgsVectorLayer::RemoveFromSelection;
+      behavior = Qgis::SelectBehavior::RemoveFromSelection;
     else
-      behavior = QgsVectorLayer::AddToSelection;
+      behavior = Qgis::SelectBehavior::AddToSelection;
   }
 
   vlayer->selectByIds( selectedFeatures, behavior );
@@ -149,7 +149,7 @@ void QgsMapToolSelectUtils::selectSingleFeature( QgsMapCanvas *canvas, const Qgs
 }
 
 void QgsMapToolSelectUtils::setSelectedFeatures( QgsMapCanvas *canvas, const QgsGeometry &selectGeometry,
-    QgsVectorLayer::SelectBehavior selectBehavior, bool doContains, bool singleSelect )
+    Qgis::SelectBehavior selectBehavior, bool doContains, bool singleSelect )
 {
   QgsVectorLayer *vlayer = QgsMapToolSelectUtils::getCurrentVectorLayer( canvas );
   if ( !vlayer )
@@ -377,7 +377,7 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
 
 QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::QgsMapToolSelectMenuActions( QgsMapCanvas *canvas,
     QgsVectorLayer *vectorLayer,
-    QgsVectorLayer::SelectBehavior behavior, const QgsGeometry &selectionGeometry,
+    Qgis::SelectBehavior behavior, const QgsGeometry &selectionGeometry,
     QObject *parent ):
   QObject( parent ),
   mCanvas( canvas ),
@@ -438,7 +438,7 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::startFeatureSearch()
   mJobData->context.setExpressionContext( mCanvas->createExpressionContext() );
   mJobData->context.expressionContext() << QgsExpressionContextUtils::layerScope( mVectorLayer );
   mJobData->selectBehavior = mBehavior;
-  if ( mBehavior != QgsVectorLayer::SetSelection )
+  if ( mBehavior != Qgis::SelectBehavior::SetSelection )
     mJobData->existingSelection = mVectorLayer->selectedFeatureIds();
   QFuture<QgsFeatureIds> future = QtConcurrent::run( search, mJobData );
   mFutureWatcher->setFuture( future );
@@ -552,16 +552,16 @@ QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseAll( qi
   {
     switch ( mBehavior )
     {
-      case QgsVectorLayer::SetSelection:
+      case Qgis::SelectBehavior::SetSelection:
         return tr( "Select Feature" );
 
-      case QgsVectorLayer::AddToSelection:
+      case Qgis::SelectBehavior::AddToSelection:
         return tr( "Add to Selection" );
 
-      case QgsVectorLayer::IntersectSelection:
+      case Qgis::SelectBehavior::IntersectSelection:
         return tr( "Intersect with Selection" );
 
-      case QgsVectorLayer::RemoveFromSelection:
+      case Qgis::SelectBehavior::RemoveFromSelection:
         return tr( "Remove from Selection" );
     }
   }
@@ -574,13 +574,13 @@ QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseAll( qi
 
   switch ( mBehavior )
   {
-    case QgsVectorLayer::SetSelection:
+    case Qgis::SelectBehavior::SetSelection:
       return tr( "Select All (%1)" ).arg( featureCountText );
-    case QgsVectorLayer::AddToSelection:
+    case Qgis::SelectBehavior::AddToSelection:
       return tr( "Add All to Selection (%1)" ).arg( featureCountText );
-    case QgsVectorLayer::IntersectSelection:
+    case Qgis::SelectBehavior::IntersectSelection:
       return tr( "Intersect All with Selection (%1)" ).arg( featureCountText );
-    case QgsVectorLayer::RemoveFromSelection:
+    case Qgis::SelectBehavior::RemoveFromSelection:
       return tr( "Remove All from Selection (%1)" ).arg( featureCountText );
   }
 
@@ -591,13 +591,13 @@ QString QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::textForChooseOneMenu
 {
   switch ( mBehavior )
   {
-    case QgsVectorLayer::SetSelection:
+    case Qgis::SelectBehavior::SetSelection:
       return tr( "Select Feature" );
-    case QgsVectorLayer::AddToSelection:
+    case Qgis::SelectBehavior::AddToSelection:
       return tr( "Add Feature to Selection" );
-    case QgsVectorLayer::IntersectSelection:
+    case Qgis::SelectBehavior::IntersectSelection:
       return tr( "Intersect Feature with Selection" );
-    case QgsVectorLayer::RemoveFromSelection:
+    case Qgis::SelectBehavior::RemoveFromSelection:
       return tr( "Remove Feature from Selection" );
   }
 
@@ -729,14 +729,14 @@ void QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::styleHighlight( QgsHigh
 
 QgsFeatureIds QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::filterIds( const QgsFeatureIds &ids,
     const QgsFeatureIds &existingSelection,
-    QgsVectorLayer::SelectBehavior behavior )
+    Qgis::SelectBehavior behavior )
 {
   QgsFeatureIds effectiveFeatureIds = ids;
   switch ( behavior )
   {
-    case QgsVectorLayer::SetSelection:
+    case Qgis::SelectBehavior::SetSelection:
       break;
-    case QgsVectorLayer::AddToSelection:
+    case Qgis::SelectBehavior::AddToSelection:
     {
       for ( QgsFeatureId newSelected : ids )
       {
@@ -745,8 +745,8 @@ QgsFeatureIds QgsMapToolSelectUtils::QgsMapToolSelectMenuActions::filterIds( con
       }
     }
     break;
-    case QgsVectorLayer::IntersectSelection:
-    case QgsVectorLayer::RemoveFromSelection:
+    case Qgis::SelectBehavior::IntersectSelection:
+    case Qgis::SelectBehavior::RemoveFromSelection:
     {
       for ( QgsFeatureId newSelected : ids )
       {

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -66,7 +66,7 @@ namespace QgsMapToolSelectUtils
   */
   void setSelectedFeatures( QgsMapCanvas *canvas,
                             const QgsGeometry &selectGeometry,
-                            QgsVectorLayer::SelectBehavior selectBehavior = QgsVectorLayer::SetSelection,
+                            Qgis::SelectBehavior selectBehavior = Qgis::SelectBehavior::SetSelection,
                             bool doContains = true,
                             bool singleSelect = false );
 
@@ -138,7 +138,7 @@ namespace QgsMapToolSelectUtils
       */
       QgsMapToolSelectMenuActions( QgsMapCanvas *canvas,
                                    QgsVectorLayer *vectorLayer,
-                                   QgsVectorLayer::SelectBehavior behavior,
+                                   Qgis::SelectBehavior behavior,
                                    const QgsGeometry &selectionGeometry,
                                    QObject *parent = nullptr );
 
@@ -161,7 +161,7 @@ namespace QgsMapToolSelectUtils
     private:
       QgsMapCanvas *mCanvas = nullptr;
       QgsVectorLayer *mVectorLayer = nullptr;
-      QgsVectorLayer::SelectBehavior mBehavior = QgsVectorLayer::SetSelection;
+      Qgis::SelectBehavior mBehavior = Qgis::SelectBehavior::SetSelection;
       QgsGeometry mSelectGeometry;
       QAction *mActionChooseAll = nullptr;
       QMenu *mMenuChooseOne = nullptr;
@@ -179,7 +179,7 @@ namespace QgsMapToolSelectUtils
 
       static QgsFeatureIds filterIds( const QgsFeatureIds &ids,
                                       const QgsFeatureIds &existingSelection,
-                                      QgsVectorLayer::SelectBehavior behavior );
+                                      Qgis::SelectBehavior behavior );
 
       struct DataForSearchingJob
       {
@@ -190,7 +190,7 @@ namespace QgsMapToolSelectUtils
         QgsRenderContext context;
         std::unique_ptr<QgsFeatureRenderer> featureRenderer;
         QString filterString;
-        QgsVectorLayer::SelectBehavior selectBehavior;
+        Qgis::SelectBehavior selectBehavior;
         QgsFeatureIds existingSelection;
       };
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2506,21 +2506,21 @@ void QgsVertexTool::deleteVertex()
       QgsFeatureId fid = it2.key();
       QList<int> &vertexIds = it2.value();
 
-      bool res = QgsVectorLayer::Success;
+      Qgis::VectorEditResult res = Qgis::VectorEditResult::Success;
       std::sort( vertexIds.begin(), vertexIds.end(), std::greater<int>() );
       for ( int vertexId : vertexIds )
       {
         QgsMessageLog::logMessage( "DELETE : fid:" + QString::number( fid ) + " ; vertexId:" + QString::number( vertexId ), "DEBUG" );
-        if ( res != QgsVectorLayer::EmptyGeometry )
+        if ( res != Qgis::VectorEditResult::EmptyGeometry )
           res = layer->deleteVertex( fid, vertexId );
-        if ( res != QgsVectorLayer::EmptyGeometry && res != QgsVectorLayer::Success )
+        if ( res != Qgis::VectorEditResult::EmptyGeometry && res != Qgis::VectorEditResult::Success )
         {
           QgsDebugMsg( QStringLiteral( "failed to delete vertex %1 %2 %3!" ).arg( layer->name() ).arg( fid ).arg( vertexId ) );
           success = false;
         }
       }
 
-      if ( res == QgsVectorLayer::EmptyGeometry )
+      if ( res == Qgis::VectorEditResult::EmptyGeometry )
       {
         emit messageEmitted( tr( "Geometry has been cleared. Use the add part tool to set geometry for this feature." ) );
       }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -479,6 +479,48 @@ class CORE_EXPORT Qgis
     Q_ENUM( SublayerPromptMode )
 
     /**
+     * Specifies how a selection should be applied.
+     *
+     * \since QGIS 3.22
+     */
+    enum class SelectBehavior SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, SelectBehavior ) : int
+      {
+      SetSelection, //!< Set selection, removing any existing selection
+      AddToSelection, //!< Add selection to current selection
+      IntersectSelection, //!< Modify current selection to include only select features which match
+      RemoveFromSelection, //!< Remove from current selection
+    };
+    Q_ENUM( SelectBehavior )
+
+    /**
+     * Specifies the result of a vector layer edit operation
+     *
+     * \since QGIS 3.22
+     */
+    enum class VectorEditResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, EditResult ) : int
+      {
+      Success = 0, //!< Edit operation was successful
+      EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
+      EditFailed = 2, //!< Edit operation failed
+      FetchFeatureFailed = 3, //!< Unable to fetch requested feature
+      InvalidLayer = 4, //!< Edit failed due to invalid layer
+    };
+    Q_ENUM( VectorEditResult )
+
+    /**
+     * Editing vertex markers, used for showing vertices during a edit operation.
+     *
+     * \since QGIS 3.22
+     */
+    enum class VertexMarkerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbolLayerUtils, VertexMarkerType ) : int
+      {
+      SemiTransparentCircle, //!< Semi-transparent circle marker
+      Cross, //!< Cross marker
+      NoMarker, //!< No marker
+    };
+    Q_ENUM( VertexMarkerType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -66,7 +66,6 @@ void QgsFeatureRenderer::copyRendererData( QgsFeatureRenderer *destRenderer ) co
 
 QgsFeatureRenderer::QgsFeatureRenderer( const QString &type )
   : mType( type )
-  , mCurrentVertexMarkerType( QgsVectorLayer::Cross )
 {
   mPaintEffect = QgsPaintEffectRegistry::defaultStack();
   mPaintEffect->setEnabled( false );
@@ -374,7 +373,7 @@ QgsLegendSymbolList QgsFeatureRenderer::legendSymbolItems() const
   return QgsLegendSymbolList();
 }
 
-void QgsFeatureRenderer::setVertexMarkerAppearance( int type, double size )
+void QgsFeatureRenderer::setVertexMarkerAppearance( Qgis::VertexMarkerType type, double size )
 {
   mCurrentVertexMarkerType = type;
   mCurrentVertexMarkerSize = size;
@@ -389,7 +388,7 @@ void QgsFeatureRenderer::renderVertexMarker( QPointF pt, QgsRenderContext &conte
 {
   int markerSize = context.convertToPainterUnits( mCurrentVertexMarkerSize, QgsUnitTypes::RenderMillimeters );
   QgsSymbolLayerUtils::drawVertexMarker( pt.x(), pt.y(), *context.painter(),
-                                         static_cast< QgsSymbolLayerUtils::VertexMarkerType >( mCurrentVertexMarkerType ),
+                                         mCurrentVertexMarkerType,
                                          markerSize );
 }
 

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -367,7 +367,7 @@ class CORE_EXPORT QgsFeatureRenderer
     virtual QString legendClassificationAttribute() const { return QString(); }
 
     //! Sets type and size of editing vertex markers for subsequent rendering
-    void setVertexMarkerAppearance( int type, double size );
+    void setVertexMarkerAppearance( Qgis::VertexMarkerType type, double size );
 
     /**
      * Returns whether the renderer will render a feature or not.
@@ -582,7 +582,8 @@ class CORE_EXPORT QgsFeatureRenderer
     bool mUsingSymbolLevels = false;
 
     //! The current type of editing marker
-    int mCurrentVertexMarkerType;
+    Qgis::VertexMarkerType mCurrentVertexMarkerType = Qgis::VertexMarkerType::Cross;
+
     //! The current size of editing marker
     double mCurrentVertexMarkerSize = 2;
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -900,7 +900,7 @@ class GeometryRestorer
 };
 ///@endcond PRIVATE
 
-void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer, bool selected, bool drawVertexMarker, int currentVertexMarkerType, double currentVertexMarkerSize )
+void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer, bool selected, bool drawVertexMarker, Qgis::VertexMarkerType currentVertexMarkerType, double currentVertexMarkerSize )
 {
   if ( context.renderingStopped() )
     return;
@@ -1435,10 +1435,10 @@ QgsSymbolRenderContext *QgsSymbol::symbolRenderContext()
   return mSymbolRenderContext.get();
 }
 
-void QgsSymbol::renderVertexMarker( QPointF pt, QgsRenderContext &context, int currentVertexMarkerType, double currentVertexMarkerSize )
+void QgsSymbol::renderVertexMarker( QPointF pt, QgsRenderContext &context, Qgis::VertexMarkerType currentVertexMarkerType, double currentVertexMarkerSize )
 {
   int markerSize = context.convertToPainterUnits( currentVertexMarkerSize, QgsUnitTypes::RenderMillimeters );
-  QgsSymbolLayerUtils::drawVertexMarker( pt.x(), pt.y(), *context.painter(), static_cast< QgsSymbolLayerUtils::VertexMarkerType >( currentVertexMarkerType ), markerSize );
+  QgsSymbolLayerUtils::drawVertexMarker( pt.x(), pt.y(), *context.painter(), currentVertexMarkerType, markerSize );
 }
 
 void QgsSymbol::initPropertyDefinitions()

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -589,7 +589,7 @@ class CORE_EXPORT QgsSymbol
      * Render a feature. Before calling this the startRender() method should be called to initialize
      * the rendering process. After rendering all features stopRender() must be called.
      */
-    void renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false, int currentVertexMarkerType = 0, double currentVertexMarkerSize = 0.0 ) SIP_THROW( QgsCsException );
+    void renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer = -1, bool selected = false, bool drawVertexMarker = false, Qgis::VertexMarkerType currentVertexMarkerType = Qgis::VertexMarkerType::SemiTransparentCircle, double currentVertexMarkerSize = 0.0 ) SIP_THROW( QgsCsException );
 
     /**
      * Returns the symbol render context. Only valid between startRender and stopRender calls.
@@ -698,7 +698,7 @@ class CORE_EXPORT QgsSymbol
      * Render editing vertex marker at specified point
      * \since QGIS 2.16
      */
-    void renderVertexMarker( QPointF pt, QgsRenderContext &context, int currentVertexMarkerType, double currentVertexMarkerSize );
+    void renderVertexMarker( QPointF pt, QgsRenderContext &context, Qgis::VertexMarkerType currentVertexMarkerType, double currentVertexMarkerSize );
 
     Qgis::SymbolType mType;
     QgsSymbolLayerList mLayers;

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -948,23 +948,23 @@ void QgsSymbolLayerUtils::drawStippledBackground( QPainter *painter, QRect rect 
   painter->fillRect( rect, brush );
 }
 
-void QgsSymbolLayerUtils::drawVertexMarker( double x, double y, QPainter &p, QgsSymbolLayerUtils::VertexMarkerType type, int markerSize )
+void QgsSymbolLayerUtils::drawVertexMarker( double x, double y, QPainter &p, Qgis::VertexMarkerType type, int markerSize )
 {
   qreal s = ( markerSize - 1 ) / 2.0;
 
   switch ( type )
   {
-    case QgsSymbolLayerUtils::SemiTransparentCircle:
+    case Qgis::VertexMarkerType::SemiTransparentCircle:
       p.setPen( QColor( 50, 100, 120, 200 ) );
       p.setBrush( QColor( 200, 200, 210, 120 ) );
       p.drawEllipse( x - s, y - s, s * 2, s * 2 );
       break;
-    case QgsSymbolLayerUtils::Cross:
+    case Qgis::VertexMarkerType::Cross:
       p.setPen( QColor( 255, 0, 0 ) );
       p.drawLine( x - s, y + s, x + s, y - s );
       p.drawLine( x - s, y - s, x + s, y + s );
       break;
-    case QgsSymbolLayerUtils::NoMarker:
+    case Qgis::VertexMarkerType::NoMarker:
       break;
   }
 }

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -58,14 +58,6 @@ class CORE_EXPORT QgsSymbolLayerUtils
 {
   public:
 
-    //! Editing vertex markers
-    enum VertexMarkerType
-    {
-      SemiTransparentCircle,
-      Cross,
-      NoMarker
-    };
-
     static QString encodeColor( const QColor &color );
     static QColor decodeColor( const QString &str );
 
@@ -303,7 +295,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * Draws a vertex symbol at (painter) coordinates x, y. (Useful to assist vertex editing.)
      * \since QGIS 3.4.5
      */
-    static void drawVertexMarker( double x, double y, QPainter &p, QgsSymbolLayerUtils::VertexMarkerType type, int markerSize );
+    static void drawVertexMarker( double x, double y, QPainter &p, Qgis::VertexMarkerType type, int markerSize );
 
     //! Returns the maximum estimated bleed for the symbol
     static double estimateMaxSymbolBleed( QgsSymbol *symbol, const QgsRenderContext &context );

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -402,27 +402,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
   public:
 
-    //! Result of an edit operation
-    enum EditResult
-    {
-      Success = 0, //!< Edit operation was successful
-      EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
-      EditFailed = 2, //!< Edit operation failed
-      FetchFeatureFailed = 3, //!< Unable to fetch requested feature
-      InvalidLayer = 4, //!< Edit failed due to invalid layer
-    };
-    Q_ENUM( EditResult )
-
-    //! Selection behavior
-    enum SelectBehavior
-    {
-      SetSelection, //!< Set selection, removing any existing selection
-      AddToSelection, //!< Add selection to current selection
-      IntersectSelection, //!< Modify current selection to include only select features which match
-      RemoveFromSelection, //!< Remove from current selection
-    };
-    Q_ENUM( SelectBehavior )
-
     /**
      * Setting options for loading vector layers.
      * \since QGIS 3.0
@@ -772,7 +751,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see selectByExpression()
      * \see selectByIds()
      */
-    Q_INVOKABLE void selectByRect( QgsRectangle &rect, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    Q_INVOKABLE void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
     /**
      * Selects matching features using an expression.
@@ -783,7 +762,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see selectByIds()
      * \since QGIS 2.16
      */
-    Q_INVOKABLE void selectByExpression( const QString &expression, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    Q_INVOKABLE void selectByExpression( const QString &expression, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
     /**
      * Selects matching features using a list of feature IDs. Will emit the
@@ -795,7 +774,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see selectByExpression()
      * \since QGIS 2.16
      */
-    Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, QgsVectorLayer::SelectBehavior behavior = QgsVectorLayer::SetSelection );
+    Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
     /**
      * Modifies the current selection on this layer
@@ -1301,7 +1280,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * changes can be discarded by calling rollBack().
      * \since QGIS 2.14
      */
-    EditResult deleteVertex( QgsFeatureId featureId, int vertex );
+    Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
      * Deletes the selected features
@@ -2030,19 +2009,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Destroy active command and reverts all changes in it
     void destroyEditCommand();
 
-    //! Editing vertex markers
-    enum VertexMarkerType
-    {
-      SemiTransparentCircle,
-      Cross,
-      NoMarker
-    };
-
     /**
      * Draws a vertex symbol at (screen) coordinates x, y. (Useful to assist vertex editing.)
      * \deprecated Use the equivalent QgsSymbolLayerUtils::drawVertexMarker function instead
      */
-    Q_DECL_DEPRECATED static void drawVertexMarker( double x, double y, QPainter &p, QgsVectorLayer::VertexMarkerType type, int vertexSize );
+    Q_DECL_DEPRECATED static void drawVertexMarker( double x, double y, QPainter &p, Qgis::VertexMarkerType type, int vertexSize );
 
     /**
      * Will regenerate the `fields` property of this layer by obtaining all fields

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -94,19 +94,19 @@ bool QgsVectorLayerEditUtils::moveVertex( const QgsPoint &p, QgsFeatureId atFeat
 }
 
 
-QgsVectorLayer::EditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId featureId, int vertex )
+Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId featureId, int vertex )
 {
   if ( !mLayer->isSpatial() )
-    return QgsVectorLayer::InvalidLayer;
+    return Qgis::VectorEditResult::InvalidLayer;
 
   QgsFeature f;
   if ( !mLayer->getFeatures( QgsFeatureRequest().setFilterFid( featureId ).setNoAttributes() ).nextFeature( f ) || !f.hasGeometry() )
-    return QgsVectorLayer::FetchFeatureFailed; // geometry not found
+    return Qgis::VectorEditResult::FetchFeatureFailed; // geometry not found
 
   QgsGeometry geometry = f.geometry();
 
   if ( !geometry.deleteVertex( vertex ) )
-    return QgsVectorLayer::EditFailed;
+    return Qgis::VectorEditResult::EditFailed;
 
   if ( geometry.constGet() && geometry.constGet()->nCoordinates() == 0 )
   {
@@ -115,7 +115,7 @@ QgsVectorLayer::EditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId f
   }
 
   mLayer->changeGeometry( featureId, geometry );
-  return !geometry.isNull() ? QgsVectorLayer::Success : QgsVectorLayer::EmptyGeometry;
+  return !geometry.isNull() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
 }
 
 QgsGeometry::OperationResult QgsVectorLayerEditUtils::addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds, QgsFeatureId *modifiedFeatureId )

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * \param vertex index of vertex to delete
      * \since QGIS 2.14
      */
-    QgsVectorLayer::EditResult deleteVertex( QgsFeatureId featureId, int vertex );
+    Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
      * Adds a ring to polygon/multipolygon features

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -120,15 +120,15 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
   QString markerTypeString = QgsSettingsRegistryCore::settingsDigitizingMarkerStyle.value();
   if ( markerTypeString == QLatin1String( "Cross" ) )
   {
-    mVertexMarkerStyle = QgsSymbolLayerUtils::Cross;
+    mVertexMarkerStyle = Qgis::VertexMarkerType::Cross;
   }
   else if ( markerTypeString == QLatin1String( "SemiTransparentCircle" ) )
   {
-    mVertexMarkerStyle = QgsSymbolLayerUtils::SemiTransparentCircle;
+    mVertexMarkerStyle = Qgis::VertexMarkerType::SemiTransparentCircle;
   }
   else
   {
-    mVertexMarkerStyle = QgsSymbolLayerUtils::NoMarker;
+    mVertexMarkerStyle = Qgis::VertexMarkerType::NoMarker;
   }
 
   mVertexMarkerSize = QgsSettingsRegistryCore::settingsDigitizingMarkerSizeMm.value();

--- a/src/core/vector/qgsvectorlayerrenderer.h
+++ b/src/core/vector/qgsvectorlayerrenderer.h
@@ -137,7 +137,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
     bool mDrawVertexMarkers;
     bool mVertexMarkerOnlyForSelection;
-    int mVertexMarkerStyle = 0;
+    Qgis::VertexMarkerType mVertexMarkerStyle = Qgis::VertexMarkerType::SemiTransparentCircle;
     double mVertexMarkerSize = 2.0;
 
     QgsWkbTypes::GeometryType mGeometryType;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -639,7 +639,7 @@ void QgsAttributeForm::displayWarning( const QString &message )
                             Qgis::MessageLevel::Warning );
 }
 
-void QgsAttributeForm::runSearchSelect( QgsVectorLayer::SelectBehavior behavior )
+void QgsAttributeForm::runSearchSelect( Qgis::SelectBehavior behavior )
 {
   QString filter = createFilterExpression();
   if ( filter.isEmpty() )
@@ -653,22 +653,22 @@ void QgsAttributeForm::runSearchSelect( QgsVectorLayer::SelectBehavior behavior 
 
 void QgsAttributeForm::searchSetSelection()
 {
-  runSearchSelect( QgsVectorLayer::SetSelection );
+  runSearchSelect( Qgis::SelectBehavior::SetSelection );
 }
 
 void QgsAttributeForm::searchAddToSelection()
 {
-  runSearchSelect( QgsVectorLayer::AddToSelection );
+  runSearchSelect( Qgis::SelectBehavior::AddToSelection );
 }
 
 void QgsAttributeForm::searchRemoveFromSelection()
 {
-  runSearchSelect( QgsVectorLayer::RemoveFromSelection );
+  runSearchSelect( Qgis::SelectBehavior::RemoveFromSelection );
 }
 
 void QgsAttributeForm::searchIntersectSelection()
 {
-  runSearchSelect( QgsVectorLayer::IntersectSelection );
+  runSearchSelect( Qgis::SelectBehavior::IntersectSelection );
 }
 
 bool QgsAttributeForm::saveMultiEdits()

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -414,7 +414,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void clearMultiEditMessages();
     void pushSelectedFeaturesMessage();
-    void runSearchSelect( QgsVectorLayer::SelectBehavior behavior );
+    void runSearchSelect( Qgis::SelectBehavior behavior );
 
     QString createFilterExpression() const;
 

--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -101,7 +101,7 @@ void QgsExpressionSelectionDialog::setMapCanvas( QgsMapCanvas *canvas )
 void QgsExpressionSelectionDialog::mActionSelect_triggered()
 {
   mLayer->selectByExpression( mExpressionBuilder->expressionText(),
-                              QgsVectorLayer::SetSelection );
+                              Qgis::SelectBehavior::SetSelection );
   pushSelectedFeaturesMessage();
   saveRecent();
 }
@@ -109,7 +109,7 @@ void QgsExpressionSelectionDialog::mActionSelect_triggered()
 void QgsExpressionSelectionDialog::mActionAddToSelection_triggered()
 {
   mLayer->selectByExpression( mExpressionBuilder->expressionText(),
-                              QgsVectorLayer::AddToSelection );
+                              Qgis::SelectBehavior::AddToSelection );
   pushSelectedFeaturesMessage();
   saveRecent();
 }
@@ -117,7 +117,7 @@ void QgsExpressionSelectionDialog::mActionAddToSelection_triggered()
 void QgsExpressionSelectionDialog::mActionSelectIntersect_triggered()
 {
   mLayer->selectByExpression( mExpressionBuilder->expressionText(),
-                              QgsVectorLayer::IntersectSelection );
+                              Qgis::SelectBehavior::IntersectSelection );
   pushSelectedFeaturesMessage();
   saveRecent();
 }
@@ -125,7 +125,7 @@ void QgsExpressionSelectionDialog::mActionSelectIntersect_triggered()
 void QgsExpressionSelectionDialog::mActionRemoveFromSelection_triggered()
 {
   mLayer->selectByExpression( mExpressionBuilder->expressionText(),
-                              QgsVectorLayer::RemoveFromSelection );
+                              Qgis::SelectBehavior::RemoveFromSelection );
   pushSelectedFeaturesMessage();
   saveRecent();
 }


### PR DESCRIPTION
Move enums from QgsVectorLayer to Qgis, promote to enum classes, and fix redundant QgsVectorLayer.VertexMarkerType enum
