### PR TITLE
fix QgsRectangle::include

### DIFF
--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -308,7 +308,7 @@ class CORE_EXPORT QgsRectangle
     {
       if ( p.x() < xMinimum() )
         setXMinimum( p.x() );
-      else if ( p.x() > xMaximum() )
+      if ( p.x() > xMaximum() )
         setXMaximum( p.x() );
       if ( p.y() < yMinimum() )
         setYMinimum( p.y() );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -372,6 +372,33 @@ void TestQgsRectangle::include()
   QCOMPARE( rect1.xMaximum(), 115.0 );
   QCOMPARE( rect1.yMaximum(), 242.0 );
 
+  rect1.setMinimal();
+
+  rect1.include( QgsPointXY( 15, 50 ) );
+  QCOMPARE( rect1.xMinimum(), 15.0 );
+  QCOMPARE( rect1.yMinimum(), 50.0 );
+  QCOMPARE( rect1.xMaximum(), 15.0 );
+  QCOMPARE( rect1.yMaximum(), 50.0 );
+
+  rect1.include( QgsPointXY( 5, 30 ) );
+  QCOMPARE( rect1.xMinimum(), 5.0 );
+  QCOMPARE( rect1.yMinimum(), 30.0 );
+  QCOMPARE( rect1.xMaximum(), 15.0 );
+  QCOMPARE( rect1.yMaximum(), 50.0 );
+
+  rect1.setMinimal();
+
+  rect1.include( QgsPointXY( 5, 30 ) );
+  QCOMPARE( rect1.xMinimum(), 5.0 );
+  QCOMPARE( rect1.yMinimum(), 30.0 );
+  QCOMPARE( rect1.xMaximum(), 5.0 );
+  QCOMPARE( rect1.yMaximum(), 30.0 );
+
+  rect1.include( QgsPointXY( 15, 50 ) );
+  QCOMPARE( rect1.xMinimum(), 5.0 );
+  QCOMPARE( rect1.yMinimum(), 30.0 );
+  QCOMPARE( rect1.xMaximum(), 15.0 );
+  QCOMPARE( rect1.yMaximum(), 50.0 );
 }
 
 void TestQgsRectangle::buffered()


### PR DESCRIPTION
before this fix, if successive points, with decreasing X value, are included after using `setMinimal()`, the `QgsRectangle` will never had a real xMaximum.