### PR TITLE
Fix WMS connection refresh functionality

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2288,6 +2288,16 @@ QgsWmsCapabilitiesDownload::~QgsWmsCapabilitiesDownload()
   abort();
 }
 
+bool QgsWmsCapabilitiesDownload::forceRefresh()
+{
+  return mForceRefresh;
+}
+
+void QgsWmsCapabilitiesDownload::setForceRefresh( bool forceRefresh )
+{
+  mForceRefresh = forceRefresh;
+}
+
 bool QgsWmsCapabilitiesDownload::downloadCapabilities( const QString &baseUrl, const QgsWmsAuthorization &auth )
 {
   mBaseUrl = baseUrl;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -1034,6 +1034,22 @@ class QgsWmsCapabilitiesDownload : public QObject
 
     bool downloadCapabilities( const QString &baseUrl, const QgsWmsAuthorization &auth );
 
+    /**
+     * Returns the download refresh state.
+     * \see setForceRefresh()
+     *
+     * \since QGIS 3.22
+     */
+    bool forceRefresh();
+
+    /**
+     * Sets the download refresh state.
+     * \see forceRefresh()
+     *
+     * \since QGIS 3.22
+     */
+    void setForceRefresh( bool forceRefresh );
+
     QString lastError() const { return mError; }
 
     QByteArray response() const { return mHttpCapabilitiesResponse; }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -41,6 +41,12 @@ QgsWMSConnectionItem::~QgsWMSConnectionItem()
   delete mCapabilitiesDownload;
 }
 
+void QgsWMSConnectionItem::refresh()
+{
+  mCapabilitiesDownload->setForceRefresh( true );
+  QgsDataItem::refresh();
+}
+
 void QgsWMSConnectionItem::deleteLater()
 {
   if ( mCapabilitiesDownload )

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -34,6 +34,7 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
+    void refresh() override;
 
   public slots:
     void deleteLater() override;


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/40350

Ensure the WMS capabilities are refetched when refreshing connection items, this enables to check if there are new 
published layers in the WMS service.

screenshot showing refresh functionality on a WMS connection item using a Qgis server WMS service.
![wms_refresh_via_qgis_server](https://user-images.githubusercontent.com/2663775/132635064-fd22d970-0f3d-4175-a2d0-59aaca55d589.gif)
