### PR TITLE
[ogr] Correctly set timezone spec on datetime values

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3216,14 +3216,6 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   if ( res.type() != originalField.type() )
     res = convertValue( originalField.type(), res.toString() );
 
-  if ( originalField.type() == QVariant::DateTime )
-  {
-    // ensure that we treat times as local time, to match behavior when iterating features
-    QDateTime temp = res.toDateTime();
-    temp.setTimeSpec( Qt::LocalTime );
-    res = temp;
-  }
-
   return res;
 }
 
@@ -3275,14 +3267,6 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
 
   if ( res.type() != originalField.type() )
     res = convertValue( originalField.type(), res.toString() );
-
-  if ( originalField.type() == QVariant::DateTime )
-  {
-    // ensure that we treat times as local time, to match behavior when iterating features
-    QDateTime temp = res.toDateTime();
-    temp.setTimeSpec( Qt::LocalTime );
-    res = temp;
-  }
 
   return res;
 }

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -347,7 +347,27 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
         else if ( field.type() == QVariant::Time )
           value = QTime( hour, minute, second );
         else
-          value = QDateTime( QDate( year, month, day ), QTime( hour, minute, second ) );
+        {
+          const QDate date( year, month, day );
+          const QTime time( hour, minute, second );
+
+          if ( ( tzf == 0 ) // unknown, treat as local time
+               || ( tzf == 1 ) // local time
+             )
+          {
+            value = QDateTime( date, time );
+          }
+          else if ( tzf == 100 ) // UTC
+          {
+            value = QDateTime( date, time, Qt::UTC );
+          }
+          else
+          {
+            // from GDAL docs: 101=GMT+15minute, 99=GMT-15minute
+            const int offsetInSeconds = ( tzf - 100 ) * 900;
+            value = QDateTime( date, time, Qt::OffsetFromUTC, offsetInSeconds );
+          }
+        }
       }
       break;
 

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -28,7 +28,12 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     NULL
 )
-from qgis.PyQt.QtCore import QDate, QTime, QDateTime
+from qgis.PyQt.QtCore import (
+    Qt,
+    QDate,
+    QTime,
+    QDateTime
+)
 
 from utilities import compareWkt
 
@@ -46,6 +51,9 @@ class FeatureSourceTestCase(object):
 
     def treat_datetime_as_string(self):
         return False
+
+    def datetime_timespec(self):
+        return Qt.LocalTime
 
     def treat_date_as_string(self):
         return False
@@ -96,11 +104,11 @@ class FeatureSourceTestCase(object):
             attributes[f['pk']] = attrs
             geometries[f['pk']] = f.hasGeometry() and f.geometry().asWkt()
 
-        expected_attributes = {5: [5, -200, NULL, 'NuLl', '5', QDateTime(QDate(2020, 5, 4), QTime(12, 13, 14)) if not self.treat_datetime_as_string() else '2020-05-04 12:13:14', QDate(2020, 5, 2) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(2020, 5, 2, 0, 0, 0) if not self.treat_date_as_string() else '2020-05-02', QTime(12, 13, 1) if not self.treat_time_as_string() else '12:13:01'],
+        expected_attributes = {5: [5, -200, NULL, 'NuLl', '5', QDateTime(QDate(2020, 5, 4), QTime(12, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-04 12:13:14', QDate(2020, 5, 2) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(QDate(2020, 5, 2), QTime(0, 0, 0), self.datetime_timespec()) if not self.treat_date_as_string() else '2020-05-02', QTime(12, 13, 1) if not self.treat_time_as_string() else '12:13:01'],
                                3: [3, 300, 'Pear', 'PEaR', '3', NULL, NULL, NULL],
-                               1: [1, 100, 'Orange', 'oranGe', '1', QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14)) if not self.treat_datetime_as_string() else '2020-05-03 12:13:14', QDate(2020, 5, 3) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(2020, 5, 3, 0, 0, 0) if not self.treat_date_as_string() else '2020-05-03', QTime(12, 13, 14) if not self.treat_time_as_string() else '12:13:14'],
-                               2: [2, 200, 'Apple', 'Apple', '2', QDateTime(QDate(2020, 5, 4), QTime(12, 14, 14)) if not self.treat_datetime_as_string() else '2020-05-04 12:14:14', QDate(2020, 5, 4) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(2020, 5, 4, 0, 0, 0) if not self.treat_date_as_string() else '2020-05-04', QTime(12, 14, 14) if not self.treat_time_as_string() else '12:14:14'],
-                               4: [4, 400, 'Honey', 'Honey', '4', QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14)) if not self.treat_datetime_as_string() else '2021-05-04 13:13:14', QDate(2021, 5, 4) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(2021, 5, 4, 0, 0, 0) if not self.treat_date_as_string() else '2021-05-04', QTime(13, 13, 14) if not self.treat_time_as_string() else '13:13:14']}
+                               1: [1, 100, 'Orange', 'oranGe', '1', QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-03 12:13:14', QDate(2020, 5, 3) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(QDate(2020, 5, 3), QTime(0, 0, 0), self.datetime_timespec()) if not self.treat_date_as_string() else '2020-05-03', QTime(12, 13, 14) if not self.treat_time_as_string() else '12:13:14'],
+                               2: [2, 200, 'Apple', 'Apple', '2', QDateTime(QDate(2020, 5, 4), QTime(12, 14, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-04 12:14:14', QDate(2020, 5, 4) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(QDate(2020, 5, 4), QTime(0, 0, 0), self.datetime_timespec()) if not self.treat_date_as_string() else '2020-05-04', QTime(12, 14, 14) if not self.treat_time_as_string() else '12:14:14'],
+                               4: [4, 400, 'Honey', 'Honey', '4', QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2021-05-04 13:13:14', QDate(2021, 5, 4) if not self.treat_date_as_datetime() and not self.treat_date_as_string() else QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec()) if not self.treat_date_as_string() else '2021-05-04', QTime(13, 13, 14) if not self.treat_time_as_string() else '13:13:14']}
 
         expected_geometries = {1: 'Point (-70.332 66.33)',
                                2: 'Point (-68.2 70.8)',
@@ -833,15 +841,15 @@ class FeatureSourceTestCase(object):
                  'cnt': set([-200, 300, 100, 200, 400]),
                  'name': set(['Pear', 'Orange', 'Apple', 'Honey', NULL]),
                  'name2': set(['NuLl', 'PEaR', 'oranGe', 'Apple', 'Honey']),
-                 'dt': set([NULL, '2021-05-04 13:13:14' if self.treat_datetime_as_string() else QDateTime(2021, 5, 4, 13, 13, 14) if not self.treat_datetime_as_string() else '2021-05-04 13:13:14',
-                            '2020-05-04 12:14:14' if self.treat_datetime_as_string() else QDateTime(2020, 5, 4, 12, 14, 14) if not self.treat_datetime_as_string() else '2020-05-04 12:14:14',
-                            '2020-05-04 12:13:14' if self.treat_datetime_as_string() else QDateTime(2020, 5, 4, 12, 13, 14) if not self.treat_datetime_as_string() else '2020-05-04 12:13:14',
-                            '2020-05-03 12:13:14' if self.treat_datetime_as_string() else QDateTime(2020, 5, 3, 12, 13, 14) if not self.treat_datetime_as_string() else '2020-05-03 12:13:14']),
+                 'dt': set([NULL, '2021-05-04 13:13:14' if self.treat_datetime_as_string() else QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2021-05-04 13:13:14',
+                            '2020-05-04 12:14:14' if self.treat_datetime_as_string() else QDateTime(QDate(2020, 5, 4), QTime(12, 14, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-04 12:14:14',
+                            '2020-05-04 12:13:14' if self.treat_datetime_as_string() else QDateTime(QDate(2020, 5, 4), QTime(12, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-04 12:13:14',
+                            '2020-05-03 12:13:14' if self.treat_datetime_as_string() else QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()) if not self.treat_datetime_as_string() else '2020-05-03 12:13:14']),
                  'date': set([NULL,
-                              '2020-05-02' if self.treat_date_as_string() else QDate(2020, 5, 2) if not self.treat_date_as_datetime() else QDateTime(2020, 5, 2, 0, 0, 0),
-                              '2020-05-03' if self.treat_date_as_string() else QDate(2020, 5, 3) if not self.treat_date_as_datetime() else QDateTime(2020, 5, 3, 0, 0, 0),
-                              '2020-05-04' if self.treat_date_as_string() else QDate(2020, 5, 4) if not self.treat_date_as_datetime() else QDateTime(2020, 5, 4, 0, 0, 0),
-                              '2021-05-04' if self.treat_date_as_string() else QDate(2021, 5, 4) if not self.treat_date_as_datetime() else QDateTime(2021, 5, 4, 0, 0, 0)]),
+                              '2020-05-02' if self.treat_date_as_string() else QDate(2020, 5, 2) if not self.treat_date_as_datetime() else QDateTime(QDate(2020, 5, 2), QTime(0, 0, 0), self.datetime_timespec()),
+                              '2020-05-03' if self.treat_date_as_string() else QDate(2020, 5, 3) if not self.treat_date_as_datetime() else QDateTime(QDate(2020, 5, 3), QTime(0, 0, 0), self.datetime_timespec()),
+                              '2020-05-04' if self.treat_date_as_string() else QDate(2020, 5, 4) if not self.treat_date_as_datetime() else QDateTime(QDate(2020, 5, 4), QTime(0, 0, 0), self.datetime_timespec()),
+                              '2021-05-04' if self.treat_date_as_string() else QDate(2021, 5, 4) if not self.treat_date_as_datetime() else QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec())]),
                  'time': set([QTime(12, 13, 1) if not self.treat_time_as_string() else '12:13:01',
                               QTime(12, 14, 14) if not self.treat_time_as_string() else '12:14:14',
                               QTime(12, 13, 14) if not self.treat_time_as_string() else '12:13:14',
@@ -898,14 +906,14 @@ class FeatureSourceTestCase(object):
                              set(['2021-05-04 13:13:14', '2020-05-04 12:14:14', '2020-05-04 12:13:14', '2020-05-03 12:13:14', NULL]))
         else:
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('dt'))),
-                             set([QDateTime(2021, 5, 4, 13, 13, 14), QDateTime(2020, 5, 4, 12, 14, 14), QDateTime(2020, 5, 4, 12, 13, 14), QDateTime(2020, 5, 3, 12, 13, 14), NULL]))
+                             set([QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()), QDateTime(QDate(2020, 5, 4), QTime(12, 14, 14), self.datetime_timespec()), QDateTime(QDate(2020, 5, 4), QTime(12, 13, 14), self.datetime_timespec()), QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()), NULL]))
 
         if self.treat_date_as_string():
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
                              set(['2020-05-03', '2020-05-04', '2021-05-04', '2020-05-02', NULL]))
         elif self.treat_date_as_datetime():
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
-                             set([QDateTime(2020, 5, 3, 0, 0, 0), QDateTime(2020, 5, 4, 0, 0, 0), QDateTime(2021, 5, 4, 0, 0, 0), QDateTime(2020, 5, 2, 0, 0, 0), NULL]))
+                             set([QDateTime(QDate(2020, 5, 3), QTime(0, 0, 0), self.datetime_timespec()), QDateTime(QDate(2020, 5, 4), QTime(0, 0, 0), self.datetime_timespec()), QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec()), QDateTime(QDate(2020, 5, 2), QTime(0, 0, 0), self.datetime_timespec()), NULL]))
         else:
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
                              set([QDate(2020, 5, 3), QDate(2020, 5, 4), QDate(2021, 5, 4), QDate(2020, 5, 2), NULL]))
@@ -923,14 +931,14 @@ class FeatureSourceTestCase(object):
         if self.treat_datetime_as_string():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('dt')), '2020-05-03 12:13:14')
         else:
-            self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('dt')), QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14)))
+            self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('dt')), QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()))
 
         if self.treat_date_as_string():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), '2020-05-02')
         elif not self.treat_date_as_datetime():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), QDate(2020, 5, 2))
         else:
-            self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), QDateTime(2020, 5, 2, 0, 0, 0))
+            self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), QDateTime(2020, 5, 2, 0, 0, 0, self.datetime_timespec()))
 
         if not self.treat_time_as_string():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('time')), QTime(12, 13, 1))
@@ -942,7 +950,7 @@ class FeatureSourceTestCase(object):
         self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('name')), 'Pear')
 
         if not self.treat_datetime_as_string():
-            self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('dt')), QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14)))
+            self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('dt')), QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()))
         else:
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('dt')), '2021-05-04 13:13:14')
 
@@ -951,7 +959,7 @@ class FeatureSourceTestCase(object):
         elif not self.treat_date_as_datetime():
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('date')), QDate(2021, 5, 4))
         else:
-            self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('date')), QDateTime(2021, 5, 4, 0, 0, 0))
+            self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('date')), QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec()))
 
         if not self.treat_time_as_string():
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('time')), QTime(13, 13, 14))

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -365,7 +365,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('dt')), '2020-05-03 12:13:14')
         else:
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('dt')),
-                             QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14)))
+                             QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()))
 
         if self.treat_date_as_string():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), '2020-05-02')
@@ -373,7 +373,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')), QDate(2020, 5, 2))
         else:
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('date')),
-                             QDateTime(2020, 5, 2, 0, 0, 0))
+                             QDateTime(QDate(2020, 5, 2), QTime(0, 0, 0), self.datetime_timespec()))
 
         if not self.treat_time_as_string():
             self.assertEqual(self.source.minimumValue(self.source.fields().lookupField('time')), QTime(12, 13, 1))
@@ -395,7 +395,7 @@ class ProviderTestCase(FeatureSourceTestCase):
 
         if not self.treat_datetime_as_string():
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('dt')),
-                             QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14)))
+                             QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()))
         else:
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('dt')), '2021-05-04 13:13:14')
 
@@ -405,7 +405,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('date')), QDate(2021, 5, 4))
         else:
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('date')),
-                             QDateTime(2021, 5, 4, 0, 0, 0))
+                             QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec()))
 
         if not self.treat_time_as_string():
             self.assertEqual(self.source.maximumValue(self.source.fields().lookupField('time')), QTime(13, 13, 14))
@@ -468,16 +468,16 @@ class ProviderTestCase(FeatureSourceTestCase):
                                   '2020-05-03 12:13:14', NULL]))
         else:
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('dt'))),
-                             set([QDateTime(2021, 5, 4, 13, 13, 14), QDateTime(2020, 5, 4, 12, 14, 14),
-                                  QDateTime(2020, 5, 4, 12, 13, 14), QDateTime(2020, 5, 3, 12, 13, 14), NULL]))
+                             set([QDateTime(QDate(2021, 5, 4), QTime(13, 13, 14), self.datetime_timespec()), QDateTime(QDate(2020, 5, 4), QTime(12, 14, 14), self.datetime_timespec()),
+                                  QDateTime(QDate(2020, 5, 4), QTime(12, 13, 14), self.datetime_timespec()), QDateTime(QDate(2020, 5, 3), QTime(12, 13, 14), self.datetime_timespec()), NULL]))
 
         if self.treat_date_as_string():
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
                              set(['2020-05-03', '2020-05-04', '2021-05-04', '2020-05-02', NULL]))
         elif self.treat_date_as_datetime():
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
-                             set([QDateTime(2020, 5, 3, 0, 0, 0), QDateTime(2020, 5, 4, 0, 0, 0),
-                                  QDateTime(2021, 5, 4, 0, 0, 0), QDateTime(2020, 5, 2, 0, 0, 0), NULL]))
+                             set([QDateTime(QDate(2020, 5, 3), QTime(0, 0, 0), self.datetime_timespec()), QDateTime(QDate(2020, 5, 4), QTime(0, 0, 0), self.datetime_timespec()),
+                                  QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0), self.datetime_timespec()), QDateTime(QDate(2020, 5, 2), QTime(0, 0, 0), self.datetime_timespec()), NULL]))
         else:
             self.assertEqual(set(self.source.uniqueValues(self.source.fields().lookupField('date'))),
                              set([QDate(2020, 5, 3), QDate(2020, 5, 4), QDate(2021, 5, 4), QDate(2020, 5, 2), NULL]))
@@ -604,18 +604,18 @@ class ProviderTestCase(FeatureSourceTestCase):
 
         f1 = QgsFeature()
         f1.setAttributes([6, -220, NULL, 'String', '15',
-                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(2019, 1, 2, 3, 4, 5),
-                          '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0,
-                                                                                     0) if self.treat_date_as_datetime() else QDate(
+                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+                          '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0,
+                                                                                                              0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(
                               2019, 1, 2),
                           '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5)])
         f1.setGeometry(QgsGeometry.fromWkt('Point (-72.345 71.987)'))
 
         f2 = QgsFeature()
         f2.setAttributes([7, 330, 'Coconut', 'CoCoNut', '13',
-                          '2018-05-06 07:08:09' if self.treat_datetime_as_string() else QDateTime(2018, 5, 6, 7, 8, 9),
-                          '2018-05-06' if self.treat_date_as_string() else QDateTime(2018, 5, 6, 0, 0,
-                                                                                     0) if self.treat_date_as_datetime() else QDate(
+                          '2018-05-06 07:08:09' if self.treat_datetime_as_string() else QDateTime(QDate(2018, 5, 6), QTime(7, 8, 9), self.datetime_timespec()),
+                          '2018-05-06' if self.treat_date_as_string() else QDateTime(QDate(2018, 5, 6), QTime(0, 0,
+                                                                                                              0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(
                               2018, 5, 6),
                           '07:08:09' if self.treat_time_as_string() else QTime(7, 8, 9)])
 
@@ -655,15 +655,15 @@ class ProviderTestCase(FeatureSourceTestCase):
         f1 = QgsFeature()
         f1.setAttributes(
             [6, -220, NULL, 'String', '15',
-             '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(2019, 1, 2, 3, 4, 5),
-             '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0, 0) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
+             '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+             '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0, 0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
              '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5)])
         f1.setGeometry(QgsGeometry.fromWkt('Point (-72.345 71.987)'))
 
         f2 = QgsFeature()
         f2.setAttributes([7, 330, 'Coconut', 'CoCoNut', '13',
-                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(2019, 1, 2, 3, 4, 5),
-                          '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0, 0) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
+                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+                          '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0, 0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
                           '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5)])
 
         if l.dataProvider().capabilities() & QgsVectorDataProvider.AddFeatures:
@@ -714,13 +714,13 @@ class ProviderTestCase(FeatureSourceTestCase):
         # we be more tricky and also add a valid feature to stress test the provider
         f1 = QgsFeature()
         f1.setAttributes([6, -220, NULL, 'String', '15',
-                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(2019, 1, 2, 3, 4, 5),
-                          '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0, 0) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
+                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+                          '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0, 0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
                           '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5)])
         f2 = QgsFeature()
         f2.setAttributes([7, -230, NULL, 'String', '15',
-                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(2019, 1, 2, 3, 4, 5),
-                          '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0, 0) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
+                          '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+                          '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0, 0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
                           '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5), 15, 16, 17])
 
         result, added = l.dataProvider().addFeatures([f1, f2])
@@ -731,8 +731,8 @@ class ProviderTestCase(FeatureSourceTestCase):
         added = [f for f in l.dataProvider().getFeatures() if f[self.pk_name] == 7][0]
         self.assertEqual(added.attributes(), [7, -230, NULL, 'String', '15',
                                               '2019-01-02 03:04:05' if self.treat_datetime_as_string() else QDateTime(
-                                                  2019, 1, 2, 3, 4, 5),
-                                              '2019-01-02' if self.treat_date_as_string() else QDateTime(2019, 1, 2, 0, 0, 0) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
+                                                  QDate(2019, 1, 2), QTime(3, 4, 5), self.datetime_timespec()),
+                                              '2019-01-02' if self.treat_date_as_string() else QDateTime(QDate(2019, 1, 2), QTime(0, 0, 0), self.datetime_timespec()) if self.treat_date_as_datetime() else QDate(2019, 1, 2),
                                               '03:04:05' if self.treat_time_as_string() else QTime(3, 4, 5)])
 
     def testAddFeatureWrongGeomType(self):

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -138,6 +138,9 @@ class TestPyQgsOGRProviderGpkgConformance(unittest.TestCase, ProviderTestCase):
     def treat_time_as_string(self):
         return True
 
+    def datetime_timespec(self):
+        return Qt.UTC
+
     def uncompiledFilters(self):
         return set(['cnt = 10 ^ 2',
                     '"name" ~ \'[OP]ra[gne]+\'',


### PR DESCRIPTION
Since Qt QDateTime functions all consider time zones, we run into many issues as different parts of QGIS use different
time specs. The only way forward is to correctly handle and expose the actual underlying time zone from the dataset...

(Note that this is going to bring the pain, because users who were previously ignoring time zones and had adjusted workflows accordingly will now be forced to pay attention to them!)