### PR TITLE
Fix select by polygon highlight

### DIFF
--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -263,9 +263,20 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
         auto vectorLayer = static_cast<QgsVectorLayer *>( layer );
         if ( vectorLayer->geometryType() == QgsWkbTypes::PolygonGeometry )
         {
+          QgsRectangle rect( x - sr, y - sr, x + sr, y + sr );
+          QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( vectorLayer );
+
+          try
+          {
+            rect = transform.transformBoundingBox( rect, QgsCoordinateTransform::ReverseTransform );
+          }
+          catch ( QgsCsException &exception )
+          {
+            QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+          }
+
           QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest()
-                                   .setDestinationCrs( mCanvas->mapSettings().destinationCrs(), mCanvas->mapSettings().transformContext() )
-                                   .setFilterRect( QgsRectangle( x - sr, y - sr, x + sr, y + sr ) )
+                                   .setFilterRect( rect )
                                    .setFlags( QgsFeatureRequest::ExactIntersect ) );
           QgsFeature f;
           while ( fit.nextFeature( f ) )
@@ -279,7 +290,20 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
     const QPoint globalPos = mCanvas->mapToGlobal( QPoint( e->pos().x() + 5, e->pos().y() + 5 ) );
     const QList<QgsMapToolIdentify::IdentifyResult> selectedFeatures = mIdentifyMenu->exec( results, globalPos );
     if ( !selectedFeatures.empty() && selectedFeatures[0].mFeature.hasGeometry() )
-      setSelectedGeometry( selectedFeatures[0].mFeature.geometry(), e->modifiers() );
+    {
+      QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( selectedFeatures.at( 0 ).mLayer );
+      QgsGeometry geom = selectedFeatures[0].mFeature.geometry();
+      try
+      {
+        geom.transform( transform );
+      }
+      catch ( QgsCsException &exception )
+      {
+        QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+      }
+
+      setSelectedGeometry( geom, e->modifiers() );
+    }
 
     return;
   }

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -270,7 +270,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
           {
             rect = transform.transformBoundingBox( rect, QgsCoordinateTransform::ReverseTransform );
           }
-          catch ( QgsCsException &exception )
+          catch ( QgsCsException & )
           {
             QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
           }
@@ -297,7 +297,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
       {
         geom.transform( transform );
       }
-      catch ( QgsCsException &exception )
+      catch ( QgsCsException & )
       {
         QgsDebugMsg( QStringLiteral( "Could not transform geometry to map CRS" ) );
       }

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -299,7 +299,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
       }
       catch ( QgsCsException &exception )
       {
-        QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+        QgsDebugMsg( QStringLiteral( "Could not transform geometry to map CRS" ) );
       }
 
       setSelectedGeometry( geom, e->modifiers() );

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -268,7 +268,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
 
           try
           {
-            rect = transform.transformBoundingBox( rect, QgsCoordinateTransform::ReverseTransform );
+            rect = transform.transformBoundingBox( rect, Qgis::TransformDirection::Reverse );
           }
           catch ( QgsCsException & )
           {


### PR DESCRIPTION
In the select by polygon tool, when layer's CRS and map's CRS are different, the highlight of selected polygon is wrong.
It comes from that the highlight needs the geometry in layer coordinates.
So need some coordinate transforms to make all good.

Before:
![selectPolygonBefore](https://user-images.githubusercontent.com/7416892/133719295-e7644f16-6aa3-4066-9fdd-2f3d5b8d7304.gif)



After:
![selectPolygonAfter](https://user-images.githubusercontent.com/7416892/133719300-3c1c2b1f-001b-432e-9fd4-695f64cfc8a9.gif)


