### PR TITLE
Port GPS tools Convert GPX feature type tool to new processing algorithm

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -102,6 +102,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmforcerhr.cpp
   processing/qgsalgorithmfuzzifyraster.cpp
   processing/qgsalgorithmgeometrybyexpression.cpp
+  processing/qgsalgorithmgpsbabeltools.cpp
   processing/qgsalgorithmgrid.cpp
   processing/qgsalgorithmhillshade.cpp
   processing/qgsalgorithmimportphotos.cpp

--- a/src/analysis/processing/qgsalgorithmgpsbabeltools.cpp
+++ b/src/analysis/processing/qgsalgorithmgpsbabeltools.cpp
@@ -1,0 +1,221 @@
+/***************************************************************************
+                         qgsalgorithmgpsbabeltools.cpp
+                         ------------------
+    begin                : July 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmgpsbabeltools.h"
+#include "qgsvectorlayer.h"
+#include "qgsrunprocess.h"
+#include "qgsproviderutils.h"
+#include "qgssettings.h"
+
+///@cond PRIVATE
+
+QString QgsConvertGpxFeatureTypeAlgorithm::name() const
+{
+  return QStringLiteral( "convertgpxfeaturetype" );
+}
+
+QString QgsConvertGpxFeatureTypeAlgorithm::displayName() const
+{
+  return QObject::tr( "Convert GPX feature type" );
+}
+
+QStringList QgsConvertGpxFeatureTypeAlgorithm::tags() const
+{
+  return QObject::tr( "gps,tools,babel,tracks,waypoints,routes" ).split( ',' );
+}
+
+QString QgsConvertGpxFeatureTypeAlgorithm::group() const
+{
+  return QObject::tr( "GPS" );
+}
+
+QString QgsConvertGpxFeatureTypeAlgorithm::groupId() const
+{
+  return QStringLiteral( "gps" );
+}
+
+void QgsConvertGpxFeatureTypeAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterFile( QStringLiteral( "INPUT" ), QObject::tr( "Input file" ), QgsProcessingParameterFile::File, QString(), QVariant(), false,
+                QObject::tr( "GPX files" ) + QStringLiteral( " (*.gpx *.GPX)" ) ) );
+
+  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "CONVERSION" ), QObject::tr( "Conversion" ),
+  {
+    QObject::tr( "Waypoints from a Route" ),
+    QObject::tr( "Waypoints from a Track" ),
+    QObject::tr( "Route from Waypoints" ),
+    QObject::tr( "Track from Waypoints" )
+  }, false, 0 ) );
+
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output" ), QObject::tr( "GPX files" ) + QStringLiteral( " (*.gpx *.GPX)" ) ) );
+
+  addOutput( new QgsProcessingOutputVectorLayer( QStringLiteral( "OUTPUT_LAYER" ), QObject::tr( "Output layer" ) ) );
+}
+
+QIcon QgsConvertGpxFeatureTypeAlgorithm::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconGps.svg" ) );
+}
+
+QString QgsConvertGpxFeatureTypeAlgorithm::svgIconPath() const
+{
+  return QgsApplication::iconPath( QStringLiteral( "/mIconGps.svg" ) );
+}
+
+QString QgsConvertGpxFeatureTypeAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm uses the GPSBabel tool to convert GPX features from one type to another (e.g. converting all waypoint features to a route feature)." );
+}
+
+QgsConvertGpxFeatureTypeAlgorithm *QgsConvertGpxFeatureTypeAlgorithm::createInstance() const
+{
+  return new QgsConvertGpxFeatureTypeAlgorithm();
+}
+
+
+QVariantMap QgsConvertGpxFeatureTypeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QStringList convertStrings;
+
+  const QString inputPath = parameterAsString( parameters, QStringLiteral( "INPUT" ), context );
+  const QString outputPath = parameterAsString( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  const ConversionType convertType = static_cast< ConversionType >( parameterAsEnum( parameters, QStringLiteral( "CONVERSION" ), context ) );
+
+  // TODO -- fix the settings path when the rest of the GPS tools plugin is migrated
+  QgsSettings settings;
+  QString babelPath = settings.value( QStringLiteral( "Plugin-GPS/gpsbabelpath" ), QString() ).toString();
+  if ( babelPath.isEmpty() )
+    babelPath = QStringLiteral( "gpsbabel" );
+
+  QStringList processArgs;
+  QStringList logArgs;
+  createArgumentLists( inputPath, outputPath, convertType, processArgs, logArgs );
+  feedback->pushCommandInfo( QObject::tr( "Conversion command: " ) + babelPath + ' ' + logArgs.join( ' ' ) );
+
+  QgsBlockingProcess babelProcess( babelPath, processArgs );
+  babelProcess.setStdErrHandler( [ = ]( const QByteArray & ba )
+  {
+    feedback->reportError( ba );
+  } );
+  babelProcess.setStdOutHandler( [ = ]( const QByteArray & ba )
+  {
+    feedback->pushDebugInfo( ba );
+  } );
+
+  const int res = babelProcess.run( feedback );
+  if ( feedback->isCanceled() && res != 0 )
+  {
+    feedback->pushInfo( QObject::tr( "Process was canceled and did not complete" ) )  ;
+  }
+  else if ( !feedback->isCanceled() && babelProcess.exitStatus() == QProcess::CrashExit )
+  {
+    throw QgsProcessingException( QObject::tr( "Process was unexpectedly terminated" ) );
+  }
+  else if ( res == 0 )
+  {
+    feedback->pushInfo( QObject::tr( "Process completed successfully" ) );
+  }
+  else if ( babelProcess.processError() == QProcess::FailedToStart )
+  {
+    throw QgsProcessingException( QObject::tr( "Process %1 failed to start. Either %1 is missing, or you may have insufficient permissions to run the program." ).arg( babelPath ) );
+  }
+  else
+  {
+    throw QgsProcessingException( QObject::tr( "Process returned error code %1" ).arg( res ) );
+  }
+
+  std::unique_ptr< QgsVectorLayer > layer;
+  const QString layerName = QgsProviderUtils::suggestLayerNameFromFilePath( outputPath );
+  // add the layer
+  switch ( convertType )
+  {
+    case QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromRoute:
+    case QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromTrack:
+      layer = std::make_unique< QgsVectorLayer >( outputPath + "?type=waypoint", layerName, QStringLiteral( "gpx" ) );
+      break;
+    case QgsConvertGpxFeatureTypeAlgorithm::RouteFromWaypoints:
+      layer = std::make_unique< QgsVectorLayer >( outputPath + "?type=route", layerName, QStringLiteral( "gpx" ) );
+      break;
+    case QgsConvertGpxFeatureTypeAlgorithm::TrackFromWaypoints:
+      layer = std::make_unique< QgsVectorLayer >( outputPath + "?type=track", layerName, QStringLiteral( "gpx" ) );
+      break;
+  }
+
+  QVariantMap outputs;
+  if ( !layer->isValid() )
+  {
+    feedback->reportError( QObject::tr( "Resulting file is not a valid GPX layer" ) );
+  }
+  else
+  {
+    const QString layerId = layer->id();
+    outputs.insert( QStringLiteral( "OUTPUT_LAYER" ), layerId );
+    QgsProcessingContext::LayerDetails details( layer->name(), context.project(), QStringLiteral( "OUTPUT_LAYER" ), QgsProcessingUtils::LayerHint::Vector );
+    context.addLayerToLoadOnCompletion( layerId, details );
+    context.temporaryLayerStore()->addMapLayer( layer.release() );
+  }
+
+  outputs.insert( QStringLiteral( "OUTPUT" ), outputPath );
+  return outputs;
+}
+
+void QgsConvertGpxFeatureTypeAlgorithm::createArgumentLists( const QString &inputPath, const QString &outputPath, ConversionType conversion, QStringList &processArgs, QStringList &logArgs )
+{
+  logArgs.reserve( 10 );
+  processArgs.reserve( 10 );
+  for ( const QString &arg : { QStringLiteral( "-i" ), QStringLiteral( "gpx" ), QStringLiteral( "-f" ) } )
+  {
+    logArgs << arg;
+    processArgs << arg;
+  }
+
+  // when showing the babel command, wrap filenames in "", which is what QProcess does internally.
+  logArgs << QStringLiteral( "\"%1\"" ).arg( inputPath );
+  processArgs << inputPath;
+
+  QStringList convertStrings;
+  switch ( conversion )
+  {
+    case QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromRoute:
+      convertStrings << QStringLiteral( "-x" ) << QStringLiteral( "transform,wpt=rte,del" );
+      break;
+    case QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromTrack:
+      convertStrings << QStringLiteral( "-x" ) << QStringLiteral( "transform,wpt=trk,del" );
+      break;
+    case QgsConvertGpxFeatureTypeAlgorithm::RouteFromWaypoints:
+      convertStrings << QStringLiteral( "-x" ) << QStringLiteral( "transform,rte=wpt,del" );
+      break;
+    case QgsConvertGpxFeatureTypeAlgorithm::TrackFromWaypoints:
+      convertStrings << QStringLiteral( "-x" ) << QStringLiteral( "transform,trk=wpt,del" );
+      break;
+  }
+  logArgs << convertStrings;
+  processArgs << convertStrings;
+
+  for ( const QString &arg : { QStringLiteral( "-o" ), QStringLiteral( "gpx" ), QStringLiteral( "-F" ) } )
+  {
+    logArgs << arg;
+    processArgs << arg;
+  }
+
+  logArgs << QStringLiteral( "\"%1\"" ).arg( outputPath );
+  processArgs << outputPath;
+
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmgpsbabeltools.h
+++ b/src/analysis/processing/qgsalgorithmgpsbabeltools.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+                         qgsalgorithmgpsbabeltools.h
+                         ------------------
+    begin                : July 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMGPSBABELTOOLS_H
+#define QGSALGORITHMGPSBABELTOOLS_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgis_analysis.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayerfeatureiterator.h"
+
+///@cond PRIVATE
+
+/**
+ * Convert GPX feature type algorithm
+ */
+class ANALYSIS_EXPORT QgsConvertGpxFeatureTypeAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsConvertGpxFeatureTypeAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QIcon icon() const override;
+    QString svgIconPath() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QgsConvertGpxFeatureTypeAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+
+    enum ConversionType
+    {
+      WaypointsFromRoute = 0,
+      WaypointsFromTrack,
+      RouteFromWaypoints,
+      TrackFromWaypoints
+    };
+
+    /**
+     * Builds the argument lists for the babel command
+     */
+    static void createArgumentLists(
+      const QString &inputFile,
+      const QString &outputFile,
+      ConversionType conversion,
+      QStringList &processArgs,
+      QStringList &logArgs
+    );
+
+    friend class TestQgsProcessingAlgs;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMGPSBABELTOOLS_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -85,6 +85,7 @@
 #include "qgsalgorithmforcerhr.h"
 #include "qgsalgorithmfuzzifyraster.h"
 #include "qgsalgorithmgeometrybyexpression.h"
+#include "qgsalgorithmgpsbabeltools.h"
 #include "qgsalgorithmgrid.h"
 #include "qgsalgorithmhillshade.h"
 #include "qgsalgorithmjoinbyattribute.h"
@@ -334,6 +335,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsFuzzifyRasterGaussianMembershipAlgorithm() );
   addAlgorithm( new QgsFuzzifyRasterNearMembershipAlgorithm() );
   addAlgorithm( new QgsGeometryByExpressionAlgorithm() );
+  addAlgorithm( new QgsConvertGpxFeatureTypeAlgorithm() );
   addAlgorithm( new QgsGridAlgorithm() );
   addAlgorithm( new QgsHillshadeAlgorithm() );
   addAlgorithm( new QgsImportPhotosAlgorithm() );

--- a/src/plugins/gps_importer/qgsgpsplugin.h
+++ b/src/plugins/gps_importer/qgsgpsplugin.h
@@ -69,10 +69,6 @@ class QgsGpsPlugin: public QObject, public QgisPlugin
                         bool importWaypoints, bool importRoutes,
                         bool importTracks, const QString &outputFileName,
                         const QString &layerName );
-    void convertGPSFile( const QString &inputFileName,
-                         int convertType,
-                         const QString &outputFileName,
-                         const QString &layerName );
     void downloadFromGPS( const QString &device, const QString &port,
                           bool downloadWaypoints, bool downloadRoutes,
                           bool downloadTracks, const QString &outputFileName,

--- a/src/plugins/gps_importer/qgsgpsplugingui.h
+++ b/src/plugins/gps_importer/qgsgpsplugingui.h
@@ -53,9 +53,6 @@ class QgsGpsPluginGui : public QDialog, private Ui::QgsGpsPluginGuiBase
     void pbnIMPInput_clicked();
     void pbnIMPOutput_clicked();
 
-    void pbnCONVInput_clicked();
-    void pbnCONVOutput_clicked();
-
     void pbnDLOutput_clicked();
 
   private:
@@ -63,7 +60,6 @@ class QgsGpsPluginGui : public QDialog, private Ui::QgsGpsPluginGuiBase
     void populateULLayerComboBox();
     void populateIMPBabelFormats();
     void populatePortComboBoxes();
-    void populateCONVDialog();
 
     void saveState();
     void restoreState();
@@ -91,10 +87,6 @@ class QgsGpsPluginGui : public QDialog, private Ui::QgsGpsPluginGuiBase
                         bool importWaypoints, bool importRoutes,
                         bool importTracks, const QString &outputFileName,
                         const QString &layerName );
-    void convertGPSFile( const QString &inputFileName,
-                         int convertType,
-                         const QString &outputFileName,
-                         const QString &layerName );
     void downloadFromGPS( const QString &device, const QString &port, bool downloadWaypoints,
                           bool downloadRoutes, bool downloadTracks,
                           const QString &outputFileName, const QString &layerName );

--- a/src/plugins/gps_importer/qgsgpspluginguibase.ui
+++ b/src/plugins/gps_importer/qgsgpspluginguibase.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab1">
       <attribute name="title">
@@ -517,116 +517,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab5">
-      <attribute name="title">
-       <string>GPX Conversions</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_6">
-       <item row="0" column="0">
-        <widget class="QLabel" name="textLabel5_4">
-         <property name="text">
-          <string>GPX input file</string>
-         </property>
-         <property name="buddy">
-          <cstring>pbnCONVInput</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="leCONVInput">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="pbnCONVInput">
-         <property name="text">
-          <string>Browse…</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="textLabel5_3">
-         <property name="text">
-          <string>Conversion</string>
-         </property>
-         <property name="buddy">
-          <cstring>cmbCONVType</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="cmbCONVType">
-         <property name="minimumSize">
-          <size>
-           <width>10</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="textLabel5_2">
-         <property name="text">
-          <string>GPX output file</string>
-         </property>
-         <property name="buddy">
-          <cstring>leCONVOutput</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLineEdit" name="leCONVOutput"/>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="textLabel5_1">
-         <property name="text">
-          <string>Layer name</string>
-         </property>
-         <property name="buddy">
-          <cstring>leCONVLayer</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLineEdit" name="leCONVLayer"/>
-       </item>
-       <item row="4" column="1">
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="5" column="1">
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="2">
-        <widget class="QPushButton" name="pbnCONVOutput">
-         <property name="text">
-          <string>Save As…</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
     </widget>
    </item>
    <item>
@@ -673,12 +563,6 @@
   <tabstop>cmbULDevice</tabstop>
   <tabstop>pbULEditDevices</tabstop>
   <tabstop>cmbULPort</tabstop>
-  <tabstop>leCONVInput</tabstop>
-  <tabstop>pbnCONVInput</tabstop>
-  <tabstop>cmbCONVType</tabstop>
-  <tabstop>leCONVOutput</tabstop>
-  <tabstop>pbnCONVOutput</tabstop>
-  <tabstop>leCONVLayer</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -60,6 +60,7 @@
 #include "qgsmeshlayer.h"
 #include "qgsmarkersymbol.h"
 #include "qgsfillsymbol.h"
+#include "qgsalgorithmgpsbabeltools.h"
 
 class TestQgsProcessingAlgs: public QObject
 {
@@ -183,6 +184,8 @@ class TestQgsProcessingAlgs: public QObject
     void fileDownloader();
 
     void rasterize();
+
+    void convertGpxFeatureType();
 
   private:
 
@@ -6631,6 +6634,150 @@ void TestQgsProcessingAlgs::rasterize()
   checker.setControlName( "expected_rasterize" );
   checker.setRenderedImage( outputTif );
   QVERIFY( checker.compareImages( "rasterize", 500 ) );
+}
+
+void TestQgsProcessingAlgs::convertGpxFeatureType()
+{
+  // test generation of babel argument lists
+  QStringList processArgs;
+  QStringList logArgs;
+
+  QgsConvertGpxFeatureTypeAlgorithm::createArgumentLists( QStringLiteral( "/home/me/my input file.gpx" ),
+      QStringLiteral( "/home/me/my output file.gpx" ),
+      QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromRoute,
+      processArgs, logArgs );
+  QCOMPARE( processArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "/home/me/my input file.gpx" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,wpt=rte,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "/home/me/my output file.gpx" )
+  } ) );
+  // when showing the babel command, filenames should be wrapped in "", which is what QProcess does internally (hence the processArgs don't have these)
+  QCOMPARE( logArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "\"/home/me/my input file.gpx\"" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,wpt=rte,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "\"/home/me/my output file.gpx\"" )
+  } ) );
+
+  logArgs.clear();
+  processArgs.clear();
+  QgsConvertGpxFeatureTypeAlgorithm::createArgumentLists( QStringLiteral( "/home/me/my input file.gpx" ),
+      QStringLiteral( "/home/me/my output file.gpx" ),
+      QgsConvertGpxFeatureTypeAlgorithm::WaypointsFromTrack,
+      processArgs, logArgs );
+  QCOMPARE( processArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "/home/me/my input file.gpx" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,wpt=trk,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "/home/me/my output file.gpx" )
+  } ) );
+  // when showing the babel command, filenames should be wrapped in "", which is what QProcess does internally (hence the processArgs don't have these)
+  QCOMPARE( logArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "\"/home/me/my input file.gpx\"" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,wpt=trk,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "\"/home/me/my output file.gpx\"" )
+  } ) );
+
+  logArgs.clear();
+  processArgs.clear();
+
+  QgsConvertGpxFeatureTypeAlgorithm::createArgumentLists( QStringLiteral( "/home/me/my input file.gpx" ),
+      QStringLiteral( "/home/me/my output file.gpx" ),
+      QgsConvertGpxFeatureTypeAlgorithm::RouteFromWaypoints,
+      processArgs, logArgs );
+  QCOMPARE( processArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "/home/me/my input file.gpx" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,rte=wpt,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "/home/me/my output file.gpx" )
+  } ) );
+  // when showing the babel command, filenames should be wrapped in "", which is what QProcess does internally (hence the processArgs don't have these)
+  QCOMPARE( logArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "\"/home/me/my input file.gpx\"" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,rte=wpt,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "\"/home/me/my output file.gpx\"" )
+  } ) );
+
+
+  logArgs.clear();
+  processArgs.clear();
+
+  QgsConvertGpxFeatureTypeAlgorithm::createArgumentLists( QStringLiteral( "/home/me/my input file.gpx" ),
+      QStringLiteral( "/home/me/my output file.gpx" ),
+      QgsConvertGpxFeatureTypeAlgorithm::TrackFromWaypoints,
+      processArgs, logArgs );
+  QCOMPARE( processArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "/home/me/my input file.gpx" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,trk=wpt,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "/home/me/my output file.gpx" )
+  } ) );
+  // when showing the babel command, filenames should be wrapped in "", which is what QProcess does internally (hence the processArgs don't have these)
+  QCOMPARE( logArgs, QStringList(
+  {
+    QStringLiteral( "-i" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-f" ),
+    QStringLiteral( "\"/home/me/my input file.gpx\"" ),
+    QStringLiteral( "-x" ),
+    QStringLiteral( "transform,trk=wpt,del" ),
+    QStringLiteral( "-o" ),
+    QStringLiteral( "gpx" ),
+    QStringLiteral( "-F" ),
+    QStringLiteral( "\"/home/me/my output file.gpx\"" )
+  } ) );
 }
 
 void TestQgsProcessingAlgs::exportMeshTimeSeries()


### PR DESCRIPTION
This algorithm uses the GPSBabel tool to convert GPX features from one type to another (e.g. converting all waypoint features to a
route feature).

It is designed as a drop-in replacement for workflows which previously used this functionality from the GPS tools plugin, but with all the benefits and improvements that come automatically from being part of Processing!

The redundant functionality has been removed from the GPS tools plugin, and users are now required to use the processing tool instead.