### PR TITLE
Selected annotation item can be moved by pressing the cursor keys

### DIFF
--- a/src/gui/annotations/qgsmaptoolmodifyannotation.h
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.h
@@ -86,6 +86,12 @@ class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsMapToolAdvancedDigitizin
 
     void setHoveredItem( const QgsRenderedAnnotationItemDetails *item, const QgsRectangle &itemMapBounds );
 
+    /**
+     * Returns the delta (in layer coordinates) by which to move items
+     * for the given key \a event.
+     */
+    QSizeF deltaForKeyEvent( QgsAnnotationLayer *layer, const QgsPointXY &originalCanvasPoint, QKeyEvent *event );
+
     Action mCurrentAction = Action::NoAction;
 
     QObjectUniquePtr<QgsRubberBand> mHoverRubberBand;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1791,7 +1791,7 @@ void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
   {
     // this is backwards, but we can't change now without breaking api because
     // forever QgsMapTools have had to explicitly mark events as ignored in order to
-    // indicate that they've consumed the event and that the default behaviour should not
+    // indicate that they've consumed the event and that the default behavior should not
     // be applied..!
     e->accept();
     if ( mMapTool )


### PR DESCRIPTION
When an annotation item is selected it can be moved by pressing the cursor keys.

This follows the same interaction pattern is layout items, where

- shift + cursor key = big movement
- alt + cursor key = 1 px movement