### PR TITLE
[Offline editing] Store original PK and use transactions with QgsOfflineEditing::synchronize

### DIFF
--- a/python/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/core/auto_generated/qgsofflineediting.sip.in
@@ -53,9 +53,12 @@ Convert current project for offline editing
 Returns ``True`` if current project is offline
 %End
 
+
     void synchronize( bool useTransaction = false );
 %Docstring
 Synchronize to remote layers
+
+:param useTransaction: enforce the remote layer modifications with the same source to be in a transaction group
 %End
 
   signals:

--- a/python/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/core/auto_generated/qgsofflineediting.sip.in
@@ -53,7 +53,7 @@ Convert current project for offline editing
 Returns ``True`` if current project is offline
 %End
 
-    void synchronize();
+    void synchronize( bool useTransaction = false );
 %Docstring
 Synchronize to remote layers
 %End

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -231,7 +231,7 @@ void QgsOfflineEditing::synchronize( bool useTransaction )
     for ( const std::shared_ptr<QgsVectorLayer> &remoteLayer : std::as_const( remoteLayersByOfflineId ) )
     {
       const QString connectionString = QgsTransaction::connectionString( remoteLayer->source() );
-      const QPair pair( remoteLayer->providerType(), connectionString );
+      const QPair<QString, QString> pair( remoteLayer->providerType(), connectionString );
       std::shared_ptr<QgsTransactionGroup> transactionGroup = transactionGroups.value( pair );
 
       if ( !transactionGroup.get() )

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     bool isOfflineProject() const;
 
     //! Synchronize to remote layers
-    void synchronize();
+    void synchronize( bool useTransaction = false );
 
   signals:
 

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -127,6 +127,11 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void applyGeometryChanges( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void updateFidLookup( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );
 
+    /**
+     * Returns the layer pk attribute index. If the pk is composite, return -1.
+     */
+    int getLayerPkIdx( const QgsVectorLayer *layer ) const;
+
     QMap<int, int> attributeLookup( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer );
 
     void showWarning( const QString &message );
@@ -135,14 +140,16 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     int getOrCreateLayerId( sqlite3 *db, const QString &qgisLayerId );
     int getCommitNo( sqlite3 *db );
     void increaseCommitNo( sqlite3 *db );
-    void addFidLookup( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsFeatureId remoteFid );
-    QgsFeatureId remoteFid( sqlite3 *db, int layerId, QgsFeatureId offlineFid );
+    void addFidLookup( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsFeatureId remoteFid, QString remotePk );
+    QgsFeatureId remoteFid( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsVectorLayer *remoteLayer );
     QgsFeatureId offlineFid( sqlite3 *db, int layerId, QgsFeatureId remoteFid );
     bool isAddedFeature( sqlite3 *db, int layerId, QgsFeatureId fid );
 
     int sqlExec( sqlite3 *db, const QString &sql );
     int sqlQueryInt( sqlite3 *db, const QString &sql, int defaultValue );
+    QString sqlQueryStr( sqlite3 *db, const QString &sql, QString &defaultValue );
     QList<int> sqlQueryInts( sqlite3 *db, const QString &sql );
+    QString sqlEscape( QString value ) const;
 
     QList<QgsField> sqlQueryAttributesAdded( sqlite3 *db, const QString &sql );
     QgsFeatureIds sqlQueryFeaturesRemoved( sqlite3 *db, const QString &sql );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -71,7 +71,11 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     //! Returns TRUE if current project is offline
     bool isOfflineProject() const;
 
-    //! Synchronize to remote layers
+
+    /**
+     * Synchronize to remote layers
+     * \param useTransaction enforce the remote layer modifications with the same source to be in a transaction group
+     */
     void synchronize( bool useTransaction = false );
 
   signals:
@@ -140,7 +144,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     int getOrCreateLayerId( sqlite3 *db, const QString &qgisLayerId );
     int getCommitNo( sqlite3 *db );
     void increaseCommitNo( sqlite3 *db );
-    void addFidLookup( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsFeatureId remoteFid, QString remotePk );
+    void addFidLookup( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsFeatureId remoteFid, const QString &remotePk );
     QgsFeatureId remoteFid( sqlite3 *db, int layerId, QgsFeatureId offlineFid, QgsVectorLayer *remoteLayer );
     QgsFeatureId offlineFid( sqlite3 *db, int layerId, QgsFeatureId remoteFid );
     bool isAddedFeature( sqlite3 *db, int layerId, QgsFeatureId fid );


### PR DESCRIPTION
This PR fixes two major problems with the current implementation of QgsOffline editing:
1) unstable `QgsFeatureId` between QGIS runs 
2) transactional update of features that consist of foreign keys

This PR resolves a whole group of issues related to sync back projects with related layers and non-integer PK.

## Unstable `QgsFeatureId` between QGIS runs 
In QGIS there is no way to guarantee there the `QgsFeatureId` is stable from run to run, especially for non-numeric PKs. However, `QgsOfflineEditing` is highly dependent on stable PKs not only among runs, but among devices. This is easy to prove wrong with PostGIS layer that uses UUIDs as PK, which is actually the recommended PK type in most cases when offline editing is needed. Why? Numerical PKs have the potential to cause conflicts if multiple people work on the same offlined project in parallel. In this PR I propose we also store textual PKs (uuid, id codes etc) to be stored in the offline editing `log_fids` table in an additional column, called `remote_pk`. 

If the PK in the remote layer is string, it will be stored in `remote_pk` and used to identify features when synchronizing, if not -> it will fallback to `remote_fid` as it does now.

The current implementation supports only textual PK, but it can easily support additional types.

## Transactional update of features that consist of foreign keys

There is a new parameter in `QgsOfflineEditing::synchronize( bool useTransaction = false )`, that enforces transactions when editing the remote layers. By default the method should work as it used to work, even though there was some reorganization in the source code. To name a few:
- removing the first extra loop to get the offline layers, now non-offline layers are just early returned
- now all the layer modifications happen in one loop for all layers.

Pretty much it solves a whole group of problems when