### PR TITLE
[JSON Widget] respect config when displayed in identify result dialog

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -726,8 +726,8 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
     {
       QgsJsonEditWidget *jsonEditWidget = new QgsJsonEditWidget();
       jsonEditWidget->setJsonText( value );
-      jsonEditWidget->setView( QgsJsonEditWidget::View::Tree );
-      jsonEditWidget->setFormatJsonMode( QgsJsonEditWidget::FormatJson::Indented );
+      jsonEditWidget->setView( static_cast<QgsJsonEditWidget::View>( setup.config().value( QStringLiteral( "DefaultView" ) ).toInt() ) );
+      jsonEditWidget->setFormatJsonMode( static_cast<QgsJsonEditWidget::FormatJson>( setup.config().value( QStringLiteral( "FormatJson" ) ).toInt() ) );
       jsonEditWidget->setControlsVisible( false );
       attrItem->setData( 1, Qt::DisplayRole, QString() );
       QTreeWidget *treeWidget = attrItem->treeWidget();


### PR DESCRIPTION
Display the JSON widget in identify result dialog in Text or Tree view mode according to its configuration. The "JSON Format" config is also taken into account