### PR TITLE
Add external storage file widget drag'n drop support

### DIFF
--- a/python/gui/auto_generated/qgsexternalstoragefilewidget.sip.in
+++ b/python/gui/auto_generated/qgsexternalstoragefilewidget.sip.in
@@ -155,6 +155,9 @@ It defines the variable containing the user selected file name
 .. versionadded:: 3.22
 %End
 
+    virtual void setReadOnly( bool readOnly );
+
+
   protected:
 
     virtual void updateLayout();
@@ -167,6 +170,12 @@ It defines the variable containing the user selected file name
 %Docstring
 Add file widget specific scope to expression context
 %End
+
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+
+    virtual void dropEvent( QDropEvent *event );
+
 
 };
 

--- a/python/gui/auto_generated/qgsfilewidget.sip.in
+++ b/python/gui/auto_generated/qgsfilewidget.sip.in
@@ -74,7 +74,7 @@ Sets the current file ``path``.
 .. seealso:: :py:func:`filePath`
 %End
 
-    void setReadOnly( bool readOnly );
+    virtual void setReadOnly( bool readOnly );
 %Docstring
 Sets whether the widget should be read only.
 %End

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -55,6 +55,7 @@ QgsExternalResourceWidget::QgsExternalResourceWidget( QWidget *parent )
 
 #ifdef WITH_QTWEBKIT
   mWebView = new QWebView( this );
+  mWebView->setAcceptDrops( false );
   layout->addWidget( mWebView, 2, 0 );
 #endif
 

--- a/src/gui/qgsexternalstoragefilewidget.h
+++ b/src/gui/qgsexternalstoragefilewidget.h
@@ -159,6 +159,8 @@ class GUI_EXPORT QgsExternalStorageFileWidget : public QgsFileWidget
      */
     static QgsExpressionContextScope *createFileWidgetScope();
 
+    void setReadOnly( bool readOnly ) override;
+
   protected:
 
     void updateLayout() override;
@@ -170,6 +172,10 @@ class GUI_EXPORT QgsExternalStorageFileWidget : public QgsFileWidget
      */
     void addFileWidgetScope();
 
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+
+    void dropEvent( QDropEvent *event ) override;
+
   private:
 
     // stores \a fileNames files using current external storage.
@@ -177,6 +183,9 @@ class GUI_EXPORT QgsExternalStorageFileWidget : public QgsFileWidget
     // fileNames. When all files have been successfully stored, current mFilePath
     // is updated
     void storeExternalFiles( QStringList fileNames, QStringList storedUrls = QStringList() );
+
+    //! Update whether the widget accept drop or not
+    void updateAcceptDrops();
 
     bool mStoreInProgress = false;
 

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -496,7 +496,7 @@ void QgsFileDropEdit::setFilters( const QString &filters )
   }
 }
 
-QString QgsFileDropEdit::acceptableFilePath( QDropEvent *event ) const
+QStringList QgsFileDropEdit::acceptableFilePaths( QDropEvent *event ) const
 {
   QStringList rawPaths;
   QStringList paths;
@@ -553,6 +553,12 @@ QString QgsFileDropEdit::acceptableFilePath( QDropEvent *event ) const
     }
   }
 
+  return paths;
+}
+
+QString QgsFileDropEdit::acceptableFilePath( QDropEvent *event ) const
+{
+  const QStringList paths = acceptableFilePaths( event );
   if ( paths.size() > 1 )
   {
     return QStringLiteral( "\"%1\"" ).arg( paths.join( QLatin1String( "\" \"" ) ) );

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -116,7 +116,7 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     /**
      * Sets whether the widget should be read only.
      */
-    void setReadOnly( bool readOnly );
+    virtual void setReadOnly( bool readOnly );
 
     /**
      * Returns the open file dialog title.
@@ -380,6 +380,9 @@ class GUI_EXPORT QgsFileDropEdit: public QgsHighlightableLineEdit
 
     void setFilters( const QString &filters );
 
+    //! Returns file names if object meets drop criteria.
+    QStringList acceptableFilePaths( QDropEvent *event ) const;
+
   signals:
 
     /**
@@ -389,14 +392,15 @@ class GUI_EXPORT QgsFileDropEdit: public QgsHighlightableLineEdit
 
   protected:
 
+    //! Returns file name if object meets drop criteria.
+    QString acceptableFilePath( QDropEvent *event ) const;
+
     void dragEnterEvent( QDragEnterEvent *event ) override;
     void dragLeaveEvent( QDragLeaveEvent *event ) override;
     void dropEvent( QDropEvent *event ) override;
 
   private:
 
-    //! Returns file name if object meets drop criteria.
-    QString acceptableFilePath( QDropEvent *event ) const;
 
     QStringList mAcceptableExtensions;
     QgsFileWidget::StorageMode mStorageMode = QgsFileWidget::GetFile;


### PR DESCRIPTION
Follows #44533

Add the possibility to drag'n drop a file directly on an external resource widget when an external storage has been defined

![dnd](https://user-images.githubusercontent.com/14358135/130989712-a949068b-0bb2-4d23-bcd0-dc802c030eaa.gif)

cc @Jean-Roc 
for review @3nids 

**Funded by Lille Metropole**