### PR TITLE
[MESH] fix #44815

### DIFF
--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -36,7 +36,7 @@ QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *
   connect( mMeshLayer,
            &QgsMeshLayer::dataChanged,
            this,
-           &QgsRendererMeshPropertiesWidget::syncToLayer );
+           &QgsRendererMeshPropertiesWidget::syncToLayerPrivate );
 
   mMeshRendererActiveDatasetWidget->setLayer( mMeshLayer );
   mMeshRendererScalarSettingsWidget->setLayer( mMeshLayer );
@@ -45,7 +45,7 @@ QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *
   mEdgeMeshSettingsWidget->setLayer( mMeshLayer, QgsMeshRendererMeshSettingsWidget::MeshType::Edge );
   mMeshRendererVectorSettingsWidget->setLayer( mMeshLayer );
   m3dAveragingSettingsWidget->setLayer( mMeshLayer );
-  syncToLayer();
+  syncToLayer( mMeshLayer );
 
   //blend mode
   mBlendModeComboBox->setBlendMode( mMeshLayer->blendMode() );
@@ -133,7 +133,25 @@ void QgsRendererMeshPropertiesWidget::apply()
   windowsSettings.setValue( QStringLiteral( "/Windows/RendererMeshProperties/tab" ), mStyleOptionsTab->currentIndex() );
 }
 
-void QgsRendererMeshPropertiesWidget::syncToLayer()
+void QgsRendererMeshPropertiesWidget::syncToLayer( QgsMapLayer *mapLayer )
+{
+  QgsMeshLayer *ml = qobject_cast<QgsMeshLayer *>( mapLayer );
+  if ( ml )
+  {
+    mLayer = ml;
+    mMeshRendererActiveDatasetWidget->setLayer( ml );
+    mNativeMeshSettingsWidget->setLayer( ml, QgsMeshRendererMeshSettingsWidget::Native );
+    mTriangularMeshSettingsWidget->setLayer( ml, QgsMeshRendererMeshSettingsWidget::Triangular );
+    mEdgeMeshSettingsWidget->setLayer( ml, QgsMeshRendererMeshSettingsWidget::Edge );
+    m3dAveragingSettingsWidget->setLayer( ml );
+  }
+  else
+    return;
+
+  syncToLayerPrivate();
+}
+
+void QgsRendererMeshPropertiesWidget::syncToLayerPrivate()
 {
   mMeshRendererActiveDatasetWidget->syncToLayer();
   mNativeMeshSettingsWidget->syncToLayer();

--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.h
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.h
@@ -47,23 +47,22 @@ class GUI_EXPORT QgsRendererMeshPropertiesWidget : public QgsMapLayerConfigWidge
      */
     QgsRendererMeshPropertiesWidget( QgsMeshLayer *layer, QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
+    /**
+     * Synchronize widgets state with associated map layer
+     *
+     * \since QGIS 3.22, replace syncToLayer() without argument
+     */
+    void syncToLayer( QgsMapLayer *mapLayer ) override;
+
   public slots:
     //! Applies the settings made in the dialog
     void apply() override;
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
-    //! Synchronize widgets state with associated mesh layer
-    void syncToLayer();
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
   private slots:
     void onActiveScalarGroupChanged( int groupIndex );
     void onActiveVectorGroupChanged( int groupIndex );
+
+    void syncToLayerPrivate();
 
   private:
     QgsMeshLayer *mMeshLayer = nullptr; //not owned


### PR DESCRIPTION
fix #44815.
This issue come from a confusion between old `QgsRendererMeshPropertiesWidget::synToLayer() ` method and the new method (since 3.14) of the base class `QgsMapLayerConfigWidget::syncToLayer( QgsMapLayer *layer )` that was used instead the first one in this fix : https://github.com/qgis/QGIS/pull/44048/files.

