### PR TITLE
When deleting files through the browser panel, ensure that all sidecar files are always deleted too

### DIFF
--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -135,6 +135,26 @@ network drive or other non-fixed device.
 .. versionadded:: 3.20
 %End
 
+    static QSet< QString > sidecarFilesForPath( const QString &path );
+%Docstring
+Returns a list of the sidecar files which exist for the dataset a the specified ``path``.
+
+In this context a sidecar file is defined as a file which shares the same base filename
+as a dataset, but which differs in file extension. It defines the list of additional
+files which must be renamed or deleted alongside the main file associated with the
+dataset in order to completely rename/delete the dataset.
+
+For instance, if ``path`` specified a .shp file then the corresponding .dbf, .idx
+and .prj files would be returned (amongst others).
+
+.. note::
+
+   QGIS metadata files (.qmd) and map layer styling files (.qml) are NOT included
+   in the returned list.
+
+.. versionadded:: 3.22
+%End
+
 };
 
 /************************************************************************

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3710,7 +3710,6 @@ QStringList QgsGdalProviderMetadata::sidecarFilesForUri( const QString &uri ) co
   if ( path.isEmpty() )
     return {};
 
-  // all gdal uris may have a .aux.xml sidecar
   const QFileInfo fileInfo( path );
   const QString suffix = fileInfo.suffix();
 
@@ -3799,6 +3798,7 @@ QStringList QgsGdalProviderMetadata::sidecarFilesForUri( const QString &uri ) co
         } )
   {
     res.append( fileInfo.dir().filePath( fileInfo.completeBaseName() + '.' + ext ) );
+    res.append( path + '.' + ext );
   }
   return res;
 }

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -137,6 +137,24 @@ class CORE_EXPORT QgsFileUtils
      */
     static bool pathIsSlowDevice( const QString &path );
 
+    /**
+     * Returns a list of the sidecar files which exist for the dataset a the specified \a path.
+     *
+     * In this context a sidecar file is defined as a file which shares the same base filename
+     * as a dataset, but which differs in file extension. It defines the list of additional
+     * files which must be renamed or deleted alongside the main file associated with the
+     * dataset in order to completely rename/delete the dataset.
+     *
+     * For instance, if \a path specified a .shp file then the corresponding .dbf, .idx
+     * and .prj files would be returned (amongst others).
+     *
+     * \note QGIS metadata files (.qmd) and map layer styling files (.qml) are NOT included
+     * in the returned list.
+     *
+     * \since QGIS 3.22
+     */
+    static QSet< QString > sidecarFilesForPath( const QString &path );
+
 };
 
 #endif // QGSFILEUTILS_H

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -121,46 +121,51 @@ class PyQgsGdalProvider(unittest.TestCase):
 
         self.assertEqual(metadata.sidecarFilesForUri(''), [])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/some_file.asc'),
-                         ['/home/me/some_file.aux.xml', '/home/me/some_file.vat.dbf', '/home/me/some_file.ovr',
-                          '/home/me/some_file.wld'])
+                         ['/home/me/some_file.aux.xml', '/home/me/some_file.asc.aux.xml', '/home/me/some_file.vat.dbf',
+                          '/home/me/some_file.asc.vat.dbf', '/home/me/some_file.ovr', '/home/me/some_file.asc.ovr',
+                          '/home/me/some_file.wld', '/home/me/some_file.asc.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.jpg'),
                          ['/home/me/special.jpw', '/home/me/special.jgw', '/home/me/special.jpgw',
-                          '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                          '/home/me/special.jpegw', '/home/me/special.aux.xml', '/home/me/special.jpg.aux.xml',
+                          '/home/me/special.vat.dbf', '/home/me/special.jpg.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.jpg.ovr', '/home/me/special.wld', '/home/me/special.jpg.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.img'),
-                         ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                         ['/home/me/special.ige', '/home/me/special.aux.xml', '/home/me/special.img.aux.xml',
+                          '/home/me/special.vat.dbf', '/home/me/special.img.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.img.ovr', '/home/me/special.wld', '/home/me/special.img.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sid'),
-                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                         ['/home/me/special.j2w', '/home/me/special.aux.xml', '/home/me/special.sid.aux.xml',
+                          '/home/me/special.vat.dbf', '/home/me/special.sid.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.sid.ovr', '/home/me/special.wld', '/home/me/special.sid.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.tif'),
                          ['/home/me/special.tifw', '/home/me/special.tfw', '/home/me/special.aux.xml',
-                          '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr', '/home/me/special.wld'])
+                          '/home/me/special.tif.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.tif.vat.dbf',
+                          '/home/me/special.ovr', '/home/me/special.tif.ovr', '/home/me/special.wld',
+                          '/home/me/special.tif.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bil'),
                          ['/home/me/special.bilw', '/home/me/special.blw', '/home/me/special.aux.xml',
-                          '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr', '/home/me/special.wld'])
+                          '/home/me/special.bil.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.bil.vat.dbf',
+                          '/home/me/special.ovr', '/home/me/special.bil.ovr', '/home/me/special.wld',
+                          '/home/me/special.bil.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.raster'),
-                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                         ['/home/me/special.rasterw', '/home/me/special.aux.xml', '/home/me/special.raster.aux.xml',
+                          '/home/me/special.vat.dbf', '/home/me/special.raster.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.raster.ovr', '/home/me/special.wld', '/home/me/special.raster.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.bt'),
-                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.vat.dbf',
-                          '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                         ['/home/me/special.btw', '/home/me/special.aux.xml', '/home/me/special.bt.aux.xml',
+                          '/home/me/special.vat.dbf', '/home/me/special.bt.vat.dbf', '/home/me/special.ovr',
+                          '/home/me/special.bt.ovr', '/home/me/special.wld', '/home/me/special.bt.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.rst'),
                          ['/home/me/special.rdc', '/home/me/special.smp', '/home/me/special.ref',
                           '/home/me/special.vct', '/home/me/special.vdc', '/home/me/special.avl',
-                          '/home/me/special.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                          '/home/me/special.aux.xml', '/home/me/special.rst.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.rst.vat.dbf', '/home/me/special.ovr', '/home/me/special.rst.ovr',
+                          '/home/me/special.wld', '/home/me/special.rst.wld'])
         self.assertEqual(metadata.sidecarFilesForUri('/home/me/special.sdat'),
                          ['/home/me/special.sgrd', '/home/me/special.mgrd', '/home/me/special.prj',
-                          '/home/me/special.aux.xml', '/home/me/special.vat.dbf', '/home/me/special.ovr',
-                          '/home/me/special.wld'])
+                          '/home/me/special.aux.xml', '/home/me/special.sdat.aux.xml', '/home/me/special.vat.dbf',
+                          '/home/me/special.sdat.vat.dbf', '/home/me/special.ovr', '/home/me/special.sdat.ovr',
+                          '/home/me/special.wld', '/home/me/special.sdat.wld'])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -16,6 +16,7 @@ import tempfile
 import os
 from qgis.core import QgsFileUtils
 from qgis.testing import unittest
+from utilities import unitTestDataPath
 
 
 class TestQgsFileUtils(unittest.TestCase):
@@ -182,6 +183,40 @@ class TestQgsFileUtils(unittest.TestCase):
         # invalid path, too deep
         files = QgsFileUtils.findFile(filename, os.path.join(nest, 'nest2'), 2, 4)
         self.assertEqual(files[0], os.path.join(nest, filename).replace(os.sep, '/'))
+
+    def test_sidecar_files_for_path(self):
+        """
+        Test QgsFileUtils.sidecarFilesForPath
+        """
+        # file which doesn't exist
+        self.assertFalse(QgsFileUtils.sidecarFilesForPath('/not a valid path'))
+        # a directory
+        self.assertFalse(QgsFileUtils.sidecarFilesForPath(unitTestDataPath()))
+        # not a spatial data file
+        self.assertFalse(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/kbs.qgs'))
+
+        # shapefile
+        self.assertEqual(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/lines.shp'),
+                         {f'{unitTestDataPath()}/lines.shx', f'{unitTestDataPath()}/lines.dbf',
+                          f'{unitTestDataPath()}/lines.prj'})
+        # gpkg
+        self.assertFalse(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/mixed_layers.gpkg'))
+
+        # MapInfo TAB file
+        self.assertEqual(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/ogr_types.tab'),
+                         {f'{unitTestDataPath()}/ogr_types.dat', f'{unitTestDataPath()}/ogr_types.id',
+                          f'{unitTestDataPath()}/ogr_types.map'})
+
+        # GML
+        self.assertEqual(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/invalidgeometries.gml'),
+                         {f'{unitTestDataPath()}/invalidgeometries.gfs'})
+
+        # netcdf
+        self.assertEqual(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/landsat2.nc'),
+                         {f'{unitTestDataPath()}/landsat2.nc.aux.xml'})
+        # tif
+        self.assertEqual(QgsFileUtils.sidecarFilesForPath(f'{unitTestDataPath()}/ALLINGES_RGF93_CC46_1_1.tif'),
+                         {f'{unitTestDataPath()}/ALLINGES_RGF93_CC46_1_1.tfw'})
 
 
 if __name__ == '__main__':

--- a/tests/testdata/landsat2.nc.aux.xml
+++ b/tests/testdata/landsat2.nc.aux.xml
@@ -1,0 +1,26 @@
+<PAMDataset>
+  <Subdataset name="Band1">
+    <PAMDataset>
+      <PAMRasterBand band="1">
+        <Metadata>
+          <MDI key="STATISTICS_MAXIMUM">130</MDI>
+          <MDI key="STATISTICS_MEAN">126.001725</MDI>
+          <MDI key="STATISTICS_MINIMUM">122</MDI>
+          <MDI key="STATISTICS_STDDEV">1.1294343825008</MDI>
+        </Metadata>
+      </PAMRasterBand>
+    </PAMDataset>
+  </Subdataset>
+  <Subdataset name="Band2">
+    <PAMDataset>
+      <PAMRasterBand band="1">
+        <Metadata>
+          <MDI key="STATISTICS_MAXIMUM">148</MDI>
+          <MDI key="STATISTICS_MEAN">140.388625</MDI>
+          <MDI key="STATISTICS_MINIMUM">133</MDI>
+          <MDI key="STATISTICS_STDDEV">1.880437611136</MDI>
+        </Metadata>
+      </PAMRasterBand>
+    </PAMDataset>
+  </Subdataset>
+</PAMDataset>


### PR DESCRIPTION
And include sidecar files in the list of files to be deleted which we show to users in the confirmation message box. Works for most common raster/vector formats, and uses the generic API so that additional formats (e.g. point clouds/mesh) can be easily supported in future too.