### PR TITLE
Plugin installer cleanup/optimization

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -95,11 +95,13 @@ class QgsPluginInstaller(QObject):
             msg.setText("%s <b>%s</b><br/><br/>%s" % (self.tr("Obsolete plugin:"), plugin["name"], self.tr("QGIS has detected an obsolete plugin that masks its more recent version shipped with this copy of QGIS. This is likely due to files associated with a previous installation of QGIS. Do you want to remove the old plugin right now and unmask the more recent version?")))
             msg.exec_()
             if not msg.result():
+                settings = QgsSettings()
+                plugin_is_active = settings.value("/PythonPlugins/" + key, False, type=bool)
+
                 # uninstall the update, update utils and reload if enabled
                 self.uninstallPlugin(key, quiet=True)
                 updateAvailablePlugins()
-                settings = QgsSettings()
-                if settings.value("/PythonPlugins/" + key, False, type=bool):
+                if plugin_is_active:
                     settings.setValue("/PythonPlugins/watchDog/" + key, True)
                     loadPlugin(key)
                     startPlugin(key)
@@ -451,6 +453,9 @@ class QgsPluginInstaller(QObject):
             self.exportPluginsToManager()
             QApplication.restoreOverrideCursor()
             iface.pluginManagerInterface().pushMessage(self.tr("Plugin uninstalled successfully"), Qgis.Info)
+
+            settings = QgsSettings()
+            settings.remove("/PythonPlugins/" + key)
 
     # ----------------------------------------- #
     def addRepository(self):

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -655,10 +655,9 @@ class QgsPluginInstaller(QObject):
             plugins.getAllInstalled()
             plugins.rebuild()
 
-            if settings.contains('/PythonPlugins/' + pluginName):
-                if settings.value('/PythonPlugins/' + pluginName, False, bool):
-                    startPlugin(pluginName)
-                    reloadPlugin(pluginName)
+            if settings.contains('/PythonPlugins/' + pluginName):  # Plugin was available?
+                if settings.value('/PythonPlugins/' + pluginName, False, bool):  # Plugin was also active?
+                    reloadPlugin(pluginName)  # unloadPlugin + loadPlugin + startPlugin
                 else:
                     unloadPlugin(pluginName)
                     loadPlugin(pluginName)


### PR DESCRIPTION
## Description

I'm currently developing a medium/big-size plugin and have encountered some optimizations in QGIS plugin installation.

**Commit https://github.com/qgis/QGIS/commit/79872e6be58aa9aea3629020b6241eab510e8388**

  Both `installPlugin()` ([here](https://github.com/qgis/QGIS/blob/45c5a91d5f17126293f6addb86a412256bcd6cba/python/pyplugin_installer/installer.py#L346)) and `installFromZipFile()` ([here](https://github.com/qgis/QGIS/blob/45c5a91d5f17126293f6addb86a412256bcd6cba/python/pyplugin_installer/installer.py#L662)) set the setting `'/PythonPlugins/' + pluginName` to `True`. Unchecking the plugin in the Plugin Manager sets it to `False`. However, `uninstallPlugin()` ([see](https://github.com/qgis/QGIS/blob/45c5a91d5f17126293f6addb86a412256bcd6cba/python/pyplugin_installer/installer.py#L403)) is not removing the setting.

This is not desirable because if such a setting exists in `QSettings`, the code thinks we are actually "reinstalling" a plugin, and does an entire reload (`unloadPlugin` + `loadPlugin` + `startPlugin`) instead of a single `startPlugin` call. We can avoid it simply removing the setting when the plugin is uninstalled, which is what the commit does.

Note: I take care of not breaking the logic surrounding of the only existing call to `uninstallPlugin()` (besides the call from Plugin Manager itself).

-------------------

**Commit https://github.com/qgis/QGIS/commit/52810dc1b0e1e3ffe3e02ced09e249e06f12e1c3**

Currently, if we are reinstalling a plugin:

 + `installPlugin()` `unloads` the current plugin, `loads` it and `starts` it again (that is, runs a `reloadPlugin()`).

 + `installFromZipFile()` first `starts` the current plugin (not sure why), then `unloads` it, `loads` it and `starts` it again (that is, it runs a `startPlugin()` and then a `reloadPlugin()`). 

It makes sense if we can make both `installFromZipFile()` and `installPlugin()` have the same behavior here, both for debugging and maintenance. This commit removes the call to `startPlugin()` from `installFromZipFile()` when reinstalling a plugin that is both available and active. After all, if the plugin is active, we don't need to immediately start it again.

--------------------------

I think this could be backported, but I'll leave the decision to a core dev.