### PR TITLE
Implement querySublayers for point cloud providers

### DIFF
--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -24,6 +24,8 @@
 #include "qgseptdataitems.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsapplication.h"
+#include "qgsprovidersublayerdetails.h"
+#include "qgsproviderutils.h"
 
 #include <QFileInfo>
 
@@ -142,6 +144,25 @@ QList<QgsDataItemProvider *> QgsEptProviderMetadata::dataItemProviders() const
   return providers;
 }
 
+QList<QgsProviderSublayerDetails> QgsEptProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags, QgsFeedback * ) const
+{
+  const QVariantMap parts = decodeUri( uri );
+  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
+  if ( fi.fileName().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  {
+    QgsProviderSublayerDetails details;
+    details.setUri( uri );
+    details.setProviderKey( QStringLiteral( "ept" ) );
+    details.setType( QgsMapLayerType::PointCloudLayer );
+    details.setName( QgsProviderUtils::suggestLayerNameFromFilePath( uri ) );
+    return {details};
+  }
+  else
+  {
+    return {};
+  }
+}
+
 int QgsEptProviderMetadata::priorityForUri( const QString &uri ) const
 {
   const QVariantMap parts = decodeUri( uri );
@@ -215,7 +236,8 @@ QString QgsEptProviderMetadata::encodeUri( const QVariantMap &parts ) const
 QgsProviderMetadata::ProviderMetadataCapabilities QgsEptProviderMetadata::capabilities() const
 {
   return ProviderMetadataCapability::LayerTypesForUri
-         | ProviderMetadataCapability::PriorityForUri;
+         | ProviderMetadataCapability::PriorityForUri
+         | ProviderMetadataCapability::QuerySublayers;
 }
 ///@endcond
 

--- a/src/core/providers/ept/qgseptprovider.h
+++ b/src/core/providers/ept/qgseptprovider.h
@@ -70,6 +70,7 @@ class QgsEptProviderMetadata : public QgsProviderMetadata
     QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     QgsEptProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     QList< QgsDataItemProvider * > dataItemProviders() const override;
+    QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
     int priorityForUri( const QString &uri ) const override;
     QList< QgsMapLayerType > validLayerTypesForUri( const QString &uri ) const override;
     bool uriIsBlocklisted( const QString &uri ) const override;

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -906,6 +906,10 @@ QList<QgsProviderSublayerDetails> QgsProviderRegistry::querySublayers( const QSt
   QList<QgsProviderSublayerDetails> res;
   for ( auto it = mProviders.begin(); it != mProviders.end(); ++it )
   {
+    // if we should defer this uri for other providers, do so
+    if ( shouldDeferUriForOtherProviders( uri, it->first ) )
+      continue;
+
     res.append( it->second->querySublayers( uri, flags, feedback ) );
     if ( feedback && feedback->isCanceled() )
       break;

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -899,6 +899,10 @@ bool QgsProviderRegistry::uriIsBlocklisted( const QString &uri ) const
 
 QList<QgsProviderSublayerDetails> QgsProviderRegistry::querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags, QgsFeedback *feedback ) const
 {
+  // never query sublayers for blocklisted uris
+  if ( uriIsBlocklisted( uri ) )
+    return {};
+
   QList<QgsProviderSublayerDetails> res;
   for ( auto it = mProviders.begin(); it != mProviders.end(); ++it )
   {

--- a/src/core/providers/qgsproviderutils.cpp
+++ b/src/core/providers/qgsproviderutils.cpp
@@ -62,5 +62,12 @@ QString QgsProviderUtils::suggestLayerNameFromFilePath( const QString &path )
     const QString dirName = info.path();
     name = QFileInfo( dirName ).completeBaseName();
   }
+  // special handling for ept.json files -- use directory as base name
+  else if ( info.fileName().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  {
+    const QString dirName = info.path();
+    name = QFileInfo( dirName ).completeBaseName();
+  }
+
   return name;
 }

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -80,6 +80,7 @@ class QgsPdalProviderMetadata : public QgsProviderMetadata
     QVariantMap decodeUri( const QString &uri ) const override;
     int priorityForUri( const QString &uri ) const override;
     QList< QgsMapLayerType > validLayerTypesForUri( const QString &uri ) const override;
+    QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
     QString filters( FilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
 };

--- a/tests/src/providers/testqgspdalprovider.cpp
+++ b/tests/src/providers/testqgspdalprovider.cpp
@@ -32,6 +32,7 @@
 #include "qgsmaplayer.h"
 #include "qgspointcloudlayer.h"
 #include "qgspdaleptgenerationtask.h"
+#include "qgsprovidersublayerdetails.h"
 
 /**
  * \ingroup UnitTests
@@ -52,6 +53,7 @@ class TestQgsPdalProvider : public QObject
     void decodeUri();
     void layerTypesForUri();
     void preferredUri();
+    void querySublayers();
     void brokenPath();
     void validLayer();
     void testEptGeneration();
@@ -131,7 +133,7 @@ void TestQgsPdalProvider::preferredUri()
   QgsProviderMetadata *pdalMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
   QVERIFY( pdalMetadata->capabilities() & QgsProviderMetadata::PriorityForUri );
 
-  // test that EPT is the preferred provider for las/laz uris
+  // test that pdal is the preferred provider for las/laz uris
   QList<QgsProviderRegistry::ProviderCandidateDetails> candidates = QgsProviderRegistry::instance()->preferredProvidersForUri( QStringLiteral( "/home/test/cloud.las" ) );
   QCOMPARE( candidates.size(), 1 );
   QCOMPARE( candidates.at( 0 ).metadata()->key(), QStringLiteral( "pdal" ) );
@@ -154,6 +156,33 @@ void TestQgsPdalProvider::preferredUri()
 
   QVERIFY( !QgsProviderRegistry::instance()->shouldDeferUriForOtherProviders( QStringLiteral( "/home/test/cloud.las" ), QStringLiteral( "pdal" ) ) );
   QVERIFY( QgsProviderRegistry::instance()->shouldDeferUriForOtherProviders( QStringLiteral( "/home/test/cloud.las" ), QStringLiteral( "ept" ) ) );
+}
+
+void TestQgsPdalProvider::querySublayers()
+{
+  // test querying sub layers for a pdal layer
+  QgsProviderMetadata *pdalMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
+
+  // invalid uri
+  QList< QgsProviderSublayerDetails >res = pdalMetadata->querySublayers( QString() );
+  QVERIFY( res.empty() );
+
+  // not a pdal layer
+  res = pdalMetadata->querySublayers( QString( TEST_DATA_DIR ) + "/lines.shp" );
+  QVERIFY( res.empty() );
+
+  // valid pdal layer
+  res = pdalMetadata->querySublayers( mTestDataDir + "/point_clouds/las/cloud.las" );
+  QCOMPARE( res.count(), 1 );
+  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "cloud" ) );
+  QCOMPARE( res.at( 0 ).uri(), mTestDataDir + "/point_clouds/las/cloud.las" );
+  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "pdal" ) );
+  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::PointCloudLayer );
+
+  // make sure result is valid to load layer from
+  QgsProviderSublayerDetails::LayerOptions options{ QgsCoordinateTransformContext() };
+  std::unique_ptr< QgsPointCloudLayer > ml( qgis::down_cast< QgsPointCloudLayer * >( res.at( 0 ).toLayer( options ) ) );
+  QVERIFY( ml->isValid() );
 }
 
 void TestQgsPdalProvider::brokenPath()

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -131,6 +131,29 @@ class TestQgsProviderRegistry(unittest.TestCase):
         self.assertIn('LAZ', details.warning)
 
     def testSublayerDetails(self):
+        ept_provider_metadata = QgsProviderRegistry.instance().providerMetadata('ept')
+        ogr_provider_metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+
+        if ept_provider_metadata is not None:
+            # test querying a uri which should be blocklisted
+            self.assertFalse(QgsProviderRegistry.instance().querySublayers(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept-build.json'))
+
+        if ept_provider_metadata is not None and ogr_provider_metadata is not None:
+            # test querying a uri which is technically capable of being opened by two providers, but which one provider is preferred
+            # in this case we are testing a ept.json file, which should ALWAYS be treated as a ept point cloud layer even though
+            # the OGR provider CAN technically open json files
+
+            # when we directly query ogr provider metadata it should report sublayers for the json file...
+            self.assertEqual([l.providerKey() for l in ogr_provider_metadata.querySublayers(
+                unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', Qgis.SublayerQueryFlags(Qgis.SublayerQueryFlag.FastScan))], ['ogr'])
+
+            # ...and when we query ept provider metadata directly it should also report sublayers for ept.json files...
+            self.assertEqual([l.providerKey() for l in ept_provider_metadata.querySublayers(
+                unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', Qgis.SublayerQueryFlags(Qgis.SublayerQueryFlag.FastScan))], ['ept'])
+
+            # ... but when we query the provider registry itself, it should ONLY report the ept provider sublayers
+            self.assertEqual([l.providerKey() for l in QgsProviderRegistry.instance().querySublayers(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept.json', Qgis.SublayerQueryFlags(Qgis.SublayerQueryFlag.FastScan))], ['ept'])
+
         provider1 = TestProviderMetadata('p1')
         provider2 = TestProviderMetadata('p2')
 
@@ -141,10 +164,6 @@ class TestQgsProviderRegistry(unittest.TestCase):
 
         self.assertCountEqual([p.providerKey() for p in QgsProviderRegistry.instance().querySublayers('test_uri')],
                               ['p1', 'p2'])
-
-        if QgsProviderRegistry.instance().providerMetadata('ept'):
-            # test querying a uri which should be blocklisted
-            self.assertFalse(QgsProviderRegistry.instance().querySublayers(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept-build.json'))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -17,9 +17,11 @@ from qgis.core import (
     QgsMapLayerType,
     QgsProviderMetadata,
     QgsProviderSublayerDetails,
-    Qgis
+    Qgis,
+    QgsProviderUtils
 )
 from qgis.testing import start_app, unittest
+from utilities import unitTestDataPath
 
 # Convenience instances in case you may need them
 # to find the srs.db
@@ -37,6 +39,8 @@ class TestProviderMetadata(QgsProviderMetadata):
     def querySublayers(self, uri: str, flags=Qgis.SublayerQueryFlags(), feedback=None):
         res = QgsProviderSublayerDetails()
         res.setProviderKey(self.key())
+        res.setUri(uri)
+        res.setName(QgsProviderUtils.suggestLayerNameFromFilePath(uri))
         return [res]
 
 
@@ -137,6 +141,10 @@ class TestQgsProviderRegistry(unittest.TestCase):
 
         self.assertCountEqual([p.providerKey() for p in QgsProviderRegistry.instance().querySublayers('test_uri')],
                               ['p1', 'p2'])
+
+        if QgsProviderRegistry.instance().providerMetadata('ept'):
+            # test querying a uri which should be blocklisted
+            self.assertFalse(QgsProviderRegistry.instance().querySublayers(unitTestDataPath() + '/point_clouds/ept/sunshine-coast/ept-build.json'))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsproviderutils.py
+++ b/tests/src/python/test_qgsproviderutils.py
@@ -147,6 +147,8 @@ class TestQgsProviderUtils(unittest.TestCase):
         self.assertEqual(QgsProviderUtils.suggestLayerNameFromFilePath('/home/me/data/rivers.shp'), 'rivers')
         # adf files should return parent dir name
         self.assertEqual(QgsProviderUtils.suggestLayerNameFromFilePath('/home/me/data/rivers/hdr.adf'), 'rivers')
+        # ept.json files should return parent dir name
+        self.assertEqual(QgsProviderUtils.suggestLayerNameFromFilePath('/home/me/data/rivers/ept.json'), 'rivers')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
~~(temporarily includes https://github.com/qgis/QGIS/pull/44291)~~

Implements querySublayers for the pdal/ept providers, and adds the required logic to skip querying the ogr provider for sublayers for ept.json files (since we know that we ALWAYS want to open these using the ept provider)