### PR TITLE
Remove unnecessary label in mesh symbology datasets tab

### DIFF
--- a/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
@@ -40,16 +40,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Dataset in selected group(s)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QgsCollapsibleGroupBox" name="mActiveDatasetMetadataGroup">
      <property name="title">
-      <string>Dataset group Metadata</string>
+      <string>Selected Dataset Group(s) Metadata</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>


### PR DESCRIPTION
Instead of the selected dataset group "teasing" label 
![image](https://user-images.githubusercontent.com/7983394/130519760-8b1a98c5-3776-4eb3-a3be-d9b1ba4eba45.png)
Remove it and mention the selection in the groupbox title, ie 
![image](https://user-images.githubusercontent.com/7983394/130520170-eda89514-1f72-4eaa-a6e6-585392ee9280.png)
