### PR TITLE
some fixes related to mesh editing

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -739,6 +739,11 @@ Returns whether all the datasets contain ``count`` values
 Calculates the statistics (minimum and maximum)
 %End
 
+    void setStatisticObsolete();
+%Docstring
+Sets statistic obsolete, that means statistic will be recalculated when requested
+%End
+
     virtual QStringList datasetGroupNamesDependentOn() const;
 %Docstring
 Returns the dataset group variable name which this dataset group depends on

--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -62,6 +62,12 @@ Constructor with a specified layer ``meshLayer``
 %End
 
 
+    QgsMeshDatasetGroup *createZValueDatasetGroup() /TransferBack/;
+%Docstring
+Creates and returns a scalar dataset group with value on vertex that is can be used to access the Z value of the edited mesh.
+The caller takes ownership.
+%End
+
     QgsMeshEditingError initialize();
 %Docstring
 Initialize the mesh editor and return errors if the internal native mesh have topologic errors

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1481,19 +1481,15 @@ void QgsMapToolEditMeshFrame::splitSelectedFaces()
 
 void QgsMapToolEditMeshFrame::triggerTransformCoordinatesDockWidget( bool checked )
 {
-  if ( !checked && mTransformDockWidget )
+  if ( mTransformDockWidget )
   {
-    mTransformDockWidget->close();
-    return;
-  }
-  else if ( mTransformDockWidget )
-  {
-    mTransformDockWidget->show();
+    mTransformDockWidget->setUserVisible( checked );
     return;
   }
 
   onEditingStarted();
   mTransformDockWidget = new QgsMeshTransformCoordinatesDockWidget( QgisApp::instance() );
+  mTransformDockWidget->setToggleVisibilityAction( mActionTransformCoordinates );
   mTransformDockWidget->setWindowTitle( tr( "Transform Mesh Vertices" ) );
   mTransformDockWidget->setObjectName( QStringLiteral( "TransformMeshVerticesDockWidget" ) );
   const QList<int> &inputVertices = mSelectedVertices.keys();

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -413,6 +413,11 @@ QWidgetAction *QgsMapToolEditMeshFrame::forceByLineWidgetActionSettings() const
   return mWidgetActionForceByLine;
 }
 
+QAction *QgsMapToolEditMeshFrame::reindexAction() const
+{
+  return mActionReindexMesh;
+}
+
 void QgsMapToolEditMeshFrame::initialize()
 {
   if ( !mFaceRubberBand )
@@ -1652,10 +1657,10 @@ void QgsMapToolEditMeshFrame::forceBySelectedLayerPolyline()
 
 void QgsMapToolEditMeshFrame::reindexMesh()
 {
+  onEditingStarted();
+
   if ( !mCurrentLayer || !mCurrentLayer->isEditable() )
     return;
-
-  onEditingStarted();
 
   if ( QMessageBox::question( canvas(), tr( "Reindex the Mesh" ),
                               tr( "Do you want to reindex the faces and vertices of the mesh layer %1?" ).arg( mCurrentLayer->name() ),

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -128,6 +128,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QList<QAction *> forceByLinesActions() const;
     QAction *defaultForceAction() const;
     QWidgetAction *forceByLineWidgetActionSettings() const;
+    QAction *reindexAction() const;
 
     void setActionsEnable( bool enable );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3869,6 +3869,8 @@ void QgisApp::createToolBars()
     mDigitizeModeToolButton->setMenu( digitizeMenu );
     for ( QAction *mapToolAction : editMeshMapTool->mapToolActions() )
       mMapToolGroup->addAction( mapToolAction );
+
+    mMeshMenu->addAction( editMeshMapTool->reindexAction() );
   }
 
   QToolButton *annotationLayerToolButton = new QToolButton();

--- a/src/core/mesh/qgsmeshdataset.cpp
+++ b/src/core/mesh/qgsmeshdataset.cpp
@@ -975,18 +975,12 @@ QDomElement QgsMeshMemoryDatasetGroup::writeXml( QDomDocument &doc, const QgsRea
 
 void QgsMeshDatasetGroup::calculateStatistic()
 {
-  double min = std::numeric_limits<double>::max();
-  double max = std::numeric_limits<double>::min();
+  updateStatictic();
+}
 
-  const int count = datasetCount();
-  for ( int i = 0; i < count; ++i )
-  {
-    const QgsMeshDatasetMetadata &meta = datasetMetadata( i );
-    min = std::min( min,  meta.minimum() );
-    max = std::max( max, meta.maximum() );
-  }
-  mMinimum = min;
-  mMaximum = max;
+void QgsMeshDatasetGroup::setStatisticObsolete()
+{
+  mIsStatisticObsolete = true;
 }
 
 QStringList QgsMeshDatasetGroup::datasetGroupNamesDependentOn() const
@@ -1002,6 +996,27 @@ QString QgsMeshDatasetGroup::description() const
 void QgsMeshDatasetGroup::setReferenceTime( const QDateTime &referenceTime )
 {
   mReferenceTime = referenceTime;
+}
+
+void QgsMeshDatasetGroup::updateStatictic() const
+{
+  if ( !mIsStatisticObsolete )
+    return;
+
+  double min = std::numeric_limits<double>::max();
+  double max = std::numeric_limits<double>::min();
+
+  const int count = datasetCount();
+  for ( int i = 0; i < count; ++i )
+  {
+    const QgsMeshDatasetMetadata &meta = datasetMetadata( i );
+    min = std::min( min,  meta.minimum() );
+    max = std::max( max, meta.maximum() );
+  }
+  mMinimum = min;
+  mMaximum = max;
+
+  mIsStatisticObsolete = false;
 }
 
 bool QgsMeshDatasetGroup::checkValueCountPerDataset( int count ) const
@@ -1021,11 +1036,13 @@ QgsMeshDatasetGroup::QgsMeshDatasetGroup( const QString &name ): mName( name ) {
 
 double QgsMeshDatasetGroup::minimum() const
 {
+  updateStatictic();
   return mMinimum;
 }
 
 double QgsMeshDatasetGroup::maximum() const
 {
+  updateStatictic();
   return mMaximum;
 }
 

--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -658,6 +658,9 @@ class CORE_EXPORT QgsMeshDatasetGroup
     //! Calculates the statistics (minimum and maximum)
     void calculateStatistic();
 
+    //! Sets statistic obsolete, that means statistic will be recalculated when requested
+    void setStatisticObsolete();
+
     //! Returns the dataset group variable name which this dataset group depends on
     virtual QStringList datasetGroupNamesDependentOn() const;
 
@@ -678,8 +681,11 @@ class CORE_EXPORT QgsMeshDatasetGroup
     bool mIsScalar = true;
 
   private:
-    double mMinimum = std::numeric_limits<double>::quiet_NaN();
-    double mMaximum = std::numeric_limits<double>::quiet_NaN();
+    mutable double mMinimum = std::numeric_limits<double>::quiet_NaN();
+    mutable double mMaximum = std::numeric_limits<double>::quiet_NaN();
+    mutable bool mIsStatisticObsolete = true;
+
+    void updateStatictic() const;
 
     QDateTime mReferenceTime;
 };

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -73,6 +73,12 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     QgsMeshEditor( QgsMesh *nativeMesh, QgsTriangularMesh *triangularMesh, QObject *parent = nullptr ); SIP_SKIP
     ~QgsMeshEditor();
 
+    /**
+     * Creates and returns a scalar dataset group with value on vertex that is can be used to access the Z value of the edited mesh.
+     * The caller takes ownership.
+     */
+    QgsMeshDatasetGroup *createZValueDatasetGroup() SIP_TRANSFERBACK;
+
     //! Initialize the mesh editor and return errors if the internal native mesh have topologic errors
     QgsMeshEditingError initialize();
 
@@ -241,6 +247,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     QgsTopologicalMesh mTopologicalMesh;
     QgsTriangularMesh *mTriangularMesh = nullptr;
     int mMaximumVerticesPerFace = 0;
+    QgsMeshDatasetGroup *mZValueDatasetGroup = nullptr;
 
     QVector<QgsMeshFace> prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error );
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -981,6 +981,7 @@ bool QgsMeshLayer::rollBackFrameEditing( const QgsCoordinateTransform &transform
   mDataProvider->populateMesh( mNativeMesh.get() );
   updateTriangularMesh( transform );
   mRendererCache.reset( new QgsMeshLayerRendererCache() );
+  trigger3DUpdate();
 
   if ( continueEditing )
   {

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -938,7 +938,10 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
 bool QgsMeshLayer::commitFrameEditing( const QgsCoordinateTransform &transform, bool continueEditing )
 {
   if ( !mMeshEditor->checkConsistency() )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Mesh layer \"%1\" not support mesh editing" ).arg( name() ), QString(), Qgis::MessageLevel::Critical );
     return false;
+  }
 
   stopFrameEditing( transform );
 
@@ -973,12 +976,15 @@ bool QgsMeshLayer::rollBackFrameEditing( const QgsCoordinateTransform &transform
   if ( !mDataProvider )
     return false;
 
+  mTriangularMeshes.clear();
   mDataProvider->reloadData();
   mDataProvider->populateMesh( mNativeMesh.get() );
   updateTriangularMesh( transform );
+  mRendererCache.reset( new QgsMeshLayerRendererCache() );
 
   if ( continueEditing )
   {
+    mMeshEditor->resetTriangularMesh( triangularMesh() );
     return mMeshEditor->initialize() == QgsMeshEditingError();
   }
   else

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -930,6 +930,7 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
 
   connect( mMeshEditor, &QgsMeshEditor::meshEdited, this, &QgsMeshLayer::onMeshEdited );
 
+  emit dataChanged();
   emit editingStarted();
 
   return true;
@@ -997,6 +998,7 @@ bool QgsMeshLayer::rollBackFrameEditing( const QgsCoordinateTransform &transform
     mDatasetGroupStore.reset( new QgsMeshDatasetGroupStore( this ) );
     mDatasetGroupStore->setPersistentProvider( mDataProvider, QStringList() );
     resetDatasetGroupTreeItem();
+    emit dataChanged();
     return true;
   }
 }
@@ -1545,8 +1547,9 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
   elemStaticDataset.setAttribute( QStringLiteral( "vector" ), mStaticVectorDatasetIndex );
   layer_node.appendChild( elemStaticDataset );
 
-  // write dataset group store
-  layer_node.appendChild( mDatasetGroupStore->writeXml( document, context ) );
+  // write dataset group store if not in edting mode
+  if ( !isEditable() )
+    layer_node.appendChild( mDatasetGroupStore->writeXml( document, context ) );
 
   // renderer specific settings
   QString errorMsg;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -925,7 +925,7 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
   // All dataset group are removed and replace by a unique virtual dataset group that provide vertices elevation value.
   mExtraDatasetUri.clear();
   mDatasetGroupStore.reset( new QgsMeshDatasetGroupStore( this ) );
-  mDatasetGroupStore->addDatasetGroup( new QgsMeshVerticesElevationDatasetGroup( tr( "vertices Z value" ), mNativeMesh.get() ) );
+  mDatasetGroupStore->addDatasetGroup( mMeshEditor->createZValueDatasetGroup() );
   resetDatasetGroupTreeItem();
 
   connect( mMeshEditor, &QgsMeshEditor::meshEdited, this, &QgsMeshLayer::onMeshEdited );

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -291,7 +291,7 @@ QgsRectangle QgsTriangularMesh::nativeExtent()
   {
     try
     {
-      nativeExtent = mCoordinateTransform.transform( mExtent, QgsCoordinateTransform::ReverseTransform );
+      nativeExtent = mCoordinateTransform.transform( extent(), QgsCoordinateTransform::ReverseTransform );
     }
     catch ( QgsCsException &cse )
     {
@@ -300,13 +300,22 @@ QgsRectangle QgsTriangularMesh::nativeExtent()
     }
   }
   else
-    nativeExtent = mExtent;
+    nativeExtent = extent();
 
   return nativeExtent;
 }
 
 QgsRectangle QgsTriangularMesh::extent() const
 {
+  if ( !mIsExtentValid )
+  {
+    mExtent.setMinimal();
+    for ( int i = 0; i < mTriangularMesh.vertices.size(); ++i )
+      if ( !mTriangularMesh.vertices.at( i ).isEmpty() )
+        mExtent.include( mTriangularMesh.vertices.at( i ) );
+
+    mIsExtentValid = true;
+  }
   return mExtent;
 }
 
@@ -795,11 +804,14 @@ void QgsTriangularMesh::applyChanges( const QgsTriangularMesh::Changes &changes 
   }
 
   for ( int i = 0; i < changes.mNativeFaceIndexesToRemove.count(); ++i )
-    mNativeMeshFaceCentroids[changes.mNativeFaceIndexesToRemove.at( i )] = QgsPoint();
+    mNativeMeshFaceCentroids[changes.mNativeFaceIndexesToRemove.at( i )] = QgsMeshVertex();
 
   // remove vertices
-  // for now, let's try to not remove the vertices, because if the vertex is not referenced in faces,
-  // there is no access anymore to the vertex. If we do not remove it, not need to store (x,y,z) in the changes instance
+  for ( int i = 0; i < changes.mVerticesIndexesToRemove.count(); ++i )
+    mTriangularMesh.vertices[changes.mVerticesIndexesToRemove.at( i )] = QgsMeshVertex();
+
+  if ( !changes.mVerticesIndexesToRemove.isEmpty() )
+    mIsExtentValid = false;
 
   // change Z value
   for ( int i = 0; i < changes.mNewZValue.count(); ++i )
@@ -850,12 +862,15 @@ void QgsTriangularMesh::reverseChanges( const QgsTriangularMesh::Changes &change
   int initialVerticesCount = mTriangularMesh.vertices.count() - changes.mAddedVertices.count();
   mTriangularMesh.vertices.resize( initialVerticesCount );
 
-  // for each vertex to remove, check if the triangular vertex is empty,
-  // that means vertices had to be updated from the native mesh but faces was empty
-  // we need to update the vertices with the reverse native face
+  if ( !changes.mAddedVertices.isEmpty() )
+    mIsExtentValid = false;
+
+  // for each vertex to remove we need to update the vertices with the native vertex
   for ( const int i : std::as_const( changes.mVerticesIndexesToRemove ) )
-    if ( mTriangularMesh.vertex( i ).isEmpty() )
-      mTriangularMesh.vertices[i] = nativeToTriangularCoordinates( nativeMesh.vertex( i ) );
+    mTriangularMesh.vertices[i] = nativeToTriangularCoordinates( nativeMesh.vertex( i ) );
+
+  if ( !changes.mVerticesIndexesToRemove.isEmpty() )
+    mIsExtentValid = false;
 
   // reverse removed faces
   QVector<QgsMeshFace> restoredTriangles;

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -361,7 +361,8 @@ class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
     QgsMeshSpatialIndex mSpatialEdgeIndex;
     QgsCoordinateTransform mCoordinateTransform; //coordinate transform used to convert native mesh vertices to map vertices
 
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
+    mutable bool mIsExtentValid = false;
 
     // average size of the triangles
     double mAverageTriangleSize = 0;


### PR DESCRIPTION
This PR fixes some minor issues related to mesh editing:

- fix cancel/rollback, the triangular mesh was not properly updated
- fix layer extent after editing, the extent was not updated after adding/removing some elements
- fix vertical extent after editing, the min/max of vertices Z value, was not properly updated
- fix 3D update, the 3D view was not updated if the editing was cancel or rollback
- fix dataset group name update, there was an issue with the displayed text of elevation dataset group.
- fix mesh transform coordinate dock widget, there was a bad handling of this widget.
- send the reindex action to the mesh menu instead of a button in the tool bar

