### PR TITLE
[processing] File downloader aglorithm feedback improvements

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -127,9 +127,9 @@ void QgsFileDownloaderAlgorithm::sendProgressFeedback()
   {
     mLastReport = mReceived;
     if ( mTotal.isEmpty() )
-      mFeedback->pushInfo( tr( "%1 downloaded." ).arg( mReceived ) );
+      mFeedback->pushInfo( tr( "%1 downloaded" ).arg( mReceived ) );
     else
-      mFeedback->pushInfo( tr( "%1 of %2 downloaded." ).arg( mReceived, mTotal ) );
+      mFeedback->pushInfo( tr( "%1 of %2 downloaded" ).arg( mReceived, mTotal ) );
   }
 }
 

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -38,14 +38,15 @@ QString QgsFileUtils::representFileSize( qint64 bytes )
   list << QObject::tr( "KB" ) << QObject::tr( "MB" ) << QObject::tr( "GB" ) << QObject::tr( "TB" );
 
   QStringListIterator i( list );
-  QString unit = QObject::tr( "bytes" );
+  QString unit = QObject::tr( "B" );
 
-  while ( bytes >= 1024.0 && i.hasNext() )
+  double fileSize = bytes;
+  while ( fileSize >= 1024.0 && i.hasNext() )
   {
+    fileSize /= 1024.0;
     unit = i.next();
-    bytes /= 1024.0;
   }
-  return QStringLiteral( "%1 %2" ).arg( QString::number( bytes ), unit );
+  return QStringLiteral( "%1 %2" ).arg( QString::number( fileSize, 'f', bytes >= 1048576 ? 2 : 0 ), unit );
 }
 
 QStringList QgsFileUtils::extensionsFromFilter( const QString &filter )

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -189,6 +189,16 @@ class TestQgsFileUtils(unittest.TestCase):
         files = QgsFileUtils.findFile(filename, os.path.join(nest, 'nest2'), 2, 4)
         self.assertEqual(files[0], os.path.join(nest, filename).replace(os.sep, '/'))
 
+    def test_represent_file_size(self):
+        """
+        Test QgsFileUtils.representFileSize
+        """
+
+        self.assertEqual(QgsFileUtils.representFileSize(1023), '1023 B')
+        self.assertEqual(QgsFileUtils.representFileSize(1024), '1 KB')
+        self.assertEqual(QgsFileUtils.representFileSize(1048576), '1.00 MB')
+        self.assertEqual(QgsFileUtils.representFileSize(9876543210), '9.20 GB')
+
     def test_sidecar_files_for_path(self):
         """
         Test QgsFileUtils.sidecarFilesForPath


### PR DESCRIPTION
## Description

This PR improves the logs feedback of the file downloader by doing the following:
- removing needless dots at the end of the `X [of Y] downloaded` strings; we don't use full sentences there (and clashes with most strings printed in the logs)
- give decimal values for file size >= 1 MB; without this change on slow connections, the file downloader provides no useful feedback for long period of times

![image](https://user-images.githubusercontent.com/1728657/130352330-22336b6e-a748-48e7-9f3a-1eb33d5105db.png)

The decimal values for string representation of file size benefits other parts of QGIS too. 1GB vs. 1.5GB is a pretty big difference, users can only benefit from this extra display of precision :)