### PR TITLE
Fix map grid decoration bottom vertical labels placement and vertical labels background placement

### DIFF
--- a/src/app/decorations/qgsdecorationgrid.cpp
+++ b/src/app/decorations/qgsdecorationgrid.cpp
@@ -363,7 +363,7 @@ void QgsDecorationGrid::drawCoordinateAnnotation( QgsRenderContext &context, QPo
       else //Vertical
       {
         xpos -= textDescent;
-        ypos -= textWidth - mAnnotationFrameDistance;
+        ypos -= textWidth + mAnnotationFrameDistance;
         rotation = 4.71239;
       }
       break;


### PR DESCRIPTION
## Description

Fixes the position of the bottom vertical label of a map grid decoration when a non zero "Distance to map frame" is set (regression introduced with https://github.com/qgis/QGIS/pull/37133 since 3.14).

~~Fixes the vertical labels background placement of a map grid decoration.
(It seems to me the QgsTextRenderer::drawText function has an issue with a rotated background placement, but I couldn't find the cause)~~ Now fixed with #45425.

Fixes https://github.com/qgis/QGIS/issues/44907.

This PR needs to be backported to ~~3.20 and~~ 3.16 branches.

Before:
![image](https://user-images.githubusercontent.com/16253859/132981889-bd44f69b-6b63-49e1-a288-e0e20e2bbe88.png)

After:
![image](https://user-images.githubusercontent.com/16253859/132981880-ddd403b6-9aed-4578-af36-079823f0428d.png)


Edited after #45425.
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
