### PR TITLE
[bugfix] Fix advanced ZM with locale

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -870,11 +870,11 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
    */
   if ( mLockZButton->isChecked() )
   {
-    point.setZ( mZLineEdit->text().toFloat() );
+    point.setZ( QLocale().toDouble( mZLineEdit->text() ) );
   }
   if ( mLockMButton->isChecked() )
   {
-    point.setM( mMLineEdit->text().toFloat() );
+    point.setM( QLocale().toDouble( mMLineEdit->text() ) );
   }
 
   // update the point list
@@ -1564,10 +1564,10 @@ QgsPoint QgsAdvancedDigitizingDockWidget::pointXYToPoint( const QgsPointXY &poin
 
 double QgsAdvancedDigitizingDockWidget::getLineZ( ) const
 {
-  return mZLineEdit->isEnabled() ? mZLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
+  return mZLineEdit->isEnabled() ? QLocale().toDouble( mZLineEdit->text() ) : std::numeric_limits<double>::quiet_NaN();
 }
 
 double QgsAdvancedDigitizingDockWidget::getLineM( ) const
 {
-  return mMLineEdit->isEnabled() ? mMLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
+  return mMLineEdit->isEnabled() ? QLocale().toDouble( mMLineEdit->text() ) : std::numeric_limits<double>::quiet_NaN();
 }


### PR DESCRIPTION
## Description

In my previous commit, I convert text to float using the standard method. When you use some locale, you to have to convert number with QLocale.

This PR fixes the issue from [twitter](https://twitter.com/totofiandaca/status/1437698466726268929)

cc @pigreco 
