### PR TITLE
[qgsquick][annotations] Render projects' main annotation layer

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -24,6 +24,7 @@
 #include "qgsmessagelog.h"
 #include "qgspallabeling.h"
 #include "qgsproject.h"
+#include "qgsannotationlayer.h"
 #include "qgsvectorlayer.h"
 #include "qgslabelingresults.h"
 
@@ -112,6 +113,11 @@ void QgsQuickMapCanvasMap::refreshMap()
     expressionContext << QgsExpressionContextUtils::projectScope( project );
 
     mapSettings.setLabelingEngineSettings( project->labelingEngineSettings() );
+
+    // render main annotation layer above all other layers
+    QList<QgsMapLayer *> allLayers = mapSettings.layers();
+    allLayers.insert( 0, project->mainAnnotationLayer() );
+    mapSettings.setLayers( allLayers );
   }
 
   mapSettings.setExpressionContext( expressionContext );


### PR DESCRIPTION
## Description

This PR adds the missing bits for the qgsquickmapcanvas to render projects' main annotation layer :tada: . Proof of life:
![image](https://user-images.githubusercontent.com/1728657/132940950-6bdbf994-faaf-4b42-8b2f-29fd48ec7c50.png)
