### PR TITLE
save mesh from URI

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -391,7 +391,7 @@ Creates a new instance of the raster data provider.
       const QString &driverName,
       const QgsCoordinateReferenceSystem &crs ) const;
 %Docstring
-Creates mesh data source from a file name \fileName and a driver \driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Creates mesh data source from a file name ``fileName`` and a driver ``driverName``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
 
 .. versionadded:: 3.16
 %End

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -387,13 +387,23 @@ Creates a new instance of the raster data provider.
 
     virtual bool createMeshData(
       const QgsMesh &mesh,
-      const QString uri,
+      const QString &fileName,
       const QString &driverName,
       const QgsCoordinateReferenceSystem &crs ) const;
 %Docstring
-Creates mesh data source, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+Creates mesh data source from a file name \fileName and a driver \driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
 
 .. versionadded:: 3.16
+%End
+
+    virtual bool createMeshData(
+      const QgsMesh &mesh,
+      const QString &uri,
+      const QgsCoordinateReferenceSystem &crs ) const;
+%Docstring
+Creates mesh data source from an ``uri``, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+
+.. versionadded:: 3.22
 %End
 
     virtual QList<QPair<QString, QString> > pyramidResamplingMethods();

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -192,11 +192,17 @@ QgsRasterDataProvider *QgsProviderMetadata::createRasterDataProvider(
   return nullptr;
 }
 
-bool QgsProviderMetadata::createMeshData(
-  const QgsMesh &,
-  const QString,
-  const QString &,
-  const QgsCoordinateReferenceSystem & ) const
+bool QgsProviderMetadata::createMeshData( const QgsMesh &,
+    const QString &,
+    const QString &,
+    const QgsCoordinateReferenceSystem & ) const
+{
+  return false;
+}
+
+bool QgsProviderMetadata::createMeshData( const QgsMesh &,
+    const QString &,
+    const QgsCoordinateReferenceSystem & ) const
 {
   return false;
 }

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -456,7 +456,7 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
       const QStringList &createOptions = QStringList() ) SIP_FACTORY;
 
     /**
-     * Creates mesh data source from a file name \fileName and a driver \driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+     * Creates mesh data source from a file name \a fileName and a driver \a driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
      * \since QGIS 3.16
      */
     virtual bool createMeshData(

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -456,13 +456,22 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
       const QStringList &createOptions = QStringList() ) SIP_FACTORY;
 
     /**
-     * Creates mesh data source, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+     * Creates mesh data source from a file name \fileName and a driver \driverName, that is the mesh frame stored in file, memory or with other way (depending of the provider)
      * \since QGIS 3.16
      */
     virtual bool createMeshData(
       const QgsMesh &mesh,
-      const QString uri,
+      const QString &fileName,
       const QString &driverName,
+      const QgsCoordinateReferenceSystem &crs ) const;
+
+    /**
+     * Creates mesh data source from an \a uri, that is the mesh frame stored in file, memory or with other way (depending of the provider)
+     * \since QGIS 3.22
+     */
+    virtual bool createMeshData(
+      const QgsMesh &mesh,
+      const QString &uri,
       const QgsCoordinateReferenceSystem &crs ) const;
 
     /**

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -972,7 +972,7 @@ QgsMdalProvider *QgsMdalProviderMetadata::createProvider( const QString &uri, co
 }
 
 
-MDAL_MeshH createMDALMesh( const QgsMesh &mesh, const QString &fileName, const QString &driverName, const QgsCoordinateReferenceSystem &crs )
+static MDAL_MeshH createMDALMesh( const QgsMesh &mesh, const QString &driverName, const QgsCoordinateReferenceSystem &crs )
 {
   MDAL_DriverH driver = MDAL_driverFromName( driverName.toStdString().c_str() );
   if ( !driver )
@@ -1033,7 +1033,7 @@ MDAL_MeshH createMDALMesh( const QgsMesh &mesh, const QString &fileName, const Q
 
 bool QgsMdalProviderMetadata::createMeshData( const QgsMesh &mesh, const QString &fileName, const QString &driverName, const QgsCoordinateReferenceSystem &crs ) const
 {
-  MDAL_MeshH mdalMesh = createMDALMesh( mesh, fileName, driverName, crs );
+  MDAL_MeshH mdalMesh = createMDALMesh( mesh, driverName, crs );
 
   if ( !mdalMesh )
     return false;
@@ -1058,7 +1058,6 @@ bool QgsMdalProviderMetadata::createMeshData( const QgsMesh &mesh, const QString
     return false;
 
   MDAL_MeshH mdalMesh = createMDALMesh( mesh,
-                                        uriComponents.value( QStringLiteral( "path" ) ).toString(),
                                         uriComponents.value( QStringLiteral( "driver" ) ).toString()
                                         , crs );
 

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -147,8 +147,11 @@ class QgsMdalProviderMetadata: public QgsProviderMetadata
     QList<QgsMeshDriverMetadata> meshDriversMetadata() override;
     QgsMdalProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     bool createMeshData( const QgsMesh &mesh,
-                         const QString uri,
+                         const QString &fileName,
                          const QString &driverName,
+                         const QgsCoordinateReferenceSystem &crs ) const override;
+    bool createMeshData( const QgsMesh &mesh,
+                         const QString &uri,
                          const QgsCoordinateReferenceSystem &crs ) const override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1610,7 +1610,7 @@ void TestQgsMeshLayer::testMdalProviderQuerySublayers()
   QCOMPARE( res.at( 0 ).name(), QStringLiteral( "quad_and_triangle" ) );
   QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "2DM:\"%1/quad_and_triangle.2dm\"" ).arg( mDataDir ) );
   QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "mdal" ) );
-  QCOMPARE( res.at( 0 ).driverName(), QString() );
+  QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "2DM" ) );
   QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::MeshLayer );
 
   // make sure result is valid to load layer from
@@ -1626,7 +1626,7 @@ void TestQgsMeshLayer::testMdalProviderQuerySublayers()
   QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "2DM:\"%1/quad_and_triangle.2dm\"" ).arg( mDataDir ) );
   QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "mdal" ) );
   QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::MeshLayer );
-  QCOMPARE( res.at( 0 ).driverName(), QString() );
+  QCOMPARE( res.at( 0 ).driverName(), "2DM" );
   ml.reset( qgis::down_cast< QgsMeshLayer * >( res.at( 0 ).toLayer( options ) ) );
   QVERIFY( ml->isValid() );
 

--- a/tests/src/providers/testqgsmdalprovider.cpp
+++ b/tests/src/providers/testqgsmdalprovider.cpp
@@ -97,12 +97,19 @@ void TestQgsMdalProvider::encodeDecodeUri()
   QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString() );
   QCOMPARE( mdalMetadata->encodeUri( parts ), QStringLiteral( "/home/data/test.nc" ) );
 
-  // uri with layer name
+  // uri with driver and layer name
   parts = mdalMetadata->decodeUri( QStringLiteral( "netcdf:\"/home/data/test.nc\":layer3" ) );
   QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QStringLiteral( "/home/data/test.nc" ) );
   QCOMPARE( parts.value( QStringLiteral( "driver" ) ).toString(), QStringLiteral( "netcdf" ) );
   QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QStringLiteral( "layer3" ) );
   QCOMPARE( mdalMetadata->encodeUri( parts ), QStringLiteral( "netcdf:\"/home/data/test.nc\":layer3" ) );
+
+  // uri with driver
+  parts = mdalMetadata->decodeUri( QStringLiteral( "Ugrid:\"/home/data/test.nc\"" ) );
+  QCOMPARE( parts.value( QStringLiteral( "path" ) ).toString(), QStringLiteral( "/home/data/test.nc" ) );
+  QCOMPARE( parts.value( QStringLiteral( "driver" ) ).toString(), QStringLiteral( "Ugrid" ) );
+  QCOMPARE( parts.value( QStringLiteral( "layerName" ) ).toString(), QString() );
+  QCOMPARE( mdalMetadata->encodeUri( parts ), QStringLiteral( "Ugrid:\"/home/data/test.nc\"" ) );
 }
 
 void TestQgsMdalProvider::load()


### PR DESCRIPTION
After editing mesh layer is saved by creating a new file overwriting the existing one with the override method `QgsMdalProviderMetadata::createMeshdata()`.

Before this PR, it was supposed that the QgsMdalProvider::dataSourceUri() was the file path, and this value was passed in the createMeshdata() method. That was a bad assumption, especially since the PR #44368 that always set the URI of opened mesh layer as <driver>:"file name":[mesh name]. As MDAL could not create mesh layer with this URI, this last PR break mesh saving after editing.
Since version 0.8.92, MDAL can create mesh layer uri.

This PR adapt QGIS code to be able to create mesh layer from the URI and fixes some issue related to mesh layer URI.

@nyalldawson can you have a quick look to see if I didn't have broken the logic of your recent work?