### PR TITLE
Reset scalebar number item segments when changing scalebar units

### DIFF
--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -683,7 +683,7 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     //! Width of a segment (in mm)
     double mSegmentMillimeters = 0.0;
 
-    //! Calculates with of a segment in mm and stores it in mSegmentMillimeters
+    //! Calculates width of a segment in mm and stores it in mSegmentMillimeters
     void refreshSegmentMillimeters();
 
     //! Returns diagonal of layout map in selected units (map units / meters / feet / nautical miles)

--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -652,6 +652,8 @@ void QgsLayoutScaleBarWidget::mUnitsComboBox_currentIndexChanged( int index )
   mScalebar->applyDefaultSize( static_cast<  QgsUnitTypes::DistanceUnit >( unitData.toInt() ) );
   mScalebar->update();
 
+  mNumberOfSegmentsSpinBox->setValue( mScalebar->numberOfSegments() );
+  mSegmentsLeftSpinBox->setValue( mScalebar->numberOfSegmentsLeft() );
   mUnitLabelLineEdit->setText( mScalebar->unitLabel() );
   mSegmentSizeSpinBox->setValue( mScalebar->unitsPerSegment() );
   mMapUnitsPerBarUnitSpinBox->setValue( mScalebar->mapUnitsPerScaleBarUnit() );


### PR DESCRIPTION
When the user changed the units (eg from km to miles) in a scalebar unit, most values in the scalebar are reset to default values.
But the number of segments and left segments were NOT updated.

Mentioned by user, see https://lists.osgeo.org/pipermail/qgis-user/2021-August/049460.html

(I did not try to pick up the 'old value' as other item properties are also set to default. I think it would be pretty hard to 'remember old values' because it would also mean to recalculate other props etc etc)

If devs want me to create an issue for this first let me know.

Also: I think this can/should be backported to (at least) 3.16/LTR?
