### PR TITLE
 [Processing][needs-docs] Add incremental field: add modulo option

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_modulus.gml
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_modulus.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ autoincrement_field_start_grouped_modulus.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>3</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_modulus fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_modulus>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_modulus.xsd
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_modulus.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="autoincrement_field_start_grouped_modulus" type="ogr:autoincrement_field_start_grouped_modulus_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="autoincrement_field_start_grouped_modulus_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AUTO" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="20"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_sorted_modulus.gml
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_sorted_modulus.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ autoincrement_field_start_grouped_sorted_modulus.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>3</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_grouped_sorted_modulus fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_grouped_sorted_modulus>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_sorted_modulus.xsd
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_grouped_sorted_modulus.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="autoincrement_field_start_grouped_sorted_modulus" type="ogr:autoincrement_field_start_grouped_sorted_modulus_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="autoincrement_field_start_grouped_sorted_modulus_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AUTO" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="20"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_modulus.gml
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_modulus.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ autoincrement_field_start_modulus.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>3</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>3</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_field_start_modulus fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>3</ogr:AUTO>
+    </ogr:autoincrement_field_start_modulus>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_modulus.xsd
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_field_start_modulus.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="autoincrement_field_start_modulus" type="ogr:autoincrement_field_start_modulus_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="autoincrement_field_start_modulus_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AUTO" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="20"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_grouped_modulus.gml
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_grouped_modulus.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ autoincrement_grouped_modulus.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_grouped_modulus fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_grouped_modulus>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_grouped_modulus.xsd
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_grouped_modulus.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="autoincrement_grouped_modulus" type="ogr:autoincrement_grouped_modulus_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="autoincrement_grouped_modulus_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AUTO" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="20"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_modulus.gml
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_modulus.gml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ autoincrement_modulus.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>0</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>1</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:autoincrement_modulus fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:AUTO>2</ogr:AUTO>
+    </ogr:autoincrement_modulus>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/autoincrement_modulus.xsd
+++ b/python/plugins/processing/tests/testdata/expected/autoincrement_modulus.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="autoincrement_modulus" type="ogr:autoincrement_modulus_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="autoincrement_modulus_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AUTO" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="20"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
@@ -543,6 +543,93 @@ tests:
         name: expected/autoincrement_sort.gml
         type: vector
 
+  - algorithm: native:addautoincrementalfield
+    name: Add incremental field (with modulus)
+    params:
+      FIELD_NAME: AUTO
+      GROUP_FIELDS:
+      - id2
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MODULUS: 3
+      SORT_ASCENDING: true
+      SORT_NULLS_FIRST: false
+      START: 0
+    results:
+      OUTPUT:
+        name: expected/autoincrement_grouped_modulus.gml
+        type: vector
+
+  - algorithm: native:addautoincrementalfield
+    name: Add incremental field (with modulus)
+    params:
+      FIELD_NAME: AUTO
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MODULUS: 3
+      SORT_ASCENDING: true
+      SORT_NULLS_FIRST: false
+      START: 0
+    results:
+      OUTPUT:
+        name: expected/autoincrement_modulus.gml
+        type: vector
+
+  - algorithm: native:addautoincrementalfield
+    name: Add incremental field (with modulus, start)
+    params:
+      FIELD_NAME: AUTO
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MODULUS: 4
+      SORT_ASCENDING: true
+      SORT_NULLS_FIRST: false
+      START: 1
+    results:
+      OUTPUT:
+        name: expected/autoincrement_field_start_modulus.gml
+        type: vector
+
+  - algorithm: native:addautoincrementalfield
+    name: Add incremental field (with modulus, grouped, start)
+    params:
+      FIELD_NAME: AUTO
+      GROUP_FIELDS:
+      - id2
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MODULUS: 4
+      SORT_ASCENDING: true
+      SORT_NULLS_FIRST: false
+      START: 1
+    results:
+      OUTPUT:
+        name: expected/autoincrement_field_start_grouped_modulus.gml
+        type: vector
+
+  - algorithm: native:addautoincrementalfield
+    name: Add incremental field (with modulus, grouped, sorted, start)
+    params:
+      FIELD_NAME: AUTO
+      GROUP_FIELDS:
+      - id2
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      MODULUS: 4
+      SORT_ASCENDING: true
+      SORT_EXPRESSION: fid
+      SORT_NULLS_FIRST: false
+      START: 1
+    results:
+      OUTPUT:
+        name: expected/autoincrement_field_start_grouped_sorted_modulus.gml
+        type: vector
+
   - algorithm: native:dissolve
     name: Dissolve using field
     params:

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -36,6 +36,7 @@ QString QgsAddIncrementalFieldAlgorithm::shortHelpString() const
                       "This field can be used as a unique ID for features in the layer. The new attribute "
                       "is not added to the input layer but a new layer is generated instead.\n\n"
                       "The initial starting value for the incremental series can be specified.\n\n"
+                      "The modulus value restart the count at START when the value is reached.\n\n"
                       "Optionally, grouping fields can be specified. If group fields are present, then the field value will "
                       "be reset for each combination of these group field values.\n\n"
                       "The sort order for features may be specified, if so, then the incremental field will respect "

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -36,7 +36,7 @@ QString QgsAddIncrementalFieldAlgorithm::shortHelpString() const
                       "This field can be used as a unique ID for features in the layer. The new attribute "
                       "is not added to the input layer but a new layer is generated instead.\n\n"
                       "The initial starting value for the incremental series can be specified.\n\n"
-                      "The modulus value restart the count at START when the value is reached.\n\n"
+                      "Specifying an optional modulus value will restart the count to START whenever the field value reaches the modulus value.\n\n"
                       "Optionally, grouping fields can be specified. If group fields are present, then the field value will "
                       "be reset for each combination of these group field values.\n\n"
                       "The sort order for features may be specified, if so, then the incremental field will respect "

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -84,7 +84,7 @@ void QgsAddIncrementalFieldAlgorithm::initParameters( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "START" ), QObject::tr( "Start values at" ),
                 QgsProcessingParameterNumber::Integer, 0, true ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MODULUS" ), QObject::tr( "Modulus value" ),
-                QgsProcessingParameterNumber::Integer, 0, true ) );
+                QgsProcessingParameterNumber::Integer, QVariant( 0 ), true ) );
   addParameter( new QgsProcessingParameterField( QStringLiteral( "GROUP_FIELDS" ), QObject::tr( "Group values by" ), QVariant(),
                 QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true ) );
 

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -82,6 +82,8 @@ void QgsAddIncrementalFieldAlgorithm::initParameters( const QVariantMap & )
   addParameter( new QgsProcessingParameterString( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Field name" ), QStringLiteral( "AUTO" ) ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "START" ), QObject::tr( "Start values at" ),
                 QgsProcessingParameterNumber::Integer, 0, true ) );
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MODULUS" ), QObject::tr( "Modulus value" ),
+                QgsProcessingParameterNumber::Integer, 0, true ) );
   addParameter( new QgsProcessingParameterField( QStringLiteral( "GROUP_FIELDS" ), QObject::tr( "Group values by" ), QVariant(),
                 QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true ) );
 
@@ -109,6 +111,7 @@ bool QgsAddIncrementalFieldAlgorithm::prepareAlgorithm( const QVariantMap &param
 {
   mStartValue = parameterAsInt( parameters, QStringLiteral( "START" ), context );
   mValue = mStartValue;
+  mModulusValue = parameterAsInt( parameters, QStringLiteral( "MODULUS" ), context );
   mFieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
   mGroupedFieldNames = parameterAsFields( parameters, QStringLiteral( "GROUP_FIELDS" ), context );
 
@@ -145,6 +148,8 @@ QgsFeatureList QgsAddIncrementalFieldAlgorithm::processFeature( const QgsFeature
   {
     attributes.append( mValue );
     mValue++;
+    if ( mModulusValue != 0 && ( mValue % mModulusValue ) == 0 )
+      mValue = mStartValue;
   }
   else
   {
@@ -157,6 +162,8 @@ QgsFeatureList QgsAddIncrementalFieldAlgorithm::processFeature( const QgsFeature
     long long value = mGroupedValues.value( groupAttributes, mStartValue );
     attributes.append( value );
     value++;
+    if ( mModulusValue != 0 && ( value % mModulusValue ) == 0 )
+      value = mStartValue;
     mGroupedValues[ groupAttributes ] = value;
   }
   f.setAttributes( attributes );

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -58,6 +58,7 @@ class QgsAddIncrementalFieldAlgorithm : public QgsProcessingFeatureBasedAlgorith
   private:
 
     long long mStartValue = 0;
+    long long mModulusValue = 0;
     long long mValue = 0;
     QString mFieldName;
     QHash< QgsAttributes, long long > mGroupedValues;


### PR DESCRIPTION
## Description

This algorithm allows to add a column with an integer that will be incremented
from START to the limit, with the possibility of grouping to resume at the
value of START following the group.

FME also offers another option (well, an other transformer) which is called
modulo counter.

This option will reset the counter to the starting value if the modulo value is
reached... 0 indicates that we don't use the modulo option.