### PR TITLE
[sipify] Add check that doxygen //!< command is only used for enum documentation

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -140,11 +140,11 @@ Sets the query execution time to ``queryExecutionTime`` milliseconds.
 
     struct SqlVectorLayerOptions
     {
-      QString sql; //!< The SQL expression that defines the SQL (query) layer
-      QString filter; //!< Additional subset string (provider-side filter), not all data providers support this feature: check support with SqlLayerDefinitionCapability::Filters capability
-      QString layerName; //!< Optional name for the new layer
-      QStringList primaryKeyColumns; //!< List of primary key column names
-      QString geometryColumn; //!< Name of the geometry column
+      QString sql;
+      QString filter;
+      QString layerName;
+      QStringList primaryKeyColumns;
+      QString geometryColumn;
       bool disableSelectAtId;
     };
 

--- a/python/core/auto_generated/qgsaggregatecalculator.sip.in
+++ b/python/core/auto_generated/qgsaggregatecalculator.sip.in
@@ -29,9 +29,9 @@ to a data provider for remote calculation.
 
     struct AggregateInfo
     {
-      QString function; //!< The expression function
-      QString name; //!< A translated, human readable name
-      QSet<QVariant::Type> supportedTypes; //!< This aggregate function can only be used with these datatypes
+      QString function;
+      QString name;
+      QSet<QVariant::Type> supportedTypes;
     };
 
     enum Aggregate

--- a/python/core/auto_generated/qgsattributetableconfig.sip.in
+++ b/python/core/auto_generated/qgsattributetableconfig.sip.in
@@ -39,8 +39,11 @@ Constructor for ColumnConfig
 
 
       QgsAttributeTableConfig::Type type;
-      QString name; //!< The name of the attribute if this column represents a field
+
+      QString name;
+
       bool hidden;
+
       int width;
     };
 

--- a/python/core/auto_generated/qgsdatadefinedsizelegend.sip.in
+++ b/python/core/auto_generated/qgsdatadefinedsizelegend.sip.in
@@ -55,8 +55,9 @@ Copy constructor
     {
       SizeClass( double size, const QString &label );
 
-      double size;    //!< Marker size in units used by the symbol (usually millimeters). May be further scaled before rendering if size scale transformer is enabled.
-      QString label;  //!< Label to be shown with the particular symbol size
+      double size;
+
+      QString label;
     };
 
     void setLegendType( LegendType type );

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -106,13 +106,14 @@ end of iterating: free the resources / lock
 
     struct FetchJoinInfo
     {
-      const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
-      QgsAttributeList attributes;      //!< Attributes to fetch
-      int indexOffset;                  //!< At what position the joined fields start
+      const QgsVectorLayerJoinInfo *joinInfo;
+      QgsAttributeList attributes;
+      int indexOffset;
 
 
-      int targetField;                  //!< Index of field (of this layer) that drives the join
-      int joinField;                    //!< Index of field (of the joined layer) must have equal value
+      int targetField;
+
+      int joinField;
 
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;

--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -44,10 +44,14 @@ class QgsSublayersDialog : QDialog
     struct LayerDefinition
     {
       int layerId;
-      QString layerName;  //!< Name of the layer (not necessarily unique)
+
+      QString layerName;
+
       int count;
-      QString type;       //!< Extra type depending on the use (e.g. geometry type for vector sublayers)
-      QString description;  //!< Description. Added in QGIS 3.10
+
+      QString type;
+
+      QString description;
     };
 
     typedef QList<QgsSublayersDialog::LayerDefinition> LayerDefinitionList;
@@ -120,6 +124,7 @@ Returns column with count or -1
 
 
   protected:
+
 
 
 };

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -794,7 +794,7 @@ while ($LINE_IDX < $LINE_COUNT){
         next;
     }
 
-    # insert metaoject for Q_GADGET
+    # insert metaobject for Q_GADGET
     if ($LINE =~ m/^\s*Q_GADGET\b.*?$/){
         if ($LINE !~ m/SIP_SKIP/){
             dbg_info('Q_GADGET');
@@ -990,7 +990,7 @@ while ($LINE_IDX < $LINE_COUNT){
                 pop(@CLASSNAME);
                 if ($#ACCESS == 0){
                     dbg_info("reached top level");
-                    # top level should stasy public
+                    # top level should stay public
                     $ACCESS[$#ACCESS] = PUBLIC;
                 }
                 $COMMENT = '';
@@ -1149,6 +1149,10 @@ while ($LINE_IDX < $LINE_COUNT){
             $COMMENT = '';
             next;
         }
+    }
+
+    if( $LINE =~ /.*\/\/\!\</ ) {
+      exit_with_error("\"\\\\!<\" doxygen command must only be used for enum documentation")
     }
 
     $IS_OVERRIDE = 1 if ( $LINE =~ m/\boverride\b/);

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -235,12 +235,18 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      */
     struct CORE_EXPORT SqlVectorLayerOptions
     {
-      QString sql; //!< The SQL expression that defines the SQL (query) layer
-      QString filter; //!< Additional subset string (provider-side filter), not all data providers support this feature: check support with SqlLayerDefinitionCapability::Filters capability
-      QString layerName; //!< Optional name for the new layer
-      QStringList primaryKeyColumns; //!< List of primary key column names
-      QString geometryColumn; //!< Name of the geometry column
-      bool disableSelectAtId = false; //!< If SelectAtId is disabled (default is false), not all data providers support this feature: check support with SqlLayerDefinitionCapability::SelectAtId capability
+      //! The SQL expression that defines the SQL (query) layer
+      QString sql;
+      //! Additional subset string (provider-side filter), not all data providers support this feature: check support with SqlLayerDefinitionCapability::Filters capability
+      QString filter;
+      //! Optional name for the new layer
+      QString layerName;
+      //! List of primary key column names
+      QStringList primaryKeyColumns;
+      //! Name of the geometry column
+      QString geometryColumn;
+      //! If SelectAtId is disabled (default is false), not all data providers support this feature: check support with SqlLayerDefinitionCapability::SelectAtId capability
+      bool disableSelectAtId = false;
     };
 
     /**

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -52,9 +52,12 @@ class CORE_EXPORT QgsAggregateCalculator
      */
     struct AggregateInfo
     {
-      QString function; //!< The expression function
-      QString name; //!< A translated, human readable name
-      QSet<QVariant::Type> supportedTypes; //!< This aggregate function can only be used with these datatypes
+      //! The expression function
+      QString function;
+      //! A translated, human readable name
+      QString name;
+      //! This aggregate function can only be used with these datatypes
+      QSet<QVariant::Type> supportedTypes;
     };
 
     /**

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -57,10 +57,17 @@ class CORE_EXPORT QgsAttributeTableConfig
       // TODO c++20 - replace with = default
       bool operator== ( const QgsAttributeTableConfig::ColumnConfig &other ) const SIP_SKIP;
 
-      QgsAttributeTableConfig::Type type = Field;    //!< The type of this column.
-      QString name; //!< The name of the attribute if this column represents a field
-      bool hidden = false;  //!< Flag that controls if the column is hidden
-      int width = -1; //!< Width of column, or -1 for default width
+      //! The type of this column.
+      QgsAttributeTableConfig::Type type = Field;
+
+      //! The name of the attribute if this column represents a field
+      QString name;
+
+      //! Flag that controls if the column is hidden
+      bool hidden = false;
+
+      //! Width of column, or -1 for default width
+      int width = -1;
     };
 
     /**

--- a/src/core/qgsdatadefinedsizelegend.h
+++ b/src/core/qgsdatadefinedsizelegend.h
@@ -73,8 +73,11 @@ class CORE_EXPORT QgsDataDefinedSizeLegend
     {
       SizeClass( double size, const QString &label ): size( size ), label( label ) {}
 
-      double size;    //!< Marker size in units used by the symbol (usually millimeters). May be further scaled before rendering if size scale transformer is enabled.
-      QString label;  //!< Label to be shown with the particular symbol size
+      //! Marker size in units used by the symbol (usually millimeters). May be further scaled before rendering if size scale transformer is enabled.
+      double size;
+
+      //! Label to be shown with the particular symbol size
+      QString label;
     };
 
     //! Sets how the legend should be rendered

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -849,8 +849,10 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     QgsLabelingEngineSettings mLabelingEngineSettings;
 
     // derived properties
-    bool mValid = false; //!< Whether the actual settings are valid (set in updateDerived())
-    QgsRectangle mVisibleExtent; //!< Extent with some additional white space that matches the output aspect ratio
+    //! Whether the actual settings are valid (set in updateDerived())
+    bool mValid = false;
+    //! Extent with some additional white space that matches the output aspect ratio
+    QgsRectangle mVisibleExtent;
     double mMapUnitsPerPixel = 1;
     double mScale = 1;
 

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -146,10 +146,14 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
      */
     struct CORE_EXPORT FetchJoinInfo
     {
-      const QgsVectorLayerJoinInfo *joinInfo;//!< Canonical source of information about the join
-      QgsAttributeList attributes;      //!< Attributes to fetch
-      QMap<int, int> attributesSourceToDestLayerMap SIP_SKIP; //!< Mapping from original attribute index to the joined layer index
-      int indexOffset;                  //!< At what position the joined fields start
+      //! Canonical source of information about the join
+      const QgsVectorLayerJoinInfo *joinInfo;
+      //! Attributes to fetch
+      QgsAttributeList attributes;
+      //! Mapping from original attribute index to the joined layer index
+      QMap<int, int> attributesSourceToDestLayerMap SIP_SKIP;
+      //! At what position the joined fields start
+      int indexOffset;
 
 #ifndef SIP_RUN
 
@@ -170,8 +174,11 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
       QgsFields joinLayerFields;
 #endif
 
-      int targetField;                  //!< Index of field (of this layer) that drives the join
-      int joinField;                    //!< Index of field (of the joined layer) must have equal value
+      //! Index of field (of this layer) that drives the join
+      int targetField;
+
+      //!< Index of field (of the joined layer) must have equal value
+      int joinField;
 
       void addJoinedAttributesCached( QgsFeature &f, const QVariant &joinValue ) const;
       void addJoinedAttributesDirect( QgsFeature &f, const QVariant &joinValue ) const;

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -76,11 +76,24 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
      */
     struct LayerDefinition
     {
-      int layerId = -1 ;        //!< Identifier of the layer (one unique layer id may have multiple types though)
-      QString layerName;  //!< Name of the layer (not necessarily unique)
-      int count = -1 ;          //!< Number of features (might be unused)
-      QString type;       //!< Extra type depending on the use (e.g. geometry type for vector sublayers)
-      QString description;  //!< Description. Added in QGIS 3.10
+      //! Identifier of the layer (one unique layer id may have multiple types though)
+      int layerId = -1;
+
+      //! Name of the layer (not necessarily unique)
+      QString layerName;
+
+      //! Number of features (might be unused)
+      int count = -1;
+
+      //! Extra type depending on the use (e.g. geometry type for vector sublayers)
+      QString type;
+
+      /**
+       * Description.
+       *
+       * \since QGIS 3.10
+       */
+      QString description;
     };
 
     /**
@@ -160,13 +173,17 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
      */
     QString mName;
     QStringList mSelectedSubLayers;
-    bool mShowCount = false;  //!< Whether to show number of features in the table
-    bool mShowType = false;   //!< Whether to show type in the table
-    bool mShowDescription = false;   //!< Whether to show description in the table
+
+    //! Whether to show number of features in the table
+    bool mShowCount = false;
+    //! Whether to show type in the table
+    bool mShowType = false;
+    //! Whether to show description in the table
+    bool mShowDescription = false;
 
   private:
-
-    bool mShowAddToGroupCheckbox = false;   //!< Whether to show the add to group checkbox
+    //! Whether to show the add to group checkbox
+    bool mShowAddToGroupCheckbox = false;
 };
 
 #endif


### PR DESCRIPTION
sipify can't handle it in other contexts, so explicitly prevent it being used 
