### PR TITLE
correction examples expr: make_rectangle_3points

### DIFF
--- a/resources/function_help/json/make_rectangle_3points
+++ b/resources/function_help/json/make_rectangle_3points
@@ -11,7 +11,7 @@
     "An optional argument to construct the rectangle. By default this value is 0. Value can be 0 (distance) or 1 (projected). Option distance: Second distance is equal to the distance between 2nd and 3rd point. Option projected: Second distance is equal to the distance of the perpendicular projection of the 3rd point on the segment or its extension."}
   ],
   "examples": [
-    { "expression":"geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 5), 0)))", "returns":"'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'"},
-    { "expression":"geom_to_wkt(make_rectangle(make_point(0, 0), make_point(0,5), make_point(5, 3), 1)))", "returns":"'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'"}
+    { "expression":"geom_to_wkt(make_rectangle_3points(make_point(0, 0), make_point(0,5), make_point(5, 5), 0)))", "returns":"'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'"},
+    { "expression":"geom_to_wkt(make_rectangle_3points(make_point(0, 0), make_point(0,5), make_point(5, 3), 1)))", "returns":"'Polygon ((0 0, 0 5, 5 5, 5 0, 0 0))'"}
   ]
 }


### PR DESCRIPTION
correction examples expressions: substituted make_rectangle_3points function name in place of make_rectangle