### PR TITLE
Split QgsBrowserDockWidget to new QgsBrowserWidget class and QgsBrowserDockWidget

### DIFF
--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -218,7 +218,6 @@ Toggle fast scan
    will be removed in QGIS 4.0
 %End
 
-
  void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated/;
 %Docstring
 Selection has changed.

--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -8,11 +8,10 @@
 
 
 
-
 class QgsBrowserDockWidget : QgsDockWidget
 {
 %Docstring(signature="appended")
-The :py:class:`QgsBrowserDockWidget` class
+A dock widget containing a :py:class:`QgsBrowserWidget` for navigating and managing data sources.
 
 .. versionadded:: 3.0
 %End
@@ -31,6 +30,13 @@ Constructor for QgsBrowserDockWidget
 :param parent: parent widget
 %End
     ~QgsBrowserDockWidget();
+
+    QgsBrowserWidget *browserWidget();
+%Docstring
+Returns a pointer to the :py:class:`QgsBrowserWidget` used by the dock widget.
+
+.. versionadded:: 3.22
+%End
 
  void addFavoriteDirectory( const QString &favDir, const QString &name = QString() ) /Deprecated/;
 %Docstring
@@ -87,9 +93,12 @@ Returns ``True`` if the index was successfully intrepreted as a map layer and lo
    will be removed in QGIS 4.0 - retrieve the :py:class:`QgsLayerItem` itself and manually add to project.
 %End
 
-    void showContextMenu( QPoint );
+ void showContextMenu( QPoint ) /Deprecated/;
 %Docstring
-Show context menu
+Show context menu.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
 
  void addFavorite() /Deprecated/;
@@ -118,49 +127,87 @@ Remove from favorite.
 
     void refresh();
 %Docstring
-Refresh browser view model (and view)
+Refresh the browser model and view.
 %End
 
-    void showFilterWidget( bool visible );
+ void showFilterWidget( bool visible ) /Deprecated/;
 %Docstring
-Show/hide filter widget
-%End
-    void enablePropertiesWidget( bool enable );
-%Docstring
-Enable/disable properties widget
-%End
-    void setFilterSyntax( QAction * );
-%Docstring
-Sets filter syntax
-%End
-    void setCaseSensitive( bool caseSensitive );
-%Docstring
-Sets filter case sensitivity
-%End
-    void setFilter();
-%Docstring
-Apply filter to the model
-%End
-    void setActiveIndex( const QModelIndex &index );
-%Docstring
-Sets the selection to ``index`` and expand it
-%End
-    void updateProjectHome();
-%Docstring
-Update project home directory
+Show/hide filter widget.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
 
-    void addSelectedLayers();
+ void enablePropertiesWidget( bool enable ) /Deprecated/;
+%Docstring
+Enable/disable properties widget.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void setFilterSyntax( QAction * ) /Deprecated/;
+%Docstring
+Sets filter syntax.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void setCaseSensitive( bool caseSensitive ) /Deprecated/;
+%Docstring
+Sets filter case sensitivity.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void setFilter() /Deprecated/;
+%Docstring
+Apply filter to the model.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void setActiveIndex( const QModelIndex &index ) /Deprecated/;
+%Docstring
+Sets the selection to ``index`` and expand it.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void updateProjectHome() /Deprecated/;
+%Docstring
+Update project home directory.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
+%End
+
+ void addSelectedLayers() /Deprecated/;
 %Docstring
 Add selected layers to the project
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
-    void showProperties();
+
+ void showProperties() /Deprecated/;
 %Docstring
-Show the layer properties
+Show the layer properties.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
-    void hideItem();
+
+ void hideItem() /Deprecated/;
 %Docstring
-Hide current item
+Hide current item.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
 
  void toggleFastScan() /Deprecated/;
@@ -172,13 +219,20 @@ Toggle fast scan
 %End
 
 
-    void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
+ void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) /Deprecated/;
 %Docstring
-Selection has changed
+Selection has changed.
+
+.. deprecated::
+   will be removed in QGIS 4.0 -- this method is not intended for public use
 %End
-    void splitterMoved();
+
+ void splitterMoved() /Deprecated/;
 %Docstring
-Splitter has been moved
+Splitter has been moved.
+
+.. deprecated::
+   no longer used.
 %End
 
   signals:
@@ -193,13 +247,6 @@ Emitted when drop uri list needs to be handled
     void connectionsChanged();
 %Docstring
 Connections changed in the browser
-%End
-
-  protected:
-    virtual void showEvent( QShowEvent *event );
-
-%Docstring
-Show event override
 %End
 
 };

--- a/python/gui/auto_generated/qgsbrowserwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserwidget.sip.in
@@ -1,0 +1,84 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsbrowserwidget.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsBrowserWidget : QgsPanelWidget
+{
+%Docstring(signature="appended")
+A widget showing a browser tree view along with toolbar and toggleable properties pane.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsbrowserwidget.h"
+%End
+  public:
+
+    explicit QgsBrowserWidget( QgsBrowserGuiModel *browserModel, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsBrowserWidget
+
+:param browserModel: instance of the (shared) browser model
+:param parent: parent widget
+%End
+    ~QgsBrowserWidget();
+
+    void setMessageBar( QgsMessageBar *bar );
+%Docstring
+Sets a message ``bar`` to use alongside the widget. Setting this allows items
+to utilize the message bar to provide non-blocking feedback to users, e.g.
+success or failure of actions.
+
+.. seealso:: :py:func:`messageBar`
+%End
+
+    QgsMessageBar *messageBar();
+%Docstring
+Returns the message bar associated with the widget.
+
+.. seealso:: :py:func:`setMessageBar`
+%End
+
+    void setDisabledDataItemsKeys( const QStringList &filter );
+%Docstring
+Sets the customization for data items based on item's data provider key
+
+By default browser model shows all items from all available data items provider and few special
+items (e.g. Favorites). To customize the behavior, set the filter to not load certain data items.
+The items that are not based on data item providers (e.g. Favorites, Home) have
+prefix "special:"
+
+Used in the proxy browser model to hide items
+%End
+
+  public slots:
+
+
+
+    void refresh();
+%Docstring
+Refreshes the browser model and view.
+%End
+
+
+  protected:
+    virtual void showEvent( QShowEvent *event );
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsbrowserwidget.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -19,6 +19,7 @@
 %Include auto_generated/qgsattributetypeloaddialog.sip
 %Include auto_generated/qgsblendmodecombobox.sip
 %Include auto_generated/qgsbrowserdockwidget.sip
+%Include auto_generated/qgsbrowserwidget.sip
 %Include auto_generated/qgsbrowserguimodel.sip
 %Include auto_generated/qgsbrowsertreeview.sip
 %Include auto_generated/qgsbusyindicatordialog.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -103,6 +103,7 @@
 #include "qgsproviderutils.h"
 #include "qgsprovidersublayersdialog.h"
 #include "qgsmaplayerfactory.h"
+#include "qgsbrowserwidget.h"
 
 #include "qgsanalysis.h"
 #include "qgsgeometrycheckregistry.h"
@@ -15891,7 +15892,7 @@ void QgisApp::showBookmarks()
 {
   mBrowserWidget->setUserVisible( true );
   QModelIndex index = browserModel()->findPath( QStringLiteral( "bookmarks:" ) );
-  mBrowserWidget->setActiveIndex( index );
+  mBrowserWidget->browserWidget()->setActiveIndex( index );
 }
 
 void QgisApp::showBookmarkManager( bool show )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -407,6 +407,7 @@ set(QGIS_GUI_SRCS
   qgsbrowsertreeview.cpp
   qgsbrowserguimodel.cpp
   qgsbrowserdockwidget.cpp
+  qgsbrowserwidget.cpp
   qgsbusyindicatordialog.cpp
   qgscharacterselectordialog.cpp
   qgscheckablecombobox.cpp
@@ -651,6 +652,7 @@ set(QGIS_GUI_HDRS
   qgsattributetypeloaddialog.h
   qgsblendmodecombobox.h
   qgsbrowserdockwidget.h
+  qgsbrowserwidget.h
   qgsbrowserguimodel.h
   qgsbrowsertreeview.h
   qgsbusyindicatordialog.h

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -207,8 +207,6 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget
      */
     Q_DECL_DEPRECATED void toggleFastScan() SIP_DEPRECATED;
 
-    // TODO QGIS 4.0: make these private
-
     /**
      * Selection has changed.
      *

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -15,31 +15,20 @@
 #ifndef QGSBROWSERDOCKWIDGET_H
 #define QGSBROWSERDOCKWIDGET_H
 
-#include "ui_qgsbrowserdockwidgetbase.h"
-#include "ui_qgsbrowserlayerpropertiesbase.h"
-#include "ui_qgsbrowserdirectorypropertiesbase.h"
-#include "ui_qgsbrowserpropertiesdialogbase.h"
-
 #include "qgsbrowsertreeview.h"
 #include "qgsdockwidget.h"
+#include "qgsmimedatautils.h"
 #include "qgis_gui.h"
-#include <QSortFilterProxyModel>
 
-class QgsBrowserGuiModel;
-class QModelIndex;
-class QgsDockBrowserTreeView;
-class QgsLayerItem;
-class QgsDataItem;
-class QgsBrowserProxyModel;
 class QgsMessageBar;
-class QgsDataItemGuiContext;
+class QgsBrowserWidget;
 
 /**
  * \ingroup gui
- * \brief The QgsBrowserDockWidget class
+ * \brief A dock widget containing a QgsBrowserWidget for navigating and managing data sources.
  * \since QGIS 3.0
  */
-class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBrowserDockWidgetBase
+class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget
 {
     Q_OBJECT
   public:
@@ -52,6 +41,13 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
       */
     explicit QgsBrowserDockWidget( const QString &name, QgsBrowserGuiModel *browserModel, QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsBrowserDockWidget() override;
+
+    /**
+     * Returns a pointer to the QgsBrowserWidget used by the dock widget.
+     *
+     * \since QGIS 3.22
+     */
+    QgsBrowserWidget *browserWidget();
 
     /**
      * Add directory to favorites.
@@ -105,8 +101,12 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
      */
     Q_DECL_DEPRECATED bool addLayerAtIndex( const QModelIndex &index ) SIP_DEPRECATED;
 
-    //! Show context menu
-    void showContextMenu( QPoint );
+    /**
+     * Show context menu.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void showContextMenu( QPoint ) SIP_DEPRECATED;
 
     /**
      * Add current item to favorite.
@@ -126,30 +126,80 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
      */
     Q_DECL_DEPRECATED void removeFavorite() SIP_DEPRECATED;
 
-    //! Refresh browser view model (and view)
+    /**
+     * Refresh the browser model and view.
+    */
     void refresh();
 
-    //! Show/hide filter widget
-    void showFilterWidget( bool visible );
-    //! Enable/disable properties widget
-    void enablePropertiesWidget( bool enable );
-    //! Sets filter syntax
-    void setFilterSyntax( QAction * );
-    //! Sets filter case sensitivity
-    void setCaseSensitive( bool caseSensitive );
-    //! Apply filter to the model
-    void setFilter();
-    //! Sets the selection to \a index and expand it
-    void setActiveIndex( const QModelIndex &index );
-    //! Update project home directory
-    void updateProjectHome();
+    /**
+     * Show/hide filter widget.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void showFilterWidget( bool visible ) SIP_DEPRECATED;
 
-    //! Add selected layers to the project
-    void addSelectedLayers();
-    //! Show the layer properties
-    void showProperties();
-    //! Hide current item
-    void hideItem();
+    /**
+     * Enable/disable properties widget.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void enablePropertiesWidget( bool enable ) SIP_DEPRECATED;
+
+    /**
+     * Sets filter syntax.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void setFilterSyntax( QAction * ) SIP_DEPRECATED;
+
+    /**
+     * Sets filter case sensitivity.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void setCaseSensitive( bool caseSensitive ) SIP_DEPRECATED;
+
+    /**
+     * Apply filter to the model.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void setFilter() SIP_DEPRECATED;
+
+    /**
+     * Sets the selection to \a index and expand it.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void setActiveIndex( const QModelIndex &index ) SIP_DEPRECATED;
+
+    /**
+     * Update project home directory.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void updateProjectHome() SIP_DEPRECATED;
+
+    /**
+     * Add selected layers to the project
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+    */
+    Q_DECL_DEPRECATED void addSelectedLayers() SIP_DEPRECATED;
+
+    /**
+     * Show the layer properties.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+    */
+    Q_DECL_DEPRECATED void showProperties() SIP_DEPRECATED;
+
+    /**
+     * Hide current item.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+    */
+    Q_DECL_DEPRECATED void hideItem() SIP_DEPRECATED;
 
     /**
      * Toggle fast scan
@@ -159,10 +209,19 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
 
     // TODO QGIS 4.0: make these private
 
-    //! Selection has changed
-    void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
-    //! Splitter has been moved
-    void splitterMoved();
+    /**
+     * Selection has changed.
+     *
+     * \deprecated will be removed in QGIS 4.0 -- this method is not intended for public use
+     */
+    Q_DECL_DEPRECATED void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected ) SIP_DEPRECATED;
+
+    /**
+     * Splitter has been moved.
+     *
+     * \deprecated no longer used.
+     */
+    Q_DECL_DEPRECATED void splitterMoved() SIP_DEPRECATED;
 
   signals:
     //! Emitted when a file needs to be opened
@@ -172,41 +231,9 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
     //! Connections changed in the browser
     void connectionsChanged();
 
-  protected:
-    //! Show event override
-    void showEvent( QShowEvent *event ) override;
-
-  private slots:
-    void itemDoubleClicked( const QModelIndex &index );
-    void onOptionsChanged();
-
   private:
-    //! Refresh the model
-    void refreshModel( const QModelIndex &index );
-    //! Add a layer
-    void addLayer( QgsLayerItem *layerItem );
-    //! Clear the properties widget
-    void clearPropertiesWidget();
-    //! Sets the properties widget
-    void setPropertiesWidget();
 
-    //! Count selected items
-    int selectedItemsCount();
-    //! Settings prefix (the object name)
-    QString settingsSection() { return objectName().toLower(); }
-
-    QgsDataItemGuiContext createContext();
-
-    QgsDockBrowserTreeView *mBrowserView = nullptr;
-    QgsBrowserGuiModel *mModel = nullptr;
-    QgsBrowserProxyModel *mProxyModel = nullptr;
-    QString mInitPath;
-    bool mPropertiesWidgetEnabled;
-    // height fraction
-    float mPropertiesWidgetHeight;
-
-    QgsMessageBar *mMessageBar = nullptr;
-    QStringList mDisabledDataItemsKeys;
+    QgsBrowserWidget *mWidget = nullptr;
 };
 
 #endif // QGSBROWSERDOCKWIDGET_H

--- a/src/gui/qgsbrowserdockwidget_p.h
+++ b/src/gui/qgsbrowserdockwidget_p.h
@@ -34,7 +34,6 @@
 
 #include <QSortFilterProxyModel>
 
-#include "ui_qgsbrowserdockwidgetbase.h"
 #include "ui_qgsbrowserlayerpropertiesbase.h"
 #include "ui_qgsbrowserdirectorypropertiesbase.h"
 #include "ui_qgsbrowserpropertiesdialogbase.h"

--- a/src/gui/qgsbrowserwidget.cpp
+++ b/src/gui/qgsbrowserwidget.cpp
@@ -1,0 +1,548 @@
+/***************************************************************************
+    qgsbrowserwidget.cpp
+    ---------------------
+    begin                : July 2011
+    copyright            : (C) 2011 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsbrowserwidget.h"
+
+#include <QAbstractTextDocumentLayout>
+#include <QHeaderView>
+#include <QTreeView>
+#include <QMenu>
+#include <QToolButton>
+#include <QFileDialog>
+#include <QPlainTextDocumentLayout>
+#include <QSortFilterProxyModel>
+
+#include "qgsbrowserguimodel.h"
+#include "qgsbrowsertreeview.h"
+#include "qgslogger.h"
+#include "qgsrasterlayer.h"
+#include "qgsvectorlayer.h"
+#include "qgsproject.h"
+#include "qgssettings.h"
+#include "qgsnewnamedialog.h"
+#include "qgsbrowserproxymodel.h"
+#include "qgsgui.h"
+#include "qgswindowmanagerinterface.h"
+#include "qgsnative.h"
+#include "qgsdataitemguiproviderregistry.h"
+#include "qgsdataitemguiprovider.h"
+#include "qgsdirectoryitem.h"
+#include "qgslayeritem.h"
+#include "qgsprojectitem.h"
+#include "qgsbrowserdockwidget_p.h"
+
+// browser layer properties dialog
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+
+#include <QDragEnterEvent>
+#include <functional>
+
+QgsBrowserWidget::QgsBrowserWidget( QgsBrowserGuiModel *browserModel, QWidget *parent )
+  : QgsPanelWidget( parent )
+  , mModel( browserModel )
+{
+  setupUi( this );
+
+  layout()->setContentsMargins( 0, 0, 0, 0 );
+  qgis::down_cast< QVBoxLayout * >( layout() )->setSpacing( 0 );
+
+  mBrowserView = new QgsDockBrowserTreeView( this );
+  mLayoutBrowser->addWidget( mBrowserView );
+
+  mWidgetFilter->hide();
+  mLeFilter->setPlaceholderText( tr( "Type here to filter visible items…" ) );
+  // icons from http://www.fatcow.com/free-icons License: CC Attribution 3.0
+
+  QMenu *menu = new QMenu( this );
+  menu->setSeparatorsCollapsible( false );
+  mBtnFilterOptions->setMenu( menu );
+  QAction *action = new QAction( tr( "Case Sensitive" ), menu );
+  action->setData( "case" );
+  action->setCheckable( true );
+  action->setChecked( false );
+  connect( action, &QAction::toggled, this, &QgsBrowserWidget::setCaseSensitive );
+  menu->addAction( action );
+  QActionGroup *group = new QActionGroup( menu );
+  action = new QAction( tr( "Filter Pattern Syntax" ), group );
+  action->setSeparator( true );
+  menu->addAction( action );
+  action = new QAction( tr( "Normal" ), group );
+  action->setData( QgsBrowserProxyModel::Normal );
+  action->setCheckable( true );
+  action->setChecked( true );
+  menu->addAction( action );
+  action = new QAction( tr( "Wildcard(s)" ), group );
+  action->setData( QgsBrowserProxyModel::Wildcards );
+  action->setCheckable( true );
+  menu->addAction( action );
+  action = new QAction( tr( "Regular Expression" ), group );
+  action->setData( QgsBrowserProxyModel::RegularExpression );
+  action->setCheckable( true );
+  menu->addAction( action );
+
+  mBrowserView->setExpandsOnDoubleClick( false );
+
+  connect( mActionRefresh, &QAction::triggered, this, &QgsBrowserWidget::refresh );
+  connect( mActionAddLayers, &QAction::triggered, this, &QgsBrowserWidget::addSelectedLayers );
+  connect( mActionCollapse, &QAction::triggered, mBrowserView, &QgsDockBrowserTreeView::collapseAll );
+  connect( mActionShowFilter, &QAction::triggered, this, &QgsBrowserWidget::showFilterWidget );
+  connect( mActionPropertiesWidget, &QAction::triggered, this, &QgsBrowserWidget::enablePropertiesWidget );
+  connect( mLeFilter, &QgsFilterLineEdit::returnPressed, this, &QgsBrowserWidget::setFilter );
+  connect( mLeFilter, &QgsFilterLineEdit::cleared, this, &QgsBrowserWidget::setFilter );
+  connect( mLeFilter, &QgsFilterLineEdit::textChanged, this, &QgsBrowserWidget::setFilter );
+  connect( group, &QActionGroup::triggered, this, &QgsBrowserWidget::setFilterSyntax );
+  connect( mBrowserView, &QgsDockBrowserTreeView::customContextMenuRequested, this, &QgsBrowserWidget::showContextMenu );
+  connect( mBrowserView, &QgsDockBrowserTreeView::doubleClicked, this, &QgsBrowserWidget::itemDoubleClicked );
+  connect( mSplitter, &QSplitter::splitterMoved, this, &QgsBrowserWidget::splitterMoved );
+
+  connect( QgsGui::instance(), &QgsGui::optionsChanged, this, &QgsBrowserWidget::onOptionsChanged );
+}
+
+QgsBrowserWidget::~QgsBrowserWidget()
+{
+  QgsSettings settings;
+  settings.setValue( settingsSection() + "/propertiesWidgetEnabled", mPropertiesWidgetEnabled );
+  //settings.setValue(settingsSection() + "/propertiesWidgetHeight", mPropertiesWidget->size().height() );
+  settings.setValue( settingsSection() + "/propertiesWidgetHeight", mPropertiesWidgetHeight );
+}
+
+void QgsBrowserWidget::showEvent( QShowEvent *e )
+{
+  // delayed initialization of the model
+  if ( !mModel->initialized( ) )
+  {
+    mModel->initialize();
+  }
+  if ( ! mProxyModel )
+  {
+    mProxyModel = new QgsBrowserProxyModel( this );
+    mProxyModel->setBrowserModel( mModel );
+    mProxyModel->setHiddenDataItemProviderKeyFilter( mDisabledDataItemsKeys );
+    mBrowserView->setSettingsSection( objectName().toLower() ); // to distinguish 2 or more instances of the browser
+    mBrowserView->setBrowserModel( mModel );
+    mBrowserView->setModel( mProxyModel );
+    mBrowserView->setSortingEnabled( true );
+    mBrowserView->sortByColumn( 0, Qt::AscendingOrder );
+    // provide a horizontal scroll bar instead of using ellipse (...) for longer items
+    mBrowserView->setTextElideMode( Qt::ElideNone );
+    mBrowserView->header()->setSectionResizeMode( 0, QHeaderView::ResizeToContents );
+    mBrowserView->header()->setStretchLastSection( false );
+
+    // selectionModel is created when model is set on tree
+    connect( mBrowserView->selectionModel(), &QItemSelectionModel::selectionChanged,
+             this, &QgsBrowserWidget::selectionChanged );
+
+    // Forward the model changed signals to the widget
+    connect( mModel, &QgsBrowserModel::connectionsChanged,
+             this, &QgsBrowserWidget::connectionsChanged );
+
+
+    // objectName used by settingsSection() is not yet set in constructor
+    QgsSettings settings;
+    mPropertiesWidgetEnabled = settings.value( settingsSection() + "/propertiesWidgetEnabled", false ).toBool();
+    mActionPropertiesWidget->setChecked( mPropertiesWidgetEnabled );
+    mPropertiesWidget->setVisible( false ); // false until item is selected
+
+    mPropertiesWidgetHeight = settings.value( settingsSection() + "/propertiesWidgetHeight" ).toFloat();
+    QList<int> sizes = mSplitter->sizes();
+    int total = sizes.value( 0 ) + sizes.value( 1 );
+    int height = static_cast<int>( total * mPropertiesWidgetHeight );
+    sizes.clear();
+    sizes << total - height << height;
+    mSplitter->setSizes( sizes );
+  }
+
+  QWidget::showEvent( e );
+}
+
+void QgsBrowserWidget::itemDoubleClicked( const QModelIndex &index )
+{
+  QgsDataItem *item = mModel->dataItem( mProxyModel->mapToSource( index ) );
+  if ( !item )
+    return;
+
+  QgsDataItemGuiContext context = createContext();
+
+  const QList< QgsDataItemGuiProvider * > providers = QgsGui::instance()->dataItemGuiProviderRegistry()->providers();
+  for ( QgsDataItemGuiProvider *provider : providers )
+  {
+    if ( provider->handleDoubleClick( item, context ) )
+      return;
+  }
+
+  // if no providers overrode the double-click handling for this item, we give the item itself a chance
+  if ( !item->handleDoubleClick() )
+  {
+    // double-click not handled by browser model, so use as default view expand behavior
+    if ( mBrowserView->isExpanded( index ) )
+      mBrowserView->collapse( index );
+    else
+      mBrowserView->expand( index );
+  }
+}
+
+void QgsBrowserWidget::onOptionsChanged()
+{
+  std::function< void( const QModelIndex &index ) > updateItem;
+  updateItem = [this, &updateItem]( const QModelIndex & index )
+  {
+    if ( QgsDirectoryItem *dirItem = qobject_cast< QgsDirectoryItem * >( mModel->dataItem( index ) ) )
+    {
+      dirItem->reevaluateMonitoring();
+    }
+
+    const int rowCount = mModel->rowCount( index );
+    for ( int i = 0; i < rowCount; ++i )
+    {
+      const QModelIndex child = mModel->index( i, 0, index );
+      updateItem( child );
+    }
+  };
+
+  for ( int i = 0; i < mModel->rowCount(); ++i )
+  {
+    updateItem( mModel->index( i, 0 ) );
+  }
+}
+
+void QgsBrowserWidget::showContextMenu( QPoint pt )
+{
+  QModelIndex index = mProxyModel->mapToSource( mBrowserView->indexAt( pt ) );
+  QgsDataItem *item = mModel->dataItem( index );
+  if ( !item )
+    return;
+
+  const QModelIndexList selection = mBrowserView->selectionModel()->selectedIndexes();
+  QList< QgsDataItem * > selectedItems;
+  selectedItems.reserve( selection.size() );
+  for ( const QModelIndex &selectedIndex : selection )
+  {
+    QgsDataItem *selectedItem = mProxyModel->dataItem( selectedIndex );
+    if ( selectedItem )
+      selectedItems << selectedItem;
+  }
+
+  QMenu *menu = new QMenu( this );
+
+  const QList<QMenu *> menus = item->menus( menu );
+  QList<QAction *> actions = item->actions( menu );
+
+  if ( !menus.isEmpty() )
+  {
+    for ( QMenu *mn : menus )
+    {
+      menu->addMenu( mn );
+    }
+  }
+
+  if ( !actions.isEmpty() )
+  {
+    if ( !menu->actions().isEmpty() )
+      menu->addSeparator();
+    // add action to the menu
+    menu->addActions( actions );
+  }
+
+  QgsDataItemGuiContext context = createContext();
+
+  const QList< QgsDataItemGuiProvider * > providers = QgsGui::instance()->dataItemGuiProviderRegistry()->providers();
+  for ( QgsDataItemGuiProvider *provider : providers )
+  {
+    provider->populateContextMenu( item, menu, selectedItems, context );
+  }
+
+  if ( menu->actions().isEmpty() )
+  {
+    delete menu;
+    return;
+  }
+
+  menu->popup( mBrowserView->mapToGlobal( pt ) );
+}
+
+void QgsBrowserWidget::setMessageBar( QgsMessageBar *bar )
+{
+  mMessageBar = bar;
+  mModel->setMessageBar( bar );
+}
+
+QgsMessageBar *QgsBrowserWidget::messageBar()
+{
+  return mMessageBar;
+}
+
+void QgsBrowserWidget::setDisabledDataItemsKeys( const QStringList &filter )
+{
+  mDisabledDataItemsKeys = filter;
+
+  if ( !mProxyModel )
+    return;
+
+  mProxyModel->setHiddenDataItemProviderKeyFilter( mDisabledDataItemsKeys );
+}
+
+void QgsBrowserWidget::refresh()
+{
+  refreshModel( QModelIndex() );
+}
+
+void QgsBrowserWidget::refreshModel( const QModelIndex &index )
+{
+  if ( mModel && mProxyModel )
+  {
+    QgsDataItem *item = mModel->dataItem( index );
+    if ( item )
+    {
+      QgsDebugMsgLevel( "path = " + item->path(), 4 );
+    }
+    else
+    {
+      QgsDebugMsgLevel( QStringLiteral( "invalid item" ), 4 );
+    }
+
+    if ( item && ( item->capabilities2() & Qgis::BrowserItemCapability::Fertile ) )
+    {
+      mModel->refresh( index );
+    }
+
+    for ( int i = 0; i < mModel->rowCount( index ); i++ )
+    {
+      QModelIndex idx = mModel->index( i, 0, index );
+      QModelIndex proxyIdx = mProxyModel->mapFromSource( idx );
+      QgsDataItem *child = mModel->dataItem( idx );
+
+      // Check also expanded descendants so that the whole expanded path does not get collapsed if one item is collapsed.
+      // Fast items (usually root items) are refreshed so that when collapsed, it is obvious they are if empty (no expand symbol).
+      if ( mBrowserView->isExpanded( proxyIdx ) || mBrowserView->hasExpandedDescendant( proxyIdx ) || ( child && child->capabilities2() & Qgis::BrowserItemCapability::Fast ) )
+      {
+        refreshModel( idx );
+      }
+      else
+      {
+        if ( child && ( child->capabilities2() & Qgis::BrowserItemCapability::Fertile ) )
+        {
+          child->depopulate();
+        }
+      }
+    }
+  }
+}
+
+void QgsBrowserWidget::addLayer( QgsLayerItem *layerItem )
+{
+  if ( !layerItem )
+    return;
+
+  emit handleDropUriList( layerItem->mimeUris() );
+}
+
+void QgsBrowserWidget::addSelectedLayers()
+{
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+
+  // get a sorted list of selected indexes
+  QModelIndexList list = mBrowserView->selectionModel()->selectedIndexes();
+  std::sort( list.begin(), list.end() );
+
+  // If any of the layer items are QGIS we just open and exit the loop
+  const auto constList = list;
+  for ( const QModelIndex &index : constList )
+  {
+    QgsDataItem *item = mModel->dataItem( mProxyModel->mapToSource( index ) );
+    if ( item && item->type() == Qgis::BrowserItemType::Project )
+    {
+      QgsProjectItem *projectItem = qobject_cast<QgsProjectItem *>( item );
+      if ( projectItem )
+        emit openFile( projectItem->path(), QStringLiteral( "project" ) );
+
+      QApplication::restoreOverrideCursor();
+      return;
+    }
+  }
+
+  // add items in reverse order so they are in correct order in the layers dock
+  for ( int i = list.size() - 1; i >= 0; i-- )
+  {
+    QgsDataItem *item = mModel->dataItem( mProxyModel->mapToSource( list[i] ) );
+    if ( item && item->type() == Qgis::BrowserItemType::Layer )
+    {
+      QgsLayerItem *layerItem = qobject_cast<QgsLayerItem *>( item );
+      if ( layerItem )
+        addLayer( layerItem );
+    }
+  }
+
+  QApplication::restoreOverrideCursor();
+}
+
+void QgsBrowserWidget::hideItem()
+{
+  QModelIndex index = mProxyModel->mapToSource( mBrowserView->currentIndex() );
+  QgsDataItem *item = mModel->dataItem( index );
+  if ( ! item )
+    return;
+
+  if ( item->type() == Qgis::BrowserItemType::Directory )
+  {
+    mModel->hidePath( item );
+  }
+}
+
+void QgsBrowserWidget::showProperties()
+{
+  QModelIndex index = mProxyModel->mapToSource( mBrowserView->currentIndex() );
+  QgsDataItem *item = mModel->dataItem( index );
+  if ( ! item )
+    return;
+
+  if ( item->type() == Qgis::BrowserItemType::Layer || item->type() == Qgis::BrowserItemType::Directory )
+  {
+    QgsBrowserPropertiesDialog *dialog = new QgsBrowserPropertiesDialog( settingsSection(), this );
+    dialog->setAttribute( Qt::WA_DeleteOnClose );
+    dialog->setItem( item, createContext() );
+    dialog->show();
+  }
+}
+
+void QgsBrowserWidget::showFilterWidget( bool visible )
+{
+  mWidgetFilter->setVisible( visible );
+  if ( ! visible )
+  {
+    mLeFilter->setText( QString() );
+    setFilter();
+  }
+  else
+  {
+    mLeFilter->setFocus();
+  }
+}
+
+void QgsBrowserWidget::setFilter()
+{
+  QString filter = mLeFilter->text();
+  if ( mProxyModel )
+    mProxyModel->setFilterString( filter );
+}
+
+void QgsBrowserWidget::updateProjectHome()
+{
+  if ( mModel )
+    mModel->updateProjectHome();
+}
+
+void QgsBrowserWidget::setFilterSyntax( QAction *action )
+{
+  if ( !action || ! mProxyModel )
+    return;
+
+  mProxyModel->setFilterSyntax( static_cast< QgsBrowserProxyModel::FilterSyntax >( action->data().toInt() ) );
+}
+
+void QgsBrowserWidget::setCaseSensitive( bool caseSensitive )
+{
+  if ( ! mProxyModel )
+    return;
+  mProxyModel->setFilterCaseSensitivity( caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive );
+}
+
+int QgsBrowserWidget::selectedItemsCount()
+{
+  QItemSelectionModel *selectionModel = mBrowserView->selectionModel();
+  if ( selectionModel )
+  {
+    return selectionModel->selectedIndexes().size();
+  }
+  return 0;
+}
+
+QgsDataItemGuiContext QgsBrowserWidget::createContext()
+{
+  QgsDataItemGuiContext context;
+  context.setMessageBar( mMessageBar );
+  return context;
+}
+
+void QgsBrowserWidget::selectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
+{
+  Q_UNUSED( selected )
+  Q_UNUSED( deselected )
+  if ( mPropertiesWidgetEnabled )
+  {
+    setPropertiesWidget();
+  }
+}
+
+void QgsBrowserWidget::clearPropertiesWidget()
+{
+  while ( mPropertiesLayout->count() > 0 )
+  {
+    delete mPropertiesLayout->itemAt( 0 )->widget();
+  }
+  mPropertiesWidget->setVisible( false );
+}
+
+void QgsBrowserWidget::setPropertiesWidget()
+{
+  clearPropertiesWidget();
+  QItemSelectionModel *selectionModel = mBrowserView->selectionModel();
+  if ( selectionModel )
+  {
+    QModelIndexList indexes = selectionModel->selectedIndexes();
+    if ( indexes.size() == 1 )
+    {
+      QModelIndex index = mProxyModel->mapToSource( indexes.value( 0 ) );
+      QgsDataItem *item = mModel->dataItem( index );
+      QgsDataItemGuiContext context = createContext();
+      QgsBrowserPropertiesWidget *propertiesWidget = QgsBrowserPropertiesWidget::createWidget( item, context, mPropertiesWidget );
+      if ( propertiesWidget )
+      {
+        propertiesWidget->setCondensedMode( true );
+        mPropertiesLayout->addWidget( propertiesWidget );
+      }
+    }
+  }
+  mPropertiesWidget->setVisible( mPropertiesLayout->count() > 0 );
+}
+
+void QgsBrowserWidget::enablePropertiesWidget( bool enable )
+{
+  mPropertiesWidgetEnabled = enable;
+  if ( enable && selectedItemsCount() == 1 )
+  {
+    setPropertiesWidget();
+  }
+  else
+  {
+    clearPropertiesWidget();
+  }
+}
+
+void QgsBrowserWidget::setActiveIndex( const QModelIndex &index )
+{
+  if ( index.isValid() )
+  {
+    QModelIndex proxyIndex = mProxyModel->mapFromSource( index );
+    mBrowserView->expand( proxyIndex );
+    mBrowserView->setCurrentIndex( proxyIndex );
+  }
+}
+
+void QgsBrowserWidget::splitterMoved()
+{
+  QList<int> sizes = mSplitter->sizes();
+  float total = sizes.value( 0 ) + sizes.value( 1 );
+  mPropertiesWidgetHeight = total > 0 ? sizes.value( 1 ) / total : 0;
+}

--- a/src/gui/qgsbrowserwidget.h
+++ b/src/gui/qgsbrowserwidget.h
@@ -1,0 +1,176 @@
+/***************************************************************************
+    qgsbrowserwidget.h
+    ---------------------
+    begin                : July 2011
+    copyright            : (C) 2011 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSBROWSERWIDGET_H
+#define QGSBROWSERWIDGET_H
+
+#include "ui_qgsbrowserwidgetbase.h"
+#include "qgsmimedatautils.h"
+#include "qgspanelwidget.h"
+#include "qgis_gui.h"
+
+class QgsBrowserGuiModel;
+class QgsDockBrowserTreeView;
+class QgsLayerItem;
+class QgsDataItem;
+class QgsBrowserProxyModel;
+class QgsMessageBar;
+class QgsDataItemGuiContext;
+
+class QModelIndex;
+class QItemSelection;
+
+/**
+ * \ingroup gui
+ * \brief A widget showing a browser tree view along with toolbar and toggleable properties pane.
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsBrowserWidget : public QgsPanelWidget, private Ui::QgsBrowserWidgetBase
+{
+    Q_OBJECT
+  public:
+
+    /**
+      * Constructor for QgsBrowserWidget
+      * \param browserModel instance of the (shared) browser model
+      * \param parent parent widget
+      */
+    explicit QgsBrowserWidget( QgsBrowserGuiModel *browserModel, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    ~QgsBrowserWidget() override;
+
+    /**
+     * Sets a message \a bar to use alongside the widget. Setting this allows items
+     * to utilize the message bar to provide non-blocking feedback to users, e.g.
+     * success or failure of actions.
+     *
+     * \see messageBar()
+     */
+    void setMessageBar( QgsMessageBar *bar );
+
+    /**
+     * Returns the message bar associated with the widget.
+     *
+     * \see setMessageBar()
+     */
+    QgsMessageBar *messageBar();
+
+    /**
+     * Sets the customization for data items based on item's data provider key
+     *
+     * By default browser model shows all items from all available data items provider and few special
+     * items (e.g. Favorites). To customize the behavior, set the filter to not load certain data items.
+     * The items that are not based on data item providers (e.g. Favorites, Home) have
+     * prefix "special:"
+     *
+     * Used in the proxy browser model to hide items
+     */
+    void setDisabledDataItemsKeys( const QStringList &filter );
+
+  public slots:
+
+    /**
+     * Update project home directory
+     * \note Not available in Python bindings.
+     */
+    void updateProjectHome() SIP_SKIP;
+
+    /**
+     * Sets the selection to \a index and expands it.
+     *
+     * \note Not available in Python bindings.
+     */
+    void setActiveIndex( const QModelIndex &index ) SIP_SKIP;
+
+    /**
+     * Refreshes the browser model and view.
+     */
+    void refresh();
+
+    // keep the stable API slim for now!
+#ifndef SIP_RUN
+
+  signals:
+    //! Emitted when a file needs to be opened
+    void openFile( const QString &fileName, const QString &fileTypeHint = QString() );
+    //! Emitted when drop uri list needs to be handled
+    void handleDropUriList( const QgsMimeDataUtils::UriList & );
+    //! Connections changed in the browser
+    void connectionsChanged();
+
+#endif
+
+  protected:
+    void showEvent( QShowEvent *event ) override;
+
+  private slots:
+    void itemDoubleClicked( const QModelIndex &index );
+    void onOptionsChanged();
+
+    //! Show context menu
+    void showContextMenu( QPoint );
+
+    //! Show/hide filter widget
+    void showFilterWidget( bool visible );
+    //! Enable/disable properties widget
+    void enablePropertiesWidget( bool enable );
+    //! Sets filter syntax
+    void setFilterSyntax( QAction * );
+    //! Sets filter case sensitivity
+    void setCaseSensitive( bool caseSensitive );
+    //! Apply filter to the model
+    void setFilter();
+
+    //! Add selected layers to the project
+    void addSelectedLayers();
+    //! Show the layer properties
+    void showProperties();
+    //! Hide current item
+    void hideItem();
+
+  private:
+    //! Selection has changed
+    void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
+    //! Splitter has been moved
+    void splitterMoved();
+    //! Refresh the model
+    void refreshModel( const QModelIndex &index );
+    //! Add a layer
+    void addLayer( QgsLayerItem *layerItem );
+    //! Clear the properties widget
+    void clearPropertiesWidget();
+    //! Sets the properties widget
+    void setPropertiesWidget();
+
+    //! Count selected items
+    int selectedItemsCount();
+    //! Settings prefix (the object name)
+    QString settingsSection() { return objectName().toLower(); }
+
+    QgsDataItemGuiContext createContext();
+
+    QgsDockBrowserTreeView *mBrowserView = nullptr;
+    QgsBrowserGuiModel *mModel = nullptr;
+    QgsBrowserProxyModel *mProxyModel = nullptr;
+    QString mInitPath;
+    bool mPropertiesWidgetEnabled = false;
+    // height fraction
+    float mPropertiesWidgetHeight = 0;
+
+    QgsMessageBar *mMessageBar = nullptr;
+    QStringList mDisabledDataItemsKeys;
+
+    friend class QgsBrowserDockWidget;
+};
+
+#endif // QGSBROWSERWIDGET_H

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -29,6 +29,7 @@
 #include "qgsmessagebar.h"
 #include "qgsgui.h"
 #include "qgsbrowserguimodel.h"
+#include "qgsbrowserwidget.h"
 
 QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserGuiModel *browserModel, QWidget *parent, QgsMapCanvas *canvas, Qt::WindowFlags fl )
   : QgsOptionsDialogBase( QStringLiteral( "Data Source Manager" ), parent, fl )
@@ -62,7 +63,7 @@ QgsDataSourceManagerDialog::QgsDataSourceManagerDialog( QgsBrowserGuiModel *brow
   connect( mBrowserWidget, &QgsBrowserDockWidget::handleDropUriList, this, &QgsDataSourceManagerDialog::handleDropUriList );
   connect( mBrowserWidget, &QgsBrowserDockWidget::openFile, this, &QgsDataSourceManagerDialog::openFile );
   connect( mBrowserWidget, &QgsBrowserDockWidget::connectionsChanged, this, &QgsDataSourceManagerDialog::connectionsChanged );
-  connect( this, &QgsDataSourceManagerDialog::updateProjectHome, mBrowserWidget, &QgsBrowserDockWidget::updateProjectHome );
+  connect( this, &QgsDataSourceManagerDialog::updateProjectHome, mBrowserWidget->browserWidget(), &QgsBrowserWidget::updateProjectHome );
 
   // Add provider dialogs
   const QList<QgsSourceSelectProvider *> sourceSelectProviders = QgsGui::sourceSelectProviderRegistry()->providers( );
@@ -115,7 +116,7 @@ void QgsDataSourceManagerDialog::setPreviousPage()
 
 void QgsDataSourceManagerDialog::refresh()
 {
-  mBrowserWidget->refresh();
+  mBrowserWidget->browserWidget()->refresh();
   emit providerDialogsRefreshRequested();
 }
 

--- a/src/ui/qgsbrowserwidgetbase.ui
+++ b/src/ui/qgsbrowserwidgetbase.ui
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QgsBrowserDockWidgetBase</class>
- <widget class="QgsDockWidget" name="QgsBrowserDockWidgetBase">
+ <class>QgsBrowserWidgetBase</class>
+ <widget class="QgsPanelWidget" name="QgsBrowserWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>216</width>
-    <height>138</height>
+    <width>256</width>
+    <height>187</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Browser</string>
   </property>
-  <widget class="QWidget" name="mContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="spacing">
      <number>6</number>
@@ -189,7 +188,6 @@
      </widget>
     </item>
    </layout>
-  </widget>
   <action name="mActionAddLayers">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -264,10 +262,9 @@
    <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsDockWidget</class>
-   <extends>QDockWidget</extends>
-   <header>qgsdockwidget.h</header>
-   <container>1</container>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
Moves the guts of QgsBrowserDockWidget to a reusable QWidget subclass "QgsBrowserWidget", so that browser widgets can easily be created which aren't a dock widget.
