### PR TITLE
Offer a slightly more helpful error string when querying layers fails

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -1477,7 +1477,7 @@ QgsOgrLayerUniquePtr QgsOgrProviderUtils::getLayer( const QString &dsName,
   GDALDatasetH hDS = OpenHelper( dsName, updateMode, options );
   if ( !hDS )
   {
-    errCause = QObject::tr( "Cannot open %1." ).arg( dsName );
+    errCause = QObject::tr( "Cannot open %1 (%2)." ).arg( dsName, QString::fromUtf8( CPLGetLastErrorMsg() ) );
     return nullptr;
   }
 


### PR DESCRIPTION
@nyalldawson , as discussed.