### PR TITLE
Read/write coordinate epoch for supported GDAL datasets

### DIFF
--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -170,6 +170,11 @@ QgsDwgImporter::~QgsDwgImporter()
   {
     commitTransaction();
   }
+  if ( mCrsH )
+  {
+    OSRRelease( mCrsH );
+    mCrsH = nullptr;
+  }
 }
 
 QString drwVersionToString( DRW::Version version )

--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -71,14 +71,13 @@ QgsDwgImporter::QgsDwgImporter( const QString &database, const QgsCoordinateRefe
   , mSplineSegs( 8 )
   , mBlockHandle( -1 )
   , mCrs( crs.srsid() )
-  , mCrsH( nullptr )
   , mUseCurves( true )
   , mEntities( 0 )
 {
   QgsDebugCall;
 
   QString crswkt( crs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL ) );
-  mCrsH = OSRNewSpatialReference( crswkt.toLocal8Bit().constData() );
+  mCrsH = QgsOgrUtils::crsToOGRSpatialReference( crs );
   QgsDebugMsg( QStringLiteral( "CRS %1[%2]: %3" ).arg( mCrs ).arg( ( qint64 ) mCrsH, 0, 16 ).arg( crswkt ) );
 }
 

--- a/src/app/dwg/qgsdwgimporter.h
+++ b/src/app/dwg/qgsdwgimporter.h
@@ -211,7 +211,7 @@ class QgsDwgImporter : public DRW_Interface
     int mSplineSegs;
     int mBlockHandle;
     int mCrs;
-    OGRSpatialReferenceH mCrsH;
+    OGRSpatialReferenceH mCrsH = nullptr;
     bool mUseCurves;
 
     QHash<QString, QString> mLayerColor;

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -794,7 +794,6 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
   }
 
   //consider spatial reference system
-  OGRSpatialReferenceH reference = nullptr;
 
   QgsCoordinateReferenceSystem mySpatialRefSys;
   if ( srs.isValid() )
@@ -806,12 +805,7 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
     mySpatialRefSys.validate();
   }
 
-  QString myWkt = mySpatialRefSys.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL );
-
-  if ( !myWkt.isNull()  &&  myWkt.length() != 0 )
-  {
-    reference = OSRNewSpatialReference( myWkt.toLocal8Bit().data() );
-  }
+  OGRSpatialReferenceH reference = QgsOgrUtils::crsToOGRSpatialReference( mySpatialRefSys );
 
   // Map the qgis geometry type to the OGR geometry type
   OGRwkbGeometryType OGRvectortype = wkbUnknown;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -674,7 +674,7 @@ void QgsOfflineEditing::convertToOfflineLayer( QgsVectorLayer *layer, sqlite3 *d
       }
 
       OGRSFDriverH hDriver = nullptr;
-      OGRSpatialReferenceH hSRS = OSRNewSpatialReference( layer->crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL ).toLocal8Bit().data() );
+      OGRSpatialReferenceH hSRS = QgsOgrUtils::crsToOGRSpatialReference( layer->crs() );
       gdal::ogr_datasource_unique_ptr hDS( OGROpen( offlineDbPath.toUtf8().constData(), true, &hDriver ) );
       OGRLayerH hLayer = OGR_DS_CreateLayer( hDS.get(), tableName.toUtf8().constData(), hSRS, static_cast<OGRwkbGeometryType>( layer->wkbType() ), options );
       CSLDestroy( options );

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -957,7 +957,37 @@ QgsCoordinateReferenceSystem QgsOgrUtils::OGRSpatialReferenceToCrs( OGRSpatialRe
   if ( wkt.isEmpty() )
     return QgsCoordinateReferenceSystem();
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,0)
+  QgsCoordinateReferenceSystem res = QgsCoordinateReferenceSystem::fromWkt( wkt );
+  const double coordinateEpoch = OSRGetCoordinateEpoch( srs );
+  if ( coordinateEpoch > 0 )
+    res.setCoordinateEpoch( coordinateEpoch );
+  return res;
+#else
   return QgsCoordinateReferenceSystem::fromWkt( wkt );
+#endif
+}
+
+OGRSpatialReferenceH QgsOgrUtils::crsToOGRSpatialReference( const QgsCoordinateReferenceSystem &crs )
+{
+  if ( crs.isValid() )
+  {
+    const QString srsWkt = crs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL );
+
+    if ( OGRSpatialReferenceH ogrSrs = OSRNewSpatialReference( srsWkt.toLocal8Bit().constData() ) )
+    {
+      OSRSetAxisMappingStrategy( ogrSrs, OAMS_TRADITIONAL_GIS_ORDER );
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,0)
+      if ( !std::isnan( crs.coordinateEpoch() ) )
+      {
+        OSRSetCoordinateEpoch( ogrSrs, crs.coordinateEpoch() );
+      }
+#endif
+      return ogrSrs;
+    }
+  }
+
+  return nullptr;
 }
 
 QString QgsOgrUtils::readShapefileEncoding( const QString &path )

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -295,6 +295,15 @@ class CORE_EXPORT QgsOgrUtils
     static QgsCoordinateReferenceSystem OGRSpatialReferenceToCrs( OGRSpatialReferenceH srs );
 
     /**
+     * Returns a OGRSpatialReferenceH corresponding to the specified \a crs object.
+     *
+     * \note Caller must release the returned object with OSRRelease.
+     *
+     * \since QGIS 3.22
+     */
+    static OGRSpatialReferenceH crsToOGRSpatialReference( const QgsCoordinateReferenceSystem &crs );
+
+    /**
      * Reads the encoding of the shapefile at the specified \a path (where \a path is the
      * location of the ".shp" file).
      *

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -430,16 +430,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     }
   }
 
-  if ( srs.isValid() )
-  {
-    QString srsWkt = srs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL );
-    QgsDebugMsgLevel( "WKT to save as is " + srsWkt, 2 );
-    mOgrRef = OSRNewSpatialReference( srsWkt.toLocal8Bit().constData() );
-    if ( mOgrRef )
-    {
-      OSRSetAxisMappingStrategy( mOgrRef, OAMS_TRADITIONAL_GIS_ORDER );
-    }
-  }
+  mOgrRef = QgsOgrUtils::crsToOGRSpatialReference( srs );
 
   // datasource created, now create the output layer
   OGRwkbGeometryType wkbType = ogrTypeFromWkbType( geometryType );
@@ -2895,7 +2886,7 @@ QgsVectorFileWriter::~QgsVectorFileWriter()
 
   if ( mOgrRef )
   {
-    OSRDestroySpatialReference( mOgrRef );
+    OSRRelease( mOgrRef );
   }
 }
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -412,8 +412,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
   QgsCoordinateReferenceSystem srs = mCrsSelector->crs();
   if ( wkbType != wkbNone && srs.isValid() )
   {
-    QString srsWkt = srs.toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED_GDAL );
-    hSRS = OSRNewSpatialReference( srsWkt.toLocal8Bit().data() );
+    hSRS = QgsOgrUtils::crsToOGRSpatialReference( srs );
   }
 
   // Set options


### PR DESCRIPTION
requires GDAL 3.4+ 