### PR TITLE
Cleanup ogr browser item "delete layer" functionality, misc fixes

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -431,6 +431,23 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
   if ( !( item->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile ) )
     return;
 
+  if ( qobject_cast< QgsDataCollectionItem * >( item ) )
+  {
+    QAction *actionRefresh = new QAction( QObject::tr( "Refresh" ), menu );
+    connect( actionRefresh, &QAction::triggered, item, [item] { item->refresh(); } );
+    QAction *separatorAction = new QAction( menu );
+    separatorAction->setSeparator( true );
+    if ( !menu->actions().empty() )
+    {
+      menu->insertAction( menu->actions().constFirst(), separatorAction );
+      menu->insertAction( menu->actions().constFirst(), actionRefresh );
+    }
+    else
+    {
+      menu->addAction( actionRefresh );
+      menu->addAction( separatorAction );
+    }
+  }
 
   if ( QgsGui::nativePlatformInterface()->capabilities() & QgsNative::NativeFilePropertiesDialog )
   {

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -36,10 +36,9 @@
 //
 
 QgsProviderSublayerItem::QgsProviderSublayerItem( QgsDataItem *parent, const QString &name,
-    const QgsProviderSublayerDetails &details, bool isFile )
+    const QgsProviderSublayerDetails &details )
   : QgsLayerItem( parent, name, details.uri(), details.uri(), layerTypeFromSublayer( details ), details.providerKey() )
   , mDetails( details )
-  , mIsFile( isFile )
 {
   mToolTip = details.uri();
 
@@ -64,11 +63,6 @@ QVector<QgsDataItem *> QgsProviderSublayerItem::createChildren()
     }
   }
   return children;
-}
-
-bool QgsProviderSublayerItem::isFile() const
-{
-  return mIsFile;
 }
 
 Qgis::BrowserLayerType QgsProviderSublayerItem::layerTypeFromSublayer( const QgsProviderSublayerDetails &sublayer )
@@ -148,7 +142,7 @@ QVector<QgsDataItem *> QgsFileDataCollectionItem::createChildren()
   children.reserve( mSublayers.size() );
   for ( const QgsProviderSublayerDetails &sublayer : std::as_const( mSublayers ) )
   {
-    QgsProviderSublayerItem *item = new QgsProviderSublayerItem( this, sublayer.name(), sublayer, true );
+    QgsProviderSublayerItem *item = new QgsProviderSublayerItem( this, sublayer.name(), sublayer );
     children.append( item );
   }
 
@@ -335,7 +329,7 @@ QgsDataItem *QgsFileBasedDataItemProvider::createDataItem( const QString &path, 
             || ( !( queryFlags & Qgis::SublayerQueryFlag::FastScan ) && !QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount ) ) )
      )
   {
-    QgsProviderSublayerItem *item = new QgsProviderSublayerItem( parentItem, name, sublayers.at( 0 ), false );
+    QgsProviderSublayerItem *item = new QgsProviderSublayerItem( parentItem, name, sublayers.at( 0 ) );
     if ( item->path() == path )
       item->setCapabilities( item->capabilities2() | Qgis::BrowserItemCapability::ItemRepresentsFile );
     return item;

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -51,25 +51,16 @@ class CORE_EXPORT QgsProviderSublayerItem final: public QgsLayerItem
      * \param parent parent item
      * \param name data item name (this should match either the layer's name or the filename of a single-layer file)
      * \param details sublayer details
-     * \param isFile set to TRUE if the item represents a single-layer file, or FALSE if the item is a sublayer from a
-     * collection item.
      */
-    QgsProviderSublayerItem( QgsDataItem *parent, const QString &name, const QgsProviderSublayerDetails &details, bool isFile );
+    QgsProviderSublayerItem( QgsDataItem *parent, const QString &name, const QgsProviderSublayerDetails &details );
     QString layerName() const override;
     QVector<QgsDataItem *> createChildren() override;
-
-    /**
-     * Returns TRUE if this item directly represents a file, i.e. it is not a sublayer
-     * of a QgsFileDataCollectionItem.
-     */
-    bool isFile() const;
 
   private:
 
     static Qgis::BrowserLayerType layerTypeFromSublayer( const QgsProviderSublayerDetails &sublayer );
 
     QgsProviderSublayerDetails mDetails;
-    bool mIsFile = false;
 
 };
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -81,9 +81,6 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
 
   if ( QgsGeoPackageCollectionItem *collectionItem = qobject_cast< QgsGeoPackageCollectionItem * >( item ) )
   {
-    QAction *actionRefresh = new QAction( QObject::tr( "Refresh" ), menu );
-    connect( actionRefresh, &QAction::triggered, collectionItem, [collectionItem] { collectionItem->refresh(); } );
-    menu->addAction( actionRefresh );
     menu->addSeparator();
 
     if ( QgsOgrDbConnection::connectionList( QStringLiteral( "GPKG" ) ).contains( collectionItem->name() ) )

--- a/src/gui/providers/ogr/qgsogritemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsogritemguiprovider.cpp
@@ -30,7 +30,6 @@
 #include "qgsdatacollectionitem.h"
 #include "qgsogrproviderutils.h"
 #include "qgsgeopackagedataitems.h"
-#include "qgsfilebaseddataitemprovider.h"
 
 void QgsOgrItemGuiProvider::populateContextMenu(
   QgsDataItem *item,
@@ -43,12 +42,10 @@ void QgsOgrItemGuiProvider::populateContextMenu(
     if ( layerItem->providerKey() == QLatin1String( "ogr" ) && !qobject_cast< QgsGeoPackageAbstractLayerItem * >( item ) )
     {
       // Messages are different for files and tables
-      QgsProviderSublayerItem *sublayerItem = qobject_cast< QgsProviderSublayerItem * >( layerItem );
-
-      QString message = sublayerItem && !sublayerItem->isFile() ? QObject::tr( "Delete Layer “%1”…" ).arg( layerItem->name() ) : QObject::tr( "Delete File “%1”…" ).arg( layerItem->name() );
+      QString message = !( layerItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile ) ? QObject::tr( "Delete Layer “%1”…" ).arg( layerItem->name() ) : QObject::tr( "Delete File “%1”…" ).arg( layerItem->name() );
       QAction *actionDeleteLayer = new QAction( message, menu );
       QVariantMap data;
-      data.insert( QStringLiteral( "isSubLayer" ), sublayerItem && !sublayerItem->isFile() );
+      data.insert( QStringLiteral( "isSubLayer" ), !( layerItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile ) );
       data.insert( QStringLiteral( "uri" ), layerItem->uri() );
       data.insert( QStringLiteral( "name" ), layerItem->name() );
       data.insert( QStringLiteral( "parent" ), QVariant::fromValue( QPointer< QgsDataItem >( layerItem->parent() ) ) );


### PR DESCRIPTION
This should only be enabled for datasets with formats where gdal supports deleting layers, or we just show misleading noise and confusing errors to the user.