### PR TITLE
Fix crash in expression array functions on qt6

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5520,6 +5520,9 @@ static QVariant fcnArrayMajority( const QVariantList &values, const QgsExpressio
     ++hash[item];
   }
   const QList< int > occurrences = hash.values();
+  if ( occurrences.empty() )
+    return QVariantList();
+
   const int maxValue = *std::max_element( occurrences.constBegin(), occurrences.constEnd() );
 
   const QString option = values.at( 1 ).toString();
@@ -5561,6 +5564,9 @@ static QVariant fcnArrayMinority( const QVariantList &values, const QgsExpressio
     ++hash[item];
   }
   const QList< int > occurrences = hash.values();
+  if ( occurrences.empty() )
+    return QVariantList();
+
   const int minValue = *std::min_element( occurrences.constBegin(), occurrences.constEnd() );
 
   const QString option = values.at( 1 ).toString();


### PR DESCRIPTION
Calling *std::min_element/max_element on an empty container leads to a crash
