### PR TITLE
UI fixes for external resource widget

### DIFF
--- a/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
+++ b/src/ui/editorwidgets/qgsexternalresourceconfigdlg.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>481</width>
-    <height>803</height>
+    <height>686</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,31 +46,39 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>467</width>
-        <height>835</height>
+        <width>481</width>
+        <height>686</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>Type</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <item>
-           <widget class="QComboBox" name="mStorageType">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Way of dealing with attachment file&lt;p&gt;&quot;Select existing file&quot; allows you to pick an existing file from the file system or set an existing URL external resource.&lt;/p&gt;&lt;p&gt;Other items allows you to pick a local resource and store it on an external storage system. You cannot use relative path in this mode and you can only pick file and not directory.&lt;/p&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="storageTypeLbl">
+           <property name="text">
+            <string>Storage type</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="mStorageType">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Way of dealing with attachment file&lt;p&gt;&quot;Select existing file&quot; allows you to pick an existing file from the file system or set an existing URL external resource.&lt;/p&gt;&lt;p&gt;Other items allows you to pick a local resource and store it on an external storage system. You cannot use relative path in this mode and you can only pick file and not directory.&lt;/p&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QGroupBox" name="mExternalStorageGroupBox">
          <property name="title">
-          <string>External storage</string>
+          <string>External Storage</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
@@ -457,20 +465,26 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Width</string>
+               </property>
+              </widget>
+             </item>
              <item row="0" column="2" rowspan="2">
               <widget class="QLabel" name="label_2">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="text">
                 <string>Specify the size of the preview. If you leave it set to Auto, an optimal size will be calculated.</string>
                </property>
                <property name="wordWrap">
                 <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Width</string>
                </property>
               </widget>
              </item>
@@ -554,7 +568,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -591,6 +605,10 @@
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mStorageType</tabstop>
+  <tabstop>mStorageUrl</tabstop>
+  <tabstop>mStorageUrlExpression</tabstop>
+  <tabstop>mStorageUrlPropertyOverrideButton</tabstop>
   <tabstop>mRootPath</tabstop>
   <tabstop>mRootPathExpression</tabstop>
   <tabstop>mRootPathButton</tabstop>


### PR DESCRIPTION
* Do not use a group box for a single item
* Fix group box title case
* Allow tip to be expanded, more elegant
* Fix tab stops

Before:
![image](https://user-images.githubusercontent.com/7983394/131480298-32e00f56-1123-44a2-a6e0-1945dcacf572.png)

PR:
![image](https://user-images.githubusercontent.com/7983394/131480027-2197ca83-9ee6-45cb-bd24-743e005be479.png)
