### PR TITLE
Annotation layer properties and effects

### DIFF
--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -12,6 +12,7 @@
 
 
 
+
 class QgsAnnotationLayer : QgsMapLayer
 {
 %Docstring(signature="appended")
@@ -155,6 +156,26 @@ Returns ``True`` if the operation was successfully applied.
 
     virtual QString htmlMetadata() const;
 
+
+    QgsPaintEffect *paintEffect() const;
+%Docstring
+Returns the current paint effect for the layer.
+
+.. seealso:: :py:func:`setPaintEffect`
+
+.. versionadded:: 3.22
+%End
+
+    void setPaintEffect( QgsPaintEffect *effect /Transfer/ );
+%Docstring
+Sets the current paint ``effect`` for the layer.
+
+Ownership is transferred to the renderer.
+
+.. seealso:: :py:func:`paintEffect`
+
+.. versionadded:: 3.22
+%End
 
 };
 

--- a/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -153,6 +153,8 @@ Returns ``True`` if the operation was successfully applied.
 
     virtual QgsDataProvider *dataProvider();
 
+    virtual QString htmlMetadata() const;
+
 
 };
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -107,6 +107,7 @@ set(QGIS_APP_SRCS
   qgsmaptooltextannotation.cpp
 
   annotations/qgsannotationitempropertieswidget.cpp
+  annotations/qgsannotationlayerproperties.cpp
 
   decorations/qgsdecorationitem.cpp
   decorations/qgsdecorationtitle.cpp

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -18,18 +18,20 @@
 
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
+#include "ui_qgsannotationitempropertieswidgetbase.h"
 #include <QPointer>
 
 class QgsAnnotationLayer;
 class QgsAnnotationItemBaseWidget;
 class QStackedWidget;
 
-class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
+class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public Ui::QgsAnnotationItemPropertiesWidgetBase
 {
     Q_OBJECT
   public:
 
     QgsAnnotationItemPropertiesWidget( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
+    ~QgsAnnotationItemPropertiesWidget() override;
 
     void syncToLayer( QgsMapLayer *layer ) override;
     void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
@@ -42,14 +44,17 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget
   private slots:
 
     void onChanged();
+    void onLayerPropertyChanged();
   private:
 
     void setItemId( const QString &itemId );
 
-    QStackedWidget *mStack = nullptr;
     QPointer< QgsAnnotationLayer > mLayer;
     QPointer< QgsAnnotationItemBaseWidget > mItemWidget;
     QWidget *mPageNoItem = nullptr;
+    bool mBlockLayerUpdates = false;
+
+    std::unique_ptr< QgsPaintEffect > mPaintEffect;
 
 };
 

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -22,11 +22,11 @@
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsapplication.h"
-#include "qgsmetadatawidget.h"
 #include "qgsmaplayerloadstyledialog.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsdatumtransformdialog.h"
+#include "qgspainteffect.h"
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -83,6 +83,8 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
   restoreOptionsBaseUi( title );
 }
 
+QgsAnnotationLayerProperties::~QgsAnnotationLayerProperties() = default;
+
 void QgsAnnotationLayerProperties::addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory )
 {
   if ( !factory->supportsLayer( mLayer ) || !factory->supportLayerPropertiesDialog() )
@@ -114,6 +116,9 @@ void QgsAnnotationLayerProperties::apply()
   // set the blend mode and opacity for the layer
   mLayer->setBlendMode( mBlendModeComboBox->blendMode() );
   mLayer->setOpacity( mOpacityWidget->opacity() );
+
+  if ( mPaintEffect )
+    mLayer->setPaintEffect( mPaintEffect->clone() );
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->apply();
@@ -161,6 +166,12 @@ void QgsAnnotationLayerProperties::syncToLayer()
   // opacity and blend modes
   mBlendModeComboBox->setBlendMode( mLayer->blendMode() );
   mOpacityWidget->setOpacity( mLayer->opacity() );
+
+  if ( mLayer->paintEffect() )
+  {
+    mPaintEffect.reset( mLayer->paintEffect()->clone() );
+    mEffectWidget->setPaintEffect( mPaintEffect.get() );
+  }
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->syncToLayer( mLayer );

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -158,7 +158,7 @@ void QgsAnnotationLayerProperties::syncToLayer()
 
   mCrsSelector->setCrs( mLayer->crs() );
 
-  // set up the scale based layer visibility stuff....
+  // scale based layer visibility
   mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
   mScaleVisibilityGroupBox->setChecked( mLayer->hasScaleBasedVisibility() );
   mScaleRangeWidget->setMapCanvas( mMapCanvas );

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -1,0 +1,298 @@
+/***************************************************************************
+  qgsannotationlayerproperties.cpp
+  --------------------------------------
+  Date                 : September 2021
+  Copyright            : (C) 2021 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationlayerproperties.h"
+
+#include "qgsfileutils.h"
+#include "qgshelp.h"
+#include "qgsmaplayerstylemanager.h"
+#include "qgsmaplayerstyleguiutils.h"
+#include "qgsgui.h"
+#include "qgsnative.h"
+#include "qgsapplication.h"
+#include "qgsmetadatawidget.h"
+#include "qgsmaplayerloadstyledialog.h"
+#include "qgsmaplayerconfigwidgetfactory.h"
+#include "qgsmaplayerconfigwidget.h"
+#include "qgsdatumtransformdialog.h"
+#include <QFileDialog>
+#include <QMenu>
+#include <QMessageBox>
+#include <QDesktopServices>
+#include <QUrl>
+
+QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *, QWidget *parent, Qt::WindowFlags flags )
+  : QgsOptionsDialogBase( QStringLiteral( "AnnotationLayerProperties" ), parent, flags )
+  , mLayer( layer )
+  , mMapCanvas( canvas )
+{
+  setupUi( this );
+
+  connect( this, &QDialog::accepted, this, &QgsAnnotationLayerProperties::apply );
+  connect( this, &QDialog::rejected, this, &QgsAnnotationLayerProperties::onCancel );
+  connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsAnnotationLayerProperties::apply );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsAnnotationLayerProperties::showHelp );
+
+  connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsAnnotationLayerProperties::crsChanged );
+
+  // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
+  // switching vertical tabs between icon/text to icon-only modes (splitter collapsed to left),
+  // and connecting QDialogButtonBox's accepted/rejected signals to dialog's accept/reject slots
+  initOptionsBase( false );
+
+  mOptsPage_Information->setContentsMargins( 0, 0, 0, 0 );
+
+  // update based on layer's current state
+  syncToLayer();
+
+  QgsSettings settings;
+  if ( !settings.contains( QStringLiteral( "/Windows/AnnotationLayerProperties/tab" ) ) )
+  {
+    settings.setValue( QStringLiteral( "Windows/AnnotationLayerProperties/tab" ),
+                       mOptStackedWidget->indexOf( mOptsPage_Information ) );
+  }
+
+  QString title = tr( "Layer Properties - %1" ).arg( mLayer->name() );
+
+  mBtnStyle = new QPushButton( tr( "Style" ) );
+  QMenu *menuStyle = new QMenu( this );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsAnnotationLayerProperties::loadStyle );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsAnnotationLayerProperties::saveStyleAs );
+  menuStyle->addSeparator();
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsAnnotationLayerProperties::saveDefaultStyle );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsAnnotationLayerProperties::loadDefaultStyle );
+  mBtnStyle->setMenu( menuStyle );
+  connect( menuStyle, &QMenu::aboutToShow, this, &QgsAnnotationLayerProperties::aboutToShowStyleMenu );
+
+  buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
+
+  if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
+    title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
+  restoreOptionsBaseUi( title );
+}
+
+void QgsAnnotationLayerProperties::addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory )
+{
+  if ( !factory->supportsLayer( mLayer ) || !factory->supportLayerPropertiesDialog() )
+  {
+    return;
+  }
+
+  QgsMapLayerConfigWidget *page = factory->createWidget( mLayer, mMapCanvas, false, this );
+  mConfigWidgets << page;
+
+  const QString beforePage = factory->layerPropertiesPagePositionHint();
+  if ( beforePage.isEmpty() )
+    addPage( factory->title(), factory->title(), factory->icon(), page );
+  else
+    insertPage( factory->title(), factory->title(), factory->icon(), page, beforePage );
+
+  page->syncToLayer( mLayer );
+}
+
+void QgsAnnotationLayerProperties::apply()
+{
+  mLayer->setName( mLayerOrigNameLineEdit->text() );
+
+  for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
+    w->apply();
+
+  mLayer->triggerRepaint();
+}
+
+void QgsAnnotationLayerProperties::onCancel()
+{
+  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
+  {
+    // need to reset style to previous - style applied directly to the layer (not in apply())
+    QString myMessage;
+    QDomDocument doc( QStringLiteral( "qgis" ) );
+    int errorLine, errorColumn;
+    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
+    mLayer->importNamedStyle( doc, myMessage );
+    syncToLayer();
+  }
+}
+
+void QgsAnnotationLayerProperties::syncToLayer()
+{
+  // populate the general information
+  mLayerOrigNameLineEdit->setText( mLayer->name() );
+
+  /*
+   * Information Tab
+   */
+  QString myStyle = QgsApplication::reportStyleSheet();
+  myStyle.append( QStringLiteral( "body { margin: 10px; }\n " ) );
+  mInformationTextBrowser->clear();
+  mInformationTextBrowser->document()->setDefaultStyleSheet( myStyle );
+  mInformationTextBrowser->setHtml( mLayer->htmlMetadata() );
+  mInformationTextBrowser->setOpenLinks( false );
+  connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsAnnotationLayerProperties::urlClicked );
+
+  mCrsSelector->setCrs( mLayer->crs() );
+
+  for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
+    w->syncToLayer( mLayer );
+}
+
+
+void QgsAnnotationLayerProperties::loadDefaultStyle()
+{
+  bool defaultLoadedFlag = false;
+  const QString myMessage = mLayer->loadDefaultStyle( defaultLoadedFlag );
+  // reset if the default style was loaded OK only
+  if ( defaultLoadedFlag )
+  {
+    syncToLayer();
+  }
+  else
+  {
+    // otherwise let the user know what went wrong
+    QMessageBox::information( this,
+                              tr( "Default Style" ),
+                              myMessage
+                            );
+  }
+}
+
+void QgsAnnotationLayerProperties::saveDefaultStyle()
+{
+  apply(); // make sure the style to save is up-to-date
+
+  // a flag passed by reference
+  bool defaultSavedFlag = false;
+  // after calling this the above flag will be set true for success
+  // or false if the save operation failed
+  const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
+  if ( !defaultSavedFlag )
+  {
+    // let the user know what went wrong
+    QMessageBox::information( this,
+                              tr( "Default Style" ),
+                              myMessage
+                            );
+  }
+}
+
+void QgsAnnotationLayerProperties::loadStyle()
+{
+  QgsSettings settings;
+  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString fileName = QFileDialog::getOpenFileName(
+                       this,
+                       tr( "Load layer properties from style file" ),
+                       lastUsedDir,
+                       tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( fileName.isEmpty() )
+    return;
+
+  // ensure the user never omits the extension from the file name
+  if ( !fileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive ) )
+    fileName += QLatin1String( ".qml" );
+
+  mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
+
+  bool defaultLoadedFlag = false;
+  const QString message = mLayer->loadNamedStyle( fileName, defaultLoadedFlag );
+  if ( defaultLoadedFlag )
+  {
+    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( fileName ).absolutePath() );
+    syncToLayer();
+  }
+  else
+  {
+    QMessageBox::information( this, tr( "Load Style" ), message );
+  }
+}
+
+void QgsAnnotationLayerProperties::saveStyleAs()
+{
+  QgsSettings settings;
+  const QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+
+  QString outputFileName = QFileDialog::getSaveFileName(
+                             this,
+                             tr( "Save layer properties as style file" ),
+                             lastUsedDir,
+                             tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( outputFileName.isEmpty() )
+    return;
+
+  // ensure the user never omits the extension from the file name
+  outputFileName = QgsFileUtils::ensureFileNameHasExtension( outputFileName, QStringList() << QStringLiteral( "qml" ) );
+
+  apply(); // make sure the style to save is up-to-date
+
+  // then export style
+  bool defaultLoadedFlag = false;
+  QString message;
+  message = mLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );
+
+  if ( defaultLoadedFlag )
+  {
+    settings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( outputFileName ).absolutePath() );
+  }
+  else
+    QMessageBox::information( this, tr( "Save Style" ), message );
+}
+
+void QgsAnnotationLayerProperties::aboutToShowStyleMenu()
+{
+  QMenu *m = qobject_cast<QMenu *>( sender() );
+
+  QgsMapLayerStyleGuiUtils::instance()->removesExtraMenuSeparators( m );
+  // re-add style manager actions!
+  m->addSeparator();
+  QgsMapLayerStyleGuiUtils::instance()->addStyleManagerActions( m, mLayer );
+}
+
+void QgsAnnotationLayerProperties::showHelp()
+{
+  const QVariant helpPage = mOptionsStackedWidget->currentWidget()->property( "helpPage" );
+
+  if ( helpPage.isValid() )
+  {
+    QgsHelp::openHelp( helpPage.toString() );
+  }
+  else
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_vector_tiles/vector_tiles_properties.html" ) );
+  }
+}
+
+void QgsAnnotationLayerProperties::urlClicked( const QUrl &url )
+{
+  const QFileInfo file( url.toLocalFile() );
+  if ( file.exists() && !file.isDir() )
+    QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+  else
+    QDesktopServices::openUrl( url );
+}
+
+void QgsAnnotationLayerProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )
+{
+  QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mMapCanvas, tr( "Select transformation for the layer" ) );
+  mLayer->setCrs( crs );
+}
+
+void QgsAnnotationLayerProperties::optionsStackedWidget_CurrentChanged( int index )
+{
+  QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( index );
+
+  mBtnStyle->setVisible( true );
+}
+

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -108,7 +108,7 @@ void QgsAnnotationLayerProperties::apply()
 {
   mLayer->setName( mLayerOrigNameLineEdit->text() );
 
-  // set up the scale based layer visibility stuff....
+  // scale based layer visibility
   mLayer->setScaleBasedVisibility( mScaleVisibilityGroupBox->isChecked() );
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -106,6 +106,15 @@ void QgsAnnotationLayerProperties::apply()
 {
   mLayer->setName( mLayerOrigNameLineEdit->text() );
 
+  // set up the scale based layer visibility stuff....
+  mLayer->setScaleBasedVisibility( mScaleVisibilityGroupBox->isChecked() );
+  mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
+  mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
+
+  // set the blend mode and opacity for the layer
+  mLayer->setBlendMode( mBlendModeComboBox->blendMode() );
+  mLayer->setOpacity( mOpacityWidget->opacity() );
+
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->apply();
 
@@ -143,6 +152,15 @@ void QgsAnnotationLayerProperties::syncToLayer()
   connect( mInformationTextBrowser, &QTextBrowser::anchorClicked, this, &QgsAnnotationLayerProperties::urlClicked );
 
   mCrsSelector->setCrs( mLayer->crs() );
+
+  // set up the scale based layer visibility stuff....
+  mScaleRangeWidget->setScaleRange( mLayer->minimumScale(), mLayer->maximumScale() );
+  mScaleVisibilityGroupBox->setChecked( mLayer->hasScaleBasedVisibility() );
+  mScaleRangeWidget->setMapCanvas( mMapCanvas );
+
+  // opacity and blend modes
+  mBlendModeComboBox->setBlendMode( mLayer->blendMode() );
+  mOpacityWidget->setOpacity( mLayer->opacity() );
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->syncToLayer( mLayer );

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -38,6 +38,7 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
     Q_OBJECT
   public:
     QgsAnnotationLayerProperties( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
+    ~QgsAnnotationLayerProperties() override;
 
     void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
 
@@ -72,6 +73,8 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
      * was loaded but dialog is canceled.
     */
     QgsMapLayerStyle mOldStyle;
+
+    std::unique_ptr< QgsPaintEffect > mPaintEffect;
 
     QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -1,0 +1,80 @@
+/***************************************************************************
+  qgsannotationlayerproperties.h
+  --------------------------------------
+  Date                 : September 2021
+  Copyright            : (C) 2021 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSANNOTATIONLAYERPROPERTIES_H
+#define QGSANNOTATIONLAYERPROPERTIES_H
+
+#include "qgsoptionsdialogbase.h"
+
+#include "ui_qgsannotationlayerpropertiesbase.h"
+
+#include "qgsmaplayerstylemanager.h"
+
+#include "qgsannotationlayer.h"
+
+class QgsMapLayer;
+class QgsMapCanvas;
+class QgsMessageBar;
+class QgsAnnotationLayer;
+class QgsMetadataWidget;
+class QgsMapLayerConfigWidgetFactory;
+class QgsMapLayerConfigWidget;
+
+
+class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::QgsAnnotationLayerPropertiesBase
+{
+    Q_OBJECT
+  public:
+    QgsAnnotationLayerProperties( QgsAnnotationLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr, Qt::WindowFlags = QgsGuiUtils::ModalDialogFlags );
+
+    void addPropertiesPageFactory( const QgsMapLayerConfigWidgetFactory *factory );
+
+  private slots:
+    void apply();
+    void onCancel();
+
+    void loadDefaultStyle();
+    void saveDefaultStyle();
+    void loadStyle();
+    void saveStyleAs();
+    void aboutToShowStyleMenu();
+    void showHelp();
+    void urlClicked( const QUrl &url );
+    void crsChanged( const QgsCoordinateReferenceSystem &crs );
+
+  protected slots:
+    void optionsStackedWidget_CurrentChanged( int index ) override SIP_SKIP ;
+
+  private:
+    void syncToLayer();
+
+  private:
+    QgsAnnotationLayer *mLayer = nullptr;
+
+    QPushButton *mBtnStyle = nullptr;
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+
+    /**
+     * Previous layer style. Used to reset style to previous state if new style
+     * was loaded but dialog is canceled.
+    */
+    QgsMapLayerStyle mOldStyle;
+
+    QList<QgsMapLayerConfigWidget *> mConfigWidgets;
+
+};
+
+#endif // QGSANNOTATIONLAYERPROPERTIES_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2984,6 +2984,10 @@ void QgisApp::createActions()
 
   connect( mActionCreateAnnotationLayer, &QAction::triggered, this, &QgisApp::createAnnotationLayer );
   connect( mActionModifyAnnotation, &QAction::triggered, this, [ = ] {  mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ); } );
+  connect( mMainAnnotationLayerProperties, &QAction::triggered, this, [ = ]
+  {
+    showLayerProperties( QgsProject::instance()->mainAnnotationLayer() );
+  } );
 
   // we can't set the shortcut these actions, because we need to restrict their context to the canvas and it's children..
   for ( QWidget *widget :
@@ -3891,6 +3895,15 @@ void QgisApp::createToolBars()
     for ( QAction *mapToolAction : editMeshMapTool->mapToolActions() )
       mMapToolGroup->addAction( mapToolAction );
   }
+
+  QToolButton *annotationLayerToolButton = new QToolButton();
+  annotationLayerToolButton->setPopupMode( QToolButton::MenuButtonPopup );
+  QMenu *annotationLayerMenu = new QMenu();
+  annotationLayerMenu->addAction( mActionCreateAnnotationLayer );
+  annotationLayerMenu->addAction( mMainAnnotationLayerProperties );
+  annotationLayerToolButton->setMenu( annotationLayerMenu );
+  annotationLayerToolButton->setDefaultAction( mActionCreateAnnotationLayer );
+  mAnnotationsToolBar->insertWidget( mAnnotationsToolBar->actions().at( 0 ), annotationLayerToolButton );
 }
 
 void QgisApp::createStatusBar()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -433,6 +433,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgssublayersdialog.h"
 #include "ogr/qgsvectorlayersaveasdialog.h"
 #include "qgsannotationitemguiregistry.h"
+#include "annotations/qgsannotationlayerproperties.h"
 #include "qgscreateannotationitemmaptool.h"
 
 #include "pointcloud/qgspointcloudelevationpropertieswidget.h"
@@ -16711,6 +16712,25 @@ void QgisApp::showLayerProperties( QgsMapLayer *mapLayer, const QString &page )
 
     case QgsMapLayerType::AnnotationLayer:
     {
+      QgsAnnotationLayerProperties annotationLayerPropertiesDialog( qobject_cast<QgsAnnotationLayer *>( mapLayer ), mMapCanvas, visibleMessageBar(), this );
+
+      if ( !page.isEmpty() )
+        annotationLayerPropertiesDialog.setCurrentPage( page );
+      else
+        annotationLayerPropertiesDialog.restoreLastPage();
+
+      for ( const QgsMapLayerConfigWidgetFactory *factory : std::as_const( providerFactories ) )
+      {
+        annotationLayerPropertiesDialog.addPropertiesPageFactory( factory );
+      }
+
+      mMapStyleWidget->blockUpdates( true );
+      if ( annotationLayerPropertiesDialog.exec() )
+      {
+        activateDeactivateLayerRelatedActions( mapLayer );
+        mMapStyleWidget->updateCurrentWidgetLayer();
+      }
+      mMapStyleWidget->blockUpdates( false ); // delete since dialog cannot be reused without updating code
       break;
     }
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -672,11 +672,12 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
       }
 
       case QgsMapLayerType::PointCloudLayer:
+      case QgsMapLayerType::AnnotationLayer:
       {
         break;
       }
+
       case QgsMapLayerType::PluginLayer:
-      case QgsMapLayerType::AnnotationLayer:
       {
         mStackedWidget->setCurrentIndex( mNotSupportedPage );
         break;

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -483,6 +483,31 @@ QString QgsAnnotationLayer::htmlMetadata() const
   // CRS
   metadata += crsHtmlMetadata();
 
+  // items section
+  metadata += QStringLiteral( "<h1>" ) + tr( "Items" ) + QStringLiteral( "</h1>\n<hr>\n" );
+
+  metadata += QLatin1String( "<table width=\"100%\" class=\"tabular-view\">\n" );
+  metadata += QLatin1String( "<tr><th>" ) + tr( "Type" ) + QLatin1String( "</th><th>" ) + tr( "Count" ) + QLatin1String( "</th></tr>\n" );
+
+  QMap< QString, int > itemCounts;
+  for ( auto it = mItems.constBegin(); it != mItems.constEnd(); ++it )
+  {
+    itemCounts[ it.value()->type() ]++;
+  }
+
+  const QMap<QString, QString> itemTypes = QgsApplication::annotationItemRegistry()->itemTypes();
+  int i = 0;
+  for ( auto it = itemTypes.begin(); it != itemTypes.end(); ++it )
+  {
+    QString rowClass;
+    if ( i % 2 )
+      rowClass = QStringLiteral( "class=\"odd-row\"" );
+    metadata += QLatin1String( "<tr " ) + rowClass + QLatin1String( "><td>" ) + it.value() + QLatin1String( "</td><td>" ) + locale.toString( static_cast<qlonglong>( itemCounts.value( it.key() ) ) ) + QLatin1String( "</td></tr>\n" );
+    i++;
+  }
+
+  metadata += QLatin1String( "</table>\n<br><br>" );
+
   metadata += QLatin1String( "\n</body>\n</html>\n" );
   return metadata;
 }

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -461,6 +461,32 @@ const QgsDataProvider *QgsAnnotationLayer::dataProvider() const
   return mDataProvider;
 }
 
+QString QgsAnnotationLayer::htmlMetadata() const
+{
+  QString metadata = QStringLiteral( "<html>\n<body>\n<h1>" ) + tr( "General" ) + QStringLiteral( "</h1>\n<hr>\n" ) + QStringLiteral( "<table class=\"list-view\">\n" );
+
+  metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
+
+  // Extent
+  metadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Extent" ) + QStringLiteral( "</td><td>" ) + extent().toString() + QStringLiteral( "</td></tr>\n" );
+
+  // item count
+  QLocale locale = QLocale();
+  locale.setNumberOptions( locale.numberOptions() &= ~QLocale::NumberOption::OmitGroupSeparator );
+  const int itemCount = mItems.size();
+  metadata += QStringLiteral( "<tr><td class=\"highlight\">" )
+              + tr( "Item count" ) + QStringLiteral( "</td><td>" )
+              + locale.toString( static_cast<qlonglong>( itemCount ) )
+              + QStringLiteral( "</td></tr>\n" );
+  metadata += QLatin1String( "</table>\n<br><br>" );
+
+  // CRS
+  metadata += crsHtmlMetadata();
+
+  metadata += QLatin1String( "\n</body>\n</html>\n" );
+  return metadata;
+}
+
 
 //
 // QgsAnnotationLayerDataProvider

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -170,6 +170,7 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     bool supportsEditing() const override;
     QgsDataProvider *dataProvider() override;
     const QgsDataProvider *dataProvider() const override SIP_SKIP;
+    QString htmlMetadata() const override;
 
   private:
 

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -25,6 +25,8 @@
 
 class QgsAnnotationItem;
 class QgsAbstractAnnotationItemEditOperation;
+class QgsPaintEffect;
+
 
 ///@cond PRIVATE
 class QgsAnnotationLayerSpatialIndex;
@@ -172,6 +174,23 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     const QgsDataProvider *dataProvider() const override SIP_SKIP;
     QString htmlMetadata() const override;
 
+    /**
+     * Returns the current paint effect for the layer.
+     * \see setPaintEffect()
+     * \since QGIS 3.22
+     */
+    QgsPaintEffect *paintEffect() const;
+
+    /**
+     * Sets the current paint \a effect for the layer.
+     *
+     * Ownership is transferred to the renderer.
+     *
+     * \see paintEffect()
+     * \since QGIS 3.22
+     */
+    void setPaintEffect( QgsPaintEffect *effect SIP_TRANSFER );
+
   private:
 
     QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
@@ -183,6 +202,8 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
     QSet< QString > mNonIndexedItems;
 
     QgsDataProvider *mDataProvider = nullptr;
+
+    std::unique_ptr< QgsPaintEffect > mPaintEffect;
 
     friend class QgsAnnotationLayerRenderer;
 

--- a/src/core/annotations/qgsannotationlayerrenderer.cpp
+++ b/src/core/annotations/qgsannotationlayerrenderer.cpp
@@ -18,6 +18,7 @@
 #include "qgsannotationlayer.h"
 #include "qgsfeedback.h"
 #include "qgsrenderedannotationitemdetails.h"
+#include "qgspainteffect.h"
 #include <optional>
 
 QgsAnnotationLayerRenderer::QgsAnnotationLayerRenderer( QgsAnnotationLayer *layer, QgsRenderContext &context )
@@ -50,6 +51,11 @@ QgsAnnotationLayerRenderer::QgsAnnotationLayerRenderer( QgsAnnotationLayer *laye
                const std::pair< QString, std::unique_ptr< QgsAnnotationItem > > &a,
                const std::pair< QString, std::unique_ptr< QgsAnnotationItem > > &b )
   { return a.second->zIndex() < b.second->zIndex(); } );
+
+  if ( layer->paintEffect() && layer->paintEffect()->enabled() )
+  {
+    mPaintEffect.reset( layer->paintEffect()->clone() );
+  }
 }
 
 QgsAnnotationLayerRenderer::~QgsAnnotationLayerRenderer() = default;
@@ -62,6 +68,11 @@ QgsFeedback *QgsAnnotationLayerRenderer::feedback() const
 bool QgsAnnotationLayerRenderer::render()
 {
   QgsRenderContext &context = *renderContext();
+
+  if ( mPaintEffect )
+  {
+    mPaintEffect->begin( context );
+  }
 
   bool canceled = false;
   for ( const std::pair< QString, std::unique_ptr< QgsAnnotationItem > > &item : std::as_const( mItems ) )
@@ -87,6 +98,12 @@ bool QgsAnnotationLayerRenderer::render()
       appendRenderedItemDetails( details.release() );
     }
   }
+
+  if ( mPaintEffect )
+  {
+    mPaintEffect->end( context );
+  }
+
   return !canceled;
 }
 

--- a/src/core/annotations/qgsannotationlayerrenderer.h
+++ b/src/core/annotations/qgsannotationlayerrenderer.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 class QgsAnnotationLayer;
+class QgsPaintEffect;
 
 /**
  * \ingroup core
@@ -53,6 +54,7 @@ class CORE_EXPORT QgsAnnotationLayerRenderer : public QgsMapLayerRenderer
     std::vector < std::pair< QString, std::unique_ptr< QgsAnnotationItem > > > mItems;
     std::unique_ptr< QgsFeedback > mFeedback;
     double mLayerOpacity = 1.0;
+    std::unique_ptr< QgsPaintEffect > mPaintEffect;
 
 };
 

--- a/src/ui/annotations/qgsannotationitempropertieswidgetbase.ui
+++ b/src/ui/annotations/qgsannotationitempropertieswidgetbase.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAnnotationItemPropertiesWidgetBase</class>
+ <widget class="QWidget" name="QgsAnnotationItemPropertiesWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>424</width>
+    <height>702</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Annotation Item Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QStackedWidget" name="mStack">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mLayerRenderingGroupBox">
+     <property name="title">
+      <string>Layer Rendering</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="saveCollapsedState" stdset="0">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="1" colspan="3">
+       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lblBlend">
+        <property name="text">
+         <string>Blending mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="4">
+       <widget class="QgsEffectStackCompactWidget" name="mEffectWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="3">
+       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsEffectStackCompactWidget</class>
+   <extends>QWidget</extends>
+   <header>qgseffectstackpropertieswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/annotations/qgsannotationitempropertieswidgetbase.ui
+++ b/src/ui/annotations/qgsannotationitempropertieswidgetbase.ui
@@ -36,7 +36,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="mLayerRenderingGroupBox">
+    <widget class="QgsCollapsibleGroupBox" name="mLayerRenderingGroupBox">
      <property name="title">
       <string>Layer Rendering</string>
      </property>
@@ -109,6 +109,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>

--- a/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
+++ b/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>815</width>
-    <height>557</height>
+    <width>966</width>
+    <height>691</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -122,6 +122,18 @@
             <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>Rendering</string>
+          </property>
+          <property name="toolTip">
+           <string>Rendering</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>
@@ -164,7 +176,7 @@
           <enum>QFrame::Plain</enum>
          </property>
          <property name="currentIndex">
-          <number>1</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -285,6 +297,146 @@
            </item>
           </layout>
          </widget>
+         <widget class="QWidget" name="page">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QgsScrollArea" name="scrollArea_19">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents_19">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>812</width>
+                <height>640</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mScaleVisibilityGroupBox">
+                 <property name="title">
+                  <string>Scale Dependen&amp;t Visibility</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_6">
+                  <item row="0" column="0">
+                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="mLayerRenderingGroupBox">
+                 <property name="title">
+                  <string>Layer Rendering</string>
+                 </property>
+                 <property name="flat">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checkable">
+                  <bool>false</bool>
+                 </property>
+                 <property name="collapsed" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <property name="saveCollapsedState" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>3</number>
+                  </property>
+                  <item row="1" column="2" colspan="2">
+                   <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>4</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="3">
+                   <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="lblTransparency">
+                    <property name="text">
+                     <string>Opacity</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="lblBlend">
+                    <property name="text">
+                     <string>Blending mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -349,6 +501,28 @@
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
+++ b/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
@@ -384,20 +384,17 @@
                   <property name="rightMargin">
                    <number>3</number>
                   </property>
-                  <item row="1" column="2" colspan="2">
-                   <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                      <horstretch>4</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                   </widget>
-                  </item>
                   <item row="0" column="1" colspan="3">
                    <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="lblBlend">
+                    <property name="text">
+                     <string>Blending mode</string>
                     </property>
                    </widget>
                   </item>
@@ -408,10 +405,26 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="lblBlend">
-                    <property name="text">
-                     <string>Blending mode</string>
+                  <item row="2" column="0" colspan="4">
+                   <widget class="QgsEffectStackCompactWidget" name="mEffectWidget" native="true">
+                    <property name="minimumSize">
+                     <size>
+                      <width>16</width>
+                      <height>16</height>
+                     </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                      <horstretch>4</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
                     </property>
                    </widget>
                   </item>
@@ -520,6 +533,12 @@
    <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsEffectStackCompactWidget</class>
+   <extends>QWidget</extends>
+   <header>qgseffectstackpropertieswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsOpacityWidget</class>
    <extends>QWidget</extends>
    <header>qgsopacitywidget.h</header>
@@ -529,6 +548,16 @@
  <tabstops>
   <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mOptionsListWidget</tabstop>
+  <tabstop>mInformationTextBrowser</tabstop>
+  <tabstop>mLayerOrigNameLineEdit</tabstop>
+  <tabstop>mCrsGroupBox</tabstop>
+  <tabstop>mCrsSelector</tabstop>
+  <tabstop>scrollArea_19</tabstop>
+  <tabstop>mScaleVisibilityGroupBox</tabstop>
+  <tabstop>mScaleRangeWidget</tabstop>
+  <tabstop>mOpacityWidget</tabstop>
+  <tabstop>mBlendModeComboBox</tabstop>
+  <tabstop>mEffectWidget</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
+++ b/src/ui/annotations/qgsannotationlayerpropertiesbase.ui
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAnnotationLayerPropertiesBase</class>
+ <widget class="QDialog" name="QgsAnnotationLayerPropertiesBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>815</width>
+    <height>557</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>700</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Annotation Layer Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="mOptionsSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QFrame" name="mOptionsListFrame">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QgsFilterLineEdit" name="mSearchLineEdit"/>
+       </item>
+       <item>
+        <widget class="QListWidget" name="mOptionsListWidget">
+         <property name="minimumSize">
+          <size>
+           <width>58</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>150</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <item>
+          <property name="text">
+           <string>Information</string>
+          </property>
+          <property name="toolTip">
+           <string>Information</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Source</string>
+          </property>
+          <property name="toolTip">
+           <string>Source</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="mOptionsFrame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QStackedWidget" name="mOptionsStackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <widget class="QWidget" name="mOptsPage_Information">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QTextBrowser" name="mInformationTextBrowser"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptsPage_Source">
+          <layout class="QVBoxLayout" name="verticalLayout_9">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="groupBox_60">
+             <property name="title">
+              <string>Settings</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_260">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_13">
+                <item>
+                 <widget class="QLabel" name="label_6">
+                  <property name="text">
+                   <string>Layer name</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="mLayerOrigNameLineEdit"/>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="mCrsGroupBox">
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+             <property name="title">
+              <string>Assigned Coordinate Reference System (CRS)</string>
+             </property>
+             <property name="checkable">
+              <bool>false</bool>
+             </property>
+             <property name="syncGroup" stdset="0">
+              <string notr="true">vectorgeneral</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_28">
+              <property name="spacing">
+               <number>6</number>
+              </property>
+              <item>
+               <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_7">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Changing this option does not modify the original data source or perform any reprojection of points. Rather, it can be used to override the layer's CRS within this project if it could not be detected or has been incorrectly detected.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="Line" name="line_2">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="mButtonBoxFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0" colspan="2">
+       <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mSearchLineEdit</tabstop>
+  <tabstop>mOptionsListWidget</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>mOptionsListWidget</sender>
+   <signal>currentRowChanged(int)</signal>
+   <receiver>mOptionsStackedWidget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>86</x>
+     <y>325</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>794</x>
+     <y>14</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1064</width>
+    <width>1277</width>
     <height>506</height>
    </rect>
   </property>
@@ -16,7 +16,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1064</width>
+     <width>1277</width>
      <height>24</height>
     </rect>
    </property>
@@ -801,7 +801,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="mActionCreateAnnotationLayer"/>
    <addaction name="mActionModifyAnnotation"/>
   </widget>
   <action name="mActionNewProject">
@@ -3564,7 +3563,7 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
   </action>
   <action name="mActionNewMeshLayer">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/mActionNewMeshLayer.svg</normaloff>:/images/themes/default/mActionNewMeshLayer.svg</iconset>
    </property>
    <property name="text">
@@ -3608,6 +3607,11 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
    </property>
    <property name="toolTip">
     <string>Modify Annotations</string>
+   </property>
+  </action>
+  <action name="mMainAnnotationLayerProperties">
+   <property name="text">
+    <string>Main Annotation Layer Properties…</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR adds more goodness for annotation layers:

- An annotation layer properties window, containing some basic information about the layer and options to set scale ranges, opacity, blend mode and draw effects for the layer
- An option to view the main annotation layer's properties via the annotation toolbar (the main annotation layer is the hidden layer which is always present above all other map layers, so it's impossible to open it's property window via the layer tree)
- Options to set an annotation layer's opacity/blend mode/paint effect in the layer styling dock for interactive changes
