### PR TITLE
Fix crash in vector layer iteration on Qt6 builds

### DIFF
--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -536,7 +536,8 @@ bool QgsVectorLayerFeatureIterator::isValid() const
 
 bool QgsVectorLayerFeatureIterator::fetchNextAddedFeature( QgsFeature &f )
 {
-  while ( mFetchAddedFeaturesIt-- != mSource->mAddedFeatures.constBegin() )
+  while ( mFetchAddedFeaturesIt != mSource->mAddedFeatures.constBegin() &&
+          mFetchAddedFeaturesIt-- != mSource->mAddedFeatures.constBegin() )
   {
     QgsFeatureId fid = mFetchAddedFeaturesIt->id();
 


### PR DESCRIPTION
Decrementing an iterator which is already at the beginning results in a crash
