### PR TITLE
Add methods to add additional layers to QgsMapLayerModel/QgsMapLayerComboBox

### DIFF
--- a/python/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayermodel.sip.in
@@ -151,8 +151,8 @@ Returns the map layer corresponding to the specified ``index``.
     void setAdditionalItems( const QStringList &items );
 %Docstring
 Sets a list of additional (non map layer) items to include at the end of the model.
-These may represent additional layers such as layers which are not included in the map
-layer registry, or paths to layers which have not yet been loaded into QGIS.
+These may represent additional layers such as layers which are not included in the active project,
+or paths to layers which have not yet been loaded into QGIS.
 
 .. seealso:: :py:func:`additionalItems`
 
@@ -166,6 +166,27 @@ Returns the list of additional (non map layer) items included at the end of the 
 .. seealso:: :py:func:`setAdditionalItems`
 
 .. versionadded:: 3.0
+%End
+
+    void setAdditionalLayers( const QList<QgsMapLayer *> &layers );
+%Docstring
+Sets a list of additional ``layers`` to include in the model.
+
+This method allows adding additional layers, which are not part of a project's
+layers, into the model.
+
+.. seealso:: :py:func:`additionalLayers`
+
+.. versionadded:: 3.22
+%End
+
+    QList< QgsMapLayer * > additionalLayers() const;
+%Docstring
+Returns the list of additional layers added to the model.
+
+.. seealso:: :py:func:`setAdditionalLayers`
+
+.. versionadded:: 3.22
 %End
 
     virtual QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -126,6 +126,27 @@ Returns the list of additional (non map layer) items included at the end of the 
 .. versionadded:: 3.0
 %End
 
+    void setAdditionalLayers( const QList<QgsMapLayer *> &layers );
+%Docstring
+Sets a list of additional ``layers`` to include in the combobox.
+
+This method allows adding additional layers, which are not part of a project's
+layers, into the combobox.
+
+.. seealso:: :py:func:`additionalLayers`
+
+.. versionadded:: 3.22
+%End
+
+    QList< QgsMapLayer * > additionalLayers() const;
+%Docstring
+Returns the list of additional layers added to the combobox.
+
+.. seealso:: :py:func:`setAdditionalLayers`
+
+.. versionadded:: 3.22
+%End
+
     QgsMapLayer *currentLayer() const;
 %Docstring
 Returns the current layer selected in the combo box.

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -53,6 +53,7 @@
 #include "qgsrasterminmaxwidget.h"
 #include "qgisapp.h"
 #include "qgssymbolwidgetcontext.h"
+#include "qgsannotationlayer.h"
 
 #ifdef HAVE_3D
 #include "qgsvectorlayer3drendererwidget.h"
@@ -109,6 +110,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, QgsMessageBa
                            | QgsMapLayerProxyModel::Filter::VectorTileLayer
                            | QgsMapLayerProxyModel::Filter::PointCloudLayer
                            | QgsMapLayerProxyModel::Filter::AnnotationLayer );
+  mLayerCombo->setAdditionalLayers( { QgsProject::instance()->mainAnnotationLayer() } );
 
   mStackedWidget->setCurrentIndex( 0 );
 }

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -156,8 +156,8 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
 
     /**
      * Sets a list of additional (non map layer) items to include at the end of the model.
-     * These may represent additional layers such as layers which are not included in the map
-     * layer registry, or paths to layers which have not yet been loaded into QGIS.
+     * These may represent additional layers such as layers which are not included in the active project,
+     * or paths to layers which have not yet been loaded into QGIS.
      * \see additionalItems()
      * \since QGIS 3.0
      */
@@ -169,6 +169,25 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      * \since QGIS 3.0
      */
     QStringList additionalItems() const { return mAdditionalItems; }
+
+    /**
+     * Sets a list of additional \a layers to include in the model.
+     *
+     * This method allows adding additional layers, which are not part of a project's
+     * layers, into the model.
+     *
+     * \see additionalLayers()
+     * \since QGIS 3.22
+     */
+    void setAdditionalLayers( const QList<QgsMapLayer *> &layers );
+
+    /**
+     * Returns the list of additional layers added to the model.
+     *
+     * \see setAdditionalLayers()
+     * \since QGIS 3.22
+     */
+    QList< QgsMapLayer * > additionalLayers() const;
 
     // QAbstractItemModel interface
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
@@ -205,6 +224,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
 
   protected:
     QList<QgsMapLayer *> mLayers;
+    QList< QPointer<QgsMapLayer> > mAdditionalLayers;
     QMap<QString, Qt::CheckState> mLayersChecked;
     bool mItemCheckable = false;
     bool mCanReorder = false;

--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -74,6 +74,16 @@ QStringList QgsMapLayerComboBox::additionalItems() const
   return mProxyModel->sourceLayerModel()->additionalItems();
 }
 
+void QgsMapLayerComboBox::setAdditionalLayers( const QList<QgsMapLayer *> &layers )
+{
+  mProxyModel->sourceLayerModel()->setAdditionalLayers( layers );
+}
+
+QList<QgsMapLayer *> QgsMapLayerComboBox::additionalLayers() const
+{
+  return mProxyModel->sourceLayerModel()->additionalLayers();
+}
+
 void QgsMapLayerComboBox::setLayer( QgsMapLayer *layer )
 {
   if ( layer == currentLayer() && ( layer || !isEditable() || currentText().isEmpty() ) )

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -121,6 +121,25 @@ class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
     QStringList additionalItems() const;
 
     /**
+     * Sets a list of additional \a layers to include in the combobox.
+     *
+     * This method allows adding additional layers, which are not part of a project's
+     * layers, into the combobox.
+     *
+     * \see additionalLayers()
+     * \since QGIS 3.22
+     */
+    void setAdditionalLayers( const QList<QgsMapLayer *> &layers );
+
+    /**
+     * Returns the list of additional layers added to the combobox.
+     *
+     * \see setAdditionalLayers()
+     * \since QGIS 3.22
+     */
+    QList< QgsMapLayer * > additionalLayers() const;
+
+    /**
      * Returns the current layer selected in the combo box.
      * \see layer
      */

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -14,6 +14,10 @@ import qgis  # NOQA
 
 from qgis.core import QgsVectorLayer, QgsMeshLayer, QgsProject, QgsMapLayerProxyModel
 from qgis.gui import QgsMapLayerComboBox
+from qgis.PyQt.QtCore import (
+    QCoreApplication,
+    QEvent
+)
 from qgis.PyQt.QtTest import QSignalSpy
 
 from qgis.testing import start_app, unittest
@@ -186,6 +190,79 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
         m.setLayer(l1)
         self.assertEqual(len(spy), 4)
         self.assertEqual(m.currentLayer(), l1)
+
+    def testAdditionalLayers(self):
+        QgsProject.instance().clear()
+        l1 = create_layer('l1')
+        l2 = create_layer('l2')
+        QgsProject.instance().addMapLayers([l1, l2])
+        m = QgsMapLayerComboBox()
+        self.assertEqual(m.count(), 2)
+        l3 = create_layer('l3')
+        l4 = create_layer('l4')
+        m.setAdditionalLayers([l3, l4])
+        self.assertEqual(m.count(), 4)
+
+        m.setAdditionalItems(['a', 'b'])
+        self.assertEqual(m.count(), 6)
+        self.assertEqual(m.itemText(0), 'l1')
+        self.assertEqual(m.itemText(1), 'l2')
+        self.assertEqual(m.itemText(2), 'l3')
+        self.assertEqual(m.itemText(3), 'l4')
+        self.assertEqual(m.itemText(4), 'a')
+        self.assertEqual(m.itemText(5), 'b')
+
+        m.setAllowEmptyLayer(True)
+        self.assertEqual(m.count(), 7)
+        self.assertFalse(m.itemText(0))
+        self.assertEqual(m.itemText(1), 'l1')
+        self.assertEqual(m.itemText(2), 'l2')
+        self.assertEqual(m.itemText(3), 'l3')
+        self.assertEqual(m.itemText(4), 'l4')
+        self.assertEqual(m.itemText(5), 'a')
+        self.assertEqual(m.itemText(6), 'b')
+
+        l3.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+        self.assertEqual(m.count(), 6)
+        self.assertFalse(m.itemText(0))
+        self.assertEqual(m.itemText(1), 'l1')
+        self.assertEqual(m.itemText(2), 'l2')
+        self.assertEqual(m.itemText(3), 'l4')
+        self.assertEqual(m.itemText(4), 'a')
+        self.assertEqual(m.itemText(5), 'b')
+
+        l5 = create_layer('l5')
+        l6 = create_layer('l6')
+        m.setAdditionalLayers([l5, l6, l4])
+        self.assertEqual(m.count(), 8)
+        self.assertFalse(m.itemText(0))
+        self.assertEqual(m.itemText(1), 'l1')
+        self.assertEqual(m.itemText(2), 'l2')
+        self.assertEqual(m.itemText(3), 'l4')
+        self.assertEqual(m.itemText(4), 'l5')
+        self.assertEqual(m.itemText(5), 'l6')
+        self.assertEqual(m.itemText(6), 'a')
+        self.assertEqual(m.itemText(7), 'b')
+
+        m.setAdditionalLayers([l5, l4])
+        self.assertEqual(m.count(), 7)
+        self.assertFalse(m.itemText(0))
+        self.assertEqual(m.itemText(1), 'l1')
+        self.assertEqual(m.itemText(2), 'l2')
+        self.assertEqual(m.itemText(3), 'l4')
+        self.assertEqual(m.itemText(4), 'l5')
+        self.assertEqual(m.itemText(5), 'a')
+        self.assertEqual(m.itemText(6), 'b')
+
+        QgsProject.instance().removeMapLayers([l1.id(), l2.id()])
+
+        self.assertEqual(m.count(), 5)
+        self.assertFalse(m.itemText(0))
+        self.assertEqual(m.itemText(1), 'l4')
+        self.assertEqual(m.itemText(2), 'l5')
+        self.assertEqual(m.itemText(3), 'a')
+        self.assertEqual(m.itemText(4), 'b')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows non-project layers to be shown in the map layer combo box.

Also uses this to expose the project's main annotation layer to the map layer styling dock