### PR TITLE
Consider maximum image width/height also for GetLegendGraphic

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -622,6 +622,11 @@ int QgsWmsRenderContext::mapHeight() const
 
 bool QgsWmsRenderContext::isValidWidthHeight() const
 {
+  return isValidWidthHeight( mapWidth(), mapHeight() );
+}
+
+bool QgsWmsRenderContext::isValidWidthHeight( int width, int height ) const
+{
   //test if maxWidth / maxHeight are set in the project or as an env variable
   //and WIDTH / HEIGHT parameter is in the range allowed range
   //WIDTH
@@ -639,7 +644,7 @@ bool QgsWmsRenderContext::isValidWidthHeight() const
     wmsMaxWidth = std::max( wmsMaxWidthProj, wmsMaxWidthEnv );
   }
 
-  if ( wmsMaxWidth != -1 && mapWidth() > wmsMaxWidth )
+  if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
   {
     return false;
   }
@@ -659,7 +664,7 @@ bool QgsWmsRenderContext::isValidWidthHeight() const
     wmsMaxHeight = std::max( wmsMaxHeightProj, wmsMaxHeightEnv );
   }
 
-  if ( wmsMaxHeight != -1 && mapHeight() > wmsMaxHeight )
+  if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
   {
     return false;
   }
@@ -680,13 +685,13 @@ bool QgsWmsRenderContext::isValidWidthHeight() const
       depth = 32;
   }
 
-  const int bytes_per_line = ( ( mapWidth() * depth + 31 ) >> 5 ) << 2; // bytes per scanline (must be multiple of 4)
+  const int bytes_per_line = ( ( width * depth + 31 ) >> 5 ) << 2; // bytes per scanline (must be multiple of 4)
 
-  if ( std::numeric_limits<int>::max() / depth < static_cast<uint>( mapWidth() )
+  if ( std::numeric_limits<int>::max() / depth < static_cast<uint>( width )
        || bytes_per_line <= 0
-       || mapHeight() <= 0
-       || std::numeric_limits<int>::max() / static_cast<uint>( bytes_per_line ) < static_cast<uint>( mapHeight() )
-       || std::numeric_limits<int>::max() / sizeof( uchar * ) < static_cast<uint>( mapHeight() ) )
+       || height <= 0
+       || std::numeric_limits<int>::max() / static_cast<uint>( bytes_per_line ) < static_cast<uint>( height )
+       || std::numeric_limits<int>::max() / sizeof( uchar * ) < static_cast<uint>( height ) )
   {
     return false;
   }

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -247,6 +247,14 @@ namespace QgsWms
       bool isValidWidthHeight() const;
 
       /**
+       * Returns true if width and height are valid according to the maximum image width/height
+       * \param width the image width in pixels
+       * \param height the image height in pixels
+       * \since QGIS 3.22
+       */
+      bool isValidWidthHeight( int width, int height ) const;
+
+      /**
        * Returns WIDTH or SRCWIDTH according to \a UseSrcWidthHeight flag.
        */
       int mapWidth() const;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -133,7 +133,7 @@ namespace QgsWms
     const QSize size( static_cast<int>( minSize.width() * dpmm ), static_cast<int>( minSize.height() * dpmm ) );
     if ( !mContext.isValidWidthHeight( size.width(), size.height() ) )
     {
-      throw ( QgsServerException( QStringLiteral( "Legend image is too large" ) ) );
+      throw QgsServerException( QStringLiteral( "Legend image is too large" ) );
     }
     image.reset( createImage( size ) );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -170,7 +170,7 @@ namespace QgsWms
     //test if legend image is larger than max width/height
     if ( !mContext.isValidWidthHeight( size.width(), size.height() ) )
     {
-      throw ( QgsServerException( QStringLiteral( "Legend image is too large" ) ) );
+      throw QgsServerException( QStringLiteral( "Legend image is too large" ) );
     }
     std::unique_ptr<QImage> image( createImage( size ) );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -131,6 +131,10 @@ namespace QgsWms
     const qreal dpmm = mContext.dotsPerMm();
     const QSizeF minSize = renderer.minimumSize();
     const QSize size( static_cast<int>( minSize.width() * dpmm ), static_cast<int>( minSize.height() * dpmm ) );
+    if ( !mContext.isValidWidthHeight( size.width(), size.height() ) )
+    {
+      throw ( QgsServerException( QStringLiteral( "Legend image is too large" ) ) );
+    }
     image.reset( createImage( size ) );
 
     // configure painter
@@ -163,6 +167,11 @@ namespace QgsWms
 
     // create image
     const QSize size( mWmsParameters.widthAsInt(), mWmsParameters.heightAsInt() );
+    //test if legend image is larger than max width/height
+    if ( !mContext.isValidWidthHeight( size.width(), size.height() ) )
+    {
+      throw ( QgsServerException( QStringLiteral( "Legend image is too large" ) ) );
+    }
     std::unique_ptr<QImage> image( createImage( size ) );
 
     // configure painter

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2139,7 +2139,7 @@
                     <item row="0" column="0" colspan="5">
                      <widget class="QLabel" name="label_21">
                       <property name="text">
-                       <string>Maximums for GetMap request</string>
+                       <string>Maximum image size for GetMap and GetLegendGraphic requests</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
When using symbols with sizes in map units, it can happen that huge images are requested with GetLegendGraphic calls. This normally results in out-of-memory problems and server crashes. I think we should also consider the maximum width/height parameters from GetMap in the GetLegendGraphic call. The code in isValidWidthHeight() also does some protection against out-of-memory problems even if max width/height is not set.
