### PR TITLE
Virtual layer ui updates

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -42,6 +42,7 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
 {
   setupUi( this );
   setupButtons( buttonBox );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVirtualLayerSourceSelect::showHelp );
 
   mQueryEdit->setLineNumbersVisible( true );
 
@@ -418,4 +419,9 @@ void QgsVirtualLayerSourceSelect::addButtonClicked()
   {
     accept();
   }
+}
+
+void QgsVirtualLayerSourceSelect::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#creating-virtual-layers" ) );
 }

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -235,6 +235,19 @@ bool QgsVirtualLayerSourceSelect::preFlight()
       }
       else
       {
+        if ( mGeometryRadio->isChecked() && mCRS->text().isEmpty() )
+        {
+          // warning when the geometryRadio is checked, but the user did not set a proper crs
+          // old implementation did NOT set a crs then...
+          if ( QMessageBox::Yes == QMessageBox::question( nullptr, tr( "Test Virtual Layer " ), tr( "No CRS defined, are you sure you want to create a layer without a crs?" ), QMessageBox::Yes | QMessageBox::No ) )
+          {
+            return true;
+          }
+          else
+          {
+            return false;
+          }
+        }
         return true;
       }
     }

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -64,6 +64,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     QgsEmbeddedLayerSelectDialog *mEmbeddedSelectionDialog = nullptr;
     void addEmbeddedLayer( const QString &name, const QString &provider, const QString &encoding, const QString &source );
     QgsLayerTreeView *mTreeView  = nullptr;
+    bool preFlight();
 };
 
 #endif

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -21,6 +21,7 @@ email                : hugo dot mercier at oslandia dot com
 
 #include "ui_qgsvirtuallayersourceselectbase.h"
 #include "qgis.h"
+#include "qgshelp.h"
 #include "qgsguiutils.h"
 #include "qgsvirtuallayerdefinition.h"
 #include "qgsproviderregistry.h"
@@ -43,6 +44,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void refresh() override;
     void addButtonClicked() override;
 
+
   private slots:
     void testQuery();
     void browseCRS();
@@ -52,6 +54,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void importLayer();
     void tableRowChanged( const QModelIndex &current, const QModelIndex &previous );
     void updateLayersList();
+    void showHelp();
 
 
   private:


### PR DESCRIPTION
See also: https://lists.osgeo.org/pipermail/qgis-developer/2021-August/063961.html

When testing the Virtual Layer functionality we had some UI issues. 

Some of them I try to address in this PR:

- the help button did not bring you to the documentation help
- the checkbox/input for the Unique Identifier column worked pretty quirky (also: WHAT is it for actually????):
  - you could uncheck it (with a value in the input) and then it still took it into account
  - the check for the fields validity was never reached
  - if you checked it you could still leave the field empty (but.. what happened?)
- when (re)defining the geometry, the default would result in a layer without CRS, you get asked for that now
- when you click the Add button, the same tests will be done as when you click the Test button (before you would just have an invalid layer)

One thing that I would(!) like to address, but could not find a way to:
- when you use the context menu 'update virtual layer' on an existing layer, the dialog reacts like you want to create a new one or a copy: asking you  a question on which you can only answer OK or Cancel 
It would be nice if you do the 'update', that you will just update the existing one (if you want to create a duplicate of the layer, use 'duplicate')
So: Question: IS there a way to distinguish between the 'creation of a new VL' and the 'update of a VL'? If so you could for example disable the layername part in the dialog or change the Add button caption to Ok or so...
