### PR TITLE
Add a 'Show in Files' action for all file items in browser

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -219,7 +219,10 @@ QgsDataItem.Rename.__doc__ = "Item can be renamed"
 QgsDataItem.Delete = Qgis.BrowserItemCapability.Delete
 QgsDataItem.Delete.is_monkey_patched = True
 QgsDataItem.Delete.__doc__ = "Item can be deleted"
-Qgis.BrowserItemCapability.__doc__ = 'Browser item capabilities.\n\n.. versionadded:: 3.20\n\n' + '* ``NoCapabilities``: ' + Qgis.BrowserItemCapability.NoCapabilities.__doc__ + '\n' + '* ``SetCrs``: ' + Qgis.BrowserItemCapability.SetCrs.__doc__ + '\n' + '* ``Fertile``: ' + Qgis.BrowserItemCapability.Fertile.__doc__ + '\n' + '* ``Fast``: ' + Qgis.BrowserItemCapability.Fast.__doc__ + '\n' + '* ``Collapse``: ' + Qgis.BrowserItemCapability.Collapse.__doc__ + '\n' + '* ``Rename``: ' + Qgis.BrowserItemCapability.Rename.__doc__ + '\n' + '* ``Delete``: ' + Qgis.BrowserItemCapability.Delete.__doc__
+QgsDataItem.ItemRepresentsFile = Qgis.BrowserItemCapability.ItemRepresentsFile
+QgsDataItem.ItemRepresentsFile.is_monkey_patched = True
+QgsDataItem.ItemRepresentsFile.__doc__ = "Item's path() directly represents a file on disk (since QGIS 3.22)"
+Qgis.BrowserItemCapability.__doc__ = 'Browser item capabilities.\n\n.. versionadded:: 3.20\n\n' + '* ``NoCapabilities``: ' + Qgis.BrowserItemCapability.NoCapabilities.__doc__ + '\n' + '* ``SetCrs``: ' + Qgis.BrowserItemCapability.SetCrs.__doc__ + '\n' + '* ``Fertile``: ' + Qgis.BrowserItemCapability.Fertile.__doc__ + '\n' + '* ``Fast``: ' + Qgis.BrowserItemCapability.Fast.__doc__ + '\n' + '* ``Collapse``: ' + Qgis.BrowserItemCapability.Collapse.__doc__ + '\n' + '* ``Rename``: ' + Qgis.BrowserItemCapability.Rename.__doc__ + '\n' + '* ``Delete``: ' + Qgis.BrowserItemCapability.Delete.__doc__ + '\n' + '* ``ItemRepresentsFile``: ' + Qgis.BrowserItemCapability.ItemRepresentsFile.__doc__
 # --
 Qgis.BrowserItemCapability.baseClass = Qgis
 QgsLayerItem.LayerType = Qgis.BrowserLayerType

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -182,6 +182,7 @@ The development version
       Collapse,
       Rename,
       Delete,
+      ItemRepresentsFile,
     };
     typedef QFlags<Qgis::BrowserItemCapability> BrowserItemCapabilities;
 

--- a/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
+++ b/python/gui/auto_generated/qgsdataitemguiprovider.sip.in
@@ -100,6 +100,19 @@ and contains accessors for useful objects like the application message bar.
 The base class method has no effect.
 %End
 
+    virtual int precedenceWhenPopulatingMenus() const;
+%Docstring
+Returns the provider's precedence to use when populating context menus via calls to :py:func:`~QgsDataItemGuiProvider.populateContextMenu`.
+
+Providers which return larger values will be called AFTER other providers when the menu is being populated.
+This allows them to nicely insert their corresponding menu items in the desired location with respect to
+existing items added by other providers.
+
+The default implementation returns 0.
+
+.. versionadded:: 3.22
+%End
+
     virtual bool rename( QgsDataItem *item, const QString &name, QgsDataItemGuiContext context );
 %Docstring
 Sets a new ``name`` for the item, and returns ``True`` if the item was successfully renamed.

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -439,8 +439,14 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
       if ( !menu->isEmpty() )
         menu->addSeparator();
 
-      QAction *action = menu->addAction( tr( "File Properties…" ) );
-      connect( action, &QAction::triggered, this, [ = ]
+      QAction *showInFilesAction = menu->addAction( tr( "Show in Files" ) );
+      connect( showInFilesAction, &QAction::triggered, this, [ = ]
+      {
+        QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( item->path() );
+      } );
+
+      QAction *filePropertiesAction = menu->addAction( tr( "File Properties…" ) );
+      connect( filePropertiesAction, &QAction::triggered, this, [ = ]
       {
         QgsGui::nativePlatformInterface()->showFileProperties( item->path() );
       } );

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -54,6 +54,21 @@ class QgsAppDirectoryItemGuiProvider : public QObject, public QgsDataItemGuiProv
     void showProperties( QgsDirectoryItem *item, QgsDataItemGuiContext context );
 };
 
+class QgsAppFileItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+
+  public:
+
+    QgsAppFileItemGuiProvider() = default;
+
+    QString name() override;
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+    int precedenceWhenPopulatingMenus() const override;
+};
+
 
 class QgsProjectHomeItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1222,6 +1222,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mTemporalControllerWidget->setMapCanvas( mMapCanvas );
 
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsAppDirectoryItemGuiProvider() );
+  QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsAppFileItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsProjectHomeItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsProjectItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsFavoritesItemGuiProvider() );

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -87,6 +87,7 @@ QgsQlrDataItem::QgsQlrDataItem( QgsDataItem *parent, const QString &name, const 
   setState( Qgis::BrowserItemState::Populated ); // no children
   setIconName( QStringLiteral( ":/images/icons/qgis-icon-16x16.png" ) );
   setToolTip( QDir::toNativeSeparators( path ) );
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
 }
 
 bool QgsQlrDataItem::hasDragEnabled() const
@@ -206,6 +207,7 @@ QgsQptDataItem::QgsQptDataItem( QgsDataItem *parent, const QString &name, const 
   setState( Qgis::BrowserItemState::Populated ); // no children
   setIconName( QStringLiteral( "/mIconQptFile.svg" ) );
   setToolTip( QDir::toNativeSeparators( path ) );
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
 }
 
 bool QgsQptDataItem::hasDragEnabled() const
@@ -249,6 +251,7 @@ QgsPyDataItem::QgsPyDataItem( QgsDataItem *parent, const QString &name, const QS
   setState( Qgis::BrowserItemState::Populated ); // no children
   setIconName( QStringLiteral( "/mIconPythonFile.svg" ) );
   setToolTip( QDir::toNativeSeparators( path ) );
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
 }
 
 bool QgsPyDataItem::hasDragEnabled() const
@@ -351,6 +354,7 @@ QgsStyleXmlDataItem::QgsStyleXmlDataItem( QgsDataItem *parent, const QString &na
   setState( Qgis::BrowserItemState::Populated ); // no children
   setIconName( QStringLiteral( "/mActionStyleManager.svg" ) );
   setToolTip( QStringLiteral( "<b>%1</b><br>%2" ).arg( tr( "QGIS style library" ), QDir::toNativeSeparators( path ) ) );
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
 }
 
 bool QgsStyleXmlDataItem::hasDragEnabled() const
@@ -470,6 +474,7 @@ QgsProjectRootDataItem::QgsProjectRootDataItem( QgsDataItem *parent, const QStri
   : QgsProjectItem( parent, QFileInfo( path ).completeBaseName(), path )
 {
   mCapabilities = Qgis::BrowserItemCapability::Collapse | Qgis::BrowserItemCapability::Fertile; // collapse by default to avoid costly population on startup
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
   setState( Qgis::BrowserItemState::NotPopulated );
 }
 
@@ -1282,6 +1287,7 @@ QgsHtmlDataItem::QgsHtmlDataItem( QgsDataItem *parent, const QString &name, cons
   setState( Qgis::BrowserItemState::Populated ); // no children
   setIconName( QStringLiteral( "/mIconHtml.svg" ) );
   setToolTip( QDir::toNativeSeparators( path ) );
+  mCapabilities |= Qgis::BrowserItemCapability::ItemRepresentsFile;
 }
 
 bool QgsHtmlDataItem::handleDoubleClick()

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -268,6 +268,7 @@ class CORE_EXPORT Qgis
       Collapse = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
       Rename = 1 << 4, //!< Item can be renamed
       Delete = 1 << 5, //!< Item can be deleted
+      ItemRepresentsFile = 1 << 6, //!< Item's path() directly represents a file on disk (since QGIS 3.22)
     };
     Q_ENUM( BrowserItemCapability )
     Q_DECLARE_FLAGS( BrowserItemCapabilities, BrowserItemCapability )

--- a/src/gui/qgsbrowserwidget.cpp
+++ b/src/gui/qgsbrowserwidget.cpp
@@ -257,8 +257,12 @@ void QgsBrowserWidget::showContextMenu( QPoint pt )
 
   QgsDataItemGuiContext context = createContext();
 
-  const QList< QgsDataItemGuiProvider * > providers = QgsGui::instance()->dataItemGuiProviderRegistry()->providers();
-  for ( QgsDataItemGuiProvider *provider : providers )
+  QList< QgsDataItemGuiProvider * > providers = QgsGui::instance()->dataItemGuiProviderRegistry()->providers();
+  std::sort( providers.begin(), providers.end(), []( QgsDataItemGuiProvider * a, QgsDataItemGuiProvider * b )
+  {
+    return a->precedenceWhenPopulatingMenus() < b->precedenceWhenPopulatingMenus();
+  } );
+  for ( QgsDataItemGuiProvider *provider : std::as_const( providers ) )
   {
     provider->populateContextMenu( item, menu, selectedItems, context );
   }

--- a/src/gui/qgsdataitemguiprovider.cpp
+++ b/src/gui/qgsdataitemguiprovider.cpp
@@ -43,6 +43,11 @@ void QgsDataItemGuiProvider::populateContextMenu( QgsDataItem *, QMenu *, const 
 
 }
 
+int QgsDataItemGuiProvider::precedenceWhenPopulatingMenus() const
+{
+  return 0;
+}
+
 bool QgsDataItemGuiProvider::rename( QgsDataItem *, const QString &, QgsDataItemGuiContext )
 {
   return false;

--- a/src/gui/qgsdataitemguiprovider.h
+++ b/src/gui/qgsdataitemguiprovider.h
@@ -121,6 +121,19 @@ class GUI_EXPORT QgsDataItemGuiProvider
                                       const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context );
 
     /**
+     * Returns the provider's precedence to use when populating context menus via calls to populateContextMenu().
+     *
+     * Providers which return larger values will be called AFTER other providers when the menu is being populated.
+     * This allows them to nicely insert their corresponding menu items in the desired location with respect to
+     * existing items added by other providers.
+     *
+     * The default implementation returns 0.
+     *
+     * \since QGIS 3.22
+     */
+    virtual int precedenceWhenPopulatingMenus() const;
+
+    /**
      * Sets a new \a name for the item, and returns TRUE if the item was successfully renamed.
      *
      * Items which implement this method should return the QgsDataItem::Rename capability.


### PR DESCRIPTION
Opens a file explorer window and directly selects the file

Also fixes the existing "File Properties" action so that it shows regardless of the file type, and doesn't show incorrectly in some circumstances.