### PR TITLE
DB Manager > Change logging :Fix behaviour of generated triggers when logging an existing layer

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/plugins/versioning/DlgVersioning.ui
+++ b/python/plugins/db_manager/db_plugins/postgis/plugins/versioning/DlgVersioning.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Table should be empty, with a primary key</string>
+        <string>Table should have a primary key</string>
        </property>
       </widget>
      </item>

--- a/python/plugins/db_manager/db_plugins/postgis/plugins/versioning/dlg_versioning.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugins/versioning/dlg_versioning.py
@@ -175,7 +175,7 @@ class DlgVersioning(QDialog, Ui_DlgVersioning):
         QMessageBox.information(self, "Help", helpText)
 
     def sql_alterTable(self):
-        return u"ALTER TABLE %s ADD %s serial, ADD %s timestamp, ADD %s timestamp, ADD %s varchar;" % (
+        return u"ALTER TABLE %s ADD %s serial, ADD %s timestamp default '-infinity', ADD %s timestamp, ADD %s varchar;" % (
             self.schematable, self.colPkey, self.colStart, self.colEnd, self.colUser)
 
     def sql_setPkey(self):


### PR DESCRIPTION
## Description

Adding logging to a layer with existing features and editing one duplicates this feature the first time.

Step to reproduce:

- have a postgis layer with some features
- use db manager to initiate logging/versioning
- edit one feature

The feature is duplicated in the `_current` view.

## Cause

When adding logging via db manager to an existing layer, all the
time_start of existing features are still null. When we modify one
feature for the first time, the update trigger fires and insert a row
for the past state of the feature. In turn, this fires the INSERT
trigger for this row, and the execution goes inside the `if
NEW.time_start is NULL`, which set the end timestamp to NULL, making the
old row still visible in the _current view.

In other word, the insert trigger makes the assumption that a null start
timestamp means now, which is not true in the case described above.

## Proposed solution

This commit fixes this assumption by initially setting it to `-infinity`
for existing rows.

