### PR TITLE
[annotations] Add framework for map tools for creating new annotation items, implement for new point text tool

### DIFF
--- a/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
+++ b/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
@@ -70,7 +70,7 @@ Returns an icon representing creation of the annotation item type.
 Creates a configuration widget for an ``item`` of this type. Can return ``None`` if no configuration GUI is required.
 %End
 
-    virtual QgsCreateAnnotationItemMapTool *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) /TransferBack/;
+    virtual QgsCreateAnnotationItemMapToolInterface *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) /TransferBack/;
 %Docstring
 Creates a map tool for a creating a new item of this type.
 

--- a/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
+++ b/python/gui/auto_generated/annotations/qgsannotationitemguiregistry.sip.in
@@ -70,6 +70,13 @@ Returns an icon representing creation of the annotation item type.
 Creates a configuration widget for an ``item`` of this type. Can return ``None`` if no configuration GUI is required.
 %End
 
+    virtual QgsCreateAnnotationItemMapTool *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) /TransferBack/;
+%Docstring
+Creates a map tool for a creating a new item of this type.
+
+May return ``None`` if no map tool is available for creating the item.
+%End
+
     virtual QgsAnnotationItem *createItem() /TransferBack/;
 %Docstring
 Creates an instance of the corresponding item type.
@@ -84,6 +91,7 @@ called for items added programmatically.
 %End
 
 };
+
 
 
 

--- a/python/gui/auto_generated/annotations/qgsannotationitemwidget.sip.in
+++ b/python/gui/auto_generated/annotations/qgsannotationitemwidget.sip.in
@@ -63,6 +63,13 @@ Returns the context in which the widget is shown, e.g., the associated map canva
 .. seealso:: :py:func:`setContext`
 %End
 
+  public slots:
+
+    virtual void focusDefaultWidget();
+%Docstring
+Focuses the default widget for the page.
+%End
+
   signals:
 
     void itemChanged();

--- a/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
+++ b/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
@@ -1,0 +1,60 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgscreateannotationitemmaptool.h                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsCreateAnnotationItemMapTool: QgsMapToolAdvancedDigitizing
+{
+%Docstring(signature="appended")
+
+A base class for map tools which create annotation items.
+
+Clients should connect to the map tool's :py:func:`~itemCreated` signal, and call the
+:py:func:`~takeCreatedItem` implementation to take ownership of the newly created item
+whenever this signal is emitted.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgscreateannotationitemmaptool.h"
+%End
+  public:
+
+    QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+%Docstring
+Constructor for QgsCreateAnnotationItemMapTool.
+%End
+
+    virtual QgsAnnotationItem *takeCreatedItem() = 0 /TransferBack/;
+%Docstring
+Takes the newly created item from the tool, transferring ownership to the caller.
+
+Subclasses must implement this method, and ensure that they emit the :py:func:`~QgsCreateAnnotationItemMapTool.itemCreated` signal whenever
+they have a created item ready for clients to take.
+%End
+
+  signals:
+
+    void itemCreated();
+%Docstring
+Emitted by the tool when a new annotation item has been created.
+
+Clients should connect to this signal and call :py:func:`~QgsCreateAnnotationItemMapTool.takeCreatedItem` to take the newly created item from the map tool.
+%End
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/annotations/qgscreateannotationitemmaptool.h                 *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
+++ b/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
@@ -8,13 +8,16 @@
 
 
 
-class QgsCreateAnnotationItemMapTool: QgsMapToolAdvancedDigitizing
+class QgsCreateAnnotationItemMapToolHandler : QObject
 {
 %Docstring(signature="appended")
 
-A base class for map tools which create annotation items.
+A handler object for map tools which create annotation items.
 
-Clients should connect to the map tool's :py:func:`~itemCreated` signal, and call the
+This object is designed to be used by map tools which implement the
+:py:class:`QgsCreateAnnotationItemMapToolInterface`, following the composition pattern.
+
+Clients should connect to the handler's :py:func:`~itemCreated` signal, and call the
 :py:func:`~takeCreatedItem` implementation to take ownership of the newly created item
 whenever this signal is emitted.
 
@@ -26,17 +29,31 @@ whenever this signal is emitted.
 %End
   public:
 
-    QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    QgsCreateAnnotationItemMapToolHandler( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, QObject *parent = 0 );
 %Docstring
-Constructor for QgsCreateAnnotationItemMapTool.
+Constructor for QgsCreateAnnotationItemMapToolHandler, with the specified ``parent`` object.
 %End
 
-    virtual QgsAnnotationItem *takeCreatedItem() = 0 /TransferBack/;
+    ~QgsCreateAnnotationItemMapToolHandler();
+
+    QgsAnnotationItem *takeCreatedItem() /TransferBack/;
 %Docstring
 Takes the newly created item from the tool, transferring ownership to the caller.
+%End
 
-Subclasses must implement this method, and ensure that they emit the :py:func:`~QgsCreateAnnotationItemMapTool.itemCreated` signal whenever
-they have a created item ready for clients to take.
+    QgsAnnotationLayer *targetLayer();
+%Docstring
+Returns the target layer for newly created items.
+%End
+
+    void pushCreatedItem( QgsAnnotationItem *item /Transfer/ );
+%Docstring
+Pushes a created ``item`` to the handler.
+
+Ownership of ``item`` is transferred to the handler.
+
+Calling this method causes the object to emit the :py:func:`~QgsCreateAnnotationItemMapToolHandler.itemCreated` signal, and queue the item
+ready for collection via a call to :py:func:`~QgsCreateAnnotationItemMapToolHandler.takeCreatedItem`.
 %End
 
   signals:
@@ -45,16 +62,40 @@ they have a created item ready for clients to take.
 %Docstring
 Emitted by the tool when a new annotation item has been created.
 
-Clients should connect to this signal and call :py:func:`~QgsCreateAnnotationItemMapTool.takeCreatedItem` to take the newly created item from the map tool.
+Clients should connect to this signal and call :py:func:`~QgsCreateAnnotationItemMapToolHandler.takeCreatedItem` to take the newly created item from the map tool.
 %End
 
-  protected:
+};
 
-    QgsAnnotationLayer *targetLayer();
+class QgsCreateAnnotationItemMapToolInterface
+{
+%Docstring(signature="appended")
+
+An interface for map tools which create annotation items.
+
+Clients should connect to the map tool's :py:func:`~QgsCreateAnnotationItemMapToolHandler.itemCreated` signal, and call the
+:py:func:`~QgsCreateAnnotationItemMapToolHandler.takeCreatedItem` implementation to take ownership of the newly created item
+whenever this signal is emitted.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgscreateannotationitemmaptool.h"
+%End
+  public:
+
+    virtual ~QgsCreateAnnotationItemMapToolInterface();
+
+    virtual QgsCreateAnnotationItemMapToolHandler *handler() = 0;
 %Docstring
-Returns the target layer for newly created items.
+Returns the handler object for the map tool.
 %End
 
+    virtual QgsMapTool *mapTool() = 0;
+%Docstring
+Returns a reference to the associated map tool.
+%End
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
+++ b/python/gui/auto_generated/annotations/qgscreateannotationitemmaptool.sip.in
@@ -48,6 +48,12 @@ Emitted by the tool when a new annotation item has been created.
 Clients should connect to this signal and call :py:func:`~QgsCreateAnnotationItemMapTool.takeCreatedItem` to take the newly created item from the map tool.
 %End
 
+  protected:
+
+    QgsAnnotationLayer *targetLayer();
+%Docstring
+Returns the target layer for newly created items.
+%End
 
 };
 

--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -129,6 +129,13 @@ Called when changes to the layer need to be made.
 Will be called when live update is enabled.
 %End
 
+    virtual void focusDefaultWidget();
+%Docstring
+Focuses the default widget for the page.
+
+.. versionadded:: 3.22
+%End
+
   signals:
 
 

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -227,6 +227,7 @@
 %Include auto_generated/annotations/qgsannotationitemcommonpropertieswidget.sip
 %Include auto_generated/annotations/qgsannotationitemguiregistry.sip
 %Include auto_generated/annotations/qgsannotationitemwidget.sip
+%Include auto_generated/annotations/qgscreateannotationitemmaptool.sip
 %Include auto_generated/annotations/qgsmaptoolmodifyannotation.sip
 %Include auto_generated/attributetable/qgsattributetabledelegate.sip
 %Include auto_generated/attributetable/qgsattributetablefiltermodel.sip

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -98,6 +98,12 @@ void QgsAnnotationItemPropertiesWidget::apply()
   mLayer->triggerRepaint();
 }
 
+void QgsAnnotationItemPropertiesWidget::focusDefaultWidget()
+{
+  if ( mItemWidget )
+    mItemWidget->focusDefaultWidget();
+}
+
 void QgsAnnotationItemPropertiesWidget::onChanged()
 {
   if ( !mLayer )

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -37,6 +37,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
 
   public slots:
     void apply() override;
+    void focusDefaultWidget() override;
 
   private slots:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2886,6 +2886,7 @@ void QgisApp::createActions()
   connect( mActionDiagramProperties, &QAction::triggered, this, &QgisApp::diagramProperties );
 
   connect( mActionCreateAnnotationLayer, &QAction::triggered, this, &QgisApp::createAnnotationLayer );
+  connect( mActionModifyAnnotation, &QAction::triggered, this, [ = ] {  mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ); } );
 
   // we can't set the shortcut these actions, because we need to restrict their context to the canvas and it's children..
   for ( QWidget *widget :

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -810,14 +810,16 @@ void QgisApp::annotationItemTypeAdded( int id )
     connect( tool, &QgsCreateAnnotationItemMapTool::itemCreated, this, [ = ]
     {
       QgsAnnotationItem *item = tool->takeCreatedItem();
-      if ( QgsAnnotationLayer *layer = qobject_cast< QgsAnnotationLayer * >( activeLayer() ) )
-      {
-        layer->addItem( item );
-      }
-      else
-      {
-        QgsProject::instance()->mainAnnotationLayer()->addItem( item );
-      }
+      QgsAnnotationLayer *targetLayer = qobject_cast< QgsAnnotationLayer * >( activeLayer() );
+      if ( !targetLayer )
+        targetLayer = QgsProject::instance()->mainAnnotationLayer();
+
+      const QString itemId = targetLayer->addItem( item );
+      // automatically select item in layer styling panel
+      mMapStyleWidget->setAnnotationItem( targetLayer, itemId );
+      mMapStylingDock->setUserVisible( true );
+      mMapStyleWidget->focusDefaultWidget();
+
       // TODO -- possibly automatically deactive the tool now?
     } );
   } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -804,12 +804,12 @@ void QgisApp::annotationItemTypeAdded( int id )
 
   connect( action, &QAction::triggered, this, [this, id]()
   {
-    QgsCreateAnnotationItemMapTool *tool = QgsGui::annotationItemGuiRegistry()->itemMetadata( id )->createMapTool( mMapCanvas, mAdvancedDigitizingDockWidget );
-    mMapCanvas->setMapTool( tool );
-    connect( tool, &QgsMapTool::deactivated, tool, &QObject::deleteLater );
-    connect( tool, &QgsCreateAnnotationItemMapTool::itemCreated, this, [ = ]
+    QgsCreateAnnotationItemMapToolInterface *tool = QgsGui::annotationItemGuiRegistry()->itemMetadata( id )->createMapTool( mMapCanvas, mAdvancedDigitizingDockWidget );
+    mMapCanvas->setMapTool( tool->mapTool() );
+    connect( tool->mapTool(), &QgsMapTool::deactivated, tool->mapTool(), &QObject::deleteLater );
+    connect( tool->handler(), &QgsCreateAnnotationItemMapToolHandler::itemCreated, this, [ = ]
     {
-      QgsAnnotationItem *item = tool->takeCreatedItem();
+      QgsAnnotationItem *item = tool->handler()->takeCreatedItem();
       QgsAnnotationLayer *targetLayer = qobject_cast< QgsAnnotationLayer * >( activeLayer() );
       if ( !targetLayer )
         targetLayer = QgsProject::instance()->mainAnnotationLayer();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -822,7 +822,7 @@ void QgisApp::annotationItemTypeAdded( int id )
 
       QgsProject::instance()->setDirty( true );
 
-      // TODO -- possibly automatically deactive the tool now?
+      // TODO -- possibly automatically deactivate the tool now?
     } );
   } );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -820,6 +820,8 @@ void QgisApp::annotationItemTypeAdded( int id )
       mMapStylingDock->setUserVisible( true );
       mMapStyleWidget->focusDefaultWidget();
 
+      QgsProject::instance()->setDirty( true );
+
       // TODO -- possibly automatically deactive the tool now?
     } );
   } );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1988,6 +1988,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void showGeoreferencer();
 #endif
 
+    void annotationItemTypeAdded( int id );
+
   signals:
 
     /**
@@ -2678,6 +2680,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsScopedOptionsWidgetFactory mCodeEditorWidgetFactory;
     QgsScopedOptionsWidgetFactory mBabelGpsDevicesWidgetFactory;
     QgsScopedOptionsWidgetFactory m3DOptionsWidgetFactory;
+
+    QMap< QString, QToolButton * > mAnnotationItemGroupToolButtons;
 
     class QgsCanvasRefreshBlocker
     {

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -712,6 +712,14 @@ void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const 
   }
 }
 
+void QgsLayerStylingWidget::focusDefaultWidget()
+{
+  if ( QgsMapLayerConfigWidget *configWidget = qobject_cast< QgsMapLayerConfigWidget * >( mWidgetStack->mainPanel() ) )
+  {
+    configWidget->focusDefaultWidget();
+  }
+}
+
 void QgsLayerStylingWidget::layerAboutToBeRemoved( QgsMapLayer *layer )
 {
   if ( layer == mCurrentLayer )

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -135,6 +135,11 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
      */
     void setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId );
 
+    /**
+     * Focuses the default widget for the current page.
+     */
+    void focusDefaultWidget();
+
   private slots:
 
     void layerAboutToBeRemoved( QgsMapLayer *layer );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -98,6 +98,8 @@ set(QGIS_GUI_SRCS
   annotations/qgsannotationitemguiregistry.cpp
   annotations/qgsannotationitemwidget.cpp
   annotations/qgsannotationitemwidget_impl.cpp
+  annotations/qgscreateannotationitemmaptool.cpp
+  annotations/qgscreateannotationitemmaptool_impl.cpp
   annotations/qgsmaptoolmodifyannotation.cpp
 
   auth/qgsauthauthoritieseditor.cpp
@@ -887,6 +889,7 @@ set(QGIS_GUI_HDRS
   annotations/qgsannotationitemcommonpropertieswidget.h
   annotations/qgsannotationitemguiregistry.h
   annotations/qgsannotationitemwidget.h
+  annotations/qgscreateannotationitemmaptool.h
   annotations/qgsmaptoolmodifyannotation.h
 
   attributeformconfig/qgsattributeformcontaineredit.h

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -34,7 +34,7 @@ QgsAnnotationItemBaseWidget *QgsAnnotationItemAbstractGuiMetadata::createItemWid
   return nullptr;
 }
 
-QgsCreateAnnotationItemMapTool *QgsAnnotationItemAbstractGuiMetadata::createMapTool( QgsMapCanvas *, QgsAdvancedDigitizingDockWidget * )
+QgsCreateAnnotationItemMapToolInterface *QgsAnnotationItemAbstractGuiMetadata::createMapTool( QgsMapCanvas *, QgsAdvancedDigitizingDockWidget * )
 {
   return nullptr;
 }
@@ -74,7 +74,7 @@ void QgsAnnotationItemGuiMetadata::newItemAddedToLayer( QgsAnnotationItem *item,
     mAddedToLayerFunc( item, layer );
 }
 
-QgsCreateAnnotationItemMapTool *QgsAnnotationItemGuiMetadata::createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+QgsCreateAnnotationItemMapToolInterface *QgsAnnotationItemGuiMetadata::createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
 {
   return mCreateMapToolFunc ? mCreateMapToolFunc( canvas, cadDockWidget ) : nullptr;
 }
@@ -180,7 +180,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
 {
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "polygon" ),
                                 QObject::tr( "Polygon" ),
-                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPolygon.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
     QgsAnnotationPolygonItemWidget *widget = new QgsAnnotationPolygonItemWidget( nullptr );
@@ -190,7 +190,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "linestring" ),
                                 QObject::tr( "Line" ),
-                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPolyline.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
     QgsAnnotationLineItemWidget *widget = new QgsAnnotationLineItemWidget( nullptr );
@@ -217,7 +217,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     widget->setItem( item );
     return widget;
   }, QString(), Qgis::AnnotationItemGuiFlags(), nullptr,
-  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapTool *
+  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapToolInterface *
   {
     return new QgsCreatePointTextItemMapTool( canvas, cadDockWidget );
   } ) );

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -200,13 +200,17 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "marker" ),
                                 QObject::tr( "Marker" ),
-                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddMarker.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
     QgsAnnotationMarkerItemWidget *widget = new QgsAnnotationMarkerItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
+  }, QString(), Qgis::AnnotationItemGuiFlags(), nullptr,
+  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapToolInterface *
+  {
+    return new QgsCreateMarkerItemMapTool( canvas, cadDockWidget );
+  } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "pointtext" ),
                                 QObject::tr( "Text at Point" ),

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -20,6 +20,25 @@
 
 #include "qgsannotationitemwidget_impl.h"
 
+//
+// QgsAnnotationItemAbstractGuiMetadata
+//
+
+QIcon QgsAnnotationItemAbstractGuiMetadata::creationIcon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddBasicRectangle.svg" ) );
+}
+
+QgsAnnotationItemBaseWidget *QgsAnnotationItemAbstractGuiMetadata::createItemWidget( QgsAnnotationItem * )
+{
+  return nullptr;
+}
+
+QgsCreateAnnotationItemMapTool *QgsAnnotationItemAbstractGuiMetadata::createMapTool( QgsMapCanvas *, QgsAdvancedDigitizingDockWidget * )
+{
+  return nullptr;
+}
+
 QgsAnnotationItem *QgsAnnotationItemAbstractGuiMetadata::createItem()
 {
   return nullptr;
@@ -29,6 +48,41 @@ void QgsAnnotationItemAbstractGuiMetadata::newItemAddedToLayer( QgsAnnotationIte
 {
 
 }
+
+//
+// QgsAnnotationItemGuiMetadata
+//
+
+QIcon QgsAnnotationItemGuiMetadata::creationIcon() const
+{
+  return mIcon.isNull() ? QgsAnnotationItemAbstractGuiMetadata::creationIcon() : mIcon;
+}
+
+QgsAnnotationItemBaseWidget *QgsAnnotationItemGuiMetadata::createItemWidget( QgsAnnotationItem *item )
+{
+  return mWidgetFunc ? mWidgetFunc( item ) : nullptr;
+}
+
+QgsAnnotationItem *QgsAnnotationItemGuiMetadata::createItem()
+{
+  return mCreateFunc ? mCreateFunc() : QgsAnnotationItemAbstractGuiMetadata::createItem();
+}
+
+void QgsAnnotationItemGuiMetadata::newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer )
+{
+  if ( mAddedToLayerFunc )
+    mAddedToLayerFunc( item, layer );
+}
+
+QgsCreateAnnotationItemMapTool *QgsAnnotationItemGuiMetadata::createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+{
+  return mCreateMapToolFunc ? mCreateMapToolFunc( canvas, cadDockWidget ) : nullptr;
+}
+
+
+//
+// QgsAnnotationItemGuiRegistry
+//
 
 QgsAnnotationItemGuiRegistry::QgsAnnotationItemGuiRegistry( QObject *parent )
   : QObject( parent )
@@ -163,15 +217,4 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     widget->setItem( item );
     return widget;
   } ) );
-}
-
-QgsAnnotationItem *QgsAnnotationItemGuiMetadata::createItem()
-{
-  return mCreateFunc ? mCreateFunc() : QgsAnnotationItemAbstractGuiMetadata::createItem();
-}
-
-void QgsAnnotationItemGuiMetadata::newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer )
-{
-  if ( mAddedToLayerFunc )
-    mAddedToLayerFunc( item, layer );
 }

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -19,7 +19,7 @@
 #include "qgsannotationitem.h"
 
 #include "qgsannotationitemwidget_impl.h"
-
+#include "qgscreateannotationitemmaptool_impl.h"
 //
 // QgsAnnotationItemAbstractGuiMetadata
 //
@@ -186,7 +186,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     QgsAnnotationPolygonItemWidget *widget = new QgsAnnotationPolygonItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  } ) );
+  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "linestring" ),
                                 QObject::tr( "Line" ),
@@ -196,7 +196,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     QgsAnnotationLineItemWidget *widget = new QgsAnnotationLineItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  } ) );
+  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "marker" ),
                                 QObject::tr( "Marker" ),
@@ -206,15 +206,19 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     QgsAnnotationMarkerItemWidget *widget = new QgsAnnotationMarkerItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  } ) );
+  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "pointtext" ),
                                 QObject::tr( "Text at Point" ),
-                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionLabel.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
     QgsAnnotationPointTextItemWidget *widget = new QgsAnnotationPointTextItemWidget( nullptr );
     widget->setItem( item );
     return widget;
+  }, QString(), Qgis::AnnotationItemGuiFlags(), nullptr,
+  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapTool *
+  {
+    return new QgsCreatePointTextItemMapTool( canvas, cadDockWidget );
   } ) );
 }

--- a/src/gui/annotations/qgsannotationitemguiregistry.h
+++ b/src/gui/annotations/qgsannotationitemguiregistry.h
@@ -28,7 +28,7 @@
 class QgsAnnotationLayer;
 class QgsAnnotationItem;
 class QgsAnnotationItemBaseWidget;
-class QgsCreateAnnotationItemMapTool;
+class QgsCreateAnnotationItemMapToolInterface;
 class QgsMapCanvas;
 class QgsAdvancedDigitizingDockWidget;
 
@@ -112,7 +112,7 @@ class GUI_EXPORT QgsAnnotationItemAbstractGuiMetadata
      *
      * May return NULLPTR if no map tool is available for creating the item.
      */
-    virtual QgsCreateAnnotationItemMapTool *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) SIP_TRANSFERBACK;
+    virtual QgsCreateAnnotationItemMapToolInterface *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) SIP_TRANSFERBACK;
 
     /**
      * Creates an instance of the corresponding item type.
@@ -140,7 +140,7 @@ class GUI_EXPORT QgsAnnotationItemAbstractGuiMetadata
 typedef std::function<QgsAnnotationItemBaseWidget *( QgsAnnotationItem * )> QgsAnnotationItemWidgetFunc SIP_SKIP;
 
 //! Create annotation map tool creation function
-typedef std::function<QgsCreateAnnotationItemMapTool *( QgsMapCanvas *, QgsAdvancedDigitizingDockWidget * )> QgsCreateAnnotationItemMapToolFunc SIP_SKIP;
+typedef std::function<QgsCreateAnnotationItemMapToolInterface *( QgsMapCanvas *, QgsAdvancedDigitizingDockWidget * )> QgsCreateAnnotationItemMapToolFunc SIP_SKIP;
 
 //! Annotation item added to layer callback
 typedef std::function<void ( QgsAnnotationItem *, QgsAnnotationLayer *layer )> QgsAnnotationItemAddedToLayerFunc SIP_SKIP;
@@ -232,7 +232,7 @@ class GUI_EXPORT QgsAnnotationItemGuiMetadata : public QgsAnnotationItemAbstract
 
     QgsAnnotationItem *createItem() override;
     void newItemAddedToLayer( QgsAnnotationItem *item, QgsAnnotationLayer *layer ) override;
-    QgsCreateAnnotationItemMapTool *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) override;
+    QgsCreateAnnotationItemMapToolInterface *createMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget ) override;
 
   protected:
     QIcon mIcon;

--- a/src/gui/annotations/qgsannotationitemwidget.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget.cpp
@@ -36,6 +36,10 @@ QgsSymbolWidgetContext QgsAnnotationItemBaseWidget::context() const
   return mContext;
 }
 
+void QgsAnnotationItemBaseWidget::focusDefaultWidget()
+{
+}
+
 bool QgsAnnotationItemBaseWidget::setNewItem( QgsAnnotationItem * )
 {
   return false;

--- a/src/gui/annotations/qgsannotationitemwidget.h
+++ b/src/gui/annotations/qgsannotationitemwidget.h
@@ -75,6 +75,13 @@ class GUI_EXPORT QgsAnnotationItemBaseWidget: public QgsPanelWidget
      */
     QgsSymbolWidgetContext context() const;
 
+  public slots:
+
+    /**
+     * Focuses the default widget for the page.
+     */
+    virtual void focusDefaultWidget();
+
   signals:
 
     /**

--- a/src/gui/annotations/qgsannotationitemwidget_impl.cpp
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.cpp
@@ -360,6 +360,12 @@ void QgsAnnotationPointTextItemWidget::setContext( const QgsSymbolWidgetContext 
   mPropertiesWidget->setContext( context );
 }
 
+void QgsAnnotationPointTextItemWidget::focusDefaultWidget()
+{
+  mTextEdit->selectAll();
+  mTextEdit->setFocus();
+}
+
 QgsAnnotationPointTextItemWidget::~QgsAnnotationPointTextItemWidget() = default;
 
 bool QgsAnnotationPointTextItemWidget::setNewItem( QgsAnnotationItem *item )

--- a/src/gui/annotations/qgsannotationitemwidget_impl.h
+++ b/src/gui/annotations/qgsannotationitemwidget_impl.h
@@ -120,6 +120,10 @@ class QgsAnnotationPointTextItemWidget : public QgsAnnotationItemBaseWidget, pri
     void setDockMode( bool dockMode ) override;
     void setContext( const QgsSymbolWidgetContext &context ) override;
 
+  public slots:
+
+    void focusDefaultWidget() override;
+
   protected:
     bool setNewItem( QgsAnnotationItem *item ) override;
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.cpp
@@ -16,17 +16,33 @@
 #include "qgscreateannotationitemmaptool.h"
 #include "qgsmapcanvas.h"
 #include "qgsannotationlayer.h"
+#include "qgsannotationitem.h"
 
-QgsCreateAnnotationItemMapTool::QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
-  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+QgsCreateAnnotationItemMapToolHandler::QgsCreateAnnotationItemMapToolHandler( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, QObject *parent )
+  : QObject( parent )
+  , mMapCanvas( canvas )
+  , mCadDockWidget( cadDockWidget )
 {
 
 }
 
-QgsAnnotationLayer *QgsCreateAnnotationItemMapTool::targetLayer()
+QgsAnnotationItem *QgsCreateAnnotationItemMapToolHandler::takeCreatedItem()
 {
-  if ( QgsAnnotationLayer *res = qobject_cast< QgsAnnotationLayer * >( canvas()->currentLayer() ) )
+  return mCreatedItem.release();
+}
+
+QgsCreateAnnotationItemMapToolHandler::~QgsCreateAnnotationItemMapToolHandler() = default;
+
+QgsAnnotationLayer *QgsCreateAnnotationItemMapToolHandler::targetLayer()
+{
+  if ( QgsAnnotationLayer *res = qobject_cast< QgsAnnotationLayer * >( mMapCanvas->currentLayer() ) )
     return res;
   else
     return QgsProject::instance()->mainAnnotationLayer();
+}
+
+void QgsCreateAnnotationItemMapToolHandler::pushCreatedItem( QgsAnnotationItem *item )
+{
+  mCreatedItem.reset( item );
+  emit itemCreated();
 }

--- a/src/gui/annotations/qgscreateannotationitemmaptool.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+                             qgscreateannotationitemmaptool.cpp
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscreateannotationitemmaptool.h"
+
+QgsCreateAnnotationItemMapTool::QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+{
+
+}

--- a/src/gui/annotations/qgscreateannotationitemmaptool.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.cpp
@@ -14,9 +14,19 @@
  ***************************************************************************/
 
 #include "qgscreateannotationitemmaptool.h"
+#include "qgsmapcanvas.h"
+#include "qgsannotationlayer.h"
 
 QgsCreateAnnotationItemMapTool::QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
 {
 
+}
+
+QgsAnnotationLayer *QgsCreateAnnotationItemMapTool::targetLayer()
+{
+  if ( QgsAnnotationLayer *res = qobject_cast< QgsAnnotationLayer * >( canvas()->currentLayer() ) )
+    return res;
+  else
+    return QgsProject::instance()->mainAnnotationLayer();
 }

--- a/src/gui/annotations/qgscreateannotationitemmaptool.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.h
@@ -20,6 +20,7 @@
 #include "qgsmaptooladvanceddigitizing.h"
 
 class QgsAnnotationItem;
+class QgsAnnotationLayer;
 
 /**
  * \class QgsCreateAnnotationItemMapTool
@@ -61,6 +62,12 @@ class GUI_EXPORT QgsCreateAnnotationItemMapTool: public QgsMapToolAdvancedDigiti
      */
     void itemCreated();
 
+  protected:
+
+    /**
+     * Returns the target layer for newly created items.
+     */
+    QgsAnnotationLayer *targetLayer();
 
 };
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.h
@@ -23,35 +23,52 @@ class QgsAnnotationItem;
 class QgsAnnotationLayer;
 
 /**
- * \class QgsCreateAnnotationItemMapTool
+ * \class QgsCreateAnnotationItemMapToolHandler
  * \ingroup gui
  *
- * \brief A base class for map tools which create annotation items.
+ * \brief A handler object for map tools which create annotation items.
  *
- * Clients should connect to the map tool's itemCreated() signal, and call the
+ * This object is designed to be used by map tools which implement the
+ * QgsCreateAnnotationItemMapToolInterface, following the composition pattern.
+ *
+ * Clients should connect to the handler's itemCreated() signal, and call the
  * takeCreatedItem() implementation to take ownership of the newly created item
  * whenever this signal is emitted.
  *
  * \since QGIS 3.22
 */
-class GUI_EXPORT QgsCreateAnnotationItemMapTool: public QgsMapToolAdvancedDigitizing
+class GUI_EXPORT QgsCreateAnnotationItemMapToolHandler : public QObject
 {
     Q_OBJECT
 
   public:
 
     /**
-     * Constructor for QgsCreateAnnotationItemMapTool.
+     * Constructor for QgsCreateAnnotationItemMapToolHandler, with the specified \a parent object.
      */
-    QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    QgsCreateAnnotationItemMapToolHandler( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, QObject *parent = nullptr );
+
+    ~QgsCreateAnnotationItemMapToolHandler() override;
 
     /**
      * Takes the newly created item from the tool, transferring ownership to the caller.
-     *
-     * Subclasses must implement this method, and ensure that they emit the itemCreated() signal whenever
-     * they have a created item ready for clients to take.
      */
-    virtual QgsAnnotationItem *takeCreatedItem() = 0 SIP_TRANSFERBACK;
+    QgsAnnotationItem *takeCreatedItem() SIP_TRANSFERBACK;
+
+    /**
+     * Returns the target layer for newly created items.
+     */
+    QgsAnnotationLayer *targetLayer();
+
+    /**
+     * Pushes a created \a item to the handler.
+     *
+     * Ownership of \a item is transferred to the handler.
+     *
+     * Calling this method causes the object to emit the itemCreated() signal, and queue the item
+     * ready for collection via a call to takeCreatedItem().
+     */
+    void pushCreatedItem( QgsAnnotationItem *item SIP_TRANSFER );
 
   signals:
 
@@ -62,13 +79,41 @@ class GUI_EXPORT QgsCreateAnnotationItemMapTool: public QgsMapToolAdvancedDigiti
      */
     void itemCreated();
 
-  protected:
+  private:
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+    QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
+    std::unique_ptr< QgsAnnotationItem > mCreatedItem;
+
+};
+
+/**
+ * \class QgsCreateAnnotationItemMapToolInterface
+ * \ingroup gui
+ *
+ * \brief An interface for map tools which create annotation items.
+ *
+ * Clients should connect to the map tool's itemCreated() signal, and call the
+ * takeCreatedItem() implementation to take ownership of the newly created item
+ * whenever this signal is emitted.
+ *
+ * \since QGIS 3.22
+*/
+class GUI_EXPORT QgsCreateAnnotationItemMapToolInterface
+{
+  public:
+
+    virtual ~QgsCreateAnnotationItemMapToolInterface() = default;
 
     /**
-     * Returns the target layer for newly created items.
+     * Returns the handler object for the map tool.
      */
-    QgsAnnotationLayer *targetLayer();
+    virtual QgsCreateAnnotationItemMapToolHandler *handler() = 0;
 
+    /**
+     * Returns a reference to the associated map tool.
+     */
+    virtual QgsMapTool *mapTool() = 0;
 };
 
 #endif // QGSCREATEANNOTATIONITEMMAPTOOL_H

--- a/src/gui/annotations/qgscreateannotationitemmaptool.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+                             qgscreateannotationitemmaptool.h
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCREATEANNOTATIONITEMMAPTOOL_H
+#define QGSCREATEANNOTATIONITEMMAPTOOL_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsmaptooladvanceddigitizing.h"
+
+class QgsAnnotationItem;
+
+/**
+ * \class QgsCreateAnnotationItemMapTool
+ * \ingroup gui
+ *
+ * \brief A base class for map tools which create annotation items.
+ *
+ * Clients should connect to the map tool's itemCreated() signal, and call the
+ * takeCreatedItem() implementation to take ownership of the newly created item
+ * whenever this signal is emitted.
+ *
+ * \since QGIS 3.22
+*/
+class GUI_EXPORT QgsCreateAnnotationItemMapTool: public QgsMapToolAdvancedDigitizing
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsCreateAnnotationItemMapTool.
+     */
+    QgsCreateAnnotationItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+
+    /**
+     * Takes the newly created item from the tool, transferring ownership to the caller.
+     *
+     * Subclasses must implement this method, and ensure that they emit the itemCreated() signal whenever
+     * they have a created item ready for clients to take.
+     */
+    virtual QgsAnnotationItem *takeCreatedItem() = 0 SIP_TRANSFERBACK;
+
+  signals:
+
+    /**
+     * Emitted by the tool when a new annotation item has been created.
+     *
+     * Clients should connect to this signal and call takeCreatedItem() to take the newly created item from the map tool.
+     */
+    void itemCreated();
+
+
+};
+
+#endif // QGSCREATEANNOTATIONITEMMAPTOOL_H

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************
+                             qgscreateannotationitemmaptool_impl.cpp
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscreateannotationitemmaptool_impl.h"
+
+///@cond PRIVATE
+
+
+///@endcond PRIVATE

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -17,6 +17,7 @@
 #include "qgsmapmouseevent.h"
 #include "qgsannotationpointtextitem.h"
 #include "qgsannotationlayer.h"
+#include "qgsstyle.h"
 
 ///@cond PRIVATE
 
@@ -37,6 +38,7 @@ void QgsCreatePointTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event
 
   mCreatedItem = std::make_unique< QgsAnnotationPointTextItem >( tr( "Text" ), layerPoint );
   mCreatedItem->setAlignment( Qt::AlignLeft );
+  mCreatedItem->setFormat( QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling ) );
   emit itemCreated();
 }
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -14,8 +14,36 @@
  ***************************************************************************/
 
 #include "qgscreateannotationitemmaptool_impl.h"
+#include "qgsmapmouseevent.h"
+#include "qgsannotationpointtextitem.h"
+#include "qgsannotationlayer.h"
 
 ///@cond PRIVATE
+
+QgsCreatePointTextItemMapTool::QgsCreatePointTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsCreateAnnotationItemMapTool( canvas, cadDockWidget )
+{
+
+}
+
+QgsCreatePointTextItemMapTool::~QgsCreatePointTextItemMapTool() = default;
+
+void QgsCreatePointTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+    return;
+
+  const QgsPointXY layerPoint = toLayerCoordinates( targetLayer(), event->mapPoint() );
+
+  mCreatedItem = std::make_unique< QgsAnnotationPointTextItem >( tr( "Text" ), layerPoint );
+  mCreatedItem->setAlignment( Qt::AlignLeft );
+  emit itemCreated();
+}
+
+QgsAnnotationItem *QgsCreatePointTextItemMapTool::takeCreatedItem()
+{
+  return mCreatedItem.release();
+}
 
 
 ///@endcond PRIVATE

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -16,9 +16,11 @@
 #include "qgscreateannotationitemmaptool_impl.h"
 #include "qgsmapmouseevent.h"
 #include "qgsannotationpointtextitem.h"
+#include "qgsannotationmarkeritem.h"
 #include "qgsannotationlayer.h"
 #include "qgsstyle.h"
 #include "qgsmapcanvas.h"
+#include "qgsmarkersymbol.h"
 
 ///@cond PRIVATE
 
@@ -57,6 +59,46 @@ QgsCreateAnnotationItemMapToolHandler *QgsCreatePointTextItemMapTool::handler()
 }
 
 QgsMapTool *QgsCreatePointTextItemMapTool::mapTool()
+{
+  return this;
+}
+
+
+
+//
+// QgsCreateMarkerMapTool
+//
+
+QgsCreateMarkerItemMapTool::QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
+{
+
+}
+
+QgsCreateMarkerItemMapTool::~QgsCreateMarkerItemMapTool() = default;
+
+void QgsCreateMarkerItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+    return;
+
+  const QgsPointXY layerPoint = toLayerCoordinates( mHandler->targetLayer(), event->mapPoint() );
+
+  std::unique_ptr< QgsAnnotationMarkerItem > createdItem = std::make_unique< QgsAnnotationMarkerItem >( QgsPoint( layerPoint ) );
+  createdItem->setSymbol( qgis::down_cast< QgsMarkerSymbol * >( QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ) ) );
+  // set reference scale to match canvas scale, but don't enable it by default for marker items
+  createdItem->setSymbologyReferenceScale( canvas()->scale() );
+
+  mHandler->pushCreatedItem( createdItem.release() );
+}
+
+QgsCreateAnnotationItemMapToolHandler *QgsCreateMarkerItemMapTool::handler()
+{
+  return mHandler;
+}
+
+QgsMapTool *QgsCreateMarkerItemMapTool::mapTool()
 {
   return this;
 }

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -22,8 +22,13 @@
 
 ///@cond PRIVATE
 
+//
+// QgsCreatePointTextItemMapTool
+//
+
 QgsCreatePointTextItemMapTool::QgsCreatePointTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
-  : QgsCreateAnnotationItemMapTool( canvas, cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
 {
 
 }
@@ -35,21 +40,25 @@ void QgsCreatePointTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event
   if ( event->button() != Qt::LeftButton )
     return;
 
-  const QgsPointXY layerPoint = toLayerCoordinates( targetLayer(), event->mapPoint() );
+  const QgsPointXY layerPoint = toLayerCoordinates( mHandler->targetLayer(), event->mapPoint() );
 
-  mCreatedItem = std::make_unique< QgsAnnotationPointTextItem >( tr( "Text" ), layerPoint );
-  mCreatedItem->setAlignment( Qt::AlignLeft );
-  mCreatedItem->setFormat( QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling ) );
+  std::unique_ptr< QgsAnnotationPointTextItem > createdItem = std::make_unique< QgsAnnotationPointTextItem >( tr( "Text" ), layerPoint );
+  createdItem->setAlignment( Qt::AlignLeft );
+  createdItem->setFormat( QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling ) );
   // newly created point text items default to using symbology reference scale at the current map scale
-  mCreatedItem->setUseSymbologyReferenceScale( true );
-  mCreatedItem->setSymbologyReferenceScale( canvas()->scale() );
-  emit itemCreated();
+  createdItem->setUseSymbologyReferenceScale( true );
+  createdItem->setSymbologyReferenceScale( canvas()->scale() );
+  mHandler->pushCreatedItem( createdItem.release() );
 }
 
-QgsAnnotationItem *QgsCreatePointTextItemMapTool::takeCreatedItem()
+QgsCreateAnnotationItemMapToolHandler *QgsCreatePointTextItemMapTool::handler()
 {
-  return mCreatedItem.release();
+  return mHandler;
 }
 
+QgsMapTool *QgsCreatePointTextItemMapTool::mapTool()
+{
+  return this;
+}
 
 ///@endcond PRIVATE

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -18,6 +18,7 @@
 #include "qgsannotationpointtextitem.h"
 #include "qgsannotationlayer.h"
 #include "qgsstyle.h"
+#include "qgsmapcanvas.h"
 
 ///@cond PRIVATE
 
@@ -39,6 +40,9 @@ void QgsCreatePointTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event
   mCreatedItem = std::make_unique< QgsAnnotationPointTextItem >( tr( "Text" ), layerPoint );
   mCreatedItem->setAlignment( Qt::AlignLeft );
   mCreatedItem->setFormat( QgsStyle::defaultStyle()->defaultTextFormat( QgsStyle::TextFormatContext::Labeling ) );
+  // newly created point text items default to using symbology reference scale at the current map scale
+  mCreatedItem->setUseSymbologyReferenceScale( true );
+  mCreatedItem->setSymbologyReferenceScale( canvas()->scale() );
   emit itemCreated();
 }
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -19,9 +19,31 @@
 #include "qgis_sip.h"
 #include "qgscreateannotationitemmaptool.h"
 
+class QgsAnnotationPointTextItem;
+
 #define SIP_NO_FILE
 
 ///@cond PRIVATE
+
+class QgsCreatePointTextItemMapTool: public QgsCreateAnnotationItemMapTool
+{
+    Q_OBJECT
+
+  public:
+
+    QgsCreatePointTextItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsCreatePointTextItemMapTool() override;
+
+    void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+
+    QgsAnnotationItem *takeCreatedItem() override;
+
+
+  private:
+
+    std::unique_ptr< QgsAnnotationPointTextItem > mCreatedItem;
+
+};
 
 ///@endcond PRIVATE
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -20,6 +20,7 @@
 #include "qgscreateannotationitemmaptool.h"
 
 class QgsAnnotationPointTextItem;
+class QgsAnnotationMarkerItem;
 
 #define SIP_NO_FILE
 
@@ -38,7 +39,24 @@ class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public
     QgsCreateAnnotationItemMapToolHandler *handler() override;
     QgsMapTool *mapTool() override;
 
-    QgsAnnotationItem *takeCreatedItem() override;
+  private:
+
+    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
+
+};
+
+class QgsCreateMarkerItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsCreateMarkerItemMapTool() override;
+
+    void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsMapTool *mapTool() override;
 
   private:
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -1,0 +1,28 @@
+/***************************************************************************
+                             qgscreateannotationitemmaptool_impl.h
+                             ------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCREATEANNOTATIONITEMMAPTOOLIMPL_H
+#define QGSCREATEANNOTATIONITEMMAPTOOLIMPL_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgscreateannotationitemmaptool.h"
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+///@endcond PRIVATE
+
+#endif // QGSCREATEANNOTATIONITEMMAPTOOLIMPL_H

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -25,7 +25,7 @@ class QgsAnnotationPointTextItem;
 
 ///@cond PRIVATE
 
-class QgsCreatePointTextItemMapTool: public QgsCreateAnnotationItemMapTool
+class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
 
@@ -35,15 +35,17 @@ class QgsCreatePointTextItemMapTool: public QgsCreateAnnotationItemMapTool
     ~QgsCreatePointTextItemMapTool() override;
 
     void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsMapTool *mapTool() override;
 
     QgsAnnotationItem *takeCreatedItem() override;
 
-
   private:
 
-    std::unique_ptr< QgsAnnotationPointTextItem > mCreatedItem;
+    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
 };
+
 
 ///@endcond PRIVATE
 

--- a/src/gui/qgsmaplayerconfigwidget.cpp
+++ b/src/gui/qgsmaplayerconfigwidget.cpp
@@ -27,3 +27,7 @@ void QgsMapLayerConfigWidget::setMapLayerConfigWidgetContext( const QgsMapLayerC
 {
   mMapLayerConfigWidgetContext = context;
 }
+
+void QgsMapLayerConfigWidget::focusDefaultWidget()
+{
+}

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -137,6 +137,13 @@ class GUI_EXPORT QgsMapLayerConfigWidget : public QgsPanelWidget
      */
     virtual void apply() = 0;
 
+    /**
+     * Focuses the default widget for the page.
+     *
+     * \since QGIS 3.22
+     */
+    virtual void focusDefaultWidget();
+
   signals:
 
 #ifndef SIP_RUN


### PR DESCRIPTION
Continues the recent annotation handling work by adding the framework for map tools for creating NEW annotation items. Currently this is implemented for the point text item only, but more will come in a future PR!..

In the meantime, feel free to salivate at how easy this makes creating free-form, geographically referenced text items... :partying_face: 


https://user-images.githubusercontent.com/1829991/132434326-211d08b0-92a6-48d4-9f00-dad568eff750.mp4

Sponsored by the Swiss QGIS user group