### PR TITLE
Reset upper border of the cumulative cut to its maximum value (fix #42717)

### DIFF
--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgsrasterrenderer.h"
 #include "qgsrasterdataprovider.h"
 #include "qgsrasterminmaxorigin.h"
+#include "qgsdoublespinbox.h"
 
 const int IDX_WHOLE_RASTER = 0;
 const int IDX_CURRENT_CANVAS = 1;
@@ -37,6 +38,10 @@ QgsRasterMinMaxWidget::QgsRasterMinMaxWidget( QgsRasterLayer *layer, QWidget *pa
 {
   QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   setupUi( this );
+
+  // use maximum value as a clear value for the upper border of the cumulative cut
+  mCumulativeCutUpperDoubleSpinBox->setClearValueMode( QgsDoubleSpinBox::MaximumValue );
+
   connect( mUserDefinedRadioButton, &QRadioButton::toggled, this, &QgsRasterMinMaxWidget::mUserDefinedRadioButton_toggled );
   connect( mMinMaxRadioButton, &QRadioButton::toggled, this, &QgsRasterMinMaxWidget::mMinMaxRadioButton_toggled );
   connect( mStdDevRadioButton, &QRadioButton::toggled, this, &QgsRasterMinMaxWidget::mStdDevRadioButton_toggled );


### PR DESCRIPTION
## Description
When resetting "Cumulative cut" maximum value in the raster layer properties, the value of the field is set to zero which is a bit unexpected from the UX point of view. This PR sets clear value to 100 which is the the maximum value of the cumulative cut.

Fixes #42717