### PR TITLE
Remove "Display As" control from layer properties dialogs

### DIFF
--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -48,7 +48,6 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsPointCloudLayerProperties::apply );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPointCloudLayerProperties::showHelp );
 
-  connect( mLayerOrigNameLineEdit, &QLineEdit::textEdited, this, &QgsPointCloudLayerProperties::originalNameEdited );
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsPointCloudLayerProperties::crsChanged );
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
@@ -172,7 +171,6 @@ void QgsPointCloudLayerProperties::syncToLayer()
 {
   // populate the general information
   mLayerOrigNameLineEdit->setText( mLayer->name() );
-  txtDisplayName->setText( mLayer->name() );
 
   /*
    * Information Tab
@@ -413,11 +411,6 @@ void QgsPointCloudLayerProperties::urlClicked( const QUrl &url )
     QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
   else
     QDesktopServices::openUrl( url );
-}
-
-void QgsPointCloudLayerProperties::originalNameEdited( const QString &text )
-{
-  txtDisplayName->setText( mLayer->formatLayerName( text ) );
 }
 
 void QgsPointCloudLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -112,7 +112,6 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     void loadDefaultMetadata();
     void showHelp();
     void urlClicked( const QUrl &url );
-    void originalNameEdited( const QString &text );
     void crsChanged( const QgsCoordinateReferenceSystem &crs );
 
   protected slots:

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -69,7 +69,6 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   mTemporalProviderTimeUnitComboBox->addItem( tr( "Hours" ), QgsUnitTypes::TemporalHours );
   mTemporalProviderTimeUnitComboBox->addItem( tr( "Days" ), QgsUnitTypes::TemporalDays );
 
-  connect( mLayerOrigNameLineEd, &QLineEdit::textEdited, this, &QgsMeshLayerProperties::updateLayerName );
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsMeshLayerProperties::changeCrs );
   connect( mDatasetGroupTreeWidget, &QgsMeshDatasetGroupTreeWidget::datasetGroupAdded, this, &QgsMeshLayerProperties::syncToLayer );
 
@@ -207,7 +206,6 @@ void QgsMeshLayerProperties::syncToLayer()
    * Source Tab
    */
   mLayerOrigNameLineEd->setText( mMeshLayer->name() );
-  leDisplayName->setText( mMeshLayer->name() );
   whileBlocking( mCrsSelector )->setCrs( mMeshLayer->crs() );
 
   if ( mMeshLayer )
@@ -418,11 +416,6 @@ void QgsMeshLayerProperties::changeCrs( const QgsCoordinateReferenceSystem &crs 
 {
   QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mCanvas, tr( "Select Transformation" ) );
   mMeshLayer->setCrs( crs );
-}
-
-void QgsMeshLayerProperties::updateLayerName( const QString &text )
-{
-  leDisplayName->setText( mMeshLayer->formatLayerName( text ) );
 }
 
 void QgsMeshLayerProperties::syncAndRepaint()

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -68,8 +68,6 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     //!Applies the settings made in the dialog without closing the box
     void apply();
-    //! \brief Slot to update layer display name as original is edited.
-    void updateLayerName( const QString &text );
     //! Synchronizes GUI state with associated mesh layer and trigger repaint
     void syncAndRepaint();
     //! Changes layer coordinate reference system

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -112,7 +112,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   mMetadataViewer = new QgsWebView( this );
   mOptsPage_Information->layout()->addWidget( mMetadataViewer );
 
-  connect( mLayerOrigNameLineEd, &QLineEdit::textEdited, this, &QgsRasterLayerProperties::mLayerOrigNameLineEd_textEdited );
   connect( buttonBuildPyramids, &QPushButton::clicked, this, &QgsRasterLayerProperties::buttonBuildPyramids_clicked );
   connect( pbnAddValuesFromDisplay, &QToolButton::clicked, this, &QgsRasterLayerProperties::pbnAddValuesFromDisplay_clicked );
   connect( pbnAddValuesManually, &QToolButton::clicked, this, &QgsRasterLayerProperties::pbnAddValuesManually_clicked );
@@ -857,9 +856,7 @@ void QgsRasterLayerProperties::sync()
    * General Tab
    */
 
-  //these properties (layer name and label) are provided by the qgsmaplayer superclass
   mLayerOrigNameLineEd->setText( mRasterLayer->name() );
-  leDisplayName->setText( mRasterLayer->name() );
 
   QgsDebugMsgLevel( QStringLiteral( "populate metadata tab" ), 2 );
   /*
@@ -1155,11 +1152,6 @@ void QgsRasterLayerProperties::apply()
 
   // notify the project we've made a change
   QgsProject::instance()->setDirty( true );
-}
-
-void QgsRasterLayerProperties::mLayerOrigNameLineEd_textEdited( const QString &text )
-{
-  leDisplayName->setText( mRasterLayer->formatLayerName( text ) );
 }
 
 void QgsRasterLayerProperties::buttonBuildPyramids_clicked()

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -128,8 +128,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     void apply();
     //! \brief Called when cancel button is pressed
     void onCancel();
-    //! \brief Slot to update layer display name as original is edited.
-    void mLayerOrigNameLineEd_textEdited( const QString &text );
     //! \brief this slot asks the rasterlayer to construct pyramids
     void buttonBuildPyramids_clicked();
     //! \brief slot executed when user presses "Add Values From Display" button on the transparency page

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -107,7 +107,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   , mOriginalSubsetSQL( lyr->subsetString() )
 {
   setupUi( this );
-  connect( mLayerOrigNameLineEdit, &QLineEdit::textEdited, this, &QgsVectorLayerProperties::mLayerOrigNameLineEdit_textEdited );
   connect( pbnQueryBuilder, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnQueryBuilder_clicked );
   connect( pbnIndex, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnIndex_clicked );
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsVectorLayerProperties::mCrsSelector_crsChanged );
@@ -518,7 +517,6 @@ void QgsVectorLayerProperties::syncToLayer()
 
   // populate the general information
   mLayerOrigNameLineEdit->setText( mLayer->name() );
-  txtDisplayName->setText( mLayer->name() );
 
   //see if we are dealing with a pg layer here
   mSubsetGroupBox->setEnabled( true );
@@ -936,11 +934,6 @@ void QgsVectorLayerProperties::pbnIndex_clicked()
 QString QgsVectorLayerProperties::htmlMetadata()
 {
   return mLayer->htmlMetadata();
-}
-
-void QgsVectorLayerProperties::mLayerOrigNameLineEdit_textEdited( const QString &text )
-{
-  txtDisplayName->setText( mLayer->formatLayerName( text ) );
 }
 
 void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -85,9 +85,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     //! Gets metadata about the layer in nice formatted html
     QString htmlMetadata();
 
-    //! Slot to update layer display name as original is edited
-    void mLayerOrigNameLineEdit_textEdited( const QString &text );
-
     //! Called when apply button is pressed or dialog is accepted
     void apply();
 

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -295,29 +295,6 @@
                     <item>
                      <widget class="QLineEdit" name="mLayerOrigNameLineEd"/>
                     </item>
-                    <item>
-                     <widget class="QLabel" name="label_13">
-                      <property name="text">
-                       <string>displayed as</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="leDisplayName">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="styleSheet">
-                       <string notr="true">color: #505050;
-background-color: #F0F0F0;
-border: 1px solid #B0B0B0;
-border-radius: 2px;</string>
-                      </property>
-                      <property name="readOnly">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
                    </layout>
                   </item>
                   <item>
@@ -902,7 +879,6 @@ border-radius: 2px;</string>
   <tabstop>mInformationTextBrowser</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>mLayerOrigNameLineEd</tabstop>
-  <tabstop>leDisplayName</tabstop>
   <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mTemporalStaticDatasetCheckBox</tabstop>

--- a/src/ui/qgspointcloudlayerpropertiesbase.ui
+++ b/src/ui/qgspointcloudlayerpropertiesbase.ui
@@ -241,29 +241,6 @@
                 <item>
                  <widget class="QLineEdit" name="mLayerOrigNameLineEdit"/>
                 </item>
-                <item>
-                 <widget class="QLabel" name="label_2">
-                  <property name="text">
-                   <string>displayed as</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="txtDisplayName">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">color: #505050;
-background-color: #F0F0F0;
-border: 1px solid #B0B0B0;
-border-radius: 2px;</string>
-                  </property>
-                  <property name="readOnly">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
                </layout>
               </item>
              </layout>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -316,26 +316,6 @@
                  <item>
                   <widget class="QLineEdit" name="mLayerOrigNameLineEd"/>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="label_9">
-                   <property name="text">
-                    <string>displayed as</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="leDisplayName">
-                   <property name="styleSheet">
-                    <string notr="true">color: #505050;
-background-color: #F0F0F0;
-border: 1px solid #B0B0B0;
-border-radius: 2px;</string>
-                   </property>
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
                </item>
                <item>
@@ -2342,7 +2322,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mOptionsListWidget</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>mLayerOrigNameLineEd</tabstop>
-  <tabstop>leDisplayName</tabstop>
   <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mResetColorRenderingBtn</tabstop>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -474,29 +474,6 @@
                     <item>
                      <widget class="QLineEdit" name="mLayerOrigNameLineEdit"/>
                     </item>
-                    <item>
-                     <widget class="QLabel" name="label_2">
-                      <property name="text">
-                       <string>displayed as</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="txtDisplayName">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="styleSheet">
-                       <string notr="true">color: #505050;
-background-color: #F0F0F0;
-border: 1px solid #B0B0B0;
-border-radius: 2px;</string>
-                      </property>
-                      <property name="readOnly">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
                    </layout>
                   </item>
                   <item>
@@ -2707,7 +2684,6 @@ border-radius: 2px;</string>
   <tabstop>teMetadataViewer</tabstop>
   <tabstop>scrollArea_4</tabstop>
   <tabstop>mLayerOrigNameLineEdit</tabstop>
-  <tabstop>txtDisplayName</tabstop>
   <tabstop>cboProviderEncoding</tabstop>
   <tabstop>mCrsGroupBox</tabstop>
   <tabstop>mCrsSelector</tabstop>


### PR DESCRIPTION
This is a weird legacy control, which is read only and which just
shows a copy of the layer name with _ replaced by space. It has
no impact on anything else!
