### PR TITLE
Vector vrt files should be marked as potential containers

### DIFF
--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -623,6 +623,7 @@ QStringList QgsGdalUtils::multiLayerFileExtensions()
     QStringLiteral( "gpx" ),
     QStringLiteral( "pdf" ),
     QStringLiteral( "pbf" ),
+    QStringLiteral( "vrt" ),
     QStringLiteral( "nc" ),
     QStringLiteral( "shp.zip" ) };
   return SUPPORTED_DB_LAYERS_EXTENSIONS;

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -676,7 +676,7 @@ void TestQgsGdalProvider::testGdalProviderQuerySublayersFastScan()
   QCOMPARE( res.at( 0 ).uri(), QStringLiteral( TEST_DATA_DIR ) + "/raster/hub13263.vrt" );
   QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
   QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
-  QVERIFY( !res.at( 0 ).skippedContainerScan() );
+  QVERIFY( res.at( 0 ).skippedContainerScan() );
 }
 
 QGSTEST_MAIN( TestQgsGdalProvider )

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2175,7 +2175,7 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(res[0].uri(), os.path.join(TEST_DATA_DIR, "vector_vrt.vrt"))
         self.assertEqual(res[0].providerKey(), "ogr")
         self.assertEqual(res[0].type(), QgsMapLayerType.VectorLayer)
-        self.assertFalse(res[0].skippedContainerScan())
+        self.assertTrue(res[0].skippedContainerScan())
 
         # raster vrt
         res = metadata.querySublayers(os.path.join(TEST_DATA_DIR, "/raster/hub13263.vrt"), Qgis.SublayerQueryFlag.FastScan)


### PR DESCRIPTION
Matches behaviour on GDAL <3.4 builds with GDAL >= 3.4 builds
