### PR TITLE
[CI] Wait for Webdav to be ready

### DIFF
--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -175,7 +175,17 @@ EOT
 
 fi
 
+#######################################
+# Wait for WebDAV container to be ready
+#######################################
 
+echo "Wait for webdav to be ready..."
+while ! curl -f -X GET -u qgis:myPasswd! http://$QGIS_WEBDAV_HOST:$QGIS_WEBDAV_PORT/webdav_tests/ &> /dev/null;
+do
+  sleep 1
+  printf "."
+done
+echo "done"
 
 ###########
 # Run tests

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -193,7 +193,6 @@ if [ $# -eq 0 ] || [ $1 = "ALL_BUT_PROVIDERS" ] || [ $1 = "ALL" ] ; then
   done
   if [[ ${COUNT} -eq 41 ]]; then
     echo "Error: WebDAV docker timeout!!!"
-    exit 1
   else
     echo "done"
   fi

--- a/.docker/docker-qgis-test.sh
+++ b/.docker/docker-qgis-test.sh
@@ -179,13 +179,25 @@ fi
 # Wait for WebDAV container to be ready
 #######################################
 
-echo "Wait for webdav to be ready..."
-while ! curl -f -X GET -u qgis:myPasswd! http://$QGIS_WEBDAV_HOST:$QGIS_WEBDAV_PORT/webdav_tests/ &> /dev/null;
-do
-  sleep 1
-  printf "."
-done
-echo "done"
+if [ $# -eq 0 ] || [ $1 = "ALL_BUT_PROVIDERS" ] || [ $1 = "ALL" ] ; then
+
+  echo "Wait for webdav to be ready..."
+  COUNT=0
+  while ! curl -f -X GET -u qgis:myPasswd! http://$QGIS_WEBDAV_HOST:$QGIS_WEBDAV_PORT/webdav_tests/ &> /dev/null;
+  do
+    printf "."
+    sleep 5
+    if [[ $(( COUNT++ )) -eq 40 ]]; then
+      break
+    fi
+  done
+  if [[ ${COUNT} -eq 41 ]]; then
+    echo "Error: WebDAV docker timeout!!!"
+    exit 1
+  else
+    echo "done"
+  fi
+fi
 
 ###########
 # Run tests


### PR DESCRIPTION
It [happens](https://github.com/qgis/QGIS/pull/44832/checks?check_run_id=3428426882) that Webdav external storage test reaches timeout. 

Normally the test only last one second, so one possible reason is that the NGINX docker isn't ready to answer HTTP requests. This PR makes the test to wait the Nginx server to be ready. 

I'm not 100% sure it comes from this. If the tests timeout even with this, I'll have to find something else...