### PR TITLE
Add contextmenu to copy key:value in Dev Tools Panel

### DIFF
--- a/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
@@ -169,7 +169,7 @@ QList<QAction *> QgsNetworkLoggerValueNode::actions( QObject *parent )
 {
   QList< QAction * > res;
 
-  QAction *copyAction = new QAction( QObject::tr( "Copy key: value" ), parent );
+  QAction *copyAction = new QAction( QObject::tr( "Copy" ), parent );
   QObject::connect( copyAction, &QAction::triggered, copyAction, [ = ]
   {
     QApplication::clipboard()->setText( QStringLiteral( "%1: %2" ).arg( mKey, mValue ) );

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
@@ -165,6 +165,21 @@ QVariant QgsNetworkLoggerValueNode::data( int role ) const
   return QVariant();
 }
 
+QList<QAction *> QgsNetworkLoggerValueNode::actions( QObject *parent )
+{
+  QList< QAction * > res;
+
+  QAction *copyAction = new QAction( QObject::tr( "Copy key: value" ), parent );
+  QObject::connect( copyAction, &QAction::triggered, copyAction, [ = ]
+  {
+    QApplication::clipboard()->setText( QStringLiteral( "%1: %2" ).arg( mKey, mValue ) );
+  } );
+
+  res << copyAction;
+
+  return res;
+}
+
 //
 // QgsNetworkLoggerGroup
 //

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -170,6 +170,7 @@ class QgsNetworkLoggerValueNode : public QgsNetworkLoggerNode
 
     QVariant data( int role = Qt::DisplayRole ) const override final;
     int childCount() const override final { return 0; }
+    QList< QAction * > actions( QObject *parent ) override final;
 
   private:
 


### PR DESCRIPTION
## Description

Scratching my own itch here... 

Developing a plugin which builds a (pretty huge) CQL-query parameter, I could see the Requests QGIS was firing AND all headers and query params, but I was not able to copy the CQL query parameter to investigate it further.

So doing:

![Screenshot-20210917091621-659x594](https://user-images.githubusercontent.com/731673/133740985-32ddc6a8-ec2b-478c-8ce3-fc85f3bccfa4.png)

you get:

`Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=AlkSsXddNDVJUkaiH2nhDrys5quiK8McGLD5FCO7%2FVUNatLLOsME%2F7ExKBHhTltLWM9%2FkcedRXqSIVp2%2FvzKyDLtas2F0FlsymkFHvQxXlTJZJ5ns0mlGI65%2Fn0fnPJPBanqFIlhTz2mR0XerfN9"}],"group":"cf-nel","max_age":604800}`

In the Debugging/Development Tools panel, in the Network Logger tab
you see a lot of Request information: Header information,
Query string parts etc etc presented as key:value pairs in the Treeview.

Sometimes (mostly the value) strings can be pretty long.
This adds a context menu (right click on the node) to copy the
key: value as a string to the clipboard.

I first thought to add 2 menu items: 'copy key' and 'copy value' but decided that most times you probably want the value anyway so just merged them into one.

Also thought about adding a copy icon in the menu, but decided to leave it without as this is the 'dev'-part of QGIS anyway.

Mmm, maybe better make it "Copy Key: Value" (use caps)?
