### PR TITLE
[ui] Relocate 'traditional' annotation toolbar actions into the new annotations toolbar

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -439,6 +439,7 @@
         <file>themes/default/mActionStop.svg</file>
         <file>themes/default/mActionStyleManager.svg</file>
         <file>themes/default/mActionSum.svg</file>
+        <file>themes/default/mActionText.svg</file>
         <file>themes/default/mActionTextAnnotation.svg</file>
         <file>themes/default/mActionToggleEditing.svg</file>
         <file>themes/default/mActionTouch.svg</file>

--- a/images/themes/default/mActionText.svg
+++ b/images/themes/default/mActionText.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-.72069 14.318)" stroke="#f0f0f0" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m10.721 2.1823h4" fill="none" stroke-width="3"/>
+  <path d="m12.721 1.6823v-8" fill="#919699" fill-rule="evenodd" stroke-width="4"/>
+  <path d="m17.221-4.3177v-2.5h-9v2.5" fill="none" stroke-width="3"/>
+ </g>
+ <g transform="matrix(.69231 0 0 .69231 1.8462 1.8462)">
+  <rect x="19" y="19" width="13" height="13" rx="2.6149" fill="#5a8c5a"/>
+  <g fill-rule="evenodd">
+   <path d="m21.6 25.5h7.8" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.6"/>
+   <path d="m25.5 29.4v-7.8" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.6"/>
+   <path d="m20.3 25.5h10.4v-2.6c0-2.6-0.65-2.6-5.2-2.6s-5.2 0-5.2 2.6z" fill="#fcffff" opacity=".3"/>
+  </g>
+ </g>
+ <g transform="translate(-.72069 14.318)" stroke="#424242">
+  <path d="m10.721 2.1823h4" fill="none"/>
+  <path d="m12.721 2.6823v-10" fill="#919699" fill-rule="evenodd" stroke-width="2"/>
+  <path d="m17.221-4.3177v-2.5h-9v2.5" fill="none"/>
+ </g>
+</svg>

--- a/images/themes/default/mActionText.svg
+++ b/images/themes/default/mActionText.svg
@@ -18,4 +18,5 @@
   <path d="m12.721 2.6823v-10" fill="#919699" fill-rule="evenodd" stroke-width="2"/>
   <path d="m17.221-4.3177v-2.5h-9v2.5" fill="none"/>
  </g>
+ <path d="m3.5 17.5h3v3h-3z" fill="#bebebe" stroke="#8c8c8c"/>
 </svg>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -781,7 +781,7 @@ void QgisApp::annotationItemTypeAdded( int id )
       groupToolButton->setAutoRaise( true );
       groupToolButton->setToolButtonStyle( Qt::ToolButtonIconOnly );
       groupToolButton->setToolTip( groupText );
-      mAnnotationsToolBar->addWidget( groupToolButton );
+      mAnnotationsToolBar->insertWidget( mAnnotationsItemInsertBefore, groupToolButton );
       mAnnotationItemGroupToolButtons.insert( groupId, groupToolButton );
       groupButton = groupToolButton;
     }
@@ -800,7 +800,7 @@ void QgisApp::annotationItemTypeAdded( int id )
     groupButton->addAction( action );
   else
   {
-    mAnnotationsToolBar->addAction( action );
+    mAnnotationsToolBar->insertAction( mAnnotationsItemInsertBefore, action );
   }
 
   connect( action, &QAction::toggled, this, [this, action, id]( bool checked )
@@ -3559,40 +3559,6 @@ void QgisApp::createToolBars()
   measureAction->setObjectName( QStringLiteral( "ActionMeasure" ) );
   connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
 
-  // annotation tool button
-
-  bt = new QToolButton();
-  bt->setPopupMode( QToolButton::MenuButtonPopup );
-  bt->addAction( mActionTextAnnotation );
-  bt->addAction( mActionFormAnnotation );
-  bt->addAction( mActionHtmlAnnotation );
-  bt->addAction( mActionSvgAnnotation );
-  bt->addAction( mActionAnnotation );
-
-  QAction *defAnnotationAction = mActionTextAnnotation;
-  switch ( settings.value( QStringLiteral( "UI/annotationTool" ), 0 ).toInt() )
-  {
-    case 0:
-      defAnnotationAction = mActionTextAnnotation;
-      break;
-    case 1:
-      defAnnotationAction = mActionFormAnnotation;
-      break;
-    case 2:
-      defAnnotationAction = mActionHtmlAnnotation;
-      break;
-    case 3:
-      defAnnotationAction = mActionSvgAnnotation;
-      break;
-    case 4:
-      defAnnotationAction = mActionAnnotation;
-      break;
-  }
-  bt->setDefaultAction( defAnnotationAction );
-  QAction *annotationAction = mAttributesToolBar->addWidget( bt );
-  annotationAction->setObjectName( QStringLiteral( "ActionAnnotation" ) );
-  connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
-
   // vector layer edits tool buttons
   QToolButton *tbAllEdits = qobject_cast<QToolButton *>( mDigitizeToolBar->widgetForAction( mActionAllEdits ) );
   tbAllEdits->setPopupMode( QToolButton::InstantPopup );
@@ -3913,6 +3879,41 @@ void QgisApp::createToolBars()
   annotationLayerToolButton->setMenu( annotationLayerMenu );
   annotationLayerToolButton->setDefaultAction( mActionCreateAnnotationLayer );
   mAnnotationsToolBar->insertWidget( mAnnotationsToolBar->actions().at( 0 ), annotationLayerToolButton );
+
+  // Registered annotation items will be inserted before this separator
+  mAnnotationsItemInsertBefore = mAnnotationsToolBar->addSeparator();
+
+  bt = new QToolButton();
+  bt->setPopupMode( QToolButton::MenuButtonPopup );
+  bt->addAction( mActionTextAnnotation );
+  bt->addAction( mActionFormAnnotation );
+  bt->addAction( mActionHtmlAnnotation );
+  bt->addAction( mActionSvgAnnotation );
+  bt->addAction( mActionAnnotation );
+
+  QAction *defAnnotationAction = mActionTextAnnotation;
+  switch ( settings.value( QStringLiteral( "UI/annotationTool" ), 0 ).toInt() )
+  {
+    case 0:
+      defAnnotationAction = mActionTextAnnotation;
+      break;
+    case 1:
+      defAnnotationAction = mActionFormAnnotation;
+      break;
+    case 2:
+      defAnnotationAction = mActionHtmlAnnotation;
+      break;
+    case 3:
+      defAnnotationAction = mActionSvgAnnotation;
+      break;
+    case 4:
+      defAnnotationAction = mActionAnnotation;
+      break;
+  }
+  bt->setDefaultAction( defAnnotationAction );
+  QAction *annotationAction = mAnnotationsToolBar->addWidget( bt );
+  annotationAction->setObjectName( QStringLiteral( "ActionAnnotation" ) );
+  connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
 }
 
 void QgisApp::createStatusBar()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2688,6 +2688,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsScopedOptionsWidgetFactory m3DOptionsWidgetFactory;
 
     QMap< QString, QToolButton * > mAnnotationItemGroupToolButtons;
+    QAction *mAnnotationsItemInsertBefore = nullptr; // Used to insert annotation items at the appropriate location in the annotations toolbar
 
     class QgsCanvasRefreshBlocker
     {

--- a/src/gui/annotations/qgsannotationitemguiregistry.cpp
+++ b/src/gui/annotations/qgsannotationitemguiregistry.cpp
@@ -222,7 +222,7 @@ void QgsAnnotationItemGuiRegistry::addDefaultItems()
 
   addAnnotationItemGuiMetadata( new QgsAnnotationItemGuiMetadata( QStringLiteral( "pointtext" ),
                                 QObject::tr( "Text at Point" ),
-                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionLabel.svg" ) ),
+                                QgsApplication::getThemeIcon( QStringLiteral( "/mActionText.svg" ) ),
                                 [ = ]( QgsAnnotationItem * item )->QgsAnnotationItemBaseWidget *
   {
     QgsAnnotationPointTextItemWidget *widget = new QgsAnnotationPointTextItemWidget( nullptr );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -793,7 +793,7 @@
   </widget>
   <widget class="QToolBar" name="mAnnotationsToolBar">
    <property name="windowTitle">
-    <string>Annotations</string>
+    <string>Annotations Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
## Description

Since we now have a dedicated toolbar for annotations, let's move the 'traditonal' annotations (the text,svg,html,form box annotations) into that toolbar:
![Screenshot from 2021-09-11 10-38-43](https://user-images.githubusercontent.com/1728657/132935264-2b4a99cf-f5e1-41e8-9497-2fd77117bb59.png)

@nyalldawson , I've taken the opportunity to also change the text at point annotation item icon as to avoid the possible confusion of the 'traditional' text annotaion icon vs. text at point.