### PR TITLE
[API] Encode and write vector tiles in different CRS than EPSG:3857

### DIFF
--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -108,9 +108,26 @@ Please note that we follow the XYZ convention of X/Y axes, i.e. top-left tile ha
 %End
   public:
 
-    static QgsTileMatrix fromWebMercator( int mZoomLevel );
+    static QgsTileMatrix fromWebMercator( int zoomLevel );
 %Docstring
 Returns a tile matrix for the usual web mercator
+%End
+
+    static QgsTileMatrix fromCustomDef( int zoomLevel, const QgsCoordinateReferenceSystem &crs,
+                                        const QgsPointXY &z0TopLeftPoint, double z0Dimension,
+                                        int z0MatrixWidth = 1, int z0MatrixHeight = 1 );
+%Docstring
+Returns a tile matrix for a specific CRS, top left point, zoom level 0 dimension in CRS units
+%End
+
+    static QgsTileMatrix fromTileMatrix( const int &zoomLevel, const QgsTileMatrix &tileMatrix );
+%Docstring
+Returns a tile matrix based on another one
+%End
+
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+Returns the authority identifier for the CRS of the tile matrix
 %End
 
     int zoomLevel() const;
@@ -156,6 +173,11 @@ Returns tile range that fully covers the given extent
     QPointF mapToTileCoordinates( const QgsPointXY &mapPoint ) const;
 %Docstring
 Returns row/column coordinates (floating point number) from the given point in map coordinates
+%End
+
+    bool isRootTileMatrix() const;
+%Docstring
+Returns the root status of the tile matrix (zoom level == 0)
 %End
 
 };

--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -128,7 +128,7 @@ See the class description about the syntax of destination URIs.
 
     void setExtent( const QgsRectangle &extent );
 %Docstring
-Sets extent of vector tile output. Currently always in EPSG:3857.
+Sets extent of vector tile output.
 If unset, it will use the full extent of all input layers combined
 %End
 
@@ -154,6 +154,11 @@ Sets that will be written to the output dataset. See class description for more 
     void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
 Sets coordinate transform context for transforms between layers and tile matrix CRS
+%End
+
+    bool setRootTileMatrix( const QgsTileMatrix &tileMatrix );
+%Docstring
+Sets zoom level 0 tile matrix
 %End
 
     bool writeTiles( QgsFeedback *feedback = 0 );

--- a/src/core/qgstiles.cpp
+++ b/src/core/qgstiles.cpp
@@ -16,22 +16,64 @@
 #include "qgstiles.h"
 
 #include "qgslogger.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgssettings.h"
 
 QgsTileMatrix QgsTileMatrix::fromWebMercator( int zoomLevel )
 {
+  double z0xMin = -20037508.3427892, z0yMax =  20037508.3427892;
+
+  return fromCustomDef( zoomLevel, QgsCoordinateReferenceSystem( "EPSG:3857" ), QgsPointXY( z0xMin, z0yMax ), 2 * z0yMax );
+}
+
+QgsTileMatrix QgsTileMatrix::fromCustomDef( int zoomLevel, const QgsCoordinateReferenceSystem &crs,
+    const QgsPointXY &z0TopLeftPoint, double z0Dimension, int z0MatrixWidth, int z0MatrixHeight )
+{
+  // Square extent calculation
+  double z0xMin = z0TopLeftPoint.x();
+  double z0yMax = z0TopLeftPoint.y();
+  double z0xMax = z0xMin + z0MatrixWidth * z0Dimension;
+  double z0yMin = z0yMax - z0MatrixHeight * z0Dimension;
+
+  // Constant for scale denominator calculation
+  const double tileSize = 256.0;
+  const double PIXELS_TO_M = 2.8 / 10000.0;  // WMS/WMTS define "standardized rendering pixel size" as 0.28mm
+  const double UNIT_TO_M = QgsUnitTypes::fromUnitToUnitFactor( crs.mapUnits(), QgsUnitTypes::DistanceMeters );
+  // Scale denominator calculation
+  double scaleDenom0 = ( z0Dimension / tileSize ) * ( UNIT_TO_M / PIXELS_TO_M );
+
   int numTiles = static_cast<int>( pow( 2, zoomLevel ) ); // assuming we won't ever go over 30 zoom levels
-  double z0xMin = -20037508.3427892, z0yMin = -20037508.3427892;
-  double z0xMax =  20037508.3427892, z0yMax =  20037508.3427892;
-  double s0 = 559082264.0287178;   // scale denominator at zoom level 0 of GoogleCRS84Quad
 
   QgsTileMatrix tm;
+  tm.mCrs = crs;
   tm.mZoomLevel = zoomLevel;
-  tm.mMatrixWidth = numTiles;
-  tm.mMatrixHeight = numTiles;
+  tm.mMatrixWidth = z0MatrixWidth * numTiles;
+  tm.mMatrixHeight = z0MatrixHeight * numTiles;
   tm.mTileXSpan = ( z0xMax - z0xMin ) / tm.mMatrixWidth;
   tm.mTileYSpan = ( z0yMax - z0yMin ) / tm.mMatrixHeight;
   tm.mExtent = QgsRectangle( z0xMin, z0yMin, z0xMax, z0yMax );
-  tm.mScaleDenom = s0 / pow( 2, zoomLevel );
+  tm.mScaleDenom = scaleDenom0 / pow( 2, zoomLevel );
+  return tm;
+}
+
+
+QgsTileMatrix QgsTileMatrix::fromTileMatrix( const int &zoomLevel, const QgsTileMatrix &tileMatrix )
+{
+  QgsTileMatrix tm;
+  int numTiles = static_cast<int>( pow( 2, zoomLevel ) ); // assuming we won't ever go over 30 zoom levels
+  int aZoomLevel = tileMatrix.zoomLevel();
+  int aNumTiles = static_cast<int>( pow( 2, aZoomLevel ) );
+  int aMatrixWidth = tileMatrix.matrixWidth();
+  int aMatrixHeight = tileMatrix.matrixHeight();
+  QgsRectangle aExtent = tileMatrix.extent();
+  tm.mCrs = tileMatrix.crs();
+  tm.mZoomLevel = zoomLevel;
+  tm.mMatrixWidth = aMatrixWidth * numTiles / aNumTiles;
+  tm.mMatrixHeight = aMatrixHeight * numTiles / aNumTiles;
+  tm.mTileXSpan = aExtent.width() / tm.mMatrixWidth;
+  tm.mTileYSpan = aExtent.height() / tm.mMatrixHeight;
+  tm.mExtent = aExtent;
+  tm.mScaleDenom = tileMatrix.scale() * pow( 2, aZoomLevel )  / pow( 2, zoomLevel );
   return tm;
 }
 

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -20,6 +20,7 @@
 #include "qgis_sip.h"
 
 #include "qgsrectangle.h"
+#include "qgscoordinatereferencesystem.h"
 
 /**
  * \ingroup core
@@ -104,7 +105,18 @@ class CORE_EXPORT QgsTileMatrix
   public:
 
     //! Returns a tile matrix for the usual web mercator
-    static QgsTileMatrix fromWebMercator( int mZoomLevel );
+    static QgsTileMatrix fromWebMercator( int zoomLevel );
+
+    //! Returns a tile matrix for a specific CRS, top left point, zoom level 0 dimension in CRS units
+    static QgsTileMatrix fromCustomDef( int zoomLevel, const QgsCoordinateReferenceSystem &crs,
+                                        const QgsPointXY &z0TopLeftPoint, double z0Dimension,
+                                        int z0MatrixWidth = 1, int z0MatrixHeight = 1 );
+
+    //! Returns a tile matrix based on another one
+    static QgsTileMatrix fromTileMatrix( const int &zoomLevel, const QgsTileMatrix &tileMatrix );
+
+    //! Returns the authority identifier for the CRS of the tile matrix
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
 
     //! Returns zoom level of the tile matrix
     int zoomLevel() const { return mZoomLevel; }
@@ -133,9 +145,14 @@ class CORE_EXPORT QgsTileMatrix
     //! Returns row/column coordinates (floating point number) from the given point in map coordinates
     QPointF mapToTileCoordinates( const QgsPointXY &mapPoint ) const;
 
+    //! Returns the root status of the tile matrix (zoom level == 0)
+    bool isRootTileMatrix() const { return mZoomLevel == 0; }
+
   private:
+    //! Crs associated with the tile matrix
+    QgsCoordinateReferenceSystem mCrs;
     //! Zoom level index associated with the tile matrix
-    int mZoomLevel;
+    int mZoomLevel = -1;
     //! Number of columns of the tile matrix
     int mMatrixWidth;
     //! Number of rows of the tile matrix

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -145,6 +145,14 @@ QgsVectorTileMVTEncoder::QgsVectorTileMVTEncoder( QgsTileXYZ tileID )
 {
   const QgsTileMatrix tm = QgsTileMatrix::fromWebMercator( mTileID.zoomLevel() );
   mTileExtent = tm.tileExtent( mTileID );
+  mCrs = tm.crs();
+}
+
+QgsVectorTileMVTEncoder::QgsVectorTileMVTEncoder( QgsTileXYZ tileID, const QgsTileMatrix &tileMatrix )
+  : mTileID( tileID )
+{
+  mTileExtent = tileMatrix.tileExtent( mTileID );
+  mCrs = tileMatrix.crs();
 }
 
 void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QgsFeedback *feedback, QString filterExpression, QString layerName )
@@ -152,7 +160,7 @@ void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QgsFeedback *feed
   if ( feedback && feedback->isCanceled() )
     return;
 
-  const QgsCoordinateTransform ct( layer->crs(), QgsCoordinateReferenceSystem( "EPSG:3857" ), mTransformContext );
+  const QgsCoordinateTransform ct( layer->crs(), mCrs, mTransformContext );
 
   QgsRectangle layerTileExtent = mTileExtent;
   try

--- a/src/core/vectortile/qgsvectortilemvtencoder.h
+++ b/src/core/vectortile/qgsvectortilemvtencoder.h
@@ -40,8 +40,11 @@
 class CORE_EXPORT QgsVectorTileMVTEncoder
 {
   public:
-    //! Creates MVT encoder for the given tile coordinates
+    //! Creates MVT encoder for the given tile coordinates for Web Mercator
     explicit QgsVectorTileMVTEncoder( QgsTileXYZ tileID );
+
+    //! Creates MVT encoder for the given tile coordinates and tile matrix
+    explicit QgsVectorTileMVTEncoder( QgsTileXYZ tileID, const QgsTileMatrix &tileMatrix );
 
     //! Returns resolution of coordinates of geometries within the tile. The default is 4096.
     int resolution() const { return mResolution; }
@@ -76,6 +79,7 @@ class CORE_EXPORT QgsVectorTileMVTEncoder
     QgsCoordinateTransformContext mTransformContext;
 
     QgsRectangle mTileExtent;
+    QgsCoordinateReferenceSystem mCrs;
 
     QgsVectorTileFeatures mFeatures;
 

--- a/src/core/vectortile/qgsvectortilewriter.cpp
+++ b/src/core/vectortile/qgsvectortilewriter.cpp
@@ -35,6 +35,18 @@
 
 QgsVectorTileWriter::QgsVectorTileWriter()
 {
+  setRootTileMatrix( QgsTileMatrix::fromWebMercator( 0 ) );
+}
+
+
+bool QgsVectorTileWriter::setRootTileMatrix( const QgsTileMatrix &tileMatrix )
+{
+  if ( tileMatrix.isRootTileMatrix() )
+  {
+    mRootTileMatrix = tileMatrix;
+    return true;
+  }
+  return false;
 }
 
 
@@ -94,7 +106,7 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
   int tilesToCreate = 0;
   for ( int zoomLevel = mMinZoom; zoomLevel <= mMaxZoom; ++zoomLevel )
   {
-    QgsTileMatrix tileMatrix = QgsTileMatrix::fromWebMercator( zoomLevel );
+    QgsTileMatrix tileMatrix = QgsTileMatrix::fromTileMatrix( zoomLevel, mRootTileMatrix );
 
     QgsTileRange tileRange = tileMatrix.tileRangeFromExtent( outputExtent );
     tilesToCreate += ( tileRange.endRow() - tileRange.startRow() + 1 ) *
@@ -137,7 +149,7 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
     {
       try
       {
-        QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( "EPSG:3857" ), QgsCoordinateReferenceSystem( "EPSG:4326" ), mTransformContext );
+        QgsCoordinateTransform ct( mRootTileMatrix.crs(), QgsCoordinateReferenceSystem( "EPSG:4326" ), mTransformContext );
         QgsRectangle wgsExtent = ct.transform( outputExtent );
         QString boundsStr = QString( "%1,%2,%3,%4" )
                             .arg( wgsExtent.xMinimum() ).arg( wgsExtent.yMinimum() )
@@ -149,12 +161,14 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
         // bounds won't be written (not a problem - it is an optional value)
       }
     }
+    if ( !mMetadata.contains( "crs" ) )
+      mbtiles->setMetadataValue( "crs",  mRootTileMatrix.crs().authid() );
   }
 
   int tilesCreated = 0;
   for ( int zoomLevel = mMinZoom; zoomLevel <= mMaxZoom; ++zoomLevel )
   {
-    QgsTileMatrix tileMatrix = QgsTileMatrix::fromWebMercator( zoomLevel );
+    QgsTileMatrix tileMatrix = QgsTileMatrix::fromTileMatrix( zoomLevel, mRootTileMatrix );
 
     QgsTileRange tileRange = tileMatrix.tileRangeFromExtent( outputExtent );
     for ( int row = tileRange.startRow(); row <= tileRange.endRow(); ++row )
@@ -216,12 +230,11 @@ bool QgsVectorTileWriter::writeTiles( QgsFeedback *feedback )
 QgsRectangle QgsVectorTileWriter::fullExtent() const
 {
   QgsRectangle extent;
-  QgsCoordinateReferenceSystem destCrs( "EPSG:3857" );
 
   for ( const Layer &layer : mLayers )
   {
     QgsVectorLayer *vl = layer.layer();
-    QgsCoordinateTransform ct( vl->crs(), destCrs, mTransformContext );
+    QgsCoordinateTransform ct( vl->crs(), mRootTileMatrix.crs(), mTransformContext );
     try
     {
       QgsRectangle r = ct.transformBoundingBox( vl->extent() );
@@ -318,4 +331,3 @@ QByteArray QgsVectorTileWriter::writeSingleTile( QgsTileXYZ tileID, QgsFeedback 
 
   return encoder.encode();
 }
-

--- a/src/core/vectortile/qgsvectortilewriter.h
+++ b/src/core/vectortile/qgsvectortilewriter.h
@@ -17,8 +17,10 @@
 #define QGSVECTORTILEWRITER_H
 
 #include <QCoreApplication>
+#include "qgstiles.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatetransformcontext.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QgsFeedback;
 class QgsTileMatrix;
@@ -128,7 +130,7 @@ class CORE_EXPORT QgsVectorTileWriter
     void setDestinationUri( const QString &uri ) { mDestinationUri = uri; }
 
     /**
-     * Sets extent of vector tile output. Currently always in EPSG:3857.
+     * Sets extent of vector tile output.
      * If unset, it will use the full extent of all input layers combined
      */
     void setExtent( const QgsRectangle &extent ) { mExtent = extent; }
@@ -146,6 +148,11 @@ class CORE_EXPORT QgsVectorTileWriter
 
     //! Sets coordinate transform context for transforms between layers and tile matrix CRS
     void setTransformContext( const QgsCoordinateTransformContext &transformContext ) { mTransformContext = transformContext; }
+
+    /**
+     * Sets zoom level 0 tile matrix
+     */
+    bool setRootTileMatrix( const QgsTileMatrix &tileMatrix );
 
     /**
      * Writes vector tiles according to the configuration.
@@ -184,6 +191,7 @@ class CORE_EXPORT QgsVectorTileWriter
     QString mbtilesJsonSchema();
 
   private:
+    QgsTileMatrix mRootTileMatrix;
     QgsRectangle mExtent;
     int mMinZoom = 0;
     int mMaxZoom = 4;

--- a/tests/src/core/testqgstiles.cpp
+++ b/tests/src/core/testqgstiles.cpp
@@ -44,6 +44,8 @@ class TestQgsTiles : public QObject
     void cleanup() {} // will be called after every testfunction.
 
     void test_matrixFromWebMercator();
+    void test_matrixFromCustomDef();
+    void test_matrixFromTileMatrix();
 };
 
 
@@ -65,6 +67,7 @@ void TestQgsTiles::cleanupTestCase()
 void TestQgsTiles::test_matrixFromWebMercator()
 {
   QgsTileMatrix tm = QgsTileMatrix::fromWebMercator( 0 );
+  QCOMPARE( tm.crs().authid(), "EPSG:3857" );
   QCOMPARE( tm.zoomLevel(), 0 );
   QCOMPARE( tm.matrixWidth(), 1 );
   QCOMPARE( tm.matrixHeight(), 1 );
@@ -72,9 +75,10 @@ void TestQgsTiles::test_matrixFromWebMercator()
   QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
   QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
   QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
-  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178, 0.00001 ) );
 
   tm = QgsTileMatrix::fromWebMercator( 3 );
+  QCOMPARE( tm.crs().authid(), "EPSG:3857" );
   QCOMPARE( tm.zoomLevel(), 3 );
   QCOMPARE( tm.matrixWidth(), 8 );
   QCOMPARE( tm.matrixHeight(), 8 );
@@ -82,7 +86,7 @@ void TestQgsTiles::test_matrixFromWebMercator()
   QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
   QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
   QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
-  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178 / 8.0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178 / 8.0, 0.00001 ) );
 
   QgsRectangle te = tm.tileExtent( QgsTileXYZ( 3, 3, 3 ) );
   QVERIFY( qgsDoubleNear( te.xMinimum(), -5009377.0856973, 0.0000001 ) );
@@ -106,6 +110,141 @@ void TestQgsTiles::test_matrixFromWebMercator()
   QCOMPARE( tr.endColumn(), 2 );
   QCOMPARE( tr.startRow(), 2 );
   QCOMPARE( tr.endRow(), 3 );
+}
+
+void TestQgsTiles::test_matrixFromCustomDef()
+{
+  // Try to build the Web Mercator tile matrix
+  QgsTileMatrix tm = QgsTileMatrix::fromCustomDef( 0, QgsCoordinateReferenceSystem( "EPSG:3857" ), QgsPointXY( -20037508.3427892, 20037508.3427892 ), 40075016.6855784 );
+  QCOMPARE( tm.crs().authid(), "EPSG:3857" );
+  QCOMPARE( tm.zoomLevel(), 0 );
+  QCOMPARE( tm.matrixWidth(), 1 );
+  QCOMPARE( tm.matrixHeight(), 1 );
+  QVERIFY( qgsDoubleNear( tm.extent().xMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178, 0.00001 ) );
+
+  tm = QgsTileMatrix::fromCustomDef( 3, QgsCoordinateReferenceSystem( "EPSG:3857" ), QgsPointXY( -20037508.3427892, 20037508.3427892 ), 40075016.6855784 );
+  QCOMPARE( tm.crs().authid(), "EPSG:3857" );
+  QCOMPARE( tm.zoomLevel(), 3 );
+  QCOMPARE( tm.matrixWidth(), 8 );
+  QCOMPARE( tm.matrixHeight(), 8 );
+  QVERIFY( qgsDoubleNear( tm.extent().xMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 559082264.0287178 / 8.0, 0.00001 ) );
+
+  QgsRectangle te = tm.tileExtent( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( te.xMinimum(), -5009377.0856973, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMinimum(), 0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.xMaximum(), 0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMaximum(), 5009377.0856973, 0.0000001 ) );
+
+  QgsPointXY tc = tm.tileCenter( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), te.xMinimum() + te.width() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), -2504688.54284865, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), te.yMinimum() + te.height() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), 2504688.54284865, 0.0000001 ) );
+
+  QgsVectorLayer *vl = new QgsVectorLayer( mDataDir + "/points.shp", "points", "ogr" );
+  QgsCoordinateReferenceSystem destCrs( "EPSG:3857" );
+  QgsCoordinateTransform ct( vl->crs(), destCrs, QgsCoordinateTransformContext() );
+  QgsRectangle r = ct.transformBoundingBox( vl->extent() );
+  QgsTileRange tr = tm.tileRangeFromExtent( r );
+  QVERIFY( tr.isValid() );
+  QCOMPARE( tr.startColumn(), 1 );
+  QCOMPARE( tr.endColumn(), 2 );
+  QCOMPARE( tr.startRow(), 2 );
+  QCOMPARE( tr.endRow(), 3 );
+
+  // Try to build the World Global tile matrix
+  tm = QgsTileMatrix::fromCustomDef( 0, QgsCoordinateReferenceSystem( "EPSG:4326" ), QgsPointXY( -180.0, 90.0 ), 180.0, 2, 1 );
+  QCOMPARE( tm.crs().authid(), "EPSG:4326" );
+  QCOMPARE( tm.zoomLevel(), 0 );
+  QCOMPARE( tm.matrixWidth(), 2 );
+  QCOMPARE( tm.matrixHeight(), 1 );
+  QVERIFY( qgsDoubleNear( tm.extent().xMinimum(), -180.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -90.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 180.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 90.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 279541132.014, 0.001 ) );
+
+  tm = QgsTileMatrix::fromCustomDef( 3, QgsCoordinateReferenceSystem( "EPSG:4326" ), QgsPointXY( -180.0, 90.0 ), 180.0, 2, 1 );
+  QCOMPARE( tm.crs().authid(), "EPSG:4326" );
+  QCOMPARE( tm.zoomLevel(), 3 );
+  QCOMPARE( tm.matrixWidth(), 16 );
+  QCOMPARE( tm.matrixHeight(), 8 );
+  QVERIFY( qgsDoubleNear( tm.extent().xMinimum(), -180.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMinimum(), -90.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().xMaximum(), 180.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.extent().yMaximum(), 90.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( tm.scale(), 279541132.014 / 8.0, 0.001 ) );
+
+  te = tm.tileExtent( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( te.xMinimum(), -112.5, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMinimum(), 0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.xMaximum(), -90, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMaximum(), 22.5, 0.0000001 ) );
+
+  tc = tm.tileCenter( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), te.xMinimum() + te.width() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), -101.25, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), te.yMinimum() + te.height() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), 11.25, 0.0000001 ) );
+
+  destCrs = QgsCoordinateReferenceSystem( "EPSG:4326" );
+  ct = QgsCoordinateTransform( vl->crs(), destCrs, QgsCoordinateTransformContext() );
+  r = ct.transformBoundingBox( vl->extent() );
+  tr = tm.tileRangeFromExtent( r );
+  QVERIFY( tr.isValid() );
+  QCOMPARE( tr.startColumn(), 2 );
+  QCOMPARE( tr.endColumn(), 4 );
+  QCOMPARE( tr.startRow(), 1 );
+  QCOMPARE( tr.endRow(), 2 );
+}
+
+void TestQgsTiles::test_matrixFromTileMatrix()
+{
+  QgsTileMatrix tm = QgsTileMatrix::fromWebMercator( 0 );
+
+  // Build level 3 from 0
+  QgsTileMatrix tm3 = QgsTileMatrix::fromTileMatrix( 3, tm );
+  QCOMPARE( tm3.crs().authid(), "EPSG:3857" );
+  QCOMPARE( tm3.zoomLevel(), 3 );
+  QCOMPARE( tm3.matrixWidth(), 8 );
+  QCOMPARE( tm3.matrixHeight(), 8 );
+  QVERIFY( qgsDoubleNear( tm3.extent().xMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm3.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm3.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm3.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm3.scale(), 559082264.0287178 / 8.0, 0.00001 ) );
+
+  QgsRectangle te = tm3.tileExtent( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( te.xMinimum(), -5009377.0856973, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMinimum(), 0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.xMaximum(), 0, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( te.yMaximum(), 5009377.0856973, 0.0000001 ) );
+
+  QgsPointXY tc = tm3.tileCenter( QgsTileXYZ( 3, 3, 3 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), te.xMinimum() + te.width() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.x(), -2504688.54284865, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), te.yMinimum() + te.height() / 2, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tc.y(), 2504688.54284865, 0.0000001 ) );
+
+  // Build level 0 from 3
+  QgsTileMatrix tm0 = QgsTileMatrix::fromTileMatrix( 0, tm3 );
+  QCOMPARE( tm0.crs().authid(), "EPSG:3857" );
+  QCOMPARE( tm0.zoomLevel(), 0 );
+  QCOMPARE( tm0.matrixWidth(), 1 );
+  QCOMPARE( tm0.matrixHeight(), 1 );
+  QVERIFY( qgsDoubleNear( tm0.extent().xMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm0.extent().yMinimum(), -20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm0.extent().xMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm0.extent().yMaximum(), 20037508.3427892, 0.0000001 ) );
+  QVERIFY( qgsDoubleNear( tm0.scale(), 559082264.0287178, 0.00001 ) );
 }
 
 

--- a/tests/src/core/testqgsvectortilewriter.cpp
+++ b/tests/src/core/testqgsvectortilewriter.cpp
@@ -54,6 +54,8 @@ class TestQgsVectorTileWriter : public QObject
     void test_mbtiles();
     void test_mbtiles_metadata();
     void test_filtering();
+    void test_z0TileMatrix3857();
+    void test_z0TileMatrix2154();
 };
 
 
@@ -313,6 +315,169 @@ void TestQgsVectorTileWriter::test_filtering()
   QCOMPARE( features0["b52"].count(), 4 );
   QCOMPARE( features0["lines"].count(), 6 );
   QCOMPARE( features0["polys"].count(), 0 );
+}
+
+
+void TestQgsVectorTileWriter::test_z0TileMatrix3857()
+{
+  QTemporaryDir dir;
+  dir.setAutoRemove( false );  // so that we can inspect the results later
+  const QString tmpDir = dir.path();
+
+  QgsDataSourceUri ds;
+  ds.setParam( "type", "xyz" );
+  ds.setParam( "url", QUrl::fromLocalFile( tmpDir ).toString() + "/custom3857-{z}-{x}-{y}.pbf" );
+
+  QgsVectorLayer *vlPoints = new QgsVectorLayer( mDataDir + "/points.shp", "points", "ogr" );
+  QgsVectorLayer *vlLines = new QgsVectorLayer( mDataDir + "/lines.shp", "lines", "ogr" );
+  QgsVectorLayer *vlPolys = new QgsVectorLayer( mDataDir + "/polys.shp", "polys", "ogr" );
+
+  QList<QgsVectorTileWriter::Layer> layers;
+  layers << QgsVectorTileWriter::Layer( vlPoints );
+  layers << QgsVectorTileWriter::Layer( vlLines );
+  layers << QgsVectorTileWriter::Layer( vlPolys );
+
+  QgsVectorTileWriter writer;
+  writer.setDestinationUri( ds.encodedUri() );
+  writer.setMaxZoom( 3 );
+  writer.setLayers( layers );
+
+  QgsTileMatrix tm0 = QgsTileMatrix::fromCustomDef( 0, QgsCoordinateReferenceSystem( "EPSG:3857" ), QgsPointXY( -20037508.3427892, 20037508.3427892 ), 40075016.6855784 );
+  writer.setRootTileMatrix( tm0 );
+  writer.setExtent( tm0.extent() );
+
+  const bool res = writer.writeTiles();
+  QVERIFY( res );
+  QVERIFY( writer.errorMessage().isEmpty() );
+
+  delete vlPoints;
+  delete vlLines;
+  delete vlPolys;
+
+  // check on the file level
+  const QDir dirInfo( tmpDir );
+  const QStringList dirFiles = dirInfo.entryList( QStringList( "*.pbf" ) );
+  QCOMPARE( dirFiles.count(), 8 );   // 1 tile at z0, 1 tile at z1, 2 tiles at z2, 4 tiles at z3
+  QVERIFY( dirFiles.contains( "custom3857-0-0-0.pbf" ) );
+
+  QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
+
+  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  QgsVectorTileMVTDecoder decoder;
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  QVERIFY( resDecode0 );
+  const QStringList layerNames = decoder.layers();
+  QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
+  const QStringList fieldNamesLines = decoder.layerFieldNames( "lines" );
+  QCOMPARE( fieldNamesLines, QStringList() << "Name" << "Value" );
+
+  QgsFields fieldsPolys;
+  fieldsPolys.append( QgsField( "Name", QVariant::String ) );
+  QMap<QString, QgsFields> perLayerFields;
+  perLayerFields["polys"] = fieldsPolys;
+  perLayerFields["lines"] = QgsFields();
+  perLayerFields["points"] = QgsFields();
+  QgsVectorTileFeatures features0 = decoder.layerFeatures( perLayerFields, QgsCoordinateTransform() );
+  QCOMPARE( features0["points"].count(), 17 );
+  QCOMPARE( features0["lines"].count(), 6 );
+  QCOMPARE( features0["polys"].count(), 10 );
+
+  QCOMPARE( features0["points"][0].geometry().wkbType(), QgsWkbTypes::Point );
+  QCOMPARE( features0["lines"][0].geometry().wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( features0["polys"][0].geometry().wkbType(), QgsWkbTypes::MultiPolygon );   // source geoms in shp are multipolygons
+
+  QgsAttributes attrsPolys0_0 = features0["polys"][0].attributes();
+  QCOMPARE( attrsPolys0_0.count(), 1 );
+  const QString attrNamePolys0_0 = attrsPolys0_0[0].toString();
+  QVERIFY( attrNamePolys0_0 == "Dam" || attrNamePolys0_0 == "Lake" );
+
+  delete vtLayer;
+}
+
+
+void TestQgsVectorTileWriter::test_z0TileMatrix2154()
+{
+  QTemporaryDir dir;
+  dir.setAutoRemove( false );  // so that we can inspect the results later
+  const QString tmpDir = dir.path();
+
+  QgsDataSourceUri ds;
+  ds.setParam( "type", "xyz" );
+  ds.setParam( "url", QUrl::fromLocalFile( tmpDir ).toString() + "/custom2154-{z}-{x}-{y}.pbf" );
+
+  QgsVectorLayer *vlPoints = new QgsVectorLayer( mDataDir + "/points.shp", "points", "ogr" );
+  QgsVectorLayer *vlLines = new QgsVectorLayer( mDataDir + "/lines.shp", "lines", "ogr" );
+  QgsVectorLayer *vlPolys = new QgsVectorLayer( mDataDir + "/polys.shp", "polys", "ogr" );
+
+  QList<QgsVectorTileWriter::Layer> layers;
+  layers << QgsVectorTileWriter::Layer( vlPoints );
+  layers << QgsVectorTileWriter::Layer( vlLines );
+  layers << QgsVectorTileWriter::Layer( vlPolys );
+
+  QgsVectorTileWriter writer;
+  writer.setDestinationUri( ds.encodedUri() );
+  writer.setMaxZoom( 3 );
+  writer.setLayers( layers );
+
+  const QgsCoordinateReferenceSystem crs( "EPSG:2154" );
+  const QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( "EPSG:4326" ), crs, QgsCoordinateTransformContext() );
+  QgsRectangle r = ct.transformBoundingBox( crs.bounds() );
+  double z0Dimension = r.width();
+  if ( r.height() > z0Dimension )
+  {
+    z0Dimension = r.height();
+  }
+  QgsTileMatrix tm0 = QgsTileMatrix::fromCustomDef( 0, crs, QgsPointXY( r.xMinimum(), r.yMaximum() ), z0Dimension );
+
+  writer.setRootTileMatrix( tm0 );
+  writer.setExtent( r );
+
+  const bool res = writer.writeTiles();
+  QVERIFY( res );
+  QVERIFY( writer.errorMessage().isEmpty() );
+
+  delete vlPoints;
+  delete vlLines;
+  delete vlPolys;
+
+  // check on the file level
+  const QDir dirInfo( tmpDir );
+  const QStringList dirFiles = dirInfo.entryList( QStringList( "*.pbf" ) );
+  QCOMPARE( dirFiles.count(), 8 );   // 1 tile at z0, 1 tile at z1, 2 tiles at z2, 4 tiles at z3
+  QVERIFY( dirFiles.contains( "custom2154-0-0-0.pbf" ) );
+
+  QgsVectorTileLayer *vtLayer = new QgsVectorTileLayer( ds.encodedUri(), "output" );
+
+  const QByteArray tile0 = vtLayer->getRawTile( QgsTileXYZ( 0, 0, 0 ) );
+  QgsVectorTileMVTDecoder decoder;
+  const bool resDecode0 = decoder.decode( QgsTileXYZ( 0, 0, 0 ), tile0 );
+  QVERIFY( resDecode0 );
+  const QStringList layerNames = decoder.layers();
+  QCOMPARE( layerNames, QStringList() << "points" << "lines" << "polys" );
+  const QStringList fieldNamesLines = decoder.layerFieldNames( "lines" );
+  QCOMPARE( fieldNamesLines, QStringList() << "Name" << "Value" );
+
+  QgsFields fieldsPolys;
+  fieldsPolys.append( QgsField( "Name", QVariant::String ) );
+  QMap<QString, QgsFields> perLayerFields;
+  perLayerFields["polys"] = fieldsPolys;
+  perLayerFields["lines"] = QgsFields();
+  perLayerFields["points"] = QgsFields();
+  QgsVectorTileFeatures features0 = decoder.layerFeatures( perLayerFields, QgsCoordinateTransform() );
+  QCOMPARE( features0["points"].count(), 17 );
+  QCOMPARE( features0["lines"].count(), 6 );
+  QCOMPARE( features0["polys"].count(), 10 );
+
+  QCOMPARE( features0["points"][0].geometry().wkbType(), QgsWkbTypes::Point );
+  QCOMPARE( features0["lines"][0].geometry().wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( features0["polys"][0].geometry().wkbType(), QgsWkbTypes::MultiPolygon );   // source geoms in shp are multipolygons
+
+  QgsAttributes attrsPolys0_0 = features0["polys"][0].attributes();
+  QCOMPARE( attrsPolys0_0.count(), 1 );
+  const QString attrNamePolys0_0 = attrsPolys0_0[0].toString();
+  QVERIFY( attrNamePolys0_0 == "Dam" || attrNamePolys0_0 == "Lake" );
+
+  delete vtLayer;
 }
 
 


### PR DESCRIPTION
## Description

The Mapbox Vector Tile specification provides these definitions for projection and bounds.

A Vector Tile represents data based on a square extent within a projection. A Vector Tile SHOULD NOT contain information about its bounds and projection. The file format assumes that the decoder knows the bounds and projection of a Vector Tile before decoding it.

Web Mercator is the projection of reference, and the Google tile scheme is the tile extent convention of reference. Together, they provide a 1-to-1 relationship between a specific geographical area, at a specific level of detail, and a path such as https://example.com/17/65535/43602.mvt.

Vector Tiles MAY be used to represent data with any projection and tile extent scheme.

It is possible to encode and write vector tiles in different CRS than EPSG:3857.

The implementation used the CRS bounds to defined the tile 0 top left coordinates and the scale denominator for 0 zoom level.

* Funded by Ifremer