### PR TITLE
VertexTool. Fixes move vertex on Z layer if CRS are differents

### DIFF
--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -195,10 +195,11 @@ The id of the feature to which the snapped geometry belongs.
 Only for a valid edge match - obtain endpoints of the edge
 %End
 
-        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &projectCrs, const QgsMapLayer *sourceLayer ) const;
+        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &destinationCrs ) const;
 %Docstring
 Convenient method to return a point on an edge with linear
 interpolation of the Z value.
+The parameter ``destinationCrs`` depends of where the instance of this Match is created (geom.cache: layer CRS, map canvas snapper: dest CRS)
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -195,7 +195,7 @@ The id of the feature to which the snapped geometry belongs.
 Only for a valid edge match - obtain endpoints of the edge
 %End
 
-        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &destinationCrs ) const;
+        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem() ) const;
 %Docstring
 Convenient method to return a point on an edge with linear
 interpolation of the Z value.

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -195,7 +195,7 @@ The id of the feature to which the snapped geometry belongs.
 Only for a valid edge match - obtain endpoints of the edge
 %End
 
-        QgsPoint interpolatedPoint() const;
+        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &projectCrs, const QgsMapLayer *sourceLayer ) const;
 %Docstring
 Convenient method to return a point on an edge with linear
 interpolation of the Z value.

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -281,6 +281,15 @@ Constructor takes a map canvas as a parameter.
 Transforms a ``point`` from screen coordinates to map coordinates.
 %End
 
+    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) /PyName=toLayerCoordinatesV2/;
+%Docstring
+Transforms a ``point`` from map coordinates to ``layer`` coordinates.
+
+.. note::
+
+   This method is available in the Python bindings as toLayerCoordinatesV2.
+%End
+
     QgsPointXY toLayerCoordinates( const QgsMapLayer *layer, QPoint point );
 %Docstring
 Transforms a ``point`` from screen coordinates to ``layer`` coordinates.

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -2574,7 +2574,7 @@ void QgsMapToolEditMeshFrame::addVertex(
     zValue = currentZValue();
   else if ( mapPointMatch.isValid() )
   {
-    QgsPoint layerPoint = mapPointMatch.interpolatedPoint();
+    QgsPoint layerPoint = mapPointMatch.interpolatedPoint( QgsProject::instance()->crs(), mCurrentLayer );
     zValue = layerPoint.z();
   }
   else if ( mCurrentFaceIndex != -1 ) //we are on a face -->interpolate the z value

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -2574,7 +2574,7 @@ void QgsMapToolEditMeshFrame::addVertex(
     zValue = currentZValue();
   else if ( mapPointMatch.isValid() )
   {
-    QgsPoint layerPoint = mapPointMatch.interpolatedPoint( QgsProject::instance()->crs(), mCurrentLayer );
+    QgsPoint layerPoint = mapPointMatch.interpolatedPoint( mCanvas->mapSettings().destinationCrs() );
     zValue = layerPoint.z();
   }
   else if ( mCurrentFaceIndex != -1 ) //we are on a face -->interpolate the z value

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2135,7 +2135,7 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
 
   // needed to get Z value
   if ( mapPointMatch && mapPointMatch->layer() && QgsWkbTypes::hasZ( mapPointMatch->layer()->wkbType() ) && ( mapPointMatch->hasEdge() || mapPointMatch->hasMiddleSegment() ) )
-    layerPoint = mapPointMatch->interpolatedPoint();
+    layerPoint = toLayerCoordinates( dragLayer, mapPointMatch->interpolatedPoint() );
 
   QgsVertexId vid;
   if ( !geom.vertexIdFromVertexNr( dragVertexId, vid ) )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2094,16 +2094,56 @@ void QgsVertexTool::stopDragging()
 
 QgsPoint QgsVertexTool::matchToLayerPoint( const QgsVectorLayer *destLayer, const QgsPointXY &mapPoint, const QgsPointLocator::Match *match )
 {
-  // try to use point coordinates in the original CRS if it is the same
-  if ( match && match->hasVertex() && match->layer() && match->layer()->crs() == destLayer->crs() )
+  if ( match->layer() )
   {
-    QgsFeature f;
-    QgsFeatureIterator fi = match->layer()->getFeatures( QgsFeatureRequest( match->featureId() ).setNoAttributes() );
-    if ( fi.nextFeature( f ) )
-      return f.geometry().vertexAt( match->vertexIndex() );
+    switch ( match->type() )
+    {
+      case QgsPointLocator::Vertex:
+      case QgsPointLocator::LineEndpoint:
+      case QgsPointLocator::All:
+      {
+        //  use point coordinates of the layer
+        QgsFeature f;
+        QgsFeatureIterator fi = match->layer()->getFeatures( QgsFeatureRequest( match->featureId() ).setNoAttributes() );
+        if ( fi.nextFeature( f ) )
+        {
+          QgsPoint layerPoint = f.geometry().vertexAt( match->vertexIndex() );
+          if ( match->layer()->crs() == destLayer->crs() )
+          {
+            return layerPoint;
+          }
+          else
+          {
+            QgsCoordinateTransform transform( match->layer()->crs(), destLayer->crs(), mCanvas->mapSettings().transformContext() );
+            if ( transform.isValid() )
+            {
+              try
+              {
+                layerPoint.transform( transform );
+                return layerPoint;
+              }
+              catch ( QgsCsException & )
+              {
+                QgsDebugMsg( QStringLiteral( "transformation to layer coordinate failed" ) );
+              }
+            }
+            return layerPoint;
+          }
+        }
+      }
+      break;
+      case QgsPointLocator::Edge:
+      case QgsPointLocator::MiddleOfSegment:
+        return toLayerCoordinates( destLayer, match->interpolatedPoint( mCanvas->mapSettings().destinationCrs() ) );
+        break;
+      case QgsPointLocator::Invalid:
+      case QgsPointLocator::Area:
+      case QgsPointLocator::Centroid:
+        break;
+    }
   }
 
-  // fall back to reprojection of the map point to layer point if they are not the same CRS
+  // fall back to reprojection of the map point to layer point
   return QgsPoint( toLayerCoordinates( destLayer, mapPoint ) );
 }
 
@@ -2132,12 +2172,6 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
   stopDragging();
 
   QgsPoint layerPoint = matchToLayerPoint( dragLayer, mapPoint, mapPointMatch );
-
-  // needed to get Z value
-  if ( mapPointMatch && mapPointMatch->layer() && QgsWkbTypes::hasZ( mapPointMatch->layer()->wkbType() ) && ( mapPointMatch->hasEdge() || mapPointMatch->hasMiddleSegment() ) )
-  {
-    layerPoint = mapPointMatch->interpolatedPoint( QgsProject::instance()->crs(), dragLayer );
-  }
 
   QgsVertexId vid;
   if ( !geom.vertexIdFromVertexNr( dragVertexId, vid ) )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2135,7 +2135,9 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
 
   // needed to get Z value
   if ( mapPointMatch && mapPointMatch->layer() && QgsWkbTypes::hasZ( mapPointMatch->layer()->wkbType() ) && ( mapPointMatch->hasEdge() || mapPointMatch->hasMiddleSegment() ) )
-    layerPoint = toLayerCoordinates( dragLayer, mapPointMatch->interpolatedPoint() );
+  {
+    layerPoint = mapPointMatch->interpolatedPoint( QgsProject::instance()->crs(), dragLayer );
+  }
 
   QgsVertexId vid;
   if ( !geom.vertexIdFromVertexNr( dragVertexId, vid ) )

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -264,7 +264,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
          * The parameter \a destinationCrs depends of where the instance of this Match is created (geom.cache: layer CRS, map canvas snapper: dest CRS)
          * \since 3.10
          */
-        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &destinationCrs ) const
+        QgsPoint interpolatedPoint( const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem() ) const
         {
           QgsPoint point;
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -296,7 +296,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
             {
               try
               {
-                point.transform( transform, Qgis::TransformDirection::ReverseTransform );
+                point.transform( transform, Qgis::TransformDirection::Reverse );
               }
               catch ( QgsCsException & )
               {

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -296,7 +296,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
             {
               try
               {
-                point.transform( transform, QgsCoordinateTransform::ReverseTransform );
+                point.transform( transform, Qgis::TransformDirection::ReverseTransform );
               }
               catch ( QgsCsException & )
               {

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -59,6 +59,11 @@ QgsPointXY QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPo
   return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
 }
 
+QgsPoint QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point )
+{
+  return mCanvas->mapSettings().mapToLayerCoordinates( layer, point );
+}
+
 QgsPointXY QgsMapTool::toMapCoordinates( const QgsMapLayer *layer, const QgsPointXY &point )
 {
   return mCanvas->mapSettings().layerToMapCoordinates( layer, point );

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -271,6 +271,12 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! Transforms a \a point from screen coordinates to map coordinates.
     QgsPointXY toMapCoordinates( QPoint point );
 
+    /**
+     * Transforms a \a point from map coordinates to \a layer coordinates.
+     * \note This method is available in the Python bindings as toLayerCoordinatesV2.
+     */
+    QgsPoint toLayerCoordinates( const QgsMapLayer *layer, const QgsPoint &point ) SIP_PYNAME( toLayerCoordinatesV2 );
+
     //! Transforms a \a point from screen coordinates to \a layer coordinates.
     QgsPointXY toLayerCoordinates( const QgsMapLayer *layer, QPoint point );
 


### PR DESCRIPTION
## Description

When a vertex is moved on layer with Z coordinates and drag and match layer CRS don't match, the vertex move to the matchlayer coordinate.

A conversion is needed, as done by matchToLayerPoint. Since there is no method `toLayerCoordinates` which accepts QgsPoint I need to add a new one.


before:

https://user-images.githubusercontent.com/7521540/132884019-858da5ef-9e32-49f9-b95a-039723233c42.mp4


after:

https://user-images.githubusercontent.com/7521540/132884069-2aaa0148-9400-46c6-9fad-060f55e39f13.mp4


Issue spotted by @vcloarec Vincent can you try this patch, please?