### PR TITLE
Fix offset tool does not apply offsets which are only directly entered into the offset distance widget (without mouse moves)

### DIFF
--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -131,6 +131,15 @@ void QgsMapToolOffsetCurve::canvasReleaseEvent( QgsMapMouseEvent *e )
   }
 }
 
+void QgsMapToolOffsetCurve::applyOffsetFromWidget( double offset, Qt::KeyboardModifiers modifiers )
+{
+  if ( mSourceLayer && !mOriginalGeometry.isNull() && !qgsDoubleNear( offset, 0 ) )
+  {
+    mGeometryModified = true;
+    applyOffset( offset, modifiers );
+  }
+}
+
 void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers modifiers )
 {
   if ( !mSourceLayer || offset == 0.0 )
@@ -579,7 +588,7 @@ void QgsMapToolOffsetCurve::createUserInputWidget()
   mUserInputWidget->setFocus( Qt::TabFocusReason );
 
   connect( mUserInputWidget, &QgsOffsetUserWidget::offsetChanged, this, &QgsMapToolOffsetCurve::updateGeometryAndRubberBand );
-  connect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingFinished, this, &QgsMapToolOffsetCurve::applyOffset );
+  connect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingFinished, this, &QgsMapToolOffsetCurve::applyOffsetFromWidget );
   connect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingCanceled, this, &QgsMapToolOffsetCurve::cancel );
 
   connect( mUserInputWidget, &QgsOffsetUserWidget::offsetConfigChanged, this, [ = ] {updateGeometryAndRubberBand( mUserInputWidget->offset() );} );
@@ -590,7 +599,7 @@ void QgsMapToolOffsetCurve::deleteUserInputWidget()
   if ( mUserInputWidget )
   {
     disconnect( mUserInputWidget, &QgsOffsetUserWidget::offsetChanged, this, &QgsMapToolOffsetCurve::updateGeometryAndRubberBand );
-    disconnect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingFinished, this, &QgsMapToolOffsetCurve::applyOffset );
+    disconnect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingFinished, this, &QgsMapToolOffsetCurve::applyOffsetFromWidget );
     disconnect( mUserInputWidget, &QgsOffsetUserWidget::offsetEditingCanceled, this, &QgsMapToolOffsetCurve::cancel );
     mUserInputWidget->releaseKeyboard();
     mUserInputWidget->deleteLater();

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -69,6 +69,8 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     //! Places curve offset from the mouse position or from the value entered in the spin box
     void updateGeometryAndRubberBand( double offset );
 
+    void applyOffsetFromWidget( double offset, Qt::KeyboardModifiers modifiers );
+
     //! Apply the offset either from the spin box or from the mouse event
     void applyOffset( double offset, Qt::KeyboardModifiers modifiers );
 


### PR DESCRIPTION
Refs #44866
