### PR TITLE
[Server] Fix: WMS GetStyles contains previous SLD_BODY requests 

### DIFF
--- a/src/server/services/wms/qgswmsrestorer.cpp
+++ b/src/server/services/wms/qgswmsrestorer.cpp
@@ -74,17 +74,18 @@ QgsLayerRestorer::~QgsLayerRestorer()
 {
   for ( QgsMapLayer *layer : mLayerSettings.keys() )
   {
-    const QgsLayerSettings settings = mLayerSettings[layer];
-    layer->styleManager()->setCurrentStyle( settings.mNamedStyle );
-    layer->setName( mLayerSettings[layer].name );
-
-    // if a SLD file has been loaded for rendering, we restore the previous style
+    // Firstly check if a SLD file has been loaded for rendering and removed it
     const QString sldStyleName { layer->customProperty( "sldStyleName", "" ).toString() };
     if ( !sldStyleName.isEmpty() )
     {
       layer->styleManager()->removeStyle( sldStyleName );
       layer->removeCustomProperty( "sldStyleName" );
     }
+
+    // Then restore the previous style
+    const QgsLayerSettings settings = mLayerSettings[layer];
+    layer->styleManager()->setCurrentStyle( settings.mNamedStyle );
+    layer->setName( mLayerSettings[layer].name );
 
     switch ( layer->type() )
     {

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -137,6 +137,45 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
                                  'getstyles_pointlabel',
                                  project=self.projectPath)
 
+        # Test SLD unchange after GetMap SLD_BODY
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "REQUEST": "GetStyles",
+            "VERSION": "1.1.1",
+            "SERVICE": "WMS",
+            "LAYERS": "db_point"
+        }.items())])
+        r, h = self._result(self._execute_request(qs))
+        assert "StyledLayerDescriptor" in str(r), "StyledLayerDescriptor not in %s" % r
+        assert "__sld_style" not in str(r), "__sld_style in %s" % r
+
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "REQUEST": "GetMap",
+            "VERSION": "1.1.1",
+            "SERVICE": "WMS",
+            "SLD_BODY": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ogc=\"http://www.opengis.net/ogc\" xsi:schemaLocation=\"http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd\" version=\"1.1.0\" xmlns:se=\"http://www.opengis.net/se\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"> <NamedLayer> <se:Name>db_point</se:Name> <UserStyle> <se:Name>db_point_style</se:Name> <se:FeatureTypeStyle> <se:Rule> <se:Name>Single symbol</se:Name> <ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\"> <ogc:PropertyIsEqualTo> <ogc:PropertyName>gid</ogc:PropertyName> <ogc:Literal>1</ogc:Literal> </ogc:PropertyIsEqualTo> </ogc:Filter> <se:PointSymbolizer uom=\"http://www.opengeospatial.org/se/units/metre\"> <se:Graphic> <se:Mark> <se:WellKnownName>square</se:WellKnownName> <se:Fill> <se:SvgParameter name=\"fill\">5e86a1</se:SvgParameter> </se:Fill> <se:Stroke> <se:SvgParameter name=\"stroke\">000000</se:SvgParameter> </se:Stroke> </se:Mark> <se:Size>0.007</se:Size> </se:Graphic> </se:PointSymbolizer> </se:Rule> </se:FeatureTypeStyle> </UserStyle> </NamedLayer> </StyledLayerDescriptor>",
+            "BBOX": "-16817707,-4710778,5696513,14587125",
+            "WIDTH": "500",
+            "HEIGHT": "500",
+            "LAYERS": "db_point",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "CRS": "EPSG:3857"
+        }.items())])
+        self._assert_status_code(200, qs)
+
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "REQUEST": "GetStyles",
+            "VERSION": "1.1.1",
+            "SERVICE": "WMS",
+            "LAYERS": "db_point"
+        }.items())])
+        r, h = self._result(self._execute_request(qs))
+        assert "StyledLayerDescriptor" in str(r), "StyledLayerDescriptor not in %s" % r
+        assert "__sld_style" not in str(r), "__sld_style in %s" % r
+
     def test_wms_getschemaextension(self):
         self.wms_request_compare('GetSchemaExtension',
                                  '',


### PR DESCRIPTION
## Description

The WMS Server restorer does not remove styles created from SLD provided in WMS requests.

The custom property that contains the SLD style name has to be checked before the layer style is restored to the project current style.

Fundex by Ifremer
