### PR TITLE
add support for plugin layers in QgsProcessingParameterMapLayer  (fix #44183)

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessing.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessing.sip.in
@@ -36,7 +36,8 @@ and parameters.
       TypeRaster,
       TypeFile,
       TypeVector,
-      TypeMesh
+      TypeMesh,
+      TypePlugin
     };
 
     enum PythonOutputType

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -37,6 +37,8 @@ value.
 
 .. seealso:: :py:func:`compatibleMeshLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -59,6 +61,8 @@ value.
 
 .. seealso:: :py:func:`compatibleMeshLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -74,9 +78,30 @@ value.
 
 .. seealso:: :py:func:`compatibleVectorLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 
 .. versionadded:: 3.6
+%End
+
+    static QList<QgsPluginLayer *> compatiblePluginLayers( QgsProject *project, bool sort = true );
+%Docstring
+Returns a list of plugin layers from a ``project`` which are compatible with the processing
+framework.
+
+If the ``sort`` argument is ``True`` then the layers will be sorted by their :py:func:`QgsMapLayer.name()`
+value.
+
+.. seealso:: :py:func:`compatibleRasterLayers`
+
+.. seealso:: :py:func:`compatibleVectorLayers`
+
+.. seealso:: :py:func:`compatibleMeshLayers`
+
+.. seealso:: :py:func:`compatibleLayers`
+
+.. versionadded:: 3.22
 %End
 
     static QList< QgsMapLayer * > compatibleLayers( QgsProject *project, bool sort = true );

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -52,7 +52,8 @@ class CORE_EXPORT QgsProcessing
       TypeRaster = 3, //!< Raster layers
       TypeFile = 4, //!< Files (i.e. non map layer sources, such as text files)
       TypeVector = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
-      TypeMesh = 6 //!< Mesh layers \since QGIS 3.6
+      TypeMesh = 6, //!< Mesh layers \since QGIS 3.6
+      TypePlugin = 7 //!< Plugin layers \since QGIS 3.22
     };
 
     //! Available Python output types
@@ -88,6 +89,8 @@ class CORE_EXPORT QgsProcessing
           return QStringLiteral( "TypeVector" );
         case QgsProcessing::TypeMesh:
           return QStringLiteral( "TypeMesh" );
+        case QgsProcessing::TypePlugin:
+          return QStringLiteral( "TypePlugin" );
       }
       return QString();
     }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2718,6 +2718,10 @@ QString QgsProcessingParameterMapLayer::asScriptCode() const
       case QgsProcessing::TypeMesh:
         code += QLatin1String( "mesh " );
         break;
+
+      case QgsProcessing::TypePlugin:
+        code += QLatin1String( "plugin " );
+        break;
     }
   }
 
@@ -2765,6 +2769,12 @@ QgsProcessingParameterMapLayer *QgsProcessingParameterMapLayer::fromScriptCode( 
     {
       types << QgsProcessing::TypeMesh;
       def = def.mid( 5 );
+      continue;
+    }
+    else if ( def.startsWith( QLatin1String( "plugin" ), Qt::CaseInsensitive ) )
+    {
+      types << QgsProcessing::TypePlugin;
+      def = def.mid( 7 );
       continue;
     }
     break;
@@ -3846,6 +3856,7 @@ QString QgsProcessingParameterMultipleLayers::createFileFilter() const
       return QgsProviderRegistry::instance()->fileMeshFilters() + QStringLiteral( ";;" ) + QObject::tr( "All files (*.*)" );
 
     case QgsProcessing::TypeMapLayer:
+    case QgsProcessing::TypePlugin:
       return createAllMapLayerFileFilter();
   }
   return QString();
@@ -5838,6 +5849,7 @@ bool QgsProcessingParameterFeatureSink::hasGeometry() const
     case QgsProcessing::TypeFile:
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeMesh:
+    case QgsProcessing::TypePlugin:
       return false;
   }
   return true;
@@ -6533,6 +6545,7 @@ bool QgsProcessingParameterVectorDestination::hasGeometry() const
     case QgsProcessing::TypeFile:
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeMesh:
+    case QgsProcessing::TypePlugin:
       return false;
   }
   return true;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -107,6 +107,29 @@ QList<QgsMeshLayer *> QgsProcessingUtils::compatibleMeshLayers( QgsProject *proj
   return layers;
 }
 
+QList<QgsPluginLayer *> QgsProcessingUtils::compatiblePluginLayers( QgsProject *project, bool sort )
+{
+  if ( !project )
+    return QList<QgsPluginLayer *>();
+
+  QList<QgsPluginLayer *> layers;
+  const auto pluginLayers = project->layers<QgsPluginLayer *>();
+  for ( QgsPluginLayer *l : pluginLayers )
+  {
+    if ( canUseLayer( l ) )
+      layers << l;
+  }
+
+  if ( sort )
+  {
+    std::sort( layers.begin(), layers.end(), []( const QgsMeshLayer * a, const QgsMeshLayer * b ) -> bool
+    {
+      return QString::localeAwareCompare( a->name(), b->name() ) < 0;
+    } );
+  }
+  return layers;
+}
+
 QList<QgsMapLayer *> QgsProcessingUtils::compatibleLayers( QgsProject *project, bool sort )
 {
   if ( !project )
@@ -491,6 +514,11 @@ QgsCoordinateReferenceSystem QgsProcessingUtils::variantToCrs( const QVariant &v
 bool QgsProcessingUtils::canUseLayer( const QgsMeshLayer *layer )
 {
   return layer && layer->dataProvider();
+}
+
+bool QgsProcessingUtils::canUseLayer( const QgsPluginLayer *layer )
+{
+  return layer && layer->isValid();
 }
 
 bool QgsProcessingUtils::canUseLayer( const QgsVectorTileLayer *layer )

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -59,6 +59,7 @@ class CORE_EXPORT QgsProcessingUtils
      * value.
      * \see compatibleVectorLayers()
      * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      */
     static QList< QgsRasterLayer * > compatibleRasterLayers( QgsProject *project, bool sort = true );
@@ -76,6 +77,7 @@ class CORE_EXPORT QgsProcessingUtils
      * value.
      * \see compatibleRasterLayers()
      * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      */
     static QList< QgsVectorLayer * > compatibleVectorLayers( QgsProject *project,
@@ -91,11 +93,28 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \see compatibleRasterLayers()
      * \see compatibleVectorLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      *
      * \since QGIS 3.6
      */
     static QList<QgsMeshLayer *> compatibleMeshLayers( QgsProject *project, bool sort = true );
+
+    /**
+     * Returns a list of plugin layers from a \a project which are compatible with the processing
+     * framework.
+     *
+     * If the \a sort argument is TRUE then the layers will be sorted by their QgsMapLayer::name()
+     * value.
+     *
+     * \see compatibleRasterLayers()
+     * \see compatibleVectorLayers()
+     * \see compatibleMeshLayers()
+     * \see compatibleLayers()
+     *
+     * \since QGIS 3.22
+     */
+    static QList<QgsPluginLayer *> compatiblePluginLayers( QgsProject *project, bool sort = true );
 
     /**
      * Returns a list of map layers from a \a project which are compatible with the processing
@@ -415,6 +434,7 @@ class CORE_EXPORT QgsProcessingUtils
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );
+    static bool canUseLayer( const QgsPluginLayer *layer );
     static bool canUseLayer( const QgsVectorTileLayer *layer );
     static bool canUseLayer( const QgsVectorLayer *layer,
                              const QList< int > &sourceTypes = QList< int >() );

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -404,6 +404,17 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
       break;
     }
 
+    case QgsProcessing::TypePlugin:
+    {
+      const QList<QgsPluginLayer *> options = QgsProcessingUtils::compatiblePluginLayers( project, false );
+      for ( const QgsPluginsLayer *layer : options )
+      {
+        addLayer( layer );
+      }
+
+      break;
+    }
+
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeVectorAnyGeometry:
     {

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -5595,6 +5595,7 @@ QgsProcessingMapLayerParameterDefinitionWidget::QgsProcessingMapLayerParameterDe
   mLayerTypeComboBox->addItem( tr( "Vector (Any Geometry Type)" ), QgsProcessing::TypeVectorAnyGeometry );
   mLayerTypeComboBox->addItem( tr( "Raster" ), QgsProcessing::TypeRaster );
   mLayerTypeComboBox->addItem( tr( "Mesh" ), QgsProcessing::TypeMesh );
+  mLayerTypeComboBox->addItem( tr( "Plugin" ), QgsProcessing::TypePlugin );
 
   if ( const QgsProcessingParameterMapLayer *layerParam = dynamic_cast<const QgsProcessingParameterMapLayer *>( definition ) )
   {
@@ -6574,6 +6575,17 @@ void QgsProcessingMultipleLayerPanelWidget::setModel( QgsProcessingModelAlgorith
       break;
     }
 
+    case QgsProcessing::TypePlugin:
+    {
+      mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterMapLayer::typeName()
+                      << QgsProcessingParameterMultipleLayers::typeName()
+                      << QgsProcessingParameterFile::typeName(),
+                      QStringList() << QgsProcessingOutputFile::typeName()
+                      << QgsProcessingOutputMapLayer::typeName()
+                      << QgsProcessingOutputMultipleLayers::typeName() );
+      break;
+    }
+
     case QgsProcessing::TypeVector:
     {
       mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterFeatureSource::typeName()
@@ -6715,6 +6727,7 @@ QgsProcessingMultipleLayerParameterDefinitionWidget::QgsProcessingMultipleLayerP
   mLayerTypeComboBox->addItem( tr( "Raster" ), QgsProcessing::TypeRaster );
   mLayerTypeComboBox->addItem( tr( "File" ), QgsProcessing::TypeFile );
   mLayerTypeComboBox->addItem( tr( "Mesh" ), QgsProcessing::TypeMesh );
+  mLayerTypeComboBox->addItem( tr( "Plugin" ), QgsProcessing::TypePlugin );
   if ( const QgsProcessingParameterMultipleLayers *layersParam = dynamic_cast<const QgsProcessingParameterMultipleLayers *>( definition ) )
     mLayerTypeComboBox->setCurrentIndex( mLayerTypeComboBox->findData( layersParam->layerType() ) );
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -2875,6 +2875,11 @@ void TestQgsProcessing::parameterMapLayer()
   QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMapLayer('non_optional', '', defaultValue='', types=[QgsProcessing.TypeRaster,QgsProcessing.TypeVectorPoint])" ) );
   code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##non_optional=layer raster point" ) );
+  def->setDataTypes( QList< int >() << QgsProcessing::TypePlugin );
+  pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMapLayer('non_optional', '', defaultValue='', types=[QgsProcessing.TypePlugin])" ) );
+  code = def->asScriptCode();
+  QCOMPARE( code, QStringLiteral( "##non_optional=layer plugin" ) );
 
   // optional
   def.reset( new QgsProcessingParameterMapLayer( "optional", QString(), v1->id(), true ) );


### PR DESCRIPTION
## Description
QGIS allows plugin authors to create custom layers, but there is no way in Processing to select such layers as input for algorithms. This PR adds a new enum item to `QgsProcessing::SourceType` and exposes plugin layers to modeler.

It is an algorithm responsibility to check whether specific plugin layer is compatible or not, proposed change only allows to specify supported layer types for input parameters.

Fixes #44183.