### PR TITLE
[release-3_20] fix docker cache "Run tests"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -302,7 +302,9 @@ jobs:
           pushd .docker
           TARGET=$( ( [[ ${TEST_BATCH} == "ORACLE"   ]] && echo "binary-for-oracle" ) \
                  || echo "binary-only" )
+          docker pull qgis/qgis3-build-deps:${DOCKER_TAG} || :
           docker build --target $TARGET --build-arg UBUNTU_BASE=${UBUNTU_BASE} --cache-from qgis/qgis3-build-deps:${DOCKER_TAG} -t qgis/qgis3-build-deps-bin-only:${DOCKER_TAG} -f qgis3-qt5-build-deps.dockerfile .
+          docker rmi -f qgis/qgis3-build-deps:${DOCKER_TAG} || :
           popd
 
       - name: Print disk space


### PR DESCRIPTION
Reduces the time it takes to create a Docker container by using the cache. (for release-3_20 CI)