### PR TITLE
Add create line/polygon annotation item tools

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -149,6 +149,8 @@ class QgsDevToolsPanelWidget;
 class QgsDevToolWidgetFactory;
 class QgsNetworkLogger;
 class QgsNetworkLoggerWidgetFactory;
+class QgsMapToolCapture;
+
 #include <QMainWindow>
 #include <QToolBar>
 #include <QAbstractSocket>
@@ -2379,6 +2381,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void enableMeshEditingTools( bool enable );
 
+    /**
+     * Returns a list of all capture map tools.
+     */
+    QList< QgsMapToolCapture * > captureTools();
 
     QgisAppStyleSheet *mStyleSheetBuilder = nullptr;
 

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -186,7 +186,11 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     QgsAnnotationPolygonItemWidget *widget = new QgsAnnotationPolygonItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
+  }, QString(), Qgis::AnnotationItemGuiFlags(), nullptr,
+  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapToolInterface *
+  {
+    return new QgsCreatePolygonItemMapTool( canvas, cadDockWidget );
+  } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "linestring" ),
                                 QObject::tr( "Line" ),
@@ -196,7 +200,11 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
     QgsAnnotationLineItemWidget *widget = new QgsAnnotationLineItemWidget( nullptr );
     widget->setItem( item );
     return widget;
-  }, QString(), Qgis::AnnotationItemGuiFlag::FlagNoCreationTools ) );
+  }, QString(), Qgis::AnnotationItemGuiFlags(), nullptr,
+  [ = ]( QgsMapCanvas * canvas, QgsAdvancedDigitizingDockWidget * cadDockWidget )->QgsCreateAnnotationItemMapToolInterface *
+  {
+    return new QgsCreateLineItemMapTool( canvas, cadDockWidget );
+  } ) );
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "marker" ),
                                 QObject::tr( "Marker" ),

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -123,6 +123,11 @@ QgsMapToolCapture::Capabilities QgsMapToolCaptureAnnotationItem::capabilities() 
   return SupportsCurves;
 }
 
+bool QgsMapToolCaptureAnnotationItem::supportsTechnique( CaptureTechnique ) const
+{
+  return true;
+}
+
 
 //
 // QgsCreateLineMapTool

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -17,10 +17,14 @@
 #include "qgsmapmouseevent.h"
 #include "qgsannotationpointtextitem.h"
 #include "qgsannotationmarkeritem.h"
+#include "qgsannotationlineitem.h"
+#include "qgsannotationpolygonitem.h"
 #include "qgsannotationlayer.h"
 #include "qgsstyle.h"
 #include "qgsmapcanvas.h"
 #include "qgsmarkersymbol.h"
+#include "qgslinesymbol.h"
+#include "qgsfillsymbol.h"
 
 ///@cond PRIVATE
 
@@ -101,6 +105,166 @@ QgsCreateAnnotationItemMapToolHandler *QgsCreateMarkerItemMapTool::handler()
 QgsMapTool *QgsCreateMarkerItemMapTool::mapTool()
 {
   return this;
+}
+
+//
+// QgsMapToolCaptureAnnotationItem
+//
+
+QgsMapToolCaptureAnnotationItem::QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
+  : QgsMapToolCapture( canvas, cadDockWidget, mode )
+{
+
+}
+
+QgsMapToolCapture::Capabilities QgsMapToolCaptureAnnotationItem::capabilities() const
+{
+  // no geometry validation!
+  return SupportsCurves;
+}
+
+
+//
+// QgsCreateLineMapTool
+//
+
+QgsCreateLineItemMapTool::QgsCreateLineItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolCaptureAnnotationItem( canvas, cadDockWidget, CaptureLine )
+  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
+{
+
+}
+
+void QgsCreateLineItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
+{
+  //add point to list and to rubber band
+  if ( e->button() == Qt::LeftButton )
+  {
+    const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
+    if ( error == 2 )
+    {
+      //problem with coordinate transformation
+      emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );
+      return;
+    }
+
+    startCapturing();
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    deleteTempRubberBand();
+
+    //find out bounding box of mCaptureList
+    if ( size() < 1 )
+    {
+      stopCapturing();
+      return;
+    }
+
+    // do it!
+    std::unique_ptr< QgsAbstractGeometry > geometry( captureCurve()->simplifiedTypeRef()->clone() );
+    if ( qgsgeometry_cast< QgsCurve * >( geometry.get() ) )
+    {
+      std::unique_ptr< QgsAnnotationLineItem > createdItem = std::make_unique< QgsAnnotationLineItem >( qgsgeometry_cast< QgsCurve * >( geometry.release() ) );
+      createdItem->setSymbol( qgis::down_cast< QgsLineSymbol * >( QgsSymbol::defaultSymbol( QgsWkbTypes::LineGeometry ) ) );
+      // set reference scale to match canvas scale, but don't enable it by default for marker items
+      createdItem->setSymbologyReferenceScale( canvas()->scale() );
+
+      mHandler->pushCreatedItem( createdItem.release() );
+    }
+    stopCapturing();
+  }
+}
+
+QgsCreateLineItemMapTool::~QgsCreateLineItemMapTool() = default;
+
+QgsCreateAnnotationItemMapToolHandler *QgsCreateLineItemMapTool::handler()
+{
+  return mHandler;
+}
+
+QgsMapTool *QgsCreateLineItemMapTool::mapTool()
+{
+  return this;
+}
+
+QgsMapLayer *QgsCreateLineItemMapTool::layer() const
+{
+  return mHandler->targetLayer();
+}
+
+
+
+//
+// QgsCreatePolygonItemMapTool
+//
+
+QgsCreatePolygonItemMapTool::QgsCreatePolygonItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolCaptureAnnotationItem( canvas, cadDockWidget, CapturePolygon )
+  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
+{
+
+}
+
+void QgsCreatePolygonItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
+{
+  //add point to list and to rubber band
+  if ( e->button() == Qt::LeftButton )
+  {
+    const int error = addVertex( e->mapPoint(), e->mapPointMatch() );
+    if ( error == 2 )
+    {
+      //problem with coordinate transformation
+      emit messageEmitted( tr( "Cannot transform the point to the layers coordinate system" ), Qgis::MessageLevel::Warning );
+      return;
+    }
+
+    startCapturing();
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    deleteTempRubberBand();
+
+    //find out bounding box of mCaptureList
+    if ( size() < 1 )
+    {
+      stopCapturing();
+      return;
+    }
+
+    closePolygon();
+
+    std::unique_ptr< QgsAbstractGeometry > geometry( captureCurve()->simplifiedTypeRef()->clone() );
+    if ( qgsgeometry_cast< QgsCurve * >( geometry.get() ) )
+    {
+      std::unique_ptr< QgsCurvePolygon > newPolygon = std::make_unique< QgsCurvePolygon >();
+      newPolygon->setExteriorRing( qgsgeometry_cast< QgsCurve * >( geometry.release() ) );
+      std::unique_ptr< QgsAnnotationPolygonItem > createdItem = std::make_unique< QgsAnnotationPolygonItem >( newPolygon.release() );
+      createdItem->setSymbol( qgis::down_cast< QgsFillSymbol * >( QgsSymbol::defaultSymbol( QgsWkbTypes::PolygonGeometry ) ) );
+      // set reference scale to match canvas scale, but don't enable it by default for marker items
+      createdItem->setSymbologyReferenceScale( canvas()->scale() );
+
+      mHandler->pushCreatedItem( createdItem.release() );
+    }
+    stopCapturing();
+  }
+}
+
+QgsCreatePolygonItemMapTool::~QgsCreatePolygonItemMapTool() = default;
+
+QgsCreateAnnotationItemMapToolHandler *QgsCreatePolygonItemMapTool::handler()
+{
+  return mHandler;
+}
+
+QgsMapTool *QgsCreatePolygonItemMapTool::mapTool()
+{
+  return this;
+}
+
+QgsMapLayer *QgsCreatePolygonItemMapTool::layer() const
+{
+  return mHandler->targetLayer();
 }
 
 ///@endcond PRIVATE

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -69,7 +69,7 @@ class QgsMapToolCaptureAnnotationItem : public QgsMapToolCapture
     QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
     QgsMapToolCapture::Capabilities capabilities() const override;
-
+    bool supportsTechnique( CaptureTechnique technique ) const override;
 
 };
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -43,7 +43,7 @@ class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public
 
 };
 
-class QgsCreateMarkerItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
+class QgsCreateMarkerItemMapTool: public QgsMapToolCapture, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
 
@@ -52,9 +52,10 @@ class QgsCreateMarkerItemMapTool: public QgsMapToolAdvancedDigitizing, public Qg
     QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
     ~QgsCreateMarkerItemMapTool() override;
 
-    void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+    void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
     QgsCreateAnnotationItemMapToolHandler *handler() override;
     QgsMapTool *mapTool() override;
+    QgsMapLayer *layer() const override;
 
   private:
 

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -18,9 +18,7 @@
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 #include "qgscreateannotationitemmaptool.h"
-
-class QgsAnnotationPointTextItem;
-class QgsAnnotationMarkerItem;
+#include "qgsmaptoolcapture.h"
 
 #define SIP_NO_FILE
 
@@ -64,6 +62,56 @@ class QgsCreateMarkerItemMapTool: public QgsMapToolAdvancedDigitizing, public Qg
 
 };
 
+class QgsMapToolCaptureAnnotationItem : public QgsMapToolCapture
+{
+    Q_OBJECT
+  public:
+    QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
+
+    QgsMapToolCapture::Capabilities capabilities() const override;
+
+
+};
+
+class QgsCreateLineItemMapTool: public QgsMapToolCaptureAnnotationItem, public QgsCreateAnnotationItemMapToolInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsCreateLineItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsCreateLineItemMapTool() override;
+
+    void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsMapTool *mapTool() override;
+    QgsMapLayer *layer() const override;
+
+  private:
+
+    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
+
+};
+
+class QgsCreatePolygonItemMapTool: public QgsMapToolCaptureAnnotationItem, public QgsCreateAnnotationItemMapToolInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsCreatePolygonItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsCreatePolygonItemMapTool() override;
+
+    void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsMapTool *mapTool() override;
+    QgsMapLayer *layer() const override;
+
+  private:
+
+    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
+
+};
 
 ///@endcond PRIVATE
 


### PR DESCRIPTION
Adds tools for creating new line and polygon annotation items. 

These use the same base class as the vector feature capture tools, so support the same interaction (snapping, tracing, cad dock, backspace to remove vertices, curve and stream digitising modes etc) as drawing vector line/polygon features

Sponsored by QGIS Swiss User Group