### PR TITLE
Add possibility to include the end of the temporal FilterRange

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertemporalproperties.sip.in
@@ -76,8 +76,8 @@ The ``enabled`` argument specifies whether the temporal properties are initially
 
     enum LimitMode
     {
-        ModeIncludeBeginExcludeEnd,
-        ModeIncludeBeginIncludeEnd,
+      ModeIncludeBeginExcludeEnd,
+      ModeIncludeBeginIncludeEnd,
     };
 
     TemporalMode mode() const;

--- a/python/core/auto_generated/vector/qgsvectorlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertemporalproperties.sip.in
@@ -74,6 +74,12 @@ The ``enabled`` argument specifies whether the temporal properties are initially
       ModeRedrawLayerOnly,
     };
 
+    enum LimitMode
+    {
+        ModeIncludeBeginExcludeEnd,
+        ModeIncludeBeginIncludeEnd,
+    };
+
     TemporalMode mode() const;
 %Docstring
 Returns the temporal properties mode.
@@ -86,6 +92,20 @@ Returns the temporal properties mode.
 Sets the temporal properties ``mode``.
 
 .. seealso:: :py:func:`mode`
+%End
+
+    LimitMode limitMode() const;
+%Docstring
+Returns the temporal limit mode (to include or exclude begin/end limits).
+
+.. seealso:: :py:func:`setLimitMode`
+%End
+
+    void setLimitMode( LimitMode mode );
+%Docstring
+Sets the temporal ``limit`` mode (to include or exclude begin/end limits).
+
+.. seealso:: :py:func:`limitMode`
 %End
 
     virtual QgsTemporalProperty::Flags flags() const;

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -99,6 +99,7 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     QgsVectorLayerTemporalContext temporalContext;
     temporalContext.setLayer( layer );
     mTemporalFilter = qobject_cast< const QgsVectorLayerTemporalProperties * >( layer->temporalProperties() )->createFilterString( temporalContext, context.temporalRange() );
+    qDebug() << "Rendering with Temporal Filter: " << mTemporalFilter;
   }
 
   // if there's already a simplification method specified via the context, we respect that. Otherwise, we fall back

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -99,7 +99,6 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     QgsVectorLayerTemporalContext temporalContext;
     temporalContext.setLayer( layer );
     mTemporalFilter = qobject_cast< const QgsVectorLayerTemporalProperties * >( layer->temporalProperties() )->createFilterString( temporalContext, context.temporalRange() );
-    qDebug() << "Rendering with Temporal Filter: " << mTemporalFilter;
   }
 
   // if there's already a simplification method specified via the context, we respect that. Otherwise, we fall back

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -99,7 +99,7 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     QgsVectorLayerTemporalContext temporalContext;
     temporalContext.setLayer( layer );
     mTemporalFilter = qobject_cast< const QgsVectorLayerTemporalProperties * >( layer->temporalProperties() )->createFilterString( temporalContext, context.temporalRange() );
-    QgsDebugMsg( "Rendering with Temporal Filter: " + mTemporalFilter );
+    QgsDebugMsgLevel( "Rendering with Temporal Filter: " + mTemporalFilter, 2 );
   }
 
   // if there's already a simplification method specified via the context, we respect that. Otherwise, we fall back

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -99,6 +99,7 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
     QgsVectorLayerTemporalContext temporalContext;
     temporalContext.setLayer( layer );
     mTemporalFilter = qobject_cast< const QgsVectorLayerTemporalProperties * >( layer->temporalProperties() )->createFilterString( temporalContext, context.temporalRange() );
+    QgsDebugMsg( "Rendering with Temporal Filter: " + mTemporalFilter );
   }
 
   // if there's already a simplification method specified via the context, we respect that. Otherwise, we fall back

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -450,11 +450,11 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayerTemp
   QgsDateTimeRange filter;
   if ( limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd )
   {
-      filter = QgsDateTimeRange(filterRange.begin(), filterRange.end(), true, true);
+    filter = QgsDateTimeRange( filterRange.begin(), filterRange.end(), true, true );
   }
   else
   {
-      filter = QgsDateTimeRange(filterRange.begin(), filterRange.end(), true, false);  // default is include begin, exclude end of filter
+    filter = QgsDateTimeRange( filterRange.begin(), filterRange.end(), true, false ); // default is include begin, exclude end of filter
   }
 
   switch ( mMode )

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -568,7 +568,7 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayerTemp
       if ( !mStartExpression.isEmpty() && !mEndExpression.isEmpty() )
       {
         return QStringLiteral( "((%1) %2 %3) AND ((%4) > %5)" ).arg( mStartExpression,
-               filterRange.includeEnd() ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
+               ( filterRange.includeEnd() or limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ) ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
                dateTimeExpressionLiteral( filterRange.end() ),
                mEndExpression,
                dateTimeExpressionLiteral( filterRange.begin() ) );

--- a/src/core/vector/qgsvectorlayertemporalproperties.cpp
+++ b/src/core/vector/qgsvectorlayertemporalproperties.cpp
@@ -472,9 +472,10 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayerTemp
       else
       {
         // Working with features with events with a duration, so taking this duration into account (+ QgsInterval( -mFixedDuration, mDurationUnit ) ))
-        return QStringLiteral( "(%1 > %2 AND %1 %3 %4) OR %1 IS NULL" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
+        return QStringLiteral( "(%1 %2 %3 AND %1 %4 %5) OR %1 IS NULL" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
+               limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ? QStringLiteral( ">=" ) : QStringLiteral( ">" ),
                dateTimeExpressionLiteral( filterRange.begin() + QgsInterval( -mFixedDuration, mDurationUnit ) ),
-               ( filterRange.includeEnd() or limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ) ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
+               filterRange.includeEnd() ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
                dateTimeExpressionLiteral( filterRange.end() ) );
       }
     }
@@ -528,10 +529,11 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayerTemp
         case QgsUnitTypes::TemporalIrregularStep:
           return QString();
       }
-      return QStringLiteral( "(%1 %2 %3 OR %1 IS NULL) AND ((%1 + %4 > %5) OR %6 IS NULL)" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
-             ( filterRange.includeEnd() or limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ) ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
+      return QStringLiteral( "(%1 %2 %3 OR %1 IS NULL) AND ((%1 + %4 %5 %6) OR %7 IS NULL)" ).arg( QgsExpression::quotedColumnRef( mStartFieldName ),
+             filterRange.includeEnd() ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
              dateTimeExpressionLiteral( filterRange.end() ),
              intervalExpression,
+             limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ? QStringLiteral( ">=" ) : QStringLiteral( ">" ),
              dateTimeExpressionLiteral( filterRange.begin() ),
              QgsExpression::quotedColumnRef( mDurationFieldName ) );
     }
@@ -567,10 +569,11 @@ QString QgsVectorLayerTemporalProperties::createFilterString( QgsVectorLayerTemp
     {
       if ( !mStartExpression.isEmpty() && !mEndExpression.isEmpty() )
       {
-        return QStringLiteral( "((%1) %2 %3) AND ((%4) > %5)" ).arg( mStartExpression,
-               ( filterRange.includeEnd() or limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ) ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
+        return QStringLiteral( "((%1) %2 %3) AND ((%4) %5 %6)" ).arg( mStartExpression,
+               filterRange.includeEnd() ? QStringLiteral( "<=" ) : QStringLiteral( "<" ),
                dateTimeExpressionLiteral( filterRange.end() ),
                mEndExpression,
+               limitMode() == QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd ? QStringLiteral( ">=" ) : QStringLiteral( ">" ),
                dateTimeExpressionLiteral( filterRange.begin() ) );
       }
       else if ( !mStartExpression.isEmpty() )

--- a/src/core/vector/qgsvectorlayertemporalproperties.h
+++ b/src/core/vector/qgsvectorlayertemporalproperties.h
@@ -101,8 +101,8 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      */
     enum LimitMode
     {
-        ModeIncludeBeginExcludeEnd = 0, //!< Default mode: include the Begin limit, but exclude the End limit
-        ModeIncludeBeginIncludeEnd, //!< Mode to include both limits of the filtering timeframe
+      ModeIncludeBeginExcludeEnd = 0, //!< Default mode: include the Begin limit, but exclude the End limit
+      ModeIncludeBeginIncludeEnd, //!< Mode to include both limits of the filtering timeframe
     };
 
     /**

--- a/src/core/vector/qgsvectorlayertemporalproperties.h
+++ b/src/core/vector/qgsvectorlayertemporalproperties.h
@@ -97,6 +97,15 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
     };
 
     /**
+     * Mode for the handling of the limits of the filtering timeframe
+     */
+    enum LimitMode
+    {
+        ModeIncludeBeginExcludeEnd = 0, //!< Default mode: include the Begin limit, but exclude the End limit
+        ModeIncludeBeginIncludeEnd, //!< Mode to include both limits of the filtering timeframe
+    };
+
+    /**
      * Returns the temporal properties mode.
      *
      *\see setMode()
@@ -109,6 +118,20 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
      *\see mode()
     */
     void setMode( TemporalMode mode );
+
+    /**
+     * Returns the temporal limit mode (to include or exclude begin/end limits).
+     *
+     *\see setLimitMode()
+    */
+    LimitMode limitMode() const;
+
+    /**
+     * Sets the temporal \a limit mode (to include or exclude begin/end limits).
+     *
+     *\see limitMode()
+    */
+    void setLimitMode( LimitMode mode );
 
     /**
      * Returns flags associated to the temporal property.
@@ -341,6 +364,9 @@ class CORE_EXPORT QgsVectorLayerTemporalProperties : public QgsMapLayerTemporalP
 
     //! Temporal layer mode.
     TemporalMode mMode = ModeFixedTemporalRange;
+
+    //! How to handle the limits of the timeframe (include or exclude)
+    LimitMode mLimitMode = ModeIncludeBeginExcludeEnd;
 
     //! Represents fixed temporal range.
     QgsDateTimeRange mFixedRange;

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -41,6 +41,9 @@ QgsVectorLayerTemporalPropertiesWidget::QgsVectorLayerTemporalPropertiesWidget( 
 
   connect( mModeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), mStackedWidget, &QStackedWidget::setCurrentIndex );
 
+  mLimitsComboBox->addItem( tr( "Include Start, Exclude End (default)" ), QgsVectorLayerTemporalProperties::ModeIncludeBeginExcludeEnd );
+  mLimitsComboBox->addItem( tr( "Include Start, Include End" ), QgsVectorLayerTemporalProperties::ModeIncludeBeginIncludeEnd );
+
   mStartTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
   mEndTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
@@ -104,6 +107,7 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
 
   properties->setIsActive( mTemporalGroupBox->isChecked() );
   properties->setMode( static_cast< QgsVectorLayerTemporalProperties::TemporalMode >( mModeComboBox->currentData().toInt() ) );
+  properties->setLimitMode(static_cast< QgsVectorLayerTemporalProperties::LimitMode >( mLimitsComboBox->currentData().toInt() ));
 
   QgsDateTimeRange normalRange = QgsDateTimeRange( mStartTemporalDateTimeEdit->dateTime(),
                                  mEndTemporalDateTimeEdit->dateTime() );
@@ -153,6 +157,8 @@ void QgsVectorLayerTemporalPropertiesWidget::syncToLayer()
 
   mModeComboBox->setCurrentIndex( mModeComboBox->findData( properties->mode() ) );
   mStackedWidget->setCurrentIndex( static_cast< int >( properties->mode() ) );
+
+  mLimitsComboBox->setCurrentIndex( mLimitsComboBox->findData( properties->limitMode() ) );
 
   mStartTemporalDateTimeEdit->setDateTime( properties->fixedTemporalRange().begin() );
   mEndTemporalDateTimeEdit->setDateTime( properties->fixedTemporalRange().end() );

--- a/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
+++ b/src/gui/qgsvectorlayertemporalpropertieswidget.cpp
@@ -107,7 +107,7 @@ void QgsVectorLayerTemporalPropertiesWidget::saveTemporalProperties()
 
   properties->setIsActive( mTemporalGroupBox->isChecked() );
   properties->setMode( static_cast< QgsVectorLayerTemporalProperties::TemporalMode >( mModeComboBox->currentData().toInt() ) );
-  properties->setLimitMode(static_cast< QgsVectorLayerTemporalProperties::LimitMode >( mLimitsComboBox->currentData().toInt() ));
+  properties->setLimitMode( static_cast< QgsVectorLayerTemporalProperties::LimitMode >( mLimitsComboBox->currentData().toInt() ) );
 
   QgsDateTimeRange normalRange = QgsDateTimeRange( mStartTemporalDateTimeEdit->dateTime(),
                                  mEndTemporalDateTimeEdit->dateTime() );

--- a/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorlayertemporalpropertieswidgetbase.ui
@@ -94,7 +94,7 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="2" column="0" colspan="2">
            <widget class="QStackedWidget" name="mStackedWidget">
             <property name="currentIndex">
              <number>0</number>
@@ -424,7 +424,7 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
             </widget>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QFrame" name="mFixedTimeRangeFrame">
             <property name="enabled">
              <bool>false</bool>
@@ -446,6 +446,16 @@ background: white;QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::ti
               <number>0</number>
              </property>
             </layout>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="mLimitsComboBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Limits</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -258,7 +258,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # OR start of feature <= end of range AND start of feature > start of range - duration
         self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         # and the temporal properties exactly the same
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
@@ -286,9 +286,9 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #                    [---.---]                     .            (true)
         #                [-------]                         .            (true)
         #          [-------]     .                         .            (false)
-        # => start of feature < end of range AND start of feature + duration > start of range
-        # OR start of feature <= end of range AND start of feature > start of range - duration
-        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        # => start of feature < end of range AND start of feature + duration >= start of range
+        # OR start of feature < end of range AND start of feature >= start of range - duration
+        self.assertEqual(props.createFilterString(context, range), '("start_field" >= make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
         props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # different unit
@@ -469,7 +469,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeBeginning=False)
         self.assertEqual(props.createFilterString(context, range), '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND ("end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL)')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         # map range              [-------------------------)
         # feature ranges         .                         . [-------)  (false)
         #                        .                         [-------)    (false)
@@ -535,7 +535,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start of feature <= end of range
         self.assertEqual(props.createFilterString(context, range), '"start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges         .                         . [-------->  (false)
@@ -584,7 +584,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '"end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges --------.-------------------------.---------)  (true)
@@ -676,7 +676,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         self.assertEqual(props.createFilterString(context, range),
                          '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)),
                                  QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
@@ -702,10 +702,10 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #                [-------]                         .            (true)
         #          [-------]     .                         .            (false)
         #
-        # => start of feature <= end of range AND start + duration > start of range
+        # => start of feature < end of range AND start + duration >= start of range
         props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
         self.assertEqual(props.createFilterString(context, range),
-                         '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
+                         '("start_field" < make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) >= make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
         props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # different units
@@ -806,7 +806,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start expression <= end of range AND end expression > start of range
         self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") <= make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13))')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges         .                         . [-------)  (false)
@@ -830,9 +830,9 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #                [-------]                         .            (true)
         #          [-------]     .                         .            (false)
         #
-        # => start expression <= end of range AND end expression > start of range
+        # => start expression < end of range AND end expression >= start of range
         props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
-        self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") <= make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13))')
+        self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") < make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") >= make_datetime(2019,3,4,11,12,13))')
         props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # features go to +eternity
@@ -919,7 +919,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '(to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13)')
 
-        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # THIS is the QGIS default: using a range with includeBeginning=true and includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges --------.-------------------------.---------)  (true)

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -694,7 +694,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
                          '("start_field" < make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
         # map range              [-------------------------)
         # feature ranges         .                         . [-------]  (false)
-        #                        .                         [-------]    (true)
+        #                        .                         [-------]    (false)
         #                        .                     [---.---]        (true)
         #                        .            [-------]    .            (true)
         #                        [-------]                 .            (true)

--- a/tests/src/python/test_qgsvectorlayertemporalproperties.py
+++ b/tests/src/python/test_qgsvectorlayertemporalproperties.py
@@ -258,6 +258,8 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # OR start of feature <= end of range AND start of feature > start of range - duration
         self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
+        # and the temporal properties exactly the same
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges         .                         . [-------)  (false)
@@ -272,6 +274,11 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start of feature < end of range AND start of feature + duration > start of range
         # OR start of feature < end of range AND start of feature > start of range - duration
         self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" < make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+
+        # since 3.22 there is also the option to include the end of the feature event
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range), '("start_field" > make_datetime(2019,3,1,11,12,13) AND "start_field" <= make_datetime(2020,5,6,8,9,10)) OR "start_field" IS NULL')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # different unit
         props.setDurationUnits(QgsUnitTypes.TemporalMinutes)
@@ -451,6 +458,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeBeginning=False)
         self.assertEqual(props.createFilterString(context, range), '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND ("end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL)')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         # map range              [-------------------------)
         # feature ranges         .                         . [-------)  (false)
         #                        .                         [-------)    (false)
@@ -464,6 +472,11 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start of feature < end of range AND end of feature > start of range
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         self.assertEqual(props.createFilterString(context, range), '("start_field" < make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND ("end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL)')
+        # since 3.22 there is also the option to include the end of the feature event
+        # => start of feature < end of range AND end of feature >= start of range
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range), '("start_field" < make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND ("end_field" >= make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL)')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # features go to +eternity
         props.setEndField('')
@@ -501,6 +514,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start of feature <= end of range
         self.assertEqual(props.createFilterString(context, range), '"start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges         .                         . [-------->  (false)
@@ -549,8 +563,9 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '"end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
-        # map range              [-------------------------]
+        # map range              [-------------------------)
         # feature ranges --------.-------------------------.---------)  (true)
         #                --------.-------------------------)            (true)
         #                --------.--------------------)    .            (true)
@@ -559,6 +574,11 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '"end_field" > make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL')
+        # since 3.22 there is also the option to include the end of the feature event
+        # => end of feature >= start of range
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range), '"end_field" >= make_datetime(2019,3,4,11,12,13) OR "end_field" IS NULL')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
     def testStartAndDurationMode(self):
         layer = QgsVectorLayer(
@@ -627,6 +647,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         self.assertEqual(props.createFilterString(context, range),
                          '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)),
                                  QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
@@ -642,6 +663,11 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start of feature < end of range AND start + duration > start of range
         self.assertEqual(props.createFilterString(context, range),
                          '("start_field" < make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
+        # => start of feature <= end of range AND start + duration > start of range
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range),
+                         '("start_field" <= make_datetime(2020,5,6,8,9,10) OR "start_field" IS NULL) AND (("start_field" + make_interval(0,0,0,0,0,0,"duration"/1000) > make_datetime(2019,3,4,11,12,13)) OR "duration" IS NULL)')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # different units
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)),
@@ -741,6 +767,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => start expression <= end of range AND end expression > start of range
         self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") <= make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13))')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges         .                         . [-------)  (false)
@@ -754,6 +781,10 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #
         # => start expression < end of range AND end expression > start of range
         self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") < make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13))')
+        # => start expression <= end of range AND end expression > start of range
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range), '((to_datetime("my string field",  \'yyyy MM dd hh::mm:ss\')") <= make_datetime(2020,5,6,8,9,10)) AND ((to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13))')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
         # features go to +eternity
         props.setEndExpression('')
@@ -839,6 +870,7 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '(to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13)')
 
+        # THIS is the QGIS default: using a range with includeBeginning=true en includeEnd=false
         range = QgsDateTimeRange(QDateTime(QDate(2019, 3, 4), QTime(11, 12, 13)), QDateTime(QDate(2020, 5, 6), QTime(8, 9, 10)), includeEnd=False)
         # map range              [-------------------------)
         # feature ranges --------.-------------------------.---------)  (true)
@@ -849,6 +881,10 @@ class TestQgsVectorLayerTemporalProperties(unittest.TestCase):
         #
         # => end of feature > start of range
         self.assertEqual(props.createFilterString(context, range), '(to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") > make_datetime(2019,3,4,11,12,13)')
+        # => end of feature >= start of range
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginIncludeEnd)
+        self.assertEqual(props.createFilterString(context, range), '(to_datetime("my end field",  \'yyyy MM dd hh::mm:ss\')") >= make_datetime(2019,3,4,11,12,13)')
+        props.setLimitMode(QgsVectorLayerTemporalProperties.LimitMode.ModeIncludeBeginExcludeEnd)  # back to default
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Default temporal filtering (of vector features) in most software will
INclude the begin/start of the filtering range, but EXclude the end of it.
So: if you filter with say a filter of 1900-1910, by default features with
1900 will be selected, but with 1910 will NOT (exclude end).

Some context:
- https://github.com/qgis/QGIS/pull/40989 (on the end comments)
- leading to: https://github.com/qgis/QGIS/issues/44589

This commit adds the possibility (in the Temporal Features tab of the
vector layer properties) to choose the 'limitMode'.
The limitmode can now also be set to INclude begin AND INclude end.
So in the above example, also the features with 1910 will be selected.

The limitMode is written to the xml project file as temporal attribute.

Below the added ComboBox

![Screenshot-20210812171016-974x216](https://user-images.githubusercontent.com/731673/129221545-16f0abd7-164b-403e-9369-0ea781c5c05b.png)

Feel free to comment on code/naming or place of combobox :-)

A small test project with a csv loaded as temporal layers:

[temporalLimitTest.zip](https://github.com/qgis/QGIS/files/6976618/temporalLimitTest.zip)


