### PR TITLE
Annotation edit tool (pt 1)

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -91,6 +91,7 @@ if(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/core/vector
       ${CMAKE_SOURCE_DIR}/src/core/vectortile
       ${CMAKE_SOURCE_DIR}/src/gui
+      ${CMAKE_SOURCE_DIR}/src/gui/annotations
       ${CMAKE_SOURCE_DIR}/src/gui/auth
       ${CMAKE_SOURCE_DIR}/src/gui/attributetable
       ${CMAKE_SOURCE_DIR}/src/gui/callouts

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -658,6 +658,11 @@ Qgis.AnnotationItemFlag.__doc__ = 'Flags for annotation items.\n\n.. versionadde
 # --
 Qgis.AnnotationItemFlag.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.AnnotationItemGuiFlag.FlagNoCreationTools.__doc__ = "Do not show item creation tools for the item type"
+Qgis.AnnotationItemGuiFlag.__doc__ = 'Flags for controlling how an annotation item behaves in the GUI.\n\n.. versionadded:: 3.22\n\n' + '* ``FlagNoCreationTools``: ' + Qgis.AnnotationItemGuiFlag.FlagNoCreationTools.__doc__
+# --
+Qgis.AnnotationItemGuiFlag.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.AnnotationItemNodeType.VertexHandle.__doc__ = "Node is a handle for manipulating vertices"
 Qgis.AnnotationItemNodeType.__doc__ = 'Annotation item node types.\n\n.. versionadded:: 3.22\n\n' + '* ``VertexHandle``: ' + Qgis.AnnotationItemNodeType.VertexHandle.__doc__
 # --

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -70,6 +70,15 @@ Ownership of ``item`` is transferred to the layer.
 Returns the unique ID assigned to the item.
 %End
 
+    void replaceItem( const QString &id, QgsAnnotationItem *item /Transfer/ );
+%Docstring
+Replaces the existing item with matching ``id`` with a new ``item``.
+
+Ownership of ``item`` is transferred to the layer.
+
+.. versionadded:: 3.22
+%End
+
     bool removeItem( const QString &id );
 %Docstring
 Removes (and deletes) the item with matching ``id``.

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -480,6 +480,13 @@ The development version
     typedef QFlags<Qgis::AnnotationItemFlag> AnnotationItemFlags;
 
 
+    enum class AnnotationItemGuiFlag
+    {
+      FlagNoCreationTools,
+    };
+    typedef QFlags<Qgis::AnnotationItemGuiFlag> AnnotationItemGuiFlags;
+
+
     enum class AnnotationItemNodeType
     {
       VertexHandle,
@@ -573,6 +580,8 @@ QFlags<Qgis::GeometryValidityFlag> operator|(Qgis::GeometryValidityFlag f1, QFla
 QFlags<Qgis::FileOperationFlag> operator|(Qgis::FileOperationFlag f1, QFlags<Qgis::FileOperationFlag> f2);
 
 QFlags<Qgis::AnnotationItemFlag> operator|(Qgis::AnnotationItemFlag f1, QFlags<Qgis::AnnotationItemFlag> f2);
+
+QFlags<Qgis::AnnotationItemGuiFlag> operator|(Qgis::AnnotationItemGuiFlag f1, QFlags<Qgis::AnnotationItemGuiFlag> f2);
 
 
 

--- a/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
+++ b/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
@@ -1,0 +1,244 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsannotationitemguiregistry.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsAnnotationItemAbstractGuiMetadata
+{
+%Docstring(signature="appended")
+Stores GUI metadata about one annotation item class.
+
+This is a companion to :py:class:`QgsAnnotationItemAbstractMetadata`, storing only
+the components related to the GUI behavior of an annotation item.
+
+.. note::
+
+   In C++ you can use :py:class:`QgsAnnotationItemGuiMetadata` convenience class.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemguiregistry.h"
+%End
+  public:
+
+    QgsAnnotationItemAbstractGuiMetadata( const QString &type, const QString &visibleName, const QString &groupId = QString(), Qgis::AnnotationItemGuiFlags flags = Qgis::AnnotationItemGuiFlags() );
+%Docstring
+Constructor for QgsAnnotationItemAbstractGuiMetadata with the specified class ``type``.
+
+``visibleName`` should be set to a translated, user visible name identifying the corresponding annotation item.
+
+An optional ``groupId`` can be set, which allows grouping of related annotation item classes. See :py:class:`QgsAnnotationItemGuiMetadata` for details.
+%End
+
+    virtual ~QgsAnnotationItemAbstractGuiMetadata();
+
+    QString type() const;
+%Docstring
+Returns the unique item type code for the annotation item class.
+%End
+
+    Qgis::AnnotationItemGuiFlags flags() const;
+%Docstring
+Returns item flags.
+%End
+
+    QString groupId() const;
+%Docstring
+Returns the item group ID, if set.
+%End
+
+    QString visibleName() const;
+%Docstring
+Returns a translated, user visible name identifying the corresponding annotation item.
+%End
+
+    virtual QIcon creationIcon() const;
+%Docstring
+Returns an icon representing creation of the annotation item type.
+%End
+
+
+    virtual QgsAnnotationItemBaseWidget *createItemWidget( QgsAnnotationItem *item ) /TransferBack/;
+%Docstring
+Creates a configuration widget for an ``item`` of this type. Can return ``None`` if no configuration GUI is required.
+%End
+
+    virtual QgsAnnotationItem *createItem() /TransferBack/;
+%Docstring
+Creates an instance of the corresponding item type.
+%End
+
+    virtual void newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer );
+%Docstring
+Called when a newly created item of the associated type has been added to a ``layer``.
+
+This is only called for additions which result from GUI operations - i.e. it is not
+called for items added programmatically.
+%End
+
+};
+
+
+
+
+class QgsAnnotationItemGuiGroup
+{
+%Docstring(signature="appended")
+Stores GUI metadata about a group of annotation item classes.
+
+:py:class:`QgsAnnotationItemGuiGroup` stores settings about groups of related annotation item classes
+which should be presented to users grouped together.
+
+For instance, the various basic shape creation tools would use :py:class:`QgsAnnotationItemGuiGroup`
+to display grouped within toolbars.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemguiregistry.h"
+%End
+  public:
+
+    QgsAnnotationItemGuiGroup( const QString &id = QString(), const QString &name = QString(), const QIcon &icon = QIcon() );
+%Docstring
+Constructor for QgsAnnotationItemGuiGroup.
+%End
+
+    QString id;
+
+    QString name;
+
+    QIcon icon;
+
+};
+
+
+class QgsAnnotationItemGuiRegistry : QObject
+{
+%Docstring(signature="appended")
+Registry of available annotation item GUI behavior.
+
+:py:class:`QgsAnnotationItemGuiRegistry` is not usually directly created, but rather accessed through
+:py:func:`QgsGui.annotationItemGuiRegistry()`.
+
+This acts as a companion to :py:class:`QgsAnnotationItemRegistry`, handling only
+the components related to the GUI behavior of annotation items.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemguiregistry.h"
+%End
+  public:
+
+    QgsAnnotationItemGuiRegistry( QObject *parent = 0 );
+%Docstring
+Creates a new empty item GUI registry.
+
+QgsAnnotationItemGuiRegistry is not usually directly created, but rather accessed through
+:py:func:`QgsGui.annotationItemGuiRegistry()`.
+%End
+
+    ~QgsAnnotationItemGuiRegistry();
+
+
+    QgsAnnotationItemAbstractGuiMetadata *itemMetadata( int metadataId ) const;
+%Docstring
+Returns the metadata for the specified item ``metadataId``. Returns ``None`` if
+a corresponding ``metadataId`` was not found in the registry.
+%End
+
+    int metadataIdForItemType( const QString &type ) const;
+%Docstring
+Returns the GUI item metadata ID which corresponds to the specified annotation item ``type``.
+
+In the case that multiple GUI metadata classes exist for a single annotation item ``type`` then
+only the first encountered GUI metadata ID will be returned.
+
+Returns -1 if no matching metadata is found in the GUI registry.
+%End
+
+    bool addAnnotationItemGuiMetadata( QgsAnnotationItemAbstractGuiMetadata *metadata /Transfer/ );
+%Docstring
+Registers the gui metadata for a new annotation item type. Takes ownership of the metadata instance.
+%End
+
+    bool addItemGroup( const QgsAnnotationItemGuiGroup &group );
+%Docstring
+Registers a new item group with the registry. This must be done before calling
+:py:func:`~QgsAnnotationItemGuiRegistry.addAnnotationItemGuiMetadata` for any item types associated with the group.
+
+Returns ``True`` if group was added, or ``False`` if group could not be added (e.g. due to
+duplicate id value).
+
+.. seealso:: :py:func:`itemGroup`
+%End
+
+    const QgsAnnotationItemGuiGroup &itemGroup( const QString &id );
+%Docstring
+Returns a reference to the item group with matching ``id``.
+
+.. seealso:: :py:func:`addItemGroup`
+%End
+
+
+    QgsAnnotationItem *createItem( int metadataId ) const /TransferBack/;
+%Docstring
+Creates a new instance of an annotation item given the item metadata ``metadataId``.
+%End
+
+    void newItemAddedToLayer( int metadataId, QgsAnnotationItem *item, QgsAnnotationLayer *layer );
+%Docstring
+Called when a newly created item of the associated metadata ``metadataId`` has been added to a ``layer``.
+
+This is only called for additions which result from GUI operations - i.e. it is not
+called for items added programmatically.
+%End
+
+
+    QgsAnnotationItemBaseWidget *createItemWidget( QgsAnnotationItem *item ) const /TransferBack/;
+%Docstring
+Creates a new instance of an annotation item configuration widget for the specified ``item``.
+%End
+
+    QList< int > itemMetadataIds() const;
+%Docstring
+Returns a list of available item metadata ids handled by the registry.
+%End
+
+    void addDefaultItems();
+%Docstring
+Populates the registry with default items.
+%End
+
+  signals:
+
+    void typeAdded( int metadataId );
+%Docstring
+Emitted whenever a new item type is added to the registry, with the specified
+``metadataId``.
+%End
+
+  private:
+    QgsAnnotationItemGuiRegistry( const QgsAnnotationItemGuiRegistry &rh );
+};
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsannotationitemguiregistry.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/annotations/qgsannotationitemwidget.sip.in
+++ b/python/gui/auto_generated/annotations/qgsannotationitemwidget.sip.in
@@ -1,0 +1,76 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsannotationitemwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsAnnotationItemBaseWidget: QgsPanelWidget
+{
+%Docstring(signature="appended")
+
+A base class for property widgets for annotation items.
+
+All annotation item widgets should inherit from this base class.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemwidget.h"
+%End
+  public:
+
+    QgsAnnotationItemBaseWidget( QWidget *parent /TransferThis/ );
+%Docstring
+Constructor for QgsAnnotationItemBaseWidget, linked with the specified annotation ``item``.
+%End
+
+    virtual QgsAnnotationItem *createItem() = 0 /Factory/;
+%Docstring
+Creates a new item matching the settings defined in the widget.
+%End
+
+    bool setItem( QgsAnnotationItem *item );
+%Docstring
+Sets the current ``item`` to show in the widget. If ``True`` is returned, ``item``
+was an acceptable type for display in this widget and the widget has been
+updated to match ``item``'s properties.
+
+If ``False`` is returned, then the widget could not be successfully updated
+to show the properties of ``item``.
+%End
+
+
+  signals:
+
+    void itemChanged();
+%Docstring
+Emitted when the annotation item definition in the widget is changed by the user.
+%End
+
+  protected:
+
+    virtual bool setNewItem( QgsAnnotationItem *item );
+%Docstring
+Attempts to update the widget to show the properties
+for the specified ``item``.
+
+Subclasses can override this if they support changing items in place.
+
+Implementations must return ``True`` if the item was accepted and
+the widget was updated.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsannotationitemwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/annotations/qgsmaptoolmodifyannotation.sip.in
+++ b/python/gui/auto_generated/annotations/qgsmaptoolmodifyannotation.sip.in
@@ -1,0 +1,55 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsmaptoolmodifyannotation.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsMapToolModifyAnnotation : QgsMapToolAdvancedDigitizing
+{
+%Docstring(signature="appended")
+A map tool for modifying annotations in a :py:class:`QgsAnnotationLayer`
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsmaptoolmodifyannotation.h"
+%End
+  public:
+
+    explicit QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+%Docstring
+Constructor for QgsMapToolModifyAnnotation
+%End
+
+    ~QgsMapToolModifyAnnotation();
+
+    virtual void deactivate();
+
+    virtual void cadCanvasMoveEvent( QgsMapMouseEvent *event );
+
+    virtual void cadCanvasPressEvent( QgsMapMouseEvent *event );
+
+
+  signals:
+
+    void itemSelected( QgsAnnotationLayer *layer, const QString &itemId );
+%Docstring
+Emitted when the selected item is changed.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgsmaptoolmodifyannotation.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1571,6 +1571,13 @@ is automatically registered within the :py:func:`QgsApplication.gpsConnectionReg
 .. versionadded:: 3.16
 %End
 
+    virtual QgsMapToolModifyAnnotation *modifyAnnotationTool() = 0;
+%Docstring
+Returns the map tool used for modifying annotation layers.
+
+.. versionadded:: 3.22
+%End
+
   signals:
 
     void currentLayerChanged( QgsMapLayer *layer );

--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -75,6 +75,13 @@ Returns the global map layer action registry, used for registering map layer act
 Returns the global layout item GUI registry, used for registering the GUI behavior of layout items.
 %End
 
+    static QgsAnnotationItemGuiRegistry *annotationItemGuiRegistry() /KeepReference/;
+%Docstring
+Returns the global annotation item GUI registry, used for registering the GUI behavior of annotation items.
+
+.. versionadded:: 3.22
+%End
+
     static QgsProcessingGuiRegistry *processingGuiRegistry() /KeepReference/;
 %Docstring
 Returns the global processing gui registry, used for registering the GUI behavior of processing algorithms.

--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -114,7 +114,7 @@ Reset to original (vector layer) values
 .. versionadded:: 3.14
 %End
 
-    virtual void setContext( const QgsMapLayerConfigWidgetContext &context );
+    virtual void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context );
 %Docstring
 Sets the ``context`` under which the widget is being shown.
 

--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -32,7 +32,7 @@ an annotation from a :py:class:`QgsAnnotationLayer`.
 
     void setAnnotationId( const QString &id );
 %Docstring
-Sets the item \id of the target annotation, when modifying
+Sets the item ``id`` of the target annotation, when modifying
 an annotation from a :py:class:`QgsAnnotationLayer`.
 
 .. seealso:: :py:func:`annotationId`

--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -9,6 +9,68 @@
 
 
 
+class QgsMapLayerConfigWidgetContext
+{
+%Docstring(signature="appended")
+Encapsulates the context for a :py:class:`QgsMapLayerConfigWidget`.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsmaplayerconfigwidget.h"
+%End
+  public:
+
+    QString annotationId() const;
+%Docstring
+Returns the item ID of the target annotation, when modifying
+an annotation from a :py:class:`QgsAnnotationLayer`.
+
+.. seealso:: :py:func:`setAnnotationId`
+%End
+
+    void setAnnotationId( const QString &id );
+%Docstring
+Sets the item \id of the target annotation, when modifying
+an annotation from a :py:class:`QgsAnnotationLayer`.
+
+.. seealso:: :py:func:`annotationId`
+%End
+
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the map ``canvas`` associated with the widget. This allows the widget to retrieve the current
+map scale and other properties from the canvas.
+
+.. seealso:: :py:func:`mapCanvas`
+%End
+
+    QgsMapCanvas *mapCanvas() const;
+%Docstring
+Returns the map canvas associated with the widget.
+
+.. seealso:: :py:func:`setMapCanvas`
+%End
+
+    void setMessageBar( QgsMessageBar *bar );
+%Docstring
+Sets the message ``bar`` associated with the widget. This allows the widget to push feedback messages
+to the appropriate message bar.
+
+.. seealso:: :py:func:`messageBar`
+%End
+
+    QgsMessageBar *messageBar() const;
+%Docstring
+Returns the message bar associated with the widget.
+
+.. seealso:: :py:func:`setMessageBar`
+%End
+
+};
+
+
 class QgsMapLayerConfigWidget : QgsPanelWidget
 {
 %Docstring(signature="appended")
@@ -50,6 +112,13 @@ be called for the layer after applying changes. This is ``True`` by default, but
 Reset to original (vector layer) values
 
 .. versionadded:: 3.14
+%End
+
+    virtual void setContext( const QgsMapLayerConfigWidgetContext &context );
+%Docstring
+Sets the ``context`` under which the widget is being shown.
+
+Subclasses should take care to call the base class implementation when overriding this method.
 %End
 
   public slots:

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -224,6 +224,8 @@
 %Include auto_generated/qgsvertexmarker.sip
 %Include auto_generated/qgsvscrollarea.sip
 %Include auto_generated/qgswindowmanagerinterface.sip
+%Include auto_generated/annotations/qgsannotationitemguiregistry.sip
+%Include auto_generated/annotations/qgsannotationitemwidget.sip
 %Include auto_generated/annotations/qgsmaptoolmodifyannotation.sip
 %Include auto_generated/attributetable/qgsattributetabledelegate.sip
 %Include auto_generated/attributetable/qgsattributetablefiltermodel.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -224,6 +224,7 @@
 %Include auto_generated/qgsvertexmarker.sip
 %Include auto_generated/qgsvscrollarea.sip
 %Include auto_generated/qgswindowmanagerinterface.sip
+%Include auto_generated/annotations/qgsmaptoolmodifyannotation.sip
 %Include auto_generated/attributetable/qgsattributetabledelegate.sip
 %Include auto_generated/attributetable/qgsattributetablefiltermodel.sip
 %Include auto_generated/attributetable/qgsattributetablemodel.sip

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -106,6 +106,8 @@ set(QGIS_APP_SRCS
   qgsmaptoolsvgannotation.cpp
   qgsmaptooltextannotation.cpp
 
+  annotations/qgsannotationitempropertieswidget.cpp
+
   decorations/qgsdecorationitem.cpp
   decorations/qgsdecorationtitle.cpp
   decorations/qgsdecorationtitledialog.cpp

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -76,6 +76,9 @@ void QgsAnnotationItemPropertiesWidget::apply()
 
 void QgsAnnotationItemPropertiesWidget::onChanged()
 {
+  if ( !mLayer )
+    return;
+
   // set the annotation layer's item's properties to match the widget
   std::unique_ptr< QgsAnnotationItem > newItem( mItemWidget->createItem() );
 
@@ -84,6 +87,9 @@ void QgsAnnotationItemPropertiesWidget::onChanged()
 
 void QgsAnnotationItemPropertiesWidget::setItemId( const QString &itemId )
 {
+  if ( !mLayer )
+    return;
+
   // try to retrieve matching item
   bool setItem = false;
   if ( QgsAnnotationItem *item = mLayer->item( itemId ) )

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -50,12 +50,12 @@ void QgsAnnotationItemPropertiesWidget::syncToLayer( QgsMapLayer *layer )
     return;
 
   // check context
-  setItemId( mContext.annotationId() );
+  setItemId( mMapLayerConfigWidgetContext.annotationId() );
 }
 
-void QgsAnnotationItemPropertiesWidget::setContext( const QgsMapLayerConfigWidgetContext &context )
+void QgsAnnotationItemPropertiesWidget::setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context )
 {
-  QgsMapLayerConfigWidget::setContext( context );
+  QgsMapLayerConfigWidget::setMapLayerConfigWidgetContext( context );
   setItemId( context.annotationId() );
 }
 
@@ -79,7 +79,7 @@ void QgsAnnotationItemPropertiesWidget::onChanged()
   // set the annotation layer's item's properties to match the widget
   std::unique_ptr< QgsAnnotationItem > newItem( mItemWidget->createItem() );
 
-  mLayer->replaceItem( mContext.annotationId(), newItem.release() );
+  mLayer->replaceItem( mMapLayerConfigWidgetContext.annotationId(), newItem.release() );
 }
 
 void QgsAnnotationItemPropertiesWidget::setItemId( const QString &itemId )

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -1,0 +1,153 @@
+/***************************************************************************
+    qgsannotationitempropertieswidget.cpp
+    ---------------------
+    begin                : December 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationitempropertieswidget.h"
+#include "qgsstyle.h"
+#include "qgsapplication.h"
+#include "qgsmaplayer.h"
+#include "qgsannotationlayer.h"
+#include "qgsannotationitemwidget.h"
+#include "qgsannotationitem.h"
+#include "qgsgui.h"
+#include "qgsannotationitemguiregistry.h"
+#include <QStackedWidget>
+#include <QHBoxLayout>
+
+QgsAnnotationItemPropertiesWidget::QgsAnnotationItemPropertiesWidget( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
+  : QgsMapLayerConfigWidget( layer, canvas, parent )
+{
+  mStack = new QStackedWidget();
+
+  setDockMode( true );
+
+  QHBoxLayout *l = new QHBoxLayout();
+  l->setContentsMargins( 0, 0, 0, 0 );
+  l->addWidget( mStack );
+  setLayout( l );
+
+  syncToLayer( layer );
+}
+
+void QgsAnnotationItemPropertiesWidget::syncToLayer( QgsMapLayer *layer )
+{
+  if ( layer == mLayer )
+    return;
+
+  mLayer = qobject_cast< QgsAnnotationLayer * >( layer );
+  if ( !mLayer )
+    return;
+
+  // check context
+  setItemId( mContext.annotationId() );
+}
+
+void QgsAnnotationItemPropertiesWidget::setContext( const QgsMapLayerConfigWidgetContext &context )
+{
+  QgsMapLayerConfigWidget::setContext( context );
+  setItemId( context.annotationId() );
+}
+
+void QgsAnnotationItemPropertiesWidget::setDockMode( bool dockMode )
+{
+  QgsMapLayerConfigWidget::setDockMode( dockMode );
+  if ( mItemWidget )
+    mItemWidget->setDockMode( dockMode );
+}
+
+void QgsAnnotationItemPropertiesWidget::apply()
+{
+  if ( !mLayer )
+    return;
+
+  mLayer->triggerRepaint();
+}
+
+void QgsAnnotationItemPropertiesWidget::onChanged()
+{
+  // set the annotation layer's item's properties to match the widget
+  std::unique_ptr< QgsAnnotationItem > newItem( mItemWidget->createItem() );
+
+  mLayer->replaceItem( mContext.annotationId(), newItem.release() );
+}
+
+void QgsAnnotationItemPropertiesWidget::setItemId( const QString &itemId )
+{
+  // try to retrieve matching item
+  bool setItem = false;
+  if ( QgsAnnotationItem *item = mLayer->item( itemId ) )
+  {
+    if ( mItemWidget )
+    {
+      setItem = mItemWidget->setItem( item );
+    }
+
+    if ( !setItem )
+    {
+      // create new item
+      mItemWidget = QgsGui::annotationItemGuiRegistry()->createItemWidget( item );
+
+      if ( mItemWidget )
+      {
+        setItem = true;
+
+        QWidget *prevWidget = mStack->currentWidget();
+        mStack->removeWidget( prevWidget );
+        delete prevWidget;
+
+        mStack->addWidget( mItemWidget );
+        connect( mItemWidget, &QgsAnnotationItemBaseWidget::itemChanged, this, &QgsAnnotationItemPropertiesWidget::onChanged );
+        mItemWidget->setDockMode( dockMode() );
+        connect( mItemWidget, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+      }
+    }
+  }
+
+  if ( !setItem )
+  {
+    // show a "no item" widget
+  }
+}
+
+//
+// QgsAnnotationItemPropertiesWidgetFactory
+//
+
+QgsAnnotationItemPropertiesWidgetFactory::QgsAnnotationItemPropertiesWidgetFactory( QObject *parent )
+  : QObject( parent )
+{
+  setIcon( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ) );
+  setTitle( tr( "Annotation" ) );
+}
+
+QgsMapLayerConfigWidget *QgsAnnotationItemPropertiesWidgetFactory::createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool, QWidget *parent ) const
+{
+  return new QgsAnnotationItemPropertiesWidget( qobject_cast< QgsAnnotationLayer * >( layer ), canvas, parent );
+}
+
+bool QgsAnnotationItemPropertiesWidgetFactory::supportLayerPropertiesDialog() const
+{
+  return false;
+}
+
+bool QgsAnnotationItemPropertiesWidgetFactory::supportsStyleDock() const
+{
+  return true;
+}
+
+bool QgsAnnotationItemPropertiesWidgetFactory::supportsLayer( QgsMapLayer *layer ) const
+{
+  return layer->type() == QgsMapLayerType::AnnotationLayer;
+}
+

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -31,7 +31,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
     QgsAnnotationItemPropertiesWidget( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
     void syncToLayer( QgsMapLayer *layer ) override;
-    void setContext( const QgsMapLayerConfigWidgetContext &context ) override;
+    void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
     void setDockMode( bool dockMode ) override;
 
   public slots:

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -18,6 +18,7 @@
 
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
+#include <QPointer>
 
 class QgsAnnotationLayer;
 class QgsAnnotationItemBaseWidget;
@@ -45,7 +46,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
     void setItemId( const QString &itemId );
 
     QStackedWidget *mStack = nullptr;
-    QgsAnnotationLayer *mLayer = nullptr;
+    QPointer< QgsAnnotationLayer > mLayer;
     QgsAnnotationItemBaseWidget *mItemWidget = nullptr;
 
 };

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -1,0 +1,68 @@
+/***************************************************************************
+    qgsannotationitempropertieswidget.h
+    ---------------------
+    begin                : September 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSANNOTATIONITEMPROPERTIESWIDGET_H
+#define QGSANNOTATIONITEMPROPERTIESWIDGET_H
+
+#include "qgsmaplayerconfigwidget.h"
+#include "qgsmaplayerconfigwidgetfactory.h"
+
+class QgsAnnotationLayer;
+class QgsAnnotationItemBaseWidget;
+class QStackedWidget;
+
+class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsAnnotationItemPropertiesWidget( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
+
+    void syncToLayer( QgsMapLayer *layer ) override;
+    void setContext( const QgsMapLayerConfigWidgetContext &context ) override;
+    void setDockMode( bool dockMode ) override;
+
+  public slots:
+    void apply() override;
+
+  private slots:
+
+    void onChanged();
+  private:
+
+    void setItemId( const QString &itemId );
+
+    QStackedWidget *mStack = nullptr;
+    QgsAnnotationLayer *mLayer = nullptr;
+    QgsAnnotationItemBaseWidget *mItemWidget = nullptr;
+
+};
+
+
+class QgsAnnotationItemPropertiesWidgetFactory : public QObject, public QgsMapLayerConfigWidgetFactory
+{
+    Q_OBJECT
+  public:
+    explicit QgsAnnotationItemPropertiesWidgetFactory( QObject *parent = nullptr );
+
+    QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget, QWidget *parent ) const override;
+    bool supportLayerPropertiesDialog() const override;
+    bool supportsStyleDock() const override;
+    bool supportsLayer( QgsMapLayer *layer ) const override;
+};
+
+
+
+#endif // QGSANNOTATIONITEMPROPERTIESWIDGET_H

--- a/src/app/maptools/qgsappmaptools.cpp
+++ b/src/app/maptools/qgsappmaptools.cpp
@@ -72,6 +72,7 @@
 #include "qgsmaptooleditmeshframe.h"
 #include "qgsspinbox.h"
 #include "qgssettingsregistrycore.h"
+#include "qgsmaptoolmodifyannotation.h"
 
 //
 // QgsStreamDigitizingSettingsAction
@@ -178,6 +179,7 @@ QgsAppMapTools::QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockW
   mTools.insert( Tool::RotateLabel, new QgsMapToolRotateLabel( canvas, cadDock ) );
   mTools.insert( Tool::ChangeLabelProperties, new QgsMapToolChangeLabelProperties( canvas, cadDock ) );
   mTools.insert( Tool::EditMeshFrame, new QgsMapToolEditMeshFrame( canvas ) );
+  mTools.insert( Tool::AnnotationEdit, new QgsMapToolModifyAnnotation( canvas, cadDock ) );
 
   mStreamDigitizingSettingsAction = new QgsStreamDigitizingSettingsAction();
 }

--- a/src/app/maptools/qgsappmaptools.h
+++ b/src/app/maptools/qgsappmaptools.h
@@ -113,7 +113,8 @@ class QgsAppMapTools
       ChangeLabelProperties,
       ReverseLine,
       TrimExtendFeature,
-      EditMeshFrame
+      EditMeshFrame,
+      AnnotationEdit
     };
 
     QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -104,6 +104,9 @@
 #include "qgsprovidersublayersdialog.h"
 #include "qgsmaplayerfactory.h"
 #include "qgsbrowserwidget.h"
+#include "annotations/qgsannotationitempropertieswidget.h"
+#include "qgsmaptoolmodifyannotation.h"
+#include "qgsannotationlayer.h"
 
 #include "qgsanalysis.h"
 #include "qgsgeometrycheckregistry.h"
@@ -1338,6 +1341,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   registerMapLayerPropertiesFactory( new QgsPointCloudLayer3DRendererWidgetFactory( this ) );
 #endif
   registerMapLayerPropertiesFactory( new QgsPointCloudElevationPropertiesWidgetFactory( this ) );
+  registerMapLayerPropertiesFactory( new QgsAnnotationItemPropertiesWidgetFactory( this ) );
 
   activateDeactivateLayerRelatedActions( nullptr ); // after members were created
 
@@ -1660,6 +1664,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   fileNewBlank(); // prepare empty project, also skips any default templates from loading
   updateCrsStatusBar();
   endProfile();
+
+  connect( qobject_cast< QgsMapToolModifyAnnotation * >( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::itemSelected,
+           mMapStyleWidget, &QgsLayerStylingWidget::setAnnotationItem );
 
   // request notification of FileOpen events (double clicking a file icon in Mac OS X Finder)
   // should come after fileNewBlank to ensure project is properly set up to receive any data source files

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -47,7 +47,8 @@
 #include "qgslocatorwidget.h"
 #include "qgslocator.h"
 #include "qgsmessagebar.h"
-
+#include "qgsappmaptools.h"
+#include "qgsmaptoolmodifyannotation.h"
 
 QgisAppInterface::QgisAppInterface( QgisApp *_qgis )
   : qgis( _qgis )
@@ -906,4 +907,9 @@ void QgisAppInterface::setGpsPanelConnection( QgsGpsConnection *connection )
 QList<QgsMapDecoration *> QgisAppInterface::activeDecorations()
 {
   return qgis->activeDecorations();
+}
+
+QgsMapToolModifyAnnotation *QgisAppInterface::modifyAnnotationTool()
+{
+  return qobject_cast< QgsMapToolModifyAnnotation * >( qgis->mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) );
 }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -322,6 +322,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() override;
     void setGpsPanelConnection( QgsGpsConnection *connection ) override;
     QList<QgsMapDecoration *> activeDecorations() override;
+    virtual QgsMapToolModifyAnnotation *modifyAnnotationTool() override;
 
   private slots:
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -71,6 +71,9 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
 {
   setupUi( this );
 
+  mContext.setMapCanvas( canvas );
+  mContext.setMessageBar( messageBar );
+
   mOptionsListWidget->setIconSize( QgisApp::instance()->iconSize( false ) );
   mOptionsListWidget->setMaximumWidth( static_cast< int >( mOptionsListWidget->iconSize().width() * 1.18 ) );
 
@@ -440,6 +443,7 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
     if ( panel )
     {
       panel->setDockMode( true );
+      panel->setContext( mContext );
       connect( panel, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
       mWidgetStack->setMainPanel( panel );
     }

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -706,7 +706,7 @@ void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const 
 
   if ( QgsMapLayerConfigWidget *configWidget = qobject_cast< QgsMapLayerConfigWidget * >( mWidgetStack->mainPanel() ) )
   {
-    configWidget->setContext( mContext );
+    configWidget->setMapLayerConfigWidgetContext( mContext );
   }
 }
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -53,6 +53,7 @@
 #include "qgsrasterminmaxwidget.h"
 #include "qgisapp.h"
 #include "qgssymbolwidgetcontext.h"
+#include "qgsannotationlayer.h"
 
 #ifdef HAVE_3D
 #include "qgsvectorlayer3drendererwidget.h"
@@ -695,6 +696,17 @@ void QgsLayerStylingWidget::setCurrentPage( QgsLayerStylingWidget::Page page )
       mOptionsListWidget->setCurrentRow( i );
       return;
     }
+  }
+}
+
+void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId )
+{
+  mContext.setAnnotationId( itemId );
+  setLayer( layer );
+
+  if ( QgsMapLayerConfigWidget *configWidget = qobject_cast< QgsMapLayerConfigWidget * >( mWidgetStack->mainPanel() ) )
+  {
+    configWidget->setContext( mContext );
   }
 }
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -444,7 +444,7 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
     if ( panel )
     {
       panel->setDockMode( true );
-      panel->setContext( mContext );
+      panel->setMapLayerConfigWidgetContext( mContext );
       connect( panel, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
       mWidgetStack->setMainPanel( panel );
     }

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -48,6 +48,7 @@ class QgsPointCloudLayer3DRendererWidget;
 class QgsMessageBar;
 class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileBasicLabelingWidget;
+class QgsAnnotationLayer;
 
 class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWidgetFactory
 {
@@ -128,6 +129,11 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
      * \param page standard page to display
      */
     void setCurrentPage( QgsLayerStylingWidget::Page page );
+
+    /**
+     * Sets an annotation item to show in the widget.
+     */
+    void setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId );
 
   private slots:
 

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -29,6 +29,7 @@
 
 #include "ui_qgsmapstylingwidgetbase.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
+#include "qgsmaplayerconfigwidget.h"
 #include "qgis_app.h"
 
 class QgsLabelingWidget;
@@ -157,6 +158,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
     QList<const QgsMapLayerConfigWidgetFactory *> mPageFactories;
     QMap<int, const QgsMapLayerConfigWidgetFactory *> mUserPages;
     QgsLayerStyleManagerWidgetFactory *mStyleManagerFactory = nullptr;
+    QgsMapLayerConfigWidgetContext mContext;
 };
 
 #endif // QGSLAYERSTYLESDOCK_H

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -98,6 +98,15 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QString addItem( QgsAnnotationItem *item SIP_TRANSFER );
 
     /**
+     * Replaces the existing item with matching \a id with a new \a item.
+     *
+     * Ownership of \a item is transferred to the layer.
+     *
+     * \since QGIS 3.22
+     */
+    void replaceItem( const QString &id, QgsAnnotationItem *item SIP_TRANSFER );
+
+    /**
      * Removes (and deletes) the item with matching \a id.
      */
     bool removeItem( const QString &id );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -755,6 +755,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( AnnotationItemFlag )
 
     /**
+     * Flags for controlling how an annotation item behaves in the GUI.
+     *
+     * \since QGIS 3.22
+     */
+    enum class AnnotationItemGuiFlag : int
+    {
+      FlagNoCreationTools = 1 << 0,  //!< Do not show item creation tools for the item type
+    };
+    Q_DECLARE_FLAGS( AnnotationItemGuiFlags, AnnotationItemGuiFlag )
+    Q_ENUM( AnnotationItemGuiFlag )
+
+    /**
      * Annotation item node types.
      *
      * \since QGIS 3.22
@@ -890,6 +902,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::BabelCommandFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::GeometryValidityFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::FileOperationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::AnnotationItemFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::AnnotationItemGuiFlags )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -94,6 +94,8 @@ set(QGIS_GUI_SRCS
   attributetable/qgsorganizetablecolumnsdialog.cpp
   attributetable/qgsfeaturefilterwidget.cpp
 
+  annotations/qgsmaptoolmodifyannotation.cpp
+
   auth/qgsauthauthoritieseditor.cpp
   auth/qgsauthcertificateinfo.cpp
   auth/qgsauthcertificatemanager.cpp
@@ -878,6 +880,8 @@ set(QGIS_GUI_HDRS
   qgsvscrollarea.h
   qgswindowmanagerinterface.h
 
+  annotations/qgsmaptoolmodifyannotation.h
+
   attributeformconfig/qgsattributeformcontaineredit.h
   attributeformconfig/qgsattributetypedialog.h
   attributeformconfig/qgsattributewidgetedit.h
@@ -1417,6 +1421,7 @@ endif()
 
 target_include_directories(qgis_gui PUBLIC
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/annotations
   ${CMAKE_SOURCE_DIR}/src/gui/attributeformconfig
   ${CMAKE_SOURCE_DIR}/src/gui/symbology
   ${CMAKE_SOURCE_DIR}/src/gui/attributetable

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -96,6 +96,7 @@ set(QGIS_GUI_SRCS
 
   annotations/qgsannotationitemguiregistry.cpp
   annotations/qgsannotationitemwidget.cpp
+  annotations/qgsannotationitemwidget_impl.cpp
   annotations/qgsmaptoolmodifyannotation.cpp
 
   auth/qgsauthauthoritieseditor.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -94,6 +94,8 @@ set(QGIS_GUI_SRCS
   attributetable/qgsorganizetablecolumnsdialog.cpp
   attributetable/qgsfeaturefilterwidget.cpp
 
+  annotations/qgsannotationitemguiregistry.cpp
+  annotations/qgsannotationitemwidget.cpp
   annotations/qgsmaptoolmodifyannotation.cpp
 
   auth/qgsauthauthoritieseditor.cpp
@@ -880,6 +882,8 @@ set(QGIS_GUI_HDRS
   qgsvscrollarea.h
   qgswindowmanagerinterface.h
 
+  annotations/qgsannotationitemguiregistry.h
+  annotations/qgsannotationitemwidget.h
   annotations/qgsmaptoolmodifyannotation.h
 
   attributeformconfig/qgsattributeformcontaineredit.h

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -1,0 +1,165 @@
+/***************************************************************************
+                            qgsannotationitemguiregistry.cpp
+                            --------------------------
+    begin                : September 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationitemguiregistry.h"
+#include "qgsannotationitemregistry.h"
+#include "qgsannotationitem.h"
+
+
+QgsAnnotationItem *QgsAnnotationItemAbstractGuiMetadata::createItem()
+{
+  return nullptr;
+}
+
+void QgsAnnotationItemAbstractGuiMetadata::newItemAddedToLayer( QgsAnnotationItem *, QgsAnnotationLayer * )
+{
+
+}
+
+QgsAnnotationItemGuiRegistry::QgsAnnotationItemGuiRegistry( QObject *parent )
+  : QObject( parent )
+{
+}
+
+QgsAnnotationItemGuiRegistry::~QgsAnnotationItemGuiRegistry()
+{
+  qDeleteAll( mMetadata );
+}
+
+QgsAnnotationItemAbstractGuiMetadata *QgsAnnotationItemGuiRegistry::itemMetadata( int metadataId ) const
+{
+  return mMetadata.value( metadataId );
+}
+
+int QgsAnnotationItemGuiRegistry::metadataIdForItemType( const QString &type ) const
+{
+  for ( auto it = mMetadata.constBegin(); it != mMetadata.constEnd(); ++it )
+  {
+    if ( it.value()->type() == type )
+      return it.key();
+  }
+  return -1;
+}
+
+bool QgsAnnotationItemGuiRegistry::addAnnotationItemGuiMetadata( QgsAnnotationItemAbstractGuiMetadata *metadata )
+{
+  if ( !metadata )
+    return false;
+
+  const int id = mMetadata.count();
+  mMetadata[id] = metadata;
+  emit typeAdded( id );
+  return true;
+}
+
+bool QgsAnnotationItemGuiRegistry::addItemGroup( const QgsAnnotationItemGuiGroup &group )
+{
+  if ( mItemGroups.contains( group.id ) )
+    return false;
+
+  mItemGroups.insert( group.id, group );
+  return true;
+}
+
+const QgsAnnotationItemGuiGroup &QgsAnnotationItemGuiRegistry::itemGroup( const QString &id )
+{
+  return mItemGroups[ id ];
+}
+
+QgsAnnotationItem *QgsAnnotationItemGuiRegistry::createItem( int metadataId ) const
+{
+  if ( !mMetadata.contains( metadataId ) )
+    return nullptr;
+
+  std::unique_ptr< QgsAnnotationItem > item( mMetadata.value( metadataId )->createItem() );
+  if ( item )
+    return item.release();
+
+  const QString type = mMetadata.value( metadataId )->type();
+  return QgsApplication::annotationItemRegistry()->createItem( type );
+}
+
+void QgsAnnotationItemGuiRegistry::newItemAddedToLayer( int metadataId, QgsAnnotationItem *item, QgsAnnotationLayer *layer )
+{
+  if ( !mMetadata.contains( metadataId ) )
+    return;
+
+  mMetadata.value( metadataId )->newItemAddedToLayer( item, layer );
+}
+
+QgsAnnotationItemBaseWidget *QgsAnnotationItemGuiRegistry::createItemWidget( QgsAnnotationItem *item ) const
+{
+  if ( !item )
+    return nullptr;
+
+  const QString &type = item->type();
+  for ( auto it = mMetadata.constBegin(); it != mMetadata.constEnd(); ++it )
+  {
+    if ( it.value()->type() == type )
+      return it.value()->createItemWidget( item );
+  }
+
+  return nullptr;
+}
+
+QList<int> QgsAnnotationItemGuiRegistry::itemMetadataIds() const
+{
+  return mMetadata.keys();
+}
+
+void QgsAnnotationItemGuiRegistry::addDefaultItems()
+{
+  addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "polygon" ),
+                                QObject::tr( "Polygon" ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
+  {
+    QgsAnnotationPolygonItemWidget *widget = new QgsAnnotationPolygonItemWidget( nullptr );
+    widget->setItem( item );
+    return widget;
+  } ) );
+
+  addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "linestring" ),
+                                QObject::tr( "Line" ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
+  {
+    QgsAnnotationLineItemWidget *widget = new QgsAnnotationLineItemWidget( nullptr );
+    widget->setItem( item );
+    return widget;
+  } ) );
+
+  addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "marker" ),
+                                QObject::tr( "Marker" ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
+  {
+    QgsAnnotationMarkerItemWidget *widget = new QgsAnnotationMarkerItemWidget( nullptr );
+    widget->setItem( item );
+    return widget;
+  } ) );
+}
+
+QgsAnnotationItem *QgsAnnotationItemGuiMetadata::createItem()
+{
+  return mCreateFunc ? mCreateFunc() : QgsAnnotationItemAbstractGuiMetadata::createItem();
+}
+
+void QgsAnnotationItemGuiMetadata::newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer )
+{
+  if ( mAddedToLayerFunc )
+    mAddedToLayerFunc( item, layer );
+}

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -18,6 +18,7 @@
 #include "qgsannotationitemregistry.h"
 #include "qgsannotationitem.h"
 
+#include "qgsannotationitemwidget_impl.h"
 
 QgsAnnotationItem *QgsAnnotationItemAbstractGuiMetadata::createItem()
 {
@@ -33,6 +34,7 @@ QgsAnnotationItemGuiRegistry::QgsAnnotationItemGuiRegistry( QObject *parent )
   : QObject( parent )
 {
 }
+
 
 QgsAnnotationItemGuiRegistry::~QgsAnnotationItemGuiRegistry()
 {

--- a/src/gui/annotations/qgsannotationitemguiregistry.h
+++ b/src/gui/annotations/qgsannotationitemguiregistry.h
@@ -1,0 +1,414 @@
+/***************************************************************************
+                            qgsannotationitemguiregistry.h
+                            --------------------------
+    begin                : September 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSANNOTATIONITEMGUIREGISTRY_H
+#define QGSANNOTATIONITEMGUIREGISTRY_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsapplication.h"
+#include "qgspathresolver.h"
+#include "qgsannotationitemregistry.h"
+#include "qgis.h"
+#include <QIcon>
+#include <functional>
+
+class QgsAnnotationLayer;
+class QgsAnnotationItem;
+class QgsAnnotationItemBaseWidget;
+
+/**
+ * \ingroup gui
+ * \brief Stores GUI metadata about one annotation item class.
+ *
+ * This is a companion to QgsAnnotationItemAbstractMetadata, storing only
+ * the components related to the GUI behavior of an annotation item.
+ *
+ * \note In C++ you can use QgsAnnotationItemGuiMetadata convenience class.
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsAnnotationItemAbstractGuiMetadata
+{
+  public:
+
+    /**
+     * Constructor for QgsAnnotationItemAbstractGuiMetadata with the specified class \a type.
+     *
+     * \a visibleName should be set to a translated, user visible name identifying the corresponding annotation item.
+     *
+     * An optional \a groupId can be set, which allows grouping of related annotation item classes. See QgsAnnotationItemGuiMetadata for details.
+     */
+    QgsAnnotationItemAbstractGuiMetadata( const QString &type, const QString &visibleName, const QString &groupId = QString(), Qgis::AnnotationItemGuiFlags flags = Qgis::AnnotationItemGuiFlags() )
+      : mType( type )
+      , mGroupId( groupId )
+      , mName( visibleName )
+      , mFlags( flags )
+    {}
+
+    virtual ~QgsAnnotationItemAbstractGuiMetadata() = default;
+
+    /**
+     * Returns the unique item type code for the annotation item class.
+     */
+    QString type() const { return mType; }
+
+    /**
+     * Returns item flags.
+     */
+    Qgis::AnnotationItemGuiFlags flags() const { return mFlags; }
+
+    /**
+     * Returns the item group ID, if set.
+     */
+    QString groupId() const { return mGroupId; }
+
+    /**
+     * Returns a translated, user visible name identifying the corresponding annotation item.
+     */
+    QString visibleName() const { return mName; }
+
+    /**
+     * Returns an icon representing creation of the annotation item type.
+     */
+    virtual QIcon creationIcon() const { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddBasicRectangle.svg" ) ); }
+
+    /*
+     * IMPORTANT: While it seems like /Factory/ would be the correct annotations here, that's not
+     * the case.
+     * As per Phil Thomson's advice on https://www.riverbankcomputing.com/pipermail/pyqt/2017-July/039450.html:
+     *
+     * "
+     * /Factory/ is used when the instance returned is guaranteed to be new to Python.
+     * In this case it isn't because it has already been seen when being returned by QgsProcessingAlgorithm::createInstance()
+     * (However for a different sub-class implemented in C++ then it would be the first time it was seen
+     * by Python so the /Factory/ on create() would be correct.)
+     *
+     * You might try using /TransferBack/ on create() instead - that might be the best compromise.
+     * "
+     */
+
+    /**
+     * Creates a configuration widget for an \a item of this type. Can return NULLPTR if no configuration GUI is required.
+     */
+    virtual QgsAnnotationItemBaseWidget *createItemWidget( QgsAnnotationItem *item ) SIP_TRANSFERBACK { Q_UNUSED( item ) return nullptr; }
+
+    /**
+     * Creates an instance of the corresponding item type.
+     */
+    virtual QgsAnnotationItem *createItem() SIP_TRANSFERBACK;
+
+    /**
+     * Called when a newly created item of the associated type has been added to a \a layer.
+     *
+     * This is only called for additions which result from GUI operations - i.e. it is not
+     * called for items added programmatically.
+     */
+    virtual void newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer );
+
+  private:
+
+    QString mType;
+    QString mGroupId;
+    QString mName;
+    Qgis::AnnotationItemGuiFlags mFlags;
+
+};
+
+//! Annotation item configuration widget creation function
+typedef std::function<QgsAnnotationItemBaseWidget *( QgsAnnotationItem * )> QgsAnnotationItemWidgetFunc SIP_SKIP;
+
+//! Annotation item added to layer callback
+typedef std::function<void ( QgsAnnotationItem *, QgsAnnotationLayer *layer )> QgsAnnotationItemAddedToLayerFunc SIP_SKIP;
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup gui
+ * \brief Convenience metadata class that uses static functions to handle annotation item GUI behavior.
+ * \note not available in Python bindings
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsAnnotationItemGuiMetadata : public QgsAnnotationItemAbstractGuiMetadata
+{
+  public:
+
+    /**
+     * Constructor for QgsAnnotationItemGuiMetadata with the specified class \a type
+     * and \a creationIcon, and function pointers for the various
+     * configuration widget creation functions.
+     *
+     * \a visibleName should be set to a translated, user visible name identifying the corresponding annotation item.
+     *
+     * An optional \a groupId can be set, which allows grouping of related annotation item classes. See QgsAnnotationItemGuiMetadata for details.
+     */
+    QgsAnnotationItemGuiMetadata( const QString &type, const QString &visibleName, const QIcon &creationIcon,
+                                  const QgsAnnotationItemWidgetFunc &pfWidget = nullptr,
+                                  const QString &groupId = QString(),
+                                  Qgis::AnnotationItemGuiFlags flags = Qgis::AnnotationItemGuiFlags(),
+                                  const QgsAnnotationItemCreateFunc &pfCreateFunc = nullptr )
+      : QgsAnnotationItemAbstractGuiMetadata( type, visibleName, groupId, flags )
+      , mIcon( creationIcon )
+      , mWidgetFunc( pfWidget )
+      , mCreateFunc( pfCreateFunc )
+    {}
+
+    /**
+     * Returns the classes' configuration widget creation function.
+     * \see setWidgetFunction()
+     */
+    QgsAnnotationItemWidgetFunc widgetFunction() const { return mWidgetFunc; }
+
+    /**
+     * Sets the classes' configuration widget creation \a function.
+     * \see widgetFunction()
+     */
+    void setWidgetFunction( const QgsAnnotationItemWidgetFunc &function ) { mWidgetFunc = function; }
+
+    /**
+     * Returns the classes' item creation function.
+     * \see setItemCreationFunction()
+     */
+    QgsAnnotationItemCreateFunc itemCreationFunction() const { return mCreateFunc; }
+
+    /**
+     * Sets the classes' item creation \a function.
+     * \see itemCreationFunction()
+     */
+    void setItemCreationFunction( const QgsAnnotationItemCreateFunc &function ) { mCreateFunc = function; }
+
+    /**
+     * Returns the classes' item added to layer function.
+     * \see setItemAddedToLayerFunction()
+     */
+    QgsAnnotationItemAddedToLayerFunc itemAddToLayerFunction() const { return mAddedToLayerFunc; }
+
+    /**
+     * Sets the classes' item creation \a function.
+     * \see itemAddToLayerFunction()
+     */
+    void setItemAddedToLayerFunction( const QgsAnnotationItemAddedToLayerFunc &function ) { mAddedToLayerFunc = function; }
+
+    QIcon creationIcon() const override { return mIcon.isNull() ? QgsAnnotationItemAbstractGuiMetadata::creationIcon() : mIcon; }
+    QgsAnnotationItemBaseWidget *createItemWidget( QgsAnnotationItem *item ) override { return mWidgetFunc ? mWidgetFunc( item ) : nullptr; }
+
+    QgsAnnotationItem *createItem() override;
+    void newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer ) override;
+
+  protected:
+    QIcon mIcon;
+    QgsAnnotationItemWidgetFunc mWidgetFunc = nullptr;
+    QgsAnnotationItemCreateFunc mCreateFunc = nullptr;
+    QgsAnnotationItemAddedToLayerFunc mAddedToLayerFunc = nullptr;
+
+};
+
+#endif
+
+/**
+ * \ingroup gui
+ * \brief Stores GUI metadata about a group of annotation item classes.
+ *
+ * QgsAnnotationItemGuiGroup stores settings about groups of related annotation item classes
+ * which should be presented to users grouped together.
+ *
+ * For instance, the various basic shape creation tools would use QgsAnnotationItemGuiGroup
+ * to display grouped within toolbars.
+ *
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsAnnotationItemGuiGroup
+{
+  public:
+
+    /**
+     * Constructor for QgsAnnotationItemGuiGroup.
+     */
+    QgsAnnotationItemGuiGroup( const QString &id = QString(), const QString &name = QString(), const QIcon &icon = QIcon() )
+      : id( id )
+      , name( name )
+      , icon( icon )
+    {}
+
+    /**
+     * Unique (untranslated) group ID string.
+     */
+    QString id;
+
+    /**
+     * Translated group name.
+     */
+    QString name;
+
+    /**
+     * Icon for group.
+     */
+    QIcon icon;
+
+};
+
+
+/**
+ * \ingroup core
+ * \class QgsAnnotationItemGuiRegistry
+ * \brief Registry of available annotation item GUI behavior.
+ *
+ * QgsAnnotationItemGuiRegistry is not usually directly created, but rather accessed through
+ * QgsGui::annotationItemGuiRegistry().
+ *
+ * This acts as a companion to QgsAnnotationItemRegistry, handling only
+ * the components related to the GUI behavior of annotation items.
+ *
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsAnnotationItemGuiRegistry : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Creates a new empty item GUI registry.
+     *
+     * QgsAnnotationItemGuiRegistry is not usually directly created, but rather accessed through
+     * QgsGui::annotationItemGuiRegistry().
+    */
+    QgsAnnotationItemGuiRegistry( QObject *parent = nullptr );
+
+    ~QgsAnnotationItemGuiRegistry() override;
+
+    //! QgsAnnotationItemGuiRegistry cannot be copied.
+    QgsAnnotationItemGuiRegistry( const QgsAnnotationItemGuiRegistry &rh ) = delete;
+    //! QgsAnnotationItemGuiRegistry cannot be copied.
+    QgsAnnotationItemGuiRegistry &operator=( const QgsAnnotationItemGuiRegistry &rh ) = delete;
+
+    /**
+     * Returns the metadata for the specified item \a metadataId. Returns NULLPTR if
+     * a corresponding \a metadataId was not found in the registry.
+     */
+    QgsAnnotationItemAbstractGuiMetadata *itemMetadata( int metadataId ) const;
+
+    /**
+     * Returns the GUI item metadata ID which corresponds to the specified annotation item \a type.
+     *
+     * In the case that multiple GUI metadata classes exist for a single annotation item \a type then
+     * only the first encountered GUI metadata ID will be returned.
+     *
+     * Returns -1 if no matching metadata is found in the GUI registry.
+     */
+    int metadataIdForItemType( const QString &type ) const;
+
+    /**
+     * Registers the gui metadata for a new annotation item type. Takes ownership of the metadata instance.
+     */
+    bool addAnnotationItemGuiMetadata( QgsAnnotationItemAbstractGuiMetadata *metadata SIP_TRANSFER );
+
+    /**
+     * Registers a new item group with the registry. This must be done before calling
+     * addAnnotationItemGuiMetadata() for any item types associated with the group.
+     *
+     * Returns TRUE if group was added, or FALSE if group could not be added (e.g. due to
+     * duplicate id value).
+     *
+     * \see itemGroup()
+     */
+    bool addItemGroup( const QgsAnnotationItemGuiGroup &group );
+
+    /**
+     * Returns a reference to the item group with matching \a id.
+     * \see addItemGroup()
+     */
+    const QgsAnnotationItemGuiGroup &itemGroup( const QString &id );
+
+    /*
+     * IMPORTANT: While it seems like /Factory/ would be the correct annotations here, that's not
+     * the case.
+     * As per Phil Thomson's advice on https://www.riverbankcomputing.com/pipermail/pyqt/2017-July/039450.html:
+     *
+     * "
+     * /Factory/ is used when the instance returned is guaranteed to be new to Python.
+     * In this case it isn't because it has already been seen when being returned by QgsProcessingAlgorithm::createInstance()
+     * (However for a different sub-class implemented in C++ then it would be the first time it was seen
+     * by Python so the /Factory/ on create() would be correct.)
+     *
+     * You might try using /TransferBack/ on create() instead - that might be the best compromise.
+     * "
+     */
+
+    /**
+     * Creates a new instance of an annotation item given the item metadata \a metadataId.
+     */
+    QgsAnnotationItem *createItem( int metadataId ) const SIP_TRANSFERBACK;
+
+    /**
+     * Called when a newly created item of the associated metadata \a metadataId has been added to a \a layer.
+     *
+     * This is only called for additions which result from GUI operations - i.e. it is not
+     * called for items added programmatically.
+     */
+    void newItemAddedToLayer( int metadataId, QgsAnnotationItem *item, QgsAnnotationLayer *layer );
+
+    /*
+     * IMPORTANT: While it seems like /Factory/ would be the correct annotations here, that's not
+     * the case.
+     * As per Phil Thomson's advice on https://www.riverbankcomputing.com/pipermail/pyqt/2017-July/039450.html:
+     *
+     * "
+     * /Factory/ is used when the instance returned is guaranteed to be new to Python.
+     * In this case it isn't because it has already been seen when being returned by QgsProcessingAlgorithm::createInstance()
+     * (However for a different sub-class implemented in C++ then it would be the first time it was seen
+     * by Python so the /Factory/ on create() would be correct.)
+     *
+     * You might try using /TransferBack/ on create() instead - that might be the best compromise.
+     * "
+     */
+
+    /**
+     * Creates a new instance of an annotation item configuration widget for the specified \a item.
+     */
+    QgsAnnotationItemBaseWidget *createItemWidget( QgsAnnotationItem *item ) const SIP_TRANSFERBACK;
+
+    /**
+     * Returns a list of available item metadata ids handled by the registry.
+     */
+    QList< int > itemMetadataIds() const;
+
+    /**
+     * Populates the registry with default items.
+     */
+    void addDefaultItems();
+
+  signals:
+
+    /**
+     * Emitted whenever a new item type is added to the registry, with the specified
+     * \a metadataId.
+     */
+    void typeAdded( int metadataId );
+
+  private:
+#ifdef SIP_RUN
+    QgsAnnotationItemGuiRegistry( const QgsAnnotationItemGuiRegistry &rh );
+#endif
+
+    QMap< int, QgsAnnotationItemAbstractGuiMetadata *> mMetadata;
+
+    QMap< QString, QgsAnnotationItemGuiGroup > mItemGroups;
+
+};
+
+#endif //QGSANNOTATIONITEMGUIREGISTRY_H
+
+
+

--- a/src/gui/annotations/qgsannotationitemwidget.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+                             qgsannotationitemwidget.cpp
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationitemwidget.h"
+
+QgsAnnotationItemBaseWidget::QgsAnnotationItemBaseWidget( QWidget *parent )
+  : QgsPanelWidget( parent )
+{
+
+}
+
+bool QgsAnnotationItemBaseWidget::setItem( QgsAnnotationItem *item )
+{
+  return setNewItem( item );
+}
+
+bool QgsAnnotationItemBaseWidget::setNewItem( QgsAnnotationItem * )
+{
+  return false;
+}

--- a/src/gui/annotations/qgsannotationitemwidget.h
+++ b/src/gui/annotations/qgsannotationitemwidget.h
@@ -1,0 +1,83 @@
+/***************************************************************************
+                             qgsannotationitemwidget.h
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSANNOTATIONITEMWIDGET_H
+#define QGSANNOTATIONITEMWIDGET_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgspanelwidget.h"
+
+class QgsAnnotationItem;
+
+/**
+ * \class QgsAnnotationItemBaseWidget
+ * \ingroup gui
+ *
+ * \brief A base class for property widgets for annotation items.
+ *
+ * All annotation item widgets should inherit from this base class.
+ *
+ * \since QGIS 3.22
+*/
+class GUI_EXPORT QgsAnnotationItemBaseWidget: public QgsPanelWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsAnnotationItemBaseWidget, linked with the specified annotation \a item.
+     */
+    QgsAnnotationItemBaseWidget( QWidget *parent SIP_TRANSFERTHIS );
+
+    /**
+     * Creates a new item matching the settings defined in the widget.
+     */
+    virtual QgsAnnotationItem *createItem() = 0 SIP_FACTORY;
+
+    /**
+     * Sets the current \a item to show in the widget. If TRUE is returned, \a item
+     * was an acceptable type for display in this widget and the widget has been
+     * updated to match \a item's properties.
+     *
+     * If FALSE is returned, then the widget could not be successfully updated
+     * to show the properties of \a item.
+     */
+    bool setItem( QgsAnnotationItem *item );
+
+
+  signals:
+
+    /**
+     * Emitted when the annotation item definition in the widget is changed by the user.
+     */
+    void itemChanged();
+
+  protected:
+
+    /**
+     * Attempts to update the widget to show the properties
+     * for the specified \a item.
+     *
+     * Subclasses can override this if they support changing items in place.
+     *
+     * Implementations must return TRUE if the item was accepted and
+     * the widget was updated.
+     */
+    virtual bool setNewItem( QgsAnnotationItem *item );
+
+};
+
+#endif // QGSANNOTATIONITEMWIDGET_H

--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -1,0 +1,207 @@
+/***************************************************************************
+                             qgsannotationitemwidget_impl.cpp
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsannotationitemwidget_impl.h"
+
+#include "qgssymbolselectordialog.h"
+#include "qgsstyle.h"
+#include "qgsfillsymbol.h"
+#include "qgslinesymbol.h"
+#include "qgsmarkersymbol.h"
+#include "qgsannotationpolygonitem.h"
+#include "qgsannotationlineitem.h"
+#include "qgsannotationmarkeritem.h"
+
+QgsAnnotationPolygonItemWidget::QgsAnnotationPolygonItemWidget( QWidget *parent )
+  : QgsAnnotationItemBaseWidget( parent )
+{
+  // setup ui
+  mSelector = new QgsSymbolSelectorWidget( mSymbol.get(), QgsStyle::defaultStyle(), nullptr, nullptr );
+  mSelector->setDockMode( dockMode() );
+  connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, [ = ]
+  {
+    if ( !mBlockChangedSignal )
+      emit itemChanged();
+  } );
+  connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+
+  QVBoxLayout *layout = new QVBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->addWidget( mSelector );
+}
+
+QgsAnnotationItem *QgsAnnotationPolygonItemWidget::createItem()
+{
+  QgsAnnotationPolygonItem *newItem = mItem->clone();
+  newItem->setSymbol( mSymbol->clone() );
+  return newItem;
+}
+
+void QgsAnnotationPolygonItemWidget::setDockMode( bool dockMode )
+{
+  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
+  if ( mSelector )
+    mSelector->setDockMode( dockMode );
+}
+
+QgsAnnotationPolygonItemWidget::~QgsAnnotationPolygonItemWidget() = default;
+
+bool QgsAnnotationPolygonItemWidget::setNewItem( QgsAnnotationItem *item )
+{
+  QgsAnnotationPolygonItem *polygonItem = dynamic_cast< QgsAnnotationPolygonItem * >( item );
+  if ( !polygonItem )
+    return false;
+
+  mItem.reset( polygonItem->clone() );
+  if ( mItem->symbol() )
+  {
+    mSymbol.reset( mItem->symbol()->clone() );
+  }
+  else
+  {
+    mSymbol.reset( QgsFillSymbol::createSimple( {} ) );
+  }
+  mBlockChangedSignal = true;
+  mSelector->loadSymbol( mSymbol.get() );
+  mSelector->updatePreview();
+  mBlockChangedSignal = false;
+
+  return true;
+}
+
+
+//
+// QgsAnnotationLineItemWidget
+//
+
+QgsAnnotationLineItemWidget::QgsAnnotationLineItemWidget( QWidget *parent )
+  : QgsAnnotationItemBaseWidget( parent )
+{
+  // setup ui
+  mSelector = new QgsSymbolSelectorWidget( mSymbol.get(), QgsStyle::defaultStyle(), nullptr, nullptr );
+  mSelector->setDockMode( dockMode() );
+  connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, [ = ]
+  {
+    if ( !mBlockChangedSignal )
+      emit itemChanged();
+  } );
+  connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+
+  QVBoxLayout *layout = new QVBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->addWidget( mSelector );
+}
+
+QgsAnnotationItem *QgsAnnotationLineItemWidget::createItem()
+{
+  QgsAnnotationLineItem *newItem = mItem->clone();
+  newItem->setSymbol( mSymbol->clone() );
+  return newItem;
+}
+
+void QgsAnnotationLineItemWidget::setDockMode( bool dockMode )
+{
+  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
+  if ( mSelector )
+    mSelector->setDockMode( dockMode );
+}
+
+QgsAnnotationLineItemWidget::~QgsAnnotationLineItemWidget() = default;
+
+bool QgsAnnotationLineItemWidget::setNewItem( QgsAnnotationItem *item )
+{
+  QgsAnnotationLineItem *lineItem = dynamic_cast< QgsAnnotationLineItem * >( item );
+  if ( !lineItem )
+    return false;
+
+  mItem.reset( lineItem->clone() );
+  if ( mItem->symbol() )
+  {
+    mSymbol.reset( mItem->symbol()->clone() );
+  }
+  else
+  {
+    mSymbol.reset( QgsLineSymbol::createSimple( {} ) );
+  }
+  mBlockChangedSignal = true;
+  mSelector->loadSymbol( mSymbol.get() );
+  mSelector->updatePreview();
+  mBlockChangedSignal = false;
+
+  return true;
+}
+
+
+//
+// QgsAnnotationMarkerItemWidget
+//
+
+QgsAnnotationMarkerItemWidget::QgsAnnotationMarkerItemWidget( QWidget *parent )
+  : QgsAnnotationItemBaseWidget( parent )
+{
+  // setup ui
+  mSelector = new QgsSymbolSelectorWidget( mSymbol.get(), QgsStyle::defaultStyle(), nullptr, nullptr );
+  mSelector->setDockMode( dockMode() );
+  connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, [ = ]
+  {
+    if ( !mBlockChangedSignal )
+      emit itemChanged();
+  } );
+  connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+
+  QVBoxLayout *layout = new QVBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->addWidget( mSelector );
+}
+
+QgsAnnotationItem *QgsAnnotationMarkerItemWidget::createItem()
+{
+  QgsAnnotationMarkerItem *newItem = mItem->clone();
+  newItem->setSymbol( mSymbol->clone() );
+  return newItem;
+}
+
+void QgsAnnotationMarkerItemWidget::setDockMode( bool dockMode )
+{
+  QgsAnnotationItemBaseWidget::setDockMode( dockMode );
+  if ( mSelector )
+    mSelector->setDockMode( dockMode );
+}
+
+QgsAnnotationMarkerItemWidget::~QgsAnnotationMarkerItemWidget() = default;
+
+bool QgsAnnotationMarkerItemWidget::setNewItem( QgsAnnotationItem *item )
+{
+  QgsAnnotationMarkerItem *markerItem = dynamic_cast< QgsAnnotationMarkerItem * >( item );
+  if ( !markerItem )
+    return false;
+
+  mItem.reset( markerItem->clone() );
+  if ( mItem->symbol() )
+  {
+    mSymbol.reset( mItem->symbol()->clone() );
+  }
+  else
+  {
+    mSymbol.reset( QgsMarkerSymbol::createSimple( {} ) );
+  }
+  mBlockChangedSignal = true;
+  mSelector->loadSymbol( mSymbol.get() );
+  mSelector->updatePreview();
+  mBlockChangedSignal = false;
+
+  return true;
+}
+
+

--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -23,6 +23,8 @@
 #include "qgsannotationlineitem.h"
 #include "qgsannotationmarkeritem.h"
 
+///@cond PRIVATE
+
 QgsAnnotationPolygonItemWidget::QgsAnnotationPolygonItemWidget( QWidget *parent )
   : QgsAnnotationItemBaseWidget( parent )
 {
@@ -204,4 +206,5 @@ bool QgsAnnotationMarkerItemWidget::setNewItem( QgsAnnotationItem *item )
   return true;
 }
 
+///@endcond PRIVATE
 

--- a/src/gui/annotations/qgsannotationitemwidget_impl.h
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.h
@@ -28,6 +28,10 @@ class QgsAnnotationPolygonItem;
 class QgsAnnotationLineItem;
 class QgsAnnotationMarkerItem;
 
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
 class QgsAnnotationPolygonItemWidget : public QgsAnnotationItemBaseWidget
 {
     Q_OBJECT
@@ -90,5 +94,7 @@ class QgsAnnotationMarkerItemWidget : public QgsAnnotationItemBaseWidget
     bool mBlockChangedSignal = false;
     std::unique_ptr< QgsAnnotationMarkerItem> mItem;
 };
+
+///@endcond
 
 #endif // QGSANNOTATIONITEMWIDGETIMPL_H

--- a/src/gui/annotations/qgsannotationitemwidget_impl.h
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+                             qgsannotationitemwidget_impl.h
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSANNOTATIONITEMWIDGETIMPL_H
+#define QGSANNOTATIONITEMWIDGETIMPL_H
+
+#include "qgsannotationitemwidget.h"
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include <memory>
+
+class QgsSymbolSelectorWidget;
+class QgsFillSymbol;
+class QgsLineSymbol;
+class QgsMarkerSymbol;
+class QgsAnnotationPolygonItem;
+class QgsAnnotationLineItem;
+class QgsAnnotationMarkerItem;
+
+class QgsAnnotationPolygonItemWidget : public QgsAnnotationItemBaseWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsAnnotationPolygonItemWidget( QWidget *parent );
+    ~QgsAnnotationPolygonItemWidget() override;
+    QgsAnnotationItem *createItem() override;
+    void setDockMode( bool dockMode ) override;
+
+  protected:
+    bool setNewItem( QgsAnnotationItem *item ) override;
+
+  private:
+
+    QgsSymbolSelectorWidget *mSelector = nullptr;
+    std::unique_ptr< QgsFillSymbol > mSymbol;
+    bool mBlockChangedSignal = false;
+    std::unique_ptr< QgsAnnotationPolygonItem> mItem;
+};
+
+class QgsAnnotationLineItemWidget : public QgsAnnotationItemBaseWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsAnnotationLineItemWidget( QWidget *parent );
+    ~QgsAnnotationLineItemWidget() override;
+    QgsAnnotationItem *createItem() override;
+    void setDockMode( bool dockMode ) override;
+
+  protected:
+    bool setNewItem( QgsAnnotationItem *item ) override;
+
+  private:
+
+    QgsSymbolSelectorWidget *mSelector = nullptr;
+    std::unique_ptr< QgsLineSymbol > mSymbol;
+    bool mBlockChangedSignal = false;
+    std::unique_ptr< QgsAnnotationLineItem> mItem;
+};
+
+class QgsAnnotationMarkerItemWidget : public QgsAnnotationItemBaseWidget
+{
+    Q_OBJECT
+
+  public:
+    QgsAnnotationMarkerItemWidget( QWidget *parent );
+    ~QgsAnnotationMarkerItemWidget() override;
+    QgsAnnotationItem *createItem() override;
+    void setDockMode( bool dockMode ) override;
+
+  protected:
+    bool setNewItem( QgsAnnotationItem *item ) override;
+
+  private:
+
+    QgsSymbolSelectorWidget *mSelector = nullptr;
+    std::unique_ptr< QgsMarkerSymbol > mSymbol;
+    bool mBlockChangedSignal = false;
+    std::unique_ptr< QgsAnnotationMarkerItem> mItem;
+};
+
+#endif // QGSANNOTATIONITEMWIDGETIMPL_H

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -1,0 +1,363 @@
+/***************************************************************************
+    qgsmaptoolmodifyannotation.cpp
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolmodifyannotation.h"
+#include "qgsrubberband.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmapcanvas.h"
+#include "qgsrendereditemresults.h"
+#include "qgsrendereditemdetails.h"
+#include "qgsannotationlayer.h"
+#include "qgsproject.h"
+#include "qgsrenderedannotationitemdetails.h"
+#include "qgsannotationitem.h"
+#include "qgsannotationitemnode.h"
+#include "RTree.h"
+
+///@cond PRIVATE
+class QgsAnnotationItemNodesSpatialIndex : public RTree<int, float, 2, float>
+{
+  public:
+
+    void insert( int index, const QgsRectangle &bounds )
+    {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
+      this->Insert(
+      {
+        scaledBounds[0], scaledBounds[ 1]
+      },
+      {
+        scaledBounds[2], scaledBounds[3]
+      },
+      index );
+    }
+
+    /**
+     * Removes existing \a data from the spatial index, with the specified \a bounds.
+     *
+     * \a data is not deleted, and it is the caller's responsibility to ensure that
+     * it is appropriately cleaned up.
+     */
+    void remove( int index, const QgsRectangle &bounds )
+    {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
+      this->Remove(
+      {
+        scaledBounds[0], scaledBounds[ 1]
+      },
+      {
+        scaledBounds[2], scaledBounds[3]
+      },
+      index );
+    }
+
+    /**
+     * Performs an intersection check against the index, for data intersecting the specified \a bounds.
+     *
+     * The \a callback function will be called once for each matching data object encountered.
+     */
+    bool intersects( const QgsRectangle &bounds, const std::function< bool( int index )> &callback ) const
+    {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
+      this->Search(
+      {
+        scaledBounds[0], scaledBounds[ 1]
+      },
+      {
+        scaledBounds[2], scaledBounds[3]
+      },
+      callback );
+      return true;
+    }
+
+  private:
+    std::array<float, 4> scaleBounds( const QgsRectangle &bounds ) const
+    {
+      return
+      {
+        static_cast< float >( bounds.xMinimum() ),
+        static_cast< float >( bounds.yMinimum() ),
+        static_cast< float >( bounds.xMaximum() ),
+        static_cast< float >( bounds.yMaximum() )
+      };
+    }
+};
+///@endcond
+
+
+QgsMapToolModifyAnnotation::QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+{
+
+}
+
+QgsMapToolModifyAnnotation::~QgsMapToolModifyAnnotation() = default;
+
+void QgsMapToolModifyAnnotation::deactivate()
+{
+  clearHoveredItem();
+  QgsMapToolAdvancedDigitizing::deactivate();
+}
+
+void QgsMapToolModifyAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
+{
+  const QgsPointXY mapPoint = event->mapPoint();
+
+  QgsRectangle searchRect = QgsRectangle( mapPoint.x(), mapPoint.y(), mapPoint.x(), mapPoint.y() );
+  searchRect.grow( searchRadiusMU( canvas() ) );
+
+  const QgsRenderedItemResults *renderedItemResults = canvas()->renderedItemResults( false );
+  if ( !renderedItemResults )
+  {
+    clearHoveredItem();
+    return;
+  }
+
+  const QList<const QgsRenderedAnnotationItemDetails *> items = renderedItemResults->renderedAnnotationItemsInBounds( searchRect );
+  if ( items.empty() )
+  {
+    clearHoveredItem();
+    return;
+  }
+
+  // find closest item
+  QgsRectangle itemBounds;
+  const QgsRenderedAnnotationItemDetails *closestItem = findClosestItemToPoint( mapPoint, items, itemBounds );
+  if ( !closestItem )
+  {
+    clearHoveredItem();
+    return;
+  }
+
+  if ( closestItem->itemId() != mHoveredItemId || closestItem->layerId() != mHoveredItemLayerId )
+  {
+    setHoveredItem( closestItem, itemBounds );
+  }
+
+  // track hovered node too!... here we want to identify the closest node to the cursor position
+  QgsAnnotationItemNode hoveredNode;
+  double currentNodeDistance = std::numeric_limits< double >::max();
+  mHoveredItemNodesSpatialIndex->intersects( searchRect, [&hoveredNode, &currentNodeDistance, &mapPoint, this]( int index )-> bool
+  {
+    const QgsAnnotationItemNode &thisNode = mHoveredItemNodes.at( index );
+    const double nodeDistance = thisNode.point().sqrDist( mapPoint );
+    if ( nodeDistance < currentNodeDistance )
+    {
+      hoveredNode = thisNode;
+      currentNodeDistance = nodeDistance;
+    }
+    return true;
+  } );
+
+  if ( hoveredNode.point().isEmpty() )
+  {
+    // no hovered node
+    if ( mHoveredNodeRubberBand )
+      mHoveredNodeRubberBand->hide();
+  }
+  else
+  {
+    if ( !mHoveredNodeRubberBand )
+      createHoveredNodeBand();
+
+    mHoveredNodeRubberBand->reset( QgsWkbTypes::PointGeometry );
+    mHoveredNodeRubberBand->addPoint( hoveredNode.point() );
+    mHoveredNodeRubberBand->show();
+  }
+
+}
+
+void QgsMapToolModifyAnnotation::cadCanvasPressEvent( QgsMapMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+    return;
+
+  if ( mHoveredItemId.isEmpty() || !mHoverRubberBand )
+  {
+    if ( mSelectedRubberBand )
+      mSelectedRubberBand->hide();
+    mSelectedItemId.clear();
+    mSelectedItemLayerId.clear();
+  }
+  else if ( mHoveredItemId != mSelectedItemId || mHoveredItemLayerId != mSelectedItemLayerId )
+  {
+    mSelectedItemId = mHoveredItemId;
+    mSelectedItemLayerId = mHoveredItemLayerId;
+
+    if ( !mSelectedRubberBand )
+      createSelectedItemBand();
+
+    mSelectedRubberBand->copyPointsFrom( mHoverRubberBand );
+    mSelectedRubberBand->show();
+
+    emit itemSelected( annotationLayerFromId( mSelectedItemLayerId ), mSelectedItemId );
+  }
+}
+
+void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItemDetails *item, const QgsRectangle &itemMapBounds )
+{
+  mHoveredItemNodeRubberBands.clear();
+  mHoveredItemId = item->itemId();
+  mHoveredItemLayerId = item->layerId();
+  if ( !mHoverRubberBand )
+    createHoverBand();
+
+  mHoverRubberBand->show();
+
+  mHoverRubberBand->reset( QgsWkbTypes::LineGeometry );
+  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
+  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMinimum() ) );
+  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMaximum() ) );
+  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMaximum() ) );
+  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
+
+  QgsAnnotationLayer *layer = annotationLayerFromId( item->layerId() );
+  const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
+  if ( !annotationItem )
+    return;
+
+  QgsCoordinateTransform layerToMapTransform = QgsCoordinateTransform( layer->crs(), canvas()->mapSettings().destinationCrs(), canvas()->mapSettings().transformContext() );
+
+  const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+
+  const QList< QgsAnnotationItemNode > itemNodes = annotationItem->nodes();
+  QgsRubberBand *vertexNodeBand = new QgsRubberBand( mCanvas, QgsWkbTypes::PointGeometry );
+
+  vertexNodeBand->setIcon( QgsRubberBand::ICON_BOX );
+  vertexNodeBand->setWidth( scaleFactor );
+  vertexNodeBand->setIconSize( scaleFactor * 5 );
+  vertexNodeBand->setColor( QColor( 200, 0, 120, 255 ) );
+
+  // store item nodes in a spatial index for quick searching
+  mHoveredItemNodesSpatialIndex = std::make_unique< QgsAnnotationItemNodesSpatialIndex >();
+  int index = 0;
+  mHoveredItemNodes.clear();
+  mHoveredItemNodes.reserve( itemNodes.size() );
+  for ( const QgsAnnotationItemNode &node : itemNodes )
+  {
+    QgsPointXY nodeMapPoint;
+    try
+    {
+      nodeMapPoint = layerToMapTransform.transform( node.point() );
+    }
+    catch ( QgsCsException & )
+    {
+      continue;
+    }
+
+    switch ( node.type() )
+    {
+      case Qgis::AnnotationItemNodeType::VertexHandle:
+        vertexNodeBand->addPoint( nodeMapPoint );
+        break;
+    }
+
+    mHoveredItemNodesSpatialIndex->insert( index, QgsRectangle( nodeMapPoint.x(), nodeMapPoint.y(),
+                                           nodeMapPoint.x(), nodeMapPoint.y() ) );
+
+    QgsAnnotationItemNode transformedNode = node;
+    transformedNode.setPoint( nodeMapPoint );
+    mHoveredItemNodes.append( transformedNode );
+
+    index++;
+  }
+
+  mHoveredItemNodeRubberBands.emplace_back( vertexNodeBand );
+}
+
+const QgsRenderedAnnotationItemDetails *QgsMapToolModifyAnnotation::findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds )
+{
+  const QgsRenderedAnnotationItemDetails *closestItem = nullptr;
+  double closestItemDistance = std::numeric_limits< double >::max();
+  int closestItemZ = 0;
+
+  for ( const QgsRenderedAnnotationItemDetails *item : items )
+  {
+    const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
+    if ( !annotationItem )
+      continue;
+
+    const QgsRectangle itemBounds = item->boundingBox();
+    const double itemDistance = itemBounds.contains( mapPoint ) ? 0 : itemBounds.distance( mapPoint );
+    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && annotationItem->zIndex() > closestItemZ ) )
+    {
+      closestItem = item;
+      closestItemDistance = itemDistance;
+      closestItemZ = annotationItem->zIndex();
+      bounds = itemBounds;
+    }
+  }
+  return closestItem;
+}
+
+QgsAnnotationLayer *QgsMapToolModifyAnnotation::annotationLayerFromId( const QString &layerId )
+{
+  QgsAnnotationLayer *layer = qobject_cast< QgsAnnotationLayer * >( QgsProject::instance()->mapLayer( layerId ) );
+  if ( !layer && layerId == QgsProject::instance()->mainAnnotationLayer()->id() )
+    layer = QgsProject::instance()->mainAnnotationLayer();
+  return layer;
+}
+
+QgsAnnotationItem *QgsMapToolModifyAnnotation::annotationItemFromId( const QString &layerId, const QString &itemId )
+{
+  QgsAnnotationLayer *layer = annotationLayerFromId( layerId );
+  return layer ? layer->item( itemId ) : nullptr;
+}
+
+void QgsMapToolModifyAnnotation::clearHoveredItem()
+{
+  if ( mHoverRubberBand )
+    mHoverRubberBand->hide();
+  if ( mHoveredNodeRubberBand )
+    mHoveredNodeRubberBand->hide();
+
+  mHoveredItemId.clear();
+  mHoveredItemLayerId.clear();
+  mHoveredItemNodeRubberBands.clear();
+  mHoveredItemNodesSpatialIndex.reset();
+}
+
+void QgsMapToolModifyAnnotation::createHoverBand()
+{
+  const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+
+  mHoverRubberBand.reset( new QgsRubberBand( mCanvas, QgsWkbTypes::LineGeometry ) );
+  mHoverRubberBand->setWidth( scaleFactor );
+  mHoverRubberBand->setSecondaryStrokeColor( QColor( 255, 255, 255, 100 ) );
+  mHoverRubberBand->setColor( QColor( 100, 100, 100, 155 ) );
+}
+
+void QgsMapToolModifyAnnotation::createHoveredNodeBand()
+{
+  const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+
+  mHoveredNodeRubberBand.reset( new QgsRubberBand( mCanvas, QgsWkbTypes::PointGeometry ) );
+  mHoveredNodeRubberBand->setIcon( QgsRubberBand::ICON_FULL_BOX );
+  mHoveredNodeRubberBand->setWidth( scaleFactor );
+  mHoveredNodeRubberBand->setIconSize( scaleFactor * 5 );
+  mHoveredNodeRubberBand->setColor( QColor( 200, 0, 120, 255 ) );
+}
+
+void QgsMapToolModifyAnnotation::createSelectedItemBand()
+{
+  const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+
+  mSelectedRubberBand.reset( new QgsRubberBand( mCanvas, QgsWkbTypes::LineGeometry ) );
+  mSelectedRubberBand->setWidth( scaleFactor );
+  mSelectedRubberBand->setSecondaryStrokeColor( QColor( 255, 255, 255, 100 ) );
+  mSelectedRubberBand->setColor( QColor( 50, 50, 50, 200 ) );
+}
+

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.h
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.h
@@ -1,0 +1,92 @@
+/***************************************************************************
+    qgsmaptoolmodifyannotation.h
+    ----------------
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLMODIFYANNOTATION_H
+#define QGSMAPTOOLMODIFYANNOTATION_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsmaptooladvanceddigitizing.h"
+#include "qobjectuniqueptr.h"
+
+class QgsRubberBand;
+class QgsRenderedAnnotationItemDetails;
+class QgsAnnotationItem;
+class QgsAnnotationLayer;
+class QgsAnnotationItemNodesSpatialIndex;
+class QgsAnnotationItemNode;
+
+/**
+ * \ingroup gui
+ * \brief A map tool for modifying annotations in a QgsAnnotationLayer
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsMapToolAdvancedDigitizing
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsMapToolModifyAnnotation
+     */
+    explicit QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+
+    ~QgsMapToolModifyAnnotation() override;
+
+    void deactivate() override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *event ) override;
+    void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+
+  signals:
+
+    /**
+     * Emitted when the selected item is changed.
+     */
+    void itemSelected( QgsAnnotationLayer *layer, const QString &itemId );
+
+  private:
+    void clearHoveredItem();
+    void createHoverBand();
+    void createHoveredNodeBand();
+    void createSelectedItemBand();
+    const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
+    QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
+    QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
+
+    void setHoveredItem( const QgsRenderedAnnotationItemDetails *item, const QgsRectangle &itemMapBounds );
+
+    QObjectUniquePtr<QgsRubberBand> mHoverRubberBand;
+    std::vector< QObjectUniquePtr<QgsRubberBand> > mHoveredItemNodeRubberBands;
+
+    // nodes from the current hovered item, reprojected onto the map canvas' CRS
+    QList< QgsAnnotationItemNode >  mHoveredItemNodes;
+
+    QObjectUniquePtr<QgsRubberBand> mHoveredNodeRubberBand;
+
+    QObjectUniquePtr<QgsRubberBand> mSelectedRubberBand;
+
+    QString mHoveredItemId;
+    QString mHoveredItemLayerId;
+
+    QString mSelectedItemId;
+    QString mSelectedItemLayerId;
+
+    std::unique_ptr< QgsAnnotationItemNodesSpatialIndex > mHoveredItemNodesSpatialIndex;
+
+};
+
+#endif // QGSMAPTOOLMODIFYANNOTATION_H

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -70,6 +70,7 @@ class QgsDevToolWidgetFactory;
 class QgsGpsConnection;
 class QgsApplicationExitBlockerInterface;
 class QgsAbstractMapToolHandler;
+class QgsMapToolModifyAnnotation;
 
 /**
  * \ingroup gui
@@ -1310,6 +1311,13 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.16
      */
     virtual void setGpsPanelConnection( QgsGpsConnection *connection ) = 0;
+
+    /**
+     * Returns the map tool used for modifying annotation layers.
+     *
+     * \since QGIS 3.22
+     */
+    virtual QgsMapToolModifyAnnotation *modifyAnnotationTool() = 0;
 
   signals:
 

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -28,6 +28,7 @@
 #include "qgslayoutitemregistry.h"
 #include "qgslayoutitemguiregistry.h"
 #include "qgslayoutviewrubberband.h"
+#include "qgsannotationitemguiregistry.h"
 #ifdef Q_OS_MACX
 #include "qgsmacnative.h"
 #elif defined (Q_OS_WIN)
@@ -124,6 +125,11 @@ QgsLayoutItemGuiRegistry *QgsGui::layoutItemGuiRegistry()
   return instance()->mLayoutItemGuiRegistry;
 }
 
+QgsAnnotationItemGuiRegistry *QgsGui::annotationItemGuiRegistry()
+{
+  return instance()->mAnnotationItemGuiRegistry;
+}
+
 QgsProcessingGuiRegistry *QgsGui::processingGuiRegistry()
 {
   return instance()->mProcessingGuiRegistry;
@@ -196,6 +202,7 @@ QgsGui::~QgsGui()
   delete mDataItemGuiProviderRegistry;
   delete mProcessingRecentAlgorithmLog;
   delete mLayoutItemGuiRegistry;
+  delete mAnnotationItemGuiRegistry;
   delete mLayerTreeEmbeddedWidgetRegistry;
   delete mEditorWidgetRegistry;
   delete mMapLayerActionRegistry;
@@ -281,6 +288,10 @@ QgsGui::QgsGui()
   mLayerTreeEmbeddedWidgetRegistry = new QgsLayerTreeEmbeddedWidgetRegistry();
   mMapLayerActionRegistry = new QgsMapLayerActionRegistry();
   mLayoutItemGuiRegistry = new QgsLayoutItemGuiRegistry();
+
+  mAnnotationItemGuiRegistry = new QgsAnnotationItemGuiRegistry();
+  mAnnotationItemGuiRegistry->addDefaultItems();
+
   mWidgetStateHelper = new QgsWidgetStateHelper();
   mProcessingRecentAlgorithmLog = new QgsProcessingRecentAlgorithmLog();
   mProcessingGuiRegistry = new QgsProcessingGuiRegistry();

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -31,6 +31,7 @@ class QgsMapLayerActionRegistry;
 class QgsSourceSelectProviderRegistry;
 class QgsNative;
 class QgsLayoutItemGuiRegistry;
+class QgsAnnotationItemGuiRegistry;
 class QgsWidgetStateHelper;
 class QgsProcessingGuiRegistry;
 class QgsProcessingRecentAlgorithmLog;
@@ -120,6 +121,13 @@ class GUI_EXPORT QgsGui : public QObject
      * Returns the global layout item GUI registry, used for registering the GUI behavior of layout items.
      */
     static QgsLayoutItemGuiRegistry *layoutItemGuiRegistry() SIP_KEEPREFERENCE;
+
+    /**
+     * Returns the global annotation item GUI registry, used for registering the GUI behavior of annotation items.
+     *
+     * \since QGIS 3.22
+     */
+    static QgsAnnotationItemGuiRegistry *annotationItemGuiRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global processing gui registry, used for registering the GUI behavior of processing algorithms.
@@ -278,6 +286,7 @@ class GUI_EXPORT QgsGui : public QObject
     QgsLayerTreeEmbeddedWidgetRegistry *mLayerTreeEmbeddedWidgetRegistry = nullptr;
     QgsMapLayerActionRegistry *mMapLayerActionRegistry = nullptr;
     QgsLayoutItemGuiRegistry *mLayoutItemGuiRegistry = nullptr;
+    QgsAnnotationItemGuiRegistry *mAnnotationItemGuiRegistry = nullptr;
     QgsProcessingGuiRegistry *mProcessingGuiRegistry = nullptr;
     QgsProcessingRecentAlgorithmLog *mProcessingRecentAlgorithmLog = nullptr;
     QgsNumericFormatGuiRegistry *mNumericFormatGuiRegistry = nullptr;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -153,6 +153,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   connect( QgsProject::instance(), &QgsProject::writeProject,
            this, &QgsMapCanvas::writeProject );
 
+  connect( QgsProject::instance()->mainAnnotationLayer(), &QgsMapLayer::repaintRequested, this, &QgsMapCanvas::layerRepaintRequested );
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsMapCanvas::mapThemeChanged );
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsMapCanvas::mapThemeRenamed );
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemesChanged, this, &QgsMapCanvas::projectThemesChanged );

--- a/src/gui/qgsmaplayerconfigwidget.cpp
+++ b/src/gui/qgsmaplayerconfigwidget.cpp
@@ -22,3 +22,8 @@ QgsMapLayerConfigWidget::QgsMapLayerConfigWidget( QgsMapLayer *layer, QgsMapCanv
 {
 
 }
+
+void QgsMapLayerConfigWidget::setContext( const QgsMapLayerConfigWidgetContext &context )
+{
+  mContext = context;
+}

--- a/src/gui/qgsmaplayerconfigwidget.cpp
+++ b/src/gui/qgsmaplayerconfigwidget.cpp
@@ -23,7 +23,7 @@ QgsMapLayerConfigWidget::QgsMapLayerConfigWidget( QgsMapLayer *layer, QgsMapCanv
 
 }
 
-void QgsMapLayerConfigWidget::setContext( const QgsMapLayerConfigWidgetContext &context )
+void QgsMapLayerConfigWidget::setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context )
 {
-  mContext = context;
+  mMapLayerConfigWidgetContext = context;
 }

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -44,7 +44,7 @@ class GUI_EXPORT QgsMapLayerConfigWidgetContext
     QString annotationId() const { return mAnnotationId; }
 
     /**
-     * Sets the item \id of the target annotation, when modifying
+     * Sets the item \a id of the target annotation, when modifying
      * an annotation from a QgsAnnotationLayer.
      *
      * \see annotationId()

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -23,6 +23,69 @@
 
 class QgsMapCanvas;
 class QgsMapLayer;
+class QgsMessageBar;
+
+/**
+ * \ingroup gui
+ * \class QgsMapLayerConfigWidgetContext
+ * \brief Encapsulates the context for a QgsMapLayerConfigWidget.
+ * \since QGIS 3.22
+ */
+class GUI_EXPORT QgsMapLayerConfigWidgetContext
+{
+  public:
+
+    /**
+     * Returns the item ID of the target annotation, when modifying
+     * an annotation from a QgsAnnotationLayer.
+     *
+     * \see setAnnotationId()
+     */
+    QString annotationId() const { return mAnnotationId; }
+
+    /**
+     * Sets the item \id of the target annotation, when modifying
+     * an annotation from a QgsAnnotationLayer.
+     *
+     * \see annotationId()
+     */
+    void setAnnotationId( const QString &id ) { mAnnotationId = id; }
+
+    /**
+     * Sets the map \a canvas associated with the widget. This allows the widget to retrieve the current
+     * map scale and other properties from the canvas.
+     *
+     * \see mapCanvas()
+     */
+    void setMapCanvas( QgsMapCanvas *canvas ) { mMapCanvas = canvas; }
+
+    /**
+     * Returns the map canvas associated with the widget.
+     * \see setMapCanvas()
+     */
+    QgsMapCanvas *mapCanvas() const { return mMapCanvas; }
+
+    /**
+     * Sets the message \a bar associated with the widget. This allows the widget to push feedback messages
+     * to the appropriate message bar.
+     * \see messageBar()
+     */
+    void setMessageBar( QgsMessageBar *bar ) { mMessageBar = bar; }
+
+    /**
+     * Returns the message bar associated with the widget.
+     * \see setMessageBar()
+     */
+    QgsMessageBar *messageBar() const { return mMessageBar; }
+
+  private:
+
+    QString mAnnotationId;
+    QgsMapCanvas *mMapCanvas = nullptr;
+    QgsMessageBar *mMessageBar = nullptr;
+
+};
+
 
 /**
  * \ingroup gui
@@ -59,6 +122,13 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
      */
     virtual void syncToLayer( QgsMapLayer *layer ) { Q_UNUSED( layer ) }
 
+    /**
+     * Sets the \a context under which the widget is being shown.
+     *
+     * Subclasses should take care to call the base class implementation when overriding this method.
+     */
+    virtual void setContext( const QgsMapLayerConfigWidgetContext &context );
+
   public slots:
 
     /**
@@ -85,6 +155,7 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
 
     QgsMapLayer *mLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
+    QgsMapLayerConfigWidgetContext mContext;
 };
 
 #endif // QGSMAPLAYERCONFIGWIDGET_H

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -127,7 +127,7 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
      *
      * Subclasses should take care to call the base class implementation when overriding this method.
      */
-    virtual void setContext( const QgsMapLayerConfigWidgetContext &context );
+    virtual void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context );
 
   public slots:
 
@@ -155,7 +155,7 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
 
     QgsMapLayer *mLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
-    QgsMapLayerConfigWidgetContext mContext;
+    QgsMapLayerConfigWidgetContext mMapLayerConfigWidgetContext;
 };
 
 #endif // QGSMAPLAYERCONFIGWIDGET_H

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
   testqgsapplocatorfilters.cpp
   testqgsdecorationscalebar.cpp
   testqgsfieldcalculator.cpp
+  testqgsmaptooleditannotation.cpp
   testqgsmaptoolidentifyaction.cpp
   testqgsmaptoollabel.cpp
   testqgsmaptoolselect.cpp

--- a/tests/src/app/testqgsmaptooleditannotation.cpp
+++ b/tests/src/app/testqgsmaptooleditannotation.cpp
@@ -1,0 +1,146 @@
+/***************************************************************************
+    testqgsmaptooleditannotation.cpp
+     --------------------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QCoreApplication>
+
+#include "qgstest.h"
+#include "qgsguiutils.h"
+#include "qgsmaptooledit.h"
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+#include "qgslogger.h"
+#include "qgsannotationlayer.h"
+#include "qgsannotationpolygonitem.h"
+#include "qgsproject.h"
+#include "testqgsmaptoolutils.h"
+#include "qgsmapmouseevent.h"
+#include "qgspolygon.h"
+#include "qgslinestring.h"
+#include "qgsmaptoolmodifyannotation.h"
+#include "qgsadvanceddigitizingdockwidget.h"
+#include "qgsrendereditemresults.h"
+
+#include <QSignalSpy>
+
+class TestQgsMapToolEditAnnotation : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsMapToolEditAnnotation() = default;
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testSelectItem();
+
+};
+
+void TestQgsMapToolEditAnnotation::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+}
+
+void TestQgsMapToolEditAnnotation::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolEditAnnotation::init()
+{
+}
+
+void TestQgsMapToolEditAnnotation::cleanup()
+{
+}
+
+void TestQgsMapToolEditAnnotation::testSelectItem()
+{
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsAnnotationLayer *layer2 = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer2->isValid() );
+  QgsProject::instance()->addMapLayers( { layer, layer2 } );
+
+  QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) ) );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+
+  QgsAnnotationPolygonItem *item2 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 4 ), QgsPoint( 5, 4 ), QgsPoint( 5, 9 ), QgsPoint( 1, 9 ), QgsPoint( 1, 4 ) } ) ) );
+  item2->setZIndex( 2 );
+  const QString i2id = layer->addItem( item2 );
+
+  QgsAnnotationPolygonItem *item3 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 7, 1 ), QgsPoint( 8, 1 ), QgsPoint( 8, 2 ), QgsPoint( 7, 2 ), QgsPoint( 7, 1 ) } ) ) );
+  item3->setZIndex( 3 );
+  const QString i3id = layer2->addItem( item3 );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  layer2->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+
+  canvas.setLayers( { layer, layer2 } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 3 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolModifyAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  QSignalSpy spy( &tool, &QgsMapToolModifyAnnotation::itemSelected );
+  TestQgsMapToolUtils utils( &tool );
+
+  // click outside of items
+  utils.mouseMove( 9, 9 );
+  utils.mouseClick( 9, 9, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 0 );
+
+  // click on items
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+  // second click on same item -- no signal
+  utils.mouseMove( 1.6, 1.5 );
+  utils.mouseClick( 1.6, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 1 );
+
+  // overlapping items, highest z order should be selected
+  utils.mouseMove( 1.5, 4.5 );
+  utils.mouseClick( 1.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 1 ).toString(), i2id );
+
+  utils.mouseMove( 7.5, 1.5 );
+  utils.mouseClick( 7.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 3 );
+  QCOMPARE( spy.at( 2 ).at( 1 ).toString(), i3id );
+}
+
+
+QGSTEST_MAIN( TestQgsMapToolEditAnnotation )
+#include "testqgsmaptooleditannotation.moc"

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
 
 set(TESTS
+  testqgsannotationitemguiregistry.cpp
   testqgsmaptoolzoom.cpp
   testqgsmaptooledit.cpp
   testqgscategorizedrendererwidget.cpp

--- a/tests/src/gui/testqgsannotationitemguiregistry.cpp
+++ b/tests/src/gui/testqgsannotationitemguiregistry.cpp
@@ -1,0 +1,170 @@
+/***************************************************************************
+    testqgsannotationitemguiregistry.cpp
+     --------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgsannotationitem.h"
+#include "qgsannotationitemguiregistry.h"
+#include "qgsannotationitemwidget.h"
+#include "qgsapplication.h"
+#include "qgsannotationitemregistry.h"
+#include <QSignalSpy>
+
+class TestQgsAnnotationItemGuiRegistry: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+    void guiRegistry();
+
+  private:
+
+};
+
+void TestQgsAnnotationItemGuiRegistry::initTestCase()
+{
+
+}
+
+void TestQgsAnnotationItemGuiRegistry::cleanupTestCase()
+{
+}
+
+void TestQgsAnnotationItemGuiRegistry::init()
+{
+}
+
+void TestQgsAnnotationItemGuiRegistry::cleanup()
+{
+}
+
+//simple item for testing, since some methods in QgsAnnotationItem are pure virtual
+class TestItem : public QgsAnnotationItem // clazy:exclude=missing-qobject-macro
+{
+  public:
+
+    TestItem() : QgsAnnotationItem() {}
+
+    int mFlag = 0;
+
+    //implement pure virtual methods
+    QString type() const override { return QStringLiteral( "mytype" ); }
+    TestItem *clone() override { return new TestItem(); }
+    QgsRectangle boundingBox() const override { return QgsRectangle();}
+    void render( QgsRenderContext &, QgsFeedback * ) override {}
+    bool writeXml( QDomElement &, QDomDocument &, const QgsReadWriteContext & ) const override { return true; }
+    bool readXml( const QDomElement &, const QgsReadWriteContext & ) override { return true; }
+
+};
+
+class TestItemWidget: public QgsAnnotationItemBaseWidget
+{
+  public:
+
+    TestItemWidget( QWidget *parent )
+      : QgsAnnotationItemBaseWidget( parent )
+    {}
+
+    QgsAnnotationItem *createItem() override { return nullptr; }
+
+};
+
+void TestQgsAnnotationItemGuiRegistry::guiRegistry()
+{
+  // test QgsAnnotationItemGuiRegistry
+  QgsAnnotationItemGuiRegistry registry;
+
+  // empty registry
+  QVERIFY( !registry.itemMetadata( -1 ) );
+  QVERIFY( registry.itemMetadataIds().isEmpty() );
+  QCOMPARE( registry.metadataIdForItemType( QString() ), -1 );
+  QVERIFY( !registry.createItemWidget( nullptr ) );
+  QVERIFY( !registry.createItemWidget( nullptr ) );
+  const std::unique_ptr< TestItem > testItem = std::make_unique< TestItem >();
+  QVERIFY( !registry.createItemWidget( testItem.get() ) ); // not in registry
+
+  const QSignalSpy spyTypeAdded( &registry, &QgsAnnotationItemGuiRegistry::typeAdded );
+
+  // add a dummy item to registry
+  auto createWidget = []( QgsAnnotationItem * )->QgsAnnotationItemBaseWidget *
+  {
+    return new TestItemWidget( nullptr );
+  };
+
+  QgsAnnotationItemGuiMetadata *metadata = new QgsAnnotationItemGuiMetadata( QStringLiteral( "mytype" ), QStringLiteral( "My Type" ), QIcon(), createWidget );
+  QVERIFY( registry.addAnnotationItemGuiMetadata( metadata ) );
+  QCOMPARE( spyTypeAdded.count(), 1 );
+  int uuid = registry.itemMetadataIds().value( 0 );
+  QCOMPARE( spyTypeAdded.value( 0 ).at( 0 ).toInt(), uuid );
+  QCOMPARE( registry.metadataIdForItemType( QStringLiteral( "mytype" ) ), uuid );
+
+  // duplicate type id is allowed
+  metadata = new QgsAnnotationItemGuiMetadata( QStringLiteral( "mytype" ), QStringLiteral( "My Type" ), QIcon(), createWidget );
+  QVERIFY( registry.addAnnotationItemGuiMetadata( metadata ) );
+  QCOMPARE( spyTypeAdded.count(), 2 );
+  //retrieve metadata
+  QVERIFY( !registry.itemMetadata( -1 ) );
+  QCOMPARE( registry.itemMetadataIds().count(), 2 );
+  QCOMPARE( registry.metadataIdForItemType( QStringLiteral( "mytype" ) ), uuid );
+
+  QVERIFY( registry.itemMetadata( uuid ) );
+  QCOMPARE( registry.itemMetadata( uuid )->visibleName(), QStringLiteral( "My Type" ) );
+
+  QWidget *widget = registry.createItemWidget( testItem.get() );
+  QVERIFY( widget );
+  delete widget;
+
+  // groups
+  QVERIFY( registry.addItemGroup( QgsAnnotationItemGuiGroup( QStringLiteral( "g1" ) ) ) );
+  QCOMPARE( registry.itemGroup( QStringLiteral( "g1" ) ).id, QStringLiteral( "g1" ) );
+  // can't add duplicate group
+  QVERIFY( !registry.addItemGroup( QgsAnnotationItemGuiGroup( QStringLiteral( "g1" ) ) ) );
+
+  //creating item
+  QgsAnnotationItem *item = registry.createItem( uuid );
+  QVERIFY( !item );
+  QgsApplication::annotationItemRegistry()->addItemType( new QgsAnnotationItemMetadata( QStringLiteral( "mytype" ), QStringLiteral( "My Type" ), QStringLiteral( "My Types" ), []( )->QgsAnnotationItem*
+  {
+    return new TestItem();
+  } ) );
+
+  item = registry.createItem( uuid );
+  QVERIFY( item );
+  QCOMPARE( item->type(), QStringLiteral( "mytype" ) );
+  QCOMPARE( static_cast< TestItem * >( item )->mFlag, 0 );
+  delete item;
+
+  // override create func
+  metadata = new QgsAnnotationItemGuiMetadata( QStringLiteral( "mytype" ), QStringLiteral( "mytype" ), QIcon(), createWidget );
+  metadata->setItemCreationFunction( []()->QgsAnnotationItem*
+  {
+    TestItem *item = new TestItem();
+    item->mFlag = 2;
+    return item;
+  } );
+  QVERIFY( registry.addAnnotationItemGuiMetadata( metadata ) );
+  uuid = spyTypeAdded.at( spyTypeAdded.count() - 1 ).at( 0 ).toInt();
+  item = registry.createItem( uuid );
+  QVERIFY( item );
+  QCOMPARE( item->type(), QStringLiteral( "mytype" ) );
+  QCOMPARE( static_cast< TestItem * >( item )->mFlag, 2 );
+  delete item;
+}
+
+
+QGSTEST_MAIN( TestQgsAnnotationItemGuiRegistry )
+#include "testqgsannotationitemguiregistry.moc"

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -114,6 +114,25 @@ class TestQgsAnnotationLayer(unittest.TestCase):
         layer.clear()
         self.assertEqual(len(layer.items()), 0)
 
+    def testReplaceItem(self):
+        layer = QgsAnnotationLayer('test', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
+
+        polygon_item_id = layer.addItem(QgsAnnotationPolygonItem(
+            QgsPolygon(QgsLineString([QgsPoint(12, 13), QgsPoint(14, 13), QgsPoint(14, 15), QgsPoint(12, 13)]))))
+        linestring_item_id = layer.addItem(
+            QgsAnnotationLineItem(QgsLineString([QgsPoint(11, 13), QgsPoint(12, 13), QgsPoint(12, 15)])))
+        marker_item_id = layer.addItem(QgsAnnotationMarkerItem(QgsPoint(12, 13)))
+
+        self.assertEqual(layer.item(polygon_item_id).geometry().asWkt(), 'Polygon ((12 13, 14 13, 14 15, 12 13))')
+        self.assertEqual(layer.item(linestring_item_id).geometry().asWkt(), 'LineString (11 13, 12 13, 12 15)')
+        self.assertEqual(layer.item(marker_item_id).geometry().asWkt(), 'POINT(12 13)')
+
+        layer.replaceItem(linestring_item_id,
+                          QgsAnnotationLineItem(QgsLineString([QgsPoint(21, 13), QgsPoint(22, 13), QgsPoint(22, 15)])))
+        self.assertEqual(layer.item(polygon_item_id).geometry().asWkt(), 'Polygon ((12 13, 14 13, 14 15, 12 13))')
+        self.assertEqual(layer.item(linestring_item_id).geometry().asWkt(), 'LineString (21 13, 22 13, 22 15)')
+        self.assertEqual(layer.item(marker_item_id).geometry().asWkt(), 'POINT(12 13)')
+
     def testReset(self):
         layer = QgsAnnotationLayer('test', QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()))
         self.assertTrue(layer.isValid())


### PR DESCRIPTION
This PR adds:

- A GUI registry for annotation layer items, modeled heavily off the approach used by layout items in order to provide a nice clean core/gui separation between annotation item classes. Currently this registry handles creation of widgets for modifying annotation items of different types
- An initial start on a map tool for modifying annotation items. This isn't (yet) shown in the QGIS UI, but the tools currently allows for users to select an existing annotation item and modify its properties (symbol styling) via the layer styling dock. 


https://user-images.githubusercontent.com/1829991/131968778-0d4a1ef5-548a-4a27-a29f-7f02becff871.mp4


The tool can be tested through the python console:

```
iface.mapCanvas().setMapTool(iface.modifyAnnotationTool())
```
(works best with https://github.com/qgis/QGIS/pull/44919 included too) 

Follow up PRs will allow the map tool to modify the shape of annotation items and move them around.