### PR TITLE
Set wait cursor while installing plugin from ZIP

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtNetwork import QNetworkRequest
 import qgis
 from qgis.core import Qgis, QgsApplication, QgsNetworkAccessManager, QgsSettings, QgsNetworkRequestParameters
 from qgis.gui import QgsMessageBar, QgsPasswordLineEdit, QgsHelp
-from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin,
+from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin, OverrideCursor,
                         reloadPlugin, updateAvailablePlugins, plugins_metadata_parser)
 from .installer_data import (repositories, plugins, officialRepo,
                              settingsGroup, reposGroup, removeDir)
@@ -112,25 +112,22 @@ class QgsPluginInstaller(QObject):
         """ Fetch plugins from all enabled repositories."""
         """  reloadMode = true:  Fully refresh data from QgsSettings to mRepositories  """
         """  reloadMode = false: Fetch unready repositories only """
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        with OverrideCursor(Qt.WaitCursor):
+            if reloadMode:
+                repositories.load()
+                plugins.clearRepoCache()
+                plugins.getAllInstalled()
 
-        if reloadMode:
-            repositories.load()
-            plugins.clearRepoCache()
-            plugins.getAllInstalled()
+            for key in repositories.allEnabled():
+                if reloadMode or repositories.all()[key]["state"] == 3:  # if state = 3 (error or not fetched yet), try to fetch once again
+                    repositories.requestFetching(key, force_reload=reloadMode)
 
-        for key in repositories.allEnabled():
-            if reloadMode or repositories.all()[key]["state"] == 3:  # if state = 3 (error or not fetched yet), try to fetch once again
-                repositories.requestFetching(key, force_reload=reloadMode)
-
-        if repositories.fetchingInProgress():
-            fetchDlg = QgsPluginInstallerFetchingDialog(iface.mainWindow())
-            fetchDlg.exec_()
-            del fetchDlg
-            for key in repositories.all():
-                repositories.killConnection(key)
-
-        QApplication.restoreOverrideCursor()
+            if repositories.fetchingInProgress():
+                fetchDlg = QgsPluginInstallerFetchingDialog(iface.mainWindow())
+                fetchDlg.exec_()
+                del fetchDlg
+                for key in repositories.all():
+                    repositories.killConnection(key)
 
         # display error messages for every unavailable repository, unless Shift pressed nor all repositories are unavailable
         keepQuiet = QgsApplication.keyboardModifiers() == Qt.KeyboardModifiers(Qt.ShiftModifier)
@@ -325,11 +322,10 @@ class QgsPluginInstaller(QObject):
                     "the list of installed plugins. You should find the plugin there, but it's not possible to "
                     "determine which of them it is and it's also not possible to inform you about available updates. "
                     "Please contact the plugin author and submit this issue.").format(plugin_path))
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            plugins.getAllInstalled()
-            plugins.rebuild()
-            self.exportPluginsToManager()
-            QApplication.restoreOverrideCursor()
+            with OverrideCursor(Qt.WaitCursor):
+                plugins.getAllInstalled()
+                plugins.rebuild()
+                self.exportPluginsToManager()
         else:
             QApplication.setOverrideCursor(Qt.WaitCursor)
             # update the list of plugins in plugin handling routines
@@ -649,24 +645,23 @@ class QgsPluginInstaller(QObject):
                     keepTrying = False
 
         if success:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            updateAvailablePlugins()
-            self.processDependencies(pluginName)
-            loadPlugin(pluginName)
-            plugins.getAllInstalled()
-            plugins.rebuild()
+            with OverrideCursor(Qt.WaitCursor):
+                updateAvailablePlugins()
+                self.processDependencies(pluginName)
+                loadPlugin(pluginName)
+                plugins.getAllInstalled()
+                plugins.rebuild()
 
-            if settings.contains('/PythonPlugins/' + pluginName):  # Plugin was available?
-                if settings.value('/PythonPlugins/' + pluginName, False, bool):  # Plugin was also active?
-                    reloadPlugin(pluginName)  # unloadPlugin + loadPlugin + startPlugin
+                if settings.contains('/PythonPlugins/' + pluginName):  # Plugin was available?
+                    if settings.value('/PythonPlugins/' + pluginName, False, bool):  # Plugin was also active?
+                        reloadPlugin(pluginName)  # unloadPlugin + loadPlugin + startPlugin
+                    else:
+                        unloadPlugin(pluginName)
+                        loadPlugin(pluginName)
                 else:
-                    unloadPlugin(pluginName)
-                    loadPlugin(pluginName)
-            else:
-                if startPlugin(pluginName):
-                    settings.setValue('/PythonPlugins/' + pluginName, True)
+                    if startPlugin(pluginName):
+                        settings.setValue('/PythonPlugins/' + pluginName, True)
 
-            QApplication.restoreOverrideCursor()
             self.exportPluginsToManager()
             msg = "<b>%s</b>" % self.tr("Plugin installed successfully")
         else:

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -649,6 +649,7 @@ class QgsPluginInstaller(QObject):
                     keepTrying = False
 
         if success:
+            QApplication.setOverrideCursor(Qt.WaitCursor)
             updateAvailablePlugins()
             self.processDependencies(pluginName)
             loadPlugin(pluginName)
@@ -665,6 +666,7 @@ class QgsPluginInstaller(QObject):
                 if startPlugin(pluginName):
                     settings.setValue('/PythonPlugins/' + pluginName, True)
 
+            QApplication.restoreOverrideCursor()
             self.exportPluginsToManager()
             msg = "<b>%s</b>" % self.tr("Plugin installed successfully")
         else:


### PR DESCRIPTION
Set the `Qt.WaitCursor` when installing a plugin from ZIP (`installPluginFromZIP()`).

The cursor is set and unset according to what is already defined in `installPlugin()`, that is: right before updating available plugins for processing dependencies and right after the plugin is loaded and started.