### PR TITLE
Add QgsProject::attachmentIdentifier and QgsProject::resolveAttachementIdentifier

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1298,6 +1298,30 @@ Removes the attached file
 .. versionadded:: 3.22
 %End
 
+    QString attachmentIdentifier( const QString &attachedFile ) const;
+%Docstring
+Returns an identifier for an attachment file path
+An attachment identifier is a string which does not depend on the project archive
+storage location.
+
+:param attachedFile: An attachment file path
+
+:return: An identifier for the attached file
+
+.. versionadded:: 3.22
+%End
+
+    QString resolveAttachmentIdentifier( const QString &identifier ) const;
+%Docstring
+Resolves an attachment identifier to a attachment file path
+
+:param identifier: An attachment identifier
+
+:return: The attachment file path, or an empty string if the identifier is invalid
+
+.. versionadded:: 3.22
+%End
+
     const QgsProjectMetadata &metadata() const;
 %Docstring
 Returns a reference to the project's metadata store.

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3700,6 +3700,20 @@ bool QgsProject::removeAttachedFile( const QString &path )
   return mArchive->removeFile( path );
 }
 
+QString QgsProject::attachmentIdentifier( const QString &attachedFile ) const
+{
+  return QStringLiteral( "attachment:///%1" ).arg( QFileInfo( attachedFile ).fileName() );
+}
+
+QString QgsProject::resolveAttachmentIdentifier( const QString &identifier ) const
+{
+  if ( identifier.startsWith( "attachment:///" ) )
+  {
+    return QDir( mArchive->dir() ).absoluteFilePath( identifier.mid( 14 ) );
+  }
+  return QString();
+}
+
 const QgsProjectMetadata &QgsProject::metadata() const
 {
   return mMetadata;

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1363,6 +1363,24 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool removeAttachedFile( const QString &path );
 
     /**
+     * Returns an identifier for an attachment file path
+     * An attachment identifier is a string which does not depend on the project archive
+     * storage location.
+     * \param attachedFile An attachment file path
+     * \return An identifier for the attached file
+     * \since QGIS 3.22
+     */
+    QString attachmentIdentifier( const QString &attachedFile ) const;
+
+    /**
+     * Resolves an attachment identifier to a attachment file path
+     * \param identifier An attachment identifier
+     * \return The attachment file path, or an empty string if the identifier is invalid
+     * \since QGIS 3.22
+     */
+    QString resolveAttachmentIdentifier( const QString &identifier ) const;
+
+    /**
      * Returns a reference to the project's metadata store.
      * \see setMetadata()
      * \see metadataChanged()

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -58,6 +58,7 @@ class TestQgsProject : public QObject
     void testDefaultRelativePaths();
     void testAttachmentsQgs();
     void testAttachmentsQgz();
+    void testAttachmentIdentifier();
 };
 
 void TestQgsProject::init()
@@ -882,6 +883,25 @@ void TestQgsProject::testAttachmentsQgz()
     QVERIFY( p2.mapLayer( p2.mapLayers().firstKey() )->source() == p2.attachedFiles().first() );
   }
 
+}
+
+void TestQgsProject::testAttachmentIdentifier()
+{
+  // Verify attachment identifiers
+  {
+    QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgz" ) );
+    projFile.open();
+
+    QgsProject p;
+    QString attachmentFileName = p.createAttachedFile( "test.jpg" );
+    QString attachmentId = p.attachmentIdentifier( attachmentFileName );
+    QCOMPARE( p.resolveAttachmentIdentifier( attachmentId ), attachmentFileName );
+    p.write( projFile.fileName() );
+
+    QgsProject p2;
+    p2.read( projFile.fileName() );
+    QVERIFY( QFile( p2.resolveAttachmentIdentifier( attachmentId ) ).exists() );
+  }
 }
 
 


### PR DESCRIPTION
Allows obtaining and resolving project archive dir agnostic attachment identifiers (so i.e. `attachment:///attachedfile.ext` rather than `/tmp/QGIS.XYZABC/attachedfile.ext`).