### PR TITLE
Cancel previous fetch when current feature changes and an external storage is set

### DIFF
--- a/src/core/network/qgsnetworkcontentfetcher.cpp
+++ b/src/core/network/qgsnetworkcontentfetcher.cpp
@@ -74,7 +74,9 @@ void QgsNetworkContentFetcher::fetchContent( const QNetworkRequest &r, const QSt
 
   auto onError = [ = ]( QNetworkReply::NetworkError code )
   {
-    emit errorOccurred( code, mReply->errorString() );
+    // could have been canceled in the meantime
+    if ( mReply )
+      emit errorOccurred( code, mReply->errorString() );
   };
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -21,9 +21,11 @@ class QWebView;
 class QgsPixmapLabel;
 class QgsMessageBar;
 class QgsExternalStorageFileWidget;
+class QgsExternalStorageFetchedContent;
 
 #include <QWidget>
 #include <QVariant>
+#include <QPointer>
 
 #include "qgsfilewidget.h"
 #include "qgis_gui.h"
@@ -196,6 +198,7 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
 
   private slots:
     void loadDocument( const QString &path );
+    void onFetchFinished();
 
   private:
     void updateDocumentViewer();
@@ -230,6 +233,7 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
     QLabel *mLoadingLabel = nullptr;
     QLabel *mErrorLabel = nullptr;
     QMovie *mLoadingMovie = nullptr;
+    QPointer<QgsExternalStorageFetchedContent> mContent;
 
     friend class TestQgsExternalResourceWidgetWrapper;
 };


### PR DESCRIPTION
From the attribute form, when the user change the current selected feature, we need to cancel the on going external storage ressource fetching.

cc @Jean-Roc 
cc for review @3nids 

Funded by Lille Metropole https://www.lillemetropole.fr/