### PR TITLE
Allow options dialog to use a tree structure for tab list

### DIFF
--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -38,6 +38,9 @@ class ConsoleOptionsFactory(QgsOptionsWidgetFactory):
     def icon(self):
         return QgsApplication.getThemeIcon('/console/mIconRunConsole.svg')
 
+    def path(self):
+        return ['ide']
+
     def createWidget(self, parent):
         return ConsoleOptionsPage(parent)
 

--- a/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
@@ -96,7 +96,7 @@ Sets the dialog ``page`` (by object name) to show.
 .. versionadded:: 3.14
 %End
 
-    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/ );
+    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QStringList &path = QStringList() );
 %Docstring
 Adds a new page to the dialog pages.
 
@@ -104,12 +104,15 @@ The ``title``, ``tooltip`` and ``icon`` arguments dictate the page list item tit
 
 The page content is specified via the ``widget`` argument. Ownership of ``widget`` is transferred to the dialog.
 
+Since QGIS 3.22, the optional ``path`` argument can be used to set the path of the item's entry in the tree view
+(for dialogs which show a tree view of options pages only).
+
 .. seealso:: :py:func:`insertPage`
 
 .. versionadded:: 3.14
 %End
 
-    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QString &before );
+    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget /Transfer/, const QString &before, const QStringList &path = QStringList() );
 %Docstring
 Inserts a new page into the dialog pages.
 
@@ -119,6 +122,9 @@ The page content is specified via the ``widget`` argument. Ownership of ``widget
 
 The ``before`` argument specifies the object name of an existing page. The new page will be inserted directly
 before the matching page.
+
+Since QGIS 3.22, the optional ``path`` argument can be used to set the path of the item's entry in the tree view
+(for dialogs which show a tree view of options pages only).
 
 .. seealso:: :py:func:`addPage`
 

--- a/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
@@ -13,6 +13,8 @@
 
 
 
+
+
 class QgsOptionsDialogBase : QDialog
 {
 %Docstring(signature="appended")
@@ -165,6 +167,7 @@ it is automatically called if a line edit has "mSearchLineEdit" as object name.
 
 .. versionadded:: 3.0
 %End
+
 
 
 

--- a/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
@@ -13,7 +13,6 @@
 
 
 
-
 class QgsOptionsDialogBase : QDialog
 {
 %Docstring(signature="appended")
@@ -166,6 +165,8 @@ it is automatically called if a line edit has "mSearchLineEdit" as object name.
 
 .. versionadded:: 3.0
 %End
+
+
 
 
 };

--- a/python/gui/auto_generated/qgsoptionsdialoghighlightwidgetsimpl.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialoghighlightwidgetsimpl.sip.in
@@ -143,6 +143,32 @@ constructs a highlight widget for a tree view or widget.
     virtual void reset();
 
 };
+
+class QgsOptionsDialogHighlightTable : QgsOptionsDialogHighlightWidget
+{
+%Docstring(signature="appended")
+A highlight widget for table widgets.
+This is used to search and highlight text in :py:class:`QgsOptionsDialogBase` implementations.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsoptionsdialoghighlightwidgetsimpl.h"
+%End
+  public:
+    QgsOptionsDialogHighlightTable( QTableView *tableView );
+%Docstring
+constructs a highlight widget for a table view or widget.
+%End
+  protected:
+    virtual bool searchText( const QString &text );
+
+    virtual bool highlightText( const QString &text );
+
+    virtual void reset();
+
+};
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -122,6 +122,17 @@ to be placed at the end of the dialog page list.
 .. versionadded:: 3.18
 %End
 
+    virtual QStringList path() const;
+%Docstring
+Returns the path to place the widget page at, for options dialogs
+which are structured using a tree view.
+
+A factory which returns "Code", "Javascript" would have its widget placed
+in a group named "Javascript", contained in a parent group named "Code".
+
+.. versionadded:: 3.22
+%End
+
     virtual QgsOptionsPageWidget *createWidget( QWidget *parent = 0 ) const = 0 /Factory/;
 %Docstring
 Factory function to create the widget on demand as needed by the options dialog.

--- a/src/app/locator/qgssettingslocatorfilter.cpp
+++ b/src/app/locator/qgssettingslocatorfilter.cpp
@@ -32,11 +32,11 @@ void QgsSettingsLocatorFilter::fetchResults( const QString &string, const QgsLoc
 {
   QMap<QString, QMap<QString, QString>> matchingSettingsPagesMap;
 
-  QMap<QString, int > optionsPagesMap = QgisApp::instance()->optionsPagesMap();
+  QMap<QString, QString > optionsPagesMap = QgisApp::instance()->optionsPagesMap();
   for ( auto optionsPagesIterator = optionsPagesMap.constBegin(); optionsPagesIterator != optionsPagesMap.constEnd(); ++optionsPagesIterator )
   {
     QString title = optionsPagesIterator.key();
-    matchingSettingsPagesMap.insert( title + " (" + tr( "Options" ) + ")", settingsPage( QStringLiteral( "optionpage" ), QString::number( optionsPagesIterator.value() ) ) );
+    matchingSettingsPagesMap.insert( title + " (" + tr( "Options" ) + ")", settingsPage( QStringLiteral( "optionpage" ), optionsPagesIterator.value() ) );
   }
 
   QMap<QString, QString> projectPropertyPagesMap = QgisApp::instance()->projectPropertiesPagesMap();
@@ -92,8 +92,7 @@ void QgsSettingsLocatorFilter::triggerResult( const QgsLocatorResult &result )
 
   if ( type == QLatin1String( "optionpage" ) )
   {
-    const int pageNumber = page.toInt();
-    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), QString(), pageNumber );
+    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), page );
   }
   else if ( type == QLatin1String( "projectpropertypage" ) )
   {

--- a/src/app/options/qgscodeeditoroptions.cpp
+++ b/src/app/options/qgscodeeditoroptions.cpp
@@ -356,3 +356,13 @@ QgsOptionsPageWidget *QgsCodeEditorOptionsFactory::createWidget( QWidget *parent
 {
   return new QgsCodeEditorOptionsWidget( parent );
 }
+
+QStringList QgsCodeEditorOptionsFactory::path() const
+{
+  return {QStringLiteral( "ide" ) };
+}
+
+QString QgsCodeEditorOptionsFactory::pagePositionHint() const
+{
+  return QStringLiteral( "consoleOptions" );
+}

--- a/src/app/options/qgscodeeditoroptions.h
+++ b/src/app/options/qgscodeeditoroptions.h
@@ -63,6 +63,8 @@ class QgsCodeEditorOptionsFactory : public QgsOptionsWidgetFactory
 
     QIcon icon() const override;
     QgsOptionsPageWidget *createWidget( QWidget *parent = nullptr ) const override;
+    QStringList path() const override;
+    QString pagePositionHint() const override;
 
 };
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -115,14 +115,16 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   crsGroup->appendRow( createItem( tr( "Transformations" ), tr( "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
   mTreeModel->appendRow( crsGroup );
 
-  mTreeModel->appendRow( createItem( tr( "Data Sources" ), tr( "Data sources" ), QStringLiteral( "propertyicons/attributes.svg" ) ) );
+  QStandardItem *dataSources = createItem( tr( "Data Sources" ), tr( "Data sources" ), QStringLiteral( "propertyicons/attributes.svg" ) );
+  mTreeModel->appendRow( dataSources );
+  dataSources->appendRow( createItem( tr( "GDAL" ), tr( "GDAL" ), QStringLiteral( "propertyicons/gdal.svg" ) ) );
+
   mTreeModel->appendRow( createItem( tr( "Rendering" ), tr( "Rendering" ), QStringLiteral( "propertyicons/rendering.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Canvas & Legend" ), tr( "Canvas and legend" ), QStringLiteral( "propertyicons/overlay.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Map Tools" ), tr( "Map tools" ), QStringLiteral( "propertyicons/map_tools.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Colors" ), tr( "Colors" ), QStringLiteral( "propertyicons/colors.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Digitizing" ), tr( "Digitizing" ), QStringLiteral( "propertyicons/digitizing.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Layouts" ), tr( "Print layouts" ), QStringLiteral( "mIconLayout.svg" ) ) );
-  mTreeModel->appendRow( createItem( tr( "GDAL" ), tr( "GDAL" ), QStringLiteral( "propertyicons/gdal.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Variables" ), tr( "Variables" ), QStringLiteral( "mIconExpression.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Authentication" ), tr( "Authentication" ), QStringLiteral( "locked.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Network" ), tr( "Network" ), QStringLiteral( "propertyicons/network_and_proxy.svg" ) ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -110,6 +110,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mTreeModel->appendRow( createItem( tr( "System" ), tr( "System" ), QStringLiteral( "propertyicons/system.svg" ) ) );
 
   QStandardItem *crsGroup = new QStandardItem( tr( "CRS and Transforms" ) );
+  crsGroup->setToolTip( tr( "CRS and Transforms" ) );
   crsGroup->setSelectable( false );
   crsGroup->appendRow( createItem( tr( "CRS" ), tr( "CRS" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );
   crsGroup->appendRow( createItem( tr( "Transformations" ), tr( "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
@@ -130,6 +131,12 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mTreeModel->appendRow( createItem( tr( "Network" ), tr( "Network" ), QStringLiteral( "propertyicons/network_and_proxy.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Locator" ), tr( "Locator" ), QStringLiteral( "search.svg" ) ) );
   mTreeModel->appendRow( createItem( tr( "Acceleration" ), tr( "GPU acceleration" ), QStringLiteral( "mIconGPU.svg" ) ) );
+
+  QStandardItem *ideGroup = new QStandardItem( tr( "IDE" ) );
+  ideGroup->setData( QStringLiteral( "ide" ) );
+  ideGroup->setToolTip( tr( "Development and Scripting Settings" ) );
+  ideGroup->setSelectable( false );
+  mTreeModel->appendRow( ideGroup );
 
   mOptionsTreeView->setModel( mTreeModel );
 
@@ -1259,9 +1266,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     mAdditionalOptionWidgets << page;
     const QString beforePage = factory->pagePositionHint();
     if ( beforePage.isEmpty() )
-      addPage( factory->title(), factory->title(), factory->icon(), page );
+      addPage( factory->title(), factory->title(), factory->icon(), page, factory->path() );
     else
-      insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage );
+      insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage, factory->path() );
 
     if ( QgsAdvancedSettingsWidget *advancedPage = qobject_cast< QgsAdvancedSettingsWidget * >( page ) )
     {
@@ -1361,6 +1368,8 @@ QgsOptions::~QgsOptions()
 
 void QgsOptions::checkPageWidgetNameMap()
 {
+  return;
+
   const QMap< QString, int > pageNames = QgisApp::instance()->optionsPagesMap();
 
   int pageCount = 0;

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -104,6 +104,33 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
 {
   setupUi( this );
+
+  mTreeModel = new QStandardItemModel( this );
+  mTreeModel->appendRow( createItem( tr( "General" ), tr( "General" ), QStringLiteral( "propertyicons/general.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "System" ), tr( "System" ), QStringLiteral( "propertyicons/system.svg" ) ) );
+
+  QStandardItem *crsGroup = new QStandardItem( tr( "CRS and Transforms" ) );
+  crsGroup->setSelectable( false );
+  crsGroup->appendRow( createItem( tr( "CRS" ), tr( "CRS" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );
+  crsGroup->appendRow( createItem( tr( "Transformations" ), tr( "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
+  mTreeModel->appendRow( crsGroup );
+
+  mTreeModel->appendRow( createItem( tr( "Data Sources" ), tr( "Data sources" ), QStringLiteral( "propertyicons/attributes.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Rendering" ), tr( "Rendering" ), QStringLiteral( "propertyicons/rendering.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Canvas & Legend" ), tr( "Canvas and legend" ), QStringLiteral( "propertyicons/overlay.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Map Tools" ), tr( "Map tools" ), QStringLiteral( "propertyicons/map_tools.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Colors" ), tr( "Colors" ), QStringLiteral( "propertyicons/colors.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Digitizing" ), tr( "Digitizing" ), QStringLiteral( "propertyicons/digitizing.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Layouts" ), tr( "Print layouts" ), QStringLiteral( "mIconLayout.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "GDAL" ), tr( "GDAL" ), QStringLiteral( "propertyicons/gdal.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Variables" ), tr( "Variables" ), QStringLiteral( "mIconExpression.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Authentication" ), tr( "Authentication" ), QStringLiteral( "locked.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Network" ), tr( "Network" ), QStringLiteral( "propertyicons/network_and_proxy.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Locator" ), tr( "Locator" ), QStringLiteral( "search.svg" ) ) );
+  mTreeModel->appendRow( createItem( tr( "Acceleration" ), tr( "GPU acceleration" ), QStringLiteral( "mIconGPU.svg" ) ) );
+
+  mOptionsTreeView->setModel( mTreeModel );
+
   connect( cbxProjectDefaultNew, &QCheckBox::toggled, this, &QgsOptions::cbxProjectDefaultNew_toggled );
   connect( leLayerGlobalCrs, &QgsProjectionSelectionWidget::crsChanged, this, &QgsOptions::leLayerGlobalCrs_crsChanged );
   connect( lstRasterDrivers, &QTreeWidget::itemDoubleClicked, this, &QgsOptions::lstRasterDrivers_itemDoubleClicked );
@@ -1334,7 +1361,10 @@ void QgsOptions::checkPageWidgetNameMap()
 {
   const QMap< QString, int > pageNames = QgisApp::instance()->optionsPagesMap();
 
+#if 0
   Q_ASSERT_X( pageNames.count() == mOptionsListWidget->count(), "QgsOptions::checkPageWidgetNameMap()", "QgisApp::optionsPagesMap() is outdated, contains too many entries" );
+
+
   for ( int idx = 0; idx < mOptionsListWidget->count(); ++idx )
   {
     QWidget *currentPage = mOptionsStackedWidget->widget( idx );
@@ -1346,6 +1376,7 @@ void QgsOptions::checkPageWidgetNameMap()
       Q_ASSERT_X( pageNames.value( title ) == idx, "QgsOptions::checkPageWidgetNameMap()", QStringLiteral( "QgisApp::optionsPagesMap() is outdated, please update. %1 should be %2 not %3" ).arg( title ).arg( idx ).arg( pageNames.value( title ) ).toLocal8Bit().constData() );
     }
   }
+#endif
 }
 
 void QgsOptions::setCurrentPage( const QString &pageWidgetName )

--- a/src/app/options/qgsoptions.h
+++ b/src/app/options/qgsoptions.h
@@ -34,6 +34,7 @@ class QgsOptionsPageWidget;
 class QgsLocatorOptionsWidget;
 class QgsAuthConfigSelect;
 class QgsBearingNumericFormat;
+class QStandardItemModel;
 
 /**
  * \class QgsOptions
@@ -312,6 +313,8 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     QgsLocatorOptionsWidget *mLocatorOptionsWidget = nullptr;
 
     std::unique_ptr< QgsBearingNumericFormat > mBearingFormat;
+
+    QStandardItemModel *mTreeModel = nullptr;
 
     void updateActionsForCurrentColorScheme( QgsColorScheme *scheme );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12557,13 +12557,13 @@ QMap< QString, int > QgisApp::optionsPagesMap()
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "mOptionsPageCRS" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QStringLiteral( "mOptionsPageTransformations" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QStringLiteral( "mOptionsPageDataSources" ) } );
+    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Rendering" ), QStringLiteral( "mOptionsPageRendering" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Canvas & Legend" ), QStringLiteral( "mOptionsPageMapCanvas" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Map Tools" ), QStringLiteral( "mOptionsPageMapTools" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Colors" ), QStringLiteral( "mOptionsPageColors" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Digitizing" ), QStringLiteral( "mOptionsPageDigitizing" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Layouts" ), QStringLiteral( "mOptionsPageComposer" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Variables" ), QStringLiteral( "mOptionsPageVariables" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Authentication" ), QStringLiteral( "mOptionsPageAuth" ) } );
     sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Network" ), QStringLiteral( "mOptionsPageNetwork" ) } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12492,7 +12492,6 @@ QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
     sProjectPropertiesPagesMap.insert( QCoreApplication::translate( "QgsProjectPropertiesBase", "Temporal" ), QStringLiteral( "mTemporalOptions" ) );
   } );
 
-  int idx = sProjectPropertiesPagesMap.count();
   for ( const QPointer< QgsOptionsWidgetFactory > &f : std::as_const( mProjectPropertiesWidgetFactories ) )
   {
     // remove any deleted factories
@@ -12500,7 +12499,6 @@ QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
     {
       sProjectPropertiesPagesMap.insert( f->title(), f->title() );
     }
-    idx++;
   }
 
   return sProjectPropertiesPagesMap;
@@ -12546,70 +12544,42 @@ void QgisApp::showSettings( const QString &page )
   }
 }
 
-QMap< QString, int > QgisApp::optionsPagesMap()
+QMap<QString, QString> QgisApp::optionsPagesMap()
 {
-  static QList< std::pair< QString, QString > > sOptionsPagesList;
+  static QMap< QString, QString > sOptionsPagesMap;
   static std::once_flag initialized;
   std::call_once( initialized, []
   {
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "General" ), QStringLiteral( "mOptionsPageGeneral" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "System" ), QStringLiteral( "mOptionsPageSystem" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "mOptionsPageCRS" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QStringLiteral( "mOptionsPageTransformations" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QStringLiteral( "mOptionsPageDataSources" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Rendering" ), QStringLiteral( "mOptionsPageRendering" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Canvas & Legend" ), QStringLiteral( "mOptionsPageMapCanvas" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Map Tools" ), QStringLiteral( "mOptionsPageMapTools" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Colors" ), QStringLiteral( "mOptionsPageColors" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Digitizing" ), QStringLiteral( "mOptionsPageDigitizing" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Layouts" ), QStringLiteral( "mOptionsPageComposer" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Variables" ), QStringLiteral( "mOptionsPageVariables" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Authentication" ), QStringLiteral( "mOptionsPageAuth" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Network" ), QStringLiteral( "mOptionsPageNetwork" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Locator" ),  QStringLiteral( "mOptionsLocatorSettings" ) } );
-    sOptionsPagesList.push_back( { QCoreApplication::translate( "QgsOptionsBase", "Acceleration" ),  QStringLiteral( "mOptionsPageAcceleration" ) } );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "General" ), QStringLiteral( "mOptionsPageGeneral" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "System" ), QStringLiteral( "mOptionsPageSystem" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "mOptionsPageCRS" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QStringLiteral( "mOptionsPageTransformations" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QStringLiteral( "mOptionsPageDataSources" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Rendering" ), QStringLiteral( "mOptionsPageRendering" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Canvas & Legend" ), QStringLiteral( "mOptionsPageMapCanvas" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Map Tools" ), QStringLiteral( "mOptionsPageMapTools" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Colors" ), QStringLiteral( "mOptionsPageColors" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Digitizing" ), QStringLiteral( "mOptionsPageDigitizing" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Layouts" ), QStringLiteral( "mOptionsPageComposer" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Variables" ), QStringLiteral( "mOptionsPageVariables" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Authentication" ), QStringLiteral( "mOptionsPageAuth" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Network" ), QStringLiteral( "mOptionsPageNetwork" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Locator" ), QStringLiteral( "mOptionsLocatorSettings" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Acceleration" ), QStringLiteral( "mOptionsPageAcceleration" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Advanced" ), QCoreApplication::translate( "QgsOptionsBase", "Advanced" ) );
   } );
 
-  QList< std::pair< QString, QString > > pages = sOptionsPagesList;
+  QMap< QString, QString > pages = sOptionsPagesMap;
   for ( const QPointer< QgsOptionsWidgetFactory > &f : std::as_const( mOptionsWidgetFactories ) )
   {
     // remove any deleted factories
     if ( f )
     {
-      const QString positionHint = f->pagePositionHint();
-      if ( positionHint.isEmpty() )
-      {
-        pages.push_back( { f->title(), QString() } );
-      }
-      else
-      {
-        bool found = false;
-        for ( int idx = 0; idx < pages.size(); ++idx )
-        {
-          if ( pages.at( idx ).second == positionHint )
-          {
-            pages.insert( idx, { f->title(), QString() } );
-            found = true;
-            break;
-          }
-        }
-        if ( !found )
-          pages.push_back( { f->title(), QString() } );
-      }
+      pages.insert( f->title(), f->title() );
     }
   }
-
-  QMap< QString, int > map;
-  int idx = 0;
-  for ( auto it = pages.constBegin(); it != pages.constEnd(); ++it )
-  {
-    map.insert( it->first, idx );
-    idx++;
-  }
-
-  map.insert( QCoreApplication::translate( "QgsOptionsBase", "Advanced" ), idx );
-  return map;
+  return pages;
 }
 
 QgsOptions *QgisApp::createOptionsDialog( QWidget *parent )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1202,7 +1202,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Settings pages section
      */
     //! Gets map of option pages
-    QMap<QString, int> optionsPagesMap();
+    QMap<QString, QString> optionsPagesMap();
     //! Gets map of project property pages
     QMap< QString, QString > projectPropertiesPagesMap();
     //! Gets map of setting pages

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -152,6 +152,23 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
                                     "    padding-right: 0px;"
                                     "}" ).arg( frameMargin );
 
+    style += QStringLiteral( "QTreeView#mOptionsTreeView {"
+                             "    background-color: rgba(69, 69, 69, 0);"
+                             "    outline: 0;"
+                             "}"
+                             "QFrame#mOptionsListFrame {"
+                             "    background-color: rgba(69, 69, 69, 220);"
+                             "}"
+                             "QTreeView#mOptionsTreeView::item {"
+                             "    color: white;"
+                             "    padding: %1px;"
+                             "}"
+                             "QTreeView#mOptionsTreeView::item::selected {"
+                             "    color: black;"
+                             "    background-color:palette(Window);"
+                             "    padding-right: 0px;"
+                             "}" ).arg( frameMargin );
+
     QString toolbarSpacing = opts.value( QStringLiteral( "toolbarSpacing" ), QString() ).toString();
     if ( !toolbarSpacing.isEmpty() )
     {

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -163,7 +163,7 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
                              "    color: white;"
                              "    padding: %1px;"
                              "}"
-                             "QTreeView#mOptionsTreeView::item::selected {"
+                             "QTreeView#mOptionsTreeView::item::selected, QTreeView#mOptionsTreeView::branch::selected {"
                              "    color: black;"
                              "    background-color:palette(Window);"
                              "    padding-right: 0px;"

--- a/src/app/qgsappscreenshots.cpp
+++ b/src/app/qgsappscreenshots.cpp
@@ -306,6 +306,7 @@ void QgsAppScreenShots::takeGlobalOptions()
   dlg->setMinimumHeight( 600 );
   dlg->show();
   QCoreApplication::processEvents();
+#if 0
   for ( int row = 0; row < dlg->mOptionsListWidget->count(); ++row )
   {
     dlg->mOptionsListWidget->setCurrentRow( row );
@@ -327,7 +328,7 @@ void QgsAppScreenShots::takeGlobalOptions()
   QCoreApplication::processEvents();
   QCoreApplication::processEvents(); // seems a second call is needed, the tabble might not be fully displayed otherwise
   takeScreenshot( QStringLiteral( "advanced_with_settings_shown" ), folder, dlg );
-
+#endif
   // exit properly
   dlg->close();
   dlg->deleteLater();

--- a/src/app/qgsappscreenshots.cpp
+++ b/src/app/qgsappscreenshots.cpp
@@ -306,21 +306,21 @@ void QgsAppScreenShots::takeGlobalOptions()
   dlg->setMinimumHeight( 600 );
   dlg->show();
   QCoreApplication::processEvents();
-#if 0
-  for ( int row = 0; row < dlg->mOptionsListWidget->count(); ++row )
+
+  for ( int page = 0; page < dlg->mOptionsStackedWidget->count(); ++page )
   {
-    dlg->mOptionsListWidget->setCurrentRow( row );
+    dlg->mOptionsStackedWidget->setCurrentIndex( page );
     dlg->adjustSize();
     QCoreApplication::processEvents();
-    QString name = dlg->mOptionsListWidget->item( row )[0].text().toLower();
+    QString name = dlg->mOptTreeView->currentIndex().data( Qt::DisplayRole ).toString().toLower();
     name.replace( QLatin1String( " " ), QLatin1String( "_" ) ).replace( QLatin1String( "&" ), QLatin1String( "and" ) );
     takeScreenshot( name, folder, dlg );
   }
   // -----------------
   // advanced settings
-  dlg->mOptionsListWidget->setCurrentRow( dlg->mOptionsListWidget->count() - 1 );
+  dlg->mOptionsStackedWidget->setCurrentIndex( dlg->mOptionsStackedWidget->count() - 1 );
   QCoreApplication::processEvents();
-  Q_ASSERT( dlg->mOptionsListWidget->currentItem()->icon().pixmap( 24, 24 ).toImage()
+  Q_ASSERT( dlg->mOptTreeView->currentIndex().data( Qt::DecorationRole ).value< QIcon >().pixmap( 24, 24 ).toImage()
             == QgsApplication::getThemeIcon( QStringLiteral( "/mIconWarning.svg" ) ).pixmap( 24, 24 ).toImage() );
   QWidget *editor = dlg->findChild< QWidget * >( QStringLiteral( "mAdvancedSettingsEditor" ) );
   if ( editor )
@@ -328,7 +328,7 @@ void QgsAppScreenShots::takeGlobalOptions()
   QCoreApplication::processEvents();
   QCoreApplication::processEvents(); // seems a second call is needed, the tabble might not be fully displayed otherwise
   takeScreenshot( QStringLiteral( "advanced_with_settings_shown" ), folder, dlg );
-#endif
+
   // exit properly
   dlg->close();
   dlg->deleteLater();

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -99,6 +99,7 @@ void QgsOptionsDialogBase::initOptionsBase( bool restoreUi, const QString &title
     mTreeProxyModel = new QgsOptionsProxyModel( this );
     mTreeProxyModel->setSourceModel( mOptTreeModel );
     mOptTreeView->setModel( mTreeProxyModel );
+    mOptTreeView->expandAll();
   }
 
   QFrame *optionsFrame = findChild<QFrame *>( QStringLiteral( "mOptionsFrame" ) );

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -507,10 +507,10 @@ void QgsOptionsDialogBase::registerTextSearchWidgets()
 
   for ( int i = 0; i < mOptStackedWidget->count(); i++ )
   {
-    const auto constWidget = mOptStackedWidget->widget( i )->findChildren<QWidget *>();
-    for ( QWidget *w : constWidget )
-    {
 
+    const QList< QWidget * > widgets = mOptStackedWidget->widget( i )->findChildren<QWidget *>();
+    for ( QWidget *w : widgets )
+    {
       // get custom highlight widget in user added pages
       QHash<QWidget *, QgsOptionsDialogHighlightWidget *> customHighlightWidgets;
       QgsOptionsPageWidget *opw = qobject_cast<QgsOptionsPageWidget *>( mOptStackedWidget->widget( i ) );

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -180,6 +180,10 @@ void QgsOptionsDialogBase::initOptionsBase( bool restoreUi, const QString &title
   {
     mSearchLineEdit->setShowSearchIcon( true );
     connect( mSearchLineEdit, &QgsFilterLineEdit::textChanged, this, &QgsOptionsDialogBase::searchText );
+    if ( mOptTreeView )
+    {
+      connect( mSearchLineEdit, &QgsFilterLineEdit::cleared, mOptTreeView, &QTreeView::expandAll );
+    }
   }
 
   mInit = true;

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -45,7 +45,7 @@ class QgsOptionsDialogHighlightWidget;
 
 #ifndef SIP_RUN
 ///@cond PRIVATE
-class QgsOptionsProxyModel : public QSortFilterProxyModel
+class GUI_EXPORT QgsOptionsProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
   public:

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -26,6 +26,7 @@
 #include <QDialog>
 #include <QPointer>
 #include <QStyledItemDelegate>
+#include <QSortFilterProxyModel>
 
 class QDialogButtonBox;
 class QListWidget;
@@ -41,6 +42,27 @@ class QStandardItemModel;
 
 class QgsFilterLineEdit;
 class QgsOptionsDialogHighlightWidget;
+
+#ifndef SIP_RUN
+///@cond PRIVATE
+class QgsOptionsProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+
+    QgsOptionsProxyModel( QObject *parent );
+
+    void setPageHidden( int page, bool hidden );
+    QModelIndex pageNumberToSourceIndex( int page ) const;
+    int sourceIndexToPageNumber( const QModelIndex &index ) const;
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
+
+  private:
+    QMap< int, bool > mHiddenPages;
+};
+///@endcond
+#endif
+
 
 /**
  * \ingroup gui
@@ -193,6 +215,8 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
     QListWidget *mOptListWidget = nullptr;
     QTreeView *mOptTreeView = nullptr;
     QStandardItemModel *mOptTreeModel = nullptr;
+    QgsOptionsProxyModel *mTreeProxyModel = nullptr;
+
     QStackedWidget *mOptStackedWidget = nullptr;
     QSplitter *mOptSplitter = nullptr;
     QDialogButtonBox *mOptButtonBox = nullptr;
@@ -207,8 +231,7 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
   private:
 
     void setListToItemAtIndex( int index );
-    QModelIndex pageNumberToTreeViewIndex( int page );
-    int viewIndexToPageNumber( const QModelIndex &index );
+
 };
 
 #endif // QGSOPTIONSDIALOGBASE_H

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -35,10 +35,12 @@ class QPainter;
 class QStackedWidget;
 class QStyleOptionViewItem;
 class QSplitter;
+class QStandardItem;
+class QTreeView;
+class QStandardItemModel;
 
 class QgsFilterLineEdit;
 class QgsOptionsDialogHighlightWidget;
-
 
 /**
  * \ingroup gui
@@ -177,21 +179,36 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      */
     void registerTextSearchWidgets();
 
+    /**
+     * Creates a new QStandardItem with the specified name, tooltip and icon.
+     *
+     * \since QGIS 3.22
+     */
+    QStandardItem *createItem( const QString &name, const QString &tooltip, const QString &icon ) SIP_SKIP;
+
     QList< QPair< QgsOptionsDialogHighlightWidget *, int > > mRegisteredSearchWidgets;
 
     QString mOptsKey;
-    bool mInit;
+    bool mInit = false;
     QListWidget *mOptListWidget = nullptr;
+    QTreeView *mOptTreeView = nullptr;
+    QStandardItemModel *mOptTreeModel = nullptr;
     QStackedWidget *mOptStackedWidget = nullptr;
     QSplitter *mOptSplitter = nullptr;
     QDialogButtonBox *mOptButtonBox = nullptr;
     QgsFilterLineEdit *mSearchLineEdit = nullptr;
     QString mDialogTitle;
-    bool mIconOnly;
+    bool mIconOnly = false;
     // pointer to app or custom, external QgsSettings
     // QPointer in case custom settings obj gets deleted while dialog is open
     QPointer<QgsSettings> mSettings;
-    bool mDelSettings;
+    bool mDelSettings = false;
+
+  private:
+
+    void setListToItemAtIndex( int index );
+    QModelIndex pageNumberToTreeViewIndex( int page );
+    int viewIndexToPageNumber( const QModelIndex &index );
 };
 
 #endif // QGSOPTIONSDIALOGBASE_H

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -149,10 +149,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      *
      * The page content is specified via the \a widget argument. Ownership of \a widget is transferred to the dialog.
      *
+     * Since QGIS 3.22, the optional \a path argument can be used to set the path of the item's entry in the tree view
+     * (for dialogs which show a tree view of options pages only).
+     *
      * \see insertPage()
      * \since QGIS 3.14
      */
-    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER );
+    void addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QStringList &path = QStringList() );
 
     /**
      * Inserts a new page into the dialog pages.
@@ -164,10 +167,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      * The \a before argument specifies the object name of an existing page. The new page will be inserted directly
      * before the matching page.
      *
+     * Since QGIS 3.22, the optional \a path argument can be used to set the path of the item's entry in the tree view
+     * (for dialogs which show a tree view of options pages only).
+     *
      * \see addPage()
      * \since QGIS 3.14
      */
-    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QString &before );
+    void insertPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget SIP_TRANSFER, const QString &before, const QStringList &path = QStringList() );
 
   public slots:
 

--- a/src/gui/qgsoptionsdialoghighlightwidget.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidget.cpp
@@ -21,6 +21,7 @@
 #include <QTimer>
 #include <QTreeView>
 #include <QTreeWidget>
+#include <QTableView>
 
 #include "qgsoptionsdialoghighlightwidget.h"
 #include "qgsmessagebaritem.h"
@@ -70,6 +71,10 @@ QgsOptionsDialogHighlightWidget *QgsOptionsDialogHighlightWidget::createWidget( 
   else if ( qobject_cast<QTreeView *>( widget ) )
   {
     return new QgsOptionsDialogHighlightTree( qobject_cast<QTreeView *>( widget ) );
+  }
+  else if ( qobject_cast<QTableView *>( widget ) )
+  {
+    return new QgsOptionsDialogHighlightTable( qobject_cast<QTableView *>( widget ) );
   }
   else
   {

--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
@@ -22,6 +22,7 @@
 #include <QTreeView>
 #include <QTreeWidget>
 #include <QAbstractItemModel>
+#include <QTableView>
 
 #include "qgsoptionsdialoghighlightwidget.h"
 #include "qgsmessagebaritem.h"
@@ -212,6 +213,15 @@ bool QgsOptionsDialogHighlightTree::searchText( const QString &text )
 {
   if ( !mTreeView || !mTreeView->model() )
     return false;
+
+  // search headers too!
+  for ( int col = 0; col < mTreeView->model()->columnCount(); ++col )
+  {
+    const QString headerText = mTreeView->model()->headerData( col, Qt::Horizontal ).toString();
+    if ( headerText.contains( text, Qt::CaseInsensitive ) )
+      return true;
+  }
+
   QModelIndexList hits = mTreeView->model()->match( mTreeView->model()->index( 0, 0 ), Qt::DisplayRole, text, 1, Qt::MatchContains | Qt::MatchRecursive );
   return !hits.isEmpty();
 }
@@ -283,4 +293,39 @@ void QgsOptionsDialogHighlightTree::reset()
     }
     mTreeInitialExpand.clear();
   }
+}
+
+
+// ****************
+// QTableView
+QgsOptionsDialogHighlightTable::QgsOptionsDialogHighlightTable( QTableView *tableView )
+  : QgsOptionsDialogHighlightWidget( tableView )
+  , mTableView( tableView )
+{
+}
+
+bool QgsOptionsDialogHighlightTable::searchText( const QString &text )
+{
+  if ( !mTableView || !mTableView->model() )
+    return false;
+
+  // search headers too!
+  for ( int col = 0; col < mTableView->model()->columnCount(); ++col )
+  {
+    const QString headerText = mTableView->model()->headerData( col, Qt::Horizontal ).toString();
+    if ( headerText.contains( text, Qt::CaseInsensitive ) )
+      return true;
+  }
+
+  QModelIndexList hits = mTableView->model()->match( mTableView->model()->index( 0, 0 ), Qt::DisplayRole, text, 1, Qt::MatchContains | Qt::MatchRecursive );
+  return !hits.isEmpty();
+}
+
+bool QgsOptionsDialogHighlightTable::highlightText( const QString & )
+{
+  return false;
+}
+
+void QgsOptionsDialogHighlightTable::reset()
+{
 }

--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
@@ -23,6 +23,7 @@
 #include <QTreeWidget>
 #include <QAbstractItemModel>
 #include <QTableView>
+#include <QTextDocumentFragment>
 
 #include "qgsoptionsdialoghighlightwidget.h"
 #include "qgsmessagebaritem.h"
@@ -57,7 +58,8 @@ bool QgsOptionsDialogHighlightLabel::searchText( const QString &text )
   if ( !mLabel )
     return false;
 
-  return mLabel->text().contains( text, Qt::CaseInsensitive );
+  const QString labelText = QTextDocumentFragment::fromHtml( mLabel->text() ).toPlainText();
+  return labelText.contains( text, Qt::CaseInsensitive );
 }
 
 bool QgsOptionsDialogHighlightLabel::highlightText( const QString &text )

--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
@@ -31,6 +31,7 @@ class QAbstractButton;
 class QGroupBox;
 class QTreeView;
 class QTreeWidgetItem;
+class QTableView;
 
 
 /**
@@ -140,5 +141,25 @@ class GUI_EXPORT QgsOptionsDialogHighlightTree : public QgsOptionsDialogHighligh
     // a map to save the tree state (backouground, font, expanded) before highlighting items
     QMap<QTreeWidgetItem *, bool> mTreeInitialExpand = QMap<QTreeWidgetItem *, bool>();
     QMap<QTreeWidgetItem *, bool> mTreeInitialVisible = QMap<QTreeWidgetItem *, bool>();
+};
+
+/**
+ * \ingroup gui
+ * \class QgsOptionsDialogHighlightTable
+ * \brief A highlight widget for table widgets.
+ * This is used to search and highlight text in QgsOptionsDialogBase implementations.
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsOptionsDialogHighlightTable : public QgsOptionsDialogHighlightWidget
+{
+    Q_OBJECT
+  public:
+    //! constructs a highlight widget for a table view or widget.
+    QgsOptionsDialogHighlightTable( QTableView *tableView );
+  protected:
+    bool searchText( const QString &text ) override;
+    bool highlightText( const QString &text ) override;
+    void reset() override;
+    QPointer<QTableView> mTableView;
 };
 #endif // QGSOPTIONSDIALOGHIGHLIGHTWIDGETSIMPL_H

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -149,6 +149,17 @@ class GUI_EXPORT QgsOptionsWidgetFactory : public QObject
     virtual QString pagePositionHint() const { return QString(); }
 
     /**
+     * Returns the path to place the widget page at, for options dialogs
+     * which are structured using a tree view.
+     *
+     * A factory which returns "Code", "Javascript" would have its widget placed
+     * in a group named "Javascript", contained in a parent group named "Code".
+     *
+     * \since QGIS 3.22
+     */
+    virtual QStringList path() const { return QStringList(); }
+
+    /**
      * \brief Factory function to create the widget on demand as needed by the options dialog.
      * \param parent The parent of the widget.
      * \returns A new widget to show as a page in the options dialog.

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2188,6 +2188,227 @@
            </item>
           </layout>
          </widget>
+         <widget class="QWidget" name="mOptionsPageGDAL">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QgsScrollArea" name="mOptionsScrollArea_02">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="mOptionsScrollAreaContents_02">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>447</width>
+                <height>431</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QTabWidget" name="tabWidget">
+                 <property name="currentIndex">
+                  <number>0</number>
+                 </property>
+                 <widget class="QWidget" name="tab_3">
+                  <attribute name="title">
+                   <string>Raster Drivers</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_24">
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_16">
+                     <property name="title">
+                      <string>Raster Driver Options</string>
+                     </property>
+                     <layout class="QGridLayout" name="gridLayout_29">
+                      <item row="0" column="1">
+                       <widget class="QComboBox" name="cmbEditCreateOptions"/>
+                      </item>
+                      <item row="0" column="3">
+                       <spacer name="horizontalSpacer_15">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item row="0" column="4">
+                       <widget class="QPushButton" name="pbnEditPyramidsOptions">
+                        <property name="text">
+                         <string>Edit Pyramids Options</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="5">
+                       <spacer name="horizontalSpacer_16">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item row="0" column="2">
+                       <widget class="QPushButton" name="pbnEditCreateOptions">
+                        <property name="text">
+                         <string>Edit Create Options</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_13">
+                     <property name="title">
+                      <string>Raster Drivers</string>
+                     </property>
+                     <layout class="QGridLayout" name="gridLayout_24">
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_17">
+                        <property name="text">
+                         <string>In some cases more than one GDAL driver can be used to load the same raster format. Use the list below to specify which to use.</string>
+                        </property>
+                        <property name="wordWrap">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QTreeWidget" name="lstRasterDrivers">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>141</height>
+                         </size>
+                        </property>
+                        <column>
+                         <property name="text">
+                          <string>Name</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Extension</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Flags</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Description</string>
+                         </property>
+                        </column>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="tab_4">
+                  <attribute name="title">
+                   <string>Vector Drivers</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_29">
+                   <item>
+                    <widget class="QGroupBox" name="groupBox_31">
+                     <property name="title">
+                      <string>Vector Drivers</string>
+                     </property>
+                     <layout class="QGridLayout" name="gridLayout_36">
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_68">
+                        <property name="text">
+                         <string>In some cases more than one GDAL driver can be used to load the same vector format. Use the list below to specify which to use.</string>
+                        </property>
+                        <property name="wordWrap">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QTreeWidget" name="lstVectorDrivers">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>141</height>
+                         </size>
+                        </property>
+                        <column>
+                         <property name="text">
+                          <string>Name</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Extension</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Flags</string>
+                         </property>
+                        </column>
+                        <column>
+                         <property name="text">
+                          <string>Description</string>
+                         </property>
+                        </column>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
          <widget class="QWidget" name="mOptionsPageRendering">
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <property name="leftMargin">
@@ -5131,227 +5352,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                   </size>
                  </property>
                 </spacer>
-               </item>
-              </layout>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="mOptionsPageGDAL">
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QgsScrollArea" name="mOptionsScrollArea_02">
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="widgetResizable">
-              <bool>true</bool>
-             </property>
-             <widget class="QWidget" name="mOptionsScrollAreaContents_02">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>498</width>
-                <height>455</height>
-               </rect>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_6">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QTabWidget" name="tabWidget">
-                 <property name="currentIndex">
-                  <number>0</number>
-                 </property>
-                 <widget class="QWidget" name="tab_3">
-                  <attribute name="title">
-                   <string>Raster Drivers</string>
-                  </attribute>
-                  <layout class="QVBoxLayout" name="verticalLayout_24">
-                   <item>
-                    <widget class="QGroupBox" name="groupBox_16">
-                     <property name="title">
-                      <string>Raster Driver Options</string>
-                     </property>
-                     <layout class="QGridLayout" name="gridLayout_29">
-                      <item row="0" column="1">
-                       <widget class="QComboBox" name="cmbEditCreateOptions"/>
-                      </item>
-                      <item row="0" column="3">
-                       <spacer name="horizontalSpacer_15">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item row="0" column="4">
-                       <widget class="QPushButton" name="pbnEditPyramidsOptions">
-                        <property name="text">
-                         <string>Edit Pyramids Options</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="5">
-                       <spacer name="horizontalSpacer_16">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item row="0" column="2">
-                       <widget class="QPushButton" name="pbnEditCreateOptions">
-                        <property name="text">
-                         <string>Edit Create Options</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QGroupBox" name="groupBox_13">
-                     <property name="title">
-                      <string>Raster Drivers</string>
-                     </property>
-                     <layout class="QGridLayout" name="gridLayout_24">
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_17">
-                        <property name="text">
-                         <string>In some cases more than one GDAL driver can be used to load the same raster format. Use the list below to specify which to use.</string>
-                        </property>
-                        <property name="wordWrap">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QTreeWidget" name="lstRasterDrivers">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>141</height>
-                         </size>
-                        </property>
-                        <column>
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Extension</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Flags</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Description</string>
-                         </property>
-                        </column>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                 <widget class="QWidget" name="tab_4">
-                  <attribute name="title">
-                   <string>Vector Drivers</string>
-                  </attribute>
-                  <layout class="QVBoxLayout" name="verticalLayout_29">
-                   <item>
-                    <widget class="QGroupBox" name="groupBox_31">
-                     <property name="title">
-                      <string>Vector Drivers</string>
-                     </property>
-                     <layout class="QGridLayout" name="gridLayout_36">
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_68">
-                        <property name="text">
-                         <string>In some cases more than one GDAL driver can be used to load the same vector format. Use the list below to specify which to use.</string>
-                        </property>
-                        <property name="wordWrap">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QTreeWidget" name="lstVectorDrivers">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>141</height>
-                         </size>
-                        </property>
-                        <column>
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Extension</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Flags</string>
-                         </property>
-                        </column>
-                        <column>
-                         <property name="text">
-                          <string>Description</string>
-                         </property>
-                        </column>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </widget>
                </item>
               </layout>
              </widget>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -61,7 +61,7 @@
         <widget class="QgsFilterLineEdit" name="mSearchLineEdit"/>
        </item>
        <item>
-        <widget class="QListWidget" name="mOptionsListWidget">
+        <widget class="QTreeView" name="mOptionsTreeView">
          <property name="minimumSize">
           <size>
            <width>58</width>
@@ -89,216 +89,6 @@
          <property name="textElideMode">
           <enum>Qt::ElideNone</enum>
          </property>
-         <property name="resizeMode">
-          <enum>QListView::Adjust</enum>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <item>
-          <property name="text">
-           <string>General</string>
-          </property>
-          <property name="toolTip">
-           <string>General</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/general.svg</normaloff>:/images/themes/default/propertyicons/general.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>System</string>
-          </property>
-          <property name="toolTip">
-           <string>System</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>CRS</string>
-          </property>
-          <property name="toolTip">
-           <string>CRS</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/CRS.svg</normaloff>:/images/themes/default/propertyicons/CRS.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Transformations</string>
-          </property>
-          <property name="toolTip">
-           <string>Coordinate transformations and operations</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/transformation.svg</normaloff>:/images/themes/default/transformation.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Data Sources</string>
-          </property>
-          <property name="toolTip">
-           <string>Data sources</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/attributes.svg</normaloff>:/images/themes/default/propertyicons/attributes.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Rendering</string>
-          </property>
-          <property name="toolTip">
-           <string>Rendering</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Canvas &amp; Legend</string>
-          </property>
-          <property name="toolTip">
-           <string>Canvas and legend</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/overlay.svg</normaloff>:/images/themes/default/propertyicons/overlay.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Map Tools</string>
-          </property>
-          <property name="toolTip">
-           <string>Map tools</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/map_tools.svg</normaloff>:/images/themes/default/propertyicons/map_tools.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Colors</string>
-          </property>
-          <property name="toolTip">
-           <string>Colors</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/colors.svg</normaloff>:/images/themes/default/propertyicons/colors.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Digitizing</string>
-          </property>
-          <property name="toolTip">
-           <string>Digitizing</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/digitizing.svg</normaloff>:/images/themes/default/propertyicons/digitizing.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Layouts</string>
-          </property>
-          <property name="toolTip">
-           <string>Print layouts</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconLayout.svg</normaloff>:/images/themes/default/mIconLayout.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>GDAL</string>
-          </property>
-          <property name="toolTip">
-           <string>GDAL</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/gdal.svg</normaloff>:/images/themes/default/propertyicons/gdal.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Variables</string>
-          </property>
-          <property name="toolTip">
-           <string>Variables</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Authentication</string>
-          </property>
-          <property name="toolTip">
-           <string>Authentication</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/locked.svg</normaloff>:/images/themes/default/locked.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Network</string>
-          </property>
-          <property name="toolTip">
-           <string>Network</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Locator</string>
-          </property>
-          <property name="toolTip">
-           <string>Locator</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/search.svg</normaloff>:/images/themes/default/search.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Acceleration</string>
-          </property>
-          <property name="toolTip">
-           <string>Configure GPU for processing algorithms</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconGPU.svg</normaloff>:/images/themes/default/mIconGPU.svg</iconset>
-          </property>
-         </item>
         </widget>
        </item>
       </layout>
@@ -6316,7 +6106,7 @@ p, li { white-space: pre-wrap; }
  </customwidgets>
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
-  <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>mOptionsTreeView</tabstop>
   <tabstop>mOptionsScrollArea_01</tabstop>
   <tabstop>grpLocale</tabstop>
   <tabstop>cboTranslation</tabstop>
@@ -6550,22 +6340,6 @@ p, li { white-space: pre-wrap; }
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>
-  <connection>
-   <sender>mOptionsListWidget</sender>
-   <signal>currentRowChanged(int)</signal>
-   <receiver>mOptionsStackedWidget</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>144</x>
-     <y>196</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>790</x>
-     <y>43</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>chkMaxThreads</sender>
    <signal>toggled(bool)</signal>


### PR DESCRIPTION
This PR sets up a framework for options dialogs to use a structured tree to list the available pages, instead of just a flat list (the current behaviour). The intention here is to help improve the usability of the rapidly growing global options dialog, by setting up a tree structure which groups similar themed pages together to aid discoverability. Right now it only groups the the CRS and Transformations items together, but I have upcoming PRs which will introduce additional pages into this dialog so I'm looking for comments on this change first. (and at some stage I'd like to move "Custom Projections" into this global options dialog too, so that's another item which would sit nicely in this same group!)

Here's how it looks right now:

![image](https://user-images.githubusercontent.com/1829991/126744008-a04fa519-dae2-4421-97fd-ee768a5a8cf7.png)

(@nirvn I'll need some assistance with the stylesheet theming here -- I can't work out why that blue bar is showing in the margin!)

TODO:

- [x] fix item hiding when a search term is entered in the dialog
- [x] fix stylesheet
- [x] allow pages created via factories to have tree structures
