### PR TITLE
Fix map grid decoration dialog in order to allow setting negative offsets

### DIFF
--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -54,6 +54,9 @@
       </item>
       <item row="10" column="2">
        <widget class="QgsDoubleSpinBox" name="mOffsetYEdit">
+        <property name="minimum">
+         <double>-10000000000000000.000000000000000</double>
+        </property>
         <property name="maximum">
          <double>10000000000000000.000000000000000</double>
         </property>
@@ -230,6 +233,9 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimum">
+         <double>-10000000000000000.000000000000000</double>
         </property>
         <property name="maximum">
          <double>10000000000000000.000000000000000</double>


### PR DESCRIPTION
## Description

Before the merging of https://github.com/qgis/QGIS/pull/43831, it was possible to insert negative values for the X and Y offsets parameters in the grid decoration dialog window, because mOffsetXEdit and mOffsetYEdit were QLineEdit widgets.
After https://github.com/qgis/QGIS/pull/43831, mOffsetXEdit and mOffsetYEdit are changed to QgsDoubleSpinBox widgets without properly setting the "minimum" property, so it is no more possible to insert negative values for the X and Y offsets.

This PR sets the mOffsetXEdit and mOffsetYEdit "minimum" property to "-10000000000000000.000000000000000" in order to allow setting negative offsets in the map grid decoration dialog.

The fixed issue only affects the master branch (https://github.com/qgis/QGIS/pull/43831 was not backported).


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
