### PR TITLE
 Add single file export option to atlas to PDF algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -267,7 +267,7 @@ QString QgsLayoutAtlasToMultiplePdfAlgorithm::shortDescription() const
 
 QString QgsLayoutAtlasToMultiplePdfAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm outputs an atlas layout to mutliple PDF files.\n\n"
+  return QObject::tr( "This algorithm outputs an atlas layout to multiple PDF files.\n\n"
                       "If a coverage layer is set, the selected layout's atlas settings exposed in this algorithm "
                       "will be overwritten. In this case, an empty filter or sort by expression will turn those "
                       "settings off.\n"

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -33,7 +33,7 @@ QString QgsLayoutAtlasToPdfAlgorithm::name() const
 
 QString QgsLayoutAtlasToPdfAlgorithm::displayName() const
 {
-  return QObject::tr( "Export atlas layout as PDF" );
+  return QObject::tr( "Export atlas layout as PDF (single file)." );
 }
 
 QStringList QgsLayoutAtlasToPdfAlgorithm::tags() const
@@ -53,19 +53,15 @@ QString QgsLayoutAtlasToPdfAlgorithm::groupId() const
 
 QString QgsLayoutAtlasToPdfAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Exports an atlas layout as a PDF." );
+  return QObject::tr( "Exports an atlas layout as a single PDF file)." );
 }
 
 QString QgsLayoutAtlasToPdfAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm outputs an atlas layout as a PDF file.\n\n"
+  return QObject::tr( "This algorithm outputs an atlas layout as a single PDF file.\n\n"
                       "If a coverage layer is set, the selected layout's atlas settings exposed in this algorithm "
                       "will be overwritten. In this case, an empty filter or sort by expression will turn those "
-                      "settings off.\n"
-                      "When the single file export option is unchecked, each layout page will be exported to its respective "
-                      "pdf file and the output filename will be used as an expression to create the pdf files names. "
-                      "If the single file export is checked, the output filename input will be used as the filename for "
-                      "output file." );
+                      "settings off." );
 }
 
 void QgsLayoutAtlasToPdfAlgorithm::initAlgorithm( const QVariantMap & )
@@ -77,8 +73,217 @@ void QgsLayoutAtlasToPdfAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExpression( QStringLiteral( "SORTBY_EXPRESSION" ), QObject::tr( "Sort expression" ), QString(), QStringLiteral( "COVERAGE_LAYER" ), true ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SORTBY_REVERSE" ), QObject::tr( "Reverse sort order (used when a sort expression is provided)" ), false, true ) );
 
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SINGLE_FILE_EXPORT" ), QObject::tr( "Single file export when possible" ), true, true ) );
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "OUTPUT_FILENAME" ), QObject::tr( "Output filename" ), QString( "atlas" ), QString(), false ) );
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "PDF file" ), QObject::tr( "PDF Format" ) + " (*.pdf *.PDF)" ) );
+
+  std::unique_ptr< QgsProcessingParameterMultipleLayers > layersParam = std::make_unique< QgsProcessingParameterMultipleLayers>( QStringLiteral( "LAYERS" ), QObject::tr( "Map layers to assign to unlocked map item(s)" ), QgsProcessing::TypeMapLayer, QVariant(), true );
+  layersParam->setFlags( layersParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( layersParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > dpiParam = std::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DPI" ), QObject::tr( "DPI (leave blank for default layout DPI)" ), QgsProcessingParameterNumber::Double, QVariant(), true, 0 );
+  dpiParam->setFlags( dpiParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( dpiParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > forceVectorParam = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "FORCE_VECTOR" ), QObject::tr( "Always export as vectors" ), false );
+  forceVectorParam->setFlags( forceVectorParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( forceVectorParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > appendGeorefParam = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "GEOREFERENCE" ), QObject::tr( "Append georeference information" ), true );
+  appendGeorefParam->setFlags( appendGeorefParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( appendGeorefParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > exportRDFParam = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "INCLUDE_METADATA" ), QObject::tr( "Export RDF metadata (title, author, etc.)" ), true );
+  exportRDFParam->setFlags( exportRDFParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( exportRDFParam.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > disableTiled = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "DISABLE_TILED" ), QObject::tr( "Disable tiled raster layer exports" ), false );
+  disableTiled->setFlags( disableTiled->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( disableTiled.release() );
+
+  std::unique_ptr< QgsProcessingParameterBoolean > simplify = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "SIMPLIFY" ), QObject::tr( "Simplify geometries to reduce output file size" ), true );
+  simplify->setFlags( simplify->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( simplify.release() );
+
+  QStringList textExportOptions
+  {
+    QObject::tr( "Always Export Text as Paths (Recommended)" ),
+    QObject::tr( "Always Export Text as Text Objects" )
+  };
+
+  std::unique_ptr< QgsProcessingParameterEnum > textFormat = std::make_unique< QgsProcessingParameterEnum >( QStringLiteral( "TEXT_FORMAT" ), QObject::tr( "Text export" ), textExportOptions, false, 0 );
+  textFormat->setFlags( textFormat->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( textFormat.release() );
+}
+
+QgsProcessingAlgorithm::Flags QgsLayoutAtlasToPdfAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagNoThreading;
+}
+
+QgsLayoutAtlasToPdfAlgorithm *QgsLayoutAtlasToPdfAlgorithm::createInstance() const
+{
+  return new QgsLayoutAtlasToPdfAlgorithm();
+}
+
+QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  // this needs to be done in main thread, layouts are not thread safe
+  QgsPrintLayout *l = parameterAsLayout( parameters, QStringLiteral( "LAYOUT" ), context );
+  if ( !l )
+    throw QgsProcessingException( QObject::tr( "Cannot find layout with name \"%1\"" ).arg( parameters.value( QStringLiteral( "LAYOUT" ) ).toString() ) );
+
+  std::unique_ptr< QgsPrintLayout > layout( l->clone() );
+  QgsLayoutAtlas *atlas = layout->atlas();
+
+  QString expression, error;
+  QgsVectorLayer *layer = parameterAsVectorLayer( parameters, QStringLiteral( "COVERAGE_LAYER" ), context );
+  if ( layer )
+  {
+    atlas->setEnabled( true );
+    atlas->setCoverageLayer( layer );
+
+    expression = parameterAsString( parameters, QStringLiteral( "FILTER_EXPRESSION" ), context );
+    atlas->setFilterExpression( expression, error );
+    atlas->setFilterFeatures( !expression.isEmpty() && error.isEmpty() );
+    if ( !expression.isEmpty() && !error.isEmpty() )
+    {
+      throw QgsProcessingException( QObject::tr( "Error setting atlas filter expression" ) );
+    }
+    error.clear();
+
+    expression = parameterAsString( parameters, QStringLiteral( "SORTBY_EXPRESSION" ), context );
+    if ( !expression.isEmpty() )
+    {
+      const bool sortByReverse = parameterAsBool( parameters, QStringLiteral( "SORTBY_REVERSE" ), context );
+      atlas->setSortFeatures( true );
+      atlas->setSortExpression( expression );
+      atlas->setSortAscending( !sortByReverse );
+    }
+    else
+    {
+      atlas->setSortFeatures( false );
+    }
+  }
+  else if ( !atlas->enabled() )
+  {
+    throw QgsProcessingException( QObject::tr( "Layout being export doesn't have an enabled atlas" ) );
+  }
+
+  QgsLayoutExporter exporter( layout.get() );
+  QgsLayoutExporter::PdfExportSettings settings;
+
+  if ( parameters.value( QStringLiteral( "DPI" ) ).isValid() )
+  {
+    settings.dpi = parameterAsDouble( parameters, QStringLiteral( "DPI" ), context );
+  }
+  settings.forceVectorOutput = parameterAsBool( parameters, QStringLiteral( "FORCE_VECTOR" ), context );
+  settings.appendGeoreference = parameterAsBool( parameters, QStringLiteral( "GEOREFERENCE" ), context );
+  settings.exportMetadata = parameterAsBool( parameters, QStringLiteral( "INCLUDE_METADATA" ), context );
+  settings.simplifyGeometries = parameterAsBool( parameters, QStringLiteral( "SIMPLIFY" ), context );
+  settings.textRenderFormat = parameterAsEnum( parameters, QStringLiteral( "TEXT_FORMAT" ), context ) == 0 ? QgsRenderContext::TextFormatAlwaysOutlines : QgsRenderContext::TextFormatAlwaysText;
+
+  if ( parameterAsBool( parameters, QStringLiteral( "DISABLE_TILED" ), context ) )
+    settings.flags = settings.flags | QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
+  else
+    settings.flags = settings.flags & ~QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
+
+  settings.predefinedMapScales = QgsLayoutUtils::predefinedScales( layout.get() );
+
+  const QList< QgsMapLayer * > layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context );
+  if ( layers.size() > 0 )
+  {
+    const QList<QGraphicsItem *> items = layout->items();
+    for ( QGraphicsItem *graphicsItem : items )
+    {
+      QgsLayoutItem *item = dynamic_cast<QgsLayoutItem *>( graphicsItem );
+      QgsLayoutItemMap *map = dynamic_cast<QgsLayoutItemMap *>( item );
+      if ( map && !map->followVisibilityPreset() && !map->keepLayerSet() )
+      {
+        map->setKeepLayerSet( true );
+        map->setLayers( layers );
+      }
+    }
+  }
+
+  const QString dest = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
+  if ( atlas->updateFeatures() )
+  {
+    feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
+    switch ( exporter.exportToPdf( atlas, dest, settings, error, feedback ) )
+    {
+      case QgsLayoutExporter::Success:
+      {
+        feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
+        break;
+      }
+
+      case QgsLayoutExporter::FileError:
+        throw QgsProcessingException( QObject::tr( "Cannot write to %1.\n\nThis file may be open in another application." ).arg( QDir::toNativeSeparators( dest ) ) );
+
+      case QgsLayoutExporter::PrintError:
+        throw QgsProcessingException( QObject::tr( "Could not create print device." ) );
+
+      case QgsLayoutExporter::MemoryError:
+        throw QgsProcessingException( QObject::tr( "Trying to create the image "
+                                      "resulted in a memory overflow.\n\n"
+                                      "Please try a lower resolution or a smaller paper size." ) );
+
+      case QgsLayoutExporter::IteratorError:
+        throw QgsProcessingException( QObject::tr( "Error encountered while exporting atlas." ) );
+
+      case QgsLayoutExporter::SvgLayerError:
+      case QgsLayoutExporter::Canceled:
+        // no meaning for imageexports, will not be encountered
+        break;
+    }
+  }
+  else
+  {
+    feedback->reportError( QObject::tr( "No atlas features found" ) );
+  }
+
+  feedback->setProgress( 100 );
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+// QgsLayoutAtlasToMultiplePdfAlgorithm
+
+QString QgsLayoutAtlasToMultiplePdfAlgorithm::name() const
+{
+  return QStringLiteral( "atlaslayouttomultiplepdf" );
+}
+
+QString QgsLayoutAtlasToMultiplePdfAlgorithm::displayName() const
+{
+  return QObject::tr( "Export atlas layout as PDF (multiple files)" );
+}
+
+QString QgsLayoutAtlasToMultiplePdfAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Exports an atlas layout to multiple PDF files." );
+}
+
+QString QgsLayoutAtlasToMultiplePdfAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm outputs an atlas layout to mutliple PDF files.\n\n"
+                      "If a coverage layer is set, the selected layout's atlas settings exposed in this algorithm "
+                      "will be overwritten. In this case, an empty filter or sort by expression will turn those "
+                      "settings off.\n"
+                    );
+}
+
+void QgsLayoutAtlasToMultiplePdfAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterLayout( QStringLiteral( "LAYOUT" ), QObject::tr( "Atlas layout" ) ) );
+
+  addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "COVERAGE_LAYER" ), QObject::tr( "Coverage layer" ), QList< int >(), QVariant(), true ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "FILTER_EXPRESSION" ), QObject::tr( "Filter expression" ), QString(), QStringLiteral( "COVERAGE_LAYER" ), true ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "SORTBY_EXPRESSION" ), QObject::tr( "Sort expression" ), QString(), QStringLiteral( "COVERAGE_LAYER" ), true ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SORTBY_REVERSE" ), QObject::tr( "Reverse sort order (used when a sort expression is provided)" ), false, true ) );
+
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "OUTPUT_FILENAME" ), QObject::tr( "Output filename" ), QString( "'output_'||@atlas_featurenumber" ), QString(), false ) );
   addParameter( new QgsProcessingParameterFile( QStringLiteral( "OUTPUT_FOLDER" ), QObject::tr( "Output folder" ), QgsProcessingParameterFile::Folder ) );
 
   std::unique_ptr< QgsProcessingParameterMultipleLayers > layersParam = std::make_unique< QgsProcessingParameterMultipleLayers>( QStringLiteral( "LAYERS" ), QObject::tr( "Map layers to assign to unlocked map item(s)" ), QgsProcessing::TypeMapLayer, QVariant(), true );
@@ -120,17 +325,13 @@ void QgsLayoutAtlasToPdfAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( textFormat.release() );
 }
 
-QgsProcessingAlgorithm::Flags QgsLayoutAtlasToPdfAlgorithm::flags() const
+
+QgsLayoutAtlasToPdfAlgorithm *QgsLayoutAtlasToMultiplePdfAlgorithm::createInstance() const
 {
-  return QgsProcessingAlgorithm::flags() | FlagNoThreading;
+  return new QgsLayoutAtlasToMultiplePdfAlgorithm();
 }
 
-QgsLayoutAtlasToPdfAlgorithm *QgsLayoutAtlasToPdfAlgorithm::createInstance() const
-{
-  return new QgsLayoutAtlasToPdfAlgorithm();
-}
-
-QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+QVariantMap QgsLayoutAtlasToMultiplePdfAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   // this needs to be done in main thread, layouts are not thread safe
   QgsPrintLayout *l = parameterAsLayout( parameters, QStringLiteral( "LAYOUT" ), context );
@@ -209,7 +410,6 @@ QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &p
       }
     }
   }
-  const bool singleFile = parameterAsBool( parameters, QStringLiteral( "SINGLE_FILE_EXPORT" ), context );
   const QString filename = parameterAsString( parameters, QStringLiteral( "OUTPUT_FILENAME" ), context );
 
   const QString destFolder = parameterAsFile( parameters, QStringLiteral( "OUTPUT_FOLDER" ), context );
@@ -221,23 +421,19 @@ QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &p
     feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
 
     QgsLayoutExporter::ExportResult result;
-    if ( singleFile )
-      result = exporter.exportToPdf( atlas, dest, settings, error, feedback );
-    else
+    if ( !atlas->setFilenameExpression( filename, error ) )
     {
-      if ( !atlas->setFilenameExpression( filename, error ) )
-      {
-        throw QgsProcessingException( QObject::tr( "Output filename could not be set to create filenames for the files, \n"
-                                      "use a correct QGIS expression" ) );
-      }
-      result = exporter.exportToPdfs( atlas, dest, settings, error, feedback );
+      throw QgsProcessingException( QObject::tr( "Output filename could not be set to create filenames for the files, \n"
+                                    "use a correct QGIS expression" ) );
     }
+
+    result = exporter.exportToPdfs( atlas, dest, settings, error, feedback );
 
     switch ( result )
     {
       case QgsLayoutExporter::Success:
       {
-        feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( dest ) ) );
+        feedback->pushInfo( QObject::tr( "Successfully exported layout to %1" ).arg( QDir::toNativeSeparators( destFolder ) ) );
         break;
       }
 
@@ -269,7 +465,7 @@ QVariantMap QgsLayoutAtlasToPdfAlgorithm::processAlgorithm( const QVariantMap &p
   feedback->setProgress( 100 );
 
   QVariantMap outputs;
-  outputs.insert( QStringLiteral( "OUTPUT" ), destFolder );
+  outputs.insert( QStringLiteral( "OUTPUT_FOLDER" ), destFolder );
   return outputs;
 }
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -78,7 +78,7 @@ void QgsLayoutAtlasToPdfAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SORTBY_REVERSE" ), QObject::tr( "Reverse sort order (used when a sort expression is provided)" ), false, true ) );
 
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SINGLE_FILE_EXPORT" ), QObject::tr( "Single file export when possible" ), true, true ) );
-  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "OUTPUT_FILENAME" ), QObject::tr( "Output filename" ), QString( "atlas" ), QStringLiteral( "" ), false ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "OUTPUT_FILENAME" ), QObject::tr( "Output filename" ), QString( "atlas" ), QString(), false ) );
   addParameter( new QgsProcessingParameterFile( QStringLiteral( "OUTPUT_FOLDER" ), QObject::tr( "Output folder" ), QgsProcessingParameterFile::Folder ) );
 
   std::unique_ptr< QgsProcessingParameterMultipleLayers > layersParam = std::make_unique< QgsProcessingParameterMultipleLayers>( QStringLiteral( "LAYERS" ), QObject::tr( "Map layers to assign to unlocked map item(s)" ), QgsProcessing::TypeMapLayer, QVariant(), true );

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
@@ -26,21 +26,34 @@
 ///@cond PRIVATE
 
 /**
- * Native export layout to image algorithm.
+ * Base class for atlas layout to pdf algorithms
  */
-class QgsLayoutAtlasToPdfAlgorithm : public QgsProcessingAlgorithm
+class QgsLayoutAtlasToPdfAlgorithmBase : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsLayoutAtlasToPdfAlgorithmBase() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+};
+
+
+/**
+ * Export atlas layout to single pdf file algorithm.
+ */
+class QgsLayoutAtlasToPdfAlgorithm : public QgsLayoutAtlasToPdfAlgorithmBase
 {
 
   public:
 
     QgsLayoutAtlasToPdfAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
-    Flags flags() const override;
     QString name() const override;
     QString displayName() const override;
-    QStringList tags() const override;
-    QString group() const override;
-    QString groupId() const override;
     QString shortDescription() const override;
     QString shortHelpString() const override;
     QgsLayoutAtlasToPdfAlgorithm *createInstance() const override SIP_FACTORY;
@@ -53,7 +66,10 @@ class QgsLayoutAtlasToPdfAlgorithm : public QgsProcessingAlgorithm
 
 };
 
-class QgsLayoutAtlasToMultiplePdfAlgorithm : public QgsLayoutAtlasToPdfAlgorithm
+/**
+ * Export atlas layout to multiple pdf files algorithm.
+ */
+class QgsLayoutAtlasToMultiplePdfAlgorithm : public QgsLayoutAtlasToPdfAlgorithmBase
 {
 
   public:
@@ -64,7 +80,7 @@ class QgsLayoutAtlasToMultiplePdfAlgorithm : public QgsLayoutAtlasToPdfAlgorithm
     QString displayName() const override;
     QString shortDescription() const override;
     QString shortHelpString() const override;
-    QgsLayoutAtlasToPdfAlgorithm *createInstance() const override SIP_FACTORY;
+    QgsLayoutAtlasToMultiplePdfAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
@@ -53,6 +53,27 @@ class QgsLayoutAtlasToPdfAlgorithm : public QgsProcessingAlgorithm
 
 };
 
+class QgsLayoutAtlasToMultiplePdfAlgorithm : public QgsLayoutAtlasToPdfAlgorithm
+{
+
+  public:
+
+    QgsLayoutAtlasToMultiplePdfAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QString shortDescription() const override;
+    QString shortHelpString() const override;
+    QgsLayoutAtlasToPdfAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSALGORITHMLAYOUTATLASTOPDF_H

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.h
@@ -22,6 +22,9 @@
 
 #include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgslayoutexporter.h"
+
+class QgsLayoutAtlas;
 
 ///@cond PRIVATE
 
@@ -39,6 +42,23 @@ class QgsLayoutAtlasToPdfAlgorithmBase : public QgsProcessingAlgorithm
     QStringList tags() const override;
     QString group() const override;
     QString groupId() const override;
+
+    QgsLayoutAtlas *atlas();
+    QgsLayoutExporter exporter();
+    QgsLayoutExporter::PdfExportSettings settings();
+    QString error();
+
+
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters,
+                           QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+  private:
+    QgsLayoutAtlas *mAtlas;
+    QgsLayoutExporter mExporter = QgsLayoutExporter( nullptr );
+    QgsLayoutExporter::PdfExportSettings mSettings;
+    QString mError;
 };
 
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -356,6 +356,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
 #ifndef QT_NO_PRINTER
   addAlgorithm( new QgsLayoutAtlasToImageAlgorithm() );
   addAlgorithm( new QgsLayoutAtlasToPdfAlgorithm() );
+  addAlgorithm( new QgsLayoutAtlasToMultiplePdfAlgorithm() );
   addAlgorithm( new QgsLayoutToImageAlgorithm() );
   addAlgorithm( new QgsLayoutToPdfAlgorithm() );
 #endif


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/44466

Splits QgsLayoutAtlasToPdfAlgorithm into two algorithms, one deals with single PDF file export and other multiple PDF files exports.

screenshot showing how two new algorithms work.
![updated_atlas_export_to_pdf](https://user-images.githubusercontent.com/2663775/132660283-2a0f4cc8-4c5e-4188-b2cf-9de1521a0634.gif)

