### PR TITLE
fix: replace referer http header by dedicated class QgsHttpHeader

### DIFF
--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -14,7 +14,7 @@ class QgsHttpHeaders
 %Docstring(signature="appended")
 This class implements simple http header management.
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
 %TypeHeaderCode
@@ -22,11 +22,10 @@ This class implements simple http header management.
 %End
   public:
 
-    static const QString KEY_PREFIX;
 
     QgsHttpHeaders( const QMap<QString, QVariant> &headers );
 %Docstring
-constructor from map
+Constructor from map
 
 :param headers:
 %End
@@ -38,7 +37,7 @@ default constructor
 
     QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
-constructor from ``:py:class:`QgsSettings```
+Constructor from :py:class:`QgsSettings` ``settings`` object
 
 :param settings:
 :param key:
@@ -48,16 +47,14 @@ constructor from ``:py:class:`QgsSettings```
 
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 %Docstring
-update the ``request`` by adding all the http headers
+Updates a ``request`` by adding all the HTTP headers
 
-:param request:
-
-:return: true if the update succeed
+:return: ``True`` if the update succeed
 %End
 
     void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 %Docstring
-update the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
+Updates the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
 
 :param settings:
 :param key: sub group path
@@ -65,7 +62,7 @@ update the ``settings`` by adding all the http headers in the path "key/KEY_PREF
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
-loads headers from the ``settings``
+Loads headers from the ``settings``
 
 :param settings:
 :param key: sub group path
@@ -73,10 +70,11 @@ loads headers from the ``settings``
 
     QVariant &operator[]( const QString &key );
 
+
     QList<QString> keys() const;
 %Docstring
 
-:return: the list of all http header key
+:return: the list of all http header keys
 %End
 
 

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -26,38 +26,58 @@ This class implements simple http header management.
 
     QgsHttpHeaders( const QMap<QString, QVariant> &headers );
 %Docstring
-Copy constructor
-@param headers
+constructor from map
+
+:param headers:
 %End
+
     QgsHttpHeaders();
+%Docstring
+default constructor
+%End
+
     QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
+%Docstring
+constructor from ``:py:class:`QgsSettings```
+
+:param settings:
+:param key:
+%End
 
     virtual ~QgsHttpHeaders();
 
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 %Docstring
 update the ``request`` by adding all the http headers
-@param request
-@return true if the update succeed
+
+:param request:
+
+:return: true if the update succeed
 %End
 
     void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 %Docstring
 update the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
-@param settings
-@param key sub group path
+
+:param settings:
+:param key: sub group path
 %End
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
 loads headers from the ``settings``
-@param settings
-@param key sub group path
+
+:param settings:
+:param key: sub group path
 %End
 
     QVariant &operator[]( const QString &key );
 
     QList<QString> keys() const;
+%Docstring
+
+:return: the list of all http header key
+%End
 
 
 };

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -1,0 +1,71 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/network/qgshttpheaders.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsHttpHeaders
+{
+%Docstring(signature="appended")
+This class implements simple http header management.
+
+.. versionadded:: 3.22
+%End
+
+%TypeHeaderCode
+#include "qgshttpheaders.h"
+%End
+  public:
+
+    static const QString KEY_PREFIX;
+
+    QgsHttpHeaders( const QMap<QString, QVariant> &headers );
+%Docstring
+Copy constructor
+@param headers
+%End
+    QgsHttpHeaders();
+    QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
+
+    virtual ~QgsHttpHeaders();
+
+    bool updateNetworkRequest( QNetworkRequest &request ) const;
+%Docstring
+update the ``request`` by adding all the http headers
+@param request
+@return true if the update succeed
+%End
+
+    void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
+%Docstring
+update the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
+@param settings
+@param key sub group path
+%End
+
+    void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
+%Docstring
+loads headers from the ``settings``
+@param settings
+@param key sub group path
+%End
+
+    QVariant &operator[]( const QString &key );
+
+    QList<QString> keys() const;
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/network/qgshttpheaders.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -32,7 +32,7 @@ Utility functions for working with ArcGIS REST services.
       ImageService,
     };
 
-    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = 0 );
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
 %Docstring
 Retrieves JSON user info for the specified user name.
 
@@ -49,7 +49,7 @@ If ``user`` is blank then the user associated with the current logon details wil
          - errorText: error text of any encountered errors
 %End
 
-    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = 0 );
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
 %Docstring
 Retrieves JSON definitions for all groups which the specified user name is a member of.
 
@@ -66,7 +66,7 @@ If ``user`` is blank then the user associated with the current logon details wil
          - errorText: error text of any encountered errors
 %End
 
-    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = 0, int pageSize = 100 );
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100 );
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``.
 
@@ -84,7 +84,7 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = 0, int pageSize = 100 );
+        QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100 );
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified ``groupId``.
 

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -32,9 +32,10 @@ Utility functions for working with ArcGIS REST services.
       ImageService,
     };
 
-    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
+
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = 0 );
 %Docstring
-Retrieves JSON user info for the specified user name.
+Retrieves JSON user info for the specified user name. Only to avoid API break.
 
 If ``user`` is blank then the user associated with the current logon details will be retrieved
 
@@ -49,9 +50,9 @@ If ``user`` is blank then the user associated with the current logon details wil
          - errorText: error text of any encountered errors
 %End
 
-    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0 );
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = 0 );
 %Docstring
-Retrieves JSON definitions for all groups which the specified user name is a member of.
+Retrieves JSON definitions for all groups which the specified user name is a member of. Only to avoid API break.
 
 If ``user`` is blank then the user associated with the current logon details will be retrieved
 
@@ -66,9 +67,9 @@ If ``user`` is blank then the user associated with the current logon details wil
          - errorText: error text of any encountered errors
 %End
 
-    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100 );
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = 0, int pageSize = 100 );
 %Docstring
-Retrieves JSON definitions for all items which belong the the specified ``groupId``.
+Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 
 :param contentUrl: should be set to the Portal's content URL, e.g. https://mysite.com/portal/sharing/rest/content
 :param groupId: ID of group to query
@@ -84,9 +85,9 @@ Retrieves JSON definitions for all items which belong the the specified ``groupI
 
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100 );
+        QString &errorTitle /Out/, QString &errorText /Out/, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = 0, int pageSize = 100 );
 %Docstring
-Retrieves JSON definitions for all items which belong the the specified ``groupId``.
+Retrieves JSON definitions for all items which belong the the specified ``groupId``. Only to avoid API break.
 
 :param contentUrl: should be set to the Portal's content URL, e.g. https://mysite.com/portal/sharing/rest/content
 :param groupId: ID of group to query

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -480,6 +480,7 @@
 %Include auto_generated/network/qgsnetworkreply.sip
 %Include auto_generated/network/qgsnewsfeedmodel.sip
 %Include auto_generated/network/qgsnewsfeedparser.sip
+%Include auto_generated/network/qgshttpheaders.sip
 %Include auto_generated/numericformats/qgsbasicnumericformat.sip
 %Include auto_generated/numericformats/qgsbearingnumericformat.sip
 %Include auto_generated/numericformats/qgscurrencynumericformat.sip

--- a/python/gui/auto_generated/qgshttpheaderwidget.sip.in
+++ b/python/gui/auto_generated/qgshttpheaderwidget.sip.in
@@ -15,7 +15,7 @@ class QgsHttpHeaderWidget : QWidget
 %Docstring(signature="appended")
 Display referer http header field and collapsible table of key/value pairs
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
 %TypeHeaderCode

--- a/python/gui/auto_generated/qgshttpheaderwidget.sip.in
+++ b/python/gui/auto_generated/qgshttpheaderwidget.sip.in
@@ -8,26 +8,53 @@
 
 
 
+
+
 class QgsHttpHeaderWidget : QWidget
 {
+%Docstring(signature="appended")
+Display referer http header field and collapsible table of key/value pairs
+
+.. versionadded:: 3.22
+%End
 
 %TypeHeaderCode
 #include "qgshttpheaderwidget.h"
 %End
   public:
+
     explicit QgsHttpHeaderWidget( QWidget *parent = 0 );
+%Docstring
+Default constructor
+
+:param parent: parent widget
+%End
     ~QgsHttpHeaderWidget();
 
     QgsHttpHeaders httpHeaders() const;
+%Docstring
+
+:return: build a new ``:py:class:`QgsHttpHeaders``` according to data in the UI
+%End
 
     void setFromSettings( const QgsSettings &settings, const QString &key );
 %Docstring
-mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
+fill the inner header map from the settings defined at ``key``
+
+.. seealso:: :py:func:`QgsHttpHeaders.setFromSettings`
+
+:param settings:
+:param key:
 %End
 
     void updateSettings( QgsSettings &settings, const QString &key ) const;
 %Docstring
-settings.setValue( key + "/referer", mRefererLineEdit->:py:func:`~QgsHttpHeaderWidget.text` ); */
+update the ``settings`` with the http headers present in the inner map.
+
+.. seealso:: :py:func:`QgsHttpHeaders.updateSettings`
+
+:param settings:
+:param key:
 %End
 
 };

--- a/python/gui/auto_generated/qgshttpheaderwidget.sip.in
+++ b/python/gui/auto_generated/qgshttpheaderwidget.sip.in
@@ -1,0 +1,41 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgshttpheaderwidget.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsHttpHeaderWidget : QWidget
+{
+
+%TypeHeaderCode
+#include "qgshttpheaderwidget.h"
+%End
+  public:
+    explicit QgsHttpHeaderWidget( QWidget *parent = 0 );
+    ~QgsHttpHeaderWidget();
+
+    QgsHttpHeaders httpHeaders() const;
+
+    void setFromSettings( const QgsSettings &settings, const QString &key );
+%Docstring
+mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
+%End
+
+    void updateSettings( QgsSettings &settings, const QString &key ) const;
+%Docstring
+settings.setValue( key + "/referer", mRefererLineEdit->:py:func:`~QgsHttpHeaderWidget.text` ); */
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgshttpheaderwidget.h                                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -97,6 +97,7 @@
 %Include auto_generated/qgshighlight.sip
 %Include auto_generated/qgshighlightablelineedit.sip
 %Include auto_generated/qgshistogramwidget.sip
+%Include auto_generated/qgshttpheaderwidget.sip
 %Include auto_generated/qgsidentifymenu.sip
 %Include auto_generated/qgskeyvaluewidget.sip
 %Include auto_generated/qgslegendfilterbutton.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -212,6 +212,7 @@ set(QGIS_CORE_SRCS
   network/qgsnetworkreplyparser.cpp
   network/qgsnewsfeedmodel.cpp
   network/qgsnewsfeedparser.cpp
+  network/qgshttpheaders.cpp
 
   processing/qgsprocessing.cpp
   processing/qgsprocessingalgorithm.cpp
@@ -1510,6 +1511,7 @@ set(QGIS_CORE_HDRS
   network/qgsnetworkreplyparser.h
   network/qgsnewsfeedmodel.h
   network/qgsnewsfeedparser.h
+  network/qgshttpheaders.h
 
   numericformats/qgsbasicnumericformat.h
   numericformats/qgsbearingnumericformat.h

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -26,14 +26,11 @@
 
 const QString QgsHttpHeaders::KEY_PREFIX = "http-header/";
 
-QgsHttpHeaders::QgsHttpHeaders()
-{
-  // nope
-}
+QgsHttpHeaders::QgsHttpHeaders() = default;
 
-QgsHttpHeaders::QgsHttpHeaders( const QMap<QString, QVariant> &hdrs )
+QgsHttpHeaders::QgsHttpHeaders( const QMap<QString, QVariant> &headers )
+  : mHeaders( headers )
 {
-  mHeaders = hdrs;
   mHeaders.detach(); // clone like
 }
 
@@ -42,10 +39,7 @@ QgsHttpHeaders::QgsHttpHeaders( const QgsSettings &settings, const QString &key 
   setFromSettings( settings, key );
 }
 
-QgsHttpHeaders::~QgsHttpHeaders()
-{
-  // nope
-}
+QgsHttpHeaders::~QgsHttpHeaders() = default;
 
 bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
 {
@@ -103,6 +97,12 @@ QVariant &QgsHttpHeaders::operator[]( const QString &key )
 const QVariant QgsHttpHeaders::operator[]( const QString &key ) const
 {
   return mHeaders[key];
+}
+
+QgsHttpHeaders &QgsHttpHeaders::operator = ( const QMap<QString, QVariant> &headers )
+{
+  mHeaders = headers;
+  return *this;
 }
 
 QList<QString> QgsHttpHeaders::keys() const

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -1,0 +1,111 @@
+/***************************************************************************
+                       qgshttpheaders.cpp
+  This class implements simple http header management.
+
+                              -------------------
+          begin                : 2021-09-09
+          copyright            : (C) 2021 B. De Mezzo
+          email                : benoit.de.mezzo@oslandia.com
+
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgshttpheaders.h"
+
+//
+// QgsHttpHeaders
+//
+
+const QString QgsHttpHeaders::KEY_PREFIX = "http-header/";
+
+QgsHttpHeaders::QgsHttpHeaders()
+{
+  // nope
+}
+
+QgsHttpHeaders::QgsHttpHeaders( const QMap<QString, QVariant> &hdrs )
+{
+  mHeaders = hdrs;
+  mHeaders.detach(); // clone like
+}
+
+QgsHttpHeaders::QgsHttpHeaders( const QgsSettings &settings, const QString &key )
+{
+  setFromSettings( settings, key );
+}
+
+QgsHttpHeaders::~QgsHttpHeaders()
+{
+  // nope
+}
+
+bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
+{
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    request.setRawHeader( ite.key().toUtf8(), ite.value().toString().toUtf8() );
+  }
+  return true;
+}
+
+void QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key ) const
+{
+  QString keyFixed = key;
+  if ( !keyFixed.isEmpty() && !keyFixed.endsWith( "/" ) )
+    keyFixed = keyFixed + "/";
+  QString keyHH = keyFixed + QgsHttpHeaders::KEY_PREFIX;
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    settings.setValue( keyHH  + ite.key(), ite.value() );
+  }
+
+  if ( !mHeaders["referer"].toString().isEmpty() && settings.contains( keyFixed + "referer" ) ) // backward comptibility
+  {
+    settings.setValue( keyFixed + "referer", mHeaders["referer"].toString() );
+  }
+}
+
+void QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString &key )
+{
+  QString keyFixed = key;
+  if ( !keyFixed.isEmpty() && !keyFixed.endsWith( "/" ) )
+    keyFixed = keyFixed + "/";
+  QString keyHH = keyFixed + QgsHttpHeaders::KEY_PREFIX;
+  QStringList keys = settings.allKeys();
+  for ( auto ite = keys.cbegin(); ite != keys.cend(); ++ite )
+  {
+    if ( ite->startsWith( keyHH ) )
+    {
+      QString name = ite->right( ite->size() - keyHH.size() );
+      mHeaders.insert( name, settings.value( *ite ).toString() );
+    }
+  }
+  if ( mHeaders["referer"].toString().isEmpty() ) // backward comptibility
+  {
+    mHeaders["referer"] = settings.value( keyFixed + "referer" ).toString(); // retrieve value from old location
+  }
+}
+
+
+QVariant &QgsHttpHeaders::operator[]( const QString &key )
+{
+  return mHeaders[key];
+}
+
+const QVariant QgsHttpHeaders::operator[]( const QString &key ) const
+{
+  return mHeaders[key];
+}
+
+QList<QString> QgsHttpHeaders::keys() const
+{
+  return mHeaders.keys();
+}

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -5,7 +5,7 @@
                               -------------------
           begin                : 2021-09-09
           copyright            : (C) 2021 B. De Mezzo
-          email                : benoit.de.mezzo@oslandia.com
+          email                : benoit dot de dot mezzo at oslandia dot com
 
 ***************************************************************************/
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -5,7 +5,7 @@
                               -------------------
           begin                : 2021-09-09
           copyright            : (C) 2021 B. De Mezzo
-          email                : benoit.de.mezzo@oslandia.com
+          email                : benoit dot de dot mezzo at oslandia dot com
 
 ***************************************************************************/
 
@@ -42,41 +42,63 @@ class CORE_EXPORT QgsHttpHeaders
     static const QString KEY_PREFIX;
 
     /**
-     * @brief Copy constructor
-     * @param headers
+     * \brief constructor from map
+     * \param headers
      */
     QgsHttpHeaders( const QMap<QString, QVariant> &headers );
+
+    /**
+     * \brief default constructor
+     */
     QgsHttpHeaders();
+
+    /**
+     * \brief constructor from \a QgsSettings
+     * \param settings
+     * \param key
+     */
     QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
 
     virtual ~QgsHttpHeaders();
 
     /**
-     * @brief update the \a request by adding all the http headers
-     * @param request
-     * @return true if the update succeed
+     * \brief update the \a request by adding all the http headers
+     * \param request
+     * \return true if the update succeed
      */
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 
     /**
-     * @brief update the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
-     * @param settings
-     * @param key sub group path
+     * \brief update the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
+     * \param settings
+     * \param key sub group path
      */
     void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 
     /**
-     * @brief loads headers from the \a settings
-     * @param settings
-     * @param key sub group path
+     * \brief loads headers from the \a settings
+     * \param settings
+     * \param key sub group path
      */
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 
+    /**
+     * \param key http header key name
+     * \return http header value
+     */
     QVariant &operator[]( const QString &key );
 
+    /**
+     * \return the list of all http header key
+     */
     QList<QString> keys() const;
 
 #ifndef SIP_RUN
+
+    /**
+     * \param key http header key name
+     * \return http header value
+     */
     const QVariant operator[]( const QString &key ) const;
 #endif
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -30,19 +30,22 @@
 /**
  * \ingroup core
  * \brief This class implements simple http header management.
- * \since QGIS 3.22
+ * \since QGIS 3.24
  */
 class CORE_EXPORT QgsHttpHeaders
 {
   public:
 
-    /**
-     * used in settings
-     */
-    static const QString KEY_PREFIX;
+#ifndef SIP_RUN
 
     /**
-     * \brief constructor from map
+     * Used in settings
+     */
+    static const QString KEY_PREFIX;
+#endif
+
+    /**
+     * \brief Constructor from map
      * \param headers
      */
     QgsHttpHeaders( const QMap<QString, QVariant> &headers );
@@ -53,7 +56,7 @@ class CORE_EXPORT QgsHttpHeaders
     QgsHttpHeaders();
 
     /**
-     * \brief constructor from \a QgsSettings
+     * \brief Constructor from QgsSettings \a settings object
      * \param settings
      * \param key
      */
@@ -62,21 +65,20 @@ class CORE_EXPORT QgsHttpHeaders
     virtual ~QgsHttpHeaders();
 
     /**
-     * \brief update the \a request by adding all the http headers
-     * \param request
-     * \return true if the update succeed
+     * \brief Updates a \a request by adding all the HTTP headers
+     * \return TRUE if the update succeed
      */
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 
     /**
-     * \brief update the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
+     * \brief Updates the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
      * \param settings
      * \param key sub group path
      */
     void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 
     /**
-     * \brief loads headers from the \a settings
+     * \brief Loads headers from the \a settings
      * \param settings
      * \param key sub group path
      */
@@ -88,8 +90,10 @@ class CORE_EXPORT QgsHttpHeaders
      */
     QVariant &operator[]( const QString &key );
 
+    QgsHttpHeaders &operator = ( const QMap<QString, QVariant> &headers ) SIP_SKIP;
+
     /**
-     * \return the list of all http header key
+     * \return the list of all http header keys
      */
     QList<QString> keys() const;
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+                       qgshttpheaders.h
+  This class implements simple http header management.
+
+                              -------------------
+          begin                : 2021-09-09
+          copyright            : (C) 2021 B. De Mezzo
+          email                : benoit.de.mezzo@oslandia.com
+
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSHTTPHEADERS_H
+#define QGSHTTPHEADERS_H
+
+#include <QNetworkRequest>
+#include <QMap>
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgssettingsentry.h"
+
+/**
+ * \ingroup core
+ * \brief This class implements simple http header management.
+ * \since QGIS 3.22
+ */
+class CORE_EXPORT QgsHttpHeaders
+{
+  public:
+
+    /**
+     * used in settings
+     */
+    static const QString KEY_PREFIX;
+
+    /**
+     * @brief Copy constructor
+     * @param headers
+     */
+    QgsHttpHeaders( const QMap<QString, QVariant> &headers );
+    QgsHttpHeaders();
+    QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
+
+    virtual ~QgsHttpHeaders();
+
+    /**
+     * @brief update the \a request by adding all the http headers
+     * @param request
+     * @return true if the update succeed
+     */
+    bool updateNetworkRequest( QNetworkRequest &request ) const;
+
+    /**
+     * @brief update the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
+     * @param settings
+     * @param key sub group path
+     */
+    void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
+
+    /**
+     * @brief loads headers from the \a settings
+     * @param settings
+     * @param key sub group path
+     */
+    void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
+
+    QVariant &operator[]( const QString &key );
+
+    QList<QString> keys() const;
+
+#ifndef SIP_RUN
+    const QVariant operator[]( const QString &key ) const;
+#endif
+
+  private:
+    QMap<QString, QVariant> mHeaders;
+};
+
+#endif // QGSHTTPHEADERS_H

--- a/src/core/providers/arcgis/qgsarcgisportalutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.cpp
@@ -38,10 +38,20 @@ QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl,
   return QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback );
 }
 
+QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback )
+{
+  return QgsArcGisPortalUtils::retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback );
+}
+
 QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback )
 {
   const QVariantMap info = retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, requestHeaders, feedback );
   return info.value( QStringLiteral( "groups" ) ).toList();
+}
+
+QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback )
+{
+  return QgsArcGisPortalUtils::retrieveUserGroups( communityUrl, user, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback );
 }
 
 QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize )
@@ -81,6 +91,11 @@ QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentU
   return items;
 }
 
+QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback, int pageSize )
+{
+  return QgsArcGisPortalUtils::retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback, pageSize );
+}
+
 QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize )
 {
   const QVariantList items = retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, requestHeaders, feedback, pageSize );
@@ -103,6 +118,12 @@ QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &cont
   }
   return result;
 }
+
+QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback, int pageSize )
+{
+  return QgsArcGisPortalUtils::retrieveGroupItemsOfType( contentUrl, groupId, authcfg, itemTypes, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback, pageSize );
+}
+
 
 QString QgsArcGisPortalUtils::typeToString( QgsArcGisPortalUtils::ItemType type )
 {

--- a/src/core/providers/arcgis/qgsarcgisportalutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.cpp
@@ -19,7 +19,7 @@
 #include <QUrl>
 #include <QUrlQuery>
 
-QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap<QString, QString> &requestHeaders, QgsFeedback *feedback )
+QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback )
 {
   QString endPoint = communityUrl;
   if ( endPoint.endsWith( '/' ) )
@@ -38,13 +38,13 @@ QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl,
   return QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback );
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap<QString, QString> &requestHeaders, QgsFeedback *feedback )
+QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback )
 {
   const QVariantMap info = retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, requestHeaders, feedback );
   return info.value( QStringLiteral( "groups" ) ).toList();
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap<QString, QString> &requestHeaders, QgsFeedback *feedback, int pageSize )
+QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize )
 {
   QString endPoint = contentUrl;
   if ( endPoint.endsWith( '/' ) )
@@ -81,7 +81,7 @@ QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentU
   return items;
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QMap<QString, QString> &requestHeaders, QgsFeedback *feedback, int pageSize )
+QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize )
 {
   const QVariantList items = retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, requestHeaders, feedback, pageSize );
 

--- a/src/core/providers/arcgis/qgsarcgisportalutils.h
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.h
@@ -47,6 +47,8 @@ class CORE_EXPORT QgsArcGisPortalUtils
       ImageService, //!< ArcGIS Server image service
     };
 
+#ifndef SIP_RUN
+
     /**
      * Retrieves JSON user info for the specified user name.
      *
@@ -115,6 +117,77 @@ class CORE_EXPORT QgsArcGisPortalUtils
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
         QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
+
+#endif
+
+    /**
+     * Retrieves JSON user info for the specified user name. Only to avoid API break.
+     *
+     * If \a user is blank then the user associated with the current logon details will be retrieved
+     *
+     * \param communityUrl should be set to the Portal's community URL, e.g. https://mysite.com/portal/sharing/rest/community/
+     * \param user username to query, or an empty string to query the current user
+     * \param authcfg authentication configuration ID
+     * \param errorTitle title summary of any encountered errors
+     * \param errorText error text of any encountered errors
+     * \param requestHeaders optional additional request headers
+     * \param feedback optional feedback argument for cancellation support
+     *
+     * \returns JSON user info
+     */
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = nullptr );
+
+    /**
+     * Retrieves JSON definitions for all groups which the specified user name is a member of. Only to avoid API break.
+     *
+     * If \a user is blank then the user associated with the current logon details will be retrieved
+     *
+     * \param communityUrl should be set to the Portal's community URL, e.g. https://mysite.com/portal/sharing/rest/community/
+     * \param user username to query, or an empty string to query the current user
+     * \param authcfg authentication configuration ID
+     * \param errorTitle title summary of any encountered errors
+     * \param errorText error text of any encountered errors
+     * \param requestHeaders optional additional request headers
+     * \param feedback optional feedback argument for cancellation support
+     *
+     * \returns a list of JSON group info
+     */
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = nullptr );
+
+    /**
+     * Retrieves JSON definitions for all items which belong the the specified \a groupId. Only to avoid API break.
+     *
+     * \param contentUrl should be set to the Portal's content URL, e.g. https://mysite.com/portal/sharing/rest/content/
+     * \param groupId ID of group to query
+     * \param authcfg authentication configuration ID
+     * \param errorTitle title summary of any encountered errors
+     * \param errorText error text of any encountered errors
+     * \param requestHeaders optional additional request headers
+     * \param feedback optional feedback argument for cancellation support
+     * \param pageSize number of results to retrieve for each request. Maximum value is 100.
+     *
+     * \returns a list of JSON item info for all items within the group
+     */
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
+
+    /**
+     * Retrieves JSON definitions for all items which belong the the specified \a groupId. Only to avoid API break.
+     *
+     * \param contentUrl should be set to the Portal's content URL, e.g. https://mysite.com/portal/sharing/rest/content/
+     * \param groupId ID of group to query
+     * \param authcfg authentication configuration ID
+     * \param itemTypes list of desired item types (using QgsArcGisPortalUtils.ItemType values)
+     * \param errorTitle title summary of any encountered errors
+     * \param errorText error text of any encountered errors
+     * \param requestHeaders optional additional request headers
+     * \param feedback optional feedback argument for cancellation support
+     * \param pageSize number of results to retrieve for each request. Maximum value is 100.
+     *
+     * \returns a list of JSON item info for all items within the group
+     */
+    static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
+        const QList< int > &itemTypes,
+        QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QVariant > &requestHeaders = QMap< QString, QVariant >(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
 
 
   private:

--- a/src/core/providers/arcgis/qgsarcgisportalutils.h
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.h
@@ -17,6 +17,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgshttpheaders.h"
 
 #include <QVariantMap>
 #include <QString>
@@ -61,7 +62,7 @@ class CORE_EXPORT QgsArcGisPortalUtils
      *
      * \returns JSON user info
      */
-    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = nullptr );
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr );
 
     /**
      * Retrieves JSON definitions for all groups which the specified user name is a member of.
@@ -78,7 +79,7 @@ class CORE_EXPORT QgsArcGisPortalUtils
      *
      * \returns a list of JSON group info
      */
-    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = nullptr );
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr );
 
     /**
      * Retrieves JSON definitions for all items which belong the the specified \a groupId.
@@ -94,7 +95,7 @@ class CORE_EXPORT QgsArcGisPortalUtils
      *
      * \returns a list of JSON item info for all items within the group
      */
-    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
 
     /**
      * Retrieves JSON definitions for all items which belong the the specified \a groupId.
@@ -113,7 +114,7 @@ class CORE_EXPORT QgsArcGisPortalUtils
      */
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
+        QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, int pageSize = 100 );
 
 
   private:

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -20,6 +20,7 @@
 #include "qgis_core.h"
 #include "qgsrectangle.h"
 #include "qgswkbtypes.h"
+#include "qgshttpheaders.h"
 
 #include <QString>
 #include <QVariantMap>
@@ -50,17 +51,17 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     /**
      * Retrieves JSON service info for the specified base URL.
      */
-    static QVariantMap getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >() );
+    static QVariantMap getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders() );
 
     /**
      * Retrieves JSON layer info for the specified layer URL.
      */
-    static QVariantMap getLayerInfo( const QString &layerurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >() );
+    static QVariantMap getLayerInfo( const QString &layerurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders() );
 
     /**
      * Retrieves all object IDs for the specified layer URL.
      */
-    static QVariantMap getObjectIds( const QString &layerurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QString > &requestHeaders = QMap< QString, QString >(),
+    static QVariantMap getObjectIds( const QString &layerurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),
                                      const QgsRectangle &bbox = QgsRectangle() );
 
     /**
@@ -68,22 +69,22 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
      */
     static QVariantMap getObjects( const QString &layerurl, const QString &authcfg, const QList<quint32> &objectIds, const QString &crs,
                                    bool fetchGeometry, const QStringList &fetchAttributes, bool fetchM, bool fetchZ,
-                                   const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr );
+                                   const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr );
 
     /**
      * Gets a list of object IDs which fall within the specified extent.
      */
-    static QList<quint32> getObjectIdsByExtent( const QString &layerurl, const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, const QString &authcfg, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr );
+    static QList<quint32> getObjectIdsByExtent( const QString &layerurl, const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, const QString &authcfg, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr );
 
     /**
      * Performs a blocking request to a URL and returns the retrieved data.
      */
-    static QByteArray queryService( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr, QString *contentType = nullptr );
+    static QByteArray queryService( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, QString *contentType = nullptr );
 
     /**
      * Performs a blocking request to a URL and returns the retrieved JSON content.
      */
-    static QVariantMap queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr );
+    static QVariantMap queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr );
 
     /**
      * Calls the specified \a visitor function on all folder items found within the given service data.
@@ -132,7 +133,7 @@ class CORE_EXPORT QgsArcGisAsyncParallelQuery : public QObject
 {
     Q_OBJECT
   public:
-    QgsArcGisAsyncParallelQuery( const QString &authcfg, const QgsStringMap &requestHeaders, QObject *parent = nullptr );
+    QgsArcGisAsyncParallelQuery( const QString &authcfg, const QgsHttpHeaders &requestHeaders, QObject *parent = nullptr );
     void start( const QVector<QUrl> &urls, QVector<QByteArray> *results, bool allowCache = false );
 
   signals:
@@ -145,7 +146,7 @@ class CORE_EXPORT QgsArcGisAsyncParallelQuery : public QObject
     int mPendingRequests = 0;
     QStringList mErrors;
     QString mAuthCfg;
-    QgsStringMap mRequestHeaders;
+    QgsHttpHeaders mRequestHeaders;
 };
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -18,6 +18,7 @@
 #include "qgslogger.h"
 #include "qgsdatasourceuri.h"
 #include "qgssettings.h"
+#include "qgshttpheaders.h"
 
 ///@cond PRIVATE
 
@@ -135,7 +136,7 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connectio
   conn.authCfg = settings.value( QStringLiteral( "authcfg" ) ).toString();
   conn.username = settings.value( QStringLiteral( "username" ) ).toString();
   conn.password = settings.value( QStringLiteral( "password" ) ).toString();
-  conn.referer = settings.value( QStringLiteral( "referer" ) ).toString();
+  conn.referer = QgsHttpHeaders( settings )[ QStringLiteral( "referer" ) ].toString();
   conn.styleUrl = settings.value( QStringLiteral( "styleUrl" ) ).toString();
 
   if ( settings.contains( QStringLiteral( "serviceType" ) ) )
@@ -164,7 +165,7 @@ void QgsVectorTileProviderConnection::addConnection( const QString &name, QgsVec
   settings.setValue( QStringLiteral( "authcfg" ), conn.authCfg );
   settings.setValue( QStringLiteral( "username" ), conn.username );
   settings.setValue( QStringLiteral( "password" ), conn.password );
-  settings.setValue( QStringLiteral( "referer" ), conn.referer );
+  QgsHttpHeaders( ( QMap<QString, QVariant> ) { {QStringLiteral( "referer" ), conn.referer}} ).updateSettings( settings );
   settings.setValue( QStringLiteral( "styleUrl" ), conn.styleUrl );
 
   switch ( conn.serviceType )

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -691,9 +691,10 @@ QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( mDataSource );
   const QString authcfg = dsUri.authConfigId();
-  const QString referer = dsUri.param( QStringLiteral( "referer" ) );
+  QgsHttpHeaders headers;
+  headers [QStringLiteral( "referer" ) ] = dsUri.param( QStringLiteral( "referer" ) );
 
-  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange, authcfg, referer );
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange, authcfg, headers );
   if ( rawTiles.isEmpty() )
     return QByteArray();
   return rawTiles.first().data;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -164,8 +164,8 @@ bool QgsVectorTileLayerRenderer::render()
       ctx.labelingEngine()->removeProvider( mLabelProvider );
       mLabelProvider = nullptr; // provider is deleted by the engine
     }
-    else
-      mRequiredLayers.unite( mLabelProvider->requiredLayers( ctx, mTileZoom ) );
+
+    mRequiredLayers.unite( mLabelProvider->requiredLayers( ctx, mTileZoom ) );
   }
 
   if ( !isAsync )

--- a/src/core/vectortile/qgsvectortilelayerrenderer.h
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.h
@@ -26,6 +26,7 @@ class QgsVectorTileLabelProvider;
 
 #include "qgsvectortilerenderer.h"
 #include "qgsmapclippingregion.h"
+#include "qgshttpheaders.h"
 
 /**
  * \ingroup core
@@ -59,7 +60,7 @@ class QgsVectorTileLayerRenderer : public QgsMapLayerRenderer
     QString mSourcePath;
 
     QString mAuthCfg;
-    QString mReferer;
+    QgsHttpHeaders mHeaders;
 
     //! Minimum zoom level at which source has any valid tiles (negative = unconstrained)
     int mSourceMinZoom = -1;

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -21,6 +21,7 @@
 class QByteArray;
 
 #include "qgsvectortilerenderer.h"
+#include "qgshttpheaders.h"
 
 /**
  * \ingroup core
@@ -67,14 +68,14 @@ class QgsVectorTileLoader : public QObject
         const QPointF &viewCenter,
         const QgsTileRange &range,
         const QString &authid,
-        const QString &referer );
+        const QgsHttpHeaders &headers );
 
     //! Returns raw tile data for a single tile, doing a HTTP request. Block the caller until tile data are downloaded.
     static QByteArray loadFromNetwork( const QgsTileXYZ &id,
                                        const QgsTileMatrix &tileMatrix,
                                        const QString &requestUrl,
                                        const QString &authid,
-                                       const QString &referer );
+                                       const QgsHttpHeaders &headers );
     //! Returns raw tile data for a single tile loaded from MBTiles file
     static QByteArray loadFromMBTiles( const QgsTileXYZ &id, QgsMbTiles &mbTileReader );
 
@@ -84,7 +85,7 @@ class QgsVectorTileLoader : public QObject
 
     //! Constructs tile loader for doing asynchronous requests and starts network requests
     QgsVectorTileLoader( const QString &uri, const QgsTileMatrix &tileMatrix, const QgsTileRange &range, const QPointF &viewCenter,
-                         const QString &authid, const QString &referer, QgsFeedback *feedback );
+                         const QString &authid, const QgsHttpHeaders &headers, QgsFeedback *feedback );
     ~QgsVectorTileLoader();
 
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
@@ -108,7 +109,7 @@ class QgsVectorTileLoader : public QObject
     QgsFeedback *mFeedback;
 
     QString mAuthCfg;
-    QString mReferer;
+    QgsHttpHeaders mHeaders;
 
     //! Running tile requests
     QList<QgsTileDownloadManagerReply *> mReplies;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -495,6 +495,7 @@ set(QGIS_GUI_SRCS
   qgshighlightablelineedit.cpp
   qgshistogramwidget.cpp
   qgshelp.cpp
+  qgshttpheaderwidget.cpp
   qgsidentifymenu.cpp
   qgsimagedroptextedit.cpp
   qgsinstallgridshiftdialog.cpp
@@ -746,6 +747,7 @@ set(QGIS_GUI_HDRS
   qgshighlightablecombobox.h
   qgshighlightablelineedit.h
   qgshistogramwidget.h
+  qgshttpheaderwidget.h
   qgsidentifymenu.h
   qgsimagedroptextedit.h
   qgsinstallgridshiftdialog.h
@@ -1345,6 +1347,7 @@ set(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionselectiondialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfeaturefilterwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgenericprojectionselectorbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgshttpheaderwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessagelogviewer.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessageviewer.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsnewvectortabledialogbase.h

--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -23,44 +23,36 @@
 #include "qgsapplication.h"
 
 
-QgsHttpHeaderWidget::QgsHttpHeaderWidget( QWidget *parent ) :
-  QWidget( parent )
+QgsHttpHeaderWidget::QgsHttpHeaderWidget( QWidget *parent )
+  : QWidget( parent )
 {
   setupUi( this );
   btnAddQueryPair->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
   btnRemoveQueryPair->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
   grpbxAdvanced->setCollapsed( true );
 
-  setupConnections();
-}
-
-QgsHttpHeaderWidget::~QgsHttpHeaderWidget()
-{
-  // nope
-}
-
-void QgsHttpHeaderWidget::setupConnections()
-{
   // Action and interaction connections
   connect( btnAddQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::addQueryPair );
   connect( btnRemoveQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::removeQueryPair );
 }
+
+QgsHttpHeaderWidget::~QgsHttpHeaderWidget() = default;
 
 void QgsHttpHeaderWidget::addQueryPairRow( const QString &key, const QString &val )
 {
   const int rowCnt = tblwdgQueryPairs->rowCount();
   tblwdgQueryPairs->insertRow( rowCnt );
 
-  const Qt::ItemFlags itmFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
-                                 | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
+  const Qt::ItemFlags itemFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
+                                  | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
 
-  QTableWidgetItem *keyItm = new QTableWidgetItem( key );
-  keyItm->setFlags( itmFlags );
-  tblwdgQueryPairs->setItem( rowCnt, 0, keyItm );
+  QTableWidgetItem *keyItem = new QTableWidgetItem( key );
+  keyItem->setFlags( itemFlags );
+  tblwdgQueryPairs->setItem( rowCnt, 0, keyItem );
 
-  QTableWidgetItem *valItm = new QTableWidgetItem( val );
-  keyItm->setFlags( itmFlags );
-  tblwdgQueryPairs->setItem( rowCnt, 1, valItm );
+  QTableWidgetItem *valueItem = new QTableWidgetItem( val );
+  keyItem->setFlags( itemFlags );
+  tblwdgQueryPairs->setItem( rowCnt, 1, valueItem );
 }
 
 QgsHttpHeaders QgsHttpHeaderWidget::httpHeaders() const
@@ -120,10 +112,8 @@ void QgsHttpHeaderWidget::setFromSettings( const QgsSettings &settings, const QS
       mRefererLineEdit->setText( headers[ *ite ].toString() );
     }
   }
-  /* mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
 }
 
-/* settings.setValue( key + "/referer", mRefererLineEdit->text() ); */
 void QgsHttpHeaderWidget::updateSettings( QgsSettings &settings, const QString &key ) const
 {
   QgsHttpHeaders h = httpHeaders();

--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -1,3 +1,23 @@
+/***************************************************************************
+                       qgshttpheaderswidget.cpp
+  This class implements simple UI for http header.
+
+                              -------------------
+          begin                : 2021-09-09
+          copyright            : (C) 2021 B. De Mezzo
+          email                : benoit dot de dot mezzo at oslandia dot com
+
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgshttpheaderwidget.h"
 #include "ui_qgshttpheaderwidget.h"
 
@@ -77,8 +97,6 @@ void QgsHttpHeaderWidget::setFromSettings( const QgsSettings &settings, const QS
   // load headers from settings
   QgsHttpHeaders headers;
   headers.setFromSettings( settings, key );
-  printf("In QgsHttpHeaderWidget::setFromSettings: headers[referer]:'%s'\n",
-         headers["referer"].toString().toStdString().c_str());
 
   // push headers to table
   tblwdgQueryPairs->clearContents();
@@ -104,7 +122,4 @@ void QgsHttpHeaderWidget::updateSettings( QgsSettings &settings, const QString &
 {
   QgsHttpHeaders h = httpHeaders();
   h.updateSettings( settings, key );
-  printf("In QgsHttpHeaderWidget::updateSettings: h[referer]:'%s', settings:'%s'\n",
-         h["referer"].toString().toStdString().c_str(),
-          settings.value( key + "referer" ).toString().toStdString().c_str());
 }

--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -1,0 +1,110 @@
+#include "qgshttpheaderwidget.h"
+#include "ui_qgshttpheaderwidget.h"
+
+QgsHttpHeaderWidget::QgsHttpHeaderWidget( QWidget *parent ) :
+  QWidget( parent )
+{
+  setupUi( this );
+  setupConnections();
+}
+
+QgsHttpHeaderWidget::~QgsHttpHeaderWidget()
+{
+  // nope
+}
+
+void QgsHttpHeaderWidget::setupConnections()
+{
+  // Action and interaction connections
+  connect( btnAddQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::addQueryPair );
+  connect( btnRemoveQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::removeQueryPair );
+}
+
+void QgsHttpHeaderWidget::addQueryPairRow( const QString &key, const QString &val )
+{
+  const int rowCnt = tblwdgQueryPairs->rowCount();
+  tblwdgQueryPairs->insertRow( rowCnt );
+
+  const Qt::ItemFlags itmFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
+                                 | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
+
+  QTableWidgetItem *keyItm = new QTableWidgetItem( key );
+  keyItm->setFlags( itmFlags );
+  tblwdgQueryPairs->setItem( rowCnt, 0, keyItm );
+
+  QTableWidgetItem *valItm = new QTableWidgetItem( val );
+  keyItm->setFlags( itmFlags );
+  tblwdgQueryPairs->setItem( rowCnt, 1, valItm );
+}
+
+QgsHttpHeaders QgsHttpHeaderWidget::httpHeaders() const
+{
+  QgsHttpHeaders querypairs;
+  for ( int i = 0; i < tblwdgQueryPairs->rowCount(); ++i )
+  {
+    if ( tblwdgQueryPairs->item( i, 0 )->text().isEmpty() )
+    {
+      continue;
+    }
+    querypairs [ tblwdgQueryPairs->item( i, 0 )->text() ] = QVariant( tblwdgQueryPairs->item( i, 1 )->text() ) ;
+  }
+
+  if ( !mRefererLineEdit->text().isEmpty() )
+  {
+    querypairs [ "referer" ] = QVariant( mRefererLineEdit->text() ) ;
+  }
+  return querypairs;
+}
+
+
+void QgsHttpHeaderWidget::addQueryPair()
+{
+  addQueryPairRow( QString(), QString() );
+  tblwdgQueryPairs->setFocus();
+  tblwdgQueryPairs->setCurrentCell( tblwdgQueryPairs->rowCount() - 1, 0 );
+  tblwdgQueryPairs->edit( tblwdgQueryPairs->currentIndex() );
+}
+
+
+void QgsHttpHeaderWidget::removeQueryPair()
+{
+  tblwdgQueryPairs->removeRow( tblwdgQueryPairs->currentRow() );
+}
+
+
+void QgsHttpHeaderWidget::setFromSettings( const QgsSettings &settings, const QString &key )
+{
+  // load headers from settings
+  QgsHttpHeaders headers;
+  headers.setFromSettings( settings, key );
+  printf("In QgsHttpHeaderWidget::setFromSettings: headers[referer]:'%s'\n",
+         headers["referer"].toString().toStdString().c_str());
+
+  // push headers to table
+  tblwdgQueryPairs->clearContents();
+  /*QTableWidgetItem * item;
+  int row = 0;*/
+  QList<QString> lst = headers.keys();
+  for ( auto ite = lst.constBegin(); ite != lst.constEnd(); ++ite )
+  {
+    if ( ite->compare( "referer" ) != 0 )
+    {
+      addQueryPairRow( *ite, headers[ *ite ].toString() );
+    }
+    else
+    {
+      mRefererLineEdit->setText( headers[ *ite ].toString() );
+    }
+  }
+  /* mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
+}
+
+/* settings.setValue( key + "/referer", mRefererLineEdit->text() ); */
+void QgsHttpHeaderWidget::updateSettings( QgsSettings &settings, const QString &key ) const
+{
+  QgsHttpHeaders h = httpHeaders();
+  h.updateSettings( settings, key );
+  printf("In QgsHttpHeaderWidget::updateSettings: h[referer]:'%s', settings:'%s'\n",
+         h["referer"].toString().toStdString().c_str(),
+          settings.value( key + "referer" ).toString().toStdString().c_str());
+}

--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -20,11 +20,17 @@
 
 #include "qgshttpheaderwidget.h"
 #include "ui_qgshttpheaderwidget.h"
+#include "qgsapplication.h"
+
 
 QgsHttpHeaderWidget::QgsHttpHeaderWidget( QWidget *parent ) :
   QWidget( parent )
 {
   setupUi( this );
+  btnAddQueryPair->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyAdd.svg" ) ) );
+  btnRemoveQueryPair->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/symbologyRemove.svg" ) ) );
+  grpbxAdvanced->setCollapsed( true );
+
   setupConnections();
 }
 

--- a/src/gui/qgshttpheaderwidget.h
+++ b/src/gui/qgshttpheaderwidget.h
@@ -1,3 +1,23 @@
+/***************************************************************************
+                       qgshttpheaderswidget.h
+  This class implements simple UI for http header.
+
+                              -------------------
+          begin                : 2021-09-09
+          copyright            : (C) 2021 B. De Mezzo
+          email                : benoit dot de dot mezzo at oslandia dot com
+
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSHTTPHEADERWIDGET_H
 #define QGSHTTPHEADERWIDGET_H
 
@@ -6,25 +26,62 @@
 #include "qgshttpheaders.h"
 
 
+/**
+ * \ingroup gui
+ * \class QgsHttpHeaderWidget
+ * \brief Display referer http header field and collapsible table of key/value pairs
+ *
+ * \since QGIS 3.22
+ */
 class GUI_EXPORT QgsHttpHeaderWidget : public QWidget, private Ui::QgsHttpHeaderWidget
 {
     Q_OBJECT
 
   public:
+
+    /**
+     * Default constructor
+     * \param parent parent widget
+     */
     explicit QgsHttpHeaderWidget( QWidget *parent = nullptr );
     ~QgsHttpHeaderWidget();
 
+    /**
+     * \return build a new \a QgsHttpHeaders according to data in the UI
+     */
     QgsHttpHeaders httpHeaders() const;
 
-    /* mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
+    /**
+     * \brief fill the inner header map from the settings defined at \a key
+     * \see QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString &key )
+     * \param settings
+     * \param key
+     */
     void setFromSettings( const QgsSettings &settings, const QString &key );
 
-    /* settings.setValue( key + "/referer", mRefererLineEdit->text() ); */
+    /**
+     * \brief update the \a settings with the http headers present in the inner map.
+     * \see QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key ) const
+     * \param settings
+     * \param key
+     */
     void updateSettings( QgsSettings &settings, const QString &key ) const;
 
   private slots:
+
+    /**
+     * create qt signal/slot connections
+     */
     void setupConnections();
+
+    /**
+     * add a new key/value http header pair in the table
+     */
     void addQueryPair();
+
+    /**
+     * remove a key/value http header pair from the table
+     */
     void removeQueryPair();
 
   private:

--- a/src/gui/qgshttpheaderwidget.h
+++ b/src/gui/qgshttpheaderwidget.h
@@ -31,7 +31,7 @@
  * \class QgsHttpHeaderWidget
  * \brief Display referer http header field and collapsible table of key/value pairs
  *
- * \since QGIS 3.22
+ * \since QGIS 3.24
  */
 class GUI_EXPORT QgsHttpHeaderWidget : public QWidget, private Ui::QgsHttpHeaderWidget
 {
@@ -68,11 +68,6 @@ class GUI_EXPORT QgsHttpHeaderWidget : public QWidget, private Ui::QgsHttpHeader
     void updateSettings( QgsSettings &settings, const QString &key ) const;
 
   private slots:
-
-    /**
-     * create qt signal/slot connections
-     */
-    void setupConnections();
 
     /**
      * add a new key/value http header pair in the table

--- a/src/gui/qgshttpheaderwidget.h
+++ b/src/gui/qgshttpheaderwidget.h
@@ -1,0 +1,35 @@
+#ifndef QGSHTTPHEADERWIDGET_H
+#define QGSHTTPHEADERWIDGET_H
+
+#include <QWidget>
+#include "ui_qgshttpheaderwidget.h"
+#include "qgshttpheaders.h"
+
+
+class GUI_EXPORT QgsHttpHeaderWidget : public QWidget, private Ui::QgsHttpHeaderWidget
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsHttpHeaderWidget( QWidget *parent = nullptr );
+    ~QgsHttpHeaderWidget();
+
+    QgsHttpHeaders httpHeaders() const;
+
+    /* mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() ); */
+    void setFromSettings( const QgsSettings &settings, const QString &key );
+
+    /* settings.setValue( key + "/referer", mRefererLineEdit->text() ); */
+    void updateSettings( QgsSettings &settings, const QString &key ) const;
+
+  private slots:
+    void setupConnections();
+    void addQueryPair();
+    void removeQueryPair();
+
+  private:
+    void addQueryPairRow( const QString &key, const QString &val );
+
+};
+
+#endif // QGSHTTPHEADERWIDGET_H

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -37,7 +37,7 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
   setupUi( this );
 
   if ( !( flags & FlagShowHttpSettings ) )
-    mHttpGroupBox->hide();
+    mHttpHeaders->hide();
 
   QgsGui::enableAutoGeometryRestore( this );
 
@@ -95,7 +95,7 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
     const QString credentialsKey = "qgis/" + mCredentialsBaseKey + '/' + connectionName;
     txtName->setText( connectionName );
     txtUrl->setText( settings.value( key + "/url" ).toString() );
-    mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() );
+    mHttpHeaders->setFromSettings( settings, key );
 
     updateServiceSpecificSettings();
 
@@ -337,7 +337,7 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   // Enable/disable these items per WFS versions
   wfsVersionCurrentIndexChanged( versionIdx );
 
-  mRefererLineEdit->setText( settings.value( wmsKey + "/referer" ).toString() );
+  mHttpHeaders->setFromSettings( settings, wmsKey );
   txtMaxNumFeatures->setText( settings.value( wfsKey + "/maxnumfeatures" ).toString() );
 
   // Only default to paging enabled if WFS 2.0.0 or higher
@@ -435,7 +435,7 @@ void QgsNewHttpConnection::accept()
 
     settings.setValue( wmsKey + "/dpiMode", dpiMode );
 
-    settings.setValue( wmsKey + "/referer", mRefererLineEdit->text() );
+    mHttpHeaders->updateSettings( settings, wmsKey );
   }
   if ( mTypes & ConnectionWms )
   {
@@ -475,8 +475,8 @@ void QgsNewHttpConnection::accept()
 
   settings.setValue( credentialsKey + "/authcfg", mAuthSettings->configId() );
 
-  if ( mHttpGroupBox->isVisible() )
-    settings.setValue( key + "/referer", mRefererLineEdit->text() );
+  if ( mHttpHeaders->isVisible() )
+    mHttpHeaders->updateSettings( settings, key );
 
   settings.setValue( mBaseKey + "/selected", txtName->text() );
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -47,7 +47,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
 
   const QString referer = mSharedData->mDataSource.param( QStringLiteral( "referer" ) );
   if ( !referer.isEmpty() )
-    mRequestHeaders[ QStringLiteral( "Referer" )] = referer;
+    mRequestHeaders[ QStringLiteral( "referer" )] = referer;
 
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -28,6 +28,7 @@
 #include "qgslayermetadata.h"
 
 #include "qgsprovidermetadata.h"
+#include "qgshttpheaders.h"
 
 /**
  * \brief A provider reading features from a ArcGIS Feature Service
@@ -89,7 +90,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QgsLayerMetadata mLayerMetadata;
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;
-    QgsStringMap mRequestHeaders;
+    QgsHttpHeaders mRequestHeaders;
 
     /**
      * Clears cache

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -60,7 +60,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
   QString errorTitle, errorMessage;
 
   const QString authcfg = mDataSource.authConfigId();
-  QgsStringMap headers;
+  QgsHttpHeaders headers;
   const QString referer = mDataSource.param( QStringLiteral( "referer" ) );
   if ( !referer.isEmpty() )
     headers[ QStringLiteral( "Referer" )] = referer;
@@ -151,7 +151,7 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
   QString errorText;
 
   const QString authcfg = mDataSource.authConfigId();
-  QgsStringMap headers;
+  QgsHttpHeaders headers;
   const QString referer = mDataSource.param( QStringLiteral( "referer" ) );
   if ( !referer.isEmpty() )
     headers[ QStringLiteral( "Referer" )] = referer;

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -21,6 +21,7 @@
 
 #include "qgsrasterdataprovider.h"
 
+#include "qgshttpheaders.h"
 #include <QNetworkRequest>
 
 #include "qgscoordinatereferencesystem.h"
@@ -152,7 +153,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QString mError;
     QImage mCachedImage;
     QgsRectangle mCachedImageExtent;
-    QgsStringMap mRequestHeaders;
+    QgsHttpHeaders mRequestHeaders;
     int mTileReqNo = 0;
     bool mTiled = false;
     bool mImageServer = false;
@@ -173,7 +174,7 @@ class QgsAmsTiledImageDownloadHandler : public QObject
     Q_OBJECT
   public:
 
-    QgsAmsTiledImageDownloadHandler( const QString &auth,  const QgsStringMap &requestHeaders, int reqNo, const QgsAmsProvider::TileRequests &requests, QImage *image, const QgsRectangle &viewExtent, QgsRasterBlockFeedback *feedback );
+    QgsAmsTiledImageDownloadHandler( const QString &auth,  const QgsHttpHeaders &requestHeaders, int reqNo, const QgsAmsProvider::TileRequests &requests, QImage *image, const QgsRectangle &viewExtent, QgsRasterBlockFeedback *feedback );
     ~QgsAmsTiledImageDownloadHandler() override;
 
     void downloadBlocking();
@@ -204,7 +205,7 @@ class QgsAmsTiledImageDownloadHandler : public QObject
     void finish() { QMetaObject::invokeMethod( mEventLoop, "quit", Qt::QueuedConnection ); }
 
     QString mAuth;
-    QgsStringMap mRequestHeaders;
+    QgsHttpHeaders mRequestHeaders;
 
     QImage *mImage = nullptr;
     QgsRectangle mViewExtent;

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -73,7 +73,7 @@ void QgsArcGisRestRootItem::onConnectionsChanged()
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void addFolderItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers, QgsDataItem *parent,
+void addFolderItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, QgsDataItem *parent,
                      const QString &supportedFormats )
 {
   QgsArcGisRestQueryUtils::visitFolderItems( [parent, &baseUrl, &items, headers, authcfg, supportedFormats]( const QString & name, const QString & url )
@@ -84,7 +84,7 @@ void addFolderItems( QVector< QgsDataItem * > &items, const QVariantMap &service
   }, serviceData, baseUrl );
 }
 
-void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers, QgsDataItem *parent,
+void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, QgsDataItem *parent,
                       const QString &supportedFormats )
 {
   QgsArcGisRestQueryUtils::visitServiceItems(
@@ -113,7 +113,7 @@ void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &servic
   }, serviceData, baseUrl );
 }
 
-void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &parentUrl, const QString &authcfg, const QgsStringMap &headers, QgsDataItem *parent, QgsArcGisRestQueryUtils::ServiceTypeFilter serviceTypeFilter,
+void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &parentUrl, const QString &authcfg, const QgsHttpHeaders &headers, QgsDataItem *parent, QgsArcGisRestQueryUtils::ServiceTypeFilter serviceTypeFilter,
                     const QString &supportedFormats )
 {
   QMultiMap< QString, QgsDataItem * > layerItems;
@@ -196,9 +196,9 @@ QVector<QgsDataItem *> QgsArcGisRestConnectionItem::createChildren()
   const QString url = connection.uri().param( QStringLiteral( "url" ) );
   const QString authcfg = connection.uri().authConfigId();
   const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
-  QgsStringMap headers;
+  QgsHttpHeaders headers;
   if ( ! referer.isEmpty() )
-    headers[ QStringLiteral( "Referer" )] = referer;
+    headers[ QStringLiteral( "referer" )] = referer;
 
   QVector<QgsDataItem *> items;
   if ( !mPortalCommunityEndpoint.isEmpty() && !mPortalContentEndpoint.isEmpty() )
@@ -247,7 +247,7 @@ QString QgsArcGisRestConnectionItem::url() const
 // QgsArcGisPortalGroupsItem
 //
 
-QgsArcGisPortalGroupsItem::QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsStringMap &headers, const QString &communityEndpoint, const QString &contentEndpoint )
+QgsArcGisPortalGroupsItem::QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers, const QString &communityEndpoint, const QString &contentEndpoint )
   : QgsDataCollectionItem( parent, tr( "Groups" ), path, QStringLiteral( "AFS" ) )
   , mAuthCfg( authcfg )
   , mHeaders( headers )
@@ -301,7 +301,7 @@ bool QgsArcGisPortalGroupsItem::equal( const QgsDataItem *other )
 //
 // QgsArcGisPortalGroupItem
 //
-QgsArcGisPortalGroupItem::QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsStringMap &headers, const QString &communityEndpoint, const QString &contentEndpoint )
+QgsArcGisPortalGroupItem::QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsHttpHeaders &headers, const QString &communityEndpoint, const QString &contentEndpoint )
   : QgsDataCollectionItem( parent, name, groupId, QStringLiteral( "AFS" ) )
   , mId( groupId )
   , mAuthCfg( authcfg )
@@ -368,7 +368,7 @@ bool QgsArcGisPortalGroupItem::equal( const QgsDataItem *other )
 // QgsArcGisRestServicesItem
 //
 
-QgsArcGisRestServicesItem::QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsStringMap &headers )
+QgsArcGisRestServicesItem::QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers )
   : QgsDataCollectionItem( parent, tr( "Services" ), path, QStringLiteral( "AFS" ) )
   , mUrl( url )
   , mAuthCfg( authcfg )
@@ -412,7 +412,7 @@ bool QgsArcGisRestServicesItem::equal( const QgsDataItem *other )
 //
 // QgsArcGisRestFolderItem
 //
-QgsArcGisRestFolderItem::QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers )
+QgsArcGisRestFolderItem::QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers )
   : QgsDataCollectionItem( parent, name, path, QStringLiteral( "AFS" ) )
   , mBaseUrl( baseUrl )
   , mAuthCfg( authcfg )
@@ -463,7 +463,7 @@ bool QgsArcGisRestFolderItem::equal( const QgsDataItem *other )
 //
 // QgsArcGisFeatureServiceItem
 //
-QgsArcGisFeatureServiceItem::QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers )
+QgsArcGisFeatureServiceItem::QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers )
   : QgsDataCollectionItem( parent, name, path, QStringLiteral( "AFS" ) )
   , mBaseUrl( baseUrl )
   , mAuthCfg( authcfg )
@@ -515,7 +515,7 @@ bool QgsArcGisFeatureServiceItem::equal( const QgsDataItem *other )
 // QgsArcGisMapServiceItem
 //
 
-QgsArcGisMapServiceItem::QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers, const QString &serviceType )
+QgsArcGisMapServiceItem::QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &serviceType )
   : QgsDataCollectionItem( parent, name, path, QStringLiteral( "AMS" ) )
   , mBaseUrl( baseUrl )
   , mAuthCfg( authcfg )
@@ -567,14 +567,14 @@ bool QgsArcGisMapServiceItem::equal( const QgsDataItem *other )
 // QgsArcGisFeatureServiceLayerItem
 //
 
-QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &title, const QString &authid, const QString &authcfg, const QgsStringMap &headers, Qgis::BrowserLayerType geometryType )
+QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &title, const QString &authid, const QString &authcfg, const QgsHttpHeaders &headers, Qgis::BrowserLayerType geometryType )
   : QgsLayerItem( parent, title, url, QString(), geometryType, QStringLiteral( "arcgisfeatureserver" ) )
 {
   mUri = QStringLiteral( "crs='%1' url='%2'" ).arg( authid, url );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
-  if ( !headers.value( QStringLiteral( "Referer" ) ).isEmpty() )
-    mUri += QStringLiteral( " referer='%1'" ).arg( headers.value( QStringLiteral( "Referer" ) ) );
+  if ( !headers [ QStringLiteral( "referer" ) ].toString().isEmpty() )
+    mUri += QStringLiteral( " referer='%1'" ).arg( headers[ QStringLiteral( "referer" ) ].toString() );
   setState( Qgis::BrowserItemState::Populated );
   setToolTip( url );
 }
@@ -583,15 +583,15 @@ QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem 
 // QgsArcGisMapServiceLayerItem
 //
 
-QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &id, const QString &title, const QString &authid, const QString &format, const QString &authcfg, const QgsStringMap &headers )
+QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &, const QString &url, const QString &id, const QString &title, const QString &authid, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers )
   : QgsLayerItem( parent, title, url, QString(), Qgis::BrowserLayerType::Raster, QStringLiteral( "arcgismapserver" ) )
 {
   const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted
   mUri = QStringLiteral( "crs='%1' format='%2' layer='%3' url='%4'" ).arg( authid, format, id, trimmedUrl );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
-  if ( !headers.value( QStringLiteral( "Referer" ) ).isEmpty() )
-    mUri += QStringLiteral( " referer='%1'" ).arg( headers.value( QStringLiteral( "Referer" ) ) );
+  if ( !headers [ QStringLiteral( "referer" ) ].toString().isEmpty() )
+    mUri += QStringLiteral( " referer='%1'" ).arg( headers [ QStringLiteral( "referer" ) ].toString() );
   setState( Qgis::BrowserItemState::Populated );
   setToolTip( mPath );
 }
@@ -600,7 +600,7 @@ QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent,
 // QgsArcGisRestParentLayerItem
 //
 
-QgsArcGisRestParentLayerItem::QgsArcGisRestParentLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &authcfg, const QgsStringMap &headers )
+QgsArcGisRestParentLayerItem::QgsArcGisRestParentLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers )
   : QgsDataItem( Qgis::BrowserItemType::Collection, parent, name, path )
   , mAuthCfg( authcfg )
   , mHeaders( headers )

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -22,6 +22,7 @@
 #include "qgsdataitemprovider.h"
 #include "qgslayeritem.h"
 #include "qgsconfig.h"
+#include "qgshttpheaders.h"
 
 
 class QgsArcGisRestRootItem : public QgsConnectionsRootItem
@@ -76,14 +77,14 @@ class QgsArcGisPortalGroupsItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsStringMap &headers,
+    QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers,
                                const QString &communityEndpoint, const QString &contentEndpoint );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
   private:
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
 };
@@ -98,7 +99,7 @@ class QgsArcGisPortalGroupItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsStringMap &headers,
+    QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsHttpHeaders &headers,
                               const QString &communityEndpoint, const QString &contentEndpoint );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
@@ -106,7 +107,7 @@ class QgsArcGisPortalGroupItem : public QgsDataCollectionItem
   private:
     QString mId;
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
 };
@@ -123,14 +124,14 @@ class QgsArcGisRestServicesItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
   private:
     QString mUrl;
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
 };
@@ -145,7 +146,7 @@ class QgsArcGisRestFolderItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers );
     void setSupportedFormats( const QString &formats );
 
     QVector<QgsDataItem *> createChildren() override;
@@ -155,7 +156,7 @@ class QgsArcGisRestFolderItem : public QgsDataCollectionItem
     QString mFolder;
     QString mBaseUrl;
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mSupportedFormats;
 };
 
@@ -170,7 +171,7 @@ class QgsArcGisFeatureServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers );
     void setSupportedFormats( const QString &formats );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
@@ -179,7 +180,7 @@ class QgsArcGisFeatureServiceItem : public QgsDataCollectionItem
     QString mFolder;
     QString mBaseUrl;
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mSupportedFormats;
 };
 
@@ -193,7 +194,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsStringMap &headers, const QString &serviceType );
+    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &serviceType );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -201,7 +202,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
     QString mFolder;
     QString mBaseUrl;
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
     QString mServiceType;
 };
 
@@ -213,13 +214,13 @@ class QgsArcGisRestParentLayerItem : public QgsDataItem
     Q_OBJECT
   public:
 
-    QgsArcGisRestParentLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisRestParentLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers );
     bool equal( const QgsDataItem *other ) override;
 
   private:
 
     QString mAuthCfg;
-    QgsStringMap mHeaders;
+    QgsHttpHeaders mHeaders;
 
 };
 
@@ -232,7 +233,7 @@ class QgsArcGisFeatureServiceLayerItem : public QgsLayerItem
 
   public:
 
-    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QString &authid, const QString &authcfg, const QgsStringMap &headers,
+    QgsArcGisFeatureServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QString &authid, const QString &authcfg, const QgsHttpHeaders &headers,
                                       Qgis::BrowserLayerType geometryType );
 
 };
@@ -246,7 +247,7 @@ class QgsArcGisMapServiceLayerItem : public QgsLayerItem
     Q_OBJECT
 
   public:
-    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &id, const QString &title, const QString &authid, const QString &format, const QString &authcfg, const QgsStringMap &headers );
+    QgsArcGisMapServiceLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &id, const QString &title, const QString &authid, const QString &format, const QString &authcfg, const QgsHttpHeaders &headers );
     void setSupportedFormats( const QString &formats ) { mSupportedFormats = formats; }
     QString supportedFormats() const { return mSupportedFormats; }
 

--- a/src/providers/arcgisrest/qgsnewarcgisrestconnection.cpp
+++ b/src/providers/arcgisrest/qgsnewarcgisrestconnection.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 #include "qgsnewarcgisrestconnection.h"
 #include "qgsauthsettingswidget.h"
+#include "qgshttpheaderwidget.h"
 #include "qgssettings.h"
 #include "qgshelp.h"
 #include "qgsgui.h"
@@ -62,7 +63,7 @@ QgsNewArcGisRestConnectionDialog::QgsNewArcGisRestConnectionDialog( QWidget *par
     const QString credentialsKey = "qgis/" + mCredentialsBaseKey + '/' + connectionName;
     txtName->setText( connectionName );
     txtUrl->setText( settings.value( key + "/url" ).toString() );
-    mRefererLineEdit->setText( settings.value( key + "/referer" ).toString() );
+    mHttpHeaders->setFromSettings( settings, key );
 
     // portal
     mContentEndPointLineEdit->setText( settings.value( key + "/content_endpoint" ).toString() );
@@ -193,8 +194,7 @@ void QgsNewArcGisRestConnectionDialog::accept()
 
   settings.setValue( credentialsKey + "/authcfg", mAuthSettings->configId() );
 
-  if ( mHttpGroupBox->isVisible() )
-    settings.setValue( key + "/referer", mRefererLineEdit->text() );
+  mHttpHeaders->updateSettings( settings, key );
 
   settings.setValue( mBaseKey + "/selected", txtName->text() );
 

--- a/src/ui/qgshttpheaderwidget.ui
+++ b/src/ui/qgshttpheaderwidget.ui
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsHttpHeaderWidget</class>
+ <widget class="QWidget" name="QgsHttpHeaderWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>324</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Http Header Widget</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="mHttpGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>HTTP headers</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QFrame" name="mRefererFrame">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="mRefererLabel">
+           <property name="text">
+            <string>Referer</string>
+           </property>
+           <property name="buddy">
+            <cstring>mRefererLineEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsFilterLineEdit" name="mRefererLineEdit"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsCollapsibleGroupBoxBasic" name="grpbxAdvanced">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>4</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Advanced</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QScrollArea" name="scrollAreaAdvanced_2">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="scrollAreaWidgetContentsAdvanced_2">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>370</width>
+              <height>221</height>
+             </rect>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
+             <property name="leftMargin">
+              <number>3</number>
+             </property>
+             <property name="topMargin">
+              <number>3</number>
+             </property>
+             <property name="rightMargin">
+              <number>3</number>
+             </property>
+             <property name="bottomMargin">
+              <number>3</number>
+             </property>
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <item row="3" column="0" colspan="2">
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <property name="spacing">
+                <number>3</number>
+               </property>
+               <item>
+                <widget class="QTableWidget" name="tblwdgQueryPairs">
+                 <property name="editTriggers">
+                  <set>QAbstractItemView::AllEditTriggers</set>
+                 </property>
+                 <property name="dragEnabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="dragDropMode">
+                  <enum>QAbstractItemView::DragOnly</enum>
+                 </property>
+                 <property name="selectionMode">
+                  <enum>QAbstractItemView::SingleSelection</enum>
+                 </property>
+                 <property name="sortingEnabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>false</bool>
+                 </property>
+                 <attribute name="horizontalHeaderMinimumSectionSize">
+                  <number>120</number>
+                 </attribute>
+                 <attribute name="horizontalHeaderDefaultSectionSize">
+                  <number>120</number>
+                 </attribute>
+                 <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+                  <bool>true</bool>
+                 </attribute>
+                 <attribute name="horizontalHeaderStretchLastSection">
+                  <bool>true</bool>
+                 </attribute>
+                 <attribute name="verticalHeaderVisible">
+                  <bool>false</bool>
+                 </attribute>
+                 <column>
+                  <property name="text">
+                   <string>Key</string>
+                  </property>
+                 </column>
+                 <column>
+                  <property name="text">
+                   <string>Value (raw)</string>
+                  </property>
+                 </column>
+                </widget>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_7">
+                 <item>
+                  <widget class="QToolButton" name="btnAddQueryPair">
+                   <property name="minimumSize">
+                    <size>
+                     <width>24</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string notr="true">+</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="btnRemoveQueryPair">
+                   <property name="minimumSize">
+                    <size>
+                     <width>24</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <weight>75</weight>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string notr="true">–</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="verticalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgshttpheaderwidget.ui
+++ b/src/ui/qgshttpheaderwidget.ui
@@ -38,7 +38,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>HTTP headers</string>
+      <string>HTTP Headers</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>

--- a/src/ui/qgsnewarcgisrestconnectionbase.ui
+++ b/src/ui/qgsnewarcgisrestconnectionbase.ui
@@ -27,24 +27,70 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="mHttpGroupBox">
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>HTTP</string>
+      <string>ArcGIS Portal Details</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Referer</string>
+     <layout class="QGridLayout" name="gridLayout1">
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mCommunityEndPointLineEdit">
+        <property name="toolTip">
+         <string>HTTP address of the Web Map Server</string>
+        </property>
+        <property name="placeholderText">
+         <string>https://mysite.com/portal/sharing/rest/community/</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QgsFilterLineEdit" name="mRefererLineEdit"/>
+      <item row="0" column="0">
+       <widget class="QLabel" name="TextLabel1_3">
+        <property name="text">
+         <string>Community endpoint URL</string>
+        </property>
+        <property name="margin">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="TextLabel1_4">
+        <property name="text">
+         <string>Content endpoint URL</string>
+        </property>
+        <property name="margin">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mContentEndPointLineEdit">
+        <property name="toolTip">
+         <string>HTTP address of the Web Map Server</string>
+        </property>
+        <property name="placeholderText">
+         <string>https://mysite.com/portal/sharing/rest/content/</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QgsHttpHeaderWidget" name="mHttpHeaders" native="true"/>
    </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="mGroupBox">
@@ -101,19 +147,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="mAuthGroupBox">
      <property name="title">
@@ -148,68 +181,20 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>ArcGIS Portal Details</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout1">
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mCommunityEndPointLineEdit">
-        <property name="toolTip">
-         <string>HTTP address of the Web Map Server</string>
-        </property>
-        <property name="placeholderText">
-         <string>https://mysite.com/portal/sharing/rest/community/</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="TextLabel1_3">
-        <property name="text">
-         <string>Community endpoint URL</string>
-        </property>
-        <property name="margin">
-         <number>5</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="TextLabel1_4">
-        <property name="text">
-         <string>Content endpoint URL</string>
-        </property>
-        <property name="margin">
-         <number>5</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="mContentEndPointLineEdit">
-        <property name="toolTip">
-         <string>HTTP address of the Web Map Server</string>
-        </property>
-        <property name="placeholderText">
-         <string>https://mysite.com/portal/sharing/rest/content/</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>auth/qgsauthsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsHttpHeaderWidget</class>
+   <extends>QWidget</extends>
+   <header>qgshttpheaderwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -219,7 +204,6 @@
   <tabstop>mCommunityEndPointLineEdit</tabstop>
   <tabstop>mContentEndPointLineEdit</tabstop>
   <tabstop>mAuthSettings</tabstop>
-  <tabstop>mRefererLineEdit</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -26,140 +26,6 @@
       <string>Connection Details</string>
      </property>
      <layout class="QGridLayout">
-      <item row="0" column="0" colspan="2">
-       <widget class="QFrame" name="frame">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="TextLabel1_2">
-           <property name="text">
-            <string>Name</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="margin">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="txtName">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Name of the new connection</string>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="TextLabel1">
-           <property name="text">
-            <string>URL</string>
-           </property>
-           <property name="margin">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="txtUrl">
-           <property name="toolTip">
-            <string>HTTP address of the Web Map Server</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QGroupBox" name="mWmsOptionsGroupBox">
-        <property name="title">
-         <string>WMS/WMTS Options</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="3" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
-           <property name="text">
-            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
-           <property name="text">
-            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
-           <property name="text">
-            <string>Ignore GetMap/GetTile/GetLegendGraphic URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
-           <property name="text">
-            <string>Smooth pixmap transform</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
-           <property name="text">
-            <string>Invert axis orientation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmbDpiMode"/>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblDpiMode">
-           <property name="text">
-            <string>DPI-&amp;Mode</string>
-           </property>
-           <property name="buddy">
-            <cstring>cmbDpiMode</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
-           <property name="text">
-            <string>Ignore reported layer extents</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item row="3" column="0" colspan="2">
        <widget class="QGroupBox" name="mWfsOptionsGroupBox">
         <property name="title">
@@ -248,6 +114,170 @@
         </layout>
        </widget>
       </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QPushButton" name="mTestConnectionButton">
+        <property name="text">
+         <string>&amp;Test Connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QGroupBox" name="mWmsOptionsGroupBox">
+        <property name="title">
+         <string>WMS/WMTS Options</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="3" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
+           <property name="text">
+            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
+           <property name="text">
+            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
+           <property name="text">
+            <string>Ignore GetMap/GetTile/GetLegendGraphic URI reported in capabilities</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
+           <property name="text">
+            <string>Smooth pixmap transform</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
+           <property name="text">
+            <string>Invert axis orientation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDpiMode"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblDpiMode">
+           <property name="text">
+            <string>DPI-&amp;Mode</string>
+           </property>
+           <property name="buddy">
+            <cstring>cmbDpiMode</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
+           <property name="text">
+            <string>Ignore reported layer extents</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QgsHttpHeaderWidget" name="mHttpHeaders" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QFrame" name="frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="TextLabel1_2">
+           <property name="text">
+            <string>Name</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtName">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Name of the new connection</string>
+           </property>
+           <property name="frame">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="TextLabel1">
+           <property name="text">
+            <string>URL</string>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="txtUrl">
+           <property name="toolTip">
+            <string>HTTP address of the Web Map Server</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QGroupBox" name="mAuthGroupBox">
         <property name="title">
@@ -279,45 +309,6 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QPushButton" name="mTestConnectionButton">
-        <property name="text">
-         <string>&amp;Test Connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QGroupBox" name="mHttpGroupBox">
-        <property name="title">
-         <string>HTTP</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Referer</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QgsFilterLineEdit" name="mRefererLineEdit"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
     </widget>
    </item>
@@ -339,15 +330,15 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
+   <class>QgsHttpHeaderWidget</class>
+   <extends>QWidget</extends>
+   <header>qgshttpheaderwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
   <tabstop>txtUrl</tabstop>
-  <tabstop>mRefererLineEdit</tabstop>
   <tabstop>cmbVersion</tabstop>
   <tabstop>mWfsVersionDetectButton</tabstop>
   <tabstop>txtMaxNumFeatures</tabstop>

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TESTS
  testqgsgraduatedsymbolrenderer.cpp
  testqgshistogram.cpp
  testqgshstoreutils.cpp
+ testqgshttpheaders.cpp
  testqgsimagecache.cpp
  testqgsimageoperation.cpp
  testqgsinternalgeometryengine.cpp

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+     testqgshttpheaders.cpp
+     --------------------------------------
+    Date                 : Tue 14 Sep 2012
+    Copyright            : (C) 2012 by Benoit De Mezzo
+    Email                : benoit dot de dot mezzo at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QFile>
+#include <QTextStream>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <qgsapplication.h>
+//header for class being tested
+#include <qgshttpheaders.h>
+#include <qgspoint.h>
+#include "qgslogger.h"
+
+class TestQgsHttpheaders: public QObject
+{
+
+    Q_OBJECT
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase() {} // will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+    void setFromSettings();
+    void updateSettings();
+};
+
+void TestQgsHttpheaders::initTestCase()
+{
+
+}
+
+void TestQgsHttpheaders::setFromSettings()
+{
+  QgsSettings settings;
+  QString keyBase = "qgis/mytest1/";
+  QString outOfHeaderKey = "outofheader";
+  settings.remove( keyBase ); // cleanup
+
+  settings.setValue( keyBase + outOfHeaderKey, "value" );
+  settings.setValue( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1", "value1" );
+  settings.setValue( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer", "valueR" );
+  QgsHttpHeaders h( settings, keyBase );
+  QVERIFY( ! h.keys().contains( outOfHeaderKey ) );
+  QVERIFY( h.keys().contains( "key1" ) );
+  QCOMPARE( h [ "key1" ].toString(), "value1" );
+  QVERIFY( h.keys().contains( "referer" ) );
+  QCOMPARE( h [ "referer" ].toString(), "valueR" );
+
+}
+
+void TestQgsHttpheaders::updateSettings()
+{
+  QgsSettings settings;
+  QString keyBase = "qgis/mytest2/";
+  settings.remove( keyBase ); // cleanup
+
+  QgsHttpHeaders h( ( QMap<QString, QVariant> ) { {QStringLiteral( "key1" ), "value1"}} );
+  h.updateSettings( settings, keyBase );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1" ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1" ).toString(), "value1" );
+
+  QList<QString> keys = settings.allKeys();
+  QVERIFY( ! settings.contains( keyBase + "referer" ) );
+  QVERIFY( ! settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ) );
+
+  h [ "referer" ] = "http://gg.com";
+
+  h.updateSettings( settings, keyBase );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ).toString(), "http://gg.com" );
+  QVERIFY( ! settings.contains( keyBase +  "referer" ) );
+
+  // test backward compability
+  settings.setValue( keyBase + "referer", "paf" ) ; // legacy referer, should be overriden
+  h.updateSettings( settings, keyBase );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ).toString(), "http://gg.com" );
+  QVERIFY( settings.contains( keyBase + "referer" ) );
+  QCOMPARE( settings.value( keyBase + "referer" ).toString(), "http://gg.com" );
+}
+
+
+QGSTEST_MAIN( TestQgsHttpheaders )
+#include "testqgshttpheaders.moc"

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -83,8 +83,8 @@ void TestQgsHttpheaders::updateSettings()
   QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ).toString(), "http://gg.com" );
   QVERIFY( ! settings.contains( keyBase +  "referer" ) );
 
-  // test backward compability
-  settings.setValue( keyBase + "referer", "paf" ) ; // legacy referer, should be overriden
+  // test backward compatibility
+  settings.setValue( keyBase + "referer", "paf" ) ; // legacy referer, should be overridden
   h.updateSettings( settings, keyBase );
   QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ) );
   QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "referer" ).toString(), "http://gg.com" );

--- a/tests/src/python/test_qgsarcgisportalutils.py
+++ b/tests/src/python/test_qgsarcgisportalutils.py
@@ -139,7 +139,8 @@ class TestPyQgsArcGisPortalUtils(unittest.TestCase):
   ]
 }""".encode('UTF-8'))
 
-        res = QgsArcGisPortalUtils.retrieveUserInfo('http://' + endpoint, 'some_user', '')
+        headers = {'referer': 'http://google.com'}
+        res = QgsArcGisPortalUtils.retrieveUserInfo('http://' + endpoint, 'some_user', '', headers)
         # no errors
         self.assertFalse(res[1])
         self.assertFalse(res[2])


### PR DESCRIPTION
## Description

This PR provides an improvement in http header management. 

Currently only the referer http header is handled in the UI when a connection to web service is needed. This management is made by duplicating the same UI components and the same c++ behavior. Furthermore it is not present each time it may be needed (f.e., new connection to *simple* vector layer does not provide it neither raster layer nor wfs layer).

![Capture d’écran du 2021-09-14 11-50-52](https://user-images.githubusercontent.com/64401067/133236205-1523330c-6ee8-414c-9dbf-928c17ee9761.png)

Also see #43951 (thanks @DelazJ).

In the case you need to define an other http header for a connection, it is not possible to set its value in the UI.

## Development 

I have created a class to handle http headers by wrapping a QMap. `QgsHttpHeaders` provides functions to :
* update request http headers
* update qgssettings
* import from qgssettings

To support this class in the UI, I have built a widget with the previous field 'referer' and with a collapsible table to set other key/value pairs.

I have replace the old http referer field in the `qgsnewarcgisrestconnection` widget by the new one. I have done the same with the `qgsvectortileconnection`.

![Capture d’écran du 2021-09-14 11-50-23](https://user-images.githubusercontent.com/64401067/133236161-8f0b3792-0053-4b3a-9e01-db4221657475.png)

If the new behavior is validated I should change all the other web service connection widget to create an uniform way to manage http headers.

An other drawback in the current way to handle the http header, is the way it is used in the `QgsDataSourceUri`. The *referer* is set as an url param but it could be an instance of QgsHttpHeaders.
