### PR TITLE
Add Annotation layer parameter type to processing, new algorithm for converting main annotation layer items to secondary annotation layer

### DIFF
--- a/python/core/auto_additions/qgsprocessingutils.py
+++ b/python/core/auto_additions/qgsprocessingutils.py
@@ -15,5 +15,8 @@ QgsProcessingUtils.LayerHint.Mesh.__doc__ = "Mesh layer type, since QGIS 3.6"
 QgsProcessingUtils.PointCloud = QgsProcessingUtils.LayerHint.PointCloud
 QgsProcessingUtils.PointCloud.is_monkey_patched = True
 QgsProcessingUtils.LayerHint.PointCloud.__doc__ = "Point cloud layer type, since QGIS 3.22"
-QgsProcessingUtils.LayerHint.__doc__ = 'Layer type hints.\n\n.. versionadded:: 3.4\n\n' + '* ``UnknownType``: ' + QgsProcessingUtils.LayerHint.UnknownType.__doc__ + '\n' + '* ``Vector``: ' + QgsProcessingUtils.LayerHint.Vector.__doc__ + '\n' + '* ``Raster``: ' + QgsProcessingUtils.LayerHint.Raster.__doc__ + '\n' + '* ``Mesh``: ' + QgsProcessingUtils.LayerHint.Mesh.__doc__ + '\n' + '* ``PointCloud``: ' + QgsProcessingUtils.LayerHint.PointCloud.__doc__
+QgsProcessingUtils.Annotation = QgsProcessingUtils.LayerHint.Annotation
+QgsProcessingUtils.Annotation.is_monkey_patched = True
+QgsProcessingUtils.LayerHint.Annotation.__doc__ = "Annotation layer type, since QGIS 3.22"
+QgsProcessingUtils.LayerHint.__doc__ = 'Layer type hints.\n\n.. versionadded:: 3.4\n\n' + '* ``UnknownType``: ' + QgsProcessingUtils.LayerHint.UnknownType.__doc__ + '\n' + '* ``Vector``: ' + QgsProcessingUtils.LayerHint.Vector.__doc__ + '\n' + '* ``Raster``: ' + QgsProcessingUtils.LayerHint.Raster.__doc__ + '\n' + '* ``Mesh``: ' + QgsProcessingUtils.LayerHint.Mesh.__doc__ + '\n' + '* ``PointCloud``: ' + QgsProcessingUtils.LayerHint.PointCloud.__doc__ + '\n' + '* ``Annotation``: ' + QgsProcessingUtils.LayerHint.Annotation.__doc__
 # --

--- a/python/core/auto_generated/processing/qgsprocessing.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessing.sip.in
@@ -38,7 +38,8 @@ and parameters.
       TypeVector,
       TypeMesh,
       TypePlugin,
-      TypePointCloud
+      TypePointCloud,
+      TypeAnnotation
     };
 
     enum PythonOutputType

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -989,6 +989,16 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
+    QgsAnnotationLayer *parameterAsAnnotationLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to an annotation layer.
+
+Annotation layers will either be taken from ``context``'s active project. Callers do not
+need to handle deletion of the returned layer.
+
+.. versionadded:: 3.22
+%End
+
     static QString invalidSourceError( const QVariantMap &parameters, const QString &name );
 %Docstring
 Returns a user-friendly string to use as an error when a source parameter could

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -993,8 +993,15 @@ need to handle deletion of the returned layer.
 %Docstring
 Evaluates the parameter with matching ``name`` to an annotation layer.
 
-Annotation layers will either be taken from ``context``'s active project. Callers do not
+Annotation layers will be taken from ``context``'s active project. Callers do not
 need to handle deletion of the returned layer.
+
+.. warning::
+
+   Working with annotation layers is generally not thread safe (unless the layers are from
+   a :py:class:`QgsProject` loaded directly in a background thread). Ensure your algorithm returns the
+   QgsProcessingAlgorithm.FlagNoThreading flag or only accesses annotation layers from a :py:func:`~QgsProcessingAlgorithm.prepareAlgorithm`
+   or :py:func:`~QgsProcessingAlgorithm.postProcessAlgorithm` step.
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -323,6 +323,8 @@ their acceptable ranges, defaults, etc.
       sipType = sipType_QgsProcessingParameterMeshDatasetTime;
     else if ( sipCpp->type() == QgsProcessingParameterPointCloudLayer::typeName() )
       sipType = sipType_QgsProcessingParameterPointCloudLayer;
+    else if ( sipCpp->type() == QgsProcessingParameterAnnotationLayer::typeName() )
+      sipType = sipType_QgsProcessingParameterAnnotationLayer;
     else
       sipType = nullptr;
 %End
@@ -1538,6 +1540,25 @@ need to handle deletion of the returned layer.
 .. versionadded:: 3.22
 %End
 
+    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` to an annotation layer.
+
+Layers will either be taken from ``context``'s active project. Callers do not
+need to handle deletion of the returned layer.
+
+.. versionadded:: 3.22
+%End
+
+    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` and ``value`` to an annotation layer.
+
+Layers will either be taken from ``context``'s active project. Callers do not
+need to handle deletion of the returned layer.
+
+.. versionadded:: 3.22
+%End
 
     static QgsProcessingParameterDefinition *parameterFromVariantMap( const QVariantMap &map ) /Factory/;
 %Docstring
@@ -4508,6 +4529,43 @@ Creates a new parameter using the definition from a script code.
 %End
 };
 
+
+class QgsProcessingParameterAnnotationLayer : QgsProcessingParameterDefinition
+{
+%Docstring(signature="appended")
+An annotation layer parameter for processing algorithms.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameters.h"
+%End
+  public:
+
+    QgsProcessingParameterAnnotationLayer( const QString &name, const QString &description = QString(),
+                                           const QVariant &defaultValue = QVariant(), bool optional = false );
+%Docstring
+Constructor for QgsProcessingParameterAnnotationLayer.
+%End
+
+    static QString typeName();
+%Docstring
+Returns the type name for the parameter class.
+%End
+    virtual QgsProcessingParameterDefinition *clone() const /Factory/;
+
+    virtual QString type() const;
+    virtual bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = 0 ) const;
+
+    virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
+
+
+    static QgsProcessingParameterAnnotationLayer *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
+%Docstring
+Creates a new parameter using the definition from a script code.
+%End
+};
 
 
 

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1544,8 +1544,15 @@ need to handle deletion of the returned layer.
 %Docstring
 Evaluates the parameter with matching ``definition`` to an annotation layer.
 
-Layers will either be taken from ``context``'s active project. Callers do not
+Layers will be taken from ``context``'s active project. Callers do not
 need to handle deletion of the returned layer.
+
+.. warning::
+
+   Working with annotation layers is generally not thread safe (unless the layers are from
+   a :py:class:`QgsProject` loaded directly in a background thread). Ensure your algorithm returns the
+   :py:class:`QgsProcessingAlgorithm`.FlagNoThreading flag or only accesses annotation layers from a :py:func:`~QgsProcessingParameters.prepareAlgorithm`
+   or :py:func:`~QgsProcessingParameters.postProcessAlgorithm` step.
 
 .. versionadded:: 3.22
 %End
@@ -1554,8 +1561,15 @@ need to handle deletion of the returned layer.
 %Docstring
 Evaluates the parameter with matching ``definition`` and ``value`` to an annotation layer.
 
-Layers will either be taken from ``context``'s active project. Callers do not
+Layers will be taken from ``context``'s active project. Callers do not
 need to handle deletion of the returned layer.
+
+.. warning::
+
+   Working with annotation layers is generally not thread safe (unless the layers are from
+   a :py:class:`QgsProject` loaded directly in a background thread). Ensure your algorithm returns the
+   :py:class:`QgsProcessingAlgorithm`.FlagNoThreading flag or only accesses annotation layers from a :py:func:`~QgsProcessingParameters.prepareAlgorithm`
+   or :py:func:`~QgsProcessingParameters.postProcessAlgorithm` step.
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -41,6 +41,8 @@ value.
 
 .. seealso:: :py:func:`compatiblePointCloudLayers`
 
+.. seealso:: :py:func:`compatibleAnnotationLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -67,6 +69,8 @@ value.
 
 .. seealso:: :py:func:`compatiblePointCloudLayers`
 
+.. seealso:: :py:func:`compatibleAnnotationLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 %End
 
@@ -85,6 +89,8 @@ value.
 .. seealso:: :py:func:`compatiblePluginLayers`
 
 .. seealso:: :py:func:`compatiblePointCloudLayers`
+
+.. seealso:: :py:func:`compatibleAnnotationLayers`
 
 .. seealso:: :py:func:`compatibleLayers`
 
@@ -107,6 +113,8 @@ value.
 
 .. seealso:: :py:func:`compatiblePointCloudLayers`
 
+.. seealso:: :py:func:`compatibleAnnotationLayers`
+
 .. seealso:: :py:func:`compatibleLayers`
 
 .. versionadded:: 3.22
@@ -127,6 +135,31 @@ value.
 .. seealso:: :py:func:`compatibleMeshLayers`
 
 .. seealso:: :py:func:`compatiblePluginLayers`
+
+.. seealso:: :py:func:`compatibleAnnotationLayers`
+
+.. seealso:: :py:func:`compatibleLayers`
+
+.. versionadded:: 3.22
+%End
+
+    static QList<QgsAnnotationLayer *> compatibleAnnotationLayers( QgsProject *project, bool sort = true );
+%Docstring
+Returns a list of annotation layers from a ``project`` which are compatible with the processing
+framework.
+
+If the ``sort`` argument is ``True`` then the layers will be sorted by their :py:func:`QgsMapLayer.name()`
+value.
+
+.. seealso:: :py:func:`compatibleRasterLayers`
+
+.. seealso:: :py:func:`compatibleVectorLayers`
+
+.. seealso:: :py:func:`compatibleMeshLayers`
+
+.. seealso:: :py:func:`compatiblePluginLayers`
+
+.. seealso:: :py:func:`compatiblePointCloudLayers`
 
 .. seealso:: :py:func:`compatibleLayers`
 
@@ -175,6 +208,7 @@ Decodes a provider key and layer ``uri`` from an encoded string, for use with
       Raster,
       Mesh,
       PointCloud,
+      Annotation,
     };
 
     static QgsMapLayer *mapLayerFromString( const QString &string, QgsProcessingContext &context, bool allowLoadingNewLayers = true, QgsProcessingUtils::LayerHint typeHint = QgsProcessingUtils::LayerHint::UnknownType );

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -60,7 +60,8 @@ from qgis.core import (QgsRasterLayer,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterColor,
-                       QgsProcessingParameterPointCloudLayer)
+                       QgsProcessingParameterPointCloudLayer,
+                       QgsProcessingParameterAnnotationLayer)
 
 from qgis.PyQt.QtCore import QCoreApplication
 
@@ -108,7 +109,10 @@ def getParameterFromString(s, context=''):
             if clazz == QgsProcessingParameterRasterLayer:
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False
-            if clazz == QgsProcessingParameterPointCloudLayer:
+            elif clazz == QgsProcessingParameterPointCloudLayer:
+                if len(params) > 3:
+                    params[3] = True if params[3].lower() == 'true' else False
+            elif clazz == QgsProcessingParameterAnnotationLayer:
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False
             elif clazz == QgsProcessingParameterBand:

--- a/python/processing/algfactory.py
+++ b/python/processing/algfactory.py
@@ -67,6 +67,7 @@ from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProcessingParameterDatabaseTable,
                        QgsProcessingParameterCoordinateOperation,
                        QgsProcessingParameterPointCloudLayer,
+                       QgsProcessingParameterAnnotationLayer,
                        QgsProcessingOutputString,
                        QgsProcessingOutputBoolean,
                        QgsProcessingOutputFile,
@@ -346,6 +347,7 @@ class ProcessingAlgFactory():
     DATABASE_TABLE = "DATABASE_TABLE"
     COORDINATE_OPERATION = "COORDINATE_OPERATION"
     POINT_CLOUD_LAYER = "POINT_CLOUD_LAYER"
+    ANNOTATION_LAYER = "ANNOTATION_LAYER"
 
     def __init__(self):
         self._current = None
@@ -486,6 +488,7 @@ class ProcessingAlgFactory():
             alg.DATABASE_TABLE: QgsProcessingParameterDatabaseTable
             alg.COORDINATE_OPERATION: QgsProcessingParameterCoordinateOperation
             alg.POINT_CLOUD_LAYER: QgsProcessingParameterPointCloudLayer
+            alg.ANNOTATION_LAYER: QgsProcessingParameterAnnotationLayer
 
         :param type: The type of the input. This should be a type define on `alg` like alg.STRING, alg.DISTANCE
         :keyword label: The label of the output. Translates into `description` arg.
@@ -544,7 +547,8 @@ input_type_mapping = {
     ProcessingAlgFactory.DATABASE_SCHEMA: QgsProcessingParameterDatabaseSchema,
     ProcessingAlgFactory.DATABASE_TABLE: QgsProcessingParameterDatabaseTable,
     ProcessingAlgFactory.COORDINATE_OPERATION: QgsProcessingParameterCoordinateOperation,
-    ProcessingAlgFactory.POINT_CLOUD_LAYER: QgsProcessingParameterPointCloudLayer
+    ProcessingAlgFactory.POINT_CLOUD_LAYER: QgsProcessingParameterPointCloudLayer,
+    ProcessingAlgFactory.ANNOTATION_LAYER: QgsProcessingParameterAnnotationLayer
 }
 
 output_type_mapping = {

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -39,6 +39,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmaffinetransform.cpp
   processing/qgsalgorithmaggregate.cpp
   processing/qgsalgorithmangletonearest.cpp
+  processing/qgsalgorithmannotations.cpp
   processing/qgsalgorithmapplylayerstyle.cpp
   processing/qgsalgorithmarraytranslatedfeatures.cpp
   processing/qgsalgorithmaspect.cpp

--- a/src/analysis/processing/qgsalgorithmannotations.cpp
+++ b/src/analysis/processing/qgsalgorithmannotations.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+                         qgsalgorithmannotations.cpp
+                         ------------------------------
+    begin                : September 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmannotations.h"
+#include "qgsannotationlayer.h"
+
+///@cond PRIVATE
+
+QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::name() const
+{
+  return QStringLiteral( "transferannotationsfrommain" );
+}
+
+QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::displayName() const
+{
+  return QObject::tr( "Transfer annotations from main layer" );
+}
+
+QStringList QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::tags() const
+{
+  return QObject::tr( "annotations,drawing,cosmetic,objects" ).split( ',' );
+}
+
+QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::group() const
+{
+  return QObject::tr( "Cartography" );
+}
+
+QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::groupId() const
+{
+  return QStringLiteral( "cartography" );
+}
+
+QgsProcessingAlgorithm::Flags QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagRequiresProject;
+}
+
+
+QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Transfer all annotations from the main annotation layer in a project to a new annotation layer." );
+}
+
+QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm *QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::createInstance() const
+{
+  return new QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm();
+}
+
+void QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "LAYER_NAME" ), QObject::tr( "New layer name" ), QObject::tr( "Annotations" ) ) );
+
+  addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "New annotation layer" ) ) );
+}
+
+QVariantMap QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  if ( !context.project() )
+    throw QgsProcessingException( QObject::tr( "No project available." ) );
+
+  QgsAnnotationLayer *main = context.project()->mainAnnotationLayer();
+  if ( !main )
+    throw QgsProcessingException( QObject::tr( "Could not load main annotation layer for project." ) );
+
+  std::unique_ptr< QgsAnnotationLayer > newLayer( main->clone() );
+  newLayer->setName( parameterAsString( parameters, QStringLiteral( "LAYER_NAME" ), context ) );
+  main->clear();
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), newLayer->id() );
+
+  context.project()->addMapLayer( newLayer.release() );
+
+  return outputs;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmannotations.cpp
+++ b/src/analysis/processing/qgsalgorithmannotations.cpp
@@ -20,55 +20,55 @@
 
 ///@cond PRIVATE
 
-QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::name() const
+QString QgsTransferAnnotationsFromMainAlgorithm::name() const
 {
   return QStringLiteral( "transferannotationsfrommain" );
 }
 
-QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::displayName() const
+QString QgsTransferAnnotationsFromMainAlgorithm::displayName() const
 {
   return QObject::tr( "Transfer annotations from main layer" );
 }
 
-QStringList QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::tags() const
+QStringList QgsTransferAnnotationsFromMainAlgorithm::tags() const
 {
   return QObject::tr( "annotations,drawing,cosmetic,objects" ).split( ',' );
 }
 
-QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::group() const
+QString QgsTransferAnnotationsFromMainAlgorithm::group() const
 {
   return QObject::tr( "Cartography" );
 }
 
-QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::groupId() const
+QString QgsTransferAnnotationsFromMainAlgorithm::groupId() const
 {
   return QStringLiteral( "cartography" );
 }
 
-QgsProcessingAlgorithm::Flags QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::flags() const
+QgsProcessingAlgorithm::Flags QgsTransferAnnotationsFromMainAlgorithm::flags() const
 {
   return QgsProcessingAlgorithm::flags() | QgsProcessingAlgorithm::FlagNoThreading | QgsProcessingAlgorithm::FlagRequiresProject;
 }
 
 
-QString QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::shortHelpString() const
+QString QgsTransferAnnotationsFromMainAlgorithm::shortHelpString() const
 {
   return QObject::tr( "Transfer all annotations from the main annotation layer in a project to a new annotation layer." );
 }
 
-QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm *QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::createInstance() const
+QgsTransferAnnotationsFromMainAlgorithm *QgsTransferAnnotationsFromMainAlgorithm::createInstance() const
 {
-  return new QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm();
+  return new QgsTransferAnnotationsFromMainAlgorithm();
 }
 
-void QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::initAlgorithm( const QVariantMap & )
+void QgsTransferAnnotationsFromMainAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterString( QStringLiteral( "LAYER_NAME" ), QObject::tr( "New layer name" ), QObject::tr( "Annotations" ) ) );
 
   addOutput( new QgsProcessingOutputMapLayer( QStringLiteral( "OUTPUT" ), QObject::tr( "New annotation layer" ) ) );
 }
 
-QVariantMap QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+QVariantMap QgsTransferAnnotationsFromMainAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   if ( !context.project() )
     throw QgsProcessingException( QObject::tr( "No project available." ) );

--- a/src/analysis/processing/qgsalgorithmannotations.h
+++ b/src/analysis/processing/qgsalgorithmannotations.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+                         qgsalgorithmannotations.h
+                         ------------------------------
+    begin                : September 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMANNOTATIONS_H
+#define QGSALGORITHMANNOTATIONS_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native transfer annotations from main annotation layer algorithm
+ */
+class QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    Flags flags() const override;
+    QString shortHelpString() const override;
+    QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMANNOTATIONS_H

--- a/src/analysis/processing/qgsalgorithmannotations.h
+++ b/src/analysis/processing/qgsalgorithmannotations.h
@@ -28,12 +28,12 @@
 /**
  * Native transfer annotations from main annotation layer algorithm
  */
-class QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm : public QgsProcessingAlgorithm
+class QgsTransferAnnotationsFromMainAlgorithm : public QgsProcessingAlgorithm
 {
 
   public:
 
-    QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm() = default;
+    QgsTransferAnnotationsFromMainAlgorithm() = default;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;
@@ -42,7 +42,7 @@ class QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm : public QgsProcess
     QString groupId() const override;
     Flags flags() const override;
     QString shortHelpString() const override;
-    QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm *createInstance() const override SIP_FACTORY;
+    QgsTransferAnnotationsFromMainAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -23,6 +23,7 @@
 #include "qgsalgorithmaffinetransform.h"
 #include "qgsalgorithmaggregate.h"
 #include "qgsalgorithmangletonearest.h"
+#include "qgsalgorithmannotations.h"
 #include "qgsalgorithmapplylayerstyle.h"
 #include "qgsalgorithmarraytranslatedfeatures.h"
 #include "qgsalgorithmaspect.h"
@@ -477,6 +478,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsTaperedBufferAlgorithm() );
   addAlgorithm( new QgsTinMeshCreationAlgorithm() );
   addAlgorithm( new QgsTransectAlgorithm() );
+  addAlgorithm( new QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm() );
   addAlgorithm( new QgsTransformAlgorithm() );
   addAlgorithm( new QgsTranslateAlgorithm() );
   addAlgorithm( new QgsTruncateTableAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -478,7 +478,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsTaperedBufferAlgorithm() );
   addAlgorithm( new QgsTinMeshCreationAlgorithm() );
   addAlgorithm( new QgsTransectAlgorithm() );
-  addAlgorithm( new QgsTransferAnnotationsFromMainAnnotationLayerAlgorithm() );
+  addAlgorithm( new QgsTransferAnnotationsFromMainAlgorithm() );
   addAlgorithm( new QgsTransformAlgorithm() );
   addAlgorithm( new QgsTranslateAlgorithm() );
   addAlgorithm( new QgsTruncateTableAlgorithm() );

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsProcessing
     //! Data source types enum
     enum SourceType
     {
-      TypeMapLayer = -2, //!< Any map layer type (raster, vector, mesh, point cloud or plugin layer)
+      TypeMapLayer = -2, //!< Any map layer type (raster, vector, mesh, point cloud, annotation or plugin layer)
       TypeVectorAnyGeometry = -1, //!< Any vector layer with geometry
       TypeVectorPoint = 0, //!< Vector point layers
       TypeVectorLine = 1, //!< Vector line layers
@@ -54,7 +54,8 @@ class CORE_EXPORT QgsProcessing
       TypeVector = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
       TypeMesh = 6, //!< Mesh layers \since QGIS 3.6
       TypePlugin = 7, //!< Plugin layers \since QGIS 3.22
-      TypePointCloud = 8 //!< Point cloud layers \since QGIS 3.22
+      TypePointCloud = 8, //!< Point cloud layers \since QGIS 3.22
+      TypeAnnotation = 9 //!< Annotation layers \since QGIS 3.22
     };
 
     //! Available Python output types
@@ -94,6 +95,8 @@ class CORE_EXPORT QgsProcessing
           return QStringLiteral( "TypePlugin" );
         case QgsProcessing::TypePointCloud:
           return QStringLiteral( "TypePointCloud" );
+        case QgsProcessing::TypeAnnotation:
+          return QStringLiteral( "TypeAnnotation" );
       }
       return QString();
     }

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -801,6 +801,11 @@ QgsPointCloudLayer *QgsProcessingAlgorithm::parameterAsPointCloudLayer( const QV
   return QgsProcessingParameters::parameterAsPointCloudLayer( parameterDefinition( name ), parameters, context );
 }
 
+QgsAnnotationLayer *QgsProcessingAlgorithm::parameterAsAnnotationLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
+{
+  return QgsProcessingParameters::parameterAsAnnotationLayer( parameterDefinition( name ), parameters, context );
+}
+
 QString QgsProcessingAlgorithm::invalidSourceError( const QVariantMap &parameters, const QString &name )
 {
   if ( !parameters.contains( name ) )

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -991,8 +991,13 @@ class CORE_EXPORT QgsProcessingAlgorithm
     /**
      * Evaluates the parameter with matching \a name to an annotation layer.
      *
-     * Annotation layers will either be taken from \a context's active project. Callers do not
+     * Annotation layers will be taken from \a context's active project. Callers do not
      * need to handle deletion of the returned layer.
+     *
+     * \warning Working with annotation layers is generally not thread safe (unless the layers are from
+     * a QgsProject loaded directly in a background thread). Ensure your algorithm returns the
+     * QgsProcessingAlgorithm::FlagNoThreading flag or only accesses annotation layers from a prepareAlgorithm()
+     * or postProcessAlgorithm() step.
      *
      * \since QGIS 3.22
      */

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -989,6 +989,16 @@ class CORE_EXPORT QgsProcessingAlgorithm
     QgsPointCloudLayer *parameterAsPointCloudLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 
     /**
+     * Evaluates the parameter with matching \a name to an annotation layer.
+     *
+     * Annotation layers will either be taken from \a context's active project. Callers do not
+     * need to handle deletion of the returned layer.
+     *
+     * \since QGIS 3.22
+     */
+    QgsAnnotationLayer *parameterAsAnnotationLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+
+    /**
      * Returns a user-friendly string to use as an error when a source parameter could
      * not be loaded.
      *

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1599,8 +1599,13 @@ class CORE_EXPORT QgsProcessingParameters
     /**
      * Evaluates the parameter with matching \a definition to an annotation layer.
      *
-     * Layers will either be taken from \a context's active project. Callers do not
+     * Layers will be taken from \a context's active project. Callers do not
      * need to handle deletion of the returned layer.
+     *
+     * \warning Working with annotation layers is generally not thread safe (unless the layers are from
+     * a QgsProject loaded directly in a background thread). Ensure your algorithm returns the
+     * QgsProcessingAlgorithm::FlagNoThreading flag or only accesses annotation layers from a prepareAlgorithm()
+     * or postProcessAlgorithm() step.
      *
      * \since QGIS 3.22
      */
@@ -1609,8 +1614,13 @@ class CORE_EXPORT QgsProcessingParameters
     /**
      * Evaluates the parameter with matching \a definition and \a value to an annotation layer.
      *
-     * Layers will either be taken from \a context's active project. Callers do not
+     * Layers will be taken from \a context's active project. Callers do not
      * need to handle deletion of the returned layer.
+     *
+     * \warning Working with annotation layers is generally not thread safe (unless the layers are from
+     * a QgsProject loaded directly in a background thread). Ensure your algorithm returns the
+     * QgsProcessingAlgorithm::FlagNoThreading flag or only accesses annotation layers from a prepareAlgorithm()
+     * or postProcessAlgorithm() step.
      *
      * \since QGIS 3.22
      */

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -43,6 +43,7 @@ class QgsProcessingProvider;
 class QgsPrintLayout;
 class QgsLayoutItem;
 class QgsPointCloudLayer;
+class QgsAnnotationLayer;
 
 /**
  * \class QgsProcessingFeatureSourceDefinition
@@ -433,6 +434,8 @@ class CORE_EXPORT QgsProcessingParameterDefinition
       sipType = sipType_QgsProcessingParameterMeshDatasetTime;
     else if ( sipCpp->type() == QgsProcessingParameterPointCloudLayer::typeName() )
       sipType = sipType_QgsProcessingParameterPointCloudLayer;
+    else if ( sipCpp->type() == QgsProcessingParameterAnnotationLayer::typeName() )
+      sipType = sipType_QgsProcessingParameterAnnotationLayer;
     else
       sipType = nullptr;
     SIP_END
@@ -1593,6 +1596,25 @@ class CORE_EXPORT QgsProcessingParameters
      */
     static QgsPointCloudLayer *parameterAsPointCloudLayer( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context );
 
+    /**
+     * Evaluates the parameter with matching \a definition to an annotation layer.
+     *
+     * Layers will either be taken from \a context's active project. Callers do not
+     * need to handle deletion of the returned layer.
+     *
+     * \since QGIS 3.22
+     */
+    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+
+    /**
+     * Evaluates the parameter with matching \a definition and \a value to an annotation layer.
+     *
+     * Layers will either be taken from \a context's active project. Callers do not
+     * need to handle deletion of the returned layer.
+     *
+     * \since QGIS 3.22
+     */
+    static QgsAnnotationLayer *parameterAsAnnotationLayer( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context );
 
     /**
      * Creates a new QgsProcessingParameterDefinition using the configuration from a
@@ -4208,6 +4230,37 @@ class CORE_EXPORT QgsProcessingParameterPointCloudLayer : public QgsProcessingPa
     static QgsProcessingParameterPointCloudLayer *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) SIP_FACTORY;
 };
 
+
+/**
+ * \class QgsProcessingParameterAnnotationLayer
+ * \ingroup core
+ * \brief An annotation layer parameter for processing algorithms.
+  * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsProcessingParameterAnnotationLayer : public QgsProcessingParameterDefinition
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingParameterAnnotationLayer.
+     */
+    QgsProcessingParameterAnnotationLayer( const QString &name, const QString &description = QString(),
+                                           const QVariant &defaultValue = QVariant(), bool optional = false );
+
+    /**
+     * Returns the type name for the parameter class.
+     */
+    static QString typeName() { return QStringLiteral( "annotation" ); }
+    QgsProcessingParameterDefinition *clone() const override SIP_FACTORY;
+    QString type() const override { return typeName(); }
+    bool checkValueIsAcceptable( const QVariant &input, QgsProcessingContext *context = nullptr ) const override;
+    QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
+
+    /**
+     * Creates a new parameter using the definition from a script code.
+     */
+    static QgsProcessingParameterAnnotationLayer *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) SIP_FACTORY;
+};
 
 // clazy:excludeall=qstring-allocations
 

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -2108,7 +2108,7 @@ class CORE_EXPORT QgsProcessingParameterTypeDatabaseTable: public QgsProcessingP
  * \brief A point cloud layer parameter for processing algorithms.
  *
  * \ingroup core
- * \note No Python bindings available. Get your copy from QgsApplication.processingRegistry().parameterType('mesh')
+ * \note No Python bindings available. Get your copy from QgsApplication.processingRegistry().parameterType('pointcloud')
  * \since QGIS 3.22
  */
 class CORE_EXPORT QgsProcessingParameterTypePointCloudLayer : public QgsProcessingParameterType
@@ -2154,6 +2154,60 @@ class CORE_EXPORT QgsProcessingParameterTypePointCloudLayer : public QgsProcessi
     QStringList acceptedStringValues() const override
     {
       return QStringList() << QObject::tr( "Path to a point cloud layer" );
+    }
+};
+
+
+/**
+ * \brief An annotation layer parameter for processing algorithms.
+ *
+ * \ingroup core
+ * \note No Python bindings available. Get your copy from QgsApplication.processingRegistry().parameterType('annotation')
+ * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsProcessingParameterTypeAnnotationLayer : public QgsProcessingParameterType
+{
+    QgsProcessingParameterDefinition *create( const QString &name ) const override SIP_FACTORY
+    {
+      return new QgsProcessingParameterAnnotationLayer( name );
+    }
+
+    QString description() const override
+    {
+      return QCoreApplication::translate( "Processing", "An annotation layer parameter." );
+    }
+
+    QString name() const override
+    {
+      return QCoreApplication::translate( "Processing", "Annotation Layer" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterAnnotationLayer" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterAnnotationLayer" );
+    }
+
+    QString id() const override
+    {
+      return QStringLiteral( "annotation" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "\"main\": main annotation layer for a project" )
+             << QStringLiteral( "QgsAnnotationLayer" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Layer ID for an annotation layer, or \"main\" for the main annotation layer in a project." );
     }
 };
 

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -74,6 +74,7 @@ QgsProcessingRegistry::QgsProcessingRegistry( QObject *parent SIP_TRANSFERTHIS )
   addParameterType( new QgsProcessingParameterTypeMeshDatasetGroups() );
   addParameterType( new QgsProcessingParameterTypeMeshDatasetTime() );
   addParameterType( new QgsProcessingParameterTypePointCloudLayer() );
+  addParameterType( new QgsProcessingParameterTypeAnnotationLayer() );
 }
 
 QgsProcessingRegistry::~QgsProcessingRegistry()

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -36,6 +36,7 @@
 #include "qgsrasterfilewriter.h"
 #include "qgsvectortilelayer.h"
 #include "qgspointcloudlayer.h"
+#include "qgsannotationlayer.h"
 #include <QRegularExpression>
 #include <QUuid>
 
@@ -80,6 +81,24 @@ QList<QgsPluginLayer *> QgsProcessingUtils::compatiblePluginLayers( QgsProject *
 QList<QgsPointCloudLayer *> QgsProcessingUtils::compatiblePointCloudLayers( QgsProject *project, bool sort )
 {
   return compatibleMapLayers< QgsPointCloudLayer >( project, sort );
+}
+
+QList<QgsAnnotationLayer *> QgsProcessingUtils::compatibleAnnotationLayers( QgsProject *project, bool sort )
+{
+  // we have to defer sorting until we've added the main annotation layer too
+  QList<QgsAnnotationLayer *> res = compatibleMapLayers< QgsAnnotationLayer >( project, false );
+  if ( project )
+    res.append( project->mainAnnotationLayer() );
+
+  if ( sort )
+  {
+    std::sort( res.begin(), res.end(), []( const QgsAnnotationLayer * a, const QgsAnnotationLayer * b ) -> bool
+    {
+      return QString::localeAwareCompare( a->name(), b->name() ) < 0;
+    } );
+  }
+
+  return res;
 }
 
 template<typename T> QList<T *> QgsProcessingUtils::compatibleMapLayers( QgsProject *project, bool sort )
@@ -127,6 +146,11 @@ QList<QgsMapLayer *> QgsProcessingUtils::compatibleLayers( QgsProject *project, 
   const auto pointCloudLayers = compatibleMapLayers< QgsPointCloudLayer >( project, false );
   for ( QgsPointCloudLayer *pcl : pointCloudLayers )
     layers << pcl;
+
+  const auto annotationLayers = compatibleMapLayers< QgsAnnotationLayer >( project, false );
+  for ( QgsAnnotationLayer *al : annotationLayers )
+    layers << al;
+  layers << project->mainAnnotationLayer();
 
   const auto pluginLayers = compatibleMapLayers< QgsPluginLayer >( project, false );
   for ( QgsPluginLayer *pl : pluginLayers )
@@ -182,10 +206,10 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromStore( const QString &string, QgsMa
         return !canUseLayer( qobject_cast< QgsMeshLayer * >( layer ) );
       case QgsMapLayerType::VectorTileLayer:
         return !canUseLayer( qobject_cast< QgsVectorTileLayer * >( layer ) );
-      case QgsMapLayerType::AnnotationLayer:
-        return true;
       case QgsMapLayerType::PointCloudLayer:
         return !canUseLayer( qobject_cast< QgsPointCloudLayer * >( layer ) );
+      case QgsMapLayerType::AnnotationLayer:
+        return !canUseLayer( qobject_cast< QgsAnnotationLayer * >( layer ) );
     }
     return true;
   } ), layers.end() );
@@ -208,6 +232,9 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromStore( const QString &string, QgsMa
 
       case LayerHint::PointCloud:
         return l->type() == QgsMapLayerType::PointCloudLayer;
+
+      case LayerHint::Annotation:
+        return l->type() == QgsMapLayerType::AnnotationLayer;
     }
     return true;
   };
@@ -351,6 +378,9 @@ QgsMapLayer *QgsProcessingUtils::mapLayerFromString( const QString &string, QgsP
     return nullptr;
 
   // prefer project layers
+  if ( context.project() && typeHint == LayerHint::Annotation && string.compare( QLatin1String( "main" ), Qt::CaseInsensitive ) == 0 )
+    return context.project()->mainAnnotationLayer();
+
   QgsMapLayer *layer = nullptr;
   if ( auto *lProject = context.project() )
   {
@@ -537,6 +567,11 @@ bool QgsProcessingUtils::canUseLayer( const QgsRasterLayer *layer )
 }
 
 bool QgsProcessingUtils::canUseLayer( const QgsPointCloudLayer *layer )
+{
+  return layer && layer->isValid();
+}
+
+bool QgsProcessingUtils::canUseLayer( const QgsAnnotationLayer *layer )
 {
   return layer && layer->isValid();
 }

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -39,6 +39,7 @@ class QgsProcessingFeatureSource;
 class QgsProcessingAlgorithm;
 class QgsVectorTileLayer;
 class QgsPointCloudLayer;
+class QgsAnnotationLayer;
 
 #include <QString>
 #include <QVariant>
@@ -63,6 +64,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \see compatibleMeshLayers()
      * \see compatiblePluginLayers()
      * \see compatiblePointCloudLayers()
+     * \see compatibleAnnotationLayers()
      * \see compatibleLayers()
      */
     static QList< QgsRasterLayer * > compatibleRasterLayers( QgsProject *project, bool sort = true );
@@ -82,6 +84,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \see compatibleMeshLayers()
      * \see compatiblePluginLayers()
      * \see compatiblePointCloudLayers()
+     * \see compatibleAnnotationLayers()
      * \see compatibleLayers()
      */
     static QList< QgsVectorLayer * > compatibleVectorLayers( QgsProject *project,
@@ -99,6 +102,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \see compatibleVectorLayers()
      * \see compatiblePluginLayers()
      * \see compatiblePointCloudLayers()
+     * \see compatibleAnnotationLayers()
      * \see compatibleLayers()
      *
      * \since QGIS 3.6
@@ -116,6 +120,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \see compatibleVectorLayers()
      * \see compatibleMeshLayers()
      * \see compatiblePointCloudLayers()
+     * \see compatibleAnnotationLayers()
      * \see compatibleLayers()
      *
      * \since QGIS 3.22
@@ -133,11 +138,30 @@ class CORE_EXPORT QgsProcessingUtils
      * \see compatibleVectorLayers()
      * \see compatibleMeshLayers()
      * \see compatiblePluginLayers()
+     * \see compatibleAnnotationLayers()
      * \see compatibleLayers()
      *
      * \since QGIS 3.22
      */
     static QList<QgsPointCloudLayer *> compatiblePointCloudLayers( QgsProject *project, bool sort = true );
+
+    /**
+     * Returns a list of annotation layers from a \a project which are compatible with the processing
+     * framework.
+     *
+     * If the \a sort argument is TRUE then the layers will be sorted by their QgsMapLayer::name()
+     * value.
+     *
+     * \see compatibleRasterLayers()
+     * \see compatibleVectorLayers()
+     * \see compatibleMeshLayers()
+     * \see compatiblePluginLayers()
+     * \see compatiblePointCloudLayers()
+     * \see compatibleLayers()
+     *
+     * \since QGIS 3.22
+     */
+    static QList<QgsAnnotationLayer *> compatibleAnnotationLayers( QgsProject *project, bool sort = true );
 
     /**
      * Returns a list of map layers from a \a project which are compatible with the processing
@@ -182,6 +206,7 @@ class CORE_EXPORT QgsProcessingUtils
       Raster, //!< Raster layer type
       Mesh, //!< Mesh layer type, since QGIS 3.6
       PointCloud, //!< Point cloud layer type, since QGIS 3.22
+      Annotation, //!< Annotation layer type, since QGIS 3.22
     };
 
     /**
@@ -461,6 +486,7 @@ class CORE_EXPORT QgsProcessingUtils
     static bool canUseLayer( const QgsPluginLayer *layer );
     static bool canUseLayer( const QgsVectorTileLayer *layer );
     static bool canUseLayer( const QgsPointCloudLayer *layer );
+    static bool canUseLayer( const QgsAnnotationLayer *layer );
     static bool canUseLayer( const QgsVectorLayer *layer,
                              const QList< int > &sourceTypes = QList< int >() );
 

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -80,6 +80,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingMeshDatasetGroupsWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingMeshDatasetTimeWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingPointCloudLayerWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingAnnotationLayerWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsrasterlayer.h"
 #include "qgspluginlayer.h"
 #include "qgspointcloudlayer.h"
+#include "qgsannotationlayer.h"
 #include "qgsproject.h"
 #include "processing/models/qgsprocessingmodelchildparametersource.h"
 #include <QStandardItemModel>
@@ -362,6 +363,9 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
 
 
     QString id = layer->id();
+    if ( layer == project->mainAnnotationLayer() )
+      id = QStringLiteral( "main" );
+
     for ( int i = 0; i < mModel->rowCount(); ++i )
     {
       // try to match project layers to current layers
@@ -417,6 +421,17 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
       break;
     }
 
+    case QgsProcessing::TypeAnnotation:
+    {
+      const QList<QgsAnnotationLayer *> options = QgsProcessingUtils::compatibleAnnotationLayers( project, false );
+      for ( const QgsAnnotationLayer *layer : options )
+      {
+        addLayer( layer );
+      }
+
+      break;
+    }
+
     case QgsProcessing::TypePointCloud:
     {
       const QList<QgsPointCloudLayer *> options = QgsProcessingUtils::compatiblePointCloudLayers( project, false );
@@ -464,6 +479,11 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
       }
       const QList<QgsPointCloudLayer *> pointClouds = QgsProcessingUtils::compatiblePointCloudLayers( project );
       for ( const QgsPointCloudLayer *layer : pointClouds )
+      {
+        addLayer( layer );
+      }
+      const QList<QgsAnnotationLayer *> annotations = QgsProcessingUtils::compatibleAnnotationLayers( project );
+      for ( const QgsAnnotationLayer *layer : annotations )
       {
         addLayer( layer );
       }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -66,6 +66,7 @@ class QgsProcessingMapLayerComboBox;
 class QgsRasterBandComboBox;
 class QgsProcessingLayerOutputDestinationWidget;
 class QgsCheckableComboBox;
+class QgsMapLayerComboBox;
 
 ///@cond PRIVATE
 
@@ -2282,6 +2283,46 @@ class GUI_EXPORT QgsProcessingPointCloudLayerWidgetWrapper : public QgsProcessin
 
     QString modelerExpressionFormatString() const override;
 
+};
+
+
+class GUI_EXPORT QgsProcessingAnnotationLayerWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingAnnotationLayerWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) override;
+    void setWidgetContext( const QgsProcessingParameterWidgetContext &context ) override;
+
+    QWidget *createWidget() override SIP_FACTORY;
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+
+    QStringList compatibleOutputTypes() const override;
+
+    QString modelerExpressionFormatString() const override;
+
+  private:
+
+    QPointer< QgsMapLayerComboBox > mComboBox;
+    int mBlockSignals = 0;
+
+    friend class TestProcessingGui;
 };
 
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -967,13 +967,13 @@ void TestQgsProcessing::compatibleLayers()
   lIds.clear();
   for ( QgsAnnotationLayer *pcl : QgsProcessingUtils::compatibleAnnotationLayers( &p ) )
     lIds << pcl->name();
-  QCOMPARE( lIds, QStringList() << "Annotations" << "secondary annotation layer" );
+  QCOMPARE( lIds, QStringList() << QObject::tr( "Annotations" ) << "secondary annotation layer" );
 
   // unsorted
   lIds.clear();
   for ( QgsAnnotationLayer *pcl : QgsProcessingUtils::compatibleAnnotationLayers( &p, false ) )
     lIds << pcl->name();
-  QCOMPARE( lIds, QStringList() << "secondary annotation layer" << "Annotations" );
+  QCOMPARE( lIds, QStringList() << "secondary annotation layer" << QObject::tr( "Annotations" ) );
 
   // point only
   lIds.clear();
@@ -1019,9 +1019,9 @@ void TestQgsProcessing::compatibleLayers()
   for ( QgsMapLayer *l : QgsProcessingUtils::compatibleLayers( &p ) )
     lIds << l->name();
 #ifdef HAVE_EPT
-  QCOMPARE( lIds, QStringList() << "Annotations" << "ar2" << "mA" << "MX" << "pA" << "pcA" << "PCX" << "PX" << "R1" << "secondary annotation layer" << "v1" << "v3" << "V4" << "vvvv4" <<  "zz" );
+  QCOMPARE( lIds, QStringList() << QObject::tr( "Annotations" ) << "ar2" << "mA" << "MX" << "pA" << "pcA" << "PCX" << "PX" << "R1" << "secondary annotation layer" << "v1" << "v3" << "V4" << "vvvv4" <<  "zz" );
 #else
-  QCOMPARE( lIds, QStringList() << "Annotations" << "ar2" << "mA" << "MX" << "pA" << "PX" << "R1" << "secondary annotation layer" << "v1" << "v3" << "V4" << "vvvv4" <<  "zz" );
+  QCOMPARE( lIds, QStringList() << QObject::tr( "Annotations" ) << "ar2" << "mA" << "MX" << "pA" << "PX" << "R1" << "secondary annotation layer" << "v1" << "v3" << "V4" << "vvvv4" <<  "zz" );
 #endif
 
   // unsorted
@@ -1029,9 +1029,9 @@ void TestQgsProcessing::compatibleLayers()
   for ( QgsMapLayer *l : QgsProcessingUtils::compatibleLayers( &p, false ) )
     lIds << l->name();
 #ifdef HAVE_EPT
-  QCOMPARE( lIds, QStringList() << "R1" << "ar2" << "zz"  << "V4" << "v1" << "v3" << "vvvv4" << "MX" << "mA" << "PCX" << "pcA" << "secondary annotation layer" << "Annotations" << "PX" << "pA" );
+  QCOMPARE( lIds, QStringList() << "R1" << "ar2" << "zz"  << "V4" << "v1" << "v3" << "vvvv4" << "MX" << "mA" << "PCX" << "pcA" << "secondary annotation layer" << QObject::tr( "Annotations" ) << "PX" << "pA" );
 #else
-  QCOMPARE( lIds, QStringList() << "R1" << "ar2" << "zz"  << "V4" << "v1" << "v3" << "vvvv4" << "MX" << "mA" << "secondary annotation layer" << "Annotations" << "PX" << "pA" );
+  QCOMPARE( lIds, QStringList() << "R1" << "ar2" << "zz"  << "V4" << "v1" << "v3" << "vvvv4" << "MX" << "mA" << "secondary annotation layer" << QObject::tr( "Annotations" ) << "PX" << "pA" );
 #endif
 }
 


### PR DESCRIPTION
This is useful for moving items created in the main layer to a secondary layer, so that the item placement can be adjusted within the
layer stack