### PR TITLE
Plugin dependencies followup: load dependent plugins after their dependencies on QGIS startup

### DIFF
--- a/python/pyplugin_installer/plugindependencies.py
+++ b/python/pyplugin_installer/plugindependencies.py
@@ -15,7 +15,7 @@ __copyright__ = 'Copyright 2018, GISCE-TI S.L.'
 from configparser import NoOptionError, NoSectionError
 from .version_compare import compareVersions
 from . import installer as plugin_installer
-from qgis.utils import updateAvailablePlugins, metadataParser
+from qgis.utils import updateAvailablePlugins, metadataParser, get_plugin_deps
 
 
 def __plugin_name_map(plugin_data_values):
@@ -23,25 +23,6 @@ def __plugin_name_map(plugin_data_values):
         plugin['name']: plugin['id']
         for plugin in plugin_data_values
     }
-
-
-def __get_plugin_deps(plugin_id):
-    result = {}
-    updateAvailablePlugins()
-    try:
-        parser = metadataParser()[plugin_id]
-        plugin_deps = parser.get('general', 'plugin_dependencies')
-    except (NoOptionError, NoSectionError, KeyError):
-        return result
-
-    for dep in plugin_deps.split(','):
-        if dep.find('==') > 0:
-            name, version_required = dep.split('==')
-        else:
-            name = dep
-            version_required = None
-        result[name] = version_required
-    return result
 
 
 def find_dependencies(plugin_id, plugin_data=None, plugin_deps=None, installed_plugins=None):
@@ -64,7 +45,8 @@ def find_dependencies(plugin_id, plugin_data=None, plugin_deps=None, installed_p
     not_found = {}
 
     if plugin_deps is None:
-        plugin_deps = __get_plugin_deps(plugin_id)
+        updateAvailablePlugins()
+        plugin_deps = get_plugin_deps(plugin_id)
 
     if installed_plugins is None:
         updateAvailablePlugins()

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -561,6 +561,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
     // check for python plugins system-wide
     const QStringList pluginList = mPythonUtils->pluginList();
     QgsDebugMsgLevel( QStringLiteral( "Loading python plugins" ), 2 );
+    QgsDebugMsg( QStringLiteral( "Python plugins will be loaded in the following order: " ) + pluginList.join( "," ) );
 
     QStringList corePlugins = QStringList();
     corePlugins << QStringLiteral( "GdalTools" );

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -561,7 +561,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
     // check for python plugins system-wide
     const QStringList pluginList = mPythonUtils->pluginList();
     QgsDebugMsgLevel( QStringLiteral( "Loading python plugins" ), 2 );
-    QgsDebugMsg( QStringLiteral( "Python plugins will be loaded in the following order: " ) + pluginList.join( "," ) );
+    QgsDebugMsgLevel( QStringLiteral( "Python plugins will be loaded in the following order: " ) + pluginList.join( "," ), 2 );
 
     QStringList corePlugins = QStringList();
     corePlugins << QStringLiteral( "GdalTools" );

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -623,7 +623,7 @@ QStringList QgsPythonUtilsImpl::extraPluginsPaths() const
 
 QStringList QgsPythonUtilsImpl::pluginList()
 {
-  runString( QStringLiteral( "qgis.utils.updateAvailablePlugins()" ) );
+  runString( QStringLiteral( "qgis.utils.updateAvailablePlugins(sort_by_dependencies=True)" ) );
 
   QString output;
   evalString( QStringLiteral( "'\\n'.join(qgis.utils.available_plugins)" ), output );

--- a/tests/src/app/testqgisapppython.cpp
+++ b/tests/src/app/testqgisapppython.cpp
@@ -44,6 +44,7 @@ class TestQgisAppPython : public QObject
     void plugins();
     void pythonPlugin();
     void pluginMetadata();
+    void pythonPluginDependencyOrder();
     void runString();
     void evalString();
 
@@ -123,6 +124,22 @@ void TestQgisAppPython::pluginMetadata()
   QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "name" ) ), QStringLiteral( "processing plugin test" ) );
   QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "hasProcessingProvider" ) ), QStringLiteral( "yes" ) );
   QVERIFY( mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "ProcessingPluginTest" ) ) );
+}
+
+void TestQgisAppPython::pythonPluginDependencyOrder()
+{
+  QVERIFY( mQgisApp->mPythonUtils->pluginList().contains( QStringLiteral( "PluginPathTest" ) ) );
+  QVERIFY( mQgisApp->mPythonUtils->pluginList().contains( QStringLiteral( "dependent_plugin_1" ) ) );
+  QVERIFY( mQgisApp->mPythonUtils->pluginList().contains( QStringLiteral( "dependent_plugin_2" ) ) );
+
+  const int indexIndependentPlugin = mQgisApp->mPythonUtils->pluginList().indexOf( QStringLiteral( "PluginPathTest" ) );
+  const int indexDependentPlugin1 = mQgisApp->mPythonUtils->pluginList().indexOf( QStringLiteral( "dependent_plugin_1" ) );
+  const int indexDependentPlugin2 = mQgisApp->mPythonUtils->pluginList().indexOf( QStringLiteral( "dependent_plugin_2" ) );
+
+  // Dependent plugins should appear in this list after their dependencies,
+  // since that's the order in which they'll be loaded to QGIS
+  QVERIFY( indexIndependentPlugin < indexDependentPlugin1 );
+  QVERIFY( indexDependentPlugin1 < indexDependentPlugin2 );
 }
 
 void TestQgisAppPython::runString()

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 ADD_PYTHON_TEST(PyCoreAdditions test_core_additions.py)
 ADD_PYTHON_TEST(PyPythonRepr test_python_repr.py)
+ADD_PYTHON_TEST(PyPythonUtils test_python_utils.py)
 ADD_PYTHON_TEST(PyQgsActionManager test_qgsactionmanager.py)
 ADD_PYTHON_TEST(PyQgsAFSProvider test_provider_afs.py)
 ADD_PYTHON_TEST(PyQgsAggregateMappingWidget test_qgsaggregatemappingwidget.py)

--- a/tests/src/python/test_python_utils.py
+++ b/tests/src/python/test_python_utils.py
@@ -1,0 +1,69 @@
+"""QGIS Unit tests for Python utils
+
+From build dir, run: ctest -R PyPythonUtils -V
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Germán Carrillo'
+__date__ = '31.8.2021'
+__copyright__ = 'Copyright 2021, The QGIS Project'
+
+import os
+
+from qgis.testing import unittest, start_app
+from qgis import utils
+
+from utilities import unitTestDataPath
+
+
+class TestPythonUtils(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        start_app()
+
+    def test_update_available_plugins(self):
+        utils.plugin_paths = [os.path.join(unitTestDataPath(), "test_plugin_path")]
+        utils.updateAvailablePlugins(True)
+        self.assertIn("PluginPathTest", utils.available_plugins)
+        self.assertIn("dependent_plugin_1", utils.available_plugins)
+        self.assertIn("dependent_plugin_2", utils.available_plugins)
+
+        idx_independent_plugin = utils.available_plugins.index("PluginPathTest")
+        idx_dependent_plugin_1 = utils.available_plugins.index("dependent_plugin_1")
+        idx_dependent_plugin_2 = utils.available_plugins.index("dependent_plugin_2")
+
+        self.assertGreater(idx_dependent_plugin_2, idx_dependent_plugin_1)
+        self.assertGreater(idx_dependent_plugin_1, idx_independent_plugin)
+
+    def test_sort_by_dependency(self):
+        plugins = ["dependent_plugin_2", "dependent_plugin_1", "PluginPathTest"]
+        plugin_name_map = {"Dependent plugin 2": "dependent_plugin_2", "Dependent plugin 1": "dependent_plugin_1", "plugin path test": "PluginPathTest"}
+
+        utils.plugin_paths = [os.path.join(unitTestDataPath(), "test_plugin_path")]
+        utils.updateAvailablePlugins()  # Required to have a proper plugins_metadata_parser
+        sorted_plugins = utils._sortAvailablePlugins(plugins, plugin_name_map)
+
+        expected_sorted_plugins = ["PluginPathTest", "dependent_plugin_1", "dependent_plugin_2"]
+        self.assertEqual(sorted_plugins, expected_sorted_plugins)
+
+    def test_sort_by_dependency_move_plugin(self):
+        plugins = ["MSP", "P1", "LPA", "P2", "LA", "A", "MB", "P3", "LAA", "P4"]
+        deps = {"A": ["MB", "MSP"], "LPA": ["A"], "LA": ["A"], "LAA": ["A"]}
+
+        sorted_plugins = plugins.copy()
+        visited = []
+
+        for plugin in plugins:
+            utils._move_plugin(plugin, deps, visited, sorted_plugins)
+
+        expected_sorted_plugins = ["MSP", "P1", "P2", "MB", "A", "LA", "LPA", "P3", "LAA", "P4"]
+
+        self.assertEqual(sorted_plugins, expected_sorted_plugins)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testdata/test_plugin_path/dependent_plugin_1/__init__.py
+++ b/tests/testdata/test_plugin_path/dependent_plugin_1/__init__.py
@@ -1,0 +1,22 @@
+from PyQt5.QtWidgets import QAction
+
+
+def classFactory(iface):
+    return DependentPlugin1(iface)
+
+
+class DependentPlugin1:
+    def __init__(self, iface):
+        self.iface = iface
+
+    def initGui(self):
+        self.action = QAction('Go!', self.iface.mainWindow())
+        self.action.triggered.connect(self.run)
+        self.iface.addToolBarIcon(self.action)
+
+    def unload(self):
+        self.iface.removeToolBarIcon(self.action)
+        del self.action
+
+    def run(self):
+        pass

--- a/tests/testdata/test_plugin_path/dependent_plugin_1/metadata.txt
+++ b/tests/testdata/test_plugin_path/dependent_plugin_1/metadata.txt
@@ -1,0 +1,7 @@
+[general]
+name=Dependent plugin 1
+description=A dependent plugin
+version=1.0
+qgisMinimumVersion=3.0
+author=Germán Carrillo
+plugin_dependencies=plugin path test

--- a/tests/testdata/test_plugin_path/dependent_plugin_2/__init__.py
+++ b/tests/testdata/test_plugin_path/dependent_plugin_2/__init__.py
@@ -1,0 +1,22 @@
+from PyQt5.QtWidgets import QAction
+
+
+def classFactory(iface):
+    return DependentPlugin2(iface)
+
+
+class DependentPlugin2:
+    def __init__(self, iface):
+        self.iface = iface
+
+    def initGui(self):
+        self.action = QAction('Go!', self.iface.mainWindow())
+        self.action.triggered.connect(self.run)
+        self.iface.addToolBarIcon(self.action)
+
+    def unload(self):
+        self.iface.removeToolBarIcon(self.action)
+        del self.action
+
+    def run(self):
+        pass

--- a/tests/testdata/test_plugin_path/dependent_plugin_2/metadata.txt
+++ b/tests/testdata/test_plugin_path/dependent_plugin_2/metadata.txt
@@ -1,0 +1,7 @@
+[general]
+name=Dependent plugin 2
+description=Yet another dependent plugin
+version=1.0
+qgisMinimumVersion=3.0
+author=Germán Carrillo
+plugin_dependencies=Dependent plugin 1


### PR DESCRIPTION
PR https://github.com/qgis/QGIS/pull/9619 introduced Python plugin dependencies to QGIS. **Besides plugin installation, QGIS should handle dependencies also on QGIS startup, which is currently missing.**

**This PR is a followup to make sure dependent plugins are only loaded once their dependencies are loaded.** Think about a modular plugin that can be extended by other plugins of the same company, depending on the clients. In such a use case, dependent plugins could add new buttons to the main (and independent) plugin's toolbar/menu. For doing so, dependent plugins require the independent plugin to be not only installed first (addressed already by Alessandro P.), but also loaded first on QGIS startup.

-------

**The only significant change introduced by this PR is sorting the plugin list that QGIS traverses to load Python plugins.** So, for instance, we won't deal with installed but disabled (aka. 'unavailable') plugins, which will need to be handled by plugin devs. Additionally, plugin unload shouldn't be an issue, because in the worst case (i.e., the independent plugin is unloaded first), independent plugins could emit a signal to inform their dependent plugins they'll have to live alone (or simply be unloaded as well) from that moment on. Therefore, plugin unload is not addressed in this PR, as in my opinion can be left to plugin devs.

As it is, **this PR will also work for `qgis_process` and, as far as I know, for `qgis_server` plugins** (although I'm not sure if the server supports plugin dependencies as well), which also traverse the `mPythonUtils->pluginList()` to load plugins.

Since QGIS code calls `updateAvailablePlugins()` from several parts, but only one of those needs the plugin list sorted, I ensured we only ask for a sorted list when loading plugins, and the other calls remain getting the original (unsorted) plugin list.

Several unit tests were added, for both C++ and Python.

--------
@elpaso, since you implemented the basis for plugin dependencies, and I'm moving one of your methods, I'd acknowledge if you can have a look at this PR.

-------

Funded by [SwissTierras-Colombia](https://github.com/SwissTierrasColombia/).