### PR TITLE
Check Geometries/Check for duplicates: avoid assertion in debug builds…

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -26,7 +26,7 @@ QString QgsGeometryDuplicateCheckError::duplicatesString( const QMap<QString, Qg
   QStringList str;
   for ( auto it = duplicates.constBegin(); it != duplicates.constEnd(); ++it )
   {
-    str.append( featurePools[it.key()]->layer()->name() + ":" );
+    str.append( featurePools[it.key()]->layerName() + ":" );
     QStringList ids;
     ids.reserve( it.value().length() );
     for ( QgsFeatureId id : it.value() )


### PR DESCRIPTION
…due to thread-unsafe usage of layer() method (fixes #44246)
