### PR TITLE
[api break] Remove QRegExp argument from QgsNewNameDialog constructor

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -22,9 +22,16 @@ QGIS 3.22        {#qgis_api_break_3_22}
 QgsApplication       {#qgis_api_break_3_22_qgsapplication}
 --------------
 
-- QgsApplication::shortNameRegExp function was removed as part of a general code migration away from deprecated
+- QgsApplication::shortNameRegExp function was removed as part of a general code migration away from the deprecated
 QRegExp class. It has been replaced with QgsApplication::shortNameRegularExpression which returns a
 QRegularExpression object.
+
+QgsNewNameDialog       {#qgis_api_break_3_22_qgsnewnamedialog}
+----------------
+
+- The `regexp` argument in the QgsNewNameDialog constructor has been removed as part of a general code migration
+away from the deprecated QRegExp class.  It has been replaced with QgsNewNameDialog::setRegularExpression which
+accepts a string argument.
 
 QGIS 3.20        {#qgis_api_break_3_20}
 =========

--- a/python/gui/auto_generated/qgsnewnamedialog.sip.in
+++ b/python/gui/auto_generated/qgsnewnamedialog.sip.in
@@ -25,7 +25,7 @@ the dialog warns users if an entered name already exists.
 
     QgsNewNameDialog( const QString &source = QString(), const QString &initial = QString(),
                       const QStringList &extensions = QStringList(), const QStringList &existing = QStringList(),
-                      const QRegExp &regexp = QRegExp(), Qt::CaseSensitivity cs = Qt::CaseSensitive,
+                      Qt::CaseSensitivity cs = Qt::CaseSensitive,
                       QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = QgsGuiUtils::ModalDialogFlags );
 %Docstring
 New dialog constructor.
@@ -34,10 +34,12 @@ New dialog constructor.
 :param initial: initial name
 :param extensions: base name extensions, e.g. raster base name band extensions or vector layer type extensions
 :param existing: existing names
-:param regexp: regular expression to be used as validator, for example db tables should have "[A-Za-z_][A-Za-z0-9_]+"
 :param cs: case sensitivity for new name to existing names comparison
-:param parent:
-:param flags:
+:param parent: parent widget
+:param flags: window flags
+
+.. versionadded:: 3.22.
+which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use :py:func:`~QgsNewNameDialog.setRegularExpression` instead.
 %End
 
     void setHintString( const QString &hintString );
@@ -119,6 +121,13 @@ Returns the string used for warning users if a conflicting name exists.
 .. seealso:: :py:func:`setConflictingNameWarning`
 
 .. versionadded:: 2.12
+%End
+
+    void setRegularExpression( const QString &expression );
+%Docstring
+Sets a regular ``expression`` to use for validating user-entered names in the dialog.
+
+.. versionadded:: 3.22
 %End
 
     QString name() const;

--- a/python/gui/auto_generated/qgsnewnamedialog.sip.in
+++ b/python/gui/auto_generated/qgsnewnamedialog.sip.in
@@ -38,8 +38,11 @@ New dialog constructor.
 :param parent: parent widget
 :param flags: window flags
 
+.. note::
+
+   Earlier versions had a similar constructor but with extra arguments for ``regexp`` which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use :py:func:`~QgsNewNameDialog.setRegularExpression` instead.
+
 .. versionadded:: 3.22.
-which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use :py:func:`~QgsNewNameDialog.setRegularExpression` instead.
 %End
 
     void setHintString( const QString &hintString );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9372,7 +9372,7 @@ bool QgisApp::uniqueLayoutTitle( QWidget *parent, QString &title, bool acceptEmp
   while ( !titleValid )
   {
 
-    QgsNewNameDialog dlg( typeString, newTitle, QStringList(), layoutNames, QRegExp(), Qt::CaseSensitive, parent );
+    QgsNewNameDialog dlg( typeString, newTitle, QStringList(), layoutNames, Qt::CaseSensitive, parent );
     dlg.setWindowTitle( windowTitle );
     dlg.setHintString( titleMsg );
     dlg.setOverwriteEnabled( false );
@@ -15606,7 +15606,7 @@ void QgisApp::renameView()
 
   QString currentName = view->mapCanvas()->objectName();
 
-  QgsNewNameDialog renameDlg( currentName, currentName, QStringList(), names, QRegExp(), Qt::CaseSensitive, this );
+  QgsNewNameDialog renameDlg( currentName, currentName, QStringList(), names, Qt::CaseSensitive, this );
   renameDlg.setWindowTitle( tr( "Map Views" ) );
   //renameDlg.setHintString( tr( "Name of the new view" ) );
   renameDlg.setOverwriteEnabled( false );

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -93,7 +93,7 @@ QMenu *QgsMapThemes::menu()
 void QgsMapThemes::addPreset()
 {
   QStringList existingNames = QgsProject::instance()->mapThemeCollection()->mapThemes();
-  QgsNewNameDialog dlg( tr( "theme" ), tr( "Theme" ), QStringList(), existingNames, QRegExp(), Qt::CaseInsensitive, mMenu );
+  QgsNewNameDialog dlg( tr( "theme" ), tr( "Theme" ), QStringList(), existingNames, Qt::CaseInsensitive, mMenu );
   dlg.setWindowTitle( tr( "Map Themes" ) );
   dlg.setHintString( tr( "Name of the new theme" ) );
   dlg.setOverwriteEnabled( false );
@@ -155,7 +155,7 @@ void QgsMapThemes::renameCurrentPreset()
       QgsNewNameDialog dlg(
         tr( "theme" ),
         tr( "%1" ).arg( actionPreset->text() ),
-        QStringList(), existingNames, QRegExp(), Qt::CaseInsensitive, mMenu );
+        QStringList(), existingNames,  Qt::CaseInsensitive, mMenu );
 
       dlg.setWindowTitle( tr( "Rename Map Theme" ) );
       dlg.setHintString( tr( "Enter the new name of the map theme" ) );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -279,11 +279,13 @@ void QgsGeoPackageItemGuiProvider::renameVectorLayer( const QString &uri, const 
   QVariantMap pieces( QgsProviderRegistry::instance()->decodeUri( key, uri ) );
   QString layerName = pieces[QStringLiteral( "layerName" )].toString();
 
+  QgsNewNameDialog dlg( uri, layerName, QStringList(), tableNames );
+
   // Allow any character, except |, which could create confusion, due to it being
   // the URI componenent separator. And ideally we should remove that restriction
   // by using proper escaping of |
-  const QRegExp checkRe( QStringLiteral( R"re([^|]+)re" ) );
-  QgsNewNameDialog dlg( uri, layerName, QStringList(), tableNames, checkRe );
+  dlg.setRegularExpression( QStringLiteral( R"re([^|]+)re" ) );
+
   dlg.setOverwriteEnabled( false );
 
   if ( dlg.exec() != dlg.Accepted || dlg.name().isEmpty() || dlg.name() == layerName )

--- a/src/gui/qgsnewnamedialog.h
+++ b/src/gui/qgsnewnamedialog.h
@@ -44,8 +44,8 @@ class GUI_EXPORT QgsNewNameDialog : public QgsDialog
      * \param cs case sensitivity for new name to existing names comparison
      * \param parent parent widget
      * \param flags window flags
-     * \since QGIS 3.22. Earlier versions had a similar constructor but with extra arguments for \a regexp
-     * which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use setRegularExpression() instead.
+     * \note Earlier versions had a similar constructor but with extra arguments for \a regexp which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use setRegularExpression() instead.
+     * \since QGIS 3.22.
      */
     QgsNewNameDialog( const QString &source = QString(), const QString &initial = QString(),
                       const QStringList &extensions = QStringList(), const QStringList &existing = QStringList(),

--- a/src/gui/qgsnewnamedialog.h
+++ b/src/gui/qgsnewnamedialog.h
@@ -22,6 +22,7 @@ class QLineEdit;
 
 #include "qgsdialog.h"
 #include "qgis_gui.h"
+#include <QRegularExpression>
 
 /**
  * \ingroup gui
@@ -40,14 +41,15 @@ class GUI_EXPORT QgsNewNameDialog : public QgsDialog
      * \param initial initial name
      * \param extensions base name extensions, e.g. raster base name band extensions or vector layer type extensions
      * \param existing existing names
-     * \param regexp regular expression to be used as validator, for example db tables should have "[A-Za-z_][A-Za-z0-9_]+"
      * \param cs case sensitivity for new name to existing names comparison
-     * \param parent
-     * \param flags
+     * \param parent parent widget
+     * \param flags window flags
+     * \since QGIS 3.22. Earlier versions had a similar constructor but with extra arguments for \a regexp
+     * which were removed in QGIS 3.22 as they relied on the deprecated QRegExp class. Use setRegularExpression() instead.
      */
     QgsNewNameDialog( const QString &source = QString(), const QString &initial = QString(),
                       const QStringList &extensions = QStringList(), const QStringList &existing = QStringList(),
-                      const QRegExp &regexp = QRegExp(), Qt::CaseSensitivity cs = Qt::CaseSensitive,
+                      Qt::CaseSensitivity cs = Qt::CaseSensitive,
                       QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = QgsGuiUtils::ModalDialogFlags );
 
     /**
@@ -114,6 +116,13 @@ class GUI_EXPORT QgsNewNameDialog : public QgsDialog
     QString conflictingNameWarning() const { return mConflictingNameWarning; }
 
     /**
+     * Sets a regular \a expression to use for validating user-entered names in the dialog.
+     *
+     * \since QGIS 3.22
+     */
+    void setRegularExpression( const QString &expression );
+
+    /**
      * Name entered by user.
      * \returns new name
      * \see newNameChanged()
@@ -147,14 +156,14 @@ class GUI_EXPORT QgsNewNameDialog : public QgsDialog
   protected:
     QStringList mExiting;
     QStringList mExtensions;
-    Qt::CaseSensitivity mCaseSensitivity;
+    Qt::CaseSensitivity mCaseSensitivity = Qt::CaseSensitive;
     QLabel *mHintLabel = nullptr;
     QLineEdit *mLineEdit = nullptr;
     //! List of names with extensions
     QLabel *mNamesLabel = nullptr;
     QLabel *mErrorLabel = nullptr;
     QString mOkString;
-    QRegExp mRegexp;
+    QRegularExpression mRegularExpression;
     bool mOverwriteEnabled = true;
     bool mAllowEmptyName = false;
     QString mConflictingNameWarning;

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -55,7 +55,7 @@
 #include <QHash>
 #include <QTextCodec>
 #include <QElapsedTimer>
-
+#include <QRegExp>
 
 extern "C"
 {
@@ -239,18 +239,17 @@ bool QgsGrassObject::mapsetIdentical( const QgsGrassObject &other ) const
   return fi == otherFi;
 }
 
-QRegExp QgsGrassObject::newNameRegExp( Type type )
+QString QgsGrassObject::newNameRegExp( Type type )
 {
-  QRegExp rx;
   if ( type == QgsGrassObject::Vector )
   {
-    rx.setPattern( QStringLiteral( "[A-Za-z_][A-Za-z0-9_]+" ) );
+    return QStringLiteral( "[A-Za-z_][A-Za-z0-9_]+" );
   }
   else // location, raster, see G_legal_filename
   {
-    rx.setPattern( QStringLiteral( "[\\w_\\-][\\w_\\-.]+" ) );
+    return QStringLiteral( "[\\w_\\-][\\w_\\-.]+" );
   }
-  return rx;
+  return QString();
 }
 
 bool QgsGrassObject::operator==( const QgsGrassObject &other ) const

--- a/src/providers/grass/qgsgrass.h
+++ b/src/providers/grass/qgsgrass.h
@@ -40,7 +40,6 @@ extern "C"
 #include <QString>
 #include <QMap>
 #include <QHash>
-#include <QRegExp>
 #include <QTemporaryFile>
 #include "qgis_grass_lib.h"
 class QgsCoordinateReferenceSystem;
@@ -113,7 +112,7 @@ class GRASS_LIB_EXPORT QgsGrassObject
     // returns true if gisdbase, location and mapset are the same
     bool mapsetIdentical( const QgsGrassObject &other ) const;
     // get regexp patter for new names, e.g. vectors should not start with number
-    static QRegExp newNameRegExp( Type type );
+    static QString newNameRegExp( Type type );
 
     bool operator==( const QgsGrassObject &other ) const;
   private:


### PR DESCRIPTION
Replaced with QgsNewNameDialog::setRegularExpression which accepts
a string argument.

QRegExp is deprecated and removed in qt6.
