### PR TITLE
[UI][FIX] Fix CAD Z/M value after snapping

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -878,7 +878,6 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
     point.setM( mMLineEdit->text().toFloat() );
   }
 
-
   // update the point list
   updateCurrentPoint( point );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -844,6 +844,13 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   }
 
   /*
+   * Ensure that Z and M are passed
+   * It will be dropped as needed later.
+   */
+  point.setZ( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
+  point.setM( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
+
+  /*
    * Constraints are applied in 2D, they are always called when using the tool
    * but they do not take into account if when you snap on a vertex it has
    * a Z value.
@@ -858,12 +865,6 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
     e->snapPoint();
     point = mSnapMatch.interpolatedPoint();
   }
-  /*
-   * Ensure that Z and M are passed
-   * It will be dropped as needed later.
-   */
-  point.addZValue( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
-  point.addMValue( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
 
   /*
    * And if M or Z lock button is activated get the value of the input.
@@ -876,6 +877,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   {
     point.setM( mMLineEdit->text().toFloat() );
   }
+
 
   // update the point list
   updateCurrentPoint( point );


### PR DESCRIPTION
## Description

I didn't look at the list of commits after  #42040 but something seems to have broken the Z/M text update.

If you snap a point, and after when you move away, the ZM value of the point is retained instead of using the default value.

Now, I force the default value before adding the potential Z/M value.
