### PR TITLE
Logging mechanisms: limit number of messages to avoid blowing RAM (fixes #44202)

### DIFF
--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -36,13 +36,33 @@ void QgsProcessingFeedback::setProgressText( const QString & )
 {
 }
 
+void QgsProcessingFeedback::log( const QString &htmlMessage, const QString &textMessage )
+{
+  constexpr int MESSAGE_COUNT_LIMIT = 10000;
+  // Avoid logging too many messages, which might blow memory.
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+    return;
+  ++mMessageLoggedCount;
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+  {
+    mHtmlLog.append( QStringLiteral( "<span style=\"color:red\">%1</span><br/>" ).arg( tr( "Message log truncated" ) ) );
+    mTextLog.append( tr( "Message log truncated" ) + '\n' );
+  }
+  else
+  {
+    mHtmlLog.append( htmlMessage );
+    mTextLog.append( textMessage );
+  }
+}
+
+
 void QgsProcessingFeedback::reportError( const QString &error, bool )
 {
   if ( mLogFeedback )
     QgsMessageLog::logMessage( error, tr( "Processing" ), Qgis::MessageLevel::Critical );
 
-  mHtmlLog.append( QStringLiteral( "<span style=\"color:red\">%1</span><br/>" ).arg( error.toHtmlEscaped() ).replace( '\n', QLatin1String( "<br>" ) ) );
-  mTextLog.append( error + '\n' );
+  log( QStringLiteral( "<span style=\"color:red\">%1</span><br/>" ).arg( error.toHtmlEscaped() ).replace( '\n', QLatin1String( "<br>" ) ),
+       error + '\n' );
 }
 
 void QgsProcessingFeedback::pushWarning( const QString &warning )
@@ -50,8 +70,8 @@ void QgsProcessingFeedback::pushWarning( const QString &warning )
   if ( mLogFeedback )
     QgsMessageLog::logMessage( warning, tr( "Processing" ), Qgis::MessageLevel::Warning );
 
-  mHtmlLog.append( QStringLiteral( "<span style=\"color:#b85a20;\">%1</span><br/>" ).arg( warning.toHtmlEscaped() ).replace( '\n', QLatin1String( "<br>" ) ) + QStringLiteral( "<br/>" ) );
-  mTextLog.append( warning + '\n' );
+  log( QStringLiteral( "<span style=\"color:#b85a20;\">%1</span><br/>" ).arg( warning.toHtmlEscaped() ).replace( '\n', QLatin1String( "<br>" ) ) + QStringLiteral( "<br/>" ),
+       warning + '\n' );
 }
 
 void QgsProcessingFeedback::pushInfo( const QString &info )
@@ -68,8 +88,8 @@ void QgsProcessingFeedback::pushCommandInfo( const QString &info )
   if ( mLogFeedback )
     QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::MessageLevel::Info );
 
-  mHtmlLog.append( QStringLiteral( "<code>%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ) );
-  mTextLog.append( info + '\n' );
+  log( QStringLiteral( "<code>%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ),
+       info + '\n' );
 }
 
 void QgsProcessingFeedback::pushDebugInfo( const QString &info )
@@ -77,8 +97,8 @@ void QgsProcessingFeedback::pushDebugInfo( const QString &info )
   if ( mLogFeedback )
     QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::MessageLevel::Info );
 
-  mHtmlLog.append( QStringLiteral( "<span style=\"color:#777\">%1</span><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ) );
-  mTextLog.append( info + '\n' );
+  log( QStringLiteral( "<span style=\"color:#777\">%1</span><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ),
+       info + '\n' );
 }
 
 void QgsProcessingFeedback::pushConsoleInfo( const QString &info )
@@ -86,8 +106,8 @@ void QgsProcessingFeedback::pushConsoleInfo( const QString &info )
   if ( mLogFeedback )
     QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::MessageLevel::Info );
 
-  mHtmlLog.append( QStringLiteral( "<code style=\"color:#777\">%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ) );
-  mTextLog.append( info + '\n' );
+  log( QStringLiteral( "<code style=\"color:#777\">%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QLatin1String( "<br>" ) ) ),
+       info + '\n' );
 }
 
 void QgsProcessingFeedback::pushVersionInfo( const QgsProcessingProvider *provider )

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -140,9 +140,13 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
     virtual QString textLog() const;
 
   private:
+
+    void log( const QString &htmlMessage, const QString &textMessage );
+
     bool mLogFeedback = true;
     QString mHtmlLog;
     QString mTextLog;
+    int mMessageLoggedCount = 0;
 
 };
 
@@ -196,6 +200,7 @@ class CORE_EXPORT QgsProcessingMultiStepFeedback : public QgsProcessingFeedback
     int mChildSteps = 0;
     int mCurrentStep = 0;
     QgsProcessingFeedback *mFeedback = nullptr;
+
 };
 
 #endif // QGSPROCESSINGFEEDBACK_H

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -677,9 +677,17 @@ QString QgsProcessingAlgorithmDialogBase::formatStringForLog( const QString &str
 
 void QgsProcessingAlgorithmDialogBase::setInfo( const QString &message, bool isError, bool escapeHtml, bool isWarning )
 {
+  constexpr int MESSAGE_COUNT_LIMIT = 10000;
+  // Avoid logging too many messages, which might blow memory.
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+    return;
+  ++mMessageLoggedCount;
+
   // note -- we have to wrap the message in a span block, or QTextEdit::append sometimes gets confused
   // and varies between treating it as a HTML string or a plain text string! (see https://github.com/qgis/QGIS/issues/37934)
-  if ( isError || isWarning )
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+    txtLog->append( QStringLiteral( "<span style=\"color:red\">%1</span>" ).arg( tr( "Message log truncated" ) ) );
+  else if ( isError || isWarning )
     txtLog->append( QStringLiteral( "<span style=\"color:%1\">%2</span>" ).arg( isError ? QStringLiteral( "red" ) : QStringLiteral( "#b85a20" ), escapeHtml ? formatStringForLog( message.toHtmlEscaped() ) : formatStringForLog( message ) ) );
   else if ( escapeHtml )
     txtLog->append( QStringLiteral( "<span>%1</span" ).arg( formatStringForLog( message.toHtmlEscaped() ) ) );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -415,6 +415,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
 
     bool mHelpCollapsed = false;
 
+    int mMessageLoggedCount = 0;
+
     QgsProcessingContext::LogLevel mLogLevel = QgsProcessingContext::DefaultLevel;
 
     QString formatHelp( QgsProcessingAlgorithm *algorithm );

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -109,6 +109,12 @@ void QgsMessageLogViewer::reject()
 
 void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
+  constexpr int MESSAGE_COUNT_LIMIT = 10000;
+  // Avoid logging too many messages, which might blow memory.
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+    return;
+  ++mMessageLoggedCount;
+
   QString cleanedTag = tag;
   if ( cleanedTag.isNull() )
     cleanedTag = tr( "General" );
@@ -164,6 +170,9 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
   QString prefix = QStringLiteral( "<font color=\"%1\">%2 &nbsp;&nbsp;&nbsp; %3 &nbsp;&nbsp;&nbsp;</font>" )
                    .arg( color.name(), QDateTime::currentDateTime().toString( Qt::ISODate ), levelString );
   QString cleanedMessage = message;
+  if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
+    cleanedMessage = tr( "Message log truncated" );
+
   cleanedMessage = cleanedMessage.prepend( prefix ).replace( '\n', QLatin1String( "<br>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;" ) );
   w->appendHtml( cleanedMessage );
   w->verticalScrollBar()->setValue( w->verticalScrollBar()->maximum() );

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -64,6 +64,7 @@ class GUI_EXPORT QgsMessageLogViewer: public QDialog, private Ui::QgsMessageLogV
 
     QString mClickedAnchor;
     QMenu *mTabBarContextMenu = nullptr;
+    int mMessageLoggedCount = 0;
 };
 
 #endif


### PR DESCRIPTION
Question to people familiar with processing algorithms: most/all of them use sink->addFeature() without checking the return value. I guess in some situations one might want to go on (like some unexpected geometry type being written in a layer that doesn't support it), but for QgsVectorizeAlgorithmBase::processAlgorithm() for example, I feel like we should just exit early.