### PR TITLE
[UI][FIX] Repeating Lock Z/M buttons should not be enabled by default

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -331,7 +331,6 @@ void QgsAdvancedDigitizingDockWidget::switchZM( )
     else
       mZLineEdit->clear();
     mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-    mRepeatingLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
 
     mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
     mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
@@ -341,7 +340,6 @@ void QgsAdvancedDigitizingDockWidget::switchZM( )
     else
       mMLineEdit->clear();
     mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-    mRepeatingLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
   }
 
 }


### PR DESCRIPTION
## Description

It was enabled if the layer contains Z or M.

![image](https://user-images.githubusercontent.com/7521540/133807603-1728bafa-7600-4167-ad9f-73864dfefcf6.png)
