### PR TITLE
Add icon for curved callouts

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -647,6 +647,7 @@
         <file>themes/default/labelingSingle.svg</file>
         <file>themes/default/labelingRuleBased.svg</file>
         <file>themes/default/labelingObstacle.svg</file>
+        <file>themes/default/labelingCalloutCurved.svg</file>
         <file>themes/default/labelingCalloutSimple.svg</file>
         <file>themes/default/labelingCalloutManhattan.svg</file>
         <file>themes/default/repositoryConnected.svg</file>

--- a/images/themes/default/labelingCalloutCurved.svg
+++ b/images/themes/default/labelingCalloutCurved.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g transform="translate(1.7019 .74323)" fill="none" stroke="#000" stroke-width="3">
+  <path d="m0.79806 14.257c-0.0077817-7.4411 5.9179-13.535 13.5-13.5" stroke="#000" stroke-width="3"/>
+ </g>
+ <g transform="translate(1.7019 .74323)" fill="none">
+  <path d="m0.79806 14.257c-0.0077817-7.4411 5.9179-13.535 13.5-13.5" stroke="#6389b8"/>
+ </g>
+</svg>

--- a/src/core/callouts/qgscalloutsregistry.cpp
+++ b/src/core/callouts/qgscalloutsregistry.cpp
@@ -51,7 +51,7 @@ QgsCalloutRegistry::QgsCalloutRegistry()
   // init registry with known callouts
   addCalloutType( new QgsCalloutMetadata( QStringLiteral( "simple" ), QObject::tr( "Simple lines" ), QgsApplication::getThemeIcon( QStringLiteral( "labelingCalloutSimple.svg" ) ), QgsSimpleLineCallout::create ) );
   addCalloutType( new QgsCalloutMetadata( QStringLiteral( "manhattan" ), QObject::tr( "Manhattan lines" ), QgsApplication::getThemeIcon( QStringLiteral( "labelingCalloutManhattan.svg" ) ), QgsManhattanLineCallout::create ) );
-  addCalloutType( new QgsCalloutMetadata( QStringLiteral( "curved" ), QObject::tr( "Curved lines" ), QgsApplication::getThemeIcon( QStringLiteral( "labelingCalloutSimple.svg" ) ), QgsCurvedLineCallout::create ) );
+  addCalloutType( new QgsCalloutMetadata( QStringLiteral( "curved" ), QObject::tr( "Curved lines" ), QgsApplication::getThemeIcon( QStringLiteral( "labelingCalloutCurved.svg" ) ), QgsCurvedLineCallout::create ) );
   addCalloutType( new QgsCalloutMetadata( QStringLiteral( "balloon" ), QObject::tr( "Balloons" ), QgsApplication::getThemeIcon( QStringLiteral( "labelingCalloutManhattan.svg" ) ), QgsBalloonCallout::create ) );
 }
 


### PR DESCRIPTION
Supersedes #43958 , thanks to @DelazJ for the original commit.

The updated SVG aligns to the pixel grid and is optimized/compressed.