### PR TITLE
Add api to QgsProviderMetadata to return any possible sidecar files which may exist for a file

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -295,6 +295,20 @@ The default method returns ``False`` for all URIs.
 .. versionadded:: 3.18
 %End
 
+    virtual QStringList sidecarFilesForUri( const QString &uri ) const;
+%Docstring
+Given a ``uri``, returns any sidecar files which are associated with the URI and this
+provider.
+
+For instance, the OGR provider would return the corresponding .dbf, .idx, etc files for a
+uri pointing at a .shp file.
+
+Implementations should files any files which MAY exist for the URI, and it is up to the caller
+to filter these to only existing files if required.
+
+.. versionadded:: 3.22
+%End
+
     virtual QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = 0 ) const;
 %Docstring
 Queries the specified ``uri`` and returns a list of any valid sublayers found in the dataset which can be handled by this provider.

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -300,11 +300,22 @@ The default method returns ``False`` for all URIs.
 Given a ``uri``, returns any sidecar files which are associated with the URI and this
 provider.
 
+In this context a sidecar file is defined as a file which shares the same base filename
+as a dataset, but which differs in file extension. It defines the list of additional
+files which must be renamed or deleted alongside the main file associated with the
+dataset in order to completely rename/delete the dataset.
+
 For instance, the OGR provider would return the corresponding .dbf, .idx, etc files for a
 uri pointing at a .shp file.
 
 Implementations should files any files which MAY exist for the URI, and it is up to the caller
 to filter these to only existing files if required.
+
+.. note::
+
+   Some file formats consist of a set of static file names, such as ESRI aigrid datasets
+   which consist of a folder with files with the names "hdr.adf", "prj.adf", etc. These statically
+   named files are NOT considered as sidecar files.
 
 .. versionadded:: 3.22
 %End

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3765,6 +3765,13 @@ QStringList QgsGdalProviderMetadata::sidecarFilesForUri( const QString &uri ) co
         QStringLiteral( "vdc" ),
         QStringLiteral( "avl" ),
       }
+    },
+    {
+      QStringLiteral( "sdat" ), {
+        QStringLiteral( "sgrd" ),
+        QStringLiteral( "mgrd" ),
+        QStringLiteral( "prj" ),
+      }
     }
   };
 
@@ -3786,8 +3793,9 @@ QStringList QgsGdalProviderMetadata::sidecarFilesForUri( const QString &uri ) co
   for ( const QString &ext :
         {
           QStringLiteral( "aux.xml" ),
+          QStringLiteral( "vat.dbf" ),
           QStringLiteral( "ovr" ),
-          QStringLiteral( "wld" )
+          QStringLiteral( "wld" ),
         } )
   {
     res.append( fileInfo.dir().filePath( fileInfo.completeBaseName() + '.' + ext ) );
@@ -3801,3 +3809,4 @@ QgsGdalProviderMetadata::QgsGdalProviderMetadata():
 }
 
 ///@endcond
+

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3755,6 +3755,16 @@ QStringList QgsGdalProviderMetadata::sidecarFilesForUri( const QString &uri ) co
       QStringLiteral( "bt" ), {
         QStringLiteral( "btw" ),
       }
+    },
+    {
+      QStringLiteral( "rst" ), {
+        QStringLiteral( "rdc" ),
+        QStringLiteral( "smp" ),
+        QStringLiteral( "ref" ),
+        QStringLiteral( "vct" ),
+        QStringLiteral( "vdc" ),
+        QStringLiteral( "avl" ),
+      }
     }
   };
 

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -385,6 +385,7 @@ class QgsGdalProviderMetadata final: public QgsProviderMetadata
     QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const override;
     ProviderCapabilities providerCapabilities() const override;
     QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+    QStringList sidecarFilesForUri( const QString &uri ) const override;
 };
 
 ///@endcond

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -1297,6 +1297,75 @@ QList<QgsProviderSublayerDetails> QgsOgrProviderMetadata::querySublayers( const 
   return res;
 }
 
+QStringList QgsOgrProviderMetadata::sidecarFilesForUri( const QString &uri ) const
+{
+  const QVariantMap uriParts = decodeUri( uri );
+  const QString path = uriParts.value( QStringLiteral( "path" ) ).toString();
+
+  if ( path.isEmpty() )
+    return {};
+
+  const QFileInfo fileInfo( path );
+  const QString suffix = fileInfo.suffix();
+
+  static QMap< QString, QStringList > sExtensions
+  {
+    {
+      QStringLiteral( "shp" ), {
+        QStringLiteral( "shx" ),
+        QStringLiteral( "dbf" ),
+        QStringLiteral( "sbn" ),
+        QStringLiteral( "sbx" ),
+        QStringLiteral( "prj" ),
+        QStringLiteral( "idm" ),
+        QStringLiteral( "ind" ),
+        QStringLiteral( "qix" ),
+        QStringLiteral( "cpg" ),
+        QStringLiteral( "qpj" ),
+        QStringLiteral( "shp.xml" ),
+      }
+    },
+    {
+      QStringLiteral( "tab" ), {
+        QStringLiteral( "dat" ),
+        QStringLiteral( "id" ),
+        QStringLiteral( "map" ),
+        QStringLiteral( "ind" ),
+        QStringLiteral( "tda" ),
+        QStringLiteral( "tin" ),
+        QStringLiteral( "tma" ),
+        QStringLiteral( "lda" ),
+        QStringLiteral( "lin" ),
+        QStringLiteral( "lma" ),
+      }
+    },
+    {
+      QStringLiteral( "gml" ), {
+        QStringLiteral( "gfs" ),
+        QStringLiteral( "xsd" ),
+      }
+    },
+    {
+      QStringLiteral( "csv" ), {
+        QStringLiteral( "csvt" ),
+      }
+    },
+  };
+
+  QStringList res;
+  for ( auto it = sExtensions.constBegin(); it != sExtensions.constEnd(); ++it )
+  {
+    if ( suffix.compare( it.key(), Qt::CaseInsensitive ) == 0 )
+    {
+      for ( const QString &ext : it.value() )
+      {
+        res.append( fileInfo.dir().filePath( fileInfo.completeBaseName() + '.' + ext ) );
+      }
+    }
+  }
+  return res;
+}
+
 QMap<QString, QgsAbstractProviderConnection *> QgsOgrProviderMetadata::connections( bool cached )
 {
   return connectionsProtected<QgsGeoPackageProviderConnection, QgsOgrDbConnection>( cached );

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -1340,6 +1340,11 @@ QStringList QgsOgrProviderMetadata::sidecarFilesForUri( const QString &uri ) con
       }
     },
     {
+      QStringLiteral( "mif" ), {
+        QStringLiteral( "mid" ),
+      }
+    },
+    {
       QStringLiteral( "gml" ), {
         QStringLiteral( "gfs" ),
         QStringLiteral( "xsd" ),

--- a/src/core/providers/ogr/qgsogrprovidermetadata.h
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.h
@@ -43,6 +43,7 @@ class QgsOgrProviderMetadata final: public QgsProviderMetadata
     ProviderCapabilities providerCapabilities() const override;
     bool uriIsBlocklisted( const QString &uri ) const override;
     QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = nullptr ) const override;
+    QStringList sidecarFilesForUri( const QString &uri ) const override;
     Qgis::VectorExportResult createEmptyLayer(
       const QString &uri,
       const QgsFields &fields,

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -107,6 +107,11 @@ bool QgsProviderMetadata::uriIsBlocklisted( const QString & ) const
   return false;
 }
 
+QStringList QgsProviderMetadata::sidecarFilesForUri( const QString & ) const
+{
+  return QStringList();
+}
+
 QList<QgsProviderSublayerDetails> QgsProviderMetadata::querySublayers( const QString &, Qgis::SublayerQueryFlags, QgsFeedback * ) const
 {
   return QList<QgsProviderSublayerDetails>();

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -358,11 +358,20 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
      * Given a \a uri, returns any sidecar files which are associated with the URI and this
      * provider.
      *
+     * In this context a sidecar file is defined as a file which shares the same base filename
+     * as a dataset, but which differs in file extension. It defines the list of additional
+     * files which must be renamed or deleted alongside the main file associated with the
+     * dataset in order to completely rename/delete the dataset.
+     *
      * For instance, the OGR provider would return the corresponding .dbf, .idx, etc files for a
      * uri pointing at a .shp file.
      *
      * Implementations should files any files which MAY exist for the URI, and it is up to the caller
      * to filter these to only existing files if required.
+     *
+     * \note Some file formats consist of a set of static file names, such as ESRI aigrid datasets
+     * which consist of a folder with files with the names "hdr.adf", "prj.adf", etc. These statically
+     * named files are NOT considered as sidecar files.
      *
      * \since QGIS 3.22
      */

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -355,6 +355,20 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     virtual bool uriIsBlocklisted( const QString &uri ) const;
 
     /**
+     * Given a \a uri, returns any sidecar files which are associated with the URI and this
+     * provider.
+     *
+     * For instance, the OGR provider would return the corresponding .dbf, .idx, etc files for a
+     * uri pointing at a .shp file.
+     *
+     * Implementations should files any files which MAY exist for the URI, and it is up to the caller
+     * to filter these to only existing files if required.
+     *
+     * \since QGIS 3.22
+     */
+    virtual QStringList sidecarFilesForUri( const QString &uri ) const;
+
+    /**
      * Queries the specified \a uri and returns a list of any valid sublayers found in the dataset which can be handled by this provider.
      *
      * The optional \a flags argument can be used to control the behavior of the query.

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -115,6 +115,28 @@ class PyQgsGdalProvider(unittest.TestCase):
         encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
         self.assertEqual(encodedUri, uri)
 
+    def test_provider_sidecar_files_for_uri(self):
+        """
+        Test retrieving sidecar files for uris
+        """
+        metadata = QgsProviderRegistry.instance().providerMetadata('gdal')
+
+        self.assertEqual(metadata.sidecarFilesForUri(''), [])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/some_file.asc'), ['/home/me/some_file.aux.xml', '/home/me/some_file.ovr', '/home/me/some_file.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.jpg'), ['/home/me/special.jpw', '/home/me/special.jgw', '/home/me/special.jpgw', '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.img'),
+                         ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sid'),
+                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tif'), ['/home/me/special.tifw', '/home/me/special.tfw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bil'),
+                         ['/home/me/special.bilw', '/home/me/special.blw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.raster'),
+                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bt'),
+                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -111,7 +111,8 @@ class PyQgsGdalProvider(unittest.TestCase):
 
         uri = '/vsizip//my/file.zip/image.tif'
         parts = QgsProviderRegistry.instance().decodeUri('gdal', uri)
-        self.assertEqual(parts, {'path': '/my/file.zip', 'layerName': None, 'vsiPrefix': '/vsizip/', 'vsiSuffix': '/image.tif'})
+        self.assertEqual(parts, {'path': '/my/file.zip', 'layerName': None, 'vsiPrefix': '/vsizip/',
+                                 'vsiSuffix': '/image.tif'})
         encodedUri = QgsProviderRegistry.instance().encodeUri('gdal', parts)
         self.assertEqual(encodedUri, uri)
 
@@ -122,20 +123,34 @@ class PyQgsGdalProvider(unittest.TestCase):
         metadata = QgsProviderRegistry.instance().providerMetadata('gdal')
 
         self.assertEqual(metadata.sidecarFilesForUri(''), [])
-        self.assertEqual(metadata.sidecarFilesForUri('/home/me/some_file.asc'), ['/home/me/some_file.aux.xml', '/home/me/some_file.ovr', '/home/me/some_file.wld'])
-        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.jpg'), ['/home/me/special.jpw', '/home/me/special.jgw', '/home/me/special.jpgw', '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/some_file.asc'),
+                         ['/home/me/some_file.aux.xml', '/home/me/some_file.ovr', '/home/me/some_file.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.jpg'),
+                         ['/home/me/special.jpw', '/home/me/special.jgw', '/home/me/special.jpgw',
+                          '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.img'),
                          ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sid'),
-                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
-        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tif'), ['/home/me/special.tifw', '/home/me/special.tfw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tif'),
+                         ['/home/me/special.tifw', '/home/me/special.tfw', '/home/me/special.aux.xml',
+                          '/home/me/special.ovr', '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bil'),
-                         ['/home/me/special.bilw', '/home/me/special.blw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+                         ['/home/me/special.bilw', '/home/me/special.blw', '/home/me/special.aux.xml',
+                          '/home/me/special.ovr', '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.raster'),
-                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bt'),
-                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.rst'),
+                         ['/home/me/special.rdc', '/home/me/special.smp', '/home/me/special.ref',
+                          '/home/me/special.vct', '/home/me/special.vdc', '/home/me/special.avl',
+                          '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -14,13 +14,10 @@ import os
 
 from qgis.core import (
     QgsProviderRegistry,
-    QgsDataProvider,
     QgsRasterLayer,
     QgsRectangle,
 )
 from qgis.testing import start_app, unittest
-
-from qgis.PyQt.QtGui import qRed
 
 from utilities import unitTestDataPath
 
@@ -124,33 +121,46 @@ class PyQgsGdalProvider(unittest.TestCase):
 
         self.assertEqual(metadata.sidecarFilesForUri(''), [])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/some_file.asc'),
-                         ['/home/me/some_file.aux.xml', '/home/me/some_file.ovr', '/home/me/some_file.wld'])
+                         ['/home/me/some_file.aux.xml', '/home/me/some_file.vat.dbf', '/home/me/some_file.ovr',
+                          '/home/me/some_file.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.jpg'),
                          ['/home/me/special.jpw', '/home/me/special.jgw', '/home/me/special.jpgw',
-                          '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                          '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.img'),
-                         ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                         ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sid'),
-                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tif'),
                          ['/home/me/special.tifw', '/home/me/special.tfw', '/home/me/special.aux.xml',
+                          '/home/me/special.vat.dbf',
                           '/home/me/special.ovr', '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bil'),
                          ['/home/me/special.bilw', '/home/me/special.blw', '/home/me/special.aux.xml',
+                          '/home/me/special.vat.dbf',
                           '/home/me/special.ovr', '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.raster'),
-                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bt'),
-                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.ovr',
+                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.ovr',
                           '/home/me/special.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.rst'),
                          ['/home/me/special.rdc', '/home/me/special.smp', '/home/me/special.ref',
                           '/home/me/special.vct', '/home/me/special.vdc', '/home/me/special.avl',
-                          '/home/me/special.aux.xml', '/home/me/special.ovr', '/home/me/special.wld'])
+                          '/home/me/special.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sdat'),
+                         ['/home/me/special.sgrd', '/home/me/special.mgrd', '/home/me/special.prj',
+                          '/home/me/special.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.wld'])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2127,6 +2127,27 @@ class PyQgsOGRProvider(unittest.TestCase):
         res = metadata.querySublayers(os.path.join(TEST_DATA_DIR, "/raster/hub13263.vrt"), Qgis.SublayerQueryFlag.FastScan)
         self.assertEqual(len(res), 0)
 
+    def test_provider_sidecar_files_for_uri(self):
+        """
+        Test retrieving sidecar files for uris
+        """
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+
+        self.assertEqual(metadata.sidecarFilesForUri(''), [])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/not special.doc'), [])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.shp'),
+                         ['/home/me/special.shx', '/home/me/special.dbf', '/home/me/special.sbn',
+                          '/home/me/special.sbx', '/home/me/special.prj', '/home/me/special.idm',
+                          '/home/me/special.ind', '/home/me/special.qix', '/home/me/special.cpg',
+                          '/home/me/special.qpj', '/home/me/special.shp.xml'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tab'),
+                         ['/home/me/special.dat', '/home/me/special.id', '/home/me/special.map', '/home/me/special.ind',
+                          '/home/me/special.tda', '/home/me/special.tin', '/home/me/special.tma',
+                          '/home/me/special.lda', '/home/me/special.lin', '/home/me/special.lma'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.gml'),
+                         ['/home/me/special.gfs', '/home/me/special.xsd'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.csv'), ['/home/me/special.csvt'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2144,6 +2144,8 @@ class PyQgsOGRProvider(unittest.TestCase):
                          ['/home/me/special.dat', '/home/me/special.id', '/home/me/special.map', '/home/me/special.ind',
                           '/home/me/special.tda', '/home/me/special.tin', '/home/me/special.tma',
                           '/home/me/special.lda', '/home/me/special.lin', '/home/me/special.lma'])
+        self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.mif'),
+                         ['/home/me/special.mid'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.gml'),
                          ['/home/me/special.gfs', '/home/me/special.xsd'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.csv'), ['/home/me/special.csvt'])


### PR DESCRIPTION
And implement initial versions for gdal/ogr provider.

There's probably quite a few missing here -- add your favourites! @PeterPetrik @wonder-sk @vcloarec please let me know if there's any mesh file types which use sidecars too, and I'll add those. 

(Long term plan is to move the ogr/gdal implementations upstream)

The motivation here is to provide a way to safely rename a file, ensuring that all the companion sidecar files get renamed accordingly.