### PR TITLE
updated connections-default.xml

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -15,4 +15,5 @@
     <csw name="UNEP GRID-Geneva Metadata Catalog" url="https://datacore-gn.unepgrid.ch/geonetwork/srv/eng/csw"/>
     <csw name="Portugal: Sistema Nacional de Informação Geográfica (SNIG)" url="https://snig.dgterritorio.gov.pt/rndg/srv/eng/csw"/>
     <csw name="Spain: Centro Nacional de Información Geográfica (CNIG)" url="http://www.ign.es/csw-inspire/srv/spa/csw"/>
+    <csw name="Germany: GDI-DE Geodatenkatalog.de" url="https://gdk.gdi-de.org/gdi-de/srv/ger/csw"/>  
 </qgsCSWConnections>


### PR DESCRIPTION
## Description
added the German spatial data catalogue (GDI-DE Geodatenkatalog.de) of the Spatial Data Infrastructure Germany (GDI-DE) to the list of the default connections

1. *what* changed: ![grafik](https://user-images.githubusercontent.com/29542183/128308630-5acc51c0-7ce2-4b60-8176-454fb236b178.png)
2. *why* changed: to provide an easy and user-friendly metadata search in the German spatial data catalogue within QGIS