### PR TITLE
[release-3_20] do not use "master ccache" for build

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -104,7 +104,6 @@ jobs:
           restore-keys: |
             build-ccache-${{ matrix.ubuntu-base }}-${{ github.actor }}-${{ github.head_ref }}-
             build-ccache-${{ matrix.ubuntu-base }}-refs/heads/${{ github.base_ref }}-
-            build-ccache-${{ matrix.ubuntu-base }}-refs/heads/master-
 
       - name: Prepare build cache for branch/tag
         # use a fork of actions/cache@v2 to upload cache even when the build or test failed
@@ -116,7 +115,6 @@ jobs:
           key: build-ccache-${{ matrix.ubuntu-base }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             build-ccache-${{ matrix.ubuntu-base }}-${{ github.ref }}-
-            build-ccache-${{ matrix.ubuntu-base }}-refs/heads/master-
 
       - name: Compile QGIS
         id: compile


### PR DESCRIPTION
I'm not sure, but it seems to me that "master ccache" will not help when compiling "release-3_20". But after compilation, the ccache will take up more space as it will contain fragments from the "master ccache".