### PR TITLE
add support for plugin layers in QgsProcessingParameterMapLayer (fix #44183)

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessing.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessing.sip.in
@@ -36,7 +36,8 @@ and parameters.
       TypeRaster,
       TypeFile,
       TypeVector,
-      TypeMesh
+      TypeMesh,
+      TypePlugin
     };
 
     enum PythonOutputType

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -37,6 +37,8 @@ value.
 
 .. seealso:: :py:func:`compatibleMeshLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -59,6 +61,8 @@ value.
 
 .. seealso:: :py:func:`compatibleMeshLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -74,9 +78,30 @@ value.
 
 .. seealso:: :py:func:`compatibleVectorLayers`
 
+.. seealso:: :py:func:`compatiblePluginLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 
 .. versionadded:: 3.6
+%End
+
+    static QList<QgsPluginLayer *> compatiblePluginLayers( QgsProject *project, bool sort = true );
+%Docstring
+Returns a list of plugin layers from a ``project`` which are compatible with the processing
+framework.
+
+If the ``sort`` argument is ``True`` then the layers will be sorted by their :py:func:`QgsMapLayer.name()`
+value.
+
+.. seealso:: :py:func:`compatibleRasterLayers`
+
+.. seealso:: :py:func:`compatibleVectorLayers`
+
+.. seealso:: :py:func:`compatibleMeshLayers`
+
+.. seealso:: :py:func:`compatibleLayers`
+
+.. versionadded:: 3.22
 %End
 
     static QList< QgsMapLayer * > compatibleLayers( QgsProject *project, bool sort = true );

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -52,7 +52,8 @@ class CORE_EXPORT QgsProcessing
       TypeRaster = 3, //!< Raster layers
       TypeFile = 4, //!< Files (i.e. non map layer sources, such as text files)
       TypeVector = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
-      TypeMesh = 6 //!< Mesh layers \since QGIS 3.6
+      TypeMesh = 6, //!< Mesh layers \since QGIS 3.6
+      TypePlugin = 7 //!< Plugin layers \since QGIS 3.22
     };
 
     //! Available Python output types
@@ -88,6 +89,8 @@ class CORE_EXPORT QgsProcessing
           return QStringLiteral( "TypeVector" );
         case QgsProcessing::TypeMesh:
           return QStringLiteral( "TypeMesh" );
+        case QgsProcessing::TypePlugin:
+          return QStringLiteral( "TypePlugin" );
       }
       return QString();
     }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -2720,6 +2720,10 @@ QString QgsProcessingParameterMapLayer::asScriptCode() const
       case QgsProcessing::TypeMesh:
         code += QLatin1String( "mesh " );
         break;
+
+      case QgsProcessing::TypePlugin:
+        code += QLatin1String( "plugin " );
+        break;
     }
   }
 
@@ -2767,6 +2771,12 @@ QgsProcessingParameterMapLayer *QgsProcessingParameterMapLayer::fromScriptCode( 
     {
       types << QgsProcessing::TypeMesh;
       def = def.mid( 5 );
+      continue;
+    }
+    else if ( def.startsWith( QLatin1String( "plugin" ), Qt::CaseInsensitive ) )
+    {
+      types << QgsProcessing::TypePlugin;
+      def = def.mid( 7 );
       continue;
     }
     break;
@@ -3848,6 +3858,7 @@ QString QgsProcessingParameterMultipleLayers::createFileFilter() const
       return QgsProviderRegistry::instance()->fileMeshFilters() + QStringLiteral( ";;" ) + QObject::tr( "All files (*.*)" );
 
     case QgsProcessing::TypeMapLayer:
+    case QgsProcessing::TypePlugin:
       return createAllMapLayerFileFilter();
   }
   return QString();
@@ -5840,6 +5851,7 @@ bool QgsProcessingParameterFeatureSink::hasGeometry() const
     case QgsProcessing::TypeFile:
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeMesh:
+    case QgsProcessing::TypePlugin:
       return false;
   }
   return true;
@@ -6535,6 +6547,7 @@ bool QgsProcessingParameterVectorDestination::hasGeometry() const
     case QgsProcessing::TypeFile:
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeMesh:
+    case QgsProcessing::TypePlugin:
       return false;
   }
   return true;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -40,26 +40,7 @@
 
 QList<QgsRasterLayer *> QgsProcessingUtils::compatibleRasterLayers( QgsProject *project, bool sort )
 {
-  if ( !project )
-    return QList<QgsRasterLayer *>();
-
-  QList<QgsRasterLayer *> layers;
-
-  const auto rasterLayers = project->layers<QgsRasterLayer *>();
-  for ( QgsRasterLayer *l : rasterLayers )
-  {
-    if ( canUseLayer( l ) )
-      layers << l;
-  }
-
-  if ( sort )
-  {
-    std::sort( layers.begin(), layers.end(), []( const QgsRasterLayer * a, const QgsRasterLayer * b ) -> bool
-    {
-      return QString::localeAwareCompare( a->name(), b->name() ) < 0;
-    } );
-  }
-  return layers;
+  return compatibleMapLayers< QgsRasterLayer >( project, sort );
 }
 
 QList<QgsVectorLayer *> QgsProcessingUtils::compatibleVectorLayers( QgsProject *project, const QList<int> &geometryTypes, bool sort )
@@ -87,35 +68,22 @@ QList<QgsVectorLayer *> QgsProcessingUtils::compatibleVectorLayers( QgsProject *
 
 QList<QgsMeshLayer *> QgsProcessingUtils::compatibleMeshLayers( QgsProject *project, bool sort )
 {
-  if ( !project )
-    return QList<QgsMeshLayer *>();
-
-  QList<QgsMeshLayer *> layers;
-  const auto meshLayers = project->layers<QgsMeshLayer *>();
-  for ( QgsMeshLayer *l : meshLayers )
-  {
-    if ( canUseLayer( l ) )
-      layers << l;
-  }
-
-  if ( sort )
-  {
-    std::sort( layers.begin(), layers.end(), []( const QgsMeshLayer * a, const QgsMeshLayer * b ) -> bool
-    {
-      return QString::localeAwareCompare( a->name(), b->name() ) < 0;
-    } );
-  }
-  return layers;
+  return compatibleMapLayers< QgsMeshLayer >( project, sort );
 }
 
 QList<QgsPluginLayer *> QgsProcessingUtils::compatiblePluginLayers( QgsProject *project, bool sort )
 {
-  if ( !project )
-    return QList<QgsPluginLayer *>();
+  return compatibleMapLayers< QgsPluginLayer >( project, sort );
+}
 
-  QList<QgsPluginLayer *> layers;
-  const auto pluginLayers = project->layers<QgsPluginLayer *>();
-  for ( QgsPluginLayer *l : pluginLayers )
+template<typename T> QList<T *> QgsProcessingUtils::compatibleMapLayers( QgsProject *project, bool sort )
+{
+  if ( !project )
+    return QList<T *>();
+
+  QList<T *> layers;
+  const auto projectLayers = project->layers<T *>();
+  for ( T *l : projectLayers )
   {
     if ( canUseLayer( l ) )
       layers << l;
@@ -123,7 +91,7 @@ QList<QgsPluginLayer *> QgsProcessingUtils::compatiblePluginLayers( QgsProject *
 
   if ( sort )
   {
-    std::sort( layers.begin(), layers.end(), []( const QgsPluginLayer * a, const QgsPluginLayer * b ) -> bool
+    std::sort( layers.begin(), layers.end(), []( const T * a, const T * b ) -> bool
     {
       return QString::localeAwareCompare( a->name(), b->name() ) < 0;
     } );
@@ -138,7 +106,8 @@ QList<QgsMapLayer *> QgsProcessingUtils::compatibleLayers( QgsProject *project, 
 
   QList<QgsMapLayer *> layers;
 
-  const auto rasterLayers = compatibleRasterLayers( project, false );
+  //~ const auto rasterLayers = compatibleRasterLayers( project, false );
+  const auto rasterLayers = compatibleMapLayers< QgsRasterLayer >( project, false );
   for ( QgsRasterLayer *rl : rasterLayers )
     layers << rl;
 
@@ -146,11 +115,13 @@ QList<QgsMapLayer *> QgsProcessingUtils::compatibleLayers( QgsProject *project, 
   for ( QgsVectorLayer *vl : vectorLayers )
     layers << vl;
 
-  const auto meshLayers = compatibleMeshLayers( project, false );
+  //~ const auto meshLayers = compatibleMeshLayers( project, false );
+  const auto meshLayers = compatibleMapLayers< QgsMeshLayer >( project, false );
   for ( QgsMeshLayer *vl : meshLayers )
     layers << vl;
 
-  const auto pluginLayers = compatiblePluginLayers( project, false );
+  //~ const auto pluginLayers = compatiblePluginLayers( project, false );
+  const auto pluginLayers = compatibleMapLayers< QgsPluginLayer >( project, false );
   for ( QgsPluginLayer *pl : pluginLayers )
     layers << pl;
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -441,6 +441,20 @@ class CORE_EXPORT QgsProcessingUtils
                              const QList< int > &sourceTypes = QList< int >() );
 
     /**
+     * Returns a list of map layers with the given layer type from a \a project which are compatible
+     * with the processing framework.
+     *
+     * If the \a sort argument is TRUE then the layers will be sorted by their QgsMapLayer::name()
+     * value.
+     * \see compatibleRasterLayers()
+     * \see compatibleVectorLayers()
+     * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
+     * \since QGIS 3.22
+     */
+    template< typename T> static QList< T * > compatibleMapLayers( QgsProject *project, bool sort = true );
+
+    /**
      * Interprets a \a string as a map layer from a store.
      *
      * This method attempts to match a string to a store map layer, using

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -30,6 +30,7 @@
 #include "qgsremappingproxyfeaturesink.h"
 
 class QgsMeshLayer;
+class QgsPluginLayer;
 class QgsProject;
 class QgsProcessingContext;
 class QgsMapLayerStore;
@@ -59,6 +60,7 @@ class CORE_EXPORT QgsProcessingUtils
      * value.
      * \see compatibleVectorLayers()
      * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      */
     static QList< QgsRasterLayer * > compatibleRasterLayers( QgsProject *project, bool sort = true );
@@ -76,6 +78,7 @@ class CORE_EXPORT QgsProcessingUtils
      * value.
      * \see compatibleRasterLayers()
      * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      */
     static QList< QgsVectorLayer * > compatibleVectorLayers( QgsProject *project,
@@ -91,11 +94,28 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \see compatibleRasterLayers()
      * \see compatibleVectorLayers()
+     * \see compatiblePluginLayers()
      * \see compatibleLayers()
      *
      * \since QGIS 3.6
      */
     static QList<QgsMeshLayer *> compatibleMeshLayers( QgsProject *project, bool sort = true );
+
+    /**
+     * Returns a list of plugin layers from a \a project which are compatible with the processing
+     * framework.
+     *
+     * If the \a sort argument is TRUE then the layers will be sorted by their QgsMapLayer::name()
+     * value.
+     *
+     * \see compatibleRasterLayers()
+     * \see compatibleVectorLayers()
+     * \see compatibleMeshLayers()
+     * \see compatibleLayers()
+     *
+     * \since QGIS 3.22
+     */
+    static QList<QgsPluginLayer *> compatiblePluginLayers( QgsProject *project, bool sort = true );
 
     /**
      * Returns a list of map layers from a \a project which are compatible with the processing
@@ -415,6 +435,7 @@ class CORE_EXPORT QgsProcessingUtils
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );
+    static bool canUseLayer( const QgsPluginLayer *layer );
     static bool canUseLayer( const QgsVectorTileLayer *layer );
     static bool canUseLayer( const QgsVectorLayer *layer,
                              const QList< int > &sourceTypes = QList< int >() );

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsmeshlayer.h"
 #include "qgsrasterlayer.h"
+#include "qgspluginlayer.h"
 #include "qgsproject.h"
 #include "processing/models/qgsprocessingmodelchildparametersource.h"
 #include <QStandardItemModel>
@@ -404,6 +405,17 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
       break;
     }
 
+    case QgsProcessing::TypePlugin:
+    {
+      const QList<QgsPluginLayer *> options = QgsProcessingUtils::compatiblePluginLayers( project, false );
+      for ( const QgsPluginLayer *layer : options )
+      {
+        addLayer( layer );
+      }
+
+      break;
+    }
+
     case QgsProcessing::TypeVector:
     case QgsProcessing::TypeVectorAnyGeometry:
     {
@@ -430,6 +442,11 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
       }
       const QList<QgsMeshLayer *> meshes = QgsProcessingUtils::compatibleMeshLayers( project );
       for ( const QgsMeshLayer *layer : meshes )
+      {
+        addLayer( layer );
+      }
+      const QList<QgsPluginLayer *> plugins = QgsProcessingUtils::compatiblePluginLayers( project );
+      for ( const QgsPluginLayer *layer : plugins )
       {
         addLayer( layer );
       }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -5757,6 +5757,7 @@ QgsProcessingMapLayerParameterDefinitionWidget::QgsProcessingMapLayerParameterDe
   mLayerTypeComboBox->addItem( tr( "Vector (Any Geometry Type)" ), QgsProcessing::TypeVectorAnyGeometry );
   mLayerTypeComboBox->addItem( tr( "Raster" ), QgsProcessing::TypeRaster );
   mLayerTypeComboBox->addItem( tr( "Mesh" ), QgsProcessing::TypeMesh );
+  mLayerTypeComboBox->addItem( tr( "Plugin" ), QgsProcessing::TypePlugin );
 
   if ( const QgsProcessingParameterMapLayer *layerParam = dynamic_cast<const QgsProcessingParameterMapLayer *>( definition ) )
   {
@@ -6736,6 +6737,17 @@ void QgsProcessingMultipleLayerPanelWidget::setModel( QgsProcessingModelAlgorith
       break;
     }
 
+    case QgsProcessing::TypePlugin:
+    {
+      mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterMapLayer::typeName()
+                      << QgsProcessingParameterMultipleLayers::typeName()
+                      << QgsProcessingParameterFile::typeName(),
+                      QStringList() << QgsProcessingOutputFile::typeName()
+                      << QgsProcessingOutputMapLayer::typeName()
+                      << QgsProcessingOutputMultipleLayers::typeName() );
+      break;
+    }
+
     case QgsProcessing::TypeVector:
     {
       mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterFeatureSource::typeName()
@@ -6877,6 +6889,7 @@ QgsProcessingMultipleLayerParameterDefinitionWidget::QgsProcessingMultipleLayerP
   mLayerTypeComboBox->addItem( tr( "Raster" ), QgsProcessing::TypeRaster );
   mLayerTypeComboBox->addItem( tr( "File" ), QgsProcessing::TypeFile );
   mLayerTypeComboBox->addItem( tr( "Mesh" ), QgsProcessing::TypeMesh );
+  mLayerTypeComboBox->addItem( tr( "Plugin" ), QgsProcessing::TypePlugin );
   if ( const QgsProcessingParameterMultipleLayers *layersParam = dynamic_cast<const QgsProcessingParameterMultipleLayers *>( definition ) )
     mLayerTypeComboBox->setCurrentIndex( mLayerTypeComboBox->findData( layersParam->layerType() ) );
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -2876,6 +2876,11 @@ void TestQgsProcessing::parameterMapLayer()
   QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMapLayer('non_optional', '', defaultValue='', types=[QgsProcessing.TypeRaster,QgsProcessing.TypeVectorPoint])" ) );
   code = def->asScriptCode();
   QCOMPARE( code, QStringLiteral( "##non_optional=layer raster point" ) );
+  def->setDataTypes( QList< int >() << QgsProcessing::TypePlugin );
+  pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMapLayer('non_optional', '', defaultValue='', types=[QgsProcessing.TypePlugin])" ) );
+  code = def->asScriptCode();
+  QCOMPARE( code, QStringLiteral( "##non_optional=layer plugin" ) );
 
   // optional
   def.reset( new QgsProcessingParameterMapLayer( "optional", QString(), v1->id(), true ) );


### PR DESCRIPTION
## Description
Allow to filter plugin layers in the `QgsProcessingParameterMapLayer` and `QgsProcessingParameterMultipleLayers`.

Fixes #44183