### PR TITLE
Correctly show picture path when clicking an existing picture item

### DIFF
--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -330,6 +330,7 @@ void QgsLayoutPictureWidget::setGuiElementValues()
       mAnchorPointComboBox->setEnabled( false );
     }
 
+    mSvgSelectorWidget->setSvgPath( mPicture->picturePath() );
     mSvgSelectorWidget->setSvgParameters( mPicture->svgDynamicParameters() );
 
     updateSvgParamGui( false );

--- a/src/ui/symbollayer/widget_svgselector.ui
+++ b/src/ui/symbollayer/widget_svgselector.ui
@@ -217,12 +217,6 @@
    </item>
    <item row="3" column="0">
     <widget class="QgsPictureSourceLineEditBase" name="mSourceLineEdit" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>


### PR DESCRIPTION
Fixes #44703, fixes #44532