### PR TITLE
[AttributeForm] always put tab widget content into a scroll area

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2094,22 +2094,14 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       {
         myContainer = new QWidget();
 
-        if ( context.formMode() != QgsAttributeEditorContext::Embed )
-        {
-          QgsScrollArea *scrollArea = new QgsScrollArea( parent );
+        QgsScrollArea *scrollArea = new QgsScrollArea( parent );
 
-          scrollArea->setWidget( myContainer );
-          scrollArea->setWidgetResizable( true );
-          scrollArea->setFrameShape( QFrame::NoFrame );
-          widgetName = QStringLiteral( "QScrollArea QWidget" );
+        scrollArea->setWidget( myContainer );
+        scrollArea->setWidgetResizable( true );
+        scrollArea->setFrameShape( QFrame::NoFrame );
+        widgetName = QStringLiteral( "QScrollArea QWidget" );
 
-          newWidgetInfo.widget = scrollArea;
-        }
-        else
-        {
-          newWidgetInfo.widget = myContainer;
-          widgetName = QStringLiteral( "QWidget" );
-        }
+        newWidgetInfo.widget = scrollArea;
       }
 
       if ( container->backgroundColor().isValid() )


### PR DESCRIPTION
Without this all tab widgets have the size of the tab with the largest content like in the screen-cast below (old behavior):
![OLD](https://user-images.githubusercontent.com/9881900/129573337-ef419504-454a-4cfb-8c0c-1db9d95f100e.gif)

With the new behavior scrollbars are shown only when needed and it is not necessary to scroll inside tabs with less controls. Widgets also don't get forced to become extremely large. This is already the behavior for non-embedded forms:
![NEW](https://user-images.githubusercontent.com/9881900/129573356-e10fc41d-36c5-44b6-8bdc-48547f89aedd.gif)


