### PR TITLE
[postgis] Expose secondary geometry columns as referenced geometries

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -58,10 +58,10 @@ jobs:
       # Qt caching
       - name: Cache Qt
         id: cache-qt
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: actions/cache@v2.1.6
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/Qt/${{ env.QT_VERSION }}
-          key: mac-qt-v4-${{ env.QT_VERSION }}
+          key: mac-qt-${{ env.QT_VERSION }}
 
       - name: Restore Qt
         if: steps.cache-qt.outputs.cache-hit == 'true'
@@ -81,10 +81,10 @@ jobs:
       # QGIS-deps caching
       - name: Cache qgis-deps
         id: cache-deps
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: actions/cache@v2.1.6
         with:
           path: ${{ env.DEPS_CACHE_DIR }}/QGIS/qgis-deps-${{ env.QGIS_DEPS_VERSION }}.${{ env.QGIS_DEPS_PATCH_VERSION }}
-          key: mac-qgis-deps-v4-${{ env.QGIS_DEPS_VERSION }}.${{ env.QGIS_DEPS_PATCH_VERSION }}
+          key: mac-qgis-deps-${{ env.QGIS_DEPS_VERSION }}.${{ env.QGIS_DEPS_PATCH_VERSION }}
 
       - name: Restore qgis-deps
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -10,11 +10,23 @@ remove them nor change their semantics. Existing code should keep working when t
 to another minor version (e.g. from 2.0 to 2.2), so all extensions of existing classes should be done in a manner that
 third party developers do not need to adjust their code to work properly with newer QGIS releases.
 
-Sometimes, however, we may need to break the API as a result of some code changes. These cases should be only exceptions
-and they should happen only after consideration and agreement of the development team. Backwards incompatible changes
-with too big impact should be deferred to a major version release.
+Sometimes, however, we need to break the API as a result of code changes. These cases are exceptions
+and they happen only after consideration and agreement of the development team.
+Backwards incompatible changes with large impact are postponed to the next major release and tracked in
+https://github.com/qgis/qgis4.0_api/issues
 
-This page tries to maintain a list with incompatible changes that happened in previous releases.
+This page maintains a list of incompatible changes that happened in previous releases.
+
+QGIS 3.24        {#qgis_api_break_3_24}
+=========
+
+Additional geometry attributes
+------------------------------
+
+- If a postgis layer has more than one geometry, the additional geometry attributes are exposed as
+QgsReferencedGeometry. Previously, they were exposed as EWKT strings. EWKT strings are still supported
+for inserting and updating features.
+
 
 QGIS 3.22        {#qgis_api_break_3_22}
 =========

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -267,7 +267,7 @@ QString QgsField::displayString( const QVariant &v ) const
     else
     {
       QString formattedText = QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );
-      if ( formattedText.length() >= 1000 )
+      if ( formattedText.length() >= 1050 )
       {
         formattedText = formattedText.left( 999 ) + QChar( 0x2026 );
       }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -262,7 +262,7 @@ QString QgsField::displayString( const QVariant &v ) const
   if ( v.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
       QgsReferencedGeometry geom = qvariant_cast<QgsReferencedGeometry>( v );
-      if( geom.isEmpty() )
+      if( geom.isNull() )
           return QgsApplication::nullRepresentation();
       else
           return QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -19,6 +19,7 @@
 #include "qgis.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
+#include "qgsreferencedgeometry.h"
 
 #include <QDataStream>
 #include <QIcon>
@@ -256,6 +257,15 @@ QString QgsField::displayString( const QVariant &v ) const
   if ( v.isNull() )
   {
     return QgsApplication::nullRepresentation();
+  }
+
+  if ( v.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
+  {
+      QgsReferencedGeometry geom = qvariant_cast<QgsReferencedGeometry>( v );
+      if( geom.isEmpty() )
+          return QgsApplication::nullRepresentation();
+      else
+          return QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );
   }
 
   // Special treatment for numeric types if group separator is set or decimalPoint is not a dot

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -266,11 +266,12 @@ QString QgsField::displayString( const QVariant &v ) const
       return QgsApplication::nullRepresentation();
     else
     {
-      QString formattedText = QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );
-      if ( formattedText.length() >= 1050 )
+      QString wkt = geom.asWkt();
+      if ( wkt.length() >= 1050 )
       {
-        formattedText = formattedText.left( 999 ) + QChar( 0x2026 );
+        wkt = wkt.left( 999 ) + QChar( 0x2026 );
       }
+      QString formattedText = QStringLiteral( "%1 [%2]" ).arg( wkt, geom.crs().userFriendlyIdentifier() );
       return formattedText;
     }
   }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -261,11 +261,18 @@ QString QgsField::displayString( const QVariant &v ) const
 
   if ( v.userType() == QMetaType::type( "QgsReferencedGeometry" ) )
   {
-      QgsReferencedGeometry geom = qvariant_cast<QgsReferencedGeometry>( v );
-      if( geom.isNull() )
-          return QgsApplication::nullRepresentation();
-      else
-          return QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );
+    QgsReferencedGeometry geom = qvariant_cast<QgsReferencedGeometry>( v );
+    if ( geom.isNull() )
+      return QgsApplication::nullRepresentation();
+    else
+    {
+      QString formattedText = QStringLiteral( "%1 [%2]" ).arg( geom.asWkt(), geom.crs().userFriendlyIdentifier() );
+      if ( formattedText.length() >= 1000 )
+      {
+        formattedText = formattedText.left( 999 ) + QChar( 0x2026 );
+      }
+      return formattedText;
+    }
   }
 
   // Special treatment for numeric types if group separator is set or decimalPoint is not a dot

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -875,7 +875,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
       int idx = mSource->mPrimaryKeyAttrs.at( 0 );
       QgsField fld = mSource->mFields.at( idx );
 
-      QVariant v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+      QVariant v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName(), mConn );
       pkVal << v;
 
       if ( !subsetOfAttributes || fetchAttributes.contains( idx ) )
@@ -900,11 +900,11 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
 
         if ( fld.type() == QVariant::LongLong )
         {
-          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName(), mConn );
         }
         else
         {
-          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName() );
+          v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName(), mConn );
         }
         primaryKeyVals << v;
 
@@ -986,13 +986,13 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
       }
       else
       {
-        v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName() );
+        v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), QString::number( mConn->getBinaryInt( queryResult, row, col ) ), fld.typeName(), mConn );
       }
       break;
     }
     default:
     {
-      v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName() );
+      v = QgsPostgresProvider::convertValue( fld.type(), fld.subType(), queryResult.PQgetvalue( row, col ), fld.typeName(), mConn );
       break;
     }
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -372,8 +372,6 @@ QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPos
   ewktInfo.wkt = ewkt.mid( regularExpressionMatch.captured( 0 ).size() );
   ewktInfo.srid = regularExpressionMatch.captured( 1 ).toInt();
 
-  if ( ewktInfo.srid < 0 )
-    return QgsReferencedGeometry();
 
   QgsGeometry geom = QgsGeometry::fromWkt( ewktInfo.wkt );
   return QgsReferencedGeometry( geom, sridToCrs( ewktInfo.srid, conn ) );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -351,7 +351,83 @@ QString QgsPostgresProvider::providerKey()
 void QgsPostgresProvider::setTransaction( QgsTransaction *transaction )
 {
   // static_cast since layers cannot be added to a transaction of a non-matching provider
-  mTransaction = static_cast<QgsPostgresTransaction *>( transaction );
+    mTransaction = static_cast<QgsPostgresTransaction *>( transaction );
+}
+
+struct Ewkt
+{
+    int srid = -1;
+    QString wkt;
+};
+
+QgsReferencedGeometry QgsPostgresProvider::fromEwkt(const QString &ewkt, QgsPostgresConn *conn)
+{
+  thread_local const QRegularExpression regularExpressionSRID( "^SRID=(\\d+);" );
+
+  QRegularExpressionMatch regularExpressionMatch = regularExpressionSRID.match( ewkt );
+  if ( !regularExpressionMatch.hasMatch() )
+    return QgsReferencedGeometry();
+
+  Ewkt ewktInfo;
+  ewktInfo.wkt = ewkt.mid( regularExpressionMatch.captured( 0 ).size() );
+  ewktInfo.srid = regularExpressionMatch.captured( 1 ).toInt();
+
+  if ( ewktInfo.srid < 0 )
+    return QgsReferencedGeometry();
+
+  QgsGeometry geom = QgsGeometry::fromWkt( ewktInfo.wkt );
+  return QgsReferencedGeometry( geom, sridToCoordSystem( ewktInfo.srid, conn ) );
+}
+
+QString QgsPostgresProvider::toEwkt(const QgsReferencedGeometry &geom)
+{
+    return QStringLiteral( "SRID=%1;%2" ).arg( QString::number( geom.crs().postgisSrid() ), geom.asWkt() );
+}
+
+QString QgsPostgresProvider::geomAttrToString(const QVariant &attr)
+{
+    if ( attr.type() == QVariant::String )
+        return attr.toString();
+    else
+        return toEwkt( attr.value<QgsReferencedGeometry>() );
+}
+
+QgsCoordinateReferenceSystem QgsPostgresProvider::sridToCoordSystem(int srid, QgsPostgresConn *conn)
+{
+    QgsCoordinateReferenceSystem crs;
+
+    static QMutex sMutex;
+
+      QMutexLocker locker( &sMutex );
+      static QMap<int, QgsCoordinateReferenceSystem> sCrsCache;
+      if ( sCrsCache.contains( srid ) )
+        crs = sCrsCache.value( srid );
+      else
+      {
+        if ( conn )
+        {
+          QgsPostgresResult result( conn->PQexec( QStringLiteral( "SELECT auth_name, auth_srid, srtext, proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
+          if ( result.PQresultStatus() == PGRES_TUPLES_OK )
+          {
+            const QString authName = result.PQgetvalue( 0, 0 );
+            const QString authSRID = result.PQgetvalue( 0, 1 );
+            const QString srText = result.PQgetvalue( 0, 2 );
+            bool ok = false;
+            if ( authName == QLatin1String( "EPSG" ) || authName == QLatin1String( "ESRI" ) )
+            {
+              ok = crs.createFromUserInput( authName + ':' + authSRID );
+            }
+            if ( !ok && !srText.isEmpty() )
+            {
+              ok = crs.createFromUserInput( srText );
+            }
+            if ( !ok )
+              crs = QgsCoordinateReferenceSystem::fromProj( result.PQgetvalue( 0, 3 ) );
+            sCrsCache.insert( srid, crs );
+          }
+        }
+      }
+    return crs;
 }
 
 void QgsPostgresProvider::disconnectDb()
@@ -1078,7 +1154,6 @@ bool QgsPostgresProvider::loadFields()
       }
       else if ( fieldTypeName == QLatin1String( "text" ) ||
                 fieldTypeName == QLatin1String( "citext" ) ||
-                fieldTypeName == QLatin1String( "geometry" ) ||
                 fieldTypeName == QLatin1String( "geography" ) ||
                 fieldTypeName == QLatin1String( "inet" ) ||
                 fieldTypeName == QLatin1String( "cidr" ) ||
@@ -1092,6 +1167,11 @@ bool QgsPostgresProvider::loadFields()
                 fieldTypeName.startsWith( QLatin1String( "date" ) ) )
       {
         fieldType = QVariant::String;
+        fieldSize = -1;
+      }
+      else if ( fieldTypeName == QLatin1String( "geometry" ) )
+      {
+        fieldType = QVariant::UserType;
         fieldSize = -1;
       }
       else if ( fieldTypeName == QLatin1String( "bpchar" ) )
@@ -2448,10 +2528,11 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
         }
         else if ( fieldTypeName == QLatin1String( "geometry" ) )
         {
+          QString val = geomAttrToString( v );
           values += QStringLiteral( "%1%2(%3)" )
                     .arg( delim,
                           connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt",
-                          quotedValue( v.toString() ) );
+                          quotedValue( val ) );
         }
         else if ( fieldTypeName == QLatin1String( "geography" ) )
         {
@@ -3054,9 +3135,11 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
           }
           else if ( fld.typeName() == QLatin1String( "geometry" ) )
           {
+              QString val = geomAttrToString( siter.value() );
+
             sql += QStringLiteral( "%1(%2)" )
                    .arg( connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt",
-                         quotedValue( siter->toString() ) );
+                         quotedValue( val ) );
           }
           else if ( fld.typeName() == QLatin1String( "geography" ) )
           {
@@ -3418,9 +3501,10 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
 
           if ( fld.typeName() == QLatin1String( "geometry" ) )
           {
+              QString val = geomAttrToString( siter.value() ) ;
             sql += QStringLiteral( "%1(%2)" )
                    .arg( connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt",
-                         quotedValue( siter->toString() ) );
+                         quotedValue( val ) );
           }
           else if ( fld.typeName() == QLatin1String( "geography" ) )
           {
@@ -4693,40 +4777,8 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
   QgsCoordinateReferenceSystem srs;
   int srid = mRequestedSrid.isEmpty() ? mDetectedSrid.toInt() : mRequestedSrid.toInt();
 
-  {
-    static QMutex sMutex;
-    QMutexLocker locker( &sMutex );
-    static QMap<int, QgsCoordinateReferenceSystem> sCrsCache;
-    if ( sCrsCache.contains( srid ) )
-      srs = sCrsCache.value( srid );
-    else
-    {
-      QgsPostgresConn *conn = connectionRO();
-      if ( conn )
-      {
-        QgsPostgresResult result( conn->PQexec( QStringLiteral( "SELECT auth_name, auth_srid, srtext, proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
-        if ( result.PQresultStatus() == PGRES_TUPLES_OK )
-        {
-          const QString authName = result.PQgetvalue( 0, 0 );
-          const QString authSRID = result.PQgetvalue( 0, 1 );
-          const QString srText = result.PQgetvalue( 0, 2 );
-          bool ok = false;
-          if ( authName == QLatin1String( "EPSG" ) || authName == QLatin1String( "ESRI" ) )
-          {
-            ok = srs.createFromUserInput( authName + ':' + authSRID );
-          }
-          if ( !ok && !srText.isEmpty() )
-          {
-            ok = srs.createFromUserInput( srText );
-          }
-          if ( !ok )
-            srs = QgsCoordinateReferenceSystem::fromProj( result.PQgetvalue( 0, 3 ) );
-          sCrsCache.insert( srid, srs );
-        }
-      }
-    }
-  }
-  return srs;
+  return sridToCoordSystem( srid, connectionRO() );
+
 }
 
 QString QgsPostgresProvider::subsetString() const
@@ -4847,7 +4899,7 @@ QVariant QgsPostgresProvider::parseJson( const QString &txt )
   return QgsJsonUtils::parseJson( txt );
 }
 
-QVariant QgsPostgresProvider::parseOtherArray( const QString &txt, QVariant::Type subType, const QString &typeName )
+QVariant QgsPostgresProvider::parseOtherArray( const QString &txt, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn )
 {
   int i = 0;
   QVariantList result;
@@ -4859,7 +4911,7 @@ QVariant QgsPostgresProvider::parseOtherArray( const QString &txt, QVariant::Typ
       QgsMessageLog::logMessage( tr( "Error parsing array: %1" ).arg( txt ), tr( "PostGIS" ) );
       break;
     }
-    result.append( QgsPostgresProvider::convertValue( subType, QVariant::Invalid, value, typeName ) );
+    result.append( convertValue( subType, QVariant::Invalid, value, typeName, conn ) );
   }
   return result;
 }
@@ -4919,7 +4971,7 @@ QVariant QgsPostgresProvider::parseMultidimensionalArray( const QString &txt )
 
 }
 
-QVariant QgsPostgresProvider::parseArray( const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName )
+QVariant QgsPostgresProvider::parseArray( const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn )
 {
   if ( !txt.startsWith( '{' ) || !txt.endsWith( '}' ) )
   {
@@ -4933,10 +4985,15 @@ QVariant QgsPostgresProvider::parseArray( const QString &txt, QVariant::Type typ
   else if ( type == QVariant::StringList )
     return parseStringArray( inner );
   else
-    return parseOtherArray( inner, subType, typeName );
+    return parseOtherArray( inner, subType, typeName, conn );
 }
 
-QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName )
+QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName ) const
+{
+    return convertValue( type, subType, value, typeName, connectionRO() );
+}
+
+QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName, QgsPostgresConn *conn )
 {
   QVariant result;
   switch ( type )
@@ -4949,7 +5006,7 @@ QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type 
       break;
     case QVariant::StringList:
     case QVariant::List:
-      result = parseArray( value, type, subType, typeName );
+      result = parseArray( value, type, subType, typeName, conn );
       break;
     case QVariant::Bool:
       if ( value == QChar( 't' ) )
@@ -4959,6 +5016,10 @@ QVariant QgsPostgresProvider::convertValue( QVariant::Type type, QVariant::Type 
       else
         result = QVariant( type );
       break;
+  case QVariant::UserType:
+      result = fromEwkt( value, conn );
+      break;
+
     default:
       result = value;
       if ( !result.convert( type ) || value.isNull() )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -354,12 +354,6 @@ void QgsPostgresProvider::setTransaction( QgsTransaction *transaction )
   mTransaction = static_cast<QgsPostgresTransaction *>( transaction );
 }
 
-struct Ewkt
-{
-  int srid = -1;
-  QString wkt;
-};
-
 QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPostgresConn *conn )
 {
   thread_local const QRegularExpression regularExpressionSRID( "^SRID=(\\d+);" );
@@ -368,13 +362,12 @@ QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPos
   if ( !regularExpressionMatch.hasMatch() )
     return QgsReferencedGeometry();
 
-  Ewkt ewktInfo;
-  ewktInfo.wkt = ewkt.mid( regularExpressionMatch.captured( 0 ).size() );
-  ewktInfo.srid = regularExpressionMatch.captured( 1 ).toInt();
+  QString wkt = ewkt.mid( regularExpressionMatch.captured( 0 ).size() );
+  int srid = regularExpressionMatch.captured( 1 ).toInt();
 
 
-  QgsGeometry geom = QgsGeometry::fromWkt( ewktInfo.wkt );
-  return QgsReferencedGeometry( geom, sridToCrs( ewktInfo.srid, conn ) );
+  QgsGeometry geom = QgsGeometry::fromWkt( wkt );
+  return QgsReferencedGeometry( geom, sridToCrs( srid, conn ) );
 }
 
 QString QgsPostgresProvider::toEwkt( const QgsReferencedGeometry &geom, QgsPostgresConn *conn )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -376,7 +376,7 @@ QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPos
     return QgsReferencedGeometry();
 
   QgsGeometry geom = QgsGeometry::fromWkt( ewktInfo.wkt );
-  return QgsReferencedGeometry( geom, sridToCoordSystem( ewktInfo.srid, conn ) );
+  return QgsReferencedGeometry( geom, sridToCrs( ewktInfo.srid, conn ) );
 }
 
 QString QgsPostgresProvider::toEwkt( const QgsReferencedGeometry &geom, QgsPostgresConn *conn )
@@ -425,7 +425,7 @@ int QgsPostgresProvider::crsToSrid( const QgsCoordinateReferenceSystem &crs, Qgs
   return -1;
 }
 
-QgsCoordinateReferenceSystem QgsPostgresProvider::sridToCoordSystem( int srid, QgsPostgresConn *conn )
+QgsCoordinateReferenceSystem QgsPostgresProvider::sridToCrs( int srid, QgsPostgresConn *conn )
 {
   QgsCoordinateReferenceSystem crs;
 
@@ -4807,7 +4807,7 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
   QgsCoordinateReferenceSystem srs;
   int srid = mRequestedSrid.isEmpty() ? mDetectedSrid.toInt() : mRequestedSrid.toInt();
 
-  return sridToCoordSystem( srid, connectionRO() );
+  return sridToCrs( srid, connectionRO() );
 
 }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -379,7 +379,10 @@ QgsReferencedGeometry QgsPostgresProvider::fromEwkt( const QString &ewkt, QgsPos
 
 QString QgsPostgresProvider::toEwkt( const QgsReferencedGeometry &geom, QgsPostgresConn *conn )
 {
-  return QStringLiteral( "SRID=%1;%2" ).arg( QString::number( crsToSrid( geom.crs(), conn ) ), geom.asWkt() );
+  if ( !geom.isNull() )
+    return QStringLiteral( "SRID=%1;%2" ).arg( QString::number( crsToSrid( geom.crs(), conn ) ), geom.asWkt() );
+  else
+    return QString();
 }
 
 QString QgsPostgresProvider::geomAttrToString( const QVariant &attr, QgsPostgresConn *conn )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -507,7 +507,7 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     static QString toEwkt( const QgsReferencedGeometry &geom, QgsPostgresConn *conn );
     static QString geomAttrToString( const QVariant &attr, QgsPostgresConn *conn );
     static int crsToSrid( const QgsCoordinateReferenceSystem &crs,  QgsPostgresConn *conn );
-    static QgsCoordinateReferenceSystem sridToCoordSystem( int srsId, QgsPostgresConn *conn );
+    static QgsCoordinateReferenceSystem sridToCrs( int srsId, QgsPostgresConn *conn );
 
 };
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -23,6 +23,7 @@
 #include "qgspostgresconn.h"
 #include "qgsfields.h"
 #include "qgsprovidermetadata.h"
+#include "qgsreferencedgeometry.h"
 #include <memory>
 
 class QgsFeature;
@@ -218,7 +219,8 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
      * \param value the value to convert
      * \returns a QVariant of the given type or a null QVariant
      */
-    static QVariant convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName );
+    QVariant convertValue(QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName) const;
+    static QVariant convertValue(QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName, QgsPostgresConn *conn );
 
     QList<QgsRelation> discoverRelations( const QgsVectorLayer *self, const QList<QgsVectorLayer *> &layers ) const override;
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override;
@@ -274,10 +276,10 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     static QString getNextString( const QString &txt, int &i, const QString &sep );
     static QVariant parseHstore( const QString &txt );
     static QVariant parseJson( const QString &txt );
-    static QVariant parseOtherArray( const QString &txt, QVariant::Type subType, const QString &typeName );
+    static QVariant parseOtherArray( const QString &txt, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn );
     static QVariant parseStringArray( const QString &txt );
     static QVariant parseMultidimensionalArray( const QString &txt );
-    static QVariant parseArray( const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName );
+    static QVariant parseArray(const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn);
 
 
     /**
@@ -500,6 +502,12 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     QgsLayerMetadata mLayerMetadata;
 
     std::unique_ptr< QgsPostgresListener > mListener;
+
+    static QgsReferencedGeometry fromEwkt(const QString &ewkt , QgsPostgresConn *conn);
+    static QString toEwkt( const QgsReferencedGeometry &geom );
+    static QString geomAttrToString( const QVariant& attr );
+    static QgsCoordinateReferenceSystem sridToCoordSystem(int srsId , QgsPostgresConn *conn);
+
 };
 
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -219,8 +219,8 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
      * \param value the value to convert
      * \returns a QVariant of the given type or a null QVariant
      */
-    QVariant convertValue(QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName) const;
-    static QVariant convertValue(QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName, QgsPostgresConn *conn );
+    QVariant convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName ) const;
+    static QVariant convertValue( QVariant::Type type, QVariant::Type subType, const QString &value, const QString &typeName, QgsPostgresConn *conn );
 
     QList<QgsRelation> discoverRelations( const QgsVectorLayer *self, const QList<QgsVectorLayer *> &layers ) const override;
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override;
@@ -279,7 +279,7 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
     static QVariant parseOtherArray( const QString &txt, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn );
     static QVariant parseStringArray( const QString &txt );
     static QVariant parseMultidimensionalArray( const QString &txt );
-    static QVariant parseArray(const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn);
+    static QVariant parseArray( const QString &txt, QVariant::Type type, QVariant::Type subType, const QString &typeName, QgsPostgresConn *conn );
 
 
     /**
@@ -503,10 +503,11 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 
     std::unique_ptr< QgsPostgresListener > mListener;
 
-    static QgsReferencedGeometry fromEwkt(const QString &ewkt , QgsPostgresConn *conn);
-    static QString toEwkt( const QgsReferencedGeometry &geom );
-    static QString geomAttrToString( const QVariant& attr );
-    static QgsCoordinateReferenceSystem sridToCoordSystem(int srsId , QgsPostgresConn *conn);
+    static QgsReferencedGeometry fromEwkt( const QString &ewkt, QgsPostgresConn *conn );
+    static QString toEwkt( const QgsReferencedGeometry &geom, QgsPostgresConn *conn );
+    static QString geomAttrToString( const QVariant &attr, QgsPostgresConn *conn );
+    static int crsToSrid( const QgsCoordinateReferenceSystem &crs,  QgsPostgresConn *conn );
+    static QgsCoordinateReferenceSystem sridToCoordSystem( int srsId, QgsPostgresConn *conn );
 
 };
 

--- a/tests/src/gui/testqgslistwidget.cpp
+++ b/tests/src/gui/testqgslistwidget.cpp
@@ -145,6 +145,8 @@ class TestQgsListWidget : public QObject
     {
       //create pg layers
       QgsVectorLayer *vl_array_int = new QgsVectorLayer( QStringLiteral( "%1 sslmode=disable key=\"pk\" table=\"qgis_test\".\"array_tbl\" sql=" ).arg( dbConn ), QStringLiteral( "json" ), QStringLiteral( "postgres" ) );
+
+      connect( vl_array_int, &QgsVectorLayer::raiseError, this, []( const QString & msg ) { qWarning() << msg; } );
       QVERIFY( vl_array_int->isValid( ) );
 
       QgsListWidgetWrapper w_array_int( vl_array_int, vl_array_int->fields().indexOf( QLatin1String( "location" ) ), nullptr, nullptr );
@@ -161,10 +163,8 @@ class TestQgsListWidget : public QObject
       new_rec_997.setAttribute( 0, QVariant( 997 ) );
       vl_array_int->addFeature( new_rec_997, QgsFeatureSink::RollBackOnErrors );
       vl_array_int->commitChanges( false );
-      bool success = vl_array_int->changeAttributeValue( 997, 1, w_array_int.value(), QVariant(), false );
-      QVERIFY( success );
-      success = vl_array_int->commitChanges( false );
-      QVERIFY( success );
+      QVERIFY( vl_array_int->changeAttributeValue( 997, 1, w_array_int.value(), QVariant(), false ) );
+      QVERIFY( vl_array_int->commitChanges( false ) );
 
       w_array_int.setFeature( vl_array_int->getFeature( 997 ) );
       QCOMPARE( widget->list( ), QList<QVariant>( ) << 100 );
@@ -208,10 +208,8 @@ class TestQgsListWidget : public QObject
       new_rec_997_str.setAttribute( 0, QVariant( 997 ) );
       vl_array_str->addFeature( new_rec_997_str, QgsFeatureSink::RollBackOnErrors );
       vl_array_str->commitChanges( false );
-      success = vl_array_str->changeAttributeValue( 997, 1, w_array_str.value(), QVariant(), false );
-      QVERIFY( success );
-      success = vl_array_str->commitChanges( false );
-      QVERIFY( success );
+      QVERIFY( vl_array_str->changeAttributeValue( 997, 1, w_array_str.value(), QVariant(), false ) );
+      QVERIFY( vl_array_str->commitChanges( false ) );
 
       w_array_str.setFeature( vl_array_str->getFeature( 997 ) );
       QCOMPARE( widget->list( ), QList<QVariant>( ) << QStringLiteral( "10\"0" ) );

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -47,7 +47,7 @@ class TestQgsPostgresProvider: public QObject
 
 void TestQgsPostgresProvider::decodeHstore()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "\"1\"=>\"2\", \"a\"=>\"b, \\\"c'\", \"backslash\"=>\"\\\\\"" ), QStringLiteral( "hstore" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "\"1\"=>\"2\", \"a\"=>\"b, \\\"c'\", \"backslash\"=>\"\\\\\"" ), QStringLiteral( "hstore" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Map );
 
   QVariantMap expected;
@@ -60,7 +60,7 @@ void TestQgsPostgresProvider::decodeHstore()
 
 void TestQgsPostgresProvider::decodeHstoreNoQuote()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "1=>2, a=>b c" ), QStringLiteral( "hstore" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "1=>2, a=>b c" ), QStringLiteral( "hstore" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Map );
 
   QVariantMap expected;
@@ -72,7 +72,7 @@ void TestQgsPostgresProvider::decodeHstoreNoQuote()
 
 void TestQgsPostgresProvider::decodeArray2StringList()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{\"1\",\"2\", \"a\\\\1\" , \"\\\\\",\"b, \\\"c'\"}" ), QStringLiteral( "hstore" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{\"1\",\"2\", \"a\\\\1\" , \"\\\\\",\"b, \\\"c'\"}" ), QStringLiteral( "hstore" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::StringList );
 
   QStringList expected;
@@ -83,7 +83,7 @@ void TestQgsPostgresProvider::decodeArray2StringList()
 
 void TestQgsPostgresProvider::decodeArray2StringListNoQuote()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{1,2, a ,b, c}" ), QStringLiteral( "hstore" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{1,2, a ,b, c}" ), QStringLiteral( "hstore" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::StringList );
 
   QStringList expected;
@@ -94,7 +94,7 @@ void TestQgsPostgresProvider::decodeArray2StringListNoQuote()
 
 void TestQgsPostgresProvider::decodeArray2IntList()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{1, 2, 3,-5,10}" ), QStringLiteral( "hstore" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{1, 2, 3,-5,10}" ), QStringLiteral( "hstore" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::StringList );
 
   QVariantList expected;
@@ -105,7 +105,7 @@ void TestQgsPostgresProvider::decodeArray2IntList()
 
 void TestQgsPostgresProvider::decode2DimensionArray()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{{foo,\"escape bracket \\}\"},{\"escape bracket and backslash \\\\\\}\",\"hello bar\"}}" ), QStringLiteral( "_text" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{{foo,\"escape bracket \\}\"},{\"escape bracket and backslash \\\\\\}\",\"hello bar\"}}" ), QStringLiteral( "_text" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::StringList );
 
   QVariantList expected;
@@ -116,7 +116,7 @@ void TestQgsPostgresProvider::decode2DimensionArray()
 
 void TestQgsPostgresProvider::decode3DimensionArray()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{{{0,1},{1,2}},{{3,4},{5,6}}}" ), QStringLiteral( "_integer" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::StringList, QVariant::String, QStringLiteral( "{{{0,1},{1,2}},{{3,4},{5,6}}}" ), QStringLiteral( "_integer" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::StringList );
 
   QVariantList expected;
@@ -127,7 +127,7 @@ void TestQgsPostgresProvider::decode3DimensionArray()
 
 void TestQgsPostgresProvider::decodeJsonList()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "[1,2,3]" ), QStringLiteral( "json" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "[1,2,3]" ), QStringLiteral( "json" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::List );
 
   QVariantList expected;
@@ -140,7 +140,7 @@ void TestQgsPostgresProvider::decodeJsonList()
 
 void TestQgsPostgresProvider::decodeJsonbList()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "[1,2,3]" ), QStringLiteral( "jsonb" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "[1,2,3]" ), QStringLiteral( "jsonb" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::List );
 
   QVariantList expected;
@@ -153,7 +153,7 @@ void TestQgsPostgresProvider::decodeJsonbList()
 
 void TestQgsPostgresProvider::decodeJsonMap()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "{\"a\":1,\"b\":2}" ), QStringLiteral( "json" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "{\"a\":1,\"b\":2}" ), QStringLiteral( "json" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Map );
 
   QVariantMap expected;
@@ -165,7 +165,7 @@ void TestQgsPostgresProvider::decodeJsonMap()
 
 void TestQgsPostgresProvider::decodeJsonbMap()
 {
-  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "{\"a\":1,\"b\":2}" ), QStringLiteral( "jsonb" ) );
+  const QVariant decoded = QgsPostgresProvider::convertValue( QVariant::Map, QVariant::String, QStringLiteral( "{\"a\":1,\"b\":2}" ), QStringLiteral( "jsonb" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Map );
 
   QVariantMap expected;
@@ -180,19 +180,19 @@ void TestQgsPostgresProvider::testDecodeDateTimes()
 
   QVariant decoded;
 
-  decoded = QgsPostgresProvider::convertValue( QVariant::DateTime, QVariant::Invalid, QStringLiteral( "2020-06-08 18:30:35.496438+02" ), QStringLiteral( "timestamptz" ) );
+  decoded = QgsPostgresProvider::convertValue( QVariant::DateTime, QVariant::Invalid, QStringLiteral( "2020-06-08 18:30:35.496438+02" ), QStringLiteral( "timestamptz" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::DateTime );
 
-  decoded = QgsPostgresProvider::convertValue( QVariant::Time, QVariant::Invalid, QStringLiteral( "18:29:27.569401+02" ), QStringLiteral( "timetz" ) );
+  decoded = QgsPostgresProvider::convertValue( QVariant::Time, QVariant::Invalid, QStringLiteral( "18:29:27.569401+02" ), QStringLiteral( "timetz" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Time );
 
-  decoded = QgsPostgresProvider::convertValue( QVariant::Date, QVariant::Invalid, QStringLiteral( "2020-06-08" ), QStringLiteral( "date" ) );
+  decoded = QgsPostgresProvider::convertValue( QVariant::Date, QVariant::Invalid, QStringLiteral( "2020-06-08" ), QStringLiteral( "date" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Date );
 
-  decoded = QgsPostgresProvider::convertValue( QVariant::DateTime, QVariant::Invalid, QStringLiteral( "2020-06-08 18:30:35.496438" ), QStringLiteral( "timestamp" ) );
+  decoded = QgsPostgresProvider::convertValue( QVariant::DateTime, QVariant::Invalid, QStringLiteral( "2020-06-08 18:30:35.496438" ), QStringLiteral( "timestamp" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::DateTime );
 
-  decoded = QgsPostgresProvider::convertValue( QVariant::Time, QVariant::Invalid, QStringLiteral( "18:29:27.569401" ), QStringLiteral( "time" ) );
+  decoded = QgsPostgresProvider::convertValue( QVariant::Time, QVariant::Invalid, QStringLiteral( "18:29:27.569401" ), QStringLiteral( "time" ), nullptr );
   QCOMPARE( decoded.type(), QVariant::Time );
 
 }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -3537,6 +3537,18 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         feature['geom'] = 'SRID=4326;Point (71 78)'
         self.assertTrue(vl.updateFeature(feature))
 
+        # addFeature
+        feature['pk'] = 8
+        self.assertTrue(vl.addFeature(feature))
+
+        # changeAttributeValue
+        geom = QgsReferencedGeometry(QgsGeometry.fromWkt('POINT(3 3)'), QgsCoordinateReferenceSystem.fromEpsgId(4326))
+
+        feature['pk'] = 8
+        self.assertTrue(vl.changeAttributeValue(8, 8, geom))
+        self.assertEqual(vl.getFeature(8)['geom'].asWkt(), geom.asWkt())
+        self.assertEqual(vl.getFeature(8)['geom'].crs(), geom.crs())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -41,6 +41,7 @@ from qgis.core import (
     QgsTransactionGroup,
     QgsReadWriteContext,
     QgsRectangle,
+    QgsReferencedGeometry,
     QgsDefaultValue,
     QgsCoordinateReferenceSystem,
     QgsProject,
@@ -3508,6 +3509,33 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         self.assertEqual(table.primaryKeyColumns(), ['id'])
 
         self.assertEqual(exported_layer.fields().names(), ['id', 'name', 'author'])
+
+    def testEwkt(self):
+        vl = QgsVectorLayer(f'{self.dbconn} table="qgis_test"."someData" sql=', "someData", "postgres")
+        tg = QgsTransactionGroup()
+        tg.addLayer(vl)
+
+        feature = next(vl.getFeatures())
+        # make sure we get a QgsReferenceGeometry and not "just" a string
+        self.assertEqual(feature['geom'].crs().authid(), 'EPSG:4326')
+
+        vl.startEditing()
+
+        # Layer accepts a referenced geometry
+        feature['geom'] = QgsReferencedGeometry(QgsGeometry.fromWkt('POINT(70 70)'), QgsCoordinateReferenceSystem.fromEpsgId(4326))
+        self.assertTrue(vl.updateFeature(feature))
+
+        # Layer will accept null geometry
+        feature['geom'] = QgsReferencedGeometry()
+        self.assertTrue(vl.updateFeature(feature))
+
+        # Layer will not accept invalid crs
+        feature['geom'] = QgsReferencedGeometry(QgsGeometry.fromWkt('POINT(1 1)'), QgsCoordinateReferenceSystem())
+        self.assertFalse(vl.updateFeature(feature))
+
+        # EWKT strings are accepted too
+        feature['geom'] = 'SRID=4326;Point (71 78)'
+        self.assertTrue(vl.updateFeature(feature))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As discussed in https://github.com/qgis/QGIS/pull/45007
This exposes additional geometry columns from postgres provider as QgsReferencedGeometry.

This allow more efficient interaction with additional geometry columns through the API. For example in label placement.
The fields will be represented as `WKT [CRS User Friendly Identifier]` in the attribute table.

Warning: This changes the behavior for existing projects.