### PR TITLE
[WFS] Fix unknown expat encoding issues

### DIFF
--- a/python/core/auto_generated/qgsgml.sip.in
+++ b/python/core/auto_generated/qgsgml.sip.in
@@ -39,7 +39,6 @@ request is finished
                      const QString &authcfg = QString() ) /PyName=getFeaturesUri/;
 %Docstring
 Does the Http GET request to the wfs server
-Supports only UTF-8, UTF-16, ISO-8859-1, ISO-8859-1 XML encodings.
 
 :param uri: GML URL
 :param wkbType: wkbType to retrieve
@@ -58,7 +57,6 @@ Supports only UTF-8, UTF-16, ISO-8859-1, ISO-8859-1 XML encodings.
     int getFeatures( const QByteArray &data, QgsWkbTypes::Type *wkbType, QgsRectangle *extent = 0 );
 %Docstring
 Read from GML data. Constructor uri param is ignored
-Supports only UTF-8, UTF-16, ISO-8859-1, ISO-8859-1 XML encodings.
 %End
 
     QMap<QgsFeatureId, QgsFeature * > featuresMap() const;

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -33,6 +33,7 @@
 #include <string>
 
 class QgsCoordinateReferenceSystem;
+class QTextCodec;
 
 #ifndef SIP_RUN
 
@@ -253,8 +254,11 @@ class CORE_EXPORT QgsGmlStreamingParser
     //! Safely (if empty) pop from mode stack
     ParseMode modeStackPop() { return mParseModeStack.isEmpty() ? None : mParseModeStack.pop(); }
 
+    //! create parser with specified encoding if any
+    void createParser( const QByteArray &encoding = QByteArray() );
+
     //! Expat parser
-    XML_Parser mParser;
+    XML_Parser mParser = nullptr;
 
     //! List of (feature, gml_id) pairs
     QVector<QgsGmlFeaturePtrGmlIdPair> mFeatureList;
@@ -344,6 +348,8 @@ class CORE_EXPORT QgsGmlStreamingParser
     std::string mGeometryString;
     //! Whether we found a unhandled geometry element
     bool mFoundUnhandledGeometryElement;
+    //! text codec used to read data with an expat unsupported encoding
+    QTextCodec *mCodec = nullptr;
 };
 
 #endif
@@ -368,7 +374,6 @@ class CORE_EXPORT QgsGml : public QObject
 
     /**
      * Does the Http GET request to the wfs server
-     *  Supports only UTF-8, UTF-16, ISO-8859-1, ISO-8859-1 XML encodings.
      *  \param uri GML URL
      *  \param wkbType wkbType to retrieve
      *  \param extent retrieved extents
@@ -387,7 +392,6 @@ class CORE_EXPORT QgsGml : public QObject
 
     /**
      * Read from GML data. Constructor uri param is ignored
-     *  Supports only UTF-8, UTF-16, ISO-8859-1, ISO-8859-1 XML encodings.
      */
     int getFeatures( const QByteArray &data, QgsWkbTypes::Type *wkbType, QgsRectangle *extent = nullptr );
 

--- a/tests/src/core/testqgsgml.cpp
+++ b/tests/src/core/testqgsgml.cpp
@@ -17,6 +17,7 @@
 #include "qgstest.h"
 #include <QUrl>
 #include <QTemporaryFile>
+#include <QTextCodec>
 
 //qgis includes...
 #include <qgsgeometry.h>
@@ -82,6 +83,8 @@ class TestQgsGML : public QObject
     void testThroughOGRGeometry_urn_EPSG_4326();
     void testAccents();
     void testSameTypeameAsGeomName();
+    void testUnknownEncoding_data();
+    void testUnknownEncoding();
 };
 
 const QString data1( "<myns:FeatureCollection "
@@ -1271,6 +1274,73 @@ void TestQgsGML::testSameTypeameAsGeomName()
   QCOMPARE( multi[0].size(), 1 );
   QCOMPARE( multi[0][0].size(), 5 );
   delete features[0].first;
+}
+
+void TestQgsGML::testUnknownEncoding_data()
+{
+  QTest::addColumn<QString>( "xmlHeader" );
+  QTest::addColumn<QByteArray>( "encoding" );
+
+  QTest::newRow( "simple quote" ) << QStringLiteral( "<?xml version='1.0' encoding='ISO-8859-15'?>" ) << QByteArrayLiteral( "ISO-8859-15" );
+  QTest::newRow( "double quote" ) << QStringLiteral( "<?xml version='1.0' encoding=\"ISO-8859-15\"?>" ) << QByteArrayLiteral( "ISO-8859-15" );
+  QTest::newRow( "UTF-8" ) << QStringLiteral( "<?xml version='1.0' encoding=\"UTF-8\"?>" ) << QByteArrayLiteral( "UTF-8" );
+  QTest::newRow( "No header" ) << QString() << QByteArrayLiteral( "UTF-8" );
+}
+
+void TestQgsGML::testUnknownEncoding()
+{
+  QFETCH( QString, xmlHeader );
+  QFETCH( QByteArray, encoding );
+
+  QgsWkbTypes::Type wkbType;
+
+  QTextCodec *codec = QTextCodec::codecForName( encoding );
+
+  QByteArray data = codec->fromUnicode(
+                      QStringLiteral(
+                        "%1<myns:FeatureCollection "
+                        "xmlns:myns='http://myns' "
+                        "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
+                        "xmlns:gml='http://www.opengis.net/gml'>"
+                        "<gml:boundedBy><gml:null>unknown</gml:null></gml:boundedBy>"
+                        "<gml:featureMember>"
+                        "<myns:mytypename fid='mytypename.1'>"
+                        "<myns:strfield>price: 10€</myns:strfield>"
+                        "<myns:mygeom>"
+                        "<gml:Point srsName='http://www.opengis.net/gml/srs/epsg.xml#27700'>"
+                        "<gml:coordinates decimal='.' cs=',' ts=' '>10,20</gml:coordinates>"
+                        "</gml:Point>"
+                        "</myns:mygeom>"
+                        "</myns:mytypename>"
+                        "</gml:featureMember>"
+                        "</myns:FeatureCollection>" ).arg( xmlHeader ) );
+
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "strfield" ), QVariant::String, QStringLiteral( "string" ) ) );
+
+  {
+    QgsGml gmlParser( QStringLiteral( "mytypename" ), QStringLiteral( "mygeom" ), fields );
+    QCOMPARE( gmlParser.getFeatures( data, &wkbType ), 0 );
+    QMap<QgsFeatureId, QgsFeature * > featureMaps = gmlParser.featuresMap();
+    QCOMPARE( featureMaps.size(), 1 );
+    QVERIFY( featureMaps.constFind( 0 ) != featureMaps.constEnd() );
+    QCOMPARE( featureMaps[ 0 ]->attributes().size(), 1 );
+    QCOMPARE( featureMaps[0]->attribute( QStringLiteral( "strfield" ) ).toString(), QString( "price: 10€" ) );
+    delete featureMaps[ 0 ];
+  }
+
+  {
+    QgsGmlStreamingParser gmlParser( QStringLiteral( "mytypename" ), QStringLiteral( "mygeom" ), fields );
+    QCOMPARE( gmlParser.processData( data.mid( 0, data.size() / 2 ), false ), true );
+    QCOMPARE( gmlParser.getAndStealReadyFeatures().size(), 0 );
+    QCOMPARE( gmlParser.processData( data.mid( data.size() / 2 ), true ), true );
+    QCOMPARE( gmlParser.isException(), false );
+    QVector<QgsGmlStreamingParser::QgsGmlFeaturePtrGmlIdPair> features = gmlParser.getAndStealReadyFeatures();
+    QCOMPARE( features.size(), 1 );
+    QCOMPARE( features[ 0 ].first->attributes().size(), 1 );
+    QCOMPARE( features[ 0 ].first->attribute( QStringLiteral( "strfield" ) ).toString(), QString( "price: 10€" ) );
+    delete features[0].first;
+  }
 }
 
 QGSTEST_MAIN( TestQgsGML )


### PR DESCRIPTION
It's not possible to read some WFS stream if they have a specific encoding (ISO-8859-15). It's due to [expat](https://ghostscript.com/doc/expat/doc/reference.html) XML reader encoding

```
There are four built-in encodings in Expat:

    UTF-8
    UTF-16
    ISO-8859-1
    US-ASCII
```

This PR fixes this. It tries to detect encoding from XML declaration when Expat fails to do so.