### PR TITLE
fix QgsBlockingNetWorkRequest race conditions

### DIFF
--- a/src/core/network/qgsblockingnetworkrequest.cpp
+++ b/src/core/network/qgsblockingnetworkrequest.cpp
@@ -162,7 +162,6 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( QgsBl
   QWaitCondition authRequestBufferNotEmpty;
   QMutex waitConditionMutex;
 
-  bool threadFinished = false;
   bool success = false;
 
   const bool requestMadeFromMainThread = QThread::currentThread() == QApplication::instance()->thread();
@@ -170,7 +169,7 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( QgsBl
   if ( mFeedback )
     connect( mFeedback, &QgsFeedback::canceled, this, &QgsBlockingNetworkRequest::abort );
 
-  const std::function<void()> downloaderFunction = [ this, request, &waitConditionMutex, &authRequestBufferNotEmpty, &threadFinished, &success, requestMadeFromMainThread ]()
+  const std::function<void()> downloaderFunction = [ this, request, &success ]()
   {
     // this function will always be run in worker threads -- either the blocking call is being made in a worker thread,
     // or the blocking call has been made from the main thread and we've fired up a new thread for this function
@@ -190,8 +189,6 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( QgsBl
       mErrorCode = NetworkError;
       mErrorMessage = errorMessageFailedAuth();
       QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
-      if ( requestMadeFromMainThread )
-        authRequestBufferNotEmpty.wakeAll();
       success = false;
     }
     else

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -800,7 +800,6 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void afterSslErrorHandled( QNetworkReply *reply );
 #endif
 
-    void unlockAfterAuthRequestHandled();
     void afterAuthRequestHandled( QNetworkReply *reply );
 
     void pauseTimeout( QNetworkReply *reply );

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -127,6 +127,8 @@ class TestAuthRequestHandler : public QgsNetworkAuthenticationHandler
 
     void handleAuthRequest( QNetworkReply *, QAuthenticator *auth ) override
     {
+      qDebug() << "authHandler";
+
       Q_ASSERT( QThread::currentThread() == QApplication::instance()->thread() );
       if ( !mUser.isEmpty() )
         auth->setUser( mUser );
@@ -816,13 +818,17 @@ void TestQgsNetworkAccessManager::testAuthRequestHandler()
   // blocking request
   hash = QUuid::createUuid().toString().mid( 1, 10 );
   u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/basic-auth/me/" ) + hash );
+
+  qDebug() << "u=" << u;
   loaded = false;
   gotAuthRequest = false;
   gotRequestAboutToBeCreatedSignal = false;
   gotAuthDetailsAdded = false;
 
   QNetworkRequest req{ u };
+  qDebug() << "hello";
   QgsNetworkReplyContent rep = QgsNetworkAccessManager::blockingGet( req );
+  qDebug() << "coucou";
   QVERIFY( rep.content().isEmpty() );
   while ( !loaded )
   {


### PR DESCRIPTION
This PR try to fix issues explained in this PR #44924

To sum up, HTTP requests are made in a thread but when there is need for authentication a handler is called (to display a dialog so the user can type its login/password for instance). This handler has to be executed in the main thread (for UI purpose). The request thread has to wait the handler before continuing the request. There is race condition issues which ends in dead lock sometimes.

This PR proposes to replace the Mutex/WaitCondition code with QEventLoop. MainThread wait the request thread to be finished and request thread wait the main thread to have properly handled authentication before continuing the request. 

I have made some stress test only on *testAuthRequestHandler* from *test_core_networkaccessmanager*, 20 iterations with random latency in code and no errors has showed for now. 

This PR is draft because I would like to now why it's bad to have a QEventLoop in the main thread (like it's mentioned in #7055) before continuing. Is there something that I'm missing? @m-kuhn Do you remember why ?

I we agree, I will make more tests and fix also the sslErrorHandler.

@MorriganR Interested on your thoughts

 
