### PR TITLE
Fix some annotation layer handling in app

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -640,3 +640,8 @@ Qgis.FileOperationFlag.IncludeStyleFile.__doc__ = "Indicates that any associated
 Qgis.FileOperationFlag.__doc__ = 'File operation flags.\n\n.. versionadded:: 3.22\n\n' + '* ``IncludeMetadataFile``: ' + Qgis.FileOperationFlag.IncludeMetadataFile.__doc__ + '\n' + '* ``IncludeStyleFile``: ' + Qgis.FileOperationFlag.IncludeStyleFile.__doc__
 # --
 Qgis.FileOperationFlag.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__ = "Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually. Since QGIS 3.22."
+Qgis.MapLayerProperty.__doc__ = 'Generic map layer properties.\n\n.. versionadded:: 3.22\n\n' + '* ``UsersCannotToggleEditing``: ' + Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__
+# --
+Qgis.MapLayerProperty.baseClass = Qgis

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -109,6 +109,10 @@ with the layer.
 
     virtual bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories );
 
+    virtual bool isEditable() const;
+
+    virtual bool supportsEditing() const;
+
 
 };
 

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -93,6 +93,8 @@ This map contains references to items owned by the layer, and ownership of these
 with the layer.
 %End
 
+    virtual Qgis::MapLayerProperties properties() const;
+
     virtual QgsAnnotationLayer *clone() const /Factory/;
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -45,10 +45,14 @@ Convert Qt.CheckState to QString
 Convert QString to Qt.CheckState
 %End
 
-    static bool layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes );
+    static bool layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes, bool ignoreLayersWhichCannotBeToggled = false );
 %Docstring
-Returns ``True`` if any of the layers is editable
+Returns ``True`` if any of the specified layers is editable.
+
+The ``ignoreLayersWhichCannotBeToggled`` argument can be used to control whether layers which cannot have their
+edit states toggled by users should be ignored or not (since QGIS 3.22).
 %End
+
     static bool layersModified( const QList<QgsLayerTreeLayer *> &layerNodes );
 %Docstring
 Returns ``True`` if any of the layers is modified

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -452,6 +452,13 @@ The development version
     typedef QFlags<Qgis::FileOperationFlag> FileOperationFlags;
 
 
+    enum class MapLayerProperty
+    {
+      UsersCannotToggleEditing,
+    };
+    typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
+
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -140,6 +140,8 @@ Returns the flags for this layer.
    For instance, even if the Removable flag is not set, the layer can still be removed with the API
    but the action will not be listed in the legend menu.
 
+.. seealso:: :py:func:`properties`
+
 .. versionadded:: 3.4
 %End
 
@@ -153,7 +155,22 @@ Returns the flags for this layer.
    For instance, even if the Removable flag is not set, the layer can still be removed with the API
    but the action will not be listed in the legend menu.
 
+.. seealso:: :py:func:`properties`
+
 .. versionadded:: 3.4
+%End
+
+    virtual Qgis::MapLayerProperties properties() const;
+%Docstring
+Returns the map layer properties of this layer.
+
+.. note::
+
+   :py:func:`~QgsMapLayer.properties` differ from :py:func:`~QgsMapLayer.flags` in that :py:func:`~QgsMapLayer.flags` are user settable, and reflect options that
+   users can enable for map layers. In contrast :py:func:`~QgsMapLayer.properties` are reflections of inherent capabilities
+   for the layer, which cannot be directly changed by users.
+
+.. versionadded:: 3.22
 %End
 
     static QString extensionPropertyType( PropertyType type );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -15610,8 +15610,79 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       break;
 
     case QgsMapLayerType::PluginLayer:
-    case QgsMapLayerType::AnnotationLayer:
       break;
+
+    case QgsMapLayerType::AnnotationLayer:
+    {
+      mActionLocalHistogramStretch->setEnabled( false );
+      mActionFullHistogramStretch->setEnabled( false );
+      mActionLocalCumulativeCutStretch->setEnabled( false );
+      mActionFullCumulativeCutStretch->setEnabled( false );
+      mActionIncreaseBrightness->setEnabled( false );
+      mActionDecreaseBrightness->setEnabled( false );
+      mActionIncreaseContrast->setEnabled( false );
+      mActionDecreaseContrast->setEnabled( false );
+      mActionIncreaseGamma->setEnabled( false );
+      mActionDecreaseGamma->setEnabled( false );
+      mActionLayerSubsetString->setEnabled( false );
+      mActionFeatureAction->setEnabled( false );
+      mActionSelectFeatures->setEnabled( false );
+      mActionSelectPolygon->setEnabled( false );
+      mActionSelectFreehand->setEnabled( false );
+      mActionSelectRadius->setEnabled( false );
+      mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( true );
+      mActionOpenTable->setEnabled( false );
+      mMenuFilterTable->setEnabled( false );
+      mActionOpenTableSelected->setEnabled( false );
+      mActionOpenTableVisible->setEnabled( false );
+      mActionOpenTableEdited->setEnabled( false );
+      mActionSelectAll->setEnabled( false );
+      mActionReselect->setEnabled( false );
+      mActionInvertSelection->setEnabled( false );
+      mActionSelectByExpression->setEnabled( false );
+      mActionSelectByForm->setEnabled( false );
+      mActionOpenFieldCalc->setEnabled( false );
+      mActionSaveLayerEdits->setEnabled( false );
+      mUndoDock->widget()->setEnabled( false );
+      mActionSaveLayerDefinition->setEnabled( false );
+      mActionLayerSaveAs->setEnabled( false );
+      mActionAddFeature->setEnabled( false );
+      mActionCircularStringCurvePoint->setEnabled( false );
+      mActionCircularStringRadius->setEnabled( false );
+      mActionDeleteSelected->setEnabled( false );
+      mActionAddRing->setEnabled( false );
+      mActionFillRing->setEnabled( false );
+      mActionAddPart->setEnabled( false );
+      mActionVertexTool->setEnabled( false );
+      mActionVertexToolActiveLayer->setEnabled( false );
+      mActionMoveFeature->setEnabled( false );
+      mActionMoveFeatureCopy->setEnabled( false );
+      mActionRotateFeature->setEnabled( false );
+      mActionScaleFeature->setEnabled( false );
+      mActionOffsetCurve->setEnabled( false );
+      mActionCopyFeatures->setEnabled( false );
+      mActionCutFeatures->setEnabled( false );
+      mActionPasteFeatures->setEnabled( false );
+      mActionRotatePointSymbols->setEnabled( false );
+      mActionOffsetPointSymbol->setEnabled( false );
+      mActionDeletePart->setEnabled( false );
+      mActionDeleteRing->setEnabled( false );
+      mActionSimplifyFeature->setEnabled( false );
+      mActionReshapeFeatures->setEnabled( false );
+      mActionSplitFeatures->setEnabled( false );
+      mActionSplitParts->setEnabled( false );
+      mActionLabeling->setEnabled( false );
+      mActionDiagramProperties->setEnabled( false );
+      mActionIdentify->setEnabled( true );
+      enableDigitizeTechniqueActions( false );
+      mActionToggleEditing->setEnabled( false );
+      mActionToggleEditing->setChecked( true ); // always editable
+      mActionUndo->setEnabled( false );
+      mActionRedo->setEnabled( false );
+      updateUndoActions();
+      break;
+    }
 
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11428,7 +11428,7 @@ void QgisApp::saveAllEdits( bool verifyAction )
       return;
   }
 
-  const auto layers = editableLayers( true );
+  const auto layers = editableLayers( true, true );
   for ( QgsMapLayer *layer : layers )
   {
     saveEdits( layer, true, false );
@@ -11456,7 +11456,7 @@ void QgisApp::rollbackAllEdits( bool verifyAction )
       return;
   }
 
-  const auto layers = editableLayers( true );
+  const auto layers = editableLayers( true, true );
   for ( QgsMapLayer *layer : layers )
   {
     cancelEdits( layer, true, false );
@@ -11484,7 +11484,7 @@ void QgisApp::cancelAllEdits( bool verifyAction )
       return;
   }
 
-  const auto layers = editableLayers();
+  const auto layers = editableLayers( false, true );
   for ( QgsMapLayer *layer : layers )
   {
     cancelEdits( layer, false, false );
@@ -11555,16 +11555,16 @@ void QgisApp::updateLayerModifiedActions()
   mActionRollbackEdits->setEnabled( QgsLayerTreeUtils::layersModified( selectedLayerNodes ) );
   mActionCancelEdits->setEnabled( QgsLayerTreeUtils::layersEditable( selectedLayerNodes ) );
 
-  bool hasEditLayers = !editableLayers().isEmpty();
+  bool hasEditLayers = !editableLayers( false, true ).isEmpty();
   mActionAllEdits->setEnabled( hasEditLayers );
   mActionCancelAllEdits->setEnabled( hasEditLayers );
 
-  bool hasModifiedLayers = !editableLayers( true ).isEmpty();
+  bool hasModifiedLayers = !editableLayers( true, true ).isEmpty();
   mActionSaveAllEdits->setEnabled( hasModifiedLayers );
   mActionRollbackAllEdits->setEnabled( hasModifiedLayers );
 }
 
-QList<QgsMapLayer *> QgisApp::editableLayers( bool modified ) const
+QList<QgsMapLayer *> QgisApp::editableLayers( bool modified, bool ignoreLayersWhichCannotBeToggled ) const
 {
   QList<QgsMapLayer *> editLayers;
   // use legend layers (instead of registry) so QList mirrors its order
@@ -11575,7 +11575,7 @@ QList<QgsMapLayer *> QgisApp::editableLayers( bool modified ) const
     if ( !layer )
       continue;
 
-    if ( layer->isEditable() && ( !modified || layer->isModified() ) )
+    if ( layer->isEditable() && ( !modified || layer->isModified() ) && ( !ignoreLayersWhichCannotBeToggled || !( layer->properties() & Qgis::MapLayerProperty::UsersCannotToggleEditing ) ) )
       editLayers << layer;
   }
   return editLayers;
@@ -15683,7 +15683,6 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       updateUndoActions();
       break;
     }
-
   }
 
   refreshFeatureActions();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -706,7 +706,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \param modified whether to return only layers that have been modified
      * \returns list of layers in legend order, or empty list
     */
-    QList<QgsMapLayer *> editableLayers( bool modified = false ) const;
+    QList<QgsMapLayer *> editableLayers( bool modified = false, bool ignoreLayersWhichCannotBeToggled = false ) const;
 
     //! emit initializationCompleted signal
     void completeInitialization();

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -236,3 +236,14 @@ bool QgsAnnotationLayer::readSymbology( const QDomNode &node, QString &, QgsRead
 
   return true;
 }
+
+bool QgsAnnotationLayer::isEditable() const
+{
+  // annotation layers are always editable
+  return true;
+}
+
+bool QgsAnnotationLayer::supportsEditing() const
+{
+  return true;
+}

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -81,6 +81,12 @@ bool QgsAnnotationLayer::isEmpty() const
   return mItems.empty();
 }
 
+Qgis::MapLayerProperties QgsAnnotationLayer::properties() const
+{
+  // annotation layers are always editable
+  return Qgis::MapLayerProperty::UsersCannotToggleEditing;
+}
+
 QgsAnnotationLayer *QgsAnnotationLayer::clone() const
 {
   const QgsAnnotationLayer::LayerOptions options( mTransformContext );

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -125,6 +125,8 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     bool writeXml( QDomNode &layer_node, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     bool writeSymbology( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &, StyleCategories categories = AllStyleCategories ) const override;
     bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories ) override;
+    bool isEditable() const override;
+    bool supportsEditing() const override;
 
   private:
     QMap<QString, QgsAnnotationItem *> mItems;

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -117,6 +117,7 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
      */
     QMap<QString, QgsAnnotationItem *> items() const { return mItems; }
 
+    Qgis::MapLayerProperties properties() const override;
     QgsAnnotationLayer *clone() const override SIP_FACTORY;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
     QgsRectangle extent() const override;

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -254,7 +254,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         icon = legendIconEmbeddedInParent( nodeLayer );
       }
 
-      if ( layer->isEditable() && testFlag( UseTextFormatting ) )
+      if ( !icon.isNull() && layer->isEditable() && testFlag( UseTextFormatting ) )
       {
         const int iconSize = scaleIconSize( 16 );
         QPixmap pixmap( icon.pixmap( iconSize, iconSize ) );

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -261,7 +261,7 @@ static void _readOldLegendLayer( const QDomElement &layerElem, QgsLayerTreeGroup
   parent->addChildNode( layerNode );
 }
 
-bool QgsLayerTreeUtils::layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes )
+bool QgsLayerTreeUtils::layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes, bool ignoreLayersWhichCannotBeToggled )
 {
   const auto constLayerNodes = layerNodes;
   for ( QgsLayerTreeLayer *layerNode : constLayerNodes )
@@ -270,7 +270,7 @@ bool QgsLayerTreeUtils::layersEditable( const QList<QgsLayerTreeLayer *> &layerN
     if ( !layer )
       continue;
 
-    if ( layer->isEditable() )
+    if ( layer->isEditable() && ( !ignoreLayersWhichCannotBeToggled || !( layer->properties() & Qgis::MapLayerProperty::UsersCannotToggleEditing ) ) )
       return true;
   }
   return false;

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -53,8 +53,14 @@ class CORE_EXPORT QgsLayerTreeUtils
     //! Convert QString to Qt::CheckState
     static Qt::CheckState checkStateFromXml( const QString &txt );
 
-    //! Returns TRUE if any of the layers is editable
-    static bool layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes );
+    /**
+     * Returns TRUE if any of the specified layers is editable.
+     *
+     * The \a ignoreLayersWhichCannotBeToggled argument can be used to control whether layers which cannot have their
+     * edit states toggled by users should be ignored or not (since QGIS 3.22).
+     */
+    static bool layersEditable( const QList<QgsLayerTreeLayer *> &layerNodes, bool ignoreLayersWhichCannotBeToggled = false );
+
     //! Returns TRUE if any of the layers is modified
     static bool layersModified( const QList<QgsLayerTreeLayer *> &layerNodes );
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -707,6 +707,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( FileOperationFlag )
 
     /**
+     * Generic map layer properties.
+     *
+     * \since QGIS 3.22
+     */
+    enum class MapLayerProperty : int
+    {
+      UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually. Since QGIS 3.22.
+    };
+    Q_DECLARE_FLAGS( MapLayerProperties, MapLayerProperty )
+    Q_ENUM( MapLayerProperty )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -155,6 +155,11 @@ void QgsMapLayer::setFlags( QgsMapLayer::LayerFlags flags )
   emit flagsChanged();
 }
 
+Qgis::MapLayerProperties QgsMapLayer::properties() const
+{
+  return Qgis::MapLayerProperties();
+}
+
 QString QgsMapLayer::id() const
 {
   return mID;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -210,6 +210,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note Flags are options specified by the user used for the UI but are not preventing any API call.
      * For instance, even if the Removable flag is not set, the layer can still be removed with the API
      * but the action will not be listed in the legend menu.
+     *
+     * \see properties()
+     *
      * \since QGIS 3.4
      */
     QgsMapLayer::LayerFlags flags() const;
@@ -219,9 +222,23 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \note Flags are options specified by the user used for the UI but are not preventing any API call.
      * For instance, even if the Removable flag is not set, the layer can still be removed with the API
      * but the action will not be listed in the legend menu.
+     *
+     * \see properties()
+     *
      * \since QGIS 3.4
      */
     void setFlags( QgsMapLayer::LayerFlags flags );
+
+    /**
+     * Returns the map layer properties of this layer.
+     *
+     * \note properties() differ from flags() in that flags() are user settable, and reflect options that
+     * users can enable for map layers. In contrast properties() are reflections of inherent capabilities
+     * for the layer, which cannot be directly changed by users.
+     *
+     * \since QGIS 3.22
+     */
+    virtual Qgis::MapLayerProperties properties() const;
 
     /**
      * Returns the extension of a Property.

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -30,6 +30,7 @@
 #include <qgssettings.h>
 #include "qgslegendsettings.h"
 #include "qgsmarkersymbol.h"
+#include "qgsannotationlayer.h"
 #include <QSignalSpy>
 
 class TestQgsLayerTree : public QObject
@@ -62,6 +63,7 @@ class TestQgsLayerTree : public QObject
     void testSymbolText();
     void testNodeDepth();
     void testRasterSymbolNode();
+    void testLayersEditable();
 
   private:
 
@@ -898,6 +900,40 @@ void TestQgsLayerTree::testRasterSymbolNode()
   const QgsRasterSymbolLegendNode rasterNode2( n.get(), QColor( 255, 0, 0 ), QStringLiteral( "my node" ), nullptr, true, QStringLiteral( "key" ) );
   QVERIFY( rasterNode2.isCheckable() );
   QCOMPARE( static_cast< int >( rasterNode2.flags() ), static_cast< int >( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable ) );
+}
+
+void TestQgsLayerTree::testLayersEditable()
+{
+  QgsProject project;
+
+  QgsVectorLayer *vl1 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer *vl2 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsAnnotationLayer *al = new QgsAnnotationLayer( QStringLiteral( "al" ), QgsAnnotationLayer::LayerOptions( project.transformContext() ) );
+
+  project.addMapLayer( vl1 );
+  project.addMapLayer( vl2 );
+  project.addMapLayer( al );
+
+  QgsLayerTree root;
+  QgsLayerTreeLayer *nodeVl1 = root.addLayer( vl1 );
+  QgsLayerTreeGroup *nodeGrp = root.addGroup( QStringLiteral( "grp" ) );
+  QgsLayerTreeLayer *nodeVl2 = nodeGrp->addLayer( vl2 );
+  QgsLayerTreeLayer *nodeAl = nodeGrp->addLayer( al );
+  QVERIFY( !QgsLayerTreeUtils::layersEditable( {} ) );
+  QVERIFY( !QgsLayerTreeUtils::layersEditable( {nodeVl1, nodeVl2} ) );
+  vl1->startEditing();
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeVl1} ) );
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeVl1, nodeVl2} ) );
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeVl2, nodeVl1 } ) );
+
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeAl} ) );
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeAl, nodeVl1} ) );
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeAl, nodeVl2} ) );
+
+  // ignore layers which can't be toggled (the annotation layer)
+  QVERIFY( !QgsLayerTreeUtils::layersEditable( {nodeAl}, true ) );
+  QVERIFY( QgsLayerTreeUtils::layersEditable( {nodeAl, nodeVl1}, true ) );
+  QVERIFY( !QgsLayerTreeUtils::layersEditable( {nodeAl, nodeVl2}, true ) );
 }
 
 QGSTEST_MAIN( TestQgsLayerTree )


### PR DESCRIPTION
Correctly reflect in app that annotation layers are ALWAYS editable (and can't be made non-editable by users)