### PR TITLE
Use same label as in Properties dialog

### DIFF
--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -493,7 +493,7 @@
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="mColorRenderingGrpBox">
                  <property name="title">
-                  <string>Color Rendering</string>
+                  <string>Layer Rendering</string>
                  </property>
                  <property name="collapsed" stdset="0">
                   <bool>false</bool>


### PR DESCRIPTION
This group is called "Color rendering" in Properties dialog but "Layer rendering" in Styling panel. Harmonizing...
![image](https://user-images.githubusercontent.com/7983394/132070744-579f9a0e-54aa-4c02-a854-80f5f68518ca.png)
![image](https://user-images.githubusercontent.com/7983394/132070776-5bbe0ff2-4125-47e5-b0e4-3edd7eb0131e.png)
