### PR TITLE
Add framework for querying annotation layer items within bounds

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -651,3 +651,8 @@ Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__ = "Indicates that users a
 Qgis.MapLayerProperty.__doc__ = 'Generic map layer properties.\n\n.. versionadded:: 3.22\n\n' + '* ``UsersCannotToggleEditing``: ' + Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__
 # --
 Qgis.MapLayerProperty.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.AnnotationItemFlag.ScaleDependentBoundingBox.__doc__ = "Item's bounding box will vary depending on map scale"
+Qgis.AnnotationItemFlag.__doc__ = 'Flags for annotation items.\n\n.. versionadded:: 3.22\n\n' + '* ``ScaleDependentBoundingBox``: ' + Qgis.AnnotationItemFlag.ScaleDependentBoundingBox.__doc__
+# --
+Qgis.AnnotationItemFlag.baseClass = Qgis

--- a/python/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -75,6 +75,11 @@ Returns a unique (untranslated) string identifying the type of item.
 Returns the bounding box of the item's geographic location, in the parent layer's coordinate reference system.
 %End
 
+    virtual QgsRectangle boundingBox( const QgsRenderContext &context ) const;
+%Docstring
+Returns the bounding box of the item's geographic location, in the parent layer's coordinate reference system.
+%End
+
     virtual void render( QgsRenderContext &context, QgsFeedback *feedback ) = 0;
 %Docstring
 Renders the item to the specified render ``context``.

--- a/python/core/auto_generated/annotations/qgsannotationitem.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitem.sip.in
@@ -53,6 +53,13 @@ Constructor for an annotation item.
 
     virtual ~QgsAnnotationItem();
 
+    virtual Qgis::AnnotationItemFlags flags() const;
+%Docstring
+Returns item flags.
+
+.. versionadded:: 3.22
+%End
+
     virtual QgsAnnotationItem *clone() = 0 /Factory/;
 %Docstring
 Returns a clone of the item. Ownership is transferred to the caller.

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -100,9 +100,10 @@ Returns the item with the specified ``id``, or ``None`` if no matching item was 
 .. versionadded:: 3.22
 %End
 
-    QStringList itemsInBounds( const QgsRectangle &bounds, QgsFeedback *feedback = 0 ) const;
+    QStringList itemsInBounds( const QgsRectangle &bounds, const QgsRenderContext &context, QgsFeedback *feedback = 0 ) const;
 %Docstring
-Returns a list of the IDs of all annotation items within the specified ``bounds``.
+Returns a list of the IDs of all annotation items within the specified ``bounds`` (in layer CRS), when
+rendered using the given render ``context``.
 
 The optional ``feedback`` argument can be used to cancel the search early.
 

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -132,8 +132,11 @@ The optional ``feedback`` argument can be used to cancel the search early.
 
     virtual bool supportsEditing() const;
 
+    virtual QgsDataProvider *dataProvider();
+
 
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/annotations/qgsannotationpointtextitem.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationpointtextitem.sip.in
@@ -29,6 +29,8 @@ Constructor for QgsAnnotationPointTextItem, containing the specified ``text`` at
 %End
     ~QgsAnnotationPointTextItem();
 
+    virtual Qgis::AnnotationItemFlags flags() const;
+
     virtual QString type() const;
 
     virtual void render( QgsRenderContext &context, QgsFeedback *feedback );
@@ -46,6 +48,8 @@ Creates a new text at point annotation item.
     virtual QgsAnnotationPointTextItem *clone() /Factory/;
 
     virtual QgsRectangle boundingBox() const;
+
+    virtual QgsRectangle boundingBox( const QgsRenderContext &context ) const;
 
 
     QgsPointXY point() const;

--- a/python/core/auto_generated/annotations/qgsrenderedannotationitemdetails.sip.in
+++ b/python/core/auto_generated/annotations/qgsrenderedannotationitemdetails.sip.in
@@ -1,0 +1,57 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/annotations/qgsrenderedannotationitemdetails.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRenderedAnnotationItemDetails : QgsRenderedItemDetails
+{
+%Docstring(signature="appended")
+Contains information about a rendered annotation item.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsrenderedannotationitemdetails.h"
+%End
+  public:
+
+    QgsRenderedAnnotationItemDetails( const QString &layerId, const QString &itemId );
+%Docstring
+Constructor for QgsRenderedAnnotationItemDetails.
+%End
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString str = QStringLiteral( "<QgsRenderedAnnotationItemDetails: %1 - %2>" ).arg( sipCpp->layerId(), sipCpp->itemId() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
+    virtual QgsRenderedAnnotationItemDetails *clone() const /Factory/;
+
+
+    QString layerId() const;
+%Docstring
+Returns the layer ID of the associated map layer.
+%End
+
+    QString itemId() const;
+%Docstring
+Returns the item ID of the associated annotation item.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/annotations/qgsrenderedannotationitemdetails.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprendererjob.sip.in
@@ -49,6 +49,8 @@ The following subclasses are available:
 
     QgsMapRendererJob( const QgsMapSettings &settings );
 
+    ~QgsMapRendererJob();
+
     void start();
 %Docstring
 Start the rendering job and immediately return.
@@ -95,6 +97,15 @@ Gets pointer to internal labeling engine (in order to get access to the results)
 This should not be used if cached labeling was redrawn - see :py:func:`~QgsMapRendererJob.usedCachedLabels`.
 
 .. seealso:: :py:func:`usedCachedLabels`
+%End
+
+    QgsRenderedItemResults *takeRenderedItemResults() /Transfer/;
+%Docstring
+Takes the rendered item results from the map render job and returns them.
+
+Ownership is transferred to the caller.
+
+.. versionadded:: 3.22
 %End
 
     void setFeatureFilterProvider( const QgsFeatureFilterProvider *f );
@@ -175,6 +186,7 @@ emitted when asynchronous rendering is finished (or canceled).
 %End
 
   protected:
+
 
 
 

--- a/python/core/auto_generated/maprenderer/qgsrendereditemresults.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsrendereditemresults.sip.in
@@ -1,0 +1,53 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/maprenderer/qgsrendereditemresults.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsRenderedItemResults
+{
+%Docstring(signature="appended")
+Stores collated details of rendered items during a map rendering operation.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsrendereditemresults.h"
+%End
+  public:
+    QgsRenderedItemResults();
+    ~QgsRenderedItemResults();
+
+
+    QList< QgsRenderedItemDetails * > renderedItems() const;
+%Docstring
+Returns a list of all rendered items.
+%End
+
+    QList<const QgsRenderedAnnotationItemDetails *> renderedAnnotationItemsInBounds( const QgsRectangle &bounds ) const;
+%Docstring
+Returns a list with details of the rendered annotation items within the specified ``bounds``.
+
+.. versionadded:: 3.22
+%End
+
+
+  private:
+    QgsRenderedItemResults( const QgsRenderedItemResults & );
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/maprenderer/qgsrendereditemresults.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -467,6 +467,13 @@ The development version
     typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
 
 
+    enum class AnnotationItemFlag
+    {
+      ScaleDependentBoundingBox,
+    };
+    typedef QFlags<Qgis::AnnotationItemFlag> AnnotationItemFlags;
+
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;
@@ -553,6 +560,8 @@ QFlags<Qgis::BabelCommandFlag> operator|(Qgis::BabelCommandFlag f1, QFlags<Qgis:
 QFlags<Qgis::GeometryValidityFlag> operator|(Qgis::GeometryValidityFlag f1, QFlags<Qgis::GeometryValidityFlag> f2);
 
 QFlags<Qgis::FileOperationFlag> operator|(Qgis::FileOperationFlag f1, QFlags<Qgis::FileOperationFlag> f2);
+
+QFlags<Qgis::AnnotationItemFlag> operator|(Qgis::AnnotationItemFlag f1, QFlags<Qgis::AnnotationItemFlag> f2);
 
 
 

--- a/python/core/auto_generated/qgsmaplayerrenderer.sip.in
+++ b/python/core/auto_generated/qgsmaplayerrenderer.sip.in
@@ -110,10 +110,34 @@ least partially) some data
 %End
 
 
+    QList< QgsRenderedItemDetails * > takeRenderedItemDetails() /TransferBack/;
+%Docstring
+Takes the list of rendered item details from the renderer.
+
+Ownership of items is transferred to the caller.
+
+.. seealso:: :py:func:`appendRenderedItemDetails`
+
+.. versionadded:: 3.22
+%End
+
   protected:
 
 
 
+
+    void appendRenderedItemDetails( QgsRenderedItemDetails *details /Transfer/ );
+%Docstring
+Appends the ``details`` of a rendered item to the renderer.
+
+Rendered item details can be retrieved by calling :py:func:`~QgsMapLayerRenderer.takeRenderedItemDetails`.
+
+Ownership of ``details`` is transferred to the renderer.
+
+.. seealso:: :py:func:`takeRenderedItemDetails`
+
+.. versionadded:: 3.22
+%End
 
 };
 

--- a/python/core/auto_generated/qgsrendereditemdetails.sip.in
+++ b/python/core/auto_generated/qgsrendereditemdetails.sip.in
@@ -1,0 +1,61 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsrendereditemdetails.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRenderedItemDetails
+{
+%Docstring(signature="appended")
+Base class for detailed information about a rendered item.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsrendereditemdetails.h"
+%End
+  public:
+
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsRenderedAnnotationItemDetails *>( sipCpp ) )
+      sipType = sipType_QgsRenderedAnnotationItemDetails;
+    else
+      sipType = 0;
+%End
+
+    virtual ~QgsRenderedItemDetails();
+
+    virtual QgsRenderedItemDetails *clone() const = 0 /Factory/;
+%Docstring
+Clones the details.
+%End
+
+    QgsRectangle boundingBox() const;
+%Docstring
+Returns the bounding box of the item (in map units).
+
+.. seealso:: :py:func:`setBoundingBox`
+%End
+
+    void setBoundingBox( const QgsRectangle &bounds );
+%Docstring
+Sets the bounding box of the item (in map units).
+
+.. seealso:: :py:func:`boundingBox`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsrendereditemdetails.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -152,6 +152,7 @@
 %Include auto_generated/qgsrenderchecker.sip
 %Include auto_generated/qgsrendercontext.sip
 %Include auto_generated/qgsrenderedfeaturehandlerinterface.sip
+%Include auto_generated/qgsrendereditemdetails.sip
 %Include auto_generated/qgsrunprocess.sip
 %Include auto_generated/qgsruntimeprofiler.sip
 %Include auto_generated/qgsscalecalculator.sip
@@ -212,6 +213,7 @@
 %Include auto_generated/annotations/qgsannotationpointtextitem.sip
 %Include auto_generated/annotations/qgsannotationpolygonitem.sip
 %Include auto_generated/annotations/qgshtmlannotation.sip
+%Include auto_generated/annotations/qgsrenderedannotationitemdetails.sip
 %Include auto_generated/annotations/qgssvgannotation.sip
 %Include auto_generated/annotations/qgstextannotation.sip
 %Include auto_generated/auth/qgsauthcertutils.sip
@@ -419,6 +421,7 @@
 %Include auto_generated/maprenderer/qgsmaprendererparalleljob.sip
 %Include auto_generated/maprenderer/qgsmaprenderersequentialjob.sip
 %Include auto_generated/maprenderer/qgsmaprenderertask.sip
+%Include auto_generated/maprenderer/qgsrendereditemresults.sip
 %Include auto_generated/mesh/qgsmesh3daveraging.sip
 %Include auto_generated/mesh/qgsmesheditor.sip
 %Include auto_generated/mesh/qgsmeshdataprovider.sip

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -117,6 +117,17 @@ as a result of an ongoing canvas render) will not be returned, and instead ``Non
 .. versionadded:: 2.4
 %End
 
+    const QgsRenderedItemResults *renderedItemResults( bool allowOutdatedResults = true ) const;
+%Docstring
+Gets access to the rendered item results (may be ``None``), which includes the results of rendering
+annotation items in the canvas map.
+
+If the ``allowOutdatedResults`` flag is ``False`` then outdated rendered item results (e.g.
+as a result of an ongoing canvas render) will not be returned, and instead ``None`` will be returned.
+
+.. versionadded:: 3.22
+%End
+
     void setCachingEnabled( bool enabled );
 %Docstring
 Set whether to cache images of rendered layers

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -174,6 +174,7 @@ set(QGIS_CORE_SRCS
   auth/qgsauthmethodregistry.cpp
 
   annotations/qgsannotation.cpp
+  annotations/qgsannotationitem.cpp
   annotations/qgsannotationitemregistry.cpp
   annotations/qgsannotationlayer.cpp
   annotations/qgsannotationlayerrenderer.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -184,6 +184,7 @@ set(QGIS_CORE_SRCS
   annotations/qgsannotationpointtextitem.cpp
   annotations/qgsannotationpolygonitem.cpp
   annotations/qgshtmlannotation.cpp
+  annotations/qgsrenderedannotationitemdetails.cpp
   annotations/qgssvgannotation.cpp
   annotations/qgstextannotation.cpp
 
@@ -397,6 +398,7 @@ set(QGIS_CORE_SRCS
   qgsmaplayerlegend.cpp
   qgsmaplayermodel.cpp
   qgsmaplayerproxymodel.cpp
+  qgsmaplayerrenderer.cpp
   qgsmaplayerstore.cpp
   qgsmaplayerstyle.cpp
   qgsmaplayerstylemanager.cpp
@@ -448,6 +450,7 @@ set(QGIS_CORE_SRCS
   qgsremappingproxyfeaturesink.cpp
   qgsrenderchecker.cpp
   qgsrendercontext.cpp
+  qgsrendereditemdetails.cpp
   qgsrunprocess.cpp
   qgsruntimeprofiler.cpp
   qgsscalecalculator.cpp
@@ -588,6 +591,7 @@ set(QGIS_CORE_SRCS
   maprenderer/qgsmaprenderersequentialjob.cpp
   maprenderer/qgsmaprendererstagedrenderjob.cpp
   maprenderer/qgsmaprenderertask.cpp
+  maprenderer/qgsrendereditemresults.cpp
 
   pal/costcalculator.cpp
   pal/feature.cpp
@@ -1084,6 +1088,7 @@ set(QGIS_CORE_HDRS
   qgsrenderchecker.h
   qgsrendercontext.h
   qgsrenderedfeaturehandlerinterface.h
+  qgsrendereditemdetails.h
   qgsrunprocess.h
   qgsruntimeprofiler.h
   qgsscalecalculator.h
@@ -1158,6 +1163,7 @@ set(QGIS_CORE_HDRS
   annotations/qgsannotationpolygonitem.h
   annotations/qgsannotationregistry.h
   annotations/qgshtmlannotation.h
+  annotations/qgsrenderedannotationitemdetails.h
   annotations/qgssvgannotation.h
   annotations/qgstextannotation.h
 
@@ -1403,6 +1409,7 @@ set(QGIS_CORE_HDRS
   maprenderer/qgsmaprenderersequentialjob.h
   maprenderer/qgsmaprendererstagedrenderjob.h
   maprenderer/qgsmaprenderertask.h
+  maprenderer/qgsrendereditemresults.h
 
   mesh/qgsmesh3daveraging.h
   mesh/qgsmesheditor.h

--- a/src/core/annotations/qgsannotationitem.cpp
+++ b/src/core/annotations/qgsannotationitem.cpp
@@ -1,0 +1,23 @@
+/***************************************************************************
+                             qgsannotationitem.cpp
+                             -----------------
+    begin                : August 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationitem.h"
+
+Qgis::AnnotationItemFlags QgsAnnotationItem::flags() const
+{
+  return Qgis::AnnotationItemFlags();
+}

--- a/src/core/annotations/qgsannotationitem.h
+++ b/src/core/annotations/qgsannotationitem.h
@@ -80,6 +80,13 @@ class CORE_EXPORT QgsAnnotationItem
     virtual ~QgsAnnotationItem() = default;
 
     /**
+     * Returns item flags.
+     *
+     * \since QGIS 3.22
+     */
+    virtual Qgis::AnnotationItemFlags flags() const;
+
+    /**
      * Returns a clone of the item. Ownership is transferred to the caller.
      */
     virtual QgsAnnotationItem *clone() = 0 SIP_FACTORY;

--- a/src/core/annotations/qgsannotationitem.h
+++ b/src/core/annotations/qgsannotationitem.h
@@ -102,6 +102,11 @@ class CORE_EXPORT QgsAnnotationItem
     virtual QgsRectangle boundingBox() const = 0;
 
     /**
+     * Returns the bounding box of the item's geographic location, in the parent layer's coordinate reference system.
+     */
+    virtual QgsRectangle boundingBox( const QgsRenderContext &context ) const { Q_UNUSED( context ) return boundingBox();}
+
+    /**
      * Renders the item to the specified render \a context.
      *
      * The \a feedback argument can be used to detect render cancellations during expensive

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -103,12 +103,14 @@ QgsAnnotationLayer::QgsAnnotationLayer( const QString &name, const LayerOptions 
 {
   mShouldValidateCrs = false;
   mValid = true;
+  mDataProvider = new QgsAnnotationLayerDataProvider( QgsDataProvider::ProviderOptions(), QgsDataProvider::ReadFlags() );
 }
 
 QgsAnnotationLayer::~QgsAnnotationLayer()
 {
   emit willBeDeleted();
   qDeleteAll( mItems );
+  delete mDataProvider;
 }
 
 void QgsAnnotationLayer::reset()
@@ -385,3 +387,50 @@ bool QgsAnnotationLayer::supportsEditing() const
 {
   return true;
 }
+
+QgsDataProvider *QgsAnnotationLayer::dataProvider()
+{
+  return mDataProvider;
+}
+
+const QgsDataProvider *QgsAnnotationLayer::dataProvider() const
+{
+  return mDataProvider;
+}
+
+
+//
+// QgsAnnotationLayerDataProvider
+//
+///@cond PRIVATE
+QgsAnnotationLayerDataProvider::QgsAnnotationLayerDataProvider(
+  const ProviderOptions &options,
+  QgsDataProvider::ReadFlags flags )
+  : QgsDataProvider( QString(), options, flags )
+{}
+
+QgsCoordinateReferenceSystem QgsAnnotationLayerDataProvider::crs() const
+{
+  return QgsCoordinateReferenceSystem();
+}
+
+QString QgsAnnotationLayerDataProvider::name() const
+{
+  return QStringLiteral( "annotation" );
+}
+
+QString QgsAnnotationLayerDataProvider::description() const
+{
+  return QString();
+}
+
+QgsRectangle QgsAnnotationLayerDataProvider::extent() const
+{
+  return QgsRectangle();
+}
+
+bool QgsAnnotationLayerDataProvider::isValid() const
+{
+  return true;
+}
+///@endcond

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -152,6 +152,9 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     const QgsDataProvider *dataProvider() const override SIP_SKIP;
 
   private:
+
+    QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
+
     QMap<QString, QgsAnnotationItem *> mItems;
     QgsCoordinateTransformContext mTransformContext;
 
@@ -159,8 +162,6 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QSet< QString > mNonIndexedItems;
 
     QgsDataProvider *mDataProvider = nullptr;
-
-    QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
 
     friend class QgsAnnotationLayerRenderer;
 

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -148,6 +148,8 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories ) override;
     bool isEditable() const override;
     bool supportsEditing() const override;
+    QgsDataProvider *dataProvider() override;
+    const QgsDataProvider *dataProvider() const override SIP_SKIP;
 
   private:
     QMap<QString, QgsAnnotationItem *> mItems;
@@ -156,10 +158,37 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     std::unique_ptr< QgsAnnotationLayerSpatialIndex > mSpatialIndex;
     QSet< QString > mNonIndexedItems;
 
+    QgsDataProvider *mDataProvider = nullptr;
+
     QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
 
     friend class QgsAnnotationLayerRenderer;
 
 };
+
+#ifndef SIP_RUN
+///@cond PRIVATE
+
+/**
+ * A minimal data provider for annotation layers.
+ *
+ * \since QGIS 3.22
+ */
+class QgsAnnotationLayerDataProvider : public QgsDataProvider
+{
+    Q_OBJECT
+
+  public:
+    QgsAnnotationLayerDataProvider( const QgsDataProvider::ProviderOptions &providerOptions,
+                                    QgsDataProvider::ReadFlags flags );
+    QgsCoordinateReferenceSystem crs() const override;
+    QString name() const override;
+    QString description() const override;
+    QgsRectangle extent() const override;
+    bool isValid() const override;
+
+};
+///@endcond
+#endif
 
 #endif // QGSANNOTATIONLAYER_H

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -128,13 +128,14 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QgsAnnotationItem *item( const QString &id );
 
     /**
-     * Returns a list of the IDs of all annotation items within the specified \a bounds.
+     * Returns a list of the IDs of all annotation items within the specified \a bounds (in layer CRS), when
+     * rendered using the given render \a context.
      *
      * The optional \a feedback argument can be used to cancel the search early.
      *
      * \since QGIS 3.22
      */
-    QStringList itemsInBounds( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
+    QStringList itemsInBounds( const QgsRectangle &bounds, const QgsRenderContext &context, QgsFeedback *feedback = nullptr ) const;
 
     Qgis::MapLayerProperties properties() const override;
     QgsAnnotationLayer *clone() const override SIP_FACTORY;
@@ -153,6 +154,11 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QgsCoordinateTransformContext mTransformContext;
 
     std::unique_ptr< QgsAnnotationLayerSpatialIndex > mSpatialIndex;
+    QSet< QString > mNonIndexedItems;
+
+    QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
+
+    friend class QgsAnnotationLayerRenderer;
 
 };
 

--- a/src/core/annotations/qgsannotationlayerrenderer.h
+++ b/src/core/annotations/qgsannotationlayerrenderer.h
@@ -23,6 +23,9 @@
 #include "qgis_sip.h"
 #include "qgsmaplayerrenderer.h"
 #include "qgsannotationitem.h"
+#include <tuple>
+#include <vector>
+#include <memory>
 
 class QgsAnnotationLayer;
 
@@ -47,7 +50,7 @@ class CORE_EXPORT QgsAnnotationLayerRenderer : public QgsMapLayerRenderer
     bool forceRasterRender() const override;
 
   private:
-    QVector< QgsAnnotationItem *> mItems;
+    std::vector < std::pair< QString, std::unique_ptr< QgsAnnotationItem > > > mItems;
     std::unique_ptr< QgsFeedback > mFeedback;
     double mLayerOpacity = 1.0;
 

--- a/src/core/annotations/qgsannotationpointtextitem.cpp
+++ b/src/core/annotations/qgsannotationpointtextitem.cpp
@@ -26,6 +26,11 @@ QgsAnnotationPointTextItem::QgsAnnotationPointTextItem( const QString &text, Qgs
 
 }
 
+Qgis::AnnotationItemFlags QgsAnnotationPointTextItem::flags() const
+{
+  return Qgis::AnnotationItemFlag::ScaleDependentBoundingBox;
+}
+
 QgsAnnotationPointTextItem::~QgsAnnotationPointTextItem() = default;
 
 QString QgsAnnotationPointTextItem::type() const

--- a/src/core/annotations/qgsannotationpointtextitem.cpp
+++ b/src/core/annotations/qgsannotationpointtextitem.cpp
@@ -28,6 +28,7 @@ QgsAnnotationPointTextItem::QgsAnnotationPointTextItem( const QString &text, Qgs
 
 Qgis::AnnotationItemFlags QgsAnnotationPointTextItem::flags() const
 {
+  // in truth this should depend on whether the text format is scale dependent or not!
   return Qgis::AnnotationItemFlag::ScaleDependentBoundingBox;
 }
 
@@ -114,6 +115,17 @@ QgsAnnotationPointTextItem *QgsAnnotationPointTextItem::clone()
 QgsRectangle QgsAnnotationPointTextItem::boundingBox() const
 {
   return QgsRectangle( mPoint.x(), mPoint.y(), mPoint.x(), mPoint.y() );
+}
+
+QgsRectangle QgsAnnotationPointTextItem::boundingBox( const QgsRenderContext &context ) const
+{
+  const double widthInPixels = QgsTextRenderer::textWidth( context, mTextFormat, mText.split( '\n' ) );
+  const double heightInPixels = QgsTextRenderer::textHeight( context, mTextFormat, mText.split( '\n' ) );
+
+  const double widthInMapUnits = context.convertToMapUnits( widthInPixels, QgsUnitTypes::RenderPixels );
+  const double heightInMapUnits = context.convertToMapUnits( heightInPixels, QgsUnitTypes::RenderPixels );
+
+  return QgsRectangle( mPoint.x(), mPoint.y(), mPoint.x() + widthInMapUnits, mPoint.y() + heightInMapUnits );
 }
 
 QgsTextFormat QgsAnnotationPointTextItem::format() const

--- a/src/core/annotations/qgsannotationpointtextitem.h
+++ b/src/core/annotations/qgsannotationpointtextitem.h
@@ -40,6 +40,7 @@ class CORE_EXPORT QgsAnnotationPointTextItem : public QgsAnnotationItem
     QgsAnnotationPointTextItem( const QString &text, QgsPointXY point );
     ~QgsAnnotationPointTextItem() override;
 
+    Qgis::AnnotationItemFlags flags() const override;
     QString type() const override;
     void render( QgsRenderContext &context, QgsFeedback *feedback ) override;
     bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;
@@ -52,6 +53,7 @@ class CORE_EXPORT QgsAnnotationPointTextItem : public QgsAnnotationItem
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context ) override;
     QgsAnnotationPointTextItem *clone() override SIP_FACTORY;
     QgsRectangle boundingBox() const override;
+    QgsRectangle boundingBox( const QgsRenderContext &context ) const override;
 
     /**
      * Returns the point location of the text.

--- a/src/core/annotations/qgsrenderedannotationitemdetails.cpp
+++ b/src/core/annotations/qgsrenderedannotationitemdetails.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+    qgsrenderedannotationitemdetails.cpp
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrenderedannotationitemdetails.h"
+
+QgsRenderedAnnotationItemDetails::QgsRenderedAnnotationItemDetails( const QString &layerId, const QString &itemId )
+  : mLayerId( layerId )
+  , mItemId( itemId )
+{
+
+}
+
+QgsRenderedAnnotationItemDetails *QgsRenderedAnnotationItemDetails::clone() const
+{
+  return new QgsRenderedAnnotationItemDetails( *this );
+}

--- a/src/core/annotations/qgsrenderedannotationitemdetails.h
+++ b/src/core/annotations/qgsrenderedannotationitemdetails.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+    qgsrenderedannotationitemdetails.h
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDEREDANNOTATIONITEMDETAILS_H
+#define QGSRENDEREDANNOTATIONITEMDETAILS_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsrendereditemdetails.h"
+
+/**
+ * \ingroup core
+ * \brief Contains information about a rendered annotation item.
+ * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsRenderedAnnotationItemDetails : public QgsRenderedItemDetails
+{
+  public:
+
+    /**
+     * Constructor for QgsRenderedAnnotationItemDetails.
+     */
+    QgsRenderedAnnotationItemDetails( const QString &layerId, const QString &itemId );
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString str = QStringLiteral( "<QgsRenderedAnnotationItemDetails: %1 - %2>" ).arg( sipCpp->layerId(), sipCpp->itemId() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
+    QgsRenderedAnnotationItemDetails *clone() const override SIP_FACTORY;
+
+    /**
+     * Returns the layer ID of the associated map layer.
+     */
+    QString layerId() const { return mLayerId; }
+
+    /**
+     * Returns the item ID of the associated annotation item.
+     */
+    QString itemId() const { return mItemId; }
+
+  private:
+
+    QString mLayerId;
+    QString mItemId;
+
+};
+
+#endif // QGSRENDEREDANNOTATIONITEMDETAILS_H

--- a/src/core/maprenderer/qgsmaprendererjob.h
+++ b/src/core/maprenderer/qgsmaprendererjob.h
@@ -37,6 +37,7 @@ class QgsLabelingResults;
 class QgsMapLayerRenderer;
 class QgsMapRendererCache;
 class QgsFeatureFilterProvider;
+class QgsRenderedItemResults;
 
 #ifndef SIP_RUN
 /// @cond PRIVATE
@@ -250,6 +251,8 @@ class CORE_EXPORT QgsMapRendererJob : public QObject SIP_ABSTRACT
 
     QgsMapRendererJob( const QgsMapSettings &settings );
 
+    ~QgsMapRendererJob() override;
+
     /**
      * Start the rendering job and immediately return.
      * Does nothing if the rendering is already in progress.
@@ -290,6 +293,15 @@ class CORE_EXPORT QgsMapRendererJob : public QObject SIP_ABSTRACT
      * \see usedCachedLabels()
      */
     virtual QgsLabelingResults *takeLabelingResults() = 0 SIP_TRANSFER;
+
+    /**
+     * Takes the rendered item results from the map render job and returns them.
+     *
+     * Ownership is transferred to the caller.
+     *
+     * \since QGIS 3.22
+     */
+    QgsRenderedItemResults *takeRenderedItemResults() SIP_TRANSFER;
 
     /**
      * Set the feature filter provider used by the QgsRenderContext of
@@ -420,6 +432,10 @@ class CORE_EXPORT QgsMapRendererJob : public QObject SIP_ABSTRACT
      * TRUE if layer rendering time should be recorded.
      */
     bool mRecordRenderingTime = true;
+
+#ifndef SIP_RUN
+    std::unique_ptr< QgsRenderedItemResults > mRenderedItemResults;
+#endif
 
     /**
      * Prepares the cache for storing the result of labeling. Returns FALSE if

--- a/src/core/maprenderer/qgsmaprenderersequentialjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderersequentialjob.cpp
@@ -19,6 +19,7 @@
 #include "qgsmaprenderercustompainterjob.h"
 #include "qgspallabeling.h"
 #include "qgslabelingresults.h"
+#include "qgsrendereditemresults.h"
 
 QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings &settings )
   : QgsMapRendererQImageJob( settings )
@@ -137,6 +138,8 @@ void QgsMapRendererSequentialJob::internalFinished()
 
   mLabelingResults.reset( mInternalJob->takeLabelingResults() );
   mUsedCachedLabels = mInternalJob->usedCachedLabels();
+
+  mRenderedItemResults.reset( mInternalJob->takeRenderedItemResults() );
 
   mErrors = mInternalJob->errors();
 

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
@@ -21,6 +21,7 @@
 #include "qgsproject.h"
 #include "qgsmaplayerrenderer.h"
 #include "qgsmaplayerlistutils.h"
+#include "qgsrendereditemresults.h"
 
 QgsMapRendererStagedRenderJob::QgsMapRendererStagedRenderJob( const QgsMapSettings &settings, Flags flags )
   : QgsMapRendererAbstractCustomPainterJob( settings )

--- a/src/core/maprenderer/qgsrendereditemresults.cpp
+++ b/src/core/maprenderer/qgsrendereditemresults.cpp
@@ -1,0 +1,129 @@
+/***************************************************************************
+  qgsrendereditemresults.cpp
+  -------------------
+   begin                : August 2021
+   copyright            : (C) Nyall Dawson
+   email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrendereditemresults.h"
+#include "qgsrendereditemdetails.h"
+#include "qgsrendercontext.h"
+#include "qgslogger.h"
+#include "qgsrenderedannotationitemdetails.h"
+#include "RTree.h"
+
+
+///@cond PRIVATE
+class QgsRenderedItemResultsSpatialIndex : public RTree<const QgsRenderedItemDetails *, float, 2, float>
+{
+  public:
+
+    void insert( const QgsRenderedItemDetails *details, const QgsRectangle &bounds )
+    {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
+      this->Insert(
+      {
+        scaledBounds[0], scaledBounds[ 1]
+      },
+      {
+        scaledBounds[2], scaledBounds[3]
+      },
+      details );
+    }
+
+    /**
+     * Performs an intersection check against the index, for data intersecting the specified \a bounds.
+     *
+     * The \a callback function will be called once for each matching data object encountered.
+     */
+    bool intersects( const QgsRectangle &bounds, const std::function< bool( const QgsRenderedItemDetails *details )> &callback ) const
+    {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
+      this->Search(
+      {
+        scaledBounds[0], scaledBounds[ 1]
+      },
+      {
+        scaledBounds[2], scaledBounds[3]
+      },
+      callback );
+      return true;
+    }
+
+  private:
+    std::array<float, 4> scaleBounds( const QgsRectangle &bounds ) const
+    {
+      return
+      {
+        static_cast< float >( bounds.xMinimum() ),
+        static_cast< float >( bounds.yMinimum() ),
+        static_cast< float >( bounds.xMaximum() ),
+        static_cast< float >( bounds.yMaximum() )
+      };
+    }
+};
+///@endcond
+
+QgsRenderedItemResults::QgsRenderedItemResults()
+  : mAnnotationItemsIndex( std::make_unique< QgsRenderedItemResultsSpatialIndex >() )
+{
+
+}
+
+QgsRenderedItemResults::~QgsRenderedItemResults() = default;
+
+QList<QgsRenderedItemDetails *> QgsRenderedItemResults::renderedItems() const
+{
+  QList< QgsRenderedItemDetails * > res;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  res.reserve( static_cast< int >( mDetails.size() ) );
+#else
+  res.reserve( mDetails.size() );
+#endif
+  std::transform( mDetails.begin(), mDetails.end(), std::back_inserter( res ), []( const auto & detail ) {return detail.get();} );
+  return res;
+}
+
+QList<const QgsRenderedAnnotationItemDetails *> QgsRenderedItemResults::renderedAnnotationItemsInBounds( const QgsRectangle &bounds ) const
+{
+  QList<const QgsRenderedAnnotationItemDetails *> res;
+
+  mAnnotationItemsIndex->intersects( bounds, [&res]( const QgsRenderedItemDetails * details )->bool
+  {
+    res << qgis::down_cast< const QgsRenderedAnnotationItemDetails * >( details );
+    return true;
+  } );
+  return res;
+}
+
+void QgsRenderedItemResults::appendResults( const QList<QgsRenderedItemDetails *> &results, const QgsRenderContext &context )
+{
+  const QgsCoordinateTransform layerToMapTransform = context.coordinateTransform();
+  for ( QgsRenderedItemDetails *details : results )
+  {
+    try
+    {
+      const QgsRectangle transformedBounds = layerToMapTransform.transformBoundingBox( details->boundingBox() );
+      details->setBoundingBox( transformedBounds );
+    }
+    catch ( QgsCsException & )
+    {
+      QgsDebugMsg( QStringLiteral( "Could not transform rendered item's bounds to map CRS" ) );
+    }
+
+    if ( QgsRenderedAnnotationItemDetails *annotationDetails = dynamic_cast< QgsRenderedAnnotationItemDetails * >( details ) )
+      mAnnotationItemsIndex->insert( annotationDetails, annotationDetails->boundingBox() );
+
+    mDetails.emplace_back( std::unique_ptr< QgsRenderedItemDetails >( details ) );
+  }
+}
+
+

--- a/src/core/maprenderer/qgsrendereditemresults.h
+++ b/src/core/maprenderer/qgsrendereditemresults.h
@@ -1,0 +1,89 @@
+/***************************************************************************
+  qgsrendereditemresults.h
+  -------------------
+   begin                : August 2021
+   copyright            : (C) Nyall Dawson
+   email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDEREDITEMRESULTS_H
+#define QGSRENDEREDITEMRESULTS_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <memory>
+#include <QList>
+#include <vector>
+
+class QgsRenderedItemDetails;
+class QgsRenderContext;
+class QgsRenderedAnnotationItemDetails;
+class QgsRectangle;
+
+///@cond PRIVATE
+class QgsRenderedItemResultsSpatialIndex;
+///@endcond
+
+/**
+ * \ingroup core
+ * \brief Stores collated details of rendered items during a map rendering operation.
+ * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsRenderedItemResults
+{
+  public:
+    QgsRenderedItemResults();
+    ~QgsRenderedItemResults();
+
+    //! QgsRenderedItemResults cannot be copied.
+    QgsRenderedItemResults( const QgsRenderedItemResults & ) = delete;
+    //! QgsRenderedItemResults cannot be copied.
+    QgsRenderedItemResults &operator=( const QgsRenderedItemResults &rh ) = delete;
+
+    /**
+     * Returns a list of all rendered items.
+     */
+    QList< QgsRenderedItemDetails * > renderedItems() const;
+
+    /**
+     * Returns a list with details of the rendered annotation items within the specified \a bounds.
+     *
+     * \since QGIS 3.22
+     */
+    QList<const QgsRenderedAnnotationItemDetails *> renderedAnnotationItemsInBounds( const QgsRectangle &bounds ) const;
+
+#ifndef SIP_RUN
+
+    /**
+     * Appends rendered item details to the results object.
+     *
+     * Ownership of \a results is transferred to the this object.
+     *
+     * The render \a context argument is used to specify the render context used to render the items. It will be used
+     * to transform the details to the destination map CRS.
+     *
+     * \note Not available in Python bindings.
+     */
+    void appendResults( const QList< QgsRenderedItemDetails * > &results, const QgsRenderContext &context );
+#endif
+
+  private:
+#ifdef SIP_RUN
+    QgsRenderedItemResults( const QgsRenderedItemResults & );
+#endif
+
+    std::vector< std::unique_ptr< QgsRenderedItemDetails > > mDetails;
+    std::unique_ptr< QgsRenderedItemResultsSpatialIndex > mAnnotationItemsIndex;
+
+};
+
+#endif // QGSRENDEREDITEMRESULTS_H

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -732,6 +732,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( MapLayerProperty )
 
     /**
+     * Flags for annotation items.
+     *
+     * \since QGIS 3.22
+     */
+    enum class AnnotationItemFlag : int
+    {
+      ScaleDependentBoundingBox = 1 << 0, //!< Item's bounding box will vary depending on map scale
+    };
+    Q_DECLARE_FLAGS( AnnotationItemFlags, AnnotationItemFlag )
+    Q_ENUM( AnnotationItemFlag )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */
@@ -855,6 +867,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelFormatCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelCommandFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::GeometryValidityFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FileOperationFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::AnnotationItemFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/core/qgsmaplayerrenderer.cpp
+++ b/src/core/qgsmaplayerrenderer.cpp
@@ -1,0 +1,30 @@
+/***************************************************************************
+  qgsmaplayerrenderer.cpp
+  --------------------------------------
+  Date                 : August 2021
+  Copyright            : (C) 2021 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaplayerrenderer.h"
+#include "qgsrendereditemdetails.h"
+
+QgsMapLayerRenderer::~QgsMapLayerRenderer() = default;
+
+
+QList<QgsRenderedItemDetails *> QgsMapLayerRenderer::takeRenderedItemDetails()
+{
+  return std::move( mRenderedItemDetails );
+}
+
+void QgsMapLayerRenderer::appendRenderedItemDetails( QgsRenderedItemDetails *details )
+{
+  mRenderedItemDetails.append( details );
+}

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -23,6 +23,7 @@
 
 class QgsFeedback;
 class QgsRenderContext;
+class QgsRenderedItemDetails;
 
 /**
  * \ingroup core
@@ -62,7 +63,7 @@ class CORE_EXPORT QgsMapLayerRenderer
       , mContext( context )
     {}
 
-    virtual ~QgsMapLayerRenderer() = default;
+    virtual ~QgsMapLayerRenderer();
 
     /**
      * Do the rendering (based on data stored in the class).
@@ -137,6 +138,16 @@ class CORE_EXPORT QgsMapLayerRenderer
      */
     virtual void setLayerRenderingTimeHint( int time ) SIP_SKIP { Q_UNUSED( time ) }
 
+    /**
+     * Takes the list of rendered item details from the renderer.
+     *
+     * Ownership of items is transferred to the caller.
+     *
+     * \see appendRenderedItemDetails()
+     * \since QGIS 3.22
+     */
+    QList< QgsRenderedItemDetails * > takeRenderedItemDetails() SIP_TRANSFERBACK;
+
   protected:
     QStringList mErrors;
     QString mLayerID;
@@ -169,6 +180,18 @@ class CORE_EXPORT QgsMapLayerRenderer
      */
     static constexpr int MAX_TIME_TO_USE_CACHED_PREVIEW_IMAGE = 3000 SIP_SKIP;
 
+    /**
+     * Appends the \a details of a rendered item to the renderer.
+     *
+     * Rendered item details can be retrieved by calling takeRenderedItemDetails().
+     *
+     * Ownership of \a details is transferred to the renderer.
+     *
+     * \see takeRenderedItemDetails()
+     * \since QGIS 3.22
+     */
+    void appendRenderedItemDetails( QgsRenderedItemDetails *details SIP_TRANSFER );
+
   private:
 
     // TODO QGIS 4.0 - make reference instead of pointer!
@@ -179,6 +202,8 @@ class CORE_EXPORT QgsMapLayerRenderer
      * \since QGIS 3.10
      */
     QgsRenderContext *mContext = nullptr;
+
+    QList<QgsRenderedItemDetails *> mRenderedItemDetails;
 };
 
 #endif // QGSMAPLAYERRENDERER_H

--- a/src/core/qgsrendereditemdetails.cpp
+++ b/src/core/qgsrendereditemdetails.cpp
@@ -1,0 +1,19 @@
+/***************************************************************************
+    qgsrendereditemdetails.cpp
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrendereditemdetails.h"
+
+QgsRenderedItemDetails::~QgsRenderedItemDetails() = default;

--- a/src/core/qgsrendereditemdetails.h
+++ b/src/core/qgsrendereditemdetails.h
@@ -1,0 +1,68 @@
+/***************************************************************************
+    qgsrendereditemdetails.h
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDEREDITEMDETAILS_H
+#define QGSRENDEREDITEMDETAILS_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsrectangle.h"
+
+/**
+ * \ingroup core
+ * \brief Base class for detailed information about a rendered item.
+ * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsRenderedItemDetails
+{
+  public:
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsRenderedAnnotationItemDetails *>( sipCpp ) )
+      sipType = sipType_QgsRenderedAnnotationItemDetails;
+    else
+      sipType = 0;
+    SIP_END
+#endif
+
+    virtual ~QgsRenderedItemDetails();
+
+    /**
+     * Clones the details.
+     */
+    virtual QgsRenderedItemDetails *clone() const = 0 SIP_FACTORY;
+
+    /**
+     * Returns the bounding box of the item (in map units).
+     *
+     * \see setBoundingBox()
+     */
+    QgsRectangle boundingBox() const { return mBounds; }
+
+    /**
+     * Sets the bounding box of the item (in map units).
+     *
+     * \see boundingBox()
+     */
+    void setBoundingBox( const QgsRectangle &bounds ) { mBounds = bounds; }
+
+  private:
+
+    QgsRectangle mBounds;
+};
+
+#endif // QGSRENDEREDITEMDETAILS_H

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -92,6 +92,7 @@ email                : sherman at mrcc.com
 #include "qgslabelingresults.h"
 #include "qgsmaplayerutils.h"
 #include "qgssettingsregistrygui.h"
+#include "qgsrendereditemresults.h"
 
 /**
  * \ingroup gui
@@ -472,6 +473,14 @@ const QgsLabelingResults *QgsMapCanvas::labelingResults( bool allowOutdatedResul
   return mLabelingResults.get();
 }
 
+const QgsRenderedItemResults *QgsMapCanvas::renderedItemResults( bool allowOutdatedResults ) const
+{
+  if ( !allowOutdatedResults && mRenderedItemResultsOutdated )
+    return nullptr;
+
+  return mRenderedItemResults.get();
+}
+
 void QgsMapCanvas::setCachingEnabled( bool enabled )
 {
   if ( enabled == isCachingEnabled() )
@@ -583,6 +592,7 @@ void QgsMapCanvas::refresh()
   mRefreshTimer->start( 1 );
 
   mLabelingResultsOutdated = true;
+  mRenderedItemResultsOutdated = true;
 }
 
 void QgsMapCanvas::refreshMap()
@@ -696,6 +706,9 @@ void QgsMapCanvas::rendererJobFinished()
       mLabelingResults.reset( mJob->takeLabelingResults() );
     }
     mLabelingResultsOutdated = false;
+
+    mRenderedItemResults.reset( mJob->takeRenderedItemResults() );
+    mRenderedItemResultsOutdated = false;
 
     QImage img = mJob->renderedImage();
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -70,6 +70,7 @@ class QgsSnappingUtils;
 class QgsRubberBand;
 class QgsMapCanvasAnnotationItem;
 class QgsReferencedRectangle;
+class QgsRenderedItemResults;
 
 class QgsTemporalController;
 
@@ -169,6 +170,17 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      * \since QGIS 2.4
      */
     const QgsLabelingResults *labelingResults( bool allowOutdatedResults = true ) const;
+
+    /**
+     * Gets access to the rendered item results (may be NULLPTR), which includes the results of rendering
+     * annotation items in the canvas map.
+     *
+     * If the \a allowOutdatedResults flag is FALSE then outdated rendered item results (e.g.
+     * as a result of an ongoing canvas render) will not be returned, and instead NULLPTR will be returned.
+     *
+     * \since QGIS 3.22
+     */
+    const QgsRenderedItemResults *renderedItemResults( bool allowOutdatedResults = true ) const;
 
     /**
      * Set whether to cache images of rendered layers
@@ -1300,6 +1312,19 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
     //! TRUE if the labeling results stored in mLabelingResults are outdated (e.g. as a result of an ongoing canvas render)
     bool mLabelingResultsOutdated = false;
+
+    /**
+     * Rendered results from the recently rendered map.
+     * \since QGIS 3.22
+     */
+    std::unique_ptr< QgsRenderedItemResults > mRenderedItemResults;
+
+    /**
+     * TRUE if the rendered item results stored in mRenderedItemResults are outdated (e.g. as a result of an ongoing canvas render)
+     *
+     * \since QGIS 3.22
+     */
+    bool mRenderedItemResultsOutdated = false;
 
     //! Whether layers are rendered sequentially or in parallel
     bool mUseParallelRendering = false;

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -159,10 +159,11 @@ class TestQgsAnnotationLayer(unittest.TestCase):
             QgsAnnotationLineItem(QgsLineString([QgsPoint(11, 13), QgsPoint(12, 13), QgsPoint(12, 150)])))
         item3uuid = layer.addItem(QgsAnnotationMarkerItem(QgsPoint(120, 13)))
 
-        self.assertFalse(layer.itemsInBounds(QgsRectangle(-10, -10, -9, 9)))
-        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(12, 13, 14, 15)), [item1uuid, item2uuid])
-        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(12, 130, 14, 150)), [item2uuid])
-        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(110, 0, 120, 20)), [item3uuid])
+        rc = QgsRenderContext()
+        self.assertFalse(layer.itemsInBounds(QgsRectangle(-10, -10, -9, 9), rc))
+        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(12, 13, 14, 15), rc), [item1uuid, item2uuid])
+        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(12, 130, 14, 150), rc), [item2uuid])
+        self.assertCountEqual(layer.itemsInBounds(QgsRectangle(110, 0, 120, 20), rc), [item3uuid])
 
     def testReadWriteXml(self):
         doc = QDomDocument("testdoc")


### PR DESCRIPTION
This PR adds the API framework necessary for querying annotation layer items visible within the map in an optimised way. It's a necessary pre-cursor to creating interactive tools for modifying annotation items.
