### PR TITLE
Fix geopackage connection

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -2531,6 +2531,10 @@ bool QgsOgrProviderUtils::saveConnection( const QString &path, const QString &og
     }
     if ( ok && ! connName.isEmpty() )
     {
+      QgsOgrDbConnection connection( connName, ogrDriverName );
+      connection.setPath( path );
+      connection.save();
+
       QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
       QgsGeoPackageProviderConnection *providerConnection =  static_cast<QgsGeoPackageProviderConnection *>( providerMetadata->createConnection( connName ) );
       providerMetadata->saveConnection( providerConnection, connName );

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -2531,9 +2531,9 @@ bool QgsOgrProviderUtils::saveConnection( const QString &path, const QString &og
     }
     if ( ok && ! connName.isEmpty() )
     {
-      QgsOgrDbConnection connection( connName, ogrDriverName );
-      connection.setPath( path );
-      connection.save();
+      const QString connection = QStringLiteral( "providers/ogr/%1/connections" ).arg( ogrDriverName );
+      QgsSettings settings;
+      settings.setValue( QStringLiteral( "%1/%2/path" ).arg( connection, connName ), path );
 
       QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
       QgsGeoPackageProviderConnection *providerConnection =  static_cast<QgsGeoPackageProviderConnection *>( providerMetadata->createConnection( connName ) );

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -2531,12 +2531,9 @@ bool QgsOgrProviderUtils::saveConnection( const QString &path, const QString &og
     }
     if ( ok && ! connName.isEmpty() )
     {
-      const QString connection = QStringLiteral( "providers/ogr/%1/connections" ).arg( ogrDriverName );
-      QgsSettings settings;
-      settings.setValue( QStringLiteral( "%1/%2/path" ).arg( connection, connName ), path );
-
       QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
       QgsGeoPackageProviderConnection *providerConnection =  static_cast<QgsGeoPackageProviderConnection *>( providerMetadata->createConnection( connName ) );
+      providerConnection->setUri( path );
       providerMetadata->saveConnection( providerConnection, connName );
       return true;
     }


### PR DESCRIPTION
## Description


Currently, creating a Geopackage connection results in an invalid item in the browser:

![gpkg](https://user-images.githubusercontent.com/9266424/132372836-ebf48c5c-bb3b-40ab-ae6a-bc8a3d8269e1.png)


Actually, the `path` is not propagated anymore and it's also noticable in the `QGIS3.ini` file:

``` bash
 [providers]
 ogr\GPKG\connections\sammo-boat.gpkg\path=
```

Follow up https://github.com/qgis/QGIS/commit/46dad154ef997b8b03b61fa9b9d5e648c513e762.
