### PR TITLE
Remove explicit template instantiations

### DIFF
--- a/python/core/auto_generated/settings/qgssettingsregistrycore.sip.in
+++ b/python/core/auto_generated/settings/qgssettingsregistrycore.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsSettingsRegistryCore : QgsSettingsRegistry
 {
 %Docstring(signature="appended")

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -27,13 +27,6 @@
 #include "qgsgeometry.h"
 #include "qgsmaplayerproxymodel.h"
 
-template class CORE_EXPORT QgsSettingsEntryEnumFlag<QgsSnappingConfig::SnappingTypes> SIP_SKIP;
-template class CORE_EXPORT QgsSettingsEntryEnumFlag<QgsTolerance::UnitType> SIP_SKIP;
-template class CORE_EXPORT QgsSettingsEntryEnumFlag<QgsGeometry::JoinStyle> SIP_SKIP;
-template class CORE_EXPORT QgsSettingsEntryEnumFlag<QgsGeometry::EndCapStyle> SIP_SKIP;
-template class CORE_EXPORT QgsSettingsEntryEnumFlag<QgsUnitTypes::LayoutUnit> SIP_SKIP;
-template class CORE_EXPORT QgsSettingsEntryEnumFlag< class QFlags<enum QgsMapLayerProxyModel::Filter> > SIP_SKIP;
-
 /**
  * \ingroup core
  * \class QgsSettingsRegistryCore


### PR DESCRIPTION
QGIS-3.20.x currently fails to build on Fedora/armv7hl due to `multiple definition of QgsSettingsEntryEnumFlag<...>` errors [1] , looks like a similar issue to [2]
Let's see if CI builds succeed or whether the explicit instantiations are needed for MSVC...

[1] https://koji.fedoraproject.org/koji/getfile?taskID=72265672&volume=DEFAULT&name=build.log&offset=-45000
[2] https://github.com/OpenKinect/libfreenect2/issues/157