### PR TITLE
Support CTRL+Click for opening links in attribute table

### DIFF
--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -281,6 +281,17 @@ links.
 .. versionadded:: 3.0
 %End
 
+    static bool isUrl( const QString &string );
+%Docstring
+Returns whether the string is a URL (http,https,ftp,file)
+
+:param string: the string to check
+
+:return: whether the string is an URL
+
+.. versionadded:: 3.22
+%End
+
     static QString wordWrap( const QString &string, int length, bool useMaxLineLength = true, const QString &customDelimiter = QString() );
 %Docstring
 Automatically wraps a ``string`` by inserting new line characters at appropriate locations in the string.

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -563,6 +563,12 @@ QString QgsStringUtils::insertLinks( const QString &string, bool *foundLinks )
   return converted;
 }
 
+bool QgsStringUtils::isUrl( const QString &string )
+{
+  const thread_local QRegularExpression rxUrl( "^(http|https|ftp|file)://\\S+$" );
+  return rxUrl.match( string ).hasMatch();
+}
+
 QString QgsStringUtils::htmlToMarkdown( const QString &html )
 {
   // Any changes in this function must be copied to qgscrashreport.cpp too

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -278,6 +278,14 @@ class CORE_EXPORT QgsStringUtils
     static QString insertLinks( const QString &string, bool *foundLinks = nullptr );
 
     /**
+     * Returns whether the string is a URL (http,https,ftp,file)
+     * \param string the string to check
+     * \returns whether the string is an URL
+     * \since QGIS 3.22
+     */
+    static bool isUrl( const QString &string );
+
+    /**
      * Automatically wraps a \a string by inserting new line characters at appropriate locations in the string.
      *
      * The \a length argument specifies either the minimum or maximum length of lines desired, depending

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QDesktopServices>
 #include <QKeyEvent>
 #include <QHeaderView>
 #include <QMenu>
@@ -34,6 +35,7 @@
 #include "qgsfeatureselectionmodel.h"
 #include "qgsmaplayeractionregistry.h"
 #include "qgsfeatureiterator.h"
+#include "qgsstringutils.h"
 #include "qgsgui.h"
 
 QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
@@ -304,6 +306,19 @@ void QgsAttributeTableView::mouseReleaseEvent( QMouseEvent *event )
   setSelectionMode( QAbstractItemView::NoSelection );
   QTableView::mouseReleaseEvent( event );
   setSelectionMode( QAbstractItemView::ExtendedSelection );
+  if ( event->modifiers() == Qt::ControlModifier )
+  {
+    QModelIndex index = indexAt( event->pos() );
+    QVariant data = model()->data( index, Qt::DisplayRole );
+    if ( data.type() == QVariant::String )
+    {
+      QString textVal = data.toString();
+      if ( QgsStringUtils::isUrl( textVal ) )
+      {
+        QDesktopServices::openUrl( QUrl( textVal ) );
+      }
+    }
+  }
 }
 
 void QgsAttributeTableView::mouseMoveEvent( QMouseEvent *event )

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -42,6 +42,7 @@ class TestQgsStringUtils : public QObject
     void htmlToMarkdown();
     void wordWrap_data();
     void wordWrap();
+    void testIsUrl();
 
 };
 
@@ -256,6 +257,18 @@ void TestQgsStringUtils::wordWrap()
   QFETCH( QString, expected );
 
   QCOMPARE( QgsStringUtils::wordWrap( input, length, isMax, delimiter ), expected );
+}
+
+void TestQgsStringUtils::testIsUrl()
+{
+  QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "http://example.com" ) ) );
+  QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "https://example.com" ) ) );
+  QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "ftp://example.com" ) ) );
+  QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "file:///path/to/file" ) ) );
+  QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "file://C:\\path\\to\\file" ) ) );
+  QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "" ) ) );
+  QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "some:random/string" ) ) );
+  QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "bla" ) ) );
 }
 
 


### PR DESCRIPTION
Allow directly opening links in the attribute table with Ctrl+Click:

![image](https://user-images.githubusercontent.com/1298852/127653338-00407c86-b00a-4159-a702-eb25d2907c0d.png)

Fairly limited implementation, only works if attribute value contains exactly one link (or at least something that resembles being a link).