### PR TITLE
Bulk qt6 cmake updates

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -195,9 +195,15 @@ add_library(qgis_3d SHARED ${QGIS_3D_SRCS} ${QGIS_3D_HDRS} ${QGIS_3D_RCCS} ${QGI
 # require c++17
 target_compile_features(qgis_3d PRIVATE cxx_std_17)
 
-target_include_directories(qgis_3d SYSTEM PUBLIC
-  ${${QT_VERSION_BASE}_3DEXTRA_INCLUDE_DIR}
-)
+if (WITH_QT6)
+  target_include_directories(qgis_3d SYSTEM PUBLIC
+    ${QT6_3DEXTRA_INCLUDE_DIR}
+  )
+else()
+  target_include_directories(qgis_3d SYSTEM PUBLIC
+    ${QT5_3DEXTRA_INCLUDE_DIR}
+  )
+endif()
 
 target_include_directories(qgis_3d PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -196,7 +196,7 @@ add_library(qgis_3d SHARED ${QGIS_3D_SRCS} ${QGIS_3D_HDRS} ${QGIS_3D_RCCS} ${QGI
 target_compile_features(qgis_3d PRIVATE cxx_std_17)
 
 target_include_directories(qgis_3d SYSTEM PUBLIC
-  ${QT5_3DEXTRA_INCLUDE_DIR}
+  ${${QT_VERSION_BASE}_3DEXTRA_INCLUDE_DIR}
 )
 
 target_include_directories(qgis_3d PUBLIC
@@ -212,7 +212,11 @@ target_include_directories(qgis_3d PUBLIC
   ${CMAKE_BINARY_DIR}/src/3d
 )
 
-target_link_libraries(qgis_3d Qt5::3DCore Qt5::3DRender Qt5::3DInput Qt5::3DLogic Qt5::3DExtras)
+if (WITH_QT6)
+  target_link_libraries(qgis_3d Qt6::3DCore Qt6::3DRender Qt6::3DInput Qt6::3DLogic Qt6::3DExtras)
+else()
+  target_link_libraries(qgis_3d Qt5::3DCore Qt5::3DRender Qt5::3DInput Qt5::3DLogic Qt5::3DExtras)
+endif()
 
 GENERATE_EXPORT_HEADER(
    qgis_3d

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -505,8 +505,8 @@ add_dependencies(qgis_gui ui)
 target_link_libraries(qgis_app
   ${QWT_LIBRARY}
   ${QWTPOLAR_LIBRARY}
-  ${Qt5Sql_LIBRARIES}
-  ${Qt5UiTools_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}UiTools_LIBRARIES}
   ${OPTIONAL_QTWEBKIT}
   #should only be needed for win
   ${QT_QTMAIN_LIBRARY}
@@ -526,7 +526,7 @@ if (WITH_BINDINGS)
 endif()
 
 if(ENABLE_MODELTEST)
-  target_link_libraries(qgis_app ${Qt5Test_LIBRARIES})
+  target_link_libraries(qgis_app ${${QT_VERSION_BASE}Test_LIBRARIES})
 endif()
 
 if (WITH_3D)

--- a/src/crashhandler/CMakeLists.txt
+++ b/src/crashhandler/CMakeLists.txt
@@ -2,8 +2,13 @@ include_directories(SYSTEM
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-QT5_WRAP_UI(CRASH_UIS_H qgscrashdialog.ui)
-QT5_WRAP_CPP(CRASH_HDR_MOC qgscrashdialog.h)
+if (WITH_QT6)
+  QT6_WRAP_UI(CRASH_UIS_H qgscrashdialog.ui)
+  QT6_WRAP_CPP(CRASH_HDR_MOC qgscrashdialog.h)
+else()
+  QT5_WRAP_UI(CRASH_UIS_H qgscrashdialog.ui)
+  QT5_WRAP_CPP(CRASH_HDR_MOC qgscrashdialog.h)
+endif()
 
 set(IMAGE_RCCS ../../images/images.qrc)
 
@@ -24,9 +29,9 @@ add_executable(qgiscrashhandler WIN32
 target_compile_features(qgiscrashhandler PRIVATE cxx_std_17)
 
 target_link_libraries(qgiscrashhandler
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Gui_LIBRARIES}
-  ${Qt5Widgets_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Gui_LIBRARIES}
+  ${${QT_VERSION_BASE}Widgets_LIBRARIES}
   dbghelp
 )
 

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_definitions(-DQT_PLUGIN)
 add_definitions(-DQT_SHARED)
 
-find_package(Qt5UiPlugin REQUIRED)
-find_package(Qt5Designer REQUIRED)
+find_package(${QT_VERSION_BASE}UiPlugin REQUIRED)
+find_package(${QT_VERSION_BASE}Designer REQUIRED)
 
 set(QT_USE_QTDESIGNER ON)
 
@@ -94,11 +94,15 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}/../ui
 )
 include_directories(SYSTEM
-  ${Qt5UiPlugin_INCLUDE_DIRS}
-  ${Qt5Designer_INCLUDE_DIRS}
+  ${${QT_VERSION_BASE}UiPlugin_INCLUDE_DIRS}
+  ${${QT_VERSION_BASE}Designer_INCLUDE_DIRS}
 )
 
-QT5_WRAP_CPP(QGIS_CUSTOMWIDGETS_MOC_SRCS ${QGIS_CUSTOMWIDGETS_MOC_HDRS})
+if (WITH_QT6)
+  QT5_WRAP_CPP(QGIS_CUSTOMWIDGETS_MOC_SRCS ${QGIS_CUSTOMWIDGETS_MOC_HDRS})
+else()
+  QT6_WRAP_CPP(QGIS_CUSTOMWIDGETS_MOC_SRCS ${QGIS_CUSTOMWIDGETS_MOC_HDRS})
+endif()
 
 #############################################################
 # qgis_customwidgets library

--- a/src/plugins/geometry_checker/CMakeLists.txt
+++ b/src/plugins/geometry_checker/CMakeLists.txt
@@ -30,7 +30,11 @@ set (geometrychecker_RCCS
 ########################################################
 # Build
 
-QT5_WRAP_UI (geometrychecker_UIS_H  ${geometrychecker_UIS})
+if (WITH_QT6)
+  QT6_WRAP_UI (geometrychecker_UIS_H  ${geometrychecker_UIS})
+else()
+  QT5_WRAP_UI (geometrychecker_UIS_H  ${geometrychecker_UIS})
+endif()
 
 add_library (geometrycheckerplugin   MODULE ${geometrychecker_SRCS}  ${geometrychecker_RCCS} ${geometrychecker_UIS_H})
 

--- a/src/plugins/gps_importer/CMakeLists.txt
+++ b/src/plugins/gps_importer/CMakeLists.txt
@@ -20,7 +20,11 @@ set (GPS_RCCS  qgsgps_plugin.qrc)
 ########################################################
 # Build
 
-QT5_WRAP_UI (GPS_UIS_H  ${GPS_UIS})
+if (WITH_QT6)
+  QT6_WRAP_UI (GPS_UIS_H  ${GPS_UIS})
+else()
+  QT5_WRAP_UI (GPS_UIS_H  ${GPS_UIS})
+endif()
 
 add_library (gpsimporterplugin MODULE ${GPS_SRCS} ${GPS_RCCS} ${GPS_UIS_H})
 

--- a/src/plugins/grass/CMakeLists.txt
+++ b/src/plugins/grass/CMakeLists.txt
@@ -170,8 +170,13 @@ macro(ADD_GRASSPLUGIN GRASS_BUILD_VERSION)
     set(GRASS_MAJOR_VERSION ${GRASS_MAJOR_VERSION${GRASS_BUILD_VERSION}})
     set(GRASS_MINOR_VERSION ${GRASS_MINOR_VERSION${GRASS_BUILD_VERSION}})
 
-    QT5_WRAP_UI (GRASS_PLUGIN_UIS_H ${GRASS_PLUGIN_UIS})
-    QT5_WRAP_CPP (GRASS_PLUGIN_MOC_SRCS ${GRASS_PLUGIN_MOC_HDRS})
+    if (WITH_QT6)
+      QT6_WRAP_UI (GRASS_PLUGIN_UIS_H ${GRASS_PLUGIN_UIS})
+      QT6_WRAP_CPP (GRASS_PLUGIN_MOC_SRCS ${GRASS_PLUGIN_MOC_HDRS})
+    else()
+      QT5_WRAP_UI (GRASS_PLUGIN_UIS_H ${GRASS_PLUGIN_UIS})
+      QT5_WRAP_CPP (GRASS_PLUGIN_MOC_SRCS ${GRASS_PLUGIN_MOC_HDRS})
+    endif()
 
     include_directories(
       ${CMAKE_BINARY_DIR}/src/providers/grass/${GRASS_BUILD_VERSION}
@@ -202,7 +207,7 @@ macro(ADD_GRASSPLUGIN GRASS_BUILD_VERSION)
     if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
       target_link_libraries(grassplugin${GRASS_BUILD_VERSION} ulog)
     endif()
-
+.
     # override default path where built files are put to allow running qgis without installing
     # the binary goes under libexec subdir
     set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_LIBEXEC_SUBDIR}/grass/bin)
@@ -215,9 +220,9 @@ macro(ADD_GRASSPLUGIN GRASS_BUILD_VERSION)
     )
 
     target_link_libraries (qgis.g.browser${GRASS_BUILD_VERSION}
-      ${Qt5Gui_LIBRARIES}
-      ${Qt5Widgets_LIBRARIES}
-      ${Qt5Core_LIBRARIES}
+      ${${QT_VERSION_BASE}Gui_LIBRARIES}
+      ${${QT_VERSION_BASE}Widgets_LIBRARIES}
+      ${${QT_VERSION_BASE}Core_LIBRARIES}
     )
 
     ########################################################

--- a/src/plugins/grass/CMakeLists.txt
+++ b/src/plugins/grass/CMakeLists.txt
@@ -207,7 +207,7 @@ macro(ADD_GRASSPLUGIN GRASS_BUILD_VERSION)
     if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
       target_link_libraries(grassplugin${GRASS_BUILD_VERSION} ulog)
     endif()
-.
+
     # override default path where built files are put to allow running qgis without installing
     # the binary goes under libexec subdir
     set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_LIBEXEC_SUBDIR}/grass/bin)

--- a/src/plugins/offline_editing/CMakeLists.txt
+++ b/src/plugins/offline_editing/CMakeLists.txt
@@ -18,7 +18,11 @@ set (offline_editing_plugin_RCCS  offline_editing_plugin.qrc)
 ########################################################
 # Build
 
-QT5_WRAP_UI(offline_editing_plugin_UIS_H ${offline_editing_plugin_UIS})
+if (WITH_QT6)
+  QT6_WRAP_UI(offline_editing_plugin_UIS_H ${offline_editing_plugin_UIS})
+else()
+  QT5_WRAP_UI(offline_editing_plugin_UIS_H ${offline_editing_plugin_UIS})
+endif()
 
 add_library (offlineeditingplugin MODULE
   ${offline_editing_plugin_SRCS}

--- a/src/plugins/topology/CMakeLists.txt
+++ b/src/plugins/topology/CMakeLists.txt
@@ -21,7 +21,11 @@ set (topol_RCCS  topol.qrc)
 ########################################################
 # Build
 
-QT5_WRAP_UI (topol_UIS_H  ${topol_UIS})
+if (WITH_QT6)
+  QT6_WRAP_UI (topol_UIS_H  ${topol_UIS})
+else()
+  QT5_WRAP_UI (topol_UIS_H  ${topol_UIS})
+endif()
 
 add_library (topolplugin MODULE ${topol_SRCS} ${topol_RCCS} ${topol_UIS_H})
 

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 target_link_libraries(qgis_process
   qgis_core
   qgis_analysis
-  ${Qt5Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
   ${PROJ_LIBRARY}
   ${GEOS_LIBRARY}
   ${GDAL_LIBRARY}

--- a/src/providers/db2/CMakeLists.txt
+++ b/src/providers/db2/CMakeLists.txt
@@ -46,7 +46,7 @@ target_compile_features(provider_db2 PRIVATE cxx_std_17)
 
 target_link_libraries (provider_db2
   qgis_core
-  ${Qt5Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
 )
 
 if (WITH_GUI)

--- a/src/providers/grass/CMakeLists.txt
+++ b/src/providers/grass/CMakeLists.txt
@@ -62,9 +62,16 @@ macro(ADD_GRASSLIB GRASS_BUILD_VERSION)
       )
     endif()
 
-    QT5_WRAP_UI (GRASS_LIBRARY_UIS_H
-      ../qgsgrassoptionsbase.ui
-    )
+    if (WITH_QT6)
+      QT6_WRAP_UI (GRASS_LIBRARY_UIS_H
+	../qgsgrassoptionsbase.ui
+      )
+    else()
+      QT5_WRAP_UI (GRASS_LIBRARY_UIS_H
+	../qgsgrassoptionsbase.ui
+      )
+    endif()
+
 
     add_library(qgisgrass${GRASS_BUILD_VERSION} SHARED
       ${GRASS_LIBRARY_SRCS}

--- a/src/providers/mssql/CMakeLists.txt
+++ b/src/providers/mssql/CMakeLists.txt
@@ -39,7 +39,7 @@ target_compile_features(provider_mssql PRIVATE cxx_std_17)
 
 target_link_libraries(provider_mssql
   qgis_core
-  ${Qt5Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
 )
 
 if (WITH_GUI)

--- a/src/providers/oracle/CMakeLists.txt
+++ b/src/providers/oracle/CMakeLists.txt
@@ -54,7 +54,7 @@ target_compile_features(provider_oracle PRIVATE cxx_std_17)
 
 target_link_libraries (provider_oracle
   qgis_core
-  ${Qt5Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
 )
 
 if (WITH_GUI)

--- a/src/providers/oracle/ocispatial/CMakeLists.txt
+++ b/src/providers/oracle/ocispatial/CMakeLists.txt
@@ -10,7 +10,7 @@ add_definitions(-DQT_SHARED)
 
 include_directories(SYSTEM
 	${OCI_INCLUDE_DIR}
-	${Qt5Sql_PRIVATE_INCLUDE_DIRS}
+	${${QT_VERSION_BASE}Sql_PRIVATE_INCLUDE_DIRS}
 )
 
 set(QSQLOCISPATIAL_SRC qsql_ocispatial.cpp main.cpp qsql_ocispatial.h main.h)
@@ -18,8 +18,8 @@ set(QSQLOCISPATIAL_SRC qsql_ocispatial.cpp main.cpp qsql_ocispatial.h main.h)
 add_library(qsqlocispatial SHARED ${QSQLOCISPATIAL_SRC})
 
 target_link_libraries(qsqlocispatial
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
   ${OCI_LIBRARY}
 )
 

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -126,12 +126,12 @@ target_link_libraries (provider_pdal
 if (WITH_GUI)
   target_link_libraries (provider_pdal
     ${PDAL_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
-    ${Qt5Sql_LIBRARIES}
-    ${Qt5Concurrent_LIBRARIES}
+    ${${QT_VERSION_BASE}Xml_LIBRARIES}
+    ${${QT_VERSION_BASE}Core_LIBRARIES}
+    ${${QT_VERSION_BASE}Svg_LIBRARIES}
+    ${${QT_VERSION_BASE}Network_LIBRARIES}
+    ${${QT_VERSION_BASE}Sql_LIBRARIES}
+    ${${QT_VERSION_BASE}Concurrent_LIBRARIES}
     qgis_gui
   )
   add_dependencies(provider_pdal ui)
@@ -145,12 +145,12 @@ target_compile_features(provider_pdal_a PRIVATE cxx_std_17)
 
 target_link_libraries (provider_pdal_a
   ${PDAL_LIBRARIES}
-  ${Qt5Xml_LIBRARIES}
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Svg_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${Qt5Sql_LIBRARIES}
-  ${Qt5Concurrent_LIBRARIES}
+  ${${QT_VERSION_BASE}Xml_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Svg_LIBRARIES}
+  ${${QT_VERSION_BASE}Network_LIBRARIES}
+  ${${QT_VERSION_BASE}Sql_LIBRARIES}
+  ${${QT_VERSION_BASE}Concurrent_LIBRARIES}
   qgis_core
 )
 
@@ -162,12 +162,12 @@ if (WITH_GUI)
 
   target_link_libraries (provider_pdal_gui_a
     ${PDAL_LIBRARIES}
-    ${Qt5Xml_LIBRARIES}
-    ${Qt5Core_LIBRARIES}
-    ${Qt5Svg_LIBRARIES}
-    ${Qt5Network_LIBRARIES}
-    ${Qt5Sql_LIBRARIES}
-    ${Qt5Concurrent_LIBRARIES}
+    ${${QT_VERSION_BASE}Xml_LIBRARIES}
+    ${${QT_VERSION_BASE}Core_LIBRARIES}
+    ${${QT_VERSION_BASE}Svg_LIBRARIES}
+    ${${QT_VERSION_BASE}Network_LIBRARIES}
+    ${${QT_VERSION_BASE}Sql_LIBRARIES}
+    ${${QT_VERSION_BASE}Concurrent_LIBRARIES}
     qgis_gui
   )
   add_dependencies(provider_pdal_gui_a ui)

--- a/src/quickgui/CMakeLists.txt
+++ b/src/quickgui/CMakeLists.txt
@@ -36,7 +36,12 @@ include_directories(SYSTEM
 
 ############################################################
 # qgis_quick shared library
-QT5_WRAP_CPP(QGIS_QUICK_GUI_MOC_SRCS ${QGIS_QUICK_GUI_MOC_HDRS})
+if (WITH_QT6)
+  QT6_WRAP_CPP(QGIS_QUICK_GUI_MOC_SRCS ${QGIS_QUICK_GUI_MOC_HDRS})
+else()
+  QT5_WRAP_CPP(QGIS_QUICK_GUI_MOC_SRCS ${QGIS_QUICK_GUI_MOC_HDRS})
+endif()
+
 if(MSVC)
   set_source_files_properties(${QGIS_QUICK_GUI_MOC_SRCS} PROPERTIES COMPILE_FLAGS "/wd4512 /wd4996" )
 else()
@@ -52,9 +57,18 @@ add_library(qgis_quick ${LIBRARY_TYPE}
 # require c++17
 target_compile_features(qgis_quick PRIVATE cxx_std_17)
 
-target_link_libraries(qgis_quick Qt5::Quick Qt5::Qml Qt5::Xml Qt5::Concurrent Qt5::Positioning qgis_core)
+if (WITH_QT6)
+  target_link_libraries(qgis_quick Qt6::Quick Qt6::Qml Qt6::Xml Qt6::Concurrent Qt6::Positioning qgis_core)
+else()
+  target_link_libraries(qgis_quick Qt5::Quick Qt5::Qml Qt5::Xml Qt5::Concurrent Qt5::Positioning qgis_core)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-  target_link_libraries(qgis_quick Qt5::AndroidExtras)
+  if (WITH_QT6)
+    target_link_libraries(qgis_quick Qt6::AndroidExtras)
+  else()
+    target_link_libraries(qgis_quick Qt5::AndroidExtras)
+  endif()
 endif()
 target_compile_definitions(qgis_quick PRIVATE "-DQT_NO_FOREACH")
 

--- a/src/quickgui/plugin/CMakeLists.txt
+++ b/src/quickgui/plugin/CMakeLists.txt
@@ -43,7 +43,12 @@ include_directories(SYSTEM
 ############################################################
 # qgis_quick_plugin module (QML) library
 
-QT5_WRAP_CPP(QGIS_QUICK_PLUGIN_MOC_SRCS ${QGIS_QUICK_PLUGIN_MOC_HDRS})
+if (WITH_QT6)
+  QT6_WRAP_CPP(QGIS_QUICK_PLUGIN_MOC_SRCS ${QGIS_QUICK_PLUGIN_MOC_HDRS})
+else()
+  QT5_WRAP_CPP(QGIS_QUICK_PLUGIN_MOC_SRCS ${QGIS_QUICK_PLUGIN_MOC_HDRS})
+endif()
+
 if(MSVC)
   set_source_files_properties(${QGIS_QUICK_PLUGIN_MOC_SRCS} PROPERTIES COMPILE_FLAGS "/wd4512 /wd4996" )
 else()

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -26,12 +26,12 @@ include_directories(SYSTEM
 target_link_libraries(qgis_bench
   qgis_core
   ${SQLITE3_LIBRARY}
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${Qt5Svg_LIBRARIES}
-  ${Qt5Xml_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Network_LIBRARIES}
+  ${${QT_VERSION_BASE}Svg_LIBRARIES}
+  ${${QT_VERSION_BASE}Xml_LIBRARIES}
   ${OPTIONAL_QTWEBKIT}
-  ${Qt5Test_LIBRARIES}
+  ${${QT_VERSION_BASE}Test_LIBRARIES}
 )
 
 if(APPLE)

--- a/tests/src/3d/CMakeLists.txt
+++ b/tests/src/3d/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 include_directories(SYSTEM
   ${QT_INCLUDE_DIR}
   ${GDAL_INCLUDE_DIR}
-  ${QT5_3DEXTRA_INCLUDE_DIR}
+  ${${QT_VERSION_BASE}_3DEXTRA_INCLUDE_DIR}
 )
 
 

--- a/tests/src/3d/sandbox/CMakeLists.txt
+++ b/tests/src/3d/sandbox/CMakeLists.txt
@@ -32,11 +32,11 @@ target_compile_features(qgis_3d_sandbox PRIVATE cxx_std_17)
 
 set_target_properties(qgis_3d_sandbox PROPERTIES AUTORCC TRUE)
 target_link_libraries(qgis_3d_sandbox
-  ${Qt5Xml_LIBRARIES}
-  ${Qt5Core_LIBRARIES}
-  ${Qt5Svg_LIBRARIES}
-  ${Qt5Network_LIBRARIES}
-  ${Qt5Test_LIBRARIES}
+  ${${QT_VERSION_BASE}Xml_LIBRARIES}
+  ${${QT_VERSION_BASE}Core_LIBRARIES}
+  ${${QT_VERSION_BASE}Svg_LIBRARIES}
+  ${${QT_VERSION_BASE}Network_LIBRARIES}
+  ${${QT_VERSION_BASE}Test_LIBRARIES}
   ${PROJ_LIBRARY}
   ${GEOS_LIBRARY}
   ${GDAL_LIBRARY}


### PR DESCRIPTION
Remove more qt5 specific cmake config. Note that most of these are
untested on qt6, as the corresponding libraries cannot be built
with qt6 yet.
