### PR TITLE
Processing duration tweak

### DIFF
--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -884,7 +884,7 @@ tests:
       DATETIME_FIELD: date
       DBSCAN*: false
       EPS: 5.0
-      EPS2: 1000.0
+      EPS2: 86400000.0
       FIELD_NAME: CLUSTER_ID
       INPUT:
         name: custom/points_with_date.shp

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.cpp
@@ -114,7 +114,7 @@ QVariantMap QgsDbscanClusteringAlgorithm::processAlgorithm( const QVariantMap &p
 
   const std::size_t minSize = static_cast< std::size_t>( parameterAsInt( parameters, QStringLiteral( "MIN_SIZE" ), context ) );
   const double eps1 = parameterAsDouble( parameters, QStringLiteral( "EPS" ), context );
-  const double eps2 = parameterAsDouble( parameters, QStringLiteral( "EPS2" ), context ) * 24 * 60 * 60;
+  const double eps2 = parameterAsDouble( parameters, QStringLiteral( "EPS2" ), context );
   const bool borderPointsAreNoise = parameterAsBoolean( parameters, QStringLiteral( "DBSCAN*" ), context );
 
   QgsFields outputFields = source->fields();

--- a/src/analysis/processing/qgsalgorithmstdbscanclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmstdbscanclustering.cpp
@@ -61,10 +61,10 @@ void QgsStDbscanClusteringAlgorithm::initAlgorithm( const QVariantMap & )
                 QgsProcessingParameterNumber::Integer, 5, false, 1 ) );
   addParameter( new QgsProcessingParameterDistance( QStringLiteral( "EPS" ),
                 QObject::tr( "Maximum distance between clustered points" ), 1, QStringLiteral( "INPUT" ), false, 0 ) );
-  QgsProcessingParameterDuration *durationParameter = new QgsProcessingParameterDuration( QStringLiteral( "EPS2" ),
-      QObject::tr( "Maximum time duration between clustered points" ), 0, false, 0 );
-  durationParameter->setDefaultUnit( QgsUnitTypes::TemporalDays );
-  addParameter( durationParameter );
+  auto durationParameter = std::make_unique<QgsProcessingParameterDuration>( QStringLiteral( "EPS2" ),
+                           QObject::tr( "Maximum time duration between clustered points" ), 0, false, 0 );
+  durationParameter->setDefaultUnit( QgsUnitTypes::TemporalHours );
+  addParameter( durationParameter.release() );
 
   auto dbscanStarParam = std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "DBSCAN*" ),
                          QObject::tr( "Treat border points as noise (DBSCAN*)" ), false, true );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1324,7 +1324,6 @@ QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingDurationWidgetWrapper:
 QWidget *QgsProcessingDurationWidgetWrapper::createWidget()
 {
   const QgsProcessingParameterDuration *durationDef = static_cast< const QgsProcessingParameterDuration * >( parameterDefinition() );
-  mBaseUnit = durationDef->defaultUnit();
 
   QWidget *spin = QgsProcessingNumericWidgetWrapper::createWidget();
   switch ( type() )
@@ -1348,7 +1347,7 @@ QWidget *QgsProcessingDurationWidgetWrapper::createWidget()
       layout->setContentsMargins( 0, 0, 0, 0 );
       w->setLayout( layout );
 
-      mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( mBaseUnit ) );
+      mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( durationDef->defaultUnit() ) );
       mUnitsCombo->show();
 
       return w;
@@ -1368,8 +1367,7 @@ QLabel *QgsProcessingDurationWidgetWrapper::createLabel()
 
   if ( type() == QgsProcessingGui::Modeler )
   {
-    const QgsProcessingParameterDuration *durationDef = static_cast< const QgsProcessingParameterDuration * >( parameterDefinition() );
-    label->setText( QStringLiteral( "%1 [%2]" ).arg( label->text(), QgsUnitTypes::toString( durationDef->defaultUnit() ) ) );
+    label->setText( QStringLiteral( "%1 [%2]" ).arg( label->text(), QgsUnitTypes::toString( mBaseUnit ) ) );
   }
 
   return label;
@@ -1386,6 +1384,20 @@ QVariant QgsProcessingDurationWidgetWrapper::widgetValue() const
   else
   {
     return val;
+  }
+}
+
+void QgsProcessingDurationWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
+{
+  if ( mUnitsCombo )
+  {
+    QgsUnitTypes::TemporalUnit displayUnit = static_cast<QgsUnitTypes::TemporalUnit >( mUnitsCombo->currentData().toInt() );
+    const QVariant val = value.toDouble() * QgsUnitTypes::fromUnitToUnitFactor( mBaseUnit, displayUnit );
+    QgsProcessingNumericWidgetWrapper::setWidgetValue( val, context );
+  }
+  else
+  {
+    QgsProcessingNumericWidgetWrapper::setWidgetValue( value, context );
   }
 }
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1267,6 +1267,9 @@ QgsProcessingDurationParameterDefinitionWidget::QgsProcessingDurationParameterDe
   mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalHours ), QgsUnitTypes::TemporalHours );
   mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalDays ), QgsUnitTypes::TemporalDays );
   mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalWeeks ), QgsUnitTypes::TemporalWeeks );
+  mUnitsCombo->addItem( tr( "years (365.25 days)" ), QgsUnitTypes::TemporalYears );
+  mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalDecades ), QgsUnitTypes::TemporalDecades );
+  mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalCenturies ), QgsUnitTypes::TemporalCenturies );
   vlayout->addWidget( mUnitsCombo );
 
   if ( const QgsProcessingParameterDuration *durationParam = dynamic_cast<const QgsProcessingParameterDuration *>( definition ) )
@@ -1338,6 +1341,9 @@ QWidget *QgsProcessingDurationWidgetWrapper::createWidget()
       mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalHours ), QgsUnitTypes::TemporalHours );
       mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalDays ), QgsUnitTypes::TemporalDays );
       mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalWeeks ), QgsUnitTypes::TemporalWeeks );
+      mUnitsCombo->addItem( tr( "years (365.25 days)" ), QgsUnitTypes::TemporalYears );
+      mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalDecades ), QgsUnitTypes::TemporalDecades );
+      mUnitsCombo->addItem( QgsUnitTypes::toString( QgsUnitTypes::TemporalCenturies ), QgsUnitTypes::TemporalCenturies );
 
       QHBoxLayout *layout = new QHBoxLayout();
       layout->addWidget( spin, 1 );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -444,6 +444,7 @@ class GUI_EXPORT QgsProcessingDurationWidgetWrapper : public QgsProcessingNumeri
   protected:
 
     QVariant widgetValue() const override;
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
 
   private:
 


### PR DESCRIPTION
## Description

This PR tweaks the newly-added processing duration parameter so it _always_ returns values in milliseconds. The parameter definition's default unit guides which default unit type the widget wrapper should set itself too but will not impact on the widget's returned value unit (which is now always ms).

@nyalldawson , I've been haunted by this since my initial implementation. I think it's ultimately much better to stick to milliseconds only for the parameter values (easier to model, easier to use via qgis_process CLI, etc.). That constant will insure users don't have to go dig in each alg. what the unit type is set to.