### PR TITLE
Avoid duplicate colors in random paletted raster rendering

### DIFF
--- a/src/core/qgscolorramp.cpp
+++ b/src/core/qgscolorramp.cpp
@@ -447,7 +447,13 @@ QColor QgsRandomColorRamp::color( double value ) const
   int maxVal = 255;
 
   //if value is nan, then use last precalculated color
-  int colorIndex = ( !std::isnan( value ) ? value : 1 ) * ( mTotalColorCount - 1 );
+  if ( std::isnan( value ) )
+  {
+    value = 1.0;
+  }
+  // Caller has converted an index into a value in [0.0, 1.0]
+  // by doing "index / (mTotalColorCount - 1)"; retrieve the original index.
+  int colorIndex = std::round( value * ( mTotalColorCount - 1 ) );
   if ( mTotalColorCount >= 1 && mPrecalculatedColors.length() > colorIndex )
   {
     //use precalculated hue

--- a/tests/src/python/test_qgscolorramp.py
+++ b/tests/src/python/test_qgscolorramp.py
@@ -288,11 +288,14 @@ class PyQgsColorRamp(unittest.TestCase):
         self.assertEqual(cloned.type(), 'randomcolors')
 
         # test with pregenerated colors
-        for i in range(10000):
-            r.setTotalColorCount(10)
-            for j in range(10):
-                c = r.color(j * 0.1)
+        for n in range(2, 100):
+            r.setTotalColorCount(n)
+            seen = set()
+            for j in range(n):
+                c = r.color(j / (n - 1))
                 self.assertTrue(c.isValid())
+                seen.add(c.rgb())
+            self.assertEqual(len(seen), n)
 
     def testQgsPresetSchemeColorRamp(self):
         # test preset color ramp


### PR DESCRIPTION
## Description

When selecting Render type "Paletted/Unique values" for a raster layer
that has 23 distinct raster values, QGIS will generate 23 random colors
in QgsRandomColorRamp, and then these colors will be queried through
QgsPalettedRasterRenderer::classDataFromRaster().

The querying of random colors goes through the generic
QgsColorRamp::color(v) interface, which takes a v between 0.0 and 1.0.

To turn a raster value index (0,1,...,22) into a value between 0.0 and 1.0,
a division by 22 is applied. QgsRandomColorRamp then converts this value
back into an index by multiplying by 22 and casting the result to an int.

Dividing an integer by 22 and multiplying the result by 22 and casting
to an int is not lossless:

	>>> int(15 / 22 * 22)
	14

This causes e.g. the 14th and 15th raster value (0-indexed) to always
have the same random color, regardless of how many times you press
"Shuffle Random Colors" on a raster with 23 distinct values.

Note that this issue is not exhibited at all for rasters with fewer than
23 distinct values, and certain cardinalities exhibit the issue much
more than others; e.g. for 50 distinct values, there are 6 duplicates!

Apply std::round() so that the correct index is obtained.

Example with 48 distinct colors, 5 duplicates:

![image](https://user-images.githubusercontent.com/373639/130046450-cf6561ed-2a26-4c2e-8529-31e830755302.png)

```
12260 205 230 44 255 12260
12286 46 205 230 255 12286
12291 79 240 82 255 12291
12299 79 240 82 255 12299 <-- DUPLICATE
12304 132 237 239 255 12304
12308 45 79 203 255 12308
12320 45 79 203 255 12320 <-- DUPLICATE
12321 19 233 101 255 12321
12374 216 25 22 255 12374
12379 220 204 83 255 12379
12390 96 216 202 255 12390
12400 210 100 222 255 12400
12403 210 100 222 255 12403 <-- DUPLICATE
12408 32 234 59 255 12408
12416 58 114 217 255 12416
12421 36 146 215 255 12421
12442 221 86 151 255 12442
12454 239 76 174 255 12454
12463 133 234 160 255 12463
12464 90 69 209 255 12464
12475 239 126 165 255 12475
12480 227 74 186 255 12480
12487 130 77 210 255 12487
12493 138 208 73 255 12493
12500 138 208 73 255 12500 <-- DUPLICATE
12505 147 217 33 255 12505
12510 233 122 133 255 12510
12518 217 119 202 255 12518
12523 203 104 38 255 12523
12532 88 35 234 255 12532
12537 182 111 221 255 12537
12542 182 111 221 255 12542 <-- DUPLICATE
12546 140 69 206 255 12546
12551 139 201 103 255 12551
12560 60 223 144 255 12560
12570 205 161 14 255 12570
12576 103 162 230 255 12576
12580 129 203 107 255 12580
12581 208 211 13 255 12581
12583 44 218 177 255 12583
12589 62 218 161 255 12589
12591 234 69 107 255 12591
12599 190 237 61 255 12599
17500 168 64 200 255 17500
17544 220 107 218 255 17544
17587 134 144 227 255 17587
17634 233 128 16 255 17634
18616 128 228 115 255 18616
```



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
