### PR TITLE
QList::removeAt crashes in qt6 if index is -1, 

### DIFF
--- a/src/core/classification/qgsclassificationmethod.cpp
+++ b/src/core/classification/qgsclassificationmethod.cpp
@@ -325,9 +325,9 @@ void QgsClassificationMethod::makeBreaksSymmetric( QList<double> &breaks, double
     }
   }
   // remove symmetry point
-  if ( astride ) // && breaks.indexOf( symmetryPoint ) != -1) // if symmetryPoint is found
+  if ( astride )
   {
-    breaks.removeAt( breaks.indexOf( symmetryPoint ) );
+    breaks.removeAll( symmetryPoint );
   }
 }
 

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -106,7 +106,7 @@ bool QgsRenderChecker::isKnownAnomaly( const QString &diffImageFile )
                                   QDir::Files | QDir::NoSymLinks );
   //remove the control file from the list as the anomalies are
   //all files except the control file
-  myList.removeAt( myList.indexOf( QFileInfo( mExpectedImageFile ).fileName() ) );
+  myList.removeAll( QFileInfo( mExpectedImageFile ).fileName() );
 
   QString myImageHash = imageToHash( diffImageFile );
 


### PR DESCRIPTION
...so use QList::removeAll instead of QList::removeAt( QList::indexOf(...
