### PR TITLE
[processing] Fix file downloader algorithm crash when download errors out

### DIFF
--- a/src/analysis/processing/qgsalgorithmfiledownloader.cpp
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.cpp
@@ -84,7 +84,7 @@ QVariantMap QgsFileDownloaderAlgorithm::processAlgorithm( const QVariantMap &par
   connect( downloader, &QgsFileDownloader::downloadError, this, [&errors, &loop]( const QStringList & e ) { errors = e; loop.exit(); } );
   connect( downloader, &QgsFileDownloader::downloadProgress, this, &QgsFileDownloaderAlgorithm::receiveProgressFromDownloader );
   connect( downloader, &QgsFileDownloader::downloadCompleted, this, [&downloadedUrl]( const QUrl url ) { downloadedUrl = url; } );
-  connect( downloader, &QgsFileDownloader::downloadExited, &loop, &QEventLoop::quit );
+  connect( downloader, &QgsFileDownloader::downloadExited, this, [&loop]() { loop.exit(); } );
   connect( &timer, &QTimer::timeout, this, &QgsFileDownloaderAlgorithm::sendProgressFeedback );
   downloader->startDownload();
   timer.start( 1000 );


### PR DESCRIPTION
## Description

TIL: do not mix QEventLoop and this pointers when connecting signals, signals wont be proceeded in order and worlds will collide.

@Gustry , this fixes #44905 .