### PR TITLE
Fix Save for external ressource dialog RelativeStorage config parameter

### DIFF
--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -178,7 +178,7 @@ QVariantMap QgsExternalResourceConfigDlg::config()
     cfg.insert( QStringLiteral( "DefaultRoot" ), mRootPath->text() );
 
   // Save Storage Mode
-  cfg.insert( QStringLiteral( "StorageMode" ), mStorageModeGroupBox->isVisible() ?
+  cfg.insert( QStringLiteral( "StorageMode" ), !mStorageType->currentIndex() ?
               mStorageButtonGroup->checkedId() : QgsFileWidget::GetFile );
 
   // Save Relative Paths option

--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -182,7 +182,7 @@ QVariantMap QgsExternalResourceConfigDlg::config()
               mStorageButtonGroup->checkedId() : QgsFileWidget::GetFile );
 
   // Save Relative Paths option
-  if ( mRelativeGroupBox->isVisible() && mRelativeGroupBox->isChecked() )
+  if ( !mStorageType->currentIndex() && mRelativeGroupBox->isChecked() )
   {
     cfg.insert( QStringLiteral( "RelativeStorage" ), mRelativeButtonGroup->checkedId() );
   }


### PR DESCRIPTION
Fixes #44799 : When clicking on "ok" button, `mRelativeGroupBox` is not visible because its parent is not visible anymore. This PR changes the condition so it works all the time