### PR TITLE
[API][M] Fix capture M

### DIFF
--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -546,6 +546,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const 
   double x = point.x();
   double y = point.y();
   double z = point.z();
+  const double m = point.m();
 
   try
   {
@@ -558,7 +559,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const 
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, z );
+  return QgsPoint( x, y, z, m );
 }
 
 
@@ -600,6 +601,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const 
   double x = point.x();
   double y = point.y();
   double z = point.z();
+  const double m = point.m();
 
   try
   {
@@ -612,7 +614,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const 
     QgsMessageLog::logMessage( QObject::tr( "Transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
   }
 
-  return QgsPoint( x, y, z );
+  return QgsPoint( x, y, z, m );
 }
 
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -1020,19 +1020,26 @@ QgsPoint QgsMapToolCapture::mapPoint( const QgsMapMouseEvent &e ) const
 {
   QgsPoint newPoint = mapPoint( e.mapPoint() );
 
-  // set z value from snapped point if necessary
-  if ( QgsWkbTypes::hasZ( newPoint.wkbType() ) )
+  // set z or m value from snapped point if necessary
+  if ( QgsWkbTypes::hasZ( newPoint.wkbType() ) || QgsWkbTypes::hasM( newPoint.wkbType() ) )
   {
-    // if snapped, z dimension is taken from the corresponding snapped
+    // if snapped, z and m dimension are taken from the corresponding snapped
     // point.
     if ( e.isSnapped() )
     {
       const QgsPointLocator::Match match = e.mapPointMatch();
 
-      if ( match.layer() && QgsWkbTypes::hasZ( match.layer()->wkbType() ) )
+      if ( match.layer() )
       {
         const QgsFeature ft = match.layer()->getFeature( match.featureId() );
-        newPoint.setZ( ft.geometry().vertexAt( match.vertexIndex() ).z() );
+        if ( QgsWkbTypes::hasZ( match.layer()->wkbType() ) )
+        {
+          newPoint.setZ( ft.geometry().vertexAt( match.vertexIndex() ).z() );
+        }
+        if ( QgsWkbTypes::hasM( match.layer()->wkbType() ) )
+        {
+          newPoint.setM( ft.geometry().vertexAt( match.vertexIndex() ).m() );
+        }
       }
     }
   }

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -663,7 +663,7 @@ void TestQgsMapToolAddFeatureLine::testCompoundCurve()
 
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  const QString wkt = "CompoundCurve ((5 6.5, 6.25 6.5),CircularString (6.25 6.5, 6.75 6.5, 7.25 6.5),(7.25 6.5, 7.5 6.5),(7.5 6.5, 7.5 6),(7.5 6, 7.703125 6))";
+  const QString wkt = "CompoundCurve ((5 6.5, 6.25 6.5),CircularString (6.25 6.5, 6.75 6.5, 7.25 6.5),(7.25 6.5, 7.5 6.5, 7.5 6, 7.703125 6))";
   QCOMPARE( mLayerLineCurved->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLineCurved->undoStack()->undo();

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -35,7 +35,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isGeosEqual( g2 );
+    return g1.equals( g2 );
 }
 
 namespace QTest
@@ -627,7 +627,7 @@ void TestQgsMapToolAddFeatureLine::testLineString()
 
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  const QString wkt = "LineStringZ (5 6.5 5, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
+  const QString wkt = "LineString (5 6.5, 6.25 6.5, 6.75 6.5, 7.25 6.5, 7.5 6.5)";
   QCOMPARE( mLayerLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
@@ -36,7 +36,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isGeosEqual( g2 );
+    return g1.equals( g2 );
 }
 
 namespace QTest
@@ -244,9 +244,9 @@ void TestQgsMapToolAddFeatureLineM::testTopologicalEditingM()
   utils.mouseClick( 8, 6.5, Qt::RightButton );
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  QString wkt = "LineStringM (6 6.5 5, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
+  QString wkt = "LineStringM (6 6.5 333, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
   QCOMPARE( mLayerTopoM->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
-  wkt = "MultiLineStringM ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 5, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
+  wkt = "MultiLineStringM ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 333, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
   QCOMPARE( mLayerTopoM->getFeature( qgis::setToList( oldFids ).last() ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
@@ -36,7 +36,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isGeosEqual( g2 );
+    return g1.equals( g2 );
 }
 
 namespace QTest
@@ -245,9 +245,9 @@ void TestQgsMapToolAddFeatureLineZ::testTopologicalEditingZ()
   utils.mouseClick( 8, 6.5, Qt::RightButton );
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  QString wkt = "LineStringZ (6 6.5 5, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
+  QString wkt = "LineStringZ (6 6.5 333, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
   QCOMPARE( mLayerTopoZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
-  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 5, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
+  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 333, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
   QCOMPARE( mLayerTopoZ->getFeature( qgis::setToList( oldFids ).last() ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();
@@ -326,7 +326,7 @@ void TestQgsMapToolAddFeatureLineZ::testZSnapping()
   newFid = utils.newFeatureId( oldFids );
 
   QCOMPARE( mLayerLineZ->getFeature( newFid ).geometry().get()->is3D(), true );
-  wkt = "LineStringZ (25 20 123, 25 25 321)";
+  wkt = "LineStringZ (25 20 321, 25 25 321)";
   QCOMPARE( mLayerLineZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLineZ->undoStack()->undo();

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
@@ -36,7 +36,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isGeosEqual( g2 );
+    return g1.equals( g2 );
 }
 
 namespace QTest


### PR DESCRIPTION
## Description

My last PR was not complete on this fix.

The fix:
- `QgsMapSettings` ignore m, so it wasn't returned.
- `QgsMapToolCapture::mapPoint` add also M as for the Z value
- `QgsMapToolDigitizeFeature::cadCanvasReleaseEvent` add M and simplify the logic of the method
- fix typo in the tests, `isGeosEqual` was used but it doesn't compare Z and M