### PR TITLE
remove ugly header from the dependencies list in the vector layer properties dialog (fix #44396)

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -2039,6 +2039,9 @@ border-radius: 2px;</string>
                 <property name="enabled">
                  <bool>true</bool>
                 </property>
+                <attribute name="headerVisible">
+                 <bool>false</bool>
+                </attribute>
                </widget>
               </item>
               <item>


### PR DESCRIPTION
## Description
There is an unused header in the dependencies list of the vector layer properties dialog. Removing it makes UI a bit cleaner.

Fix #44396.