### PR TITLE
Remove unused include

### DIFF
--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsJsonExporter
 {
 %Docstring(signature="appended")

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -22,11 +22,6 @@
 #include "qgscoordinatetransform.h"
 #include "qgsfields.h"
 
-#ifndef SIP_RUN
-#include <json_fwd.hpp>
-using namespace nlohmann;
-#endif
-
 #include <QPointer>
 #include <QJsonObject>
 


### PR DESCRIPTION
Avoids unnecessarily including private header `json_fwd.hpp` in public (installed) header.