### PR TITLE
[processing] Fix NODATA parameters in GDAL Merge algorithm

### DIFF
--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -71,7 +71,7 @@ class merge(GdalAlgorithm):
 
         nodata_param = QgsProcessingParameterNumber(self.NODATA_INPUT,
                                                     self.tr('Input pixel value to treat as "nodata"'),
-                                                    type=QgsProcessingParameterNumber.Integer,
+                                                    type=QgsProcessingParameterNumber.Double,
                                                     defaultValue=None,
                                                     optional=True)
         nodata_param.setFlags(nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
@@ -79,7 +79,7 @@ class merge(GdalAlgorithm):
 
         nodata_out_param = QgsProcessingParameterNumber(self.NODATA_OUTPUT,
                                                         self.tr('Assign specified "nodata" value to output'),
-                                                        type=QgsProcessingParameterNumber.Integer,
+                                                        type=QgsProcessingParameterNumber.Double,
                                                         defaultValue=None,
                                                         optional=True)
         nodata_out_param.setFlags(nodata_out_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
@@ -141,12 +141,12 @@ class merge(GdalAlgorithm):
             arguments.append('-separate')
 
         if self.NODATA_INPUT in parameters and parameters[self.NODATA_INPUT] is not None:
-            nodata_input = self.parameterAsInt(parameters, self.NODATA_INPUT, context)
+            nodata_input = self.parameterAsDouble(parameters, self.NODATA_INPUT, context)
             arguments.append('-n')
             arguments.append(str(nodata_input))
 
         if self.NODATA_OUTPUT in parameters and parameters[self.NODATA_OUTPUT] is not None:
-            nodata_output = self.parameterAsInt(parameters, self.NODATA_OUTPUT, context)
+            nodata_output = self.parameterAsDouble(parameters, self.NODATA_OUTPUT, context)
             arguments.append('-a_nodata')
             arguments.append(str(nodata_output))
 

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2004,7 +2004,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
             cmd[1] = t[:t.find('--optfile') + 10] + t[t.find('mergeInputFiles.txt'):]
             self.assertEqual(cmd,
                              ['gdal_merge.py',
-                              '-a_nodata -9999 -ot Float32 -of GTiff ' +
+                              '-a_nodata -9999.0 -ot Float32 -of GTiff ' +
                               '-o ' + outdir + '/check.tif ' +
                               '--optfile mergeInputFiles.txt'])
 


### PR DESCRIPTION
## Description

Sets NODATA_INPUT and NODATA_OUTPUT parameters of the GDAL Merge (gdal:merge) algorithm as QgsProcessingParameterNumber.Double type, instead of the current incorrect QgsProcessingParameterNumber.Integer type.

This PR needs to be backported to both 3.16 and 3.20 branches.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
