### PR TITLE
fix Z/M value of advanced digitizing when decimal separator isn't point

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1575,10 +1575,10 @@ QgsPoint QgsAdvancedDigitizingDockWidget::pointXYToPoint( const QgsPointXY &poin
 
 double QgsAdvancedDigitizingDockWidget::getLineZ( ) const
 {
-  return mZLineEdit->isEnabled() ? mZLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
+  return mZLineEdit->isEnabled() ? QLocale().toFloat( mZLineEdit->text() ) : std::numeric_limits<double>::quiet_NaN();
 }
 
 double QgsAdvancedDigitizingDockWidget::getLineM( ) const
 {
-  return mMLineEdit->isEnabled() ? mMLineEdit->text().toFloat() : std::numeric_limits<double>::quiet_NaN();
+  return mMLineEdit->isEnabled() ? QLocale().toFloat( mMLineEdit->text() ) : std::numeric_limits<double>::quiet_NaN();
 }


### PR DESCRIPTION
I always have got 0 for Z value without this fix