### PR TITLE
Create QgsGdalUtils::pathIsCheapToOpen

### DIFF
--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -132,6 +132,22 @@ class CORE_EXPORT QgsGdalUtils
     static void setupProxy();
 #endif
 
+    /**
+     * Returns TRUE if the dataset at the specified \a path is considered "cheap" to open.
+     *
+     * Datasets which are considered cheap to open may correspond to very small file sizes, or data types
+     * which only require some inexpensive header parsing to open.
+     *
+     * One use case for this method is to test whether a remote dataset can be safely opened
+     * to resolve the geometry types and other metadata without causing undue network traffic.
+     *
+     * The \a smallFileSizeLimit argument specifies the maximum file size (in bytes) which will
+     * be considered as small.
+     *
+     * \since QGIS 3.22
+     */
+    static bool pathIsCheapToOpen( const QString &path, int smallFileSizeLimit = 50000 );
+
     friend class TestQgsGdalUtils;
 };
 

--- a/tests/src/core/testqgsgdalutils.cpp
+++ b/tests/src/core/testqgsgdalutils.cpp
@@ -41,6 +41,7 @@ class TestQgsGdalUtils: public QObject
     void testResampleSingleBandRaster();
     void testImageToDataset();
     void testResampleImageToImage();
+    void testPathIsCheapToOpen();
 
   private:
 
@@ -266,6 +267,21 @@ void TestQgsGdalUtils::testResampleImageToImage()
   QCOMPARE( qGreen( res.pixel( 40, 40 ) ), 0 );
   QCOMPARE( qBlue( res.pixel( 40, 40 ) ), 255 );
   QCOMPARE( qAlpha( res.pixel( 40, 40 ) ), 255 );
+}
+
+void TestQgsGdalUtils::testPathIsCheapToOpen()
+{
+  // should be safe and report false paths which don't exist
+  QVERIFY( !QgsGdalUtils::pathIsCheapToOpen( "/not/a/file" ) );
+
+  // for now, tiff aren't marked as cheap to open
+  QVERIFY( !QgsGdalUtils::pathIsCheapToOpen( QStringLiteral( TEST_DATA_DIR ) + "/big_raster.tif" ) );
+
+  // a csv is considered cheap to open
+  QVERIFY( QgsGdalUtils::pathIsCheapToOpen( QStringLiteral( TEST_DATA_DIR ) + "/delimitedtext/test.csv" ) );
+
+  // ... unless it's larger than the specified file size limit (500 bytes)
+  QVERIFY( !QgsGdalUtils::pathIsCheapToOpen( QStringLiteral( TEST_DATA_DIR ) + "/delimitedtext/testdms.csv", 500 ) );
 }
 
 double TestQgsGdalUtils::identify( GDALDatasetH dataset, int band, int px, int py )


### PR DESCRIPTION
Returns true if a dataset is considered "cheap" to open.

The logic is very rudimentary for now, and considers only the file
size of a few hardcoded formats.

Refs discussion in https://github.com/qgis/QGIS/pull/44291#discussion_r674399623
