### PR TITLE
Fix geometry handling in postgres expression compiler

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1239,6 +1239,13 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
     case QVariant::List:
       return quotedList( value.toList() );
 
+    case QVariant::UserType:
+      if ( value.canConvert<QgsGeometry>() )
+      {
+        QgsGeometry geom = value.value<QgsGeometry>();
+        return QString( "ST_GeomFromText('%1')" ).arg( geom.asWkt() );
+      }
+
     case QVariant::Double:
     case QVariant::String:
     default:

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1239,13 +1239,6 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
     case QVariant::List:
       return quotedList( value.toList() );
 
-    case QVariant::UserType:
-      if ( value.canConvert<QgsGeometry>() )
-      {
-        QgsGeometry geom = value.value<QgsGeometry>();
-        return QString( "ST_GeomFromText('%1')" ).arg( geom.asWkt() );
-      }
-
     case QVariant::Double:
     case QVariant::String:
     default:

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -44,6 +44,10 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
     case QVariant::Double:
       return value.toString();
 
+    //most likely a geometry
+    case QVariant::UserType:
+      ok = false;
+
     default:
       break;
   }

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -44,6 +44,13 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
     case QVariant::Double:
       return value.toString();
 
+    case QVariant::UserType:
+      if ( value.canConvert<QgsGeometry>() )
+      {
+        QgsGeometry geom = value.value<QgsGeometry>();
+        return QString( "ST_GeomFromText('%1',%2)" ).arg( geom.asWkt() ).arg( mRequestedSrid.isEmpty() ? mDetectedSrid : mRequestedSrid );
+      }
+
     default:
       break;
   }

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -50,6 +50,7 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
         QgsGeometry geom = value.value<QgsGeometry>();
         return QString( "ST_GeomFromText('%1',%2)" ).arg( geom.asWkt() ).arg( mRequestedSrid.isEmpty() ? mDetectedSrid : mRequestedSrid );
       }
+      break;
 
     default:
       break;

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -47,7 +47,7 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
     case QVariant::UserType:
       if ( value.canConvert<QgsGeometry>() )
       {
-        QgsGeometry geom = value.value<QgsGeometry>();
+        const QgsGeometry geom = value.value<QgsGeometry>();
         return QString( "ST_GeomFromText('%1',%2)" ).arg( geom.asWkt() ).arg( mRequestedSrid.isEmpty() ? mDetectedSrid : mRequestedSrid );
       }
       break;

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -44,10 +44,6 @@ QString QgsPostgresExpressionCompiler::quotedValue( const QVariant &value, bool 
     case QVariant::Double:
       return value.toString();
 
-    //most likely a geometry
-    case QVariant::UserType:
-      ok = false;
-
     default:
       break;
   }

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -34,6 +34,7 @@ add_qgis_test(testqgswmscapabilities.cpp MODULE provider LINKEDLIBRARIES provide
 add_qgis_test(testqgswmsccapabilities.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
 add_qgis_test(testqgswmsprovider.cpp MODULE provider LINKEDLIBRARIES provider_wms_a qgis_core)
 
+add_qgis_test(testqgspostgresexpressioncompiler.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
 add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
 add_qgis_test(testqgspostgresconn.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
 

--- a/tests/src/providers/testqgspostgresexpressioncompiler.cpp
+++ b/tests/src/providers/testqgspostgresexpressioncompiler.cpp
@@ -1,0 +1,62 @@
+/***************************************************************************
+
+ testqgspostgresexpressioncompiler.cpp
+
+ ---------------------
+ begin                : 23.07.2021
+ copyright            : (C) 2021 by Marco Hugentobler
+ email                : marco at sourcepole dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgspostgresexpressioncompiler.h"
+#include "qgspostgresfeatureiterator.h"
+#include "qgspostgresprovider.h"
+
+//The only purpose of this class is to set geomColumn and srid
+class QgsTestPostgresExpressionCompiler: public QgsPostgresExpressionCompiler
+{
+  public:
+    QgsTestPostgresExpressionCompiler( QgsPostgresFeatureSource *source, const QString &srid, const QString &geometryColumn ): QgsPostgresExpressionCompiler( source )
+    {
+      mDetectedSrid = srid;
+      mGeometryColumn = geometryColumn;
+    }
+};
+
+class TestQgsPostgresExpressionCompiler: public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    TestQgsPostgresExpressionCompiler() = default;
+
+  private slots:
+    void testGeometryFromWkt();
+};
+
+void TestQgsPostgresExpressionCompiler::testGeometryFromWkt()
+{
+  QgsPostgresProvider p( QStringLiteral( "" ), QgsDataProvider::ProviderOptions() );
+  QgsPostgresFeatureSource featureSource( &p );
+  QgsTestPostgresExpressionCompiler compiler( &featureSource, QStringLiteral( "4326" ), QStringLiteral( "geom" ) );
+  QgsExpression exp( QStringLiteral( "intersects($geometry,geom_from_wkt('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'))" ) );
+  QgsExpressionContext expContext;
+  exp.prepare( &expContext );
+  QgsSqlExpressionCompiler::Result r = compiler.compile( &exp );
+  QCOMPARE( r, QgsSqlExpressionCompiler::Complete );
+  QString sql = compiler.result();
+  QCOMPARE( sql, QStringLiteral( "ST_Intersects(\"geom\",ST_GeomFromText('Polygon ((0 0, 1 0, 1 1, 0 1, 0 0))'))" ) );
+}
+
+QGSTEST_MAIN( TestQgsPostgresExpressionCompiler )
+
+#include "testqgspostgresexpressioncompiler.moc"

--- a/tests/src/providers/testqgspostgresexpressioncompiler.cpp
+++ b/tests/src/providers/testqgspostgresexpressioncompiler.cpp
@@ -54,7 +54,7 @@ void TestQgsPostgresExpressionCompiler::testGeometryFromWkt()
   QgsSqlExpressionCompiler::Result r = compiler.compile( &exp );
   QCOMPARE( r, QgsSqlExpressionCompiler::Complete );
   QString sql = compiler.result();
-  QCOMPARE( sql, QStringLiteral( "ST_Intersects(\"geom\",ST_GeomFromText('Polygon ((0 0, 1 0, 1 1, 0 1, 0 0))'))" ) );
+  QCOMPARE( sql, QStringLiteral( "ST_Intersects(\"geom\",ST_GeomFromText('Polygon ((0 0, 1 0, 1 1, 0 1, 0 0))',4326))" ) );
 }
 
 QGSTEST_MAIN( TestQgsPostgresExpressionCompiler )


### PR DESCRIPTION
The postgres expression compiler sometimes cannot compile expressions with geometry, e.g. "intersects($geometry,geom_from_wkt('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'))" results in "ST_Intersects("geom",)". The reason is that the geometry variant type is not handled in QgsPostgresExpressionCompiler::quotedValue and the method still returns true. This PR implements handling in quotedValue() to fix this issue (it would also possible to not handle it and return false in quotedValue()).
