### PR TITLE
[WIP] Fix customization #45116

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1515,7 +1515,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   // do main window customization - after window state has been restored, before the window is shown
   startProfile( tr( "Update customization on main window" ) );
-  QgsCustomization::instance()->updateMainWindow( mToolbarMenu );
+  QgsCustomization::instance()->updateMainWindow( mToolbarMenu, mPanelMenu );
   endProfile();
 
   mSplash->showMessage( tr( "Populate saved styles" ), Qt::AlignHCenter | Qt::AlignBottom, splashTextColor );

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -882,6 +882,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu )
       {
         mw->removeDockWidget( dw );
         dw->setParent( NULL );
+        // remove also from menu, because dock removed here, switched on later from menu don't work correctly
         panelMenu->removeAction( dw->toggleViewAction() );
       }
     }

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -823,7 +823,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu )
       if ( !visible )
       {
         mw->removeToolBar( tb );
-        tb->setParent( NULL );
+        tb->setParent( nullptr );
         // remove also from menu, because toolbars removed here, switched on later from menu don't work correctly
         toolBarMenu->removeAction( tb->toggleViewAction() );
       }
@@ -881,7 +881,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu )
       if ( !visible )
       {
         mw->removeDockWidget( dw );
-        dw->setParent( NULL );
+        dw->setParent( nullptr );
         // remove also from menu, because dock removed here, switched on later from menu don't work correctly
         panelMenu->removeAction( dw->toggleViewAction() );
       }

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -774,7 +774,7 @@ QgsCustomization::QgsCustomization()
   mEnabled = settings.value( QStringLiteral( "UI/Customization/enabled" ), "false" ).toString() == QLatin1String( "true" );
 }
 
-void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
+void QgsCustomization::updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu )
 {
   // collect tree items even if the customization is disabled
   createTreeItemMenus();
@@ -823,6 +823,7 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
       if ( !visible )
       {
         mw->removeToolBar( tb );
+        tb->setParent( NULL );
         // remove also from menu, because toolbars removed here, switched on later from menu don't work correctly
         toolBarMenu->removeAction( tb->toggleViewAction() );
       }
@@ -880,6 +881,8 @@ void QgsCustomization::updateMainWindow( QMenu *toolBarMenu )
       if ( !visible )
       {
         mw->removeDockWidget( dw );
+        dw->setParent( NULL );
+        panelMenu->removeAction( dw->toggleViewAction() );
       }
     }
   }

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -132,7 +132,7 @@ class APP_EXPORT QgsCustomization : public QObject
     static void removeFromLayout( QLayout *layout, QWidget *widget );
 
     void updateBrowserWidget( QgsBrowserDockWidget *model );
-    void updateMainWindow( QMenu *toolBarMenu );
+    void updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu );
 
     // make sure to enable/disable before creating QgisApp in order to get it customized (or not)
     void setEnabled( bool enabled ) { mEnabled = enabled; }


### PR DESCRIPTION
## Description

FIX  #45116

Since QGIS 3.20, the customization configuration (QGISCUSTOMIZATION3.ini or indicated file in cli) doesn't work for toolbars and docks.

I tried to debug qgscustomization.cpp, it seems QGIS reads the file correctly and uses the QgisApp methods removeToolBar and removeDockWidget but without being effective (cf.  [qgscustomization.cpp](https://github.com/qgis/QGIS/blob/master/src/app/qgscustomization.cpp#L825) ). I'm not sure what is the cause as the code of qgscustomization.cpp did not change between 3.18 and 3.20, but removing the parent of removed toolbars/dockwidget does the job