### PR TITLE
Transactions in MSSQL provider

### DIFF
--- a/python/core/auto_generated/qgstransaction.sip.in
+++ b/python/core/auto_generated/qgstransaction.sip.in
@@ -110,7 +110,7 @@ returns the last created savepoint if it's not dirty
 .. versionadded:: 3.0
 %End
 
-    QString createSavepoint( const QString &savePointId, QString &error /Out/ );
+    virtual QString createSavepoint( const QString &savePointId, QString &error /Out/ );
 %Docstring
 creates a save point
 returns empty string on error
@@ -118,7 +118,7 @@ returns empty string on error
 .. versionadded:: 3.0
 %End
 
-    bool rollbackToSavepoint( const QString &name, QString &error /Out/ );
+    virtual bool rollbackToSavepoint( const QString &name, QString &error /Out/ );
 %Docstring
 rollback to save point, the save point is maintained and is "undertied"
 

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -223,16 +223,7 @@ QString QgsTransaction::createSavepoint( QString &error SIP_OUT )
   }
 
   const QString name( QStringLiteral( "qgis" ) + ( QUuid::createUuid().toString().mid( 1, 24 ).replace( '-', QString() ) ) );
-
-  if ( !executeSql( QStringLiteral( "SAVEPOINT %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error ) )
-  {
-    QgsMessageLog::logMessage( tr( "Could not create savepoint (%1)" ).arg( error ) );
-    return QString();
-  }
-
-  mSavepoints.push( name );
-  mLastSavePointIsDirty = false;
-  return name;
+  return createSavepoint( name, error );
 }
 
 QString QgsTransaction::createSavepoint( const QString &savePointId, QString &error SIP_OUT )

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -132,13 +132,13 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
      * returns empty string on error
      * \since QGIS 3.0
      */
-    QString createSavepoint( const QString &savePointId, QString &error SIP_OUT );
+    virtual QString createSavepoint( const QString &savePointId, QString &error SIP_OUT );
 
     /**
      * rollback to save point, the save point is maintained and is "undertied"
      * \since QGIS 3.0
      */
-    bool rollbackToSavepoint( const QString &name, QString &error SIP_OUT );
+    virtual bool rollbackToSavepoint( const QString &name, QString &error SIP_OUT );
 
     /**
      * dirty save point such that next call to createSavepoint will create a new one
@@ -179,17 +179,16 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     QgsTransaction( const QString &connString ) SIP_SKIP;
 
     QString mConnString;
+    bool mTransactionActive;
+    QStack< QString > mSavepoints;
+    bool mLastSavePointIsDirty;
 
   private slots:
     void onLayerDeleted();
 
   private:
 
-    bool mTransactionActive;
     QSet<QgsVectorLayer *> mLayers;
-
-    QStack< QString > mSavepoints;
-    bool mLastSavePointIsDirty;
 
     void setLayerTransactionIds( QgsTransaction *transaction );
 

--- a/src/providers/mssql/CMakeLists.txt
+++ b/src/providers/mssql/CMakeLists.txt
@@ -8,6 +8,8 @@ set(MSSQL_SRCS
   qgsmssqlexpressioncompiler.cpp
   qgsmssqlfeatureiterator.cpp
   qgsmssqlgeomcolumntypethread.cpp
+  qgsmssqltransaction.cpp
+  qgsmssqldatabase.cpp
 )
 
 if (WITH_GUI)
@@ -47,6 +49,30 @@ if (WITH_GUI)
     qgis_gui
   )
   add_dependencies(provider_mssql ui)
+endif()
+
+# static library
+add_library (provider_mssql_a STATIC ${MSSQL_SRCS} ${MSSQL_HDRS})
+
+# require c++17
+target_compile_features(provider_mssql_a PRIVATE cxx_std_17)
+
+target_link_libraries (provider_mssql_a
+  qgis_core
+  ${POSTGRES_LIBRARY}
+  ${Qt5Xml_LIBRARIES}
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Svg_LIBRARIES}
+  ${Qt5Network_LIBRARIES}
+  ${Qt5Sql_LIBRARIES}
+  ${Qt5Concurrent_LIBRARIES}
+)
+
+if (WITH_GUI)
+  target_link_libraries (provider_mssql_a
+    qgis_gui
+  )
+  add_dependencies(provider_mssql_a ui)
 endif()
 
 ########################################################

--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -219,24 +219,24 @@ QStringList QgsMssqlConnection::schemas( const QString &uri, QString *errorMessa
 {
   const QgsDataSourceUri dsUri( uri );
 
-// connect to database
+  // connect to database
   std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  return schemas( db->db(), errorMessage );
+  return schemas( db, errorMessage );
 }
 
-QStringList QgsMssqlConnection::schemas( QSqlDatabase &dataBase, QString *errorMessage )
+QStringList QgsMssqlConnection::schemas( std::shared_ptr<QgsMssqlDatabase> db, QString *errorMessage )
 {
-  if ( !QgsMssqlDatabase::openDatabase( dataBase ) )
+  if ( !db->isValid() )
   {
     if ( errorMessage )
-      *errorMessage = dataBase.lastError().text();
+      *errorMessage = db->errorText();
     return QStringList();
   }
 
   const QString sql = QStringLiteral( "select s.name as schema_name from sys.schemas s" );
 
-  QSqlQuery q = QSqlQuery( dataBase );
+  QSqlQuery q = QSqlQuery( db->db() );
   q.setForwardOnly( true );
   if ( !q.exec( sql ) )
   {

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -26,6 +26,8 @@
 class QString;
 class QSqlDatabase;
 
+class QgsMssqlDatabase;
+
 /**
  * \class QgsMssqlConnection
  * Connection handler for SQL Server provider
@@ -186,7 +188,7 @@ class QgsMssqlConnection
      * Returns a list of all schemas on the \a dataBase.
      * \since QGIS 3.18
      */
-    static QStringList schemas( QSqlDatabase &dataBase, QString *errorMessage );
+    static QStringList schemas( std::shared_ptr<QgsMssqlDatabase> db, QString *errorMessage );
 
     /**
      * Returns true if the given \a schema is a system schema.

--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -19,7 +19,6 @@
 #define QGSMSSQLCONNECTION_H
 
 #include <QStringList>
-#include <QMutex>
 
 #include "qgsdatasourceuri.h"
 #include "qgsvectordataprovider.h"
@@ -28,7 +27,7 @@ class QString;
 class QSqlDatabase;
 
 /**
- * \class QgsMssqlProvider
+ * \class QgsMssqlConnection
  * Connection handler for SQL Server provider
  *
 */
@@ -36,16 +35,6 @@ class QgsMssqlConnection
 {
 
   public:
-
-    /**
-     * Returns a QSqlDatabase object for queries to SQL Server.
-     *
-     * The database may not be open -- openDatabase() should be called to
-     * ensure that it is ready for use.
-     */
-    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password );
-
-    static bool openDatabase( QSqlDatabase &db );
 
     /**
      * Returns true if the connection with matching \a name should
@@ -265,18 +254,7 @@ class QgsMssqlConnection
 
   private:
 
-    /**
-     * Returns a thread-safe connection name for use with QSqlDatabase
-     */
-    static QString dbConnectionName( const QString &name );
 
-    static int sConnectionId;
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    static QMutex sMutex;
-#else
-    static QRecursiveMutex sMutex;
-#endif
 };
 
 #endif // QGSMSSQLCONNECTION_H

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -20,6 +20,7 @@
 
 #include <QCoreApplication>
 #include <QtDebug>
+#include <QFile>
 #include <QThread>
 
 

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -1,0 +1,231 @@
+/***************************************************************************
+  qgsmssqldatabase.cpp
+  --------------------------------------
+  Date                 : August 2021
+  Copyright            : (C) 2021 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmssqldatabase.h"
+
+#include "qgsdatasourceuri.h"
+#include "qgslogger.h"
+
+#include <QCoreApplication>
+#include <QtDebug>
+#include <QThread>
+
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+QMutex QgsMssqlDatabase::sMutex { QMutex::Recursive };
+#else
+QRecursiveMutex QgsMssqlDatabase::sMutex;
+#endif
+
+QMap<QString, std::weak_ptr<QgsMssqlDatabase> > QgsMssqlDatabase::sConnections;
+
+
+QString _connName( const QString &service, const QString &host, const QString &database, bool transaction )
+{
+  QString connectionName;
+  if ( service.isEmpty() )
+  {
+    if ( !host.isEmpty() )
+      connectionName = host + '.';
+
+    if ( database.isEmpty() )
+    {
+      QgsDebugMsg( QStringLiteral( "QgsMssqlProvider database name not specified" ) );
+      return QString();
+    }
+
+    connectionName += database;
+  }
+  else
+    connectionName = service;
+
+  if ( !transaction )
+    connectionName += QStringLiteral( ":0x%1" ).arg( reinterpret_cast<quintptr>( QThread::currentThread() ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) );
+  else
+    connectionName += ":transaction";
+  return connectionName;
+}
+
+
+std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QString &uri, bool transaction )
+{
+  QgsDataSourceUri dsUri( uri );
+  return connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password(), transaction );
+}
+
+std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction )
+{
+  // try to use existing conn or create a new one
+
+  QMutexLocker locker( &sMutex );
+
+  QString connName = _connName( service, host, database, transaction );
+
+  if ( sConnections.contains( connName ) && !sConnections[connName].expired() )
+    return sConnections[connName].lock();
+
+  QSqlDatabase db = QgsMssqlDatabase::getDatabase( service, host, database, username, password, transaction );
+
+  std::shared_ptr<QgsMssqlDatabase> c( new QgsMssqlDatabase( db, transaction ) );
+
+  // we return connection even if it failed to open (because the error message may be useful)
+  // but do not add it to connections as it is not useful
+  if ( !c->isValid() )
+    return c;
+
+  sConnections[connName] = c;
+  return c;
+}
+
+QgsMssqlDatabase::QgsMssqlDatabase( const QSqlDatabase &db, bool transaction )
+{
+  mTransaction = transaction;
+  mDB = db;
+
+  if ( mTransaction )
+  {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    mTransactionMutex.reset( new QMutex { QMutex::Recursive } );
+#else
+    mTransactionMutex.reset( new QRecursiveMutex );
+#endif
+  }
+
+  if ( !QgsMssqlDatabase::openDatabase( mDB ) )
+  {
+    QgsDebugMsg( "Failed to open MSSQL database: " + mDB.lastError().text() );
+  }
+}
+
+QgsMssqlDatabase::~QgsMssqlDatabase()
+{
+  // close DB if it is open
+  if ( mDB.isOpen() )
+  {
+    mDB.close();
+
+    // TODO: also remove DB?
+  }
+}
+
+
+// -------------------
+
+
+QSqlDatabase QgsMssqlDatabase::getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction )
+{
+  QSqlDatabase db;
+
+  // while everything we use from QSqlDatabase here is thread safe, we need to ensure
+  // that the connection cleanup on thread finalization happens in a predictable order
+  QMutexLocker locker( &sMutex );
+
+  const QString threadSafeConnectionName = _connName( service, host, database, transaction ); //dbConnectionName( connectionName );
+
+  if ( !QSqlDatabase::contains( threadSafeConnectionName ) )
+  {
+    db = QSqlDatabase::addDatabase( QStringLiteral( "QODBC" ), threadSafeConnectionName );
+    db.setConnectOptions( QStringLiteral( "SQL_ATTR_CONNECTION_POOLING=SQL_CP_ONE_PER_HENV" ) );
+
+    // for background threads, remove database when current thread finishes
+    if ( QThread::currentThread() != QCoreApplication::instance()->thread() )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Scheduled auth db remove on thread close" ), 2 );
+
+      // IMPORTANT - we use a direct connection here, because the database removal must happen immediately
+      // when the thread finishes, and we cannot let this get queued on the main thread's event loop.
+      // Otherwise, the QSqlDatabase's private data's thread gets reset immediately the QThread::finished,
+      // and a subsequent call to QSqlDatabase::database with the same thread address (yep it happens, actually a lot)
+      // triggers a condition in QSqlDatabase which detects the nullptr private thread data and returns an invalid database instead.
+      // QSqlDatabase::removeDatabase is thread safe, so this is ok to do.
+      QObject::connect( QThread::currentThread(), &QThread::finished, QThread::currentThread(), [threadSafeConnectionName]
+      {
+        const QMutexLocker locker( &sMutex );
+        QSqlDatabase::removeDatabase( threadSafeConnectionName );
+      }, Qt::DirectConnection );
+    }
+  }
+  else
+  {
+    db = QSqlDatabase::database( threadSafeConnectionName );
+  }
+  locker.unlock();
+
+  db.setHostName( host );
+  QString connectionString;
+  if ( !service.isEmpty() )
+  {
+    // driver was specified explicitly
+    connectionString = service;
+  }
+  else
+  {
+#ifdef Q_OS_WIN
+    connectionString = "driver={SQL Server}";
+#elif defined (Q_OS_MAC)
+    QString freeTDSDriver( QCoreApplication::applicationDirPath().append( "/lib/libtdsodbc.so" ) );
+    if ( QFile::exists( freeTDSDriver ) )
+    {
+      connectionString = QStringLiteral( "driver=%1;port=1433;TDS_Version=auto" ).arg( freeTDSDriver );
+    }
+    else
+    {
+      connectionString = QStringLiteral( "driver={FreeTDS};port=1433;TDS_Version=auto" );
+    }
+#else
+    // It seems that FreeTDS driver by default uses an ancient TDS protocol version (4.2) to communicate with MS SQL
+    // which was causing various data corruption errors, for example:
+    // - truncating data from varchar columns to 255 chars - failing to read WKT for CRS
+    // - truncating binary data to 4096 bytes (see @@TEXTSIZE) - failing to parse larger geometries
+    // The added "TDS_Version=auto" should negotiate more recent version (manually setting e.g. 7.2 worked fine too)
+    connectionString = QStringLiteral( "driver={FreeTDS};port=1433;TDS_Version=auto" );
+#endif
+  }
+
+  if ( !host.isEmpty() )
+    connectionString += ";server=" + host;
+
+  if ( !database.isEmpty() )
+    connectionString += ";database=" + database;
+
+  if ( password.isEmpty() )
+    connectionString += QLatin1String( ";trusted_connection=yes" );
+  else
+    connectionString += ";uid=" + username + ";pwd=" + password;
+
+  if ( !username.isEmpty() )
+    db.setUserName( username );
+
+  if ( !password.isEmpty() )
+    db.setPassword( password );
+
+  db.setDatabaseName( connectionString );
+
+  // only uncomment temporarily -- it can show connection password otherwise!
+  // QgsDebugMsg( connectionString );
+  return db;
+}
+
+bool QgsMssqlDatabase::openDatabase( QSqlDatabase &db )
+{
+  if ( !db.isOpen() )
+  {
+    if ( !db.open() )
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -56,16 +56,6 @@ class QgsMssqlDatabase
     static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &uri, bool transaction = false );
     static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
 
-    /**
-     * Returns a QSqlDatabase object for queries to SQL Server.
-     *
-     * The database may not be open -- openDatabase() should be called to
-     * ensure that it is ready for use.
-     */
-    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
-
-    static bool openDatabase( QSqlDatabase &db );
-
     /////
 
     ~QgsMssqlDatabase();
@@ -92,6 +82,16 @@ class QgsMssqlDatabase
 #endif
 
     friend class QgsMssqlQuery;
+
+    static QString connectionName( const QString &service, const QString &host, const QString &database, bool transaction );
+
+    /**
+     * Returns a QSqlDatabase object for queries to SQL Server.
+     *
+     * The database may not be open -- openDatabase() should be called to
+     * ensure that it is ready for use.
+     */
+    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
 
     static QMap<QString, std::weak_ptr<QgsMssqlDatabase> > sConnections;
 

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -1,0 +1,133 @@
+/***************************************************************************
+  qgsmssqldatabase.h
+  --------------------------------------
+  Date                 : August 2021
+  Copyright            : (C) 2021 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMSSQLDATABASE_H
+#define QGSMSSQLDATABASE_H
+
+
+#include <QMap>
+#include <QMutex>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+
+#include <memory>
+
+class QgsDataSourceUri;
+
+/**
+ * This is a wrapper around QSqlDatabase.
+ *
+ * Under normal conditions, each thread gets a dedicated connection (QSqlDatabase) for a database within a host.
+ * When a transaction has been started, all threads will use a single shared QSqlDatabase and access to it
+ * is controlled by a mutex.
+ *
+ * QtSql does not like sharing QSqlDatabase objects among threads (since Qt 5.11, QSqlDatabase::database()
+ * will refuse to return a database object that was added in a different thread), but... we use proper locking
+ * to avoid multiple threads using a single connection at once AND it was verified that QSqlDatabase works fine
+ * in multi-threaded environment at least with MSSQL. And by the way, Oracle provider also uses a single shared
+ * QSqlDatabase for transactions...
+ */
+class QgsMssqlDatabase
+{
+  public:
+
+    /**
+     * Tries to connect to a MSSQL database and returns shared pointer to the connection. On success,
+     * the returned database object (QSqlDatabase) is already open and it is not necessary to call open().
+     *
+     * It always returns an instance, but the caller should check whether the returned instance is valid
+     * before using it.
+     *
+     * \note The function is thread-safe
+     */
+    static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &uri, bool transaction = false );
+    static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
+
+    /**
+     * Returns a QSqlDatabase object for queries to SQL Server.
+     *
+     * The database may not be open -- openDatabase() should be called to
+     * ensure that it is ready for use.
+     */
+    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
+
+    static bool openDatabase( QSqlDatabase &db );
+
+    /////
+
+    ~QgsMssqlDatabase();
+
+    //! Returns true if we were successful to open the database (and so we can use the database connection)
+    bool isValid() const { return mDB.isOpen(); }
+    //! Returns error text for the error if database failed to open
+    QString errorText() const { return mDB.lastError().text(); }
+    //! Returns reference to the internal database connection
+    QSqlDatabase &db() { return mDB; }
+    //! Returns whether this connection is used in a transaction
+    bool hasTransaction() const { return mTransaction; }
+
+  private:
+    QgsMssqlDatabase( const QSqlDatabase &db, bool transaction );
+
+    QSqlDatabase mDB;
+    bool mTransaction = false;
+    //! locking for transactions because with transaction enabled, one connection may be shared among multiple threads
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    std::unique_ptr<QMutex> mTransactionMutex;
+#else
+    std::unique_ptr<QResursiveMutex> mTransactionMutex;
+#endif
+
+    friend class QgsMssqlQuery;
+
+    static QMap<QString, std::weak_ptr<QgsMssqlDatabase> > sConnections;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    static QMutex sMutex;
+#else
+    static QRecursiveMutex sMutex;
+#endif
+};
+
+
+/**
+ * A light wrapper around QSqlQuery that provides locking for database connections when
+ * running in a transaction.
+ */
+class QgsMssqlQuery : public QSqlQuery
+{
+  public:
+    explicit QgsMssqlQuery( std::shared_ptr<QgsMssqlDatabase> db )
+      : QSqlQuery( db->db() )
+      , mDb( db )
+    {
+      if ( mDb->hasTransaction() )
+        mDb->mTransactionMutex->lock();
+    }
+
+    ~QgsMssqlQuery()
+    {
+      if ( mDb->hasTransaction() )
+        mDb->mTransactionMutex->unlock();
+    }
+
+  private:
+    std::shared_ptr<QgsMssqlDatabase> mDb;
+
+};
+
+
+#endif // QGSMSSQLDATABASE_H

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -88,7 +88,7 @@ class QgsMssqlDatabase
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     std::unique_ptr<QMutex> mTransactionMutex;
 #else
-    std::unique_ptr<QResursiveMutex> mTransactionMutex;
+    std::unique_ptr<QRecursiveMutex> mTransactionMutex;
 #endif
 
     friend class QgsMssqlQuery;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -28,6 +28,7 @@
 #include "qgsmssqlprovider.h"
 
 class QgsMssqlProvider;
+class QgsMssqlQuery;
 
 class QgsMssqlFeatureSource final: public QgsAbstractFeatureSource
 {
@@ -69,6 +70,8 @@ class QgsMssqlFeatureSource final: public QgsAbstractFeatureSource
 
     QgsCoordinateReferenceSystem mCrs;
 
+    std::shared_ptr<QgsMssqlDatabase> mTransactionConn;
+
     // Return True if this feature source has spatial attributes.
     bool isSpatial() { return !mGeometryColName.isEmpty() || !mGeometryColType.isEmpty(); }
 
@@ -102,10 +105,10 @@ class QgsMssqlFeatureIterator final: public QgsAbstractFeatureIteratorFromSource
     double validLon( double longitude ) const;
 
     // The current database
-    QSqlDatabase mDatabase;
+    std::shared_ptr< QgsMssqlDatabase > mDatabase;
 
     // The current sql query
-    std::unique_ptr< QSqlQuery > mQuery;
+    std::unique_ptr< QgsMssqlQuery > mQuery;
 
     // The current sql statement
     QString mStatement;

--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -19,7 +19,7 @@
 
 #include "qgslogger.h"
 #include "qgsmssqlprovider.h"
-#include "qgsmssqlconnection.h"
+#include "qgsmssqldatabase.h"
 
 QgsMssqlGeomColumnTypeThread::QgsMssqlGeomColumnTypeThread( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool useEstimatedMetadata )
   : mService( service )
@@ -71,14 +71,14 @@ void QgsMssqlGeomColumnTypeThread::run()
                                   layerProperty.sql.isEmpty() ? QString() : QStringLiteral( " AND %1" ).arg( layerProperty.sql ) );
 
       // issue the sql query
-      QSqlDatabase db = QgsMssqlConnection::getDatabase( mService, mHost, mDatabase, mUsername, mPassword );
-      if ( !QgsMssqlConnection::openDatabase( db ) )
+      std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( mService, mHost, mDatabase, mUsername, mPassword );
+      if ( !db->isValid() )
       {
-        QgsDebugMsg( db.lastError().text() );
+        QgsDebugMsg( db->errorText() );
         continue;
       }
 
-      QSqlQuery q = QSqlQuery( db );
+      QSqlQuery q = QSqlQuery( db->db() );
       q.setForwardOnly( true );
       if ( !q.exec( query ) )
       {

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -27,6 +27,7 @@
 #include "qgsmssqlprovider.h"
 #include "qgssettings.h"
 #include "qgsmssqlconnection.h"
+#include "qgsmssqldatabase.h"
 #include "qgsgui.h"
 
 QgsMssqlNewConnection::QgsMssqlNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )
@@ -305,11 +306,11 @@ QSqlDatabase QgsMssqlNewConnection::getDatabase( const QString &name ) const
     database = item->text();
   }
 
-  return QgsMssqlConnection::getDatabase( txtService->text().trimmed(),
-                                          txtHost->text().trimmed(),
-                                          database,
-                                          txtUsername->text().trimmed(),
-                                          txtPassword->text().trimmed() );
+  return QgsMssqlDatabase::getDatabase( txtService->text().trimmed(),
+                                        txtHost->text().trimmed(),
+                                        database,
+                                        txtUsername->text().trimmed(),
+                                        txtPassword->text().trimmed() );
 }
 
 
@@ -378,7 +379,7 @@ bool QgsMssqlNewConnection::testExtentInGeometryColumns() const
 {
   QSqlDatabase db = getDatabase();
 
-  if ( !QgsMssqlConnection::openDatabase( db ) )
+  if ( !QgsMssqlDatabase::openDatabase( db ) )
     return false;
 
   const QString queryStr = QStringLiteral( "SELECT qgis_xmin,qgis_xmax,qgis_ymin,qgis_ymax FROM geometry_columns" );
@@ -394,7 +395,7 @@ bool QgsMssqlNewConnection::testPrimaryKeyInGeometryColumns() const
 {
   QSqlDatabase db = getDatabase();
 
-  if ( !QgsMssqlConnection::openDatabase( db ) )
+  if ( !QgsMssqlDatabase::openDatabase( db ) )
     return false;
 
   const QString queryStr = QStringLiteral( "SELECT qgis_pkey FROM geometry_columns" );

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -23,6 +23,8 @@
 
 #include <QSqlDatabase>
 
+class QgsMssqlDatabase;
+
 /**
  * \class QgsMssqlNewConnection
  * \brief Dialog to allow the user to configure and save connection
@@ -99,7 +101,7 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     QVariantMap mSchemaSettings; //store the schema settings edited during this QDialog life time
     SchemaModel mSchemaModel;
 
-    QSqlDatabase getDatabase( const QString &name = QString() ) const;
+    std::shared_ptr<QgsMssqlDatabase> getDatabase( const QString &name = QString() ) const;
 
     bool testExtentInGeometryColumns() const;
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsmssqlprovider.h"
 #include "qgsmssqlconnection.h"
+#include "qgsmssqldatabase.h"
 #include "qgsmssqlproviderconnection.h"
 #include "qgsfeedback.h"
 
@@ -50,6 +51,7 @@
 
 #include "qgsmssqldataitems.h"
 #include "qgsmssqlfeatureiterator.h"
+#include "qgsmssqltransaction.h"
 
 
 const QString QgsMssqlProvider::MSSQL_PROVIDER_KEY = QStringLiteral( "mssql" );
@@ -94,18 +96,21 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
 
   mSqlWhereClause = anUri.sql();
 
-  mDatabase = QgsMssqlConnection::getDatabase( mService, mHost, mDatabaseName, mUserName, mPassword );
-
-  if ( !QgsMssqlConnection::openDatabase( mDatabase ) )
+  mConn = QgsMssqlDatabase::connectDb( mService, mHost, mDatabaseName, mUserName, mPassword, false );
+  if ( !mConn )
   {
-    setLastError( mDatabase.lastError().text() );
+    mValid = false;
+    return;
+  }
+  QSqlDatabase db = mConn->db();
+
+  if ( !db.isOpen() )
+  {
+    setLastError( db.lastError().text() );
     QgsDebugMsg( mLastError );
     mValid = false;
     return;
   }
-
-  // Create a query for default connection
-  mQuery = QSqlQuery( mDatabase );
 
   // Database successfully opened; we can now issue SQL commands.
   if ( !anUri.schema().isEmpty() )
@@ -128,7 +133,7 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
   else
   {
     // Get a list of table
-    mTables = mDatabase.tables( QSql::Tables );
+    mTables = db.tables( QSql::Tables );
     if ( !mTables.isEmpty() )
       mTableName = mTables[0];
     else
@@ -220,8 +225,6 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
 
 QgsMssqlProvider::~QgsMssqlProvider()
 {
-  if ( mDatabase.isOpen() )
-    mDatabase.close();
 }
 
 QgsAbstractFeatureSource *QgsMssqlProvider::featureSource() const
@@ -339,11 +342,13 @@ void QgsMssqlProvider::setLastError( const QString &error )
 
 QSqlQuery QgsMssqlProvider::createQuery() const
 {
-  if ( !mDatabase.isOpen() )
+  std::shared_ptr<QgsMssqlDatabase> conn = connection();
+  QSqlDatabase d = conn->db();
+  if ( !d.isOpen() )
   {
-    mDatabase = QgsMssqlConnection::getDatabase( mService, mHost, mDatabaseName, mUserName, mPassword );
+    QgsDebugMsg( "Creating query, but the database is not open!" );
   }
-  return QSqlQuery( mDatabase );
+  return QSqlQuery( d );
 }
 
 void QgsMssqlProvider::loadFields()
@@ -1746,7 +1751,7 @@ void QgsMssqlProvider::updateExtents()
 
 QgsVectorDataProvider::Capabilities QgsMssqlProvider::capabilities() const
 {
-  QgsVectorDataProvider::Capabilities cap = CreateAttributeIndex | AddFeatures | AddAttributes;
+  QgsVectorDataProvider::Capabilities cap = CreateAttributeIndex | AddFeatures | AddAttributes | TransactionSupport;
   bool hasGeom = false;
   if ( !mGeometryColName.isEmpty() )
   {
@@ -1850,6 +1855,23 @@ QgsCoordinateReferenceSystem QgsMssqlProvider::crs() const
     }
   }
   return mCrs;
+}
+
+
+void QgsMssqlProvider::setTransaction( QgsTransaction *transaction )
+{
+  // static_cast since layers cannot be added to a transaction of a non-matching provider
+  mTransaction = static_cast<QgsMssqlTransaction *>( transaction );
+}
+
+QgsTransaction *QgsMssqlProvider::transaction() const
+{
+  return mTransaction;
+}
+
+std::shared_ptr<QgsMssqlDatabase> QgsMssqlProvider::connection() const
+{
+  return mTransaction ? mTransaction->conn() : QgsMssqlDatabase::connectDb( uri().connectionInfo(), false );
 }
 
 QString QgsMssqlProvider::subsetString() const
@@ -2053,12 +2075,12 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
   QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  QSqlDatabase db = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( db ) )
+  if ( !db->isValid() )
   {
     if ( errorMessage )
-      *errorMessage = db.lastError().text();
+      *errorMessage = db->errorText();
     return Qgis::VectorExportResult::ErrorConnectionFailed;
   }
 
@@ -2119,7 +2141,7 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
     primaryKeyType = QStringLiteral( "serial" );
 
   QString sql;
-  QSqlQuery q = QSqlQuery( db );
+  QSqlQuery q = QSqlQuery( db->db() );
   q.setForwardOnly( true );
 
   // initialize metadata tables (same as OGR SQL)
@@ -2334,6 +2356,11 @@ QList<QgsDataItemProvider *> QgsMssqlProviderMetadata::dataItemProviders() const
   return providers;
 }
 
+QgsTransaction *QgsMssqlProviderMetadata::createTransaction( const QString &connString )
+{
+  return new QgsMssqlTransaction( connString );
+}
+
 QMap<QString, QgsAbstractProviderConnection *> QgsMssqlProviderMetadata::connections( bool cached )
 {
   return connectionsProtected<QgsMssqlProviderConnection, QgsMssqlConnection>( cached );
@@ -2386,16 +2413,16 @@ bool QgsMssqlProviderMetadata::saveStyle( const QString &uri,
 {
   const QgsDataSourceUri dsUri( uri );
   // connect to database
-  QSqlDatabase mDatabase = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( mDatabase ) )
+  if ( !db->isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Error connecting to database" ) );
-    QgsDebugMsg( mDatabase.lastError().text() );
+    QgsDebugMsg( db->errorText() );
     return false;
   }
 
-  QSqlQuery query = QSqlQuery( mDatabase );
+  QSqlQuery query = QSqlQuery( db->db() );
   query.setForwardOnly( true );
   if ( !query.exec( QStringLiteral( "SELECT COUNT(*) FROM information_schema.tables WHERE table_name= N'layer_styles'" ) ) )
   {
@@ -2544,16 +2571,16 @@ QString QgsMssqlProviderMetadata::loadStyle( const QString &uri, QString &errCau
 {
   const QgsDataSourceUri dsUri( uri );
   // connect to database
-  QSqlDatabase mDatabase = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( mDatabase ) )
+  if ( !db->isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Error connecting to database" ) );
-    QgsDebugMsg( mDatabase.lastError().text() );
+    QgsDebugMsg( db->errorText() );
     return QString();
   }
 
-  QSqlQuery query = QSqlQuery( mDatabase );
+  QSqlQuery query = QSqlQuery( db->db() );
   query.setForwardOnly( true );
 
   const QString selectQmlQuery = QString( "SELECT top 1 styleQML"
@@ -2592,16 +2619,16 @@ int QgsMssqlProviderMetadata::listStyles( const QString &uri,
 {
   const QgsDataSourceUri dsUri( uri );
   // connect to database
-  QSqlDatabase mDatabase = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( mDatabase ) )
+  if ( !db->isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Error connecting to database" ) );
-    QgsDebugMsg( mDatabase.lastError().text() );
+    QgsDebugMsg( db->errorText() );
     return -1;
   }
 
-  QSqlQuery query = QSqlQuery( mDatabase );
+  QSqlQuery query = QSqlQuery( db->db() );
   query.setForwardOnly( true );
 
   // check if layer_styles table already exist
@@ -2677,16 +2704,16 @@ QString QgsMssqlProviderMetadata::getStyleById( const QString &uri, QString styl
 {
   const QgsDataSourceUri dsUri( uri );
   // connect to database
-  QSqlDatabase mDatabase = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( mDatabase ) )
+  if ( !db->isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Error connecting to database" ) );
-    QgsDebugMsg( mDatabase.lastError().text() );
+    QgsDebugMsg( db->errorText() );
     return QString();
   }
 
-  QSqlQuery query = QSqlQuery( mDatabase );
+  QSqlQuery query = QSqlQuery( db->db() );
   query.setForwardOnly( true );
 
   QString style;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1378,6 +1378,9 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     }
   }
 
+  if ( mTransaction )
+    mTransaction->dirtyLastSavePoint();
+
   return true;
 }
 
@@ -1422,6 +1425,10 @@ bool QgsMssqlProvider::addAttributes( const QList<QgsField> &attributes )
   }
 
   loadFields();
+
+  if ( mTransaction )
+    mTransaction->dirtyLastSavePoint();
+
   return true;
 }
 
@@ -1452,6 +1459,10 @@ bool QgsMssqlProvider::deleteAttributes( const QgsAttributeIds &attributes )
 
   query.finish();
   loadFields();
+
+  if ( mTransaction )
+    mTransaction->dirtyLastSavePoint();
+
   return true;
 }
 
@@ -1607,6 +1618,9 @@ bool QgsMssqlProvider::changeAttributeValues( const QgsChangedAttributesMap &att
     }
   }
 
+  if ( mTransaction )
+    mTransaction->dirtyLastSavePoint();
+
   return true;
 }
 
@@ -1677,6 +1691,9 @@ bool QgsMssqlProvider::changeGeometryValues( const QgsGeometryMap &geometry_map 
     }
   }
 
+  if ( mTransaction )
+    mTransaction->dirtyLastSavePoint();
+
   return true;
 }
 
@@ -1704,7 +1721,11 @@ bool QgsMssqlProvider::deleteFeatures( const QgsFeatureIds &ids )
     if ( query.exec( statement ) )
     {
       if ( query.numRowsAffected() == ids.size() )
+      {
+        if ( mTransaction )
+          mTransaction->dirtyLastSavePoint();
         return true;
+      }
 
       pushError( tr( "Only %1 of %2 features deleted" ).arg( query.numRowsAffected() ).arg( ids.size() ) );
     }
@@ -1735,7 +1756,11 @@ bool QgsMssqlProvider::deleteFeatures( const QgsFeatureIds &ids )
     }
 
     if ( i == ids.size() )
+    {
+      if ( mTransaction )
+        mTransaction->dirtyLastSavePoint();
       return true;
+    }
 
     if ( i > 0 )
       pushError( tr( "Only %1 of %2 features deleted" ).arg( i ).arg( ids.size() ) );

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -38,6 +38,8 @@ class QTextStream;
 
 class QgsMssqlFeatureIterator;
 class QgsMssqlSharedData;
+class QgsMssqlTransaction;
+class QgsMssqlDatabase;
 
 #include "qgsdatasourceuri.h"
 #include "qgsgeometry.h"
@@ -159,6 +161,11 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
 
     QgsCoordinateReferenceSystem crs() const override;
 
+    void setTransaction( QgsTransaction *transaction ) override;
+    QgsTransaction *transaction() const override;
+
+    std::shared_ptr<QgsMssqlDatabase> connection() const;
+
   protected:
     //! Loads fields from input file to member attributeFields
     QVariant::Type DecodeSqlType( const QString &sqlTypeName );
@@ -209,15 +216,6 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
 
     mutable QgsWkbTypes::Type mWkbType = QgsWkbTypes::Unknown;
 
-    // The database object
-    mutable QSqlDatabase mDatabase;
-
-    // The current sql query
-    QSqlQuery mQuery;
-
-    // The current sql statement
-    QString mStatement;
-
     // current layer name
     QString mSchemaName;
     QString mTableName;
@@ -238,6 +236,11 @@ class QgsMssqlProvider final: public QgsVectorDataProvider
     QString mSqlWhereClause;
 
     bool mDisableInvalidGeometryHandling = false;
+
+    // this makes sure that we keep the DB connection open while the provider is alive
+    std::shared_ptr<QgsMssqlDatabase> mConn;
+
+    QgsMssqlTransaction *mTransaction = nullptr;
 
     // Sets the error messages
     void setLastError( const QString &error );
@@ -309,6 +312,7 @@ class QgsMssqlProviderMetadata final: public QgsProviderMetadata
       const QMap<QString, QVariant> *options ) override;
     QgsMssqlProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
     virtual QList< QgsDataItemProvider * > dataItemProviders() const override;
+    QgsTransaction *createTransaction( const QString &connString ) override;
 
     // Connections API
     QMap<QString, QgsAbstractProviderConnection *> connections( bool cached = true ) override;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsmssqlproviderconnection.h"
 #include "qgsmssqlconnection.h"
+#include "qgsmssqldatabase.h"
 #include "qgssettings.h"
 #include "qgsmssqlprovider.h"
 #include "qgsexception.h"
@@ -243,12 +244,12 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
   const QgsDataSourceUri dsUri { uri() };
 
   // connect to database
-  QSqlDatabase db = QgsMssqlConnection::getDatabase( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
 
-  if ( !QgsMssqlConnection::openDatabase( db ) )
+  if ( !db->isValid() )
   {
     throw QgsProviderConnectionException( QObject::tr( "Connection to %1 failed: %2" )
-                                          .arg( uri(), db.lastError().text() ) );
+                                          .arg( uri(), db->errorText() ) );
   }
   else
   {
@@ -259,7 +260,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
     }
 
     //qDebug() << "MSSQL QUERY:" << sql;
-    QSqlQuery q = QSqlQuery( db );
+    QSqlQuery q = QSqlQuery( db->db() );
     q.setForwardOnly( true );
 
     const std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();

--- a/src/providers/mssql/qgsmssqltransaction.cpp
+++ b/src/providers/mssql/qgsmssqltransaction.cpp
@@ -1,0 +1,160 @@
+/***************************************************************************
+  qgsmssqltransaction.cpp - QgsMssqlTransaction
+ ---------------------
+ begin                : 11.3.2021
+ copyright            : (C) 2021 by Vincent Cloarec
+ email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmssqltransaction.h"
+
+#include "qgsmssqldatabase.h"
+
+#include "qgsexpression.h"
+#include "qgsmessagelog.h"
+
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QtDebug>
+
+
+QgsMssqlTransaction::QgsMssqlTransaction( const QString &connString )
+  : QgsTransaction( connString )
+{
+}
+
+QgsMssqlTransaction::~QgsMssqlTransaction()
+{
+}
+
+
+bool QgsMssqlTransaction::executeSql( const QString &sql, QString &error, bool isDirty, const QString &name )
+{
+  QSqlDatabase &database = mConn->db();
+
+  if ( !database.isValid() )
+    return false;
+  if ( !database.isOpen() )
+    return false;
+
+  if ( isDirty )
+  {
+    QgsTransaction::createSavepoint( error );
+    if ( ! error.isEmpty() )
+    {
+      return false;
+    }
+  }
+
+  QSqlQuery query( database );
+  if ( !query.exec( sql ) )
+  {
+    if ( isDirty )
+      rollbackToSavepoint( savePoints().last(), error );
+
+    QString msg = tr( "MSSQL query failed: %1" ).arg( query.lastError().text() );
+    if ( error.isEmpty() )
+      error = msg;
+    else
+      error = QStringLiteral( "%1\n%2" ).arg( error, msg );
+
+    return false;
+  }
+
+  if ( isDirty )
+  {
+    dirtyLastSavePoint();
+    emit dirtied( sql, name );
+  }
+
+  return true;
+}
+
+
+QString QgsMssqlTransaction::createSavepoint( const QString &savePointId, QString &error )
+{
+  if ( !mTransactionActive )
+    return QString();
+
+  if ( !executeSql( QStringLiteral( "SAVE TRAN %1" ).arg( QgsExpression::quotedColumnRef( savePointId ) ), error ) )
+  {
+    QgsMessageLog::logMessage( tr( "Could not create savepoint (%1)" ).arg( error ) );
+    return QString();
+  }
+
+  mSavepoints.push( savePointId );
+  mLastSavePointIsDirty = false;
+  return savePointId;
+}
+
+
+bool QgsMssqlTransaction::rollbackToSavepoint( const QString &name, QString &error )
+{
+  if ( !mTransactionActive )
+    return false;
+
+  const int idx = mSavepoints.indexOf( name );
+
+  if ( idx == -1 )
+    return false;
+
+  mSavepoints.resize( idx );
+  // Rolling back always dirties the previous savepoint because
+  // the status of the DB has changed between the previous savepoint and the
+  // one we are rolling back to.
+  mLastSavePointIsDirty = true;
+  return executeSql( QStringLiteral( "ROLLBACK TRANSACTION %1" ).arg( QgsExpression::quotedColumnRef( name ) ), error );
+}
+
+
+bool QgsMssqlTransaction::beginTransaction( QString &error, int /*statementTimeout*/ )
+{
+  mConn = QgsMssqlDatabase::connectDb( mConnString, true /*transaction*/ );
+
+  if ( !mConn->isValid() )
+  {
+    error = mConn->errorText();
+    return false;
+  }
+
+  if ( !mConn->db().transaction() )
+  {
+    error = mConn->errorText();
+    return false;
+  }
+
+  return true;
+}
+
+
+bool QgsMssqlTransaction::commitTransaction( QString &error )
+{
+  if ( mConn->db().commit() )
+  {
+    return true;
+  }
+
+  error = mConn->db().lastError().text();
+  // TODO? mConn.reset(); // should delete conn if we're the last ones
+  return false;
+}
+
+
+bool QgsMssqlTransaction::rollbackTransaction( QString &error )
+{
+  if ( mConn->db().rollback() )
+  {
+    return true;
+  }
+
+  error = mConn->db().lastError().text();
+  // TODO? mConn.reset(); // should delete conn if we're the last ones
+  return false;
+}

--- a/src/providers/mssql/qgsmssqltransaction.cpp
+++ b/src/providers/mssql/qgsmssqltransaction.cpp
@@ -142,7 +142,6 @@ bool QgsMssqlTransaction::commitTransaction( QString &error )
   }
 
   error = mConn->db().lastError().text();
-  // TODO? mConn.reset(); // should delete conn if we're the last ones
   return false;
 }
 
@@ -155,6 +154,5 @@ bool QgsMssqlTransaction::rollbackTransaction( QString &error )
   }
 
   error = mConn->db().lastError().text();
-  // TODO? mConn.reset(); // should delete conn if we're the last ones
   return false;
 }

--- a/src/providers/mssql/qgsmssqltransaction.cpp
+++ b/src/providers/mssql/qgsmssqltransaction.cpp
@@ -30,9 +30,7 @@ QgsMssqlTransaction::QgsMssqlTransaction( const QString &connString )
 {
 }
 
-QgsMssqlTransaction::~QgsMssqlTransaction()
-{
-}
+QgsMssqlTransaction::~QgsMssqlTransaction() = default;
 
 
 bool QgsMssqlTransaction::executeSql( const QString &sql, QString &error, bool isDirty, const QString &name )

--- a/src/providers/mssql/qgsmssqltransaction.h
+++ b/src/providers/mssql/qgsmssqltransaction.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+  qgsmssqltransaction.h - QgsMssqlTransaction
+ ---------------------
+ begin                : 11.3.2021
+ copyright            : (C) 2021 by Vincent Cloarec
+ email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMSSQLTRANSACTION_H
+#define QGSMSSQLTRANSACTION_H
+
+#include "qgstransaction.h"
+#include <memory>
+
+class QgsMssqlDatabase;
+
+
+class QgsMssqlTransaction : public QgsTransaction
+{
+    Q_OBJECT
+  public:
+    QgsMssqlTransaction( const QString &connString );
+    ~QgsMssqlTransaction();
+
+    virtual bool executeSql( const QString &sql, QString &error, bool isDirty = false, const QString &name = QString() ) override;
+
+    QString createSavepoint( const QString &savePointId, QString &error ) override;
+    bool rollbackToSavepoint( const QString &name, QString &error ) override;
+
+    std::shared_ptr<QgsMssqlDatabase> conn() { return mConn; }
+
+  private:
+    virtual bool beginTransaction( QString &error, int statementTimeout ) override;
+    virtual bool commitTransaction( QString &error ) override;
+    virtual bool rollbackTransaction( QString &error ) override;
+
+  private:
+    //! connection is primarily owned by this class, but it may be also shared with QgsMssqlFeatureSource
+    std::shared_ptr<QgsMssqlDatabase> mConn;
+};
+
+
+#endif // QGSMSSQLTRANSACTION_H

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -40,7 +40,7 @@ add_qgis_test(testqgspostgresexpressioncompiler.cpp MODULE provider LINKEDLIBRAR
 add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
 add_qgis_test(testqgspostgresconn.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
 
-set(ENABLE_MSSQLTEST_CPP FALSE CACHE BOOL "Enable MsSQL provider C++ tests")
+set(ENABLE_MSSQLTEST_CPP FALSE CACHE BOOL "Enable MSSQL provider C++ tests")
 if (ENABLE_MSSQLTEST_CPP)
   add_qgis_test(testqgsmssqlprovider.cpp MODULE provider LINKEDLIBRARIES provider_mssql_a qgis_core LABELS "MSSQL")
   # also depend on dynamic lib, so that building this test will also build the dynamic lib

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/src/providers/wms
   ${CMAKE_SOURCE_DIR}/src/providers/postgres
   ${CMAKE_SOURCE_DIR}/src/providers/mdal
+  ${CMAKE_SOURCE_DIR}/src/providers/mssql
   ${CMAKE_SOURCE_DIR}/src/providers/ogr
   ${CMAKE_SOURCE_DIR}/src/providers/virtualraster
   ${CMAKE_SOURCE_DIR}/src/test
@@ -38,6 +39,13 @@ add_qgis_test(testqgswmsprovider.cpp MODULE provider LINKEDLIBRARIES provider_wm
 add_qgis_test(testqgspostgresexpressioncompiler.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
 add_qgis_test(testqgspostgresprovider.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core)
 add_qgis_test(testqgspostgresconn.cpp MODULE provider LINKEDLIBRARIES provider_postgres_a qgis_core LABELS "POSTGRES")
+
+set(ENABLE_MSSQLTEST_CPP FALSE CACHE BOOL "Enable MsSQL provider C++ tests")
+if (ENABLE_MSSQLTEST_CPP)
+  add_qgis_test(testqgsmssqlprovider.cpp MODULE provider LINKEDLIBRARIES provider_mssql_a qgis_core LABELS "MSSQL")
+  # also depend on dynamic lib, so that building this test will also build the dynamic lib
+  add_dependencies(test_provider_mssqlprovider provider_mssql)
+endif()
 
 if (NOT FORCE_STATIC_PROVIDERS)
   add_qgis_test(testqgsmdalprovider.cpp MODULE provider LINKEDLIBRARIES qgis_core)

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -1,0 +1,193 @@
+/***************************************************************************
+  testqgsmssqlprovider.cpp - %{Cpp:License:ClassName}
+ ---------------------
+ begin                : 16.3.2021
+ copyright            : (C) 2021 by Vincent Cloarec
+ email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+#include <QSqlError>
+#include <QRandomGenerator>
+#include <qtconcurrentrun.h>
+
+//qgis includes...
+#include "qgis.h"
+#include "qgsapplication.h"
+#include "qgsmssqltransaction.h"
+#include "qgsmssqlconnection.h"
+#include "qgsvectorlayer.h"
+//#include "qgsmssqldatabase.h"
+#include "qgsproject.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the gdal provider
+ */
+class TestQgsMssqlProvider : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {}// will be called before each testfunction is executed.
+    void cleanup() {}// will be called after every testfunction.
+
+    void openLayer();
+
+    void projectTransaction();
+
+  private:
+
+    QString mDbConn;
+
+    QStringList mSomeDataWktGeom;
+    QStringList mSomeDataPolyWktGeom;
+    QList<QVariantList> mSomeDataAttributes;
+
+};
+
+//runs before all tests
+void TestQgsMssqlProvider::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  mDbConn = qEnvironmentVariable( "QGIS_MSSQLTEST_DB",
+                                  "service='testsqlserver' user=sa password='<YourStrong!Passw0rd>' " );
+
+  mSomeDataWktGeom << QStringLiteral( "Point (-70.33199999999999363 66.32999999999999829)" )
+                   << QStringLiteral( "Point (-68.20000000000000284 70.79999999999999716)" )
+                   << QString()
+                   << QStringLiteral( "Point (-65.31999999999999318 78.29999999999999716)" )
+                   << QStringLiteral( "Point (-71.12300000000000466 78.23000000000000398)" );
+
+  QVariantList varList;
+  varList << 1ll << 100 << "Orange" <<  "oranGe" <<  "1" << QDateTime( QDate( 2020, 05, 03 ), QTime( 12, 13, 14 ) ) << QDate( 2020, 05, 03 ) << QTime( 12, 13, 14 ) ;
+  mSomeDataAttributes << varList;
+  varList.clear();
+  varList << 2ll << 200 << "Apple" <<  "Apple" <<  "2" << QDateTime( QDate( 2020, 05, 04 ), QTime( 12, 14, 14 ) ) << QDate( 2020, 05, 04 ) << QTime( 12, 14, 14 ) ;
+  mSomeDataAttributes << varList;
+  varList.clear();
+  varList << 3ll << 300 << "Pear" <<  "PEaR" <<  "3" << QDateTime() << QDate() << QTime();
+  mSomeDataAttributes << varList;
+  varList.clear();
+  varList << 4ll << 400 << "Honey" <<  "Honey" <<  "4" << QDateTime( QDate( 2021, 05, 04 ), QTime( 13, 13, 14 ) ) << QDate( 2021, 05, 04 ) << QTime( 13, 13, 14 ) ;
+  mSomeDataAttributes << varList;
+  varList.clear();
+  varList << 5ll << -200 << "" <<  "NuLl" <<  "5" << QDateTime( QDate( 2020, 05, 04 ), QTime( 12, 13, 14 ) ) << QDate( 2020, 05, 02 ) << QTime( 12, 13, 1 ) ;
+  mSomeDataAttributes << varList;
+
+
+  mSomeDataPolyWktGeom << QStringLiteral( "Polygon ((-69 81.40000000000000568, -69 80.20000000000000284, -73.70000000000000284 80.20000000000000284, -73.70000000000000284 76.29999999999999716, -74.90000000000000568 76.29999999999999716, -74.90000000000000568 81.40000000000000568, -69 81.40000000000000568))" )
+                       << QStringLiteral( "Polygon ((-67.59999999999999432 81.20000000000000284, -66.29999999999999716 81.20000000000000284, -66.29999999999999716 76.90000000000000568, -67.59999999999999432 76.90000000000000568, -67.59999999999999432 81.20000000000000284))" )
+                       << QStringLiteral( "Polygon ((-68.40000000000000568 75.79999999999999716, -67.5 72.59999999999999432, -68.59999999999999432 73.70000000000000284, -70.20000000000000284 72.90000000000000568, -68.40000000000000568 75.79999999999999716))" )
+                       << QString();
+}
+
+
+//runs after all tests
+void TestQgsMssqlProvider::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMssqlProvider::openLayer()
+{
+  QString uri( mDbConn + QStringLiteral( " key = \"pk\" srid=4326 type=POINT schema=\"qgis_test\" table=\"someData\" (geom) sql=" ) );
+
+  QgsVectorLayer vl( uri, QStringLiteral( "point_layer" ), QStringLiteral( "mssql" ) );
+
+  QVERIFY( vl.isValid() );
+  QCOMPARE( vl.featureCount(), 5 );
+
+  QVERIFY( vl.isValid() );
+}
+
+
+void TestQgsMssqlProvider::projectTransaction()
+{
+  QString uriPoint( mDbConn + QStringLiteral( " key = \"pk\" srid=4326 type=POINT schema=\"qgis_test\" table=\"someData\" (geom) sql=" ) );
+  QString uriPolygon( mDbConn + QStringLiteral( " key = \"pk\" srid=4326 type=POLYGON schema=\"qgis_test\" table=\"some_poly_data\" (geom) sql=" ) );
+
+  QgsProject project;
+
+  QgsVectorLayer *vectorLayerPoint = new QgsVectorLayer( uriPoint, QStringLiteral( "point_layer" ), QStringLiteral( "mssql" ) );
+  QgsVectorLayer *vectorLayerPoly = new QgsVectorLayer( uriPolygon, QStringLiteral( "poly_layer" ), QStringLiteral( "mssql" ) );
+  project.addMapLayer( vectorLayerPoint );
+  project.addMapLayer( vectorLayerPoly );
+
+  project.setAutoTransaction( true );
+
+  QVERIFY( vectorLayerPoint->startEditing() );
+  QVERIFY( vectorLayerPoint->isEditable() );
+  QVERIFY( vectorLayerPoly->isEditable() );
+
+  // test geometries and attributes of exisintg layer
+  QgsFeatureIterator featIt = vectorLayerPoint->getFeatures();
+  QgsFeature feat;
+  QList<QVariantList> attributes;
+  QStringList geoms;
+  while ( featIt.nextFeature( feat ) )
+  {
+    attributes.append( feat.attributes().toList() );
+    geoms.append( feat.geometry().asWkt() );
+  }
+  QCOMPARE( attributes.size(), mSomeDataAttributes.size() );
+  QVERIFY( attributes == mSomeDataAttributes );
+  QVERIFY( geoms == mSomeDataWktGeom );
+
+  featIt = vectorLayerPoly->getFeatures();
+  geoms.clear();
+  while ( featIt.nextFeature( feat ) )
+    geoms.append( feat.geometry().asWkt() );
+
+  QVERIFY( geoms == mSomeDataPolyWktGeom );
+
+  // add a point to the layer point
+  feat = QgsFeature();
+  feat.setFields( vectorLayerPoint->fields(), true );
+  feat.setAttribute( 0, 10 );
+  feat.setGeometry( QgsGeometry( new QgsPoint( -71, 67 ) ) );
+
+  QStringList newGeoms = mSomeDataWktGeom;
+  newGeoms << QStringLiteral( "Point (-71 67)" );
+  QList<QVariantList> newAttributes = mSomeDataAttributes;
+  QVariantList attrList;
+  attrList << 10ll << 0 << "" << "" << "" << QDateTime() << QDate() << QTime();
+  newAttributes.append( attrList );
+
+  vectorLayerPoint->addFeature( feat );
+
+  QCOMPARE( vectorLayerPoint->featureCount(), 6 );
+
+  featIt = vectorLayerPoint->getFeatures();
+  attributes.clear();
+  geoms.clear();
+  while ( featIt.nextFeature( feat ) )
+  {
+    attributes.append( feat.attributes().toList() );
+    geoms.append( feat.geometry().asWkt() );
+  }
+  QCOMPARE( attributes.size(), newAttributes.size() );
+  QVERIFY( attributes == newAttributes );
+  QVERIFY( geoms == newGeoms );
+
+  vectorLayerPoint->rollBack();
+
+  QCOMPARE( vectorLayerPoint->featureCount(), 5 );
+}
+
+QGSTEST_MAIN( TestQgsMssqlProvider )
+#include "testqgsmssqlprovider.moc"

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-  testqgsmssqlprovider.cpp - %{Cpp:License:ClassName}
+  testqgsmssqlprovider.cpp
  ---------------------
  begin                : 16.3.2021
  copyright            : (C) 2021 by Vincent Cloarec

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (ENABLE_MSSQLTEST FALSE CACHE BOOL "Enable MsSQL provider tests")
+set (ENABLE_MSSQLTEST FALSE CACHE BOOL "Enable MSSQL provider tests")
 set (ENABLE_ORACLETEST FALSE CACHE BOOL "Enable Oracle provider tests")
 set (ENABLE_HANATEST FALSE CACHE BOOL "Enable HANA provider tests")
 


### PR DESCRIPTION
Addition of transaction support to the MSSQL data provider.

## How to use

There are no GUI-related changes, users can enable transactional editing just like with other providers - by going to the Project Properties > Data Sources tab > "Automatically create transaction groups where possible".

## Overview

Transactional support requires that when a transaction has been started, access to the map layers is done through a single database connection where the transaction is currently running. This is a bit tricky - MSSQL provider uses QtSql (QSqlDatabase & friends) to run queries - and QtSql does not really like sharing of a single QSqlDatabase among multiple threads - since Qt 5.11 there were some extra checks added that do not allow using static QSqlDatabase::database(...) to get a database that was created in another thread ([QTBUG-68486](https://bugreports.qt.io/browse/QTBUG-68486)).

## Implementation details

With @vcloarec we have done a couple of prototypes on how to approach the issue with QtSql and multi-threading:
- implementing a "proxy" database driver which would have a dedicated thread where all queries for a transaction would be run - see https://github.com/vcloarec/QGIS/pull/40
- implementing a database connection wrapper that would have a dedicated thread for a connection with transactions - see https://github.com/vcloarec/QGIS/pull/55

Both of these approaches ended up with quite complex code logic, and possibly having performance issues, as all calls to QSqlQuery would require blocking, switching to other thread and back.

As another option, we did further tests with a shared QSqlDatabase with locking, i.e. in case of transaction, there would be a single QSqlDatabase, but any queries would be executed only with a mutex locked. The tests ended up positive - with locking in place, queries were executing correctly even when multiple threads. This approach is also used by Oracle provider - it is also based on QtSql and it uses a mutex to avoid concurrent access - and it seems to work fine. I guess the reason why QtSql does not like multi-threading is that _generally_ the drivers are not guaranteed to work correctly in multi-threaded environment, but in the case of MSSQL or Oracle, the drivers are fine.

The good thing about the implementation is that the common use case without transactions is not affected by the changes, therefore:
- if there is no transaction, each thread gets its own connection - connections are not shared across threads (as before)
- if there is a transaction, there is a single connection and access to it is guarded by a mutex

Few more notes about the implementation:
- added a new class `QgsMssqlDatabase` which encapsulates database connection handling logic, and it is a container for the internal `QSqlDatabase` object
- added a new class `QgsMssqlQuery` which takes care of locking the database connection's mutex (in case of transaction)
- simplified the connection logic - when calling connectDb(), the returned database should be already open, so the client does not need to check for that and try to open it

## How MSSQL deals with transactions

It is worth noting that by default MSSQL deals with transactions in a different way from how things work in PostgreSQL.

By default, a running transaction will block other readers/writers from accessing the same data. For example, if one client starts a transaction and adds/modifies a feature in a table, other client will get blocked when trying to read data of the table until the transaction is finished.

There is database-level configuration option `READ_COMMITTED_SNAPSHOT` (which is `OFF` by default) - when it is turned on, the behavior changes to the way how e.g. PostgreSQL works - transactions do not cause blocking and the database supports multiple versions of data. This is not something that can be automatically set by QGIS when connecting to the database as it is a database-level property configured by the administrator. It can be set like this:

```sql
ALTER DATABASE my_db SET READ_COMMITTED_SNAPSHOT ON
```

Generally people wanting to use transactions will also want to enable this option - the default behavior may otherwise cause freezes in QGIS or in other clients. This may be something obvious for MSSQL DB admins, but as I was not aware of that, others may hopefully also find this note useful :-)

More reading:
https://docs.microsoft.com/en-us/sql/relational-databases/sql-server-transaction-locking-and-row-versioning-guide?view=sql-server-ver15#behavior-in-summary
https://www.mssqltips.com/sqlservertip/6368/sql-server-readcommittedsnapshot-database-option-and-read-commited-transaction-isolation-level/

---

To do:
- [x] update new connection dialog's code
- [x] add more auto tests

---

Funded by ms.GIS