### PR TITLE
Fix singleFile atlas layout property

### DIFF
--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -34,6 +34,9 @@ QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
 
   //listen out for layer removal
   connect( mLayout->project(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsLayoutAtlas::removeLayers );
+
+  if ( mLayout->customProperty( QStringLiteral( "singleFile" ) ).isNull() )
+    mLayout->setCustomProperty( QStringLiteral( "singleFile" ), true );
 }
 
 QString QgsLayoutAtlas::stringType() const

--- a/src/gui/layout/qgslayoutatlaswidget.cpp
+++ b/src/gui/layout/qgslayoutatlaswidget.cpp
@@ -392,9 +392,6 @@ void QgsLayoutAtlasWidget::updateGuiElements()
   mAtlasFilenamePatternEdit->setText( mAtlas->filenameExpression() );
   mAtlasHideCoverageCheckBox->setCheckState( mAtlas->hideCoverage() ? Qt::Checked : Qt::Unchecked );
 
-  if ( mLayout->customProperty( QStringLiteral( "singleFile" ) ).isNull() )
-    mLayout->setCustomProperty( QStringLiteral( "singleFile" ), true );
-
   bool singleFile = mLayout->customProperty( QStringLiteral( "singleFile" ) ).toBool();
   mAtlasSingleFileCheckBox->setCheckState( singleFile ? Qt::Checked : Qt::Unchecked );
   mAtlasFilenamePatternEdit->setEnabled( !singleFile );

--- a/src/gui/layout/qgslayoutatlaswidget.cpp
+++ b/src/gui/layout/qgslayoutatlaswidget.cpp
@@ -392,7 +392,10 @@ void QgsLayoutAtlasWidget::updateGuiElements()
   mAtlasFilenamePatternEdit->setText( mAtlas->filenameExpression() );
   mAtlasHideCoverageCheckBox->setCheckState( mAtlas->hideCoverage() ? Qt::Checked : Qt::Unchecked );
 
-  bool singleFile = mLayout->customProperty( QStringLiteral( "singleFile" ), true ).toBool();
+  if ( mLayout->customProperty( QStringLiteral( "singleFile" ) ).isNull() )
+    mLayout->setCustomProperty( QStringLiteral( "singleFile" ), true );
+
+  bool singleFile = mLayout->customProperty( QStringLiteral( "singleFile" ) ).toBool();
   mAtlasSingleFileCheckBox->setCheckState( singleFile ? Qt::Checked : Qt::Unchecked );
   mAtlasFilenamePatternEdit->setEnabled( !singleFile );
   mAtlasFilenameExpressionButton->setEnabled( !singleFile );


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/44531

Ensures the `singleFile` layout property is set when generating atlas.