### PR TITLE
Ensure that LayerRenderJob objects are never copied

### DIFF
--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -161,9 +161,9 @@ void QgsMapRendererCustomPainterJob::cancelWithoutBlocking()
   }
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
-    it->context.setRenderingStopped( true );
+    it->context()->setRenderingStopped( true );
     if ( it->renderer && it->renderer->feedback() )
       it->renderer->feedback()->cancel();
   }
@@ -284,19 +284,19 @@ void QgsMapRendererCustomPainterJob::staticRender( QgsMapRendererCustomPainterJo
 
 void QgsMapRendererCustomPainterJob::doRender()
 {
-  bool hasSecondPass = ! mSecondPassLayerJobs.isEmpty();
+  bool hasSecondPass = ! mSecondPassLayerJobs.empty();
   QgsDebugMsgLevel( QStringLiteral( "Starting to render layer stack." ), 5 );
   QElapsedTimer renderTime;
   renderTime.start();
 
-  for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
     LayerRenderJob &job = *it;
 
-    if ( job.context.renderingStopped() )
+    if ( job.context()->renderingStopped() )
       break;
 
-    if ( ! hasSecondPass && job.context.useAdvancedEffects() )
+    if ( ! hasSecondPass && job.context()->useAdvancedEffects() )
     {
       // Set the QPainter composition mode so that this layer is rendered using
       // the desired blending mode
@@ -371,7 +371,7 @@ void QgsMapRendererCustomPainterJob::doRender()
   {
     for ( LayerRenderJob &job : mSecondPassLayerJobs )
     {
-      if ( job.context.renderingStopped() )
+      if ( job.context()->renderingStopped() )
         break;
 
       if ( !job.cached )

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -161,11 +161,11 @@ void QgsMapRendererCustomPainterJob::cancelWithoutBlocking()
   }
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( LayerRenderJob &job : mLayerJobs )
   {
-    it->context()->setRenderingStopped( true );
-    if ( it->renderer && it->renderer->feedback() )
-      it->renderer->feedback()->cancel();
+    job.context()->setRenderingStopped( true );
+    if ( job.renderer && job.renderer->feedback() )
+      job.renderer->feedback()->cancel();
   }
 }
 
@@ -289,10 +289,8 @@ void QgsMapRendererCustomPainterJob::doRender()
   QElapsedTimer renderTime;
   renderTime.start();
 
-  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( LayerRenderJob &job : mLayerJobs )
   {
-    LayerRenderJob &job = *it;
-
     if ( job.context()->renderingStopped() )
       break;
 

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.h
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.h
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererAbstract
     QgsLabelingResults *takeLabelingResults() SIP_TRANSFER override;
 
     //! \note not available in Python bindings
-    const LayerRenderJobs &jobs() const { return mLayerJobs; } SIP_SKIP
+    const std::vector< LayerRenderJob > &jobs() const { return mLayerJobs; } SIP_SKIP
 
     /**
      * Wait for the job to be finished - and keep the thread's event loop running while waiting.
@@ -145,13 +145,13 @@ class CORE_EXPORT QgsMapRendererCustomPainterJob : public QgsMapRendererAbstract
     std::unique_ptr< QgsLabelingEngine > mLabelingEngineV2;
 
     bool mActive;
-    LayerRenderJobs mLayerJobs;
+    std::vector< LayerRenderJob > mLayerJobs;
     LabelRenderJob mLabelJob;
     bool mRenderSynchronously = false;
     bool mPrepared = false;
     bool mPrepareOnly = false;
 
-    LayerRenderJobs mSecondPassLayerJobs;
+    std::vector< LayerRenderJob > mSecondPassLayerJobs;
 };
 
 

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -796,9 +796,8 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
 
 void QgsMapRendererJob::cleanupJobs( std::vector<LayerRenderJob> &jobs )
 {
-  for ( auto it = jobs.begin(); it != jobs.end(); ++it )
+  for ( LayerRenderJob &job : jobs )
   {
-    LayerRenderJob &job = *it;
     if ( job.img )
     {
       delete job.context()->painter();
@@ -842,7 +841,7 @@ void QgsMapRendererJob::cleanupJobs( std::vector<LayerRenderJob> &jobs )
 
 void QgsMapRendererJob::cleanupSecondPassJobs( std::vector< LayerRenderJob > &jobs )
 {
-  for ( auto &job : jobs )
+  for ( LayerRenderJob &job : jobs )
   {
     if ( job.img )
     {
@@ -909,10 +908,8 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings,
 #if DEBUG_RENDERING
   int i = 0;
 #endif
-  for ( auto it = jobs.begin(); it != jobs.end(); ++it )
+  for ( const LayerRenderJob &job : jobs )
   {
-    const LayerRenderJob &job = *it;
-
     if ( job.layer && job.layer->customProperty( QStringLiteral( "rendering/renderAboveLabels" ) ).toBool() )
       continue; // skip layer for now, it will be rendered after labels
 
@@ -952,10 +949,8 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings,
   }
 
   // render any layers with the renderAboveLabels flag now
-  for ( auto it = jobs.begin(); it != jobs.end(); ++it )
+  for ( const LayerRenderJob &job : jobs )
   {
-    const LayerRenderJob &job = *it;
-
     if ( !job.layer || !job.layer->customProperty( QStringLiteral( "rendering/renderAboveLabels" ) ).toBool() )
       continue;
 

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -703,13 +703,26 @@ std::vector< LayerRenderJob > QgsMapRendererJob::prepareSecondPassJobs( std::vec
     secondPassJobs.emplace_back( LayerRenderJob() );
     LayerRenderJob &job2 = secondPassJobs.back();
 
-#if 0
-    job2 = job;
-
-#endif
-
+    // copy safe(?) things from first pass job
+    // TODO -- this list should be refined, there's a lot of pointer copies here
+    // which are likely unsafe
+    job2.setContext( std::make_unique< QgsRenderContext >( *job.context() ) );
+    job2.imageInitialized = job.imageInitialized;
+    job2.renderer = job.renderer;
+    job2.img = job.img;
+    job2.blendMode = job.blendMode;
+    job2.opacity = job.opacity;
+    job2.layer = job.layer;
+    job2.completed = job.completed;
+    job2.renderingTime = job.renderingTime;
+    job2.estimatedRenderingTime = job.estimatedRenderingTime ;
+    job2.errors = job.errors;
+    job2.layerId = job.layerId;
+    job2.maskImage = job.maskImage;
+    job.maskJobs = job.maskJobs;
     job2.cached = false;
     job2.firstPassJob = &job;
+
     QgsVectorLayer *vl1 = qobject_cast<QgsVectorLayer *>( job.layer );
 
     // ... but clear the image

--- a/src/core/maprenderer/qgsmaprendererparalleljob.cpp
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.cpp
@@ -80,9 +80,9 @@ void QgsMapRendererParallelJob::cancel()
   QgsDebugMsgLevel( QStringLiteral( "PARALLEL cancel at status %1" ).arg( mStatus ), 2 );
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
-    it->context.setRenderingStopped( true );
+    it->context()->setRenderingStopped( true );
     if ( it->renderer && it->renderer->feedback() )
       it->renderer->feedback()->cancel();
   }
@@ -125,9 +125,9 @@ void QgsMapRendererParallelJob::cancelWithoutBlocking()
   QgsDebugMsgLevel( QStringLiteral( "PARALLEL cancel at status %1" ).arg( mStatus ), 2 );
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
-    it->context.setRenderingStopped( true );
+    it->context()->setRenderingStopped( true );
     if ( it->renderer && it->renderer->feedback() )
       it->renderer->feedback()->cancel();
   }
@@ -224,8 +224,7 @@ void QgsMapRendererParallelJob::renderLayersFinished()
 {
   Q_ASSERT( mStatus == RenderingLayers );
 
-  LayerRenderJobs::const_iterator it = mLayerJobs.constBegin();
-  for ( ; it != mLayerJobs.constEnd(); ++it )
+  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
     if ( !it->errors.isEmpty() )
     {
@@ -234,7 +233,7 @@ void QgsMapRendererParallelJob::renderLayersFinished()
   }
 
   // compose final image for labeling
-  if ( mSecondPassLayerJobs.isEmpty() )
+  if ( mSecondPassLayerJobs.empty() )
   {
     mFinalImage = composeImage( mSettings, mLayerJobs, mLabelJob, mCache );
   }
@@ -285,7 +284,7 @@ void QgsMapRendererParallelJob::renderingFinished()
     mLabelJob.maskImage->save( QString( "/tmp/labels_mask.png" ) );
   }
 #endif
-  if ( ! mSecondPassLayerJobs.isEmpty() )
+  if ( ! mSecondPassLayerJobs.empty() )
   {
     mStatus = RenderingSecondPass;
     // We have a second pass to do.
@@ -344,7 +343,7 @@ void QgsMapRendererParallelJob::renderLayersSecondPassFinished()
 
 void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob &job )
 {
-  if ( job.context.renderingStopped() )
+  if ( job.context()->renderingStopped() )
     return;
 
   if ( job.cached )

--- a/src/core/maprenderer/qgsmaprendererparalleljob.cpp
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.cpp
@@ -80,11 +80,11 @@ void QgsMapRendererParallelJob::cancel()
   QgsDebugMsgLevel( QStringLiteral( "PARALLEL cancel at status %1" ).arg( mStatus ), 2 );
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( LayerRenderJob &job : mLayerJobs )
   {
-    it->context()->setRenderingStopped( true );
-    if ( it->renderer && it->renderer->feedback() )
-      it->renderer->feedback()->cancel();
+    job.context()->setRenderingStopped( true );
+    if ( job.renderer && job.renderer->feedback() )
+      job.renderer->feedback()->cancel();
   }
 
   if ( mStatus == RenderingLayers )
@@ -125,11 +125,11 @@ void QgsMapRendererParallelJob::cancelWithoutBlocking()
   QgsDebugMsgLevel( QStringLiteral( "PARALLEL cancel at status %1" ).arg( mStatus ), 2 );
 
   mLabelJob.context.setRenderingStopped( true );
-  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( LayerRenderJob &job : mLayerJobs )
   {
-    it->context()->setRenderingStopped( true );
-    if ( it->renderer && it->renderer->feedback() )
-      it->renderer->feedback()->cancel();
+    job.context()->setRenderingStopped( true );
+    if ( job.renderer && job.renderer->feedback() )
+      job.renderer->feedback()->cancel();
   }
 
   if ( mStatus == RenderingLayers )
@@ -224,11 +224,11 @@ void QgsMapRendererParallelJob::renderLayersFinished()
 {
   Q_ASSERT( mStatus == RenderingLayers );
 
-  for ( auto it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
+  for ( const LayerRenderJob &job : mLayerJobs )
   {
-    if ( !it->errors.isEmpty() )
+    if ( !job.errors.isEmpty() )
     {
-      mErrors.append( Error( it->layer->id(), it->errors.join( ',' ) ) );
+      mErrors.append( Error( job.layerId, job.errors.join( ',' ) ) );
     }
   }
 

--- a/src/core/maprenderer/qgsmaprendererparalleljob.h
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.h
@@ -72,10 +72,10 @@ class CORE_EXPORT QgsMapRendererParallelJob : public QgsMapRendererQImageJob
     QFuture<void> mFuture;
     QFutureWatcher<void> mFutureWatcher;
 
-    LayerRenderJobs mLayerJobs;
+    std::vector< LayerRenderJob > mLayerJobs;
     LabelRenderJob mLabelJob;
 
-    LayerRenderJobs mSecondPassLayerJobs;
+    std::vector< LayerRenderJob > mSecondPassLayerJobs;
     QFuture<void> mSecondPassFuture;
     QFutureWatcher<void> mSecondPassFutureWatcher;
 

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
@@ -104,7 +104,7 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
     LayerRenderJob &job = *mJobIt;
     job.renderer->renderContext()->setPainter( painter );
 
-    if ( job.context.useAdvancedEffects() )
+    if ( job.context()->useAdvancedEffects() )
     {
       // Set the QPainter composition mode so that this layer is rendered using
       // the desired blending mode
@@ -126,7 +126,7 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
       painter->drawImage( 0, 0, *job.img );
       painter->setOpacity( 1.0 );
     }
-    job.context.setPainter( nullptr );
+    job.context()->setPainter( nullptr );
   }
   else
   {

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.h
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.h
@@ -119,9 +119,9 @@ class CORE_EXPORT QgsMapRendererStagedRenderJob : public QgsMapRendererAbstractC
 
     std::unique_ptr< QgsLabelingEngine > mLabelingEngineV2;
 
-    LayerRenderJobs mLayerJobs;
+    std::vector< LayerRenderJob > mLayerJobs;
     LabelRenderJob mLabelJob;
-    LayerRenderJobs::iterator mJobIt;
+    std::vector< LayerRenderJob >::iterator mJobIt;
 
     bool mNextIsLabel = false;
     bool mExportedLabels = false;


### PR DESCRIPTION
When a LayerRenderJob object is copied, it would create a new
copy-constructed QgsRenderContext member as a result. But we
store references to the LayerRenderJob's context in the
QgsMapLayerRenderer instances, so this potentially results
in using references to deleted objects.

In Qt5 builds this wasn't an issue, as LayerRenderJob objects
weren't being copied. But Qt6's revamped containers WERE
detaching and copying LayerRenderJob objects, resulting
in crashes in all the map renderer tests.

So... explicitly block copying of LayerRenderJob to fix this.
And then use std::vector instead of QList for storage of job
lists as we can't use Qt containers with non-copy-constructible
classes.

(This is a step forward anyway, because the ownership of the
raw pointers in LayerRenderJob has always been somewhat opaque,
and by avoiding copies of LayerRenderJob we have the opportunity
to later clean this up and make them unique_ptrs were appropriate)

Fixes all map renders crashing on Qt6 builds
