### PR TITLE
[ogr] Whenever we open a dataset, use the LIST_ALL_TABLES=YES open option

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -966,6 +966,7 @@ GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUp
   CPLErrorReset();
 
   char **papszOpenOptions = CSLDuplicate( papszOpenOptionsIn );
+  papszOpenOptions = CSLAddString( papszOpenOptions, "LIST_ALL_TABLES=YES" );
 
   QString filePath( QString::fromUtf8( pszPath ) );
 


### PR DESCRIPTION
If we don't set this then it's impossible to open a table which
is only returned by GDAL when the LIST_ALL_TABLES=YES option is
set, as the dataset layers will not have included these layers
and calls to GDALDataset::GetLayerByName will fail
