### PR TITLE
[Backport release-3_16] Vertex editor: make displayed coordinate precision configurable

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -133,7 +133,7 @@ class APP_EXPORT CoordinateItemDelegate : public QStyledItemDelegate
 
   public:
 
-    explicit CoordinateItemDelegate( QObject *parent = nullptr );
+    explicit CoordinateItemDelegate( const QgsCoordinateReferenceSystem &crs, QObject *parent = nullptr );
 
     QString displayText( const QVariant &value, const QLocale &locale ) const override;
 
@@ -141,6 +141,11 @@ class APP_EXPORT CoordinateItemDelegate : public QStyledItemDelegate
     QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem & /*option*/, const QModelIndex &index ) const override;
     void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
     void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+
+  private:
+    //! Returns number of decimal places to display after the dot
+    int displayDecimalPlaces() const;
+    QgsCoordinateReferenceSystem mCrs;
 };
 
 

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -67,6 +67,31 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
   return dp;
 }
 
+int QgsCoordinateUtils::calculateCoordinatePrecisionForCrs( const QgsCoordinateReferenceSystem &crs, QgsProject *project )
+{
+  QgsProject *prj = project;
+  if ( !prj )
+  {
+    prj = QgsProject::instance();
+  }
+
+  bool automatic = prj->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
+  if ( !automatic )
+  {
+    return prj->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ), 6 );
+  }
+
+  QgsUnitTypes::DistanceUnit unit = crs.mapUnits();
+  if ( unit == QgsUnitTypes::DistanceDegrees )
+  {
+    return 8;
+  }
+  else
+  {
+    return 3;
+  }
+}
+
 QString QgsCoordinateUtils::formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision )
 {
   if ( !project )

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -61,6 +61,15 @@ class CORE_EXPORT QgsCoordinateUtils
     Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project = nullptr );
 
     /**
+     * Calculates coordinate precision for a CRS / Project. Considers CRS units and project settings
+     * \param crs Coordinate system
+     * \param project QGIS project. Takes QgsProject::instance() if NULL
+     * \returns number of decimal places behind the dot
+     * \since QGIS 3.18
+     */
+    Q_INVOKABLE static int calculateCoordinatePrecisionForCrs( const QgsCoordinateReferenceSystem &crs, QgsProject *project = nullptr );
+
+    /**
      * Formats a \a point coordinate for use with the specified \a project, respecting the project's
      * coordinate display settings.
      * \since QGIS 3.2


### PR DESCRIPTION
## Description

Manual backport #39751 to release-3_16.

Fixes https://github.com/qgis/QGIS/issues/44931 for QGIS 3.16.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
