### PR TITLE
[offline editing] fix overwriting of first field on remote layer when it has virtual fields

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1000,12 +1000,15 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVec
   {
     // NOTE: SpatiaLite provider ignores position of geometry column
     // restore gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
-    QMap<int, int> attrLookup = attributeLookup( offlineLayer, remoteLayer );
+    const QMap<int, int> attrLookup = attributeLookup( offlineLayer, remoteLayer );
     QgsAttributes newAttrs( newAttrsCount );
     const QgsAttributes attrs = it->attributes();
     for ( int it = 0; it < attrs.count(); ++it )
     {
-      const int remoteAttributeIndex = attrLookup[ it ];
+      const int remoteAttributeIndex = attrLookup.value( it, -1 );
+      // if virtual or non existing field
+      if ( remoteAttributeIndex == -1 )
+        continue;
       QVariant attr = attrs.at( it );
       if ( remoteLayer->fields().at( remoteAttributeIndex ).type() == QVariant::StringList )
       {


### PR DESCRIPTION
using `[]`operator on the lookup table was returning 0 for non existing fields.
