### PR TITLE
Fix 3D mesh terrain when CRS are different from map

### DIFF
--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -69,7 +69,7 @@ float QgsMeshTerrainGenerator::rootChunkError( const Qgs3DMapSettings & ) const
 void QgsMeshTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) const
 {
   float min = std::numeric_limits<float>::max();
-  float max = std::numeric_limits<float>::min();
+  float max = -std::numeric_limits<float>::max();
 
   for ( int i = 0; i < mTriangularMesh.vertices().count(); ++i )
   {
@@ -126,25 +126,7 @@ QgsTerrainGenerator::Type QgsMeshTerrainGenerator::type() const {return QgsTerra
 
 QgsRectangle QgsMeshTerrainGenerator::extent() const
 {
-  QgsRectangle layerextent;
-  if ( mLayer )
-    layerextent = mLayer->extent();
-  else
-    return QgsRectangle();
-
-  const QgsCoordinateTransform terrainToMapTransform( mLayer->crs(), mCrs, mTransformContext );
-  QgsRectangle extentInMap;
-
-  try
-  {
-    extentInMap = terrainToMapTransform.transform( mLayer->extent() );
-  }
-  catch ( QgsCsException & )
-  {
-    extentInMap = mLayer->extent();
-  }
-
-  return extentInMap;
+  return mTriangularMesh.extent();
 }
 
 void QgsMeshTerrainGenerator::writeXml( QDomElement &elem ) const
@@ -185,7 +167,7 @@ void QgsMeshTerrainGenerator::updateTriangularMesh()
 {
   if ( meshLayer() )
   {
-    const QgsCoordinateTransform transform( mCrs, meshLayer()->crs(), mTransformContext );
+    const QgsCoordinateTransform transform( meshLayer()->crs(), mCrs, mTransformContext );
     meshLayer()->updateTriangularMesh( transform );
     mTriangularMesh = *meshLayer()->triangularMeshByLodIndex( mSymbol->levelOfDetailIndex() );
     mTerrainTilingScheme = QgsTilingScheme( mTriangularMesh.extent(), mCrs );


### PR DESCRIPTION
when CRS of mesh layer and CRS of map were different, there was an issue with the mesh terrain extent in the 3D view.
This PR fixes this issue.