### PR TITLE
[NOT FOR MERGE] play with test TestQgsNetworkAccessManager::testAuthRequestHandler()

### DIFF
--- a/.docker/docker-compose-testing.yml
+++ b/.docker/docker-compose-testing.yml
@@ -26,3 +26,5 @@ services:
       - LANG=C.UTF-8
       - LC_ALL=en_US.UTF-8
       - QGIS_HTTPBIN_HOST=httpbin
+    cap_add:
+      - NET_ADMIN

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,6 +198,8 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
+tc qdisc add dev eth0 root netem delay 100ms || :
+ping -c 2 httpbin || :
 TESTCOUNT=0
 while :
 do

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -201,7 +201,7 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 TESTCOUNT=0
 while :
 do
-  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest || :
+  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure
   if [[ $(( TESTCOUNT++ )) -eq 40 ]]; then
     break
   fi

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -203,7 +203,8 @@ ping -c 2 httpbin || :
 TESTCOUNT=0
 while :
 do
-  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure
+  echo "Test # $TESTCOUNT"
+  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure || :
   if [[ $(( TESTCOUNT++ )) -eq 40 ]]; then
     break
   fi

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,7 +198,7 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
-tc qdisc add dev eth0 root netem delay 100ms || :
+tc qdisc add dev eth0 root netem delay 500ms || :
 ping -c 2 httpbin || :
 TESTCOUNT=0
 while :

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -194,5 +194,18 @@ df -h
 
 python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUDE_TESTS}" -S /root/QGIS/.ci/config_test.ctest --output-on-failure
 
+# cd /root/QGIS || :
+# pwd
+# ls -la
+# cd build || :
+TESTCOUNT=0
+while :
+do
+  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest || :
+  if [[ $(( TESTCOUNT++ )) -eq 40 ]]; then
+    break
+  fi
+done
+
 echo "Print disk space"
 df -h

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -192,13 +192,13 @@ echo "List of skipped tests: $EXCLUDE_TESTS"
 echo "Print disk space"
 df -h
 
-python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUDE_TESTS}" -S /root/QGIS/.ci/config_test.ctest --output-on-failure
+python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUDE_TESTS}" -S /root/QGIS/.ci/config_test.ctest --output-on-failure || :
 
 # cd /root/QGIS || :
 # pwd
 # ls -la
 # cd build || :
-#tc qdisc add dev eth0 root netem delay 500ms || :
+tc qdisc add dev eth0 root netem delay 250ms || :
 #ping -c 2 httpbin || :
 TESTCOUNT=0
 TESTCOUNTFAIL=0
@@ -207,7 +207,7 @@ do
   echo "Test # $TESTCOUNT"
   python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure \
     || echo $(( TESTCOUNTFAIL++ ))
-  if [[ $(( TESTCOUNT++ )) -eq 40 ]]; then
+  if [[ $(( TESTCOUNT++ )) -eq 100 ]]; then
     break
   fi
 done

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,7 +198,7 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
-tc qdisc add dev eth0 root netem delay 250ms || :
+#tc qdisc add dev eth0 root netem delay 250ms || :
 #ping -c 2 httpbin || :
 TESTCOUNT=0
 TESTCOUNTFAIL=0

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,17 +198,20 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
-tc qdisc add dev eth0 root netem delay 500ms || :
-ping -c 2 httpbin || :
+#tc qdisc add dev eth0 root netem delay 500ms || :
+#ping -c 2 httpbin || :
 TESTCOUNT=0
+TESTCOUNTFAIL=0
 while :
 do
   echo "Test # $TESTCOUNT"
-  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure || :
+  python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V -R test_core_networkaccessmanager -S /root/QGIS/.ci/config_test.ctest --output-on-failure \
+    || echo $(( TESTCOUNTFAIL++ ))
   if [[ $(( TESTCOUNT++ )) -eq 40 ]]; then
     break
   fi
 done
+echo "TESTCOUNTFAIL = $TESTCOUNTFAIL"
 
 echo "Print disk space"
 df -h

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,7 +198,7 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
-#tc qdisc add dev eth0 root netem delay 250ms || :
+tc qdisc add dev eth0 root netem delay 5ms || :
 #ping -c 2 httpbin || :
 TESTCOUNT=0
 TESTCOUNTFAIL=0

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -198,7 +198,7 @@ python3 /root/QGIS/.ci/ctest2ci.py xvfb-run ctest -V $CTEST_OPTIONS -E "${EXCLUD
 # pwd
 # ls -la
 # cd build || :
-tc qdisc add dev eth0 root netem delay 5ms || :
+# tc qdisc add dev eth0 root netem delay 5ms || :
 #ping -c 2 httpbin || :
 TESTCOUNT=0
 TESTCOUNTFAIL=0

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -784,7 +784,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   connect( QgsNetworkAccessManager::instance(), qOverload< QgsNetworkReplyContent >( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent & reply )
   {
     QWARN( ( lastTest + QStringLiteral( "finished --->>>" ) ).toLatin1().data() );
-    QWARN( reply.errorString().toLatin1().data() );
+    QWARN( ( lastTest + QStringLiteral( " errorString: " ) + reply.errorString() ).toLatin1().data() );
     QCOMPARE( reply.error(), expectedError );
     QCOMPARE( reply.requestId(), requestId );
     QCOMPARE( reply.request().url(), u );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -819,7 +819,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
 
   QVERIFY( gotRequestAboutToBeCreatedSignal );
-/*
+
   // blocking request
   lastTest = QStringLiteral( "TEST_02 blocking request --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
@@ -838,7 +838,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
-*/
+
   // now try in a thread
   lastTest = QStringLiteral( "TEST_03 now try in a thread --->>> " );
   loaded = false;
@@ -900,7 +900,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   {
     qApp->processEvents();
   }
-/*
+
   // blocking request
   lastTest = QStringLiteral( "TEST_06 blocking request --->>> " );
   loaded = false;
@@ -920,7 +920,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
-*/
+
   // correct username and password, in a thread
   lastTest = QStringLiteral( "TEST_07 correct username and password, in a thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -756,8 +756,8 @@ void TestQgsNetworkAccessManager::testSslErrorHandler()
 
 void TestQgsNetworkAccessManager::testAuthRequestHandler()
 {
-  if ( QgsTest::isCIRun() )
-    QSKIP( "Skip remote test, looks like problem with httpbin" );
+  //if ( QgsTest::isCIRun() )
+  //  QSKIP( "Skip remote test, looks like problem with httpbin" );
   // initially this request should fail -- we aren't providing the username and password required
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QString(), QString() ) );
 
@@ -811,6 +811,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
     gotAuthDetailsAdded = true;
   } );
 
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_01 initially this request should fail -- we aren't providing the username and password required --->>> " );
   expectedError = QNetworkReply::AuthenticationRequiredError;
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
@@ -823,6 +824,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QVERIFY( gotRequestAboutToBeCreatedSignal );
 
   // blocking request
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_02 blocking request --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -842,6 +844,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QCOMPARE( rep.requestId(), requestId );
 
   // now try in a thread
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_03 now try in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -864,6 +867,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   thread->deleteLater();
 
   // blocking request in a thread
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_04 blocking request in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -884,6 +888,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   blockingThread->deleteLater();
 
   // try with username and password specified
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_05 try with username and password specified --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -904,6 +909,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
 
   // blocking request
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_06 blocking request --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -924,6 +930,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QCOMPARE( rep.requestId(), requestId );
 
   // correct username and password, in a thread
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_07 correct username and password, in a thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );
@@ -949,6 +956,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
 
 
   // blocking request in worker thread
+  QThread::sleep(2);
   lastTest = QStringLiteral( "TEST_08 blocking request in worker thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -811,7 +811,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
     gotAuthDetailsAdded = true;
   } );
 
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_01 initially this request should fail -- we aren't providing the username and password required --->>> " );
   expectedError = QNetworkReply::AuthenticationRequiredError;
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
@@ -824,7 +824,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QVERIFY( gotRequestAboutToBeCreatedSignal );
 
   // blocking request
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_02 blocking request --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -844,7 +844,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QCOMPARE( rep.requestId(), requestId );
 
   // now try in a thread
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_03 now try in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -867,7 +867,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   thread->deleteLater();
 
   // blocking request in a thread
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_04 blocking request in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -888,7 +888,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   blockingThread->deleteLater();
 
   // try with username and password specified
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_05 try with username and password specified --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -909,7 +909,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
 
   // blocking request
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_06 blocking request --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -930,7 +930,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QCOMPARE( rep.requestId(), requestId );
 
   // correct username and password, in a thread
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_07 correct username and password, in a thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );
@@ -956,7 +956,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
 
 
   // blocking request in worker thread
-  QThread::sleep(2);
+  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_08 blocking request in worker thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -756,6 +756,8 @@ void TestQgsNetworkAccessManager::testSslErrorHandler()
 
 void TestQgsNetworkAccessManager::testAuthRequestHandler()
 {
+  if ( QgsTest::isCIRun() )
+    QSKIP( "Skip remote test, looks like problem with httpbin" );
   // initially this request should fail -- we aren't providing the username and password required
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QString(), QString() ) );
 

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -819,7 +819,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
 
   QVERIFY( gotRequestAboutToBeCreatedSignal );
-
+/*
   // blocking request
   lastTest = QStringLiteral( "TEST_02 blocking request --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
@@ -838,7 +838,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
-
+*/
   // now try in a thread
   lastTest = QStringLiteral( "TEST_03 now try in a thread --->>> " );
   loaded = false;
@@ -900,7 +900,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   {
     qApp->processEvents();
   }
-
+/*
   // blocking request
   lastTest = QStringLiteral( "TEST_06 blocking request --->>> " );
   loaded = false;
@@ -920,7 +920,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
-
+*/
   // correct username and password, in a thread
   lastTest = QStringLiteral( "TEST_07 correct username and password, in a thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -835,11 +835,12 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
 
   QNetworkRequest req{ u };
   QgsNetworkReplyContent rep = QgsNetworkAccessManager::blockingGet( req );
+  QWARN( ( lastTest + QStringLiteral( " ? finished ? " ) ).toLatin1().data() );
   QVERIFY( rep.content().isEmpty() );
-  while ( !loaded )
-  {
-    qApp->processEvents();
-  }
+  //while ( !loaded )
+  //{
+  //  qApp->processEvents();
+  //}
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
 
@@ -921,11 +922,12 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
   req = QNetworkRequest{ u };
   rep = QgsNetworkAccessManager::blockingGet( req );
+  QWARN( ( lastTest + QStringLiteral( " ? finished ? " ) ).toLatin1().data() );
   QVERIFY( rep.content().contains( "\"user\": \"me\"" ) );
-  while ( !loaded )
-  {
-    qApp->processEvents();
-  }
+  //while ( !loaded )
+  //{
+  //  qApp->processEvents();
+  //}
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
 

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -759,6 +759,7 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   //if ( QgsTest::isCIRun() )
   //  QSKIP( "Skip remote test, looks like problem with httpbin" );
   // initially this request should fail -- we aren't providing the username and password required
+  QgsNetworkAccessManager::setTimeout( 5000 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QString(), QString() ) );
 
   const QObject context;
@@ -837,10 +838,10 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QgsNetworkReplyContent rep = QgsNetworkAccessManager::blockingGet( req );
   QWARN( ( lastTest + QStringLiteral( " ? finished ? " ) ).toLatin1().data() );
   QVERIFY( rep.content().isEmpty() );
-  //while ( !loaded )
-  //{
-  //  qApp->processEvents();
-  //}
+  while ( !loaded )
+  {
+    qApp->processEvents();
+  }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
 
@@ -924,10 +925,10 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   rep = QgsNetworkAccessManager::blockingGet( req );
   QWARN( ( lastTest + QStringLiteral( " ? finished ? " ) ).toLatin1().data() );
   QVERIFY( rep.content().contains( "\"user\": \"me\"" ) );
-  //while ( !loaded )
-  //{
-  //  qApp->processEvents();
-  //}
+  while ( !loaded )
+  {
+    qApp->processEvents();
+  }
   QVERIFY( gotRequestAboutToBeCreatedSignal );
   QCOMPARE( rep.requestId(), requestId );
 

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -813,7 +813,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
     gotAuthDetailsAdded = true;
   } );
 
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_01 initially this request should fail -- we aren't providing the username and password required --->>> " );
   expectedError = QNetworkReply::AuthenticationRequiredError;
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
@@ -826,7 +825,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   QVERIFY( gotRequestAboutToBeCreatedSignal );
 
   // now try in a thread
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_03 now try in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -849,7 +847,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   thread->deleteLater();
 
   // blocking request in a thread
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_04 blocking request in a thread --->>> " );
   loaded = false;
   gotAuthRequest = false;
@@ -870,7 +867,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   blockingThread->deleteLater();
 
   // try with username and password specified
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_05 try with username and password specified --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -891,7 +887,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   }
 
   // correct username and password, in a thread
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_07 correct username and password, in a thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );
@@ -917,7 +912,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
 
 
   // blocking request in worker thread
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_08 blocking request in worker thread --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   QgsNetworkAccessManager::instance()->setAuthHandler( std::make_unique< TestAuthRequestHandler >( QStringLiteral( "me2" ), hash ) );
@@ -1003,7 +997,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandlerBlockingMain()
   } );
 
   // blocking request
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_02 blocking request --->>> " );
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
@@ -1025,7 +1018,6 @@ void TestQgsNetworkAccessManager::testAuthRequestHandlerBlockingMain()
   QCOMPARE( rep.requestId(), requestId );
 
   // blocking request
-  QThread::sleep( 2 );
   lastTest = QStringLiteral( "TEST_06 blocking request --->>> " );
   loaded = false;
   gotAuthRequest = false;


### PR DESCRIPTION
After all tests are complete, the script runs test_core_networkaccessmanager 101 more times. The results are shown in the tables below.

test results #44853 https://github.com/qgis/QGIS/actions/runs/1171838559

| after test       | httpbin server | net delay, ms | fail rate, % |
| ----------------- |:------------------:| -----------------:| --------------: |
| ALL_BUT...   |        local         |                   0 |                1 |
| POSTGRES |   httpbin.org    |                   0 |                 5 |
| HANA           |        local         |                   0 |                6 |
| ORACLE      |   httpbin.org    |                   0 |               18 |

test results https://github.com/qgis/QGIS/actions/runs/1163020047

| after test       | httpbin server | net delay, ms | fail rate, % |
| ----------------- |:------------------:| -----------------:| --------------: |
| ALL_BUT...   |        local         |                   0 |       __79__ |
| POSTGRES |   httpbin.org    |                   0 |                 8 |
| HANA           |        local         |                   0 |       __81__ |
| ORACLE      |   httpbin.org    |                   0 |               27 |

test results https://github.com/qgis/QGIS/actions/runs/1162709412

| after test       | httpbin server | net delay, ms | fail rate, % |
| ----------------- |:------------------:| -----------------:| --------------: |
| ALL_BUT...   |        local         |               250 |                 3 |
| POSTGRES |   httpbin.org    |               250 |                 9 |
| HANA           |        local         |               250 |                 6 |
| ORACLE      |   httpbin.org    |                   0 |               29 |

usually the test fails for `TestQgsNetworkAccessManager::testAuthRequestHandler()`