### PR TITLE
fix maximum vertices count per face for mesh editing

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -66,7 +66,8 @@ Constructs driver metadata with selected capabilities
                            const QString &description,
                            const MeshDriverCapabilities &capabilities,
                            const QString &writeDatasetOnFileSuffix,
-                           const QString &writeMeshFrameOnFileSuffix );
+                           const QString &writeMeshFrameOnFileSuffix,
+                           int maxVerticesPerface );
 %Docstring
 Constructs driver metadata with selected capabilities
 
@@ -102,6 +103,13 @@ Returns the suffix used to write datasets on file
     QString writeMeshFrameOnFileSuffix() const;
 %Docstring
 Returns the suffix used to write mesh on file
+
+.. versionadded:: 3.22
+%End
+
+    int maximumVerticesCountPerFace() const;
+%Docstring
+Returns the maximum number of vertices per face supported by the driver
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -76,6 +76,7 @@ Constructs driver metadata with selected capabilities
 :param capabilities: driver's capabilities
 :param writeDatasetOnFileSuffix: suffix used to write datasets on file
 :param writeMeshFrameOnFileSuffix: suffix used to write mesh frame on file
+:param maxVerticesPerface: maximum vertices count per face supported by the driver
 
 .. versionadded:: 3.22
 %End

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -359,12 +359,14 @@ QgsMeshDriverMetadata::QgsMeshDriverMetadata( const QString &name,
     const QString &description,
     const MeshDriverCapabilities &capabilities,
     const QString &writeDatasetOnfileSuffix,
-    const QString &writeMeshFrameOnFileSuffix )
+    const QString &writeMeshFrameOnFileSuffix,
+    int maxVerticesPerface )
   : mName( name )
   , mDescription( description )
   , mCapabilities( capabilities )
   , mWriteDatasetOnFileSuffix( writeDatasetOnfileSuffix )
   , mWriteMeshFrameOnFileSuffix( ( writeMeshFrameOnFileSuffix ) )
+  , mMaxVerticesPerFace( maxVerticesPerface )
 {
 }
 
@@ -391,4 +393,9 @@ QString QgsMeshDriverMetadata::writeDatasetOnFileSuffix() const
 QString QgsMeshDriverMetadata::writeMeshFrameOnFileSuffix() const
 {
   return mWriteMeshFrameOnFileSuffix;
+}
+
+int QgsMeshDriverMetadata::maximumVerticesCountPerFace() const
+{
+  return mMaxVerticesPerFace;
 }

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -101,6 +101,7 @@ class CORE_EXPORT QgsMeshDriverMetadata
      * \param capabilities driver's capabilities
      * \param writeDatasetOnFileSuffix suffix used to write datasets on file
      * \param writeMeshFrameOnFileSuffix suffix used to write mesh frame on file
+     * \param maxVerticesPerface maximum vertices count per face supported by the driver
      *
      * \since QGIS 3.22
      */

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -108,7 +108,8 @@ class CORE_EXPORT QgsMeshDriverMetadata
                            const QString &description,
                            const MeshDriverCapabilities &capabilities,
                            const QString &writeDatasetOnFileSuffix,
-                           const QString &writeMeshFrameOnFileSuffix );
+                           const QString &writeMeshFrameOnFileSuffix,
+                           int maxVerticesPerface );
 
     /**
      * Returns the capabilities for this driver.
@@ -137,12 +138,20 @@ class CORE_EXPORT QgsMeshDriverMetadata
      */
     QString writeMeshFrameOnFileSuffix() const;
 
+    /**
+     * Returns the maximum number of vertices per face supported by the driver
+     *
+     * \since QGIS 3.22
+     */
+    int maximumVerticesCountPerFace() const;
+
   private:
     QString mName;
     QString mDescription;
     MeshDriverCapabilities mCapabilities;
     QString mWriteDatasetOnFileSuffix;
     QString mWriteMeshFrameOnFileSuffix;
+    int mMaxVerticesPerFace = -1;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMeshDriverMetadata::MeshDriverCapabilities )

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -224,10 +224,7 @@ QgsRectangle QgsMdalProvider::extent() const
 
 int QgsMdalProvider::maximumVerticesCountPerFace() const
 {
-  if ( !mMeshH )
-    return 0;
-
-  return MDAL_M_faceVerticesMaximumCount( mMeshH );
+  return driverMetadata().maximumVerticesCountPerFace();
 }
 
 QgsMeshDriverMetadata QgsMdalProvider::driverMetadata() const
@@ -240,6 +237,7 @@ QgsMeshDriverMetadata QgsMdalProvider::driverMetadata() const
   QString longName = MDAL_DR_longName( mdalDriver );
   QString writeDatasetSuffix = MDAL_DR_writeDatasetsSuffix( mdalDriver );
   QString writeMeshFrameSuffix = MDAL_DR_saveMeshSuffix( mdalDriver );
+  int maxVerticesPerFace = MDAL_DR_faceVerticesMaximumCount( mdalDriver );
 
   QgsMeshDriverMetadata::MeshDriverCapabilities capabilities;
   bool hasSaveFaceDatasetsCapability = MDAL_DR_writeDatasetsCapability( mdalDriver, MDAL_DataLocation::DataOnFaces );
@@ -254,7 +252,7 @@ QgsMeshDriverMetadata QgsMdalProvider::driverMetadata() const
   bool hasMeshSaveCapability = MDAL_DR_saveMeshCapability( mdalDriver );
   if ( hasMeshSaveCapability )
     capabilities |= QgsMeshDriverMetadata::CanWriteMeshData;
-  const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix );
+  const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix, maxVerticesPerFace );
 
   return meta;
 }
@@ -1204,6 +1202,7 @@ QList<QgsMeshDriverMetadata> QgsMdalProviderMetadata::meshDriversMetadata()
     QString longName = MDAL_DR_longName( mdalDriver );
     QString writeDatasetSuffix = MDAL_DR_writeDatasetsSuffix( mdalDriver );
     QString writeMeshFrameSuffix = MDAL_DR_saveMeshSuffix( mdalDriver );
+    int maxVerticesPerFace = MDAL_DR_faceVerticesMaximumCount( mdalDriver );
 
     QgsMeshDriverMetadata::MeshDriverCapabilities capabilities;
     bool hasSaveFaceDatasetsCapability = MDAL_DR_writeDatasetsCapability( mdalDriver, MDAL_DataLocation::DataOnFaces );
@@ -1218,7 +1217,7 @@ QList<QgsMeshDriverMetadata> QgsMdalProviderMetadata::meshDriversMetadata()
     bool hasMeshSaveCapability = MDAL_DR_saveMeshCapability( mdalDriver );
     if ( hasMeshSaveCapability )
       capabilities |= QgsMeshDriverMetadata::CanWriteMeshData;
-    const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix );
+    const QgsMeshDriverMetadata meta( name, longName, capabilities, writeDatasetSuffix, writeMeshFrameSuffix, maxVerticesPerFace );
     ret.push_back( meta );
   }
   return ret;

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -1249,7 +1249,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   centroid = meshLayerQuadTriangle->snapOnElement( QgsMesh::Face, QgsPoint( 2050, 2800, 0 ), 10 );
   QVERIFY( centroid.compare( QgsPointXY( 2166.6666666, 2422.22222222 ), 1e-6 ) ); //same face
 
-  QVERIFY( !editor->canBeMerged( 2, 3 ) ); //leads to 5 vertices per face, limited to 4
+  QVERIFY( editor->canBeMerged( 2, 3 ) );
 
   //split
   QVERIFY( editor->faceCanBeSplit( 8 ) );


### PR DESCRIPTION
Before this PR, the maximum vertices per face allowed for mesh editing was token from MDAL with the method `MDAL_M_faceVerticesMaximumCount`(). But this method returns the maximum vertices per face of the specified mesh, not supported by the associated format. 
For 2DM, when there is no face, this value is by default 4, but for UGRID format, this value is 0 if there is no face, so when creating new mesh layer, the maximum vertices count per face supported was 0, so no way to create faces...

MDAL 0.8.92 introduce the new method MDAL_DR_faceVerticesMaximumCount() that returns the maximum vertices count per face **supported by the driver**. 

This PR adapts code of QGIS to use this new method and fixes the above issue.