### PR TITLE
Disable ultra-fragile mesh terrain rendering test on CI

### DIFF
--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -340,6 +340,9 @@ void TestQgs3DRendering::testTerrainShading()
 
 void TestQgs3DRendering::testMeshTerrain()
 {
+  if ( !QgsTest::runFlakyTests() )
+    QSKIP( "This test is flaky and disabled on CI" );
+
   QgsRectangle fullExtent = mLayerMeshTerrain->extent();
 
   Qgs3DMapSettings *map = new Qgs3DMapSettings;


### PR DESCRIPTION
This test fails > 50% of the time... :vomiting_face: 