### PR TITLE
Add option to QgsFeatureRequest to request features within a certain distance of a reference geometry

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -627,3 +627,10 @@ QgsGeometry.JoinStyleBevel.__doc__ = "Use beveled joins"
 Qgis.JoinStyle.__doc__ = 'Join styles for buffers.\n\n.. versionadded:: 3.22\n\n' + '* ``JoinStyleRound``: ' + Qgis.JoinStyle.Round.__doc__ + '\n' + '* ``JoinStyleMiter``: ' + Qgis.JoinStyle.Miter.__doc__ + '\n' + '* ``JoinStyleBevel``: ' + Qgis.JoinStyle.Bevel.__doc__
 # --
 Qgis.JoinStyle.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.SpatialFilterType.NoFilter.__doc__ = "No spatial filtering of features"
+Qgis.SpatialFilterType.BoundingBox.__doc__ = "Filter using a bounding box"
+Qgis.SpatialFilterType.DistanceWithin.__doc__ = "Filter by distance to reference geometry"
+Qgis.SpatialFilterType.__doc__ = 'Feature request spatial filter types.\n\n.. versionadded:: 3.22\n\n' + '* ``NoFilter``: ' + Qgis.SpatialFilterType.NoFilter.__doc__ + '\n' + '* ``BoundingBox``: ' + Qgis.SpatialFilterType.BoundingBox.__doc__ + '\n' + '* ``DistanceWithin``: ' + Qgis.SpatialFilterType.DistanceWithin.__doc__
+# --
+Qgis.SpatialFilterType.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -437,6 +437,13 @@ The development version
       Bevel,
     };
 
+    enum class SpatialFilterType
+    {
+      NoFilter,
+      BoundingBox,
+      DistanceWithin,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgscachedfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgscachedfeatureiterator.sip.in
@@ -28,6 +28,8 @@ This constructor creates a feature iterator, that delivers all cached features. 
 :param featureRequest: The feature request to answer
 %End
 
+    ~QgsCachedFeatureIterator();
+
     virtual bool rewind();
 
 %Docstring
@@ -67,6 +69,8 @@ We have a local special iterator for FilterFids, no need to run the generic.
 :return: bool  ``True`` if the operation was OK
 %End
 
+  private:
+    QgsCachedFeatureIterator( const QgsCachedFeatureIterator &other );
 };
 
 class QgsCachedFeatureWriterIterator : QgsAbstractFeatureIterator

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -15,17 +15,18 @@ class QgsFeatureRequest
 %Docstring(signature="appended")
 This class wraps a request for features to a vector layer (or directly its vector data provider).
 
-The request may apply a filter to fetch only a particular subset of features. Currently supported filters:
+The request may apply an attribute/ID filter to fetch only a particular subset of features. Currently supported filters:
 
 - no filter - all features are returned
 - feature id - only feature that matches given feature id is returned
 - feature ids - only features that match any of the given feature ids are returned
 - filter expression - only features that match the given filter expression are returned
 
-Additionally a spatial rectangle can be set in combination:
-Only features that intersect given rectangle should be fetched. For the sake of speed,
-the intersection is often done only using feature's bounding box. There is a flag
-ExactIntersect that makes sure that only intersecting features will be returned.
+Additionally a spatial filter can be set in combination with the attribute/ID filter. Supported
+spatial filters are:
+
+- Qgis.SpatialFilterType.BoundingBox: Only features that intersect a given rectangle will be fetched. For the sake of speed, the intersection is often done only using feature's bounding box. There is a flag ExactIntersect that makes sure that only intersecting features will be returned.
+- Qgis.SpatialFilterType.DistanceWithin: Only features within a specified distance of a reference geometry will be fetched.
 
 For efficiency, it is also possible to tell provider that some data is not required:
 
@@ -52,8 +53,12 @@ Examples:
        QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
        # fetch only features from particular extent
        QgsFeatureRequest().setFilterRect(QgsRectangle(0,0,1,1))
+       # fetch only features from particular extent, where the 'type' attribute is equal to 'road':
+       QgsFeatureRequest().setFilterRect(QgsRectangle(0,0,1,1)).setFilterExpression('"type"=\'road\'')
        # fetch only one feature
        QgsFeatureRequest().setFilterFid(45)
+       # fetch features within 50 map units of a linestring geometry
+       QgsFeatureRequest().setDistanceWithin(QgsGeometry.fromWkt('LineString(0 0, 10 0, 12 1)'), 50)
 %End
 
 %TypeHeaderCode
@@ -301,11 +306,38 @@ construct a request with a filter expression
 copy constructor
 %End
 
+    ~QgsFeatureRequest();
+
     FilterType filterType() const;
 %Docstring
-Returns the filter type which is currently set on this request
+Returns the attribute/ID filter type which is currently set on this request.
 
-:return: Filter type
+This type will automatically be set to the appropriate value whenever :py:func:`~QgsFeatureRequest.setFilterFid`,
+:py:func:`~QgsFeatureRequest.setFilterFids`, :py:func:`~QgsFeatureRequest.setFilterExpression` or :py:func:`~QgsFeatureRequest.disableFilter` are called.
+
+.. note::
+
+   A feature request may have both an attribute/ID filter AND a spatial filter
+   set. See :py:func:`~QgsFeatureRequest.spatialFilterType` to retrieve the spatial filter.
+
+.. seealso:: :py:func:`spatialFilterType`
+%End
+
+    Qgis::SpatialFilterType spatialFilterType() const;
+%Docstring
+Returns the spatial filter type which is currently set on this request.
+
+This type will automatically be set to the appropriate value whenever :py:func:`~QgsFeatureRequest.setFilterRect`,
+or :py:func:`~QgsFeatureRequest.setDistanceWithin` are called.
+
+.. note::
+
+   A feature request may have both an attribute/ID filter AND a spatial filter
+   set. See :py:func:`~QgsFeatureRequest.filterType` to retrieve the attribute/ID filter.
+
+.. seealso:: :py:func:`filterType`
+
+.. versionadded:: 3.22
 %End
 
     QgsFeatureRequest &setFilterRect( const QgsRectangle &rectangle );
@@ -316,13 +348,21 @@ When a destination CRS is set using :py:func:`~QgsFeatureRequest.setDestinationC
 is expected to be in the same CRS as the :py:func:`~QgsFeatureRequest.destinationCrs`. Otherwise, ``rectangle``
 should use the same CRS as the source layer/provider.
 
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.spatialFilterType` to Qgis.SpatialFilterType.BoundingBox.
+If ``rectangle`` is a null rectangle then :py:func:`~QgsFeatureRequest.spatialFilterType` will be reset to Qgis.SpatialFilterType.NoFilter.
+
 .. seealso:: :py:func:`filterRect`
 %End
 
-    const QgsRectangle &filterRect() const;
+    QgsRectangle filterRect() const;
 %Docstring
 Returns the rectangle from which features will be taken. If the returned
 rectangle is null, then no filter rectangle is set.
+
+If :py:func:`~QgsFeatureRequest.spatialFilterType` is Qgis.SpatialFilterType.BoundingBox then only
+features from within this bounding box will be fetched. If :py:func:`~QgsFeatureRequest.spatialFilterType`
+is Qgis.SpatialFilterType.DistanceWithin then the returned rectangle
+represents the bounding box of the :py:func:`~QgsFeatureRequest.referenceGeometry` extended by :py:func:`~QgsFeatureRequest.distanceWithin`.
 
 When a destination CRS is set using :py:func:`~QgsFeatureRequest.setDestinationCrs`, the rectangle
 will be in the same CRS as the :py:func:`~QgsFeatureRequest.destinationCrs`. Otherwise, the rectangle
@@ -331,22 +371,93 @@ will use the same CRS as the source layer/provider.
 .. seealso:: :py:func:`setFilterRect`
 %End
 
+    QgsFeatureRequest &setDistanceWithin( const QgsGeometry &geometry, double distance );
+%Docstring
+Sets a reference ``geometry`` and a maximum ``distance`` from this geometry to retrieve
+features within.
+
+When a destination CRS is set using :py:func:`~QgsFeatureRequest.setDestinationCrs`, ``geometry``
+is expected to be in the same CRS as the :py:func:`~QgsFeatureRequest.destinationCrs` and ``distance`` is in
+the spatial units of the :py:func:`~QgsFeatureRequest.destinationCrs`. Otherwise, ``geometry``
+should use the same CRS as the source layer/provider and ``distance``
+should use the spatial units as this same CRS.
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.spatialFilterType` to Qgis.SpatialFilterType.DistanceWithin.
+
+.. seealso:: :py:func:`filterRect`
+
+.. versionadded:: 3.22
+%End
+
+    QgsGeometry referenceGeometry() const;
+%Docstring
+Returns the reference geometry used for spatial filtering of features.
+
+When :py:func:`~QgsFeatureRequest.spatialFilterType` is Qgis.SpatialFilterType.DistanceWithin then only
+features within :py:func:`~QgsFeatureRequest.distanceWithin` units of the reference geometry will be
+fetched.
+
+When a destination CRS is set using :py:func:`~QgsFeatureRequest.setDestinationCrs`, the geometry
+will be in the same CRS as the :py:func:`~QgsFeatureRequest.destinationCrs`. Otherwise, the geometry
+will use the same CRS as the source layer/provider.
+
+.. seealso:: :py:func:`setDistanceWithin`
+
+.. versionadded:: 3.22
+%End
+
+    double distanceWithin() const;
+%Docstring
+Returns the maximum distance from the :py:func:`~QgsFeatureRequest.referenceGeometry` of fetched
+features, if :py:func:`~QgsFeatureRequest.spatialFilterType` is Qgis.SpatialFilterType.DistanceWithin.
+
+When a destination CRS is set using :py:func:`~QgsFeatureRequest.setDestinationCrs`, the distance
+will be in the spatial units of :py:func:`~QgsFeatureRequest.destinationCrs`. Otherwise, the distance
+will use the same units as the CRS of the source layer/provider.
+
+.. seealso:: :py:func:`setDistanceWithin`
+
+.. versionadded:: 3.22
+%End
+
     QgsFeatureRequest &setFilterFid( QgsFeatureId fid );
 %Docstring
-Sets feature ID that should be fetched.
+Sets the feature ID that should be fetched.
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.filterType` to QgsFeatureRequest.FilterFid.
+
+.. seealso:: :py:func:`filterFid`
+
+.. seealso:: :py:func:`setFilterFids`
 %End
+
     QgsFeatureId filterFid() const;
 %Docstring
-Gets the feature ID that should be fetched.
+Returns the feature ID that should be fetched.
+
+.. seealso:: :py:func:`setFilterFid`
+
+.. seealso:: :py:func:`filterFids`
 %End
 
     QgsFeatureRequest &setFilterFids( const QgsFeatureIds &fids );
 %Docstring
-Sets feature IDs that should be fetched.
+Sets the feature IDs that should be fetched.
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.filterType` to QgsFeatureRequest.FilterFids.
+
+.. seealso:: :py:func:`filterFids`
+
+.. seealso:: :py:func:`setFilterFid`
 %End
+
     const QgsFeatureIds &filterFids() const;
 %Docstring
-Gets feature IDs that should be fetched.
+Returns the feature IDs that should be fetched.
+
+.. seealso:: :py:func:`setFilterFids`
+
+.. seealso:: :py:func:`filterFid`
 %End
 
     QgsFeatureRequest &setInvalidGeometryCheck( InvalidGeometryCheck check );
@@ -400,9 +511,11 @@ called using the feature with invalid geometry as a parameter.
 
     QgsFeatureRequest &setFilterExpression( const QString &expression );
 %Docstring
-Set the filter expression. {:py:class:`QgsExpression`}
+Set the filter ``expression``. {:py:class:`QgsExpression`}
 
 :param expression: expression string
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.filterType` to QgsFeatureRequest.FilterExpression.
 
 .. seealso:: :py:func:`filterExpression`
 
@@ -411,7 +524,7 @@ Set the filter expression. {:py:class:`QgsExpression`}
 
     QgsExpression *filterExpression() const;
 %Docstring
-Returns the filter expression if set.
+Returns the filter expression (if set).
 
 .. seealso:: :py:func:`setFilterExpression`
 
@@ -423,6 +536,8 @@ Returns the filter expression if set.
 Modifies the existing filter expression to add an additional expression filter. The
 filter expressions are combined using AND, so only features matching both
 the existing expression and the additional expression will be returned.
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.filterType` to QgsFeatureRequest.FilterExpression.
 
 .. versionadded:: 2.14
 %End
@@ -451,10 +566,16 @@ Sets the expression context used to evaluate filter expressions.
 
     QgsFeatureRequest &disableFilter();
 %Docstring
-Disables filter conditions.
-The spatial filter (filterRect) will be kept in place.
+Disables any attribute/ID filtering.
+
+Calling this method will automatically set :py:func:`~QgsFeatureRequest.filterType` to QgsFeatureRequest.FilterNone.
+
+.. note::
+
+   Spatial filters will be left in place.
 
 :return: The object the method is called on for chaining
+
 
 .. versionadded:: 2.12
 %End
@@ -519,9 +640,17 @@ Returns the maximum number of features to request, or -1 if no limit set.
 
     QgsFeatureRequest &setFlags( QgsFeatureRequest::Flags flags );
 %Docstring
-Sets flags that affect how features will be fetched
+Sets ``flags`` that affect how features will be fetched.
+
+.. seealso:: :py:func:`flags`
 %End
-    const Flags &flags() const;
+
+    Flags flags() const;
+%Docstring
+Returns the flags which affect how features are fetched.
+
+.. seealso:: :py:func:`setFlags`
+%End
 
     QgsFeatureRequest &setSubsetOfAttributes( const QgsAttributeList &attrs );
 %Docstring
@@ -530,44 +659,63 @@ Set a subset of attributes that will be fetched.
 An empty attributes list indicates that no attributes will be fetched.
 To revert a call to setSubsetOfAttributes and fetch all available attributes,
 the SubsetOfAttributes flag should be removed from the request.
+
+.. seealso:: :py:func:`subsetOfAttributes`
+
+.. seealso:: :py:func:`setNoAttributes`
 %End
 
     QgsFeatureRequest &setNoAttributes();
 %Docstring
 Set that no attributes will be fetched.
+
 To revert a call to setNoAttributes and fetch all or some available attributes,
 the SubsetOfAttributes flag should be removed from the request.
+
+.. seealso:: :py:func:`setSubsetOfAttributes`
 
 .. versionadded:: 3.4
 %End
 
     QgsAttributeList subsetOfAttributes() const;
 %Docstring
-Returns the subset of attributes which at least need to be fetched
+Returns the subset of attributes which at least need to be fetched.
 
 :return: A list of attributes to be fetched
+
+.. seealso:: :py:func:`setSubsetOfAttributes`
+
+.. seealso:: :py:func:`setNoAttributes`
 %End
 
     QgsFeatureRequest &setSubsetOfAttributes( const QStringList &attrNames, const QgsFields &fields );
 %Docstring
-Sets a subset of attributes by names that will be fetched
+Sets a subset of attributes by names that will be fetched.
+
+.. seealso:: :py:func:`subsetOfAttributes`
 %End
 
     QgsFeatureRequest &setSubsetOfAttributes( const QSet<QString> &attrNames, const QgsFields &fields );
 %Docstring
-Sets a subset of attributes by names that will be fetched
+Sets a subset of attributes by names that will be fetched.
+
+.. seealso:: :py:func:`subsetOfAttributes`
 %End
 
     QgsFeatureRequest &setSimplifyMethod( const QgsSimplifyMethod &simplifyMethod );
 %Docstring
-Set a simplification method for geometries that will be fetched
+Set a simplification method for geometries that will be fetched.
+
+.. seealso:: :py:func:`simplifyMethod`
 
 .. versionadded:: 2.2
 %End
 
     const QgsSimplifyMethod &simplifyMethod() const;
 %Docstring
-Gets simplification method for geometries that will be fetched
+Returns the simplification method for geometries that will be fetched.
+
+.. seealso:: :py:func:`setSimplifyMethod`
 
 .. versionadded:: 2.2
 %End
@@ -606,8 +754,8 @@ system to this desired reference system. If ``crs`` is an invalid
 and all features will be left with their original geometry.
 
 When a ``crs`` is set using :py:func:`~QgsFeatureRequest.setDestinationCrs`, then any :py:func:`~QgsFeatureRequest.filterRect`
-set on the request is expected to be in the same CRS as the destination
-CRS.
+or :py:func:`~QgsFeatureRequest.referenceGeometry` set on the request is expected to be in the
+same CRS as the destination CRS.
 
 The feature geometry transformation to the destination CRS is performed
 after all filter expressions are tested and any virtual fields are
@@ -703,6 +851,8 @@ feature is returned. A negative value (which is set by default) will wait foreve
 
    Only works if the provider supports this option.
 
+.. seealso:: :py:func:`setTimeout`
+
 .. versionadded:: 3.4
 %End
 
@@ -714,6 +864,8 @@ feature is returned. A negative value (which is set by default) will wait foreve
 .. note::
 
    Only works if the provider supports this option.
+
+.. seealso:: :py:func:`timeout`
 
 .. versionadded:: 3.4
 %End
@@ -729,6 +881,8 @@ connections to avoid deadlocks.
 For example, this should be set on requests that are issued from an
 expression function.
 
+.. seealso:: :py:func:`setRequestMayBeNested`
+
 .. versionadded:: 3.4
 %End
 
@@ -742,6 +896,8 @@ connections to avoid deadlocks.
 
 For example, this should be set on requests that are issued from an
 expression function.
+
+.. seealso:: :py:func:`requestMayBeNested`
 
 .. versionadded:: 3.4
 %End
@@ -770,6 +926,13 @@ if it should be canceled, if set.
 %End
 
   protected:
+
+
+
+
+
+
+
 };
 
 QFlags<QgsFeatureRequest::Flag> operator|(QgsFeatureRequest::Flag f1, QFlags<QgsFeatureRequest::Flag> f2);

--- a/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerfeatureiterator.sip.in
@@ -158,6 +158,7 @@ Setup the simplification of geometries to fetch using the specified simplify met
 
 
 
+
   private:
     QgsVectorLayerFeatureIterator( const QgsVectorLayerFeatureIterator &rhs );
 };

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -502,7 +502,7 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer *layer, const 
   bool useGeometry = exp.needsGeometry();
 
   QgsFeatureRequest request( mMainView->masterModel()->request() );
-  useGeometry |= !request.filterRect().isNull();
+  useGeometry |= !( request.spatialFilterType() == Qgis::SpatialFilterType::NoFilter );
   request.setFlags( useGeometry ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry );
 
   int rownum = 1;

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.h
@@ -72,6 +72,8 @@ class QgsMemoryFeatureIterator final: public QgsAbstractFeatureIteratorFromSourc
 
     QgsGeometry mSelectRectGeom;
     std::unique_ptr< QgsGeometryEngine > mSelectRectEngine;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
     QgsRectangle mFilterRect;
     QgsFeatureMap::const_iterator mSelectIterator;
     bool mUsingFeatureIdList = false;

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -513,9 +513,9 @@ bool QgsOgrFeatureIterator::readFeature( const gdal::ogr_feature_unique_ptr &fet
   feature.initAttributes( mSource->mFields.count() );
   feature.setFields( mSource->mFields ); // allow name-based attribute lookups
 
-  bool useIntersect = !mRequest.filterRect().isNull();
+  bool useIntersect = mRequest.spatialFilterType() == Qgis::SpatialFilterType::BoundingBox;
   bool geometryTypeFilter = mSource->mOgrGeometryTypeFilter != wkbUnknown;
-  if ( mFetchGeometry || useIntersect || geometryTypeFilter )
+  if ( mFetchGeometry || mRequest.spatialFilterType() != Qgis::SpatialFilterType::NoFilter || geometryTypeFilter )
   {
     OGRGeometryH geom = OGR_F_GetGeometryRef( fet.get() );
 

--- a/src/core/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.h
@@ -117,6 +117,9 @@ class QgsOgrFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
      * a transaction for SQLITE-based layers */
     bool mAllowResetReading = true;
 
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+
     bool fetchFeatureWithId( QgsFeatureId id, QgsFeature &feature ) const;
 
     void resetReading();

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -681,6 +681,19 @@ class CORE_EXPORT Qgis
     Q_ENUM( JoinStyle )
 
     /**
+     * Feature request spatial filter types.
+     *
+     * \since QGIS 3.22
+     */
+    enum class SpatialFilterType : int
+    {
+      NoFilter, //!< No spatial filtering of features
+      BoundingBox, //!< Filter using a bounding box
+      DistanceWithin, //!< Filter by distance to reference geometry
+    };
+    Q_ENUM( SpatialFilterType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -40,6 +40,8 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
      */
     QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache, const QgsFeatureRequest &featureRequest );
 
+    ~QgsCachedFeatureIterator() override;
+
     /**
      * Rewind to the beginning of the iterator
      *
@@ -76,11 +78,19 @@ class CORE_EXPORT QgsCachedFeatureIterator : public QgsAbstractFeatureIterator
     bool nextFeatureFilterFids( QgsFeature &f ) override { return fetchFeature( f ); }
 
   private:
+#ifdef SIP_RUN
+    QgsCachedFeatureIterator( const QgsCachedFeatureIterator &other );
+#endif
+
     QList< QgsFeatureId > mFeatureIds;
     QgsVectorLayerCache *mVectorLayerCache = nullptr;
     QList< QgsFeatureId >::ConstIterator mFeatureIdIterator;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+    double mDistanceWithin = 0;
 };
 
 /**
@@ -133,5 +143,6 @@ class CORE_EXPORT QgsCachedFeatureWriterIterator : public QgsAbstractFeatureIter
     QgsFeatureIds mFids;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+
 };
 #endif // QGSCACHEDFEATUREITERATOR_H

--- a/src/core/vector/qgsvectorlayercache.cpp
+++ b/src/core/vector/qgsvectorlayercache.cpp
@@ -224,7 +224,7 @@ void QgsVectorLayerCache::requestCompleted( const QgsFeatureRequest &featureRequ
       idx->requestCompleted( featureRequest, fids );
     }
     if ( featureRequest.filterType() == QgsFeatureRequest::FilterNone &&
-         ( featureRequest.filterRect().isNull() || featureRequest.filterRect().contains( mLayer->extent() ) ) )
+         ( featureRequest.spatialFilterType() == Qgis::SpatialFilterType::NoFilter || featureRequest.filterRect().contains( mLayer->extent() ) ) )
     {
       mFullCache = true;
     }

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -277,7 +277,7 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
         providerLimit += mSource->mChangedAttributeValues.size();
       }
 
-      if ( mProviderRequest.filterType() == QgsFeatureRequest::FilterExpression || !mProviderRequest.filterRect().isNull() )
+      if ( mProviderRequest.filterType() == QgsFeatureRequest::FilterExpression || mProviderRequest.spatialFilterType() != Qgis::SpatialFilterType::NoFilter )
       {
         // geometry changes may mean some features no longer match expression or rect, so increase limit sent to provider
         providerLimit += mSource->mChangedGeometries.size();

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -270,6 +270,10 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
 
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+    double mDistanceWithin = 0;
+
     // only related to editing
     QSet<QgsFeatureId> mFetchConsidered;
     QgsGeometryMap::ConstIterator mFetchChangedGeomIt;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -614,7 +614,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
   renderer->startRender( renderContext, layer()->fields() );
 
   QgsFeatureRequest r( masterModel()->request() );
-  if ( !r.filterRect().isNull() )
+  if ( r.spatialFilterType() == Qgis::SpatialFilterType::BoundingBox )
   {
     r.setFilterRect( r.filterRect().intersect( rect ) );
   }

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -134,7 +134,7 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   QgsAttributeForm emptyForm( mLayer, QgsFeature(), mEditorContext );
 
   const bool needsGeometry = !( request.flags() & QgsFeatureRequest::NoGeometry )
-                             || !request.filterRect().isNull()
+                             || ( request.spatialFilterType() != Qgis::SpatialFilterType::NoFilter )
                              || emptyForm.needsGeometry();
 
   initLayerCache( needsGeometry );
@@ -328,7 +328,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
   QgsFeatureRequest r = mMasterModel->request();
   bool needsGeometry = filterMode == QgsAttributeTableFilterModel::ShowVisible;
 
-  bool requiresTableReload = ( r.filterType() != QgsFeatureRequest::FilterNone || !r.filterRect().isNull() ) // previous request was subset
+  bool requiresTableReload = ( r.filterType() != QgsFeatureRequest::FilterNone || r.spatialFilterType() != Qgis::SpatialFilterType::NoFilter ) // previous request was subset
                              || ( needsGeometry && r.flags() & QgsFeatureRequest::NoGeometry ) // no geometry for last request
                              || ( mMasterModel->rowCount() == 0 ); // no features
 
@@ -1190,7 +1190,7 @@ void QgsDualView::onSortColumnChanged()
 void QgsDualView::updateSelectedFeatures()
 {
   QgsFeatureRequest r = mMasterModel->request();
-  if ( r.filterType() == QgsFeatureRequest::FilterNone && r.filterRect().isNull() )
+  if ( r.filterType() == QgsFeatureRequest::FilterNone && r.spatialFilterType() == Qgis::SpatialFilterType::NoFilter )
     return; // already requested all features
 
   r.setFilterFids( masterModel()->layer()->selectedFeatureIds() );
@@ -1202,7 +1202,7 @@ void QgsDualView::updateSelectedFeatures()
 void QgsDualView::updateEditedAddedFeatures()
 {
   QgsFeatureRequest r = mMasterModel->request();
-  if ( r.filterType() == QgsFeatureRequest::FilterNone && r.filterRect().isNull() )
+  if ( r.filterType() == QgsFeatureRequest::FilterNone && r.spatialFilterType() == Qgis::SpatialFilterType::NoFilter )
     return; // already requested all features
 
   r.setFilterFids( masterModel()->layer()->editBuffer() ? masterModel()->layer()->editBuffer()->allAddedOrEditedFeatures() : QgsFeatureIds() );

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -20,6 +20,7 @@
 #include "qgsexception.h"
 #include "qgsarcgisrestutils.h"
 #include "qgsfeedback.h"
+#include "qgsgeometryengine.h"
 
 QgsAfsFeatureSource::QgsAfsFeatureSource( const std::shared_ptr<QgsAfsSharedData> &sharedData )
   : mSharedData( sharedData )
@@ -81,6 +82,23 @@ QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool 
     // (but if we've already cached ALL the features, we skip this -- there's no need for
     // firing off another request to the server)
     mDeferredFeaturesInFilterRectCheck = true;
+  }
+
+  // prepare spatial filter geometries for optimal speed
+  switch ( mRequest.spatialFilterType() )
+  {
+    case Qgis::SpatialFilterType::NoFilter:
+    case Qgis::SpatialFilterType::BoundingBox:
+      break;
+
+    case Qgis::SpatialFilterType::DistanceWithin:
+      if ( !mRequest.referenceGeometry().isEmpty() )
+      {
+        mDistanceWithinGeom = mRequest.referenceGeometry();
+        mDistanceWithinEngine.reset( QgsGeometry::createGeometryEngine( mDistanceWithinGeom.constGet() ) );
+        mDistanceWithinEngine->prepareGeometry();
+      }
+      break;
   }
 
   mFeatureIdList = qgis::setToList( requestIds );
@@ -156,7 +174,12 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         return false;
 
       geometryToDestinationCrs( f, mTransform );
+      if ( mDistanceWithinEngine && mDistanceWithinEngine->distance( f.geometry().constGet() ) > mRequest.distanceWithin() )
+      {
+        result = false;
+      }
       f.setValid( result );
+
       mRemainingFeatureIds.removeAll( f.id() );
       return result;
     }
@@ -191,7 +214,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
             success = false;
           else
           {
-            if ( mRequest.flags() & QgsFeatureRequest::ExactIntersect )
+            if ( mRequest.spatialFilterType() == Qgis::SpatialFilterType::BoundingBox && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
             {
               // exact intersection check requested
               if ( !f.geometry().intersects( mFilterRect ) )
@@ -209,8 +232,13 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         if ( !success )
           continue;
         geometryToDestinationCrs( f, mTransform );
-        f.setValid( true );
-        return true;
+
+        bool result = true;
+        if ( mDistanceWithinEngine && mDistanceWithinEngine->distance( f.geometry().constGet() ) > mRequest.distanceWithin() )
+          result = false;
+
+        if ( result )
+          return true;
       }
       return false;
     }

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -58,6 +58,8 @@ class QgsAfsFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsAfs
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 
     QgsFeedback *mInterruptionChecker = nullptr;
     bool mDeferredFeaturesInFilterRectCheck = false;

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -104,6 +104,8 @@ class QgsDb2FeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 };
 
 #endif // QGSDB2FEATUREITERATOR_H

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -73,9 +73,17 @@ class QgsDelimitedTextFeatureIterator final: public QgsAbstractFeatureIteratorFr
     bool rewind() override;
     bool close() override;
 
-    // Tests whether the geometry is required, given that testGeometry is true.
-    bool wantGeometry( const QgsPointXY &point ) const;
-    bool wantGeometry( const QgsGeometry &geom ) const;
+    /**
+     * Check to see if the point is within the selection rectangle or within
+     * the desired distance from the reference geometry.
+     */
+    bool testSpatialFilter( const QgsPointXY &point ) const;
+
+    /**
+     * Check to see if the geometry is within the selection rectangle or within
+     * the desired distance from the reference geometry.
+     */
+    bool testSpatialFilter( const QgsGeometry &geom ) const;
 
   protected:
     bool fetchFeature( QgsFeature &feature ) override;
@@ -98,6 +106,9 @@ class QgsDelimitedTextFeatureIterator final: public QgsAbstractFeatureIteratorFr
     bool mLoadGeometry = false;
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
+
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 };
 
 

--- a/src/providers/gpx/qgsgpxfeatureiterator.h
+++ b/src/providers/gpx/qgsgpxfeatureiterator.h
@@ -84,6 +84,8 @@ class QgsGPXFeatureIterator final: public QgsAbstractFeatureIteratorFromSource<Q
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 };
 
 #endif // QGSGPXFEATUREITERATOR_H

--- a/src/providers/hana/qgshanafeatureiterator.h
+++ b/src/providers/hana/qgshanafeatureiterator.h
@@ -87,6 +87,8 @@ class QgsHanaFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsHa
     QString mSqlQuery;
     QVariantList mSqlQueryParams;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
     QgsAttributeList mAttributesToFetch;
     QgsCoordinateTransform mTransform;
     bool mHasAttributes = false;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -125,6 +125,8 @@ class QgsMssqlFeatureIterator final: public QgsAbstractFeatureIteratorFromSource
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 };
 
 #endif // QGSMSSQLFEATUREITERATOR_H

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -98,6 +98,10 @@ class QgsOracleFeatureIterator final: public QgsAbstractFeatureIteratorFromSourc
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+
     bool mIsTransactionConnection = false;
 };
 

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1060,9 +1060,9 @@ QString QgsPostgresConn::postgisVersion() const
     result = PQexec( QStringLiteral( "SELECT postgis_geos_version(), postgis_proj_version()" ) );
     mGeosAvailable = result.PQntuples() == 1 && !result.PQgetisnull( 0, 0 );
     mProjAvailable = result.PQntuples() == 1 && !result.PQgetisnull( 0, 1 );
-    QgsDebugMsg( QStringLiteral( "geos:%1 proj:%2" )
-                 .arg( mGeosAvailable ? result.PQgetvalue( 0, 0 ) : "none" )
-                 .arg( mProjAvailable ? result.PQgetvalue( 0, 1 ) : "none" ) );
+    QgsDebugMsgLevel( QStringLiteral( "geos:%1 proj:%2" )
+                      .arg( mGeosAvailable ? result.PQgetvalue( 0, 0 ) : "none" )
+                      .arg( mProjAvailable ? result.PQgetvalue( 0, 1 ) : "none" ), 2 );
   }
   else
   {

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -127,6 +127,9 @@ class QgsPostgresFeatureIterator final: public QgsAbstractFeatureIteratorFromSou
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+
 };
 
 #endif // QGSPOSTGRESFEATUREITERATOR_H

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -25,6 +25,7 @@
 #include "qgsjsonutils.h"
 #include "qgssettings.h"
 #include "qgsexception.h"
+#include "qgsgeometryengine.h"
 
 QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsSpatiaLiteFeatureSource>( source, ownSource, request )
@@ -64,9 +65,27 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
     return;
   }
 
+  // prepare spatial filter geometries for optimal speed
+  switch ( mRequest.spatialFilterType() )
+  {
+    case Qgis::SpatialFilterType::NoFilter:
+    case Qgis::SpatialFilterType::BoundingBox:
+      break;
+
+    case Qgis::SpatialFilterType::DistanceWithin:
+      if ( !mRequest.referenceGeometry().isEmpty() )
+      {
+        mDistanceWithinGeom = mRequest.referenceGeometry();
+        mDistanceWithinEngine.reset( QgsGeometry::createGeometryEngine( mDistanceWithinGeom.constGet() ) );
+        mDistanceWithinEngine->prepareGeometry();
+        mFetchGeometry = true;
+      }
+      break;
+  }
+
   //beware - limitAtProvider needs to be set to false if the request cannot be completely handled
   //by the provider (e.g., utilising QGIS expression filters)
-  bool limitAtProvider = ( mRequest.limit() >= 0 );
+  bool limitAtProvider = ( mRequest.limit() >= 0 ) && mRequest.spatialFilterType() != Qgis::SpatialFilterType::DistanceWithin;
 
   if ( !mFilterRect.isNull() && !mSource->mGeometryColumn.isNull() )
   {
@@ -238,16 +257,27 @@ bool QgsSpatiaLiteFeatureIterator::fetchFeature( QgsFeature &feature )
     return false;
   }
 
-  if ( !getFeature( sqliteStatement, feature ) )
+  bool foundMatchingFeature = false;
+  while ( !foundMatchingFeature )
   {
-    sqlite3_finalize( sqliteStatement );
-    sqliteStatement = nullptr;
-    close();
-    return false;
-  }
+    if ( !getFeature( sqliteStatement, feature ) )
+    {
+      sqlite3_finalize( sqliteStatement );
+      sqliteStatement = nullptr;
+      close();
+      return false;
+    }
 
-  feature.setValid( true );
-  geometryToDestinationCrs( feature, mTransform );
+    foundMatchingFeature = true;
+    feature.setValid( true );
+    geometryToDestinationCrs( feature, mTransform );
+
+    if ( mDistanceWithinEngine && mDistanceWithinEngine->distance( feature.geometry().constGet() ) > mRequest.distanceWithin() )
+    {
+      foundMatchingFeature = false;
+      feature.setValid( false );
+    }
+  }
   return true;
 }
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -110,6 +110,8 @@ class QgsSpatiaLiteFeatureIterator final: public QgsAbstractFeatureIteratorFromS
 
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 };
 
 #endif // QGSSPATIALITEFEATUREITERATOR_H

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
@@ -74,7 +74,8 @@ class QgsVirtualLayerFeatureIterator final: public QgsAbstractFeatureIteratorFro
     QgsFeatureId mFid = 0;
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
-
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
     std::unique_ptr< QgsGeometryEngine > mRectEngine;
 };
 

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
@@ -377,6 +377,8 @@ class QgsBackgroundCachedFeatureIterator final: public QObject,
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
+    QgsGeometry mDistanceWithinGeom;
+    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
 
     //! typically to save a FilterFid/FilterFids request that will not be captured by mRequest
     QgsFeatureRequest mAdditionalRequest;

--- a/tests/src/python/test_provider_gpx.py
+++ b/tests/src/python/test_provider_gpx.py
@@ -101,6 +101,10 @@ class TestPyQgsGpxProvider(unittest.TestCase, ProviderTestCase):
         pass
 
     @unittest.skip('Base provider test is not suitable for GPX provider')
+    def testGetFeaturesDistanceWithinTests(self):
+        pass
+
+    @unittest.skip('Base provider test is not suitable for GPX provider')
     def testFields(self):
         pass
 

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -843,8 +843,8 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
 
         # Check DataItem
         registry = QgsApplication.dataItemProviderRegistry()
-        ogrprovider = next(provider for provider in registry.providers() if provider.name() == 'OGR')
-        item = ogrprovider.createDataItem(tmpfile, None)
+        files_provider = next(provider for provider in registry.providers() if provider.name() == 'files')
+        item = files_provider.createDataItem(tmpfile, None)
         self.assertTrue(item.uri().endswith('testShzSupport.shz'))
 
     def testShpZipSupport(self):
@@ -899,17 +899,13 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
 
         # Check DataItem
         registry = QgsApplication.dataItemProviderRegistry()
-        ogrprovider = next(provider for provider in registry.providers() if provider.name() == 'OGR')
-        item = ogrprovider.createDataItem(tmpfile, None)
+        files_provider = next(provider for provider in registry.providers() if provider.name() == 'files')
+        item = files_provider.createDataItem(tmpfile, None)
         children = item.createChildren()
         self.assertEqual(len(children), 2)
         uris = sorted([children[i].uri() for i in range(2)])
         self.assertIn('testShpZipSupport.shp.zip|layername=layer1', uris[0])
         self.assertIn('testShpZipSupport.shp.zip|layername=layer2', uris[1])
-
-        gdalprovider = next(provider for provider in registry.providers() if provider.name() == 'GDAL')
-        item = gdalprovider.createDataItem(tmpfile, None)
-        assert not item
 
     def testWriteShapefileWithSingleConversion(self):
         """Check writing geometries from a POLYGON ESRI shapefile does not

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -489,7 +489,7 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         self.assertFalse(vl.crs().isValid())
 
         # even if provider has a crs - we don't respect it for non-spatial layers!
-        vl = QgsVectorLayer('None?crs=epsg:3111field=pk:integer', 'test', 'memory')
+        vl = QgsVectorLayer('None?crs=epsg:3111&field=pk:integer', 'test', 'memory')
         self.assertFalse(vl.isSpatial())
         self.assertFalse(vl.crs().isValid())
 


### PR DESCRIPTION
E.g. this request will retrieve all features within 50 map units of the provided linestring:

    QgsFeatureRequest().setDistanceWithin(QgsGeometry.fromWkt('LineString(0 0, 10 0, 12 1)'), 50)

A new enum Qgis::SpatialFilterType has been added to reflect whether a request uses no spatial filter, a BoundingBox filter (via
setFilterRect), or the new DistanceWithin filter.

Distance within filters are treated like bounding box filters, in that they are independant of any attribute/id filters (such as
feature ids or expressions).

Provider feature iterators can potentially delegate the distance within search to the backend (e.g. postgres could use a ST_DWithin query) for optimal index use.

~~Currently handled only with the memory provider -- if the api and approach is deemed satisfactory then I'll implement for the other providers.~~
