### PR TITLE
Fix dragging geometry collection files like .tab files only adds layer with one geometry type

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13151,7 +13151,7 @@ T *QgisApp::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QSt
       // since the layer is bad, stomp on it
       return nullptr;
     }
-    else if ( sublayers.size() > 1 )
+    else if ( sublayers.size() > 1 || QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, true ) )
     {
       // ask user for sublayers (unless user settings dictate otherwise!)
       switch ( shouldAskUserForSublayers( sublayers ) )


### PR DESCRIPTION
When dragging a vector layer with unknown geometry type from browser, ensure the sublayers dialog is shown if the layer has unknown geometry type

Master only
