### PR TITLE
Enable calendar widget in layout map composer temporal range input

### DIFF
--- a/src/ui/layout/qgslayoutmapwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapwidgetbase.ui
@@ -88,9 +88,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-376</y>
+        <y>0</y>
         <width>548</width>
-        <height>1398</height>
+        <height>1336</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -467,6 +467,9 @@
             <property name="displayFormat">
              <string>M/d/yyyy h:mm AP</string>
             </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
             <property name="timeSpec">
              <enum>Qt::UTC</enum>
             </property>
@@ -502,6 +505,9 @@
             </property>
             <property name="displayFormat">
              <string>M/d/yyyy h:mm AP</string>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
             </property>
             <property name="timeSpec">
              <enum>Qt::UTC</enum>


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/42885

Enables calendar popup in the layout map temporal range datetime inputs

screenshot showing the calendar popups in action
![calendar_popup_in_print_layout_range](https://user-images.githubusercontent.com/2663775/131802081-b49c260d-50f3-44d5-adf6-fa0ddf94e022.gif)
