### PR TITLE
Simplify whitespaces in saved expression labels

### DIFF
--- a/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
@@ -49,10 +49,6 @@ Returns the label text
 Returns the help text
 %End
 
-    bool isLabelModified();
-%Docstring
-Returns whether the label text was modified
-%End
 
 };
 

--- a/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
@@ -49,6 +49,11 @@ Returns the label text
 Returns the help text
 %End
 
+    bool isLabelModified();
+%Docstring
+Returns whether the label text was modified
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -912,7 +912,7 @@ void QgsExpressionBuilderWidget::storeCurrentUserExpression()
   QgsExpressionStoreDialog dlg { expression, expression, QString( ), mExpressionTreeView->userExpressionLabels() };
   if ( dlg.exec() == QDialog::DialogCode::Accepted )
   {
-    mExpressionTreeView->saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
+    mExpressionTreeView->saveToUserExpressions( dlg.label().simplified(), dlg.expression(), dlg.helpText() );
   }
 }
 
@@ -931,17 +931,17 @@ void QgsExpressionBuilderWidget::editSelectedUserExpression()
 
   QgsSettings settings;
   QString helpText = settings.value( QStringLiteral( "user/%1/helpText" ).arg( item->text() ), "", QgsSettings::Section::Expressions ).toString();
-  QgsExpressionStoreDialog dlg { item->text(), item->getExpressionText(), helpText };
+  QgsExpressionStoreDialog dlg { item->text(), item->getExpressionText(), helpText, mExpressionTreeView->userExpressionLabels() };
 
   if ( dlg.exec() == QDialog::DialogCode::Accepted )
   {
     // label has changed removed the old one before adding the new one
-    if ( dlg.label() != item->text() )
+    if ( dlg.isLabelModified() )
     {
       mExpressionTreeView->removeFromUserExpressions( item->text() );
     }
 
-    mExpressionTreeView->saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
+    mExpressionTreeView->saveToUserExpressions( dlg.label().simplified(), dlg.expression(), dlg.helpText() );
   }
 }
 

--- a/src/gui/qgsexpressionstoredialog.cpp
+++ b/src/gui/qgsexpressionstoredialog.cpp
@@ -20,6 +20,7 @@
 QgsExpressionStoreDialog::QgsExpressionStoreDialog( const QString &label, const QString &expression, const QString &helpText, const QStringList &existingLabels, QWidget *parent )
   : QDialog( parent )
   , mExistingLabels( existingLabels )
+  , mOriginalLabel( label )
 {
   setupUi( this );
   mExpression->setText( expression );
@@ -33,7 +34,8 @@ QgsExpressionStoreDialog::QgsExpressionStoreDialog( const QString &label, const 
   connect( mLabel, &QLineEdit::textChanged, this, [ = ]( const QString & text )
   {
     QString errorMessage;
-    if ( mExistingLabels.contains( text ) )
+    if ( mOriginalLabel.simplified() != text.simplified() &&
+         mExistingLabels.contains( text.simplified() ) )
     {
       errorMessage = tr( "A stored expression with this name already exists" );
     }
@@ -56,7 +58,7 @@ QgsExpressionStoreDialog::QgsExpressionStoreDialog( const QString &label, const 
   // No slashes in labels!
   QString labelFixed { label };
   labelFixed.remove( '/' ).remove( '\\' );
-  mLabel->setText( labelFixed );
+  mLabel->setText( labelFixed.simplified() );
 }
 
 QString QgsExpressionStoreDialog::helpText() const

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
      * Returns whether the label text was modified either manually by the user,
      * or automatically because it contained slashes or leading/trailing whitespace characters
      */
-    bool isLabelModified() { return mLabel->text() != mOriginalLabel; } SIP_SKIP
+    bool isLabelModified() const { return mLabel->text() != mOriginalLabel; } SIP_SKIP
 
   private:
 

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -58,9 +58,10 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
     QString helpText() const;
 
     /**
-     * Returns whether the label text was modified
+     * Returns whether the label text was modified either manually by the user,
+     * or automatically because it contained slashes or leading/trailing whitespace characters
      */
-    bool isLabelModified() { return mLabel->text() != mOriginalLabel; }
+    bool isLabelModified() { return mLabel->text() != mOriginalLabel; } SIP_SKIP
 
   private:
 

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -57,9 +57,15 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
      */
     QString helpText() const;
 
+    /**
+     * Returns whether the label text was modified
+     */
+    bool isLabelModified() { return mLabel->text() != mOriginalLabel; }
+
   private:
 
     QStringList mExistingLabels;
+    QString mOriginalLabel;
 
 };
 


### PR DESCRIPTION
## Description
When saving expressions to the *User expressions* in the expression builder, the default label is the whole expression itself. This is ok for simple expressions but for multiline expressions this leads to a weird looking list, where some entries contain a single line while others span over multiple lines making it harder to navigate (see #41545 for the same issue in *recent expressions*)

This PR makes sure the label is converted to a single line and trimmed by using `QString::simplified()`. New labels will be single-line, existing labels will be converted to single-line once edited.

Also fixes unreported bug, where a user can overwrite one existing saved expression while editing a different saved expression. Checking for existing labels was present only when saving a new expression and not when editing an existing one.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
