### PR TITLE
Temporarily block test_core_networkaccessmanager on CI for now

### DIFF
--- a/.ci/test_blocklist_qt5.txt
+++ b/.ci/test_blocklist_qt5.txt
@@ -22,3 +22,7 @@ test_core_layerdefinition
 
 # MSSQL requires the MSSQL docker
 PyQgsProviderConnectionMssql
+
+# Too fragile at the moment
+test_core_networkaccessmanager
+


### PR DESCRIPTION
It's failing all the time. Let's disable till https://github.com/qgis/QGIS/pull/44924 is resolved.