### PR TITLE
Add activeDecorations to QgisInterface

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -124,7 +124,9 @@ Returns a pointer to the map canvas
 
     virtual QList<QgsMapDecoration *> activeDecorations() = 0;
 %Docstring
-Returns a list of the active decorations
+Returns a list of the active decorations.
+
+.. versionadded:: 3.22
 %End
 
     virtual QgsLayerTreeMapCanvasBridge *layerTreeCanvasBridge() = 0;

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -122,6 +122,11 @@ Returns a pointer to the active layer (layer selected in the legend)
 Returns a pointer to the map canvas
 %End
 
+    virtual QList<QgsMapDecoration *> activeDecorations() = 0;
+%Docstring
+Returns a list of the active decorations
+%End
+
     virtual QgsLayerTreeMapCanvasBridge *layerTreeCanvasBridge() = 0;
 %Docstring
 Returns a pointer to the layer tree canvas bridge

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -902,3 +902,8 @@ void QgisAppInterface::setGpsPanelConnection( QgsGpsConnection *connection )
 {
   qgis->setGpsPanelConnection( connection );
 }
+
+QList<QgsMapDecoration *> QgisAppInterface::activeDecorations()
+{
+  return qgis->activeDecorations();
+}

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -321,6 +321,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QgsBrowserGuiModel *browserModel() override;
     QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() override;
     void setGpsPanelConnection( QgsGpsConnection *connection ) override;
+    QList<QgsMapDecoration *> activeDecorations() override;
 
   private slots:
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -166,7 +166,10 @@ class GUI_EXPORT QgisInterface : public QObject
     //! Returns a pointer to the map canvas
     virtual QgsMapCanvas *mapCanvas() = 0;
 
-    //! Returns a list of the active decorations
+    /**
+     * Returns a list of the active decorations.
+     * \since QGIS 3.22
+     */
     virtual QList<QgsMapDecoration *> activeDecorations() = 0;
 
     /**

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -53,6 +53,7 @@ class QgsMapCanvas;
 class QgsMapLayer;
 enum class QgsMapLayerType;
 class QgsMapLayerConfigWidgetFactory;
+class QgsMapDecoration;
 class QgsMessageBar;
 class QgsPluginManagerInterface;
 class QgsRasterLayer;
@@ -164,6 +165,9 @@ class GUI_EXPORT QgisInterface : public QObject
 
     //! Returns a pointer to the map canvas
     virtual QgsMapCanvas *mapCanvas() = 0;
+
+    //! Returns a list of the active decorations
+    virtual QList<QgsMapDecoration *> activeDecorations() = 0;
 
     /**
      * Returns a pointer to the layer tree canvas bridge


### PR DESCRIPTION
This allows plugins and scripts to export animations with decorations

## Description

As of the current version of PyQGIS, in a script/plugin, there is no way to get the active decorations in the project.
This small patch exposes activeDecorations() method in QgisApp class to QgisInterface class/iface object in PyQGIS.

For example, it enables the plugin and script programmers to export animations with decorations.
I put an example code here: https://qiita.com/keigoi/items/24e274816e3f7a39a917

(As the change is apparent and small, I don't include any tests for now.)
