### PR TITLE
Generalise QgsMapToolCapture

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -157,7 +157,7 @@ Converts a map point to layer coordinates
 
 :return:
          0 in case of success
-         1 if the current layer is ``None`` or not a vector layer
+         1 if the current layer is ``None``
          2 if the transformation failed
 %End
 

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -303,6 +303,16 @@ Set the points on which to work
 Close an open polygon
 %End
 
+    virtual QgsMapLayer *layer() const;
+%Docstring
+Returns the map layer associated with the geometry being captured.
+
+The base class implementation always returns the current map canvas layer, but
+subclasses can override this if they need to be associated with a specific layer.
+
+.. versionadded:: 3.22
+%End
+
   protected slots:
 
     void stopCapturing();

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -219,7 +219,7 @@ WkbType of the current layer).
 %Docstring
 Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
 
-:return: 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed
+:return: 0 in case of success, 2 if coordinate transformation failed
 %End
 
     int addVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match &match );

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -40,6 +40,7 @@ class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
     {
       NoCapabilities,
       SupportsCurves,
+      ValidateGeometries,
     };
 
     typedef QFlags<QgsMapToolCapture::Capability> Capabilities;

--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -293,7 +293,7 @@ If additional geometries are to be added then set ``doUpdate`` to ``False`` to d
 After adding the final geometry :py:func:`~QgsRubberBand.updatePosition` should be called.
 
 :param geometry: the geometry object. Will be treated as a collection of vertices.
-:param layer: the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to themap crs. If ``layer`` is ``None`` no coordinate transformation will occur.
+:param layer: the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to the map crs. If ``layer`` is ``None`` no coordinate transformation will occur.
 :param doUpdate: set to ``False`` to defer updates of the rubber band.
 %End
 

--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -281,7 +281,7 @@ Copies the points from another rubber band.
 .. versionadded:: 3.22
 %End
 
-    void addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer, bool doUpdate = true );
+    void addGeometry( const QgsGeometry &geometry, QgsMapLayer *layer, bool doUpdate = true );
 %Docstring
 Adds the geometry of an existing feature to a rubberband
 This is useful for multi feature highlighting.
@@ -293,8 +293,7 @@ If additional geometries are to be added then set ``doUpdate`` to ``False`` to d
 After adding the final geometry :py:func:`~QgsRubberBand.updatePosition` should be called.
 
 :param geometry: the geometry object. Will be treated as a collection of vertices.
-:param layer: the layer containing the feature, used for coord transformation to map
-              crs. If ``layer`` is ``None``, the coordinates are not going to be transformed.
+:param layer: the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to themap crs. If ``layer`` is ``None`` no coordinate transformation will occur.
 :param doUpdate: set to ``False`` to defer updates of the rubber band.
 %End
 

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -114,12 +114,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       if ( e->button() == Qt::LeftButton )
       {
         const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
-        if ( error == 1 )
-        {
-          QgsDebugMsg( QStringLiteral( "current layer is not a vector layer" ) );
-          return;
-        }
-        else if ( error == 2 )
+        if ( error == 2 )
         {
           //problem with coordinate transformation
           emit messageEmitted( tr( "Coordinate transform error. Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -37,7 +37,7 @@ QgsMapToolAddPart::QgsMapToolAddPart( QgsMapCanvas *canvas )
 
 QgsMapToolCapture::Capabilities QgsMapToolAddPart::capabilities() const
 {
-  return QgsMapToolCapture::SupportsCurves;
+  return QgsMapToolCapture::SupportsCurves | QgsMapToolCapture::ValidateGeometries;
 }
 
 bool QgsMapToolAddPart::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -71,12 +71,7 @@ void QgsMapToolAddRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   if ( e->button() == Qt::LeftButton )
   {
     const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
-    if ( error == 1 )
-    {
-      //current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
+    if ( error == 2 )
     {
       //problem with coordinate transformation
       emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system." ), Qgis::MessageLevel::Warning );

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -73,12 +73,7 @@ void QgsMapToolFillRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     // add point to list and to rubber band
 
     const int error = addVertex( e->mapPoint() );
-    if ( error == 1 )
-    {
-      // current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
+    if ( error == 2 )
     {
       // problem with coordinate transformation
       emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -50,12 +50,7 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   if ( e->button() == Qt::LeftButton )
   {
     const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
-    if ( error == 1 )
-    {
-      //current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
+    if ( error == 2 )
     {
       //problem with coordinate transformation
       emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -76,12 +76,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     }
 
     const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
-    if ( error == 1 )
-    {
-      //current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
+    if ( error == 2 )
     {
       //problem with coordinate transformation
       QgisApp::instance()->messageBar()->pushMessage(

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -77,12 +77,7 @@ void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     }
 
     const int error = addVertex( e->mapPoint() );
-    if ( error == 1 )
-    {
-      //current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
+    if ( error == 2 )
     {
       //problem with coordinate transformation
       QgisApp::instance()->messageBar()->pushMessage(

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -557,16 +557,23 @@ int QgsMapToolCapture::addVertex( const QgsPointXY &point, const QgsPointLocator
   if ( mCapturing && mStreamingEnabled && !mAllowAddingStreamingPoints )
     return 0;
 
-  int res;
+  int res = 0;
   QgsPoint layerPoint;
-  res = fetchLayerPoint( match, layerPoint );
-  if ( res != 0 )
+  if ( mCanvas->currentLayer() && mCanvas->currentLayer()->type() == QgsMapLayerType::VectorLayer )
   {
-    res = nextPoint( QgsPoint( point ), layerPoint );
+    res = fetchLayerPoint( match, layerPoint );
     if ( res != 0 )
     {
-      return res;
+      res = nextPoint( QgsPoint( point ), layerPoint );
+      if ( res != 0 )
+      {
+        return res;
+      }
     }
+  }
+  else
+  {
+    layerPoint = QgsPoint( point );
   }
   const QgsPoint mapPoint = toMapCoordinates( canvas()->currentLayer(), layerPoint );
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -308,7 +308,7 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
 
   // adjust last captured point
   const QgsPoint lastPt = mCaptureCurve.endPoint();
-  mCaptureLastPoint = toMapCoordinates( qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() ), lastPt );
+  mCaptureLastPoint = toMapCoordinates( mCanvas->currentLayer(), lastPt );
 
   return true;
 }
@@ -346,8 +346,7 @@ void QgsMapToolCapture::resetRubberBand()
     return;
   QgsLineString *lineString = mCaptureCurve.curveToLine();
   mRubberBand->reset( mCaptureMode == CapturePolygon ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry );
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
-  mRubberBand->addGeometry( QgsGeometry( lineString ), vlayer );
+  mRubberBand->addGeometry( QgsGeometry( lineString ), mCanvas->currentLayer() );
 }
 
 QgsRubberBand *QgsMapToolCapture::takeRubberBand()
@@ -679,8 +678,7 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
   }
 
   //transform back to layer CRS in case map CRS and layer CRS are different
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
-  const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( vlayer );
+  const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( mCanvas->currentLayer() );
   if ( ct.isValid() )
   {
     c->transform( ct, QgsCoordinateTransform::ReverseTransform );
@@ -782,7 +780,7 @@ void QgsMapToolCapture::undo( bool isAutoRepeat )
     if ( mCaptureCurve.numPoints() > 0 )
     {
       const QgsPoint lastPt = mCaptureCurve.endPoint();
-      mCaptureLastPoint = toMapCoordinates( qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() ), lastPt );
+      mCaptureLastPoint = toMapCoordinates( mCanvas->currentLayer(), lastPt );
       mTempRubberBand->addPoint( lastCapturedMapPoint() );
       mTempRubberBand->movePoint( lastPoint );
     }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -90,7 +90,7 @@ QgsMapToolCapture::~QgsMapToolCapture()
 
 QgsMapToolCapture::Capabilities QgsMapToolCapture::capabilities() const
 {
-  return QgsMapToolCapture::NoCapabilities;
+  return QgsMapToolCapture::ValidateGeometries;
 }
 
 bool QgsMapToolCapture::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const
@@ -872,7 +872,9 @@ QgsMapLayer *QgsMapToolCapture::layer() const
 
 void QgsMapToolCapture::validateGeometry()
 {
-  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries.value() == 0 )
+  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries.value() == 0
+       || !( capabilities() & ValidateGeometries )
+     )
     return;
 
   if ( mValidator )

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -288,7 +288,7 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPointXY &point )
   {
     // If the tool and the layer support curves
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
-    if ( capabilities().testFlag( QgsMapToolCapture::Capability::SupportsCurves ) && vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) )
+    if ( vlayer && capabilities().testFlag( QgsMapToolCapture::Capability::SupportsCurves ) && vlayer->dataProvider()->capabilities().testFlag( QgsVectorDataProvider::Capability::CircularGeometries ) )
     {
       const QgsGeometry linear = QgsGeometry( mCaptureCurve.segmentize() );
       const QgsGeometry curved = linear.convertToCurves(

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -149,8 +149,9 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! Specific capabilities of the tool
     enum Capability
     {
-      NoCapabilities = 0,       //!< No specific capabilities
-      SupportsCurves = 1,       //!< Supports curved geometries input
+      NoCapabilities = 1 << 0, //!< No specific capabilities
+      SupportsCurves = 1 << 1, //!< Supports curved geometries input
+      ValidateGeometries = 1 << 2, //!< Tool supports geometry validation (since QGIS 3.22)
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -390,6 +390,16 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     void closePolygon();
 
+    /**
+     * Returns the map layer associated with the geometry being captured.
+     *
+     * The base class implementation always returns the current map canvas layer, but
+     * subclasses can override this if they need to be associated with a specific layer.
+     *
+     * \since QGIS 3.22
+     */
+    virtual QgsMapLayer *layer() const;
+
   protected slots:
 
     /**

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -256,7 +256,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      *  \param[in,out] layerPoint the point in layer coordinates
      *  \returns
      *   0 in case of success
-     *   1 if the current layer is NULLPTR or not a vector layer
+     *   1 if the current layer is NULLPTR
      *   2 if the transformation failed
      */
     int nextPoint( const QgsPoint &mapPoint, QgsPoint &layerPoint );

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -314,7 +314,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     /**
      * Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
-     * \returns 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed
+     * \returns 0 in case of success, 2 if coordinate transformation failed
      */
     int addVertex( const QgsPointXY &point );
 
@@ -474,6 +474,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool mStartNewCurve = false;
 
     bool mIgnoreSubsequentAutoRepeatUndo = false;
+
+    friend class TestQgsMapToolCapture;
 
 };
 

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -45,7 +45,7 @@ QgsMapToolDigitizeFeature::QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsA
 
 QgsMapToolCapture::Capabilities QgsMapToolDigitizeFeature::capabilities() const
 {
-  return QgsMapToolCapture::SupportsCurves;
+  return QgsMapToolCapture::SupportsCurves | QgsMapToolCapture::ValidateGeometries;
 }
 
 bool QgsMapToolDigitizeFeature::supportsTechnique( QgsMapToolCapture::CaptureTechnique technique ) const

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -245,12 +245,7 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     if ( e->button() == Qt::LeftButton )
     {
       const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
-      if ( error == 1 )
-      {
-        //current layer is not a vector layer
-        return;
-      }
-      else if ( error == 2 )
+      if ( error == 2 )
       {
         //problem with coordinate transformation
         emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -284,7 +284,7 @@ void QgsRubberBand::setToGeometry( const QgsGeometry &geom, const QgsCoordinateR
   addGeometry( geom, crs );
 }
 
-void QgsRubberBand::addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer, bool doUpdate )
+void QgsRubberBand::addGeometry( const QgsGeometry &geometry, QgsMapLayer *layer, bool doUpdate )
 {
   QgsGeometry geom = geometry;
   if ( layer )

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -337,11 +337,10 @@ class GUI_EXPORT QgsRubberBand : public QgsMapCanvasItem
      * After adding the final geometry updatePosition() should be called.
      *
      *  \param geometry the geometry object. Will be treated as a collection of vertices.
-     *  \param layer the layer containing the feature, used for coord transformation to map
-     *               crs. If \a layer is NULLPTR, the coordinates are not going to be transformed.
+     *  \param layer the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to themap crs. If \a layer is NULLPTR no coordinate transformation will occur.
      *  \param doUpdate set to FALSE to defer updates of the rubber band.
      */
-    void addGeometry( const QgsGeometry &geometry, QgsVectorLayer *layer, bool doUpdate = true );
+    void addGeometry( const QgsGeometry &geometry, QgsMapLayer *layer, bool doUpdate = true );
 
     /**
      * Adds a \a geometry to the rubberband.

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -337,7 +337,7 @@ class GUI_EXPORT QgsRubberBand : public QgsMapCanvasItem
      * After adding the final geometry updatePosition() should be called.
      *
      *  \param geometry the geometry object. Will be treated as a collection of vertices.
-     *  \param layer the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to themap crs. If \a layer is NULLPTR no coordinate transformation will occur.
+     *  \param layer the layer associated with the geometry. This is used for transforming the geometry from the layer's CRS to the map crs. If \a layer is NULLPTR no coordinate transformation will occur.
      *  \param doUpdate set to FALSE to defer updates of the rubber band.
      */
     void addGeometry( const QgsGeometry &geometry, QgsMapLayer *layer, bool doUpdate = true );

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TESTS
   testqgsfocuswatcher.cpp
   testqgshtmlwidgetwrapper.cpp
   testqgsmapcanvas.cpp
+  testqgsmaptoolcapture.cpp
   testqgsmessagebar.cpp
   testprojectionissues.cpp
   testqgsgui.cpp

--- a/tests/src/gui/testqgsmaptoolcapture.cpp
+++ b/tests/src/gui/testqgsmaptoolcapture.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+    testqgsmaptooledit.cpp
+     --------------------------------------
+    Date                 : September 2021
+    Copyright            : (C) 2021 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QCoreApplication>
+
+#include "qgstest.h"
+#include "qgsguiutils.h"
+#include "qgsmaptoolcapture.h"
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+#include "qgslogger.h"
+#include "qgsannotationlayer.h"
+#include "qgsadvanceddigitizingdockwidget.h"
+
+class TestQgsMapToolCapture : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsMapToolCapture() = default;
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void addVertexNonVectorLayer();
+
+};
+
+void TestQgsMapToolCapture::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+}
+
+void TestQgsMapToolCapture::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolCapture::init()
+{
+}
+
+void TestQgsMapToolCapture::cleanup()
+{
+}
+
+void TestQgsMapToolCapture::addVertexNonVectorLayer()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer} );
+
+  canvas.setLayers( { layer } );
+  canvas.setCurrentLayer( layer );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolCapture tool( &canvas, &cadDock, QgsMapToolCapture::CaptureLine );
+  canvas.setMapTool( &tool );
+
+  // even though we don't have a vector layer selected, adding vertices should still be allowed
+  QCOMPARE( tool.addVertex( QgsPoint( 5, 5 ), QgsPointLocator::Match() ), 0 );
+
+
+}
+
+QGSTEST_MAIN( TestQgsMapToolCapture )
+#include "testqgsmaptoolcapture.moc"

--- a/tests/src/gui/testqgsmaptoolcapture.cpp
+++ b/tests/src/gui/testqgsmaptoolcapture.cpp
@@ -71,7 +71,7 @@ void TestQgsMapToolCapture::addVertexNonVectorLayer()
 
   QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
   QVERIFY( layer->isValid() );
-  QgsProject::instance()->addMapLayers( { layer} );
+  QgsProject::instance()->addMapLayers( { layer } );
 
   canvas.setLayers( { layer } );
   canvas.setCurrentLayer( layer );

--- a/tests/src/gui/testqgsmaptoolcapture.cpp
+++ b/tests/src/gui/testqgsmaptoolcapture.cpp
@@ -83,7 +83,11 @@ void TestQgsMapToolCapture::addVertexNonVectorLayer()
   // even though we don't have a vector layer selected, adding vertices should still be allowed
   QCOMPARE( tool.addVertex( QgsPoint( 5, 5 ), QgsPointLocator::Match() ), 0 );
 
-
+  // the nextPoint method must also accept non vector layers
+  QgsPoint layerPoint;
+  QCOMPARE( tool.nextPoint( QgsPoint( 5, 6 ), layerPoint ), 0 );
+  QCOMPARE( layerPoint.x(), 5.0 );
+  QCOMPARE( layerPoint.y(), 6.0 );
 }
 
 QGSTEST_MAIN( TestQgsMapToolCapture )


### PR DESCRIPTION
This class was built on the assumption that it would always be used with vector layers, but there's lots of use cases where it's useful for non-vector layers too!

This PR generalises the class to remove the assumption that it's used with a vector layer only.