### PR TITLE
fix docker cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -120,7 +120,7 @@ jobs:
           DOCKER_IMAGE: ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }}
 
       - name: Push Qt5 deps image to Docker hub
-        if: ${{ github.repository_owner == 'qgis' && github.event_name != 'pull_request' && matrix.qt-version == '5' }}
+        if: ${{ github.repository_owner == 'qgis' && github.event_name != 'pull_request' && matrix.qt-version == '5' && matrix.distro-version == '20.04' }}
         run: |
           docker tag qgis3-build-deps qgis/qgis3-build-deps:${DOCKER_TAG}
           docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,7 +106,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          image_name: qgis3-qt6-build-deps
+          image_name: qgis3-dv${{ matrix.distro-version }}-qt${{ matrix.qt-version }}-build-deps
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"
           push_git_tag: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis3-dv${{ matrix.distro-version }}-qt${{ matrix.qt-version }}-build-deps
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"
@@ -342,7 +342,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           image_name: qgis3-qt${{ matrix.qt-version }}-build-deps-bin-only
           dockerfile: .docker/qgis3-qt${{ matrix.qt-version }}-build-deps.dockerfile
           build_extra_args: "--target ${{ matrix.docker-target }} --build-arg=DISTRO_VERSION=${{ matrix.distro-version }}"


### PR DESCRIPTION
After these changes step `Build Docker Container with Build Environment` will take less than 3 minutes to complete (for ordinary PR).

Disadvantages: instead of the old 4 docker containers:
```
qgis3-qt6-build-deps
qgis/qgis3-qt5-build-deps-bin-only
qgis3-qt6-build-deps-stages
qgis/qgis3-qt5-build-deps-bin-only-stages
```
6 new packages will be created:
```
qgis3-dv20.04-qt5-build-deps
qgis3-dv21.04-qt5-build-deps
qgis3-qt5-build-deps-bin-only
qgis3-dv20.04-qt5-build-deps-stages
qgis3-dv21.04-qt5-build-deps-stages
qgis3-qt5-build-deps-bin-only-stages
```