### PR TITLE
Option to export all keyboard shortcuts to XML and PDF

### DIFF
--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -50,7 +50,7 @@ QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget *parent, QgsSh
   mSaveMenu->addAction( mSaveUserShortcuts );
   connect( mSaveUserShortcuts, &QAction::triggered, this, [this] { saveShortcuts( false ); } );
 
-  mSaveAllShortcuts = new QAction( tr( "Save All Shportcuts…" ), this );
+  mSaveAllShortcuts = new QAction( tr( "Save All Shortcuts…" ), this );
   mSaveMenu->addAction( mSaveAllShortcuts );
   connect( mSaveAllShortcuts, &QAction::triggered, this, [this] { saveShortcuts(); } );
 
@@ -554,9 +554,9 @@ void QgsConfigureShortcutsDialog::saveShortcutsPdf()
   tableFormat.setHeaderRowCount( 1 );
 
   QVector<QTextLength> constraints;
-  constraints << QTextLength( QTextLength::PercentageLength, 2 );
+  constraints << QTextLength( QTextLength::PercentageLength, 5 );
   constraints << QTextLength( QTextLength::PercentageLength, 80 );
-  constraints << QTextLength( QTextLength::PercentageLength, 18 );
+  constraints << QTextLength( QTextLength::PercentageLength, 15 );
   tableFormat.setColumnWidthConstraints( constraints );
 
   QTextTableCellFormat headerFormat;
@@ -635,9 +635,12 @@ void QgsConfigureShortcutsDialog::saveShortcutsPdf()
     table->cellAt( row, 2 ).firstCursorPosition().insertText( sequence );
   }
 
-  QPrinter printer( QPrinter::PrinterResolution );
+  QPrinter printer( QPrinter::ScreenResolution );
   printer.setOutputFormat( QPrinter::PdfFormat );
   printer.setPaperSize( QPrinter::A4 );
+  printer.setPageOrientation( QPageLayout::Portrait );
+  printer.setPageMargins( QMarginsF( 20, 10, 10, 10 ), QPageLayout::Millimeter );
   printer.setOutputFileName( fileName );
+  document->setPageSize( QSizeF( printer.pageRect().size() ) );
   document->print( &printer );
 }

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -30,6 +30,13 @@
 #include <QTextStream>
 #include <QMenu>
 #include <QAction>
+#include <QPrinter>
+#include <QTextDocument>
+#include <QTextCursor>
+#include <QTextTable>
+#include <QTextTableFormat>
+#include <QTextTableCellFormat>
+#include <QTextCharFormat>
 
 QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget *parent, QgsShortcutsManager *manager )
   : QDialog( parent )
@@ -46,6 +53,10 @@ QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget *parent, QgsSh
   mSaveAllShortcuts = new QAction( tr( "Save All Shportcuts…" ), this );
   mSaveMenu->addAction( mSaveAllShortcuts );
   connect( mSaveAllShortcuts, &QAction::triggered, this, [this] { saveShortcuts(); } );
+
+  mSaveAsPdf = new QAction( tr( "Save as PDF…" ), this );
+  mSaveMenu->addAction( mSaveAsPdf );
+  connect( mSaveAsPdf, &QAction::triggered, this, &QgsConfigureShortcutsDialog::saveShortcutsPdf );
 
   btnSaveShortcuts->setMenu( mSaveMenu );
 
@@ -518,4 +529,115 @@ void QgsConfigureShortcutsDialog::mLeFilter_textChanged( const QString &text )
 void QgsConfigureShortcutsDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#keyboard-shortcuts" ) );
+}
+
+void QgsConfigureShortcutsDialog::saveShortcutsPdf()
+{
+  QString fileName = QFileDialog::getSaveFileName( this, tr( "Save Shortcuts" ), QDir::homePath(),
+                     tr( "PDF file" ) + " (*.pdf);;" + tr( "All files" ) + " (*)" );
+
+  if ( fileName.isEmpty() )
+    return;
+
+  if ( !fileName.endsWith( QLatin1String( ".pdf" ), Qt::CaseInsensitive ) )
+  {
+    fileName += QLatin1String( ".pdf" );
+  }
+
+  QTextDocument *document = new QTextDocument;
+  QTextCursor cursor( document );
+
+  QTextTableFormat tableFormat;
+  tableFormat.setBorder( 0 );
+  tableFormat.setCellSpacing( 0 );
+  tableFormat.setCellPadding( 4 );
+  tableFormat.setHeaderRowCount( 1 );
+
+  QVector<QTextLength> constraints;
+  constraints << QTextLength( QTextLength::PercentageLength, 2 );
+  constraints << QTextLength( QTextLength::PercentageLength, 80 );
+  constraints << QTextLength( QTextLength::PercentageLength, 18 );
+  tableFormat.setColumnWidthConstraints( constraints );
+
+  QTextTableCellFormat headerFormat;
+  headerFormat.setFontWeight( QFont::Bold );
+  headerFormat.setBottomPadding( 4 );
+
+  QTextCharFormat rowFormat;
+  rowFormat.setVerticalAlignment( QTextCharFormat::AlignMiddle );
+
+  QTextCharFormat altRowFormat;
+  altRowFormat.setBackground( QBrush( QColor( 238, 238, 236 ) ) );
+  altRowFormat.setVerticalAlignment( QTextCharFormat::AlignMiddle );
+
+  int row = 0;
+  QTextTable *table = cursor.insertTable( 1, 3, tableFormat );
+  table->mergeCells( 0, 0, 1, 2 );
+  QTextCursor c = table->cellAt( row, 0 ).firstCursorPosition();
+  c.setCharFormat( headerFormat );
+  c.insertText( tr( "Action" ) );
+  c = table->cellAt( row, 2 ).firstCursorPosition();
+  c.setCharFormat( headerFormat );
+  c.insertText( tr( "Shortcut" ) );
+
+  const QList<QObject *> objects = mManager->listAll();
+  for ( QObject *obj : objects )
+  {
+    QString actionText;
+    QString sequence;
+    QIcon icon;
+
+    if ( QAction *action = qobject_cast< QAction * >( obj ) )
+    {
+      actionText = action->text().remove( '&' );
+      sequence = action->shortcut().toString( QKeySequence::NativeText );
+      icon = action->icon();
+    }
+    else if ( QShortcut *shortcut = qobject_cast< QShortcut * >( obj ) )
+    {
+      actionText = shortcut->whatsThis();
+      sequence = shortcut->key().toString( QKeySequence::NativeText );
+      icon = shortcut->property( "Icon" ).value<QIcon>();
+    }
+    else
+    {
+      continue;
+    }
+
+    // skip actions without shortcut and name
+    if ( actionText.isEmpty() || sequence.isEmpty() )
+    {
+      continue;
+    }
+
+    row += 1;
+    table->appendRows( 1 );
+
+    if ( row % 2 )
+    {
+      table->cellAt( row, 0 ).setFormat( altRowFormat );
+      table->cellAt( row, 1 ).setFormat( altRowFormat );
+      table->cellAt( row, 2 ).setFormat( altRowFormat );
+    }
+    else
+    {
+      table->cellAt( row, 0 ).setFormat( rowFormat );
+      table->cellAt( row, 1 ).setFormat( rowFormat );
+      table->cellAt( row, 2 ).setFormat( rowFormat );
+    }
+
+    if ( !icon.isNull() )
+    {
+      c = table->cellAt( row, 0 ).firstCursorPosition();
+      c.insertImage( icon.pixmap( QSize( 24, 24 ) ).toImage() );
+    }
+    table->cellAt( row, 1 ).firstCursorPosition().insertText( actionText );
+    table->cellAt( row, 2 ).firstCursorPosition().insertText( sequence );
+  }
+
+  QPrinter printer( QPrinter::PrinterResolution );
+  printer.setOutputFormat( QPrinter::PdfFormat );
+  printer.setPaperSize( QPrinter::A4 );
+  printer.setOutputFileName( fileName );
+  document->print( &printer );
 }

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -55,7 +55,6 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     void changeShortcut();
     void resetShortcut();
     void setNoShortcut();
-    void saveShortcuts();
     void loadShortcuts();
     void mLeFilter_textChanged( const QString &text );
 
@@ -78,11 +77,17 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     //! Returns the currently selected QShortcut, or NULLPTR if no shortcut selected
     QShortcut *currentShortcut();
 
+    //! Saves custom or all shortcuts to XML file
+    void saveShortcuts( bool saveAll = true );
+
     void setGettingShortcut( bool getting );
     void setCurrentActionShortcut( const QKeySequence &s );
     void updateShortcutText();
 
     QgsShortcutsManager *mManager = nullptr;
+    QMenu *mSaveMenu = nullptr;
+    QAction *mSaveUserShortcuts = nullptr;
+    QAction *mSaveAllShortcuts = nullptr;
 
     bool mGettingShortcut = false;
     int mModifiers = 0, mKey = 0;

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     void resetShortcut();
     void setNoShortcut();
     void loadShortcuts();
+    void saveShortcutsPdf();
     void mLeFilter_textChanged( const QString &text );
 
     void actionChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous );
@@ -88,6 +89,7 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     QMenu *mSaveMenu = nullptr;
     QAction *mSaveUserShortcuts = nullptr;
     QAction *mSaveAllShortcuts = nullptr;
+    QAction *mSaveAsPdf = nullptr;
 
     bool mGettingShortcut = false;
     int mModifiers = 0, mKey = 0;


### PR DESCRIPTION
## Description
Using Settings → Keyboard Shortcuts users can export shortcuts. However it works only if there are some user-defined/overridden shortcuts, otherwise an empty file will be created.

This PR adds a drop-down menu to the "Save" button with options to export either only user-defined or all available keyboard shortcuts to an XML file.

![shortcuts](https://user-images.githubusercontent.com/776954/132033186-a4498839-35b4-4690-b741-82abf25ee0d5.png)

Additionally it is now possible to create a PDF with the list of all defined QGIS shortcuts, which looks as below

![pdf](https://user-images.githubusercontent.com/776954/132033286-1944d4b7-aaf9-495d-8e4d-e0acb429d079.png)



Fixes #40995.