### PR TITLE
Add Rename action under the manage submenu for files in browser

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -634,3 +634,9 @@ Qgis.SpatialFilterType.DistanceWithin.__doc__ = "Filter by distance to reference
 Qgis.SpatialFilterType.__doc__ = 'Feature request spatial filter types.\n\n.. versionadded:: 3.22\n\n' + '* ``NoFilter``: ' + Qgis.SpatialFilterType.NoFilter.__doc__ + '\n' + '* ``BoundingBox``: ' + Qgis.SpatialFilterType.BoundingBox.__doc__ + '\n' + '* ``DistanceWithin``: ' + Qgis.SpatialFilterType.DistanceWithin.__doc__
 # --
 Qgis.SpatialFilterType.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.FileOperationFlag.IncludeMetadataFile.__doc__ = "Indicates that any associated .qmd metadata file should be included with the operation"
+Qgis.FileOperationFlag.IncludeStyleFile.__doc__ = "Indicates that any associated .qml styling file should be included with the operation"
+Qgis.FileOperationFlag.__doc__ = 'File operation flags.\n\n.. versionadded:: 3.22\n\n' + '* ``IncludeMetadataFile``: ' + Qgis.FileOperationFlag.IncludeMetadataFile.__doc__ + '\n' + '* ``IncludeStyleFile``: ' + Qgis.FileOperationFlag.IncludeStyleFile.__doc__
+# --
+Qgis.FileOperationFlag.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -444,6 +444,14 @@ The development version
       DistanceWithin,
     };
 
+    enum class FileOperationFlag
+    {
+      IncludeMetadataFile,
+      IncludeStyleFile,
+    };
+    typedef QFlags<Qgis::FileOperationFlag> FileOperationFlags;
+
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;
@@ -526,6 +534,8 @@ QFlags<Qgis::BabelFormatCapability> operator|(Qgis::BabelFormatCapability f1, QF
 QFlags<Qgis::BabelCommandFlag> operator|(Qgis::BabelCommandFlag f1, QFlags<Qgis::BabelCommandFlag> f2);
 
 QFlags<Qgis::GeometryValidityFlag> operator|(Qgis::GeometryValidityFlag f1, QFlags<Qgis::GeometryValidityFlag> f2);
+
+QFlags<Qgis::FileOperationFlag> operator|(Qgis::FileOperationFlag f1, QFlags<Qgis::FileOperationFlag> f2);
 
 
 

--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -155,6 +155,32 @@ and .prj files would be returned (amongst others).
 .. versionadded:: 3.22
 %End
 
+    static bool renameDataset( const QString &oldPath, const QString &newPath, QString &error /Out/, Qgis::FileOperationFlags flags = Qgis::FileOperationFlag::IncludeMetadataFile | Qgis::FileOperationFlag::IncludeStyleFile );
+%Docstring
+Renames the dataset at ``oldPath`` to ``newPath``, renaming both the file at ``oldPath`` and
+all associated sidecar files which exist for it.
+
+For instance, if ``oldPath`` specified a .shp file then the corresponding .dbf, .idx
+and .prj files would be renamed (amongst others).
+
+The destination directory must already exist.
+
+The optional ``flags`` argument can be used to control whether QMD metadata files and
+QML styling files should also be renamed accordingly. By default these will be renamed,
+but manually specifying a different set of flags allows callers to avoid this when
+desired.
+
+:param oldPath: original path to dataset
+:param newPath: new path for dataset
+:param flags: optional flags to control file operation behavior
+
+:return: - ``True`` if the dataset was successfully renamed, or ``False`` if an error occurred
+         - error: will be set to a descriptive error message if the rename operation fails
+
+
+.. versionadded:: 3.22
+%End
+
 };
 
 /************************************************************************

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -503,24 +503,24 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
   QMenu *manageFileMenu = new QMenu( tr( "Manage" ), menu );
 
-  QStringList selectedManagableFiles;
+  QStringList selectedFiles;
   QList< QPointer< QgsDataItem > > selectedParents;
   for ( QgsDataItem *selectedItem : selectedItems )
   {
     if ( selectedItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile )
     {
-      selectedManagableFiles.append( selectedItem->path() );
+      selectedFiles.append( selectedItem->path() );
       selectedParents << selectedItem->parent();
     }
   }
 
-  if ( selectedManagableFiles.size() == 1 )
+  if ( selectedFiles.size() == 1 )
   {
     const QString renameText = tr( "Rename “%1”…" ).arg( fi.fileName() );
     QAction *renameAction = new QAction( renameText, menu );
     connect( renameAction, &QAction::triggered, this, [ = ]
     {
-      const QString oldPath = selectedManagableFiles.value( 0 );
+      const QString oldPath = selectedFiles.value( 0 );
       // Check if the file corresponds to paths in the project
       const QList<QgsMapLayer *> layersList = QgsProjectUtils::layersMatchingPath( QgsProject::instance(), oldPath );
 
@@ -601,21 +601,21 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     manageFileMenu->addAction( renameAction );
   }
 
-  const QString deleteText = selectedManagableFiles.count() == 1 ? tr( "Delete “%1”…" ).arg( fi.fileName() )
+  const QString deleteText = selectedFiles.count() == 1 ? tr( "Delete “%1”…" ).arg( fi.fileName() )
                              : tr( "Delete Selected Files…" );
   QAction *deleteAction = new QAction( deleteText, menu );
   connect( deleteAction, &QAction::triggered, this, [ = ]
   {
     // Check if the files correspond to paths in the project
     QList<QgsMapLayer *> layersList;
-    for ( const QString &path : std::as_const( selectedManagableFiles ) )
+    for ( const QString &path : std::as_const( selectedFiles ) )
     {
       layersList << QgsProjectUtils::layersMatchingPath( QgsProject::instance(), path );
     }
 
     // now expand out the list of files to include all sidecar files (e.g. .aux.xml files)
     QSet< QString > allFilesWithSidecars;
-    for ( const QString &file : std::as_const( selectedManagableFiles ) )
+    for ( const QString &file : std::as_const( selectedFiles ) )
     {
       allFilesWithSidecars.insert( file );
       allFilesWithSidecars.unite( QgsFileUtils::sidecarFilesForPath( file ) );
@@ -630,9 +630,9 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     if ( layersList.empty() )
     {
       // generic warning
-      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedManagableFiles.at( 0 ) ).fileName() ),
+      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
                            sortedAllFilesWithSidecars.size() > 1 ? tr( "Permanently delete %1 files?" ).arg( sortedAllFilesWithSidecars.size() )
-                           : tr( "Permanently delete “%1”?" ).arg( QFileInfo( selectedManagableFiles.at( 0 ) ).fileName() ),
+                           : tr( "Permanently delete “%1”?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
                            QMessageBox::Yes | QMessageBox::No );
       message.setDefaultButton( QMessageBox::No );
 
@@ -653,9 +653,9 @@ void QgsAppFileItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
     }
     else
     {
-      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedManagableFiles.at( 0 ) ).fileName() ),
+      QMessageBox message( QMessageBox::Warning, sortedAllFilesWithSidecars.size() > 1 ? tr( "Delete Files" ) : tr( "Delete %1" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
                            sortedAllFilesWithSidecars.size() > 1 ? tr( "One or more selected files exist in the current project. Are you sure you want to delete these files?" )
-                           : tr( "The file %1 exists in the current project. Are you sure you want to delete it?" ).arg( QFileInfo( selectedManagableFiles.at( 0 ) ).fileName() ),
+                           : tr( "The file %1 exists in the current project. Are you sure you want to delete it?" ).arg( QFileInfo( selectedFiles.at( 0 ) ).fileName() ),
                            QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel );
       message.setDefaultButton( QMessageBox::Cancel );
       message.setButtonText( QMessageBox::Yes, tr( "Delete and Remove Layers" ) );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -694,6 +694,19 @@ class CORE_EXPORT Qgis
     Q_ENUM( SpatialFilterType )
 
     /**
+     * File operation flags.
+     *
+     * \since QGIS 3.22
+     */
+    enum class FileOperationFlag : int
+    {
+      IncludeMetadataFile = 1 << 0, //!< Indicates that any associated .qmd metadata file should be included with the operation
+      IncludeStyleFile = 1 << 1, //!< Indicates that any associated .qml styling file should be included with the operation
+    };
+    Q_DECLARE_FLAGS( FileOperationFlags, FileOperationFlag )
+    Q_ENUM( FileOperationFlag )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */
@@ -815,6 +828,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SqlLayerDefinitionCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelFormatCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelCommandFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::GeometryValidityFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FileOperationFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -389,3 +389,75 @@ QSet<QString> QgsFileUtils::sidecarFilesForPath( const QString &path )
   }
   return res;
 }
+
+bool QgsFileUtils::renameDataset( const QString &oldPath, const QString &newPath, QString &error, Qgis::FileOperationFlags flags )
+{
+  if ( !QFile::exists( oldPath ) )
+  {
+    error = QObject::tr( "File does not exist" );
+    return false;
+  }
+
+  const QFileInfo oldPathInfo( oldPath );
+  QSet< QString > sidecars = sidecarFilesForPath( oldPath );
+  if ( flags & Qgis::FileOperationFlag::IncludeMetadataFile )
+  {
+    const QString qmdPath = oldPathInfo.dir().filePath( oldPathInfo.completeBaseName() + QStringLiteral( ".qmd" ) );
+    if ( QFile::exists( qmdPath ) )
+      sidecars.insert( qmdPath );
+  }
+  if ( flags & Qgis::FileOperationFlag::IncludeStyleFile )
+  {
+    const QString qmlPath = oldPathInfo.dir().filePath( oldPathInfo.completeBaseName() + QStringLiteral( ".qml" ) );
+    if ( QFile::exists( qmlPath ) )
+      sidecars.insert( qmlPath );
+  }
+
+  const QFileInfo newPathInfo( newPath );
+
+  bool res = true;
+  QStringList errors;
+  errors.reserve( sidecars.size() );
+  // first check if all sidecars CAN be renamed -- we don't want to get partly through the rename and then find a clash
+  for ( const QString &sidecar : std::as_const( sidecars ) )
+  {
+    const QFileInfo sidecarInfo( sidecar );
+    const QString newSidecarName = newPathInfo.dir().filePath( newPathInfo.completeBaseName() + '.' + sidecarInfo.suffix() );
+    if ( newSidecarName != sidecar && QFile::exists( newSidecarName ) )
+    {
+      res = false;
+      errors.append( QDir::toNativeSeparators( newSidecarName ) );
+    }
+  }
+  if ( !res )
+  {
+    error = QObject::tr( "Destination files already exist %1" ).arg( errors.join( QStringLiteral( ", " ) ) );
+    return false;
+  }
+
+  if ( !QFile::rename( oldPath, newPath ) )
+  {
+    error = QObject::tr( "Could not rename %1" ).arg( QDir::toNativeSeparators( oldPath ) );
+    return false;
+  }
+
+  for ( const QString &sidecar : std::as_const( sidecars ) )
+  {
+    const QFileInfo sidecarInfo( sidecar );
+    const QString newSidecarName = newPathInfo.dir().filePath( newPathInfo.completeBaseName() + '.' + sidecarInfo.suffix() );
+    if ( newSidecarName == sidecar )
+      continue;
+
+    if ( !QFile::rename( sidecar, newSidecarName ) )
+    {
+      errors.append( QDir::toNativeSeparators( sidecar ) );
+      res = false;
+    }
+  }
+  if ( !res )
+  {
+    error = QObject::tr( "Could not rename %1" ).arg( errors.join( QStringLiteral( ", " ) ) );
+  }
+
+  return res;
+}

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -155,6 +155,31 @@ class CORE_EXPORT QgsFileUtils
      */
     static QSet< QString > sidecarFilesForPath( const QString &path );
 
+    /**
+     * Renames the dataset at \a oldPath to \a newPath, renaming both the file at \a oldPath and
+     * all associated sidecar files which exist for it.
+     *
+     * For instance, if \a oldPath specified a .shp file then the corresponding .dbf, .idx
+     * and .prj files would be renamed (amongst others).
+     *
+     * The destination directory must already exist.
+     *
+     * The optional \a flags argument can be used to control whether QMD metadata files and
+     * QML styling files should also be renamed accordingly. By default these will be renamed,
+     * but manually specifying a different set of flags allows callers to avoid this when
+     * desired.
+     *
+     * \param oldPath original path to dataset
+     * \param newPath new path for dataset
+     * \param error will be set to a descriptive error message if the rename operation fails
+     * \param flags optional flags to control file operation behavior
+     *
+     * \returns TRUE if the dataset was successfully renamed, or FALSE if an error occurred
+     *
+     * \since QGIS 3.22
+     */
+    static bool renameDataset( const QString &oldPath, const QString &newPath, QString &error SIP_OUT, Qgis::FileOperationFlags flags = Qgis::FileOperationFlag::IncludeMetadataFile | Qgis::FileOperationFlag::IncludeStyleFile );
+
 };
 
 #endif // QGSFILEUTILS_H


### PR DESCRIPTION
Allows renaming of files directly in the browser. If the file
corresponds to a spatial dataset with multiple sidecar files then
these will all be renamed accordingly too.

Additionally, users are warned if the file is a layer which is exists
in the current project and are asked whether they want to automatically
update all the layer paths accordingly.

Refs #14611