### PR TITLE
[Attachment widget] Fix widget not respecting relative paths settings by drag&drop

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -59,6 +59,7 @@ QgsFileWidget::QgsFileWidget( QWidget *parent )
   mLineEdit->setDragEnabled( true );
   mLineEdit->setToolTip( tr( "Full path to the file(s), including name and extension" ) );
   connect( mLineEdit, &QLineEdit::textChanged, this, &QgsFileWidget::textEdited );
+  connect( mLineEdit, &QgsFileDropEdit::fileDropped, this, &QgsFileWidget::fileDropped );
   mLayout->addWidget( mLineEdit );
 
   mLinkEditButton = new QToolButton( this );
@@ -188,6 +189,13 @@ void QgsFileWidget::editLink()
 
   mIsLinkEdited = !mIsLinkEdited;
   updateLayout();
+}
+
+void QgsFileWidget::fileDropped( const QString &filePath )
+{
+  setSelectedFileNames( QStringList() << filePath );
+  mLineEdit->selectAll();
+  mLineEdit->setFocus( Qt::MouseFocusReason );
 }
 
 bool QgsFileWidget::useLink() const
@@ -585,12 +593,11 @@ void QgsFileDropEdit::dropEvent( QDropEvent *event )
   QString filePath = acceptableFilePath( event );
   if ( !filePath.isEmpty() )
   {
-    setText( filePath );
-    selectAll();
-    setFocus( Qt::MouseFocusReason );
     event->acceptProposedAction();
-    setHighlighted( false );
+    emit fileDropped( filePath );
   }
+
+  setHighlighted( false );
 }
 
 ///@endcond

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -298,6 +298,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     void openFileDialog();
     void textEdited( const QString &path );
     void editLink();
+    void fileDropped( const QString &filePath );
 
   protected:
 
@@ -378,6 +379,13 @@ class GUI_EXPORT QgsFileDropEdit: public QgsHighlightableLineEdit
     void setStorageMode( QgsFileWidget::StorageMode storageMode ) { mStorageMode = storageMode; }
 
     void setFilters( const QString &filters );
+
+  signals:
+
+    /**
+     * Emitted when the file \a filePath is droppen onto the line edit.
+     */
+    void fileDropped( const QString &filePath );
 
   protected:
 


### PR DESCRIPTION
Attachment widget relative paths settings should be respected not only using the "browse" button but also when drag&dropping a file into the line edit.
