### PR TITLE
Mesh editing: fix crash after undo when removing vertices/faces

### DIFF
--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -184,7 +184,7 @@ void QgsMeshEditor::applyEdit( QgsMeshEditor::Edit &edit )
 void QgsMeshEditor::reverseEdit( QgsMeshEditor::Edit &edit )
 {
   mTopologicalMesh.reverseChanges( edit.topologicalChanges );
-  mTriangularMesh->reverseChanges( edit.triangularMeshChanges );
+  mTriangularMesh->reverseChanges( edit.triangularMeshChanges, *mMesh );
 }
 
 void QgsMeshEditor::applyAddVertex( QgsMeshEditor::Edit &edit, const QgsMeshVertex &vertex )

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -30,6 +30,9 @@ using namespace SpatialIndex;
 static Region faceToRegion( const QgsMesh &mesh, int id )
 {
   const QgsMeshFace face = mesh.face( id );
+
+  Q_ASSERT( !face.isEmpty() );
+
   const QVector<QgsMeshVertex> &vertices = mesh.vertices;
 
   double xMinimum = vertices[face[0]].x();
@@ -190,14 +193,19 @@ class QgsMeshIteratorDataStream : public IDataStream
     void readNextEntry()
     {
       SpatialIndex::Region r;
-      if ( mIterator < mFeaturesCount )
+      while ( mIterator < mFeaturesCount )
       {
-        r = mFeatureToRegionFunction( mMesh, mIterator );
-        mNextData = new RTree::Data(
-          0,
-          nullptr,
-          r,
-          mIterator );
+        if ( !mMesh.faces.at( mIterator ).isEmpty() )
+        {
+          r = mFeatureToRegionFunction( mMesh, mIterator );
+          mNextData = new RTree::Data(
+            0,
+            nullptr,
+            r,
+            mIterator );
+          ++mIterator;
+          return;
+        }
         ++mIterator;
       }
     }

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -739,6 +739,11 @@ QList<int> QgsTopologicalMesh::Changes::nativeFacesIndexesGeometryChanged() cons
   return mNativeFacesIndexesGeometryChanged;
 }
 
+QList<int> QgsTopologicalMesh::Changes::verticesToRemoveIndexes() const
+{
+  return mVerticesToRemoveIndexes;
+}
+
 int QgsTopologicalMesh::Changes::addedFaceIndexInMesh( int internalIndex ) const
 {
   if ( internalIndex == -1 )

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -100,6 +100,9 @@ class CORE_EXPORT QgsTopologicalMesh
         //! Returns the added vertices with this changes
         QVector<QgsMeshVertex> addedVertices() const;
 
+        //! Returns the indexes of vertices to remove
+        QList<int> verticesToRemoveIndexes() const;
+
         //! Returns the indexes of vertices that have changed coordinates
         QList<int> changedCoordinatesVerticesIndexes() const;
 

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -263,6 +263,7 @@ class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
       private:
         // triangular mesh elements that can be changed if the triangular mesh is updated, are not stored and have to be retrieve
         QVector<QgsMeshVertex> mAddedVertices;
+        QList<int> mVerticesIndexesToRemove;
         QList<int> mChangedVerticesCoordinates;
         mutable QList<double> mOldZValue;
         QList<double> mNewZValue;
@@ -294,7 +295,7 @@ class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
      *
      * \since QGIS 3.22
      */
-    void reverseChanges( const Changes &changes );
+    void reverseChanges( const Changes &changes, const QgsMesh &nativeMesh );
 
     /**
      * Transforms the \a vertex from native coordinates system to triangular mesh coordinates system.

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -22,6 +22,7 @@
 #include "qgsmeshlayer.h"
 #include "qgsmesheditor.h"
 #include "qgsmeshadvancedediting.h"
+#include "qgstransformeffect.h"
 
 
 class TestQgsMeshEditor : public QObject
@@ -984,7 +985,7 @@ void TestQgsMeshEditor::particularCases()
         }
       }
 
-    const QgsCoordinateTransform transform;
+    QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
 
@@ -1009,8 +1010,15 @@ void TestQgsMeshEditor::particularCases()
 
     QVERIFY( meshEditor.removeVertices( verticesToRemove, false ) == QgsMeshEditingError() );
     QVERIFY( meshEditor.checkConsistency() );
+
+    // just create a valid different transform to update the vertices of the triangular mesh
+    transform = QgsCoordinateTransform( QgsCoordinateReferenceSystem( "EPSG:32620" ),
+                                        QgsCoordinateReferenceSystem( "EPSG:32620" ),
+                                        QgsCoordinateTransformContext() );
+    triangularMesh.update( &mesh, transform );
     meshEditor.mUndoStack->undo();
     QVERIFY( meshEditor.checkConsistency() );
+    meshEditor.mUndoStack->redo();
   }
 }
 


### PR DESCRIPTION
The crash came from empty vertices in the triangular mesh due to an update of vertices from native mesh.
Also an spatial index issue when triangular faces are empty.