### PR TITLE
Restore PyQgsOracleProvider test

### DIFF
--- a/.ci/test_flaky.txt
+++ b/.ci/test_flaky.txt
@@ -7,6 +7,3 @@ test_core_ziplayer
 # Flaky, the ms odbc driver crashes a lot on the ubuntu docker image. Retest when
 # the docker base image is upgraded
 PyQgsMssqlProvider
-
-# Crashes randomly from time to time on CI in the OCI library
-PyQgsOracleProvider

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -426,7 +426,7 @@ if (ENABLE_MSSQLTEST)
 endif()
 
 if (ENABLE_ORACLETEST)
-  ADD_PYTHON_TEST(PyQgsOracleProvider test_provider_oracle.py)
+  ADD_PYTHON_TEST(PyQgsOracleProvider test_provider_oracle.py TEST_TIMEOUT=300)
   ADD_PYTHON_TEST(PyQgsProviderConnectionOracle test_qgsproviderconnection_oracle.py)
   SET_TESTS_PROPERTIES(PyQgsOracleProvider PyQgsProviderConnectionOracle PROPERTIES LABELS "ORACLE")
 endif()


### PR DESCRIPTION
This PR reverts #42790 and restore `PyQgsOracleProvider` test.

The real issue with `PyQgsOracleProvider` was not that it crashed randomly but that its timeout time was too short (I miss the timeout display among all other logging messages!).

I set the timeout to 300s which should be more than enough.

**Funded by Lille Metropole**

cc @Jean-Roc 
