### PR TITLE
Adapt mesh editing following new CAD Z value

### DIFF
--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -153,7 +153,15 @@ Changes the Z values of the vertices with indexes in ``vertices`` indexes with t
     void changeXYValues( const QList<int> &verticesIndexes, const QList<QgsPointXY> &newValues );
 %Docstring
 Changes the (X,Y) coordinates values of the vertices with indexes in ``vertices`` indexes with the values in ``newValues``.
+The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
+New values are in layer CRS.
+%End
+
+    void changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
+%Docstring
+Changes the (X,Y,Z) coordinates values of the vertices with indexes in ``vertices`` indexes with the values in ``newValues``.
 The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
+New coordinates are in layer CRS.
 %End
 
     void advancedEdit( QgsMeshAdvancedEditing *editing );

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -221,6 +221,20 @@ Determines if Z or M will be enabled.
 .. versionadded:: 3.22
 %End
 
+    void setEnabledZ( bool enable );
+%Docstring
+Sets whether Z is enabled
+
+.. versionadded:: 3.22
+%End
+
+    void setEnabledM( bool enable );
+%Docstring
+Sets whether M is enabled
+
+.. versionadded:: 3.22
+%End
+
     bool constructionMode() const;
 %Docstring
 construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -85,7 +85,6 @@ QgsZValueWidget::QgsZValueWidget( const QString &label, QWidget *parent ): QWidg
 double QgsZValueWidget::zValue() const
 {
   mZValueSpinBox->interpretText();
-  double v = mZValueSpinBox->value();
   return mZValueSpinBox->value();
 }
 

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -188,6 +188,8 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     const QgsPointXY mapVertexXY( int index ) const;
     const QgsMeshFace nativeFace( int index ) const;
 
+    double currentZValue();
+
     void highLight( const QgsPointXY &mapPoint );
     void highlightCurrentHoveredFace( const QgsPointXY &mapPoint );
     void highlightCloseVertex( const QgsPointXY &mapPoint );
@@ -262,6 +264,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QList<int> mNewFaceCandidate;
     bool mDoubleClicks = false;
     QgsPointXY mFirstClickPoint; //the first click point when double clicks, we need it when the point is constraint by the cad tool, second click could not be constraint
+    double mFirstClickZValue;
     double mUserZValue = 0;
 
     //! Rubber band used to highlight a face that is on mouse over and not dragging anything, own by map canvas

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -203,7 +203,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     void clearAll();
 
-    void addVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match &mapPointMatch, Qt::KeyboardModifiers modifiers );
+    void addVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match &mapPointMatch );
     void updateFreeVertices();
 
     //! Checks if we are closed to a vertex, if yes return the index of the vertex;
@@ -262,9 +262,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QList<int> mNewFaceCandidate;
     bool mDoubleClicks = false;
     QgsPointXY mFirstClickPoint; //the first click point when double clicks, we need it when the point is constraint by the cad tool, second click could not be constraint
-    double mOrdinaryZValue = 0;
-    bool mIsSelectedZValue = false;
-    double mSelectedZValue = 0;
+    double mUserZValue = 0;
 
     //! Rubber band used to highlight a face that is on mouse over and not dragging anything, own by map canvas
     QgsRubberBand *mFaceRubberBand = nullptr;

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -684,6 +684,11 @@ void QgsMeshEditor::changeXYValues( const QList<int> &verticesIndexes, const QLi
   mUndoStack->push( new QgsMeshLayerUndoCommandChangeXYValue( this, verticesIndexes, newValues ) );
 }
 
+void QgsMeshEditor::changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates )
+{
+  mUndoStack->push( new QgsMeshLayerUndoCommandChangeCoordinates( this, verticesIndexes, newCoordinates ) );
+}
+
 void QgsMeshEditor::advancedEdit( QgsMeshAdvancedEditing *editing )
 {
   mUndoStack->push( new QgsMeshLayerUndoCommandAdvancedEditing( this, editing ) );
@@ -938,6 +943,45 @@ void QgsMeshLayerUndoCommandChangeXYValue::redo()
       mMeshEditor->applyEdit( edit );
   }
 }
+
+
+QgsMeshLayerUndoCommandChangeCoordinates::QgsMeshLayerUndoCommandChangeCoordinates( QgsMeshEditor *meshEditor, const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates )
+  : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
+  , mVerticesIndexes( verticesIndexes )
+  , mNewCoordinates( newCoordinates )
+{}
+
+void QgsMeshLayerUndoCommandChangeCoordinates::redo()
+{
+  if ( !mVerticesIndexes.isEmpty() )
+  {
+    QgsMeshEditor::Edit editXY;
+    QList<QgsPointXY> newXY;
+    newXY.reserve( mNewCoordinates.count() );
+    QgsMeshEditor::Edit editZ;
+    QList<double> newZ;
+    newZ.reserve( mNewCoordinates.count() );
+
+    for ( const QgsPoint &pt : std::as_const( mNewCoordinates ) )
+    {
+      newXY.append( pt );
+      newZ.append( pt.z() );
+    }
+
+    mMeshEditor->applyChangeXYValue( editXY, mVerticesIndexes, newXY );
+    mEdits.append( editXY );
+    mMeshEditor->applyChangeZValue( editZ, mVerticesIndexes, newZ );
+    mEdits.append( editZ );
+    mVerticesIndexes.clear();
+    mNewCoordinates.clear();
+  }
+  else
+  {
+    for ( QgsMeshEditor::Edit &edit : mEdits )
+      mMeshEditor->applyEdit( edit );
+  }
+}
+
 
 
 QgsMeshLayerUndoCommandFlipEdge::QgsMeshLayerUndoCommandFlipEdge( QgsMeshEditor *meshEditor, int vertexIndex1, int vertexIndex2 )

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -176,9 +176,17 @@ class CORE_EXPORT QgsMeshEditor : public QObject
 
     /**
      * Changes the (X,Y) coordinates values of the vertices with indexes in \a vertices indexes with the values in \a newValues.
-     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
+     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
+     * New values are in layer CRS.
      */
     void changeXYValues( const QList<int> &verticesIndexes, const QList<QgsPointXY> &newValues );
+
+    /**
+     * Changes the (X,Y,Z) coordinates values of the vertices with indexes in \a vertices indexes with the values in \a newValues.
+     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
+     * New coordinates are in layer CRS.
+     */
+    void changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
 
     /**
      * Applies an advance editing on the edited mesh, see QgsMeshAdvancedEditing
@@ -285,6 +293,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     friend class QgsMeshLayerUndoCommandSetZValue;
     friend class QgsMeshLayerUndoCommandChangeZValue;
     friend class QgsMeshLayerUndoCommandChangeXYValue;
+    friend class QgsMeshLayerUndoCommandChangeCoordinates;
     friend class QgsMeshLayerUndoCommandFlipEdge;
     friend class QgsMeshLayerUndoCommandMerge;
     friend class QgsMeshLayerUndoCommandSplitFaces;
@@ -437,6 +446,29 @@ class QgsMeshLayerUndoCommandChangeXYValue : public QgsMeshLayerUndoCommandMeshE
   private:
     QList<int> mVerticesIndexes;
     QList<QgsPointXY> mNewValues;
+};
+
+/**
+ * \ingroup core
+ *
+ * \brief  Class for undo/redo command for changing coordinate (X,Y,Z) values of vertices
+ *
+ * \since QGIS 3.22
+ */
+class QgsMeshLayerUndoCommandChangeCoordinates : public QgsMeshLayerUndoCommandMeshEdit
+{
+  public:
+
+    /**
+     * Constructor with the associated \a meshEditor and indexes \a verticesIndexes of the vertices that will have
+     * the coordinate (X,Y,Z) values changed with \a newCoordinates
+     */
+    QgsMeshLayerUndoCommandChangeCoordinates( QgsMeshEditor *meshEditor, const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
+    void redo() override;
+
+  private:
+    QList<int> mVerticesIndexes;
+    QList<QgsPoint> mNewCoordinates;
 };
 
 /**

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -38,6 +38,7 @@
 #include "qgsproject.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmessagelog.h"
+#include "qgsmeshlayer.h"
 
 #include <QActionGroup>
 
@@ -319,29 +320,55 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 
 void QgsAdvancedDigitizingDockWidget::switchZM( )
 {
+  bool enableZ = false;
+  bool enableM = false;
 
-  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() ) )
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
+  if ( vlayer )
   {
     const QgsWkbTypes::Type type = vlayer->wkbType();
-    mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-    mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
-    mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
-    if ( mZLineEdit->isEnabled() )
-      mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
-    else
-      mZLineEdit->clear();
-    mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
-
-    mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
-    mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
-    mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
-    if ( mMLineEdit->isEnabled() )
-      mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
-    else
-      mMLineEdit->clear();
-    mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+    enableZ = QgsWkbTypes::hasZ( type );
+    enableM = QgsWkbTypes::hasM( type );
   }
 
+  QgsMeshLayer *mlayer = qobject_cast<QgsMeshLayer *>( mMapCanvas->currentLayer() );
+  if ( mlayer )
+    enableZ = mlayer->isEditable();
+
+  setEnabledZ( enableZ );
+
+  mRelativeMButton->setEnabled( enableM );
+  mMLabel->setEnabled( enableM );
+  mMLineEdit->setEnabled( enableM );
+  if ( mMLineEdit->isEnabled() )
+    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
+  else
+    mMLineEdit->clear();
+  mLockMButton->setEnabled( enableM );
+}
+
+void QgsAdvancedDigitizingDockWidget::setEnabledZ( bool enable )
+{
+  mRelativeZButton->setEnabled( enable );
+  mZLabel->setEnabled( enable );
+  mZLineEdit->setEnabled( enable );
+  if ( mZLineEdit->isEnabled() )
+    mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
+  else
+    mZLineEdit->clear();
+  mLockZButton->setEnabled( enable );
+}
+
+void QgsAdvancedDigitizingDockWidget::setEnabledM( bool enable )
+{
+  mRelativeMButton->setEnabled( enable );
+  mMLabel->setEnabled( enable );
+  mMLineEdit->setEnabled( enable );
+  if ( mMLineEdit->isEnabled() )
+    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
+  else
+    mMLineEdit->clear();
+  mLockMButton->setEnabled( enable );
 }
 
 void QgsAdvancedDigitizingDockWidget::activateCad( bool enabled )

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -336,15 +336,7 @@ void QgsAdvancedDigitizingDockWidget::switchZM( )
     enableZ = mlayer->isEditable();
 
   setEnabledZ( enableZ );
-
-  mRelativeMButton->setEnabled( enableM );
-  mMLabel->setEnabled( enableM );
-  mMLineEdit->setEnabled( enableM );
-  if ( mMLineEdit->isEnabled() )
-    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
-  else
-    mMLineEdit->clear();
-  mLockMButton->setEnabled( enableM );
+  setEnabledM( enableM );
 }
 
 void QgsAdvancedDigitizingDockWidget::setEnabledZ( bool enable )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -256,6 +256,18 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void switchZM( );
 
+    /**
+     * Sets whether Z is enabled
+     * \since QGIS 3.22
+     */
+    void setEnabledZ( bool enable );
+
+    /**
+     * Sets whether M is enabled
+     * \since QGIS 3.22
+     */
+    void setEnabledM( bool enable );
+
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
     bool constructionMode() const { return mConstructionMode; }
 


### PR DESCRIPTION
Following the new Z value constraint in the cad advanced editing dock widget (PR #42040), this PR aims to use this new feature for mesh editing and then simplify the proper handling of the z value of mesh editing.

With standard mode, the Z value of vertices is handled as follows:

An input widget is present in the top-right of the map canvas to handle the Z value.

When a vertex is selected, its Z value is set in the widget. The user can change it by entering a new value and press "enter".
If several vertices are selected, the average Z value is set in the widget; the user can also change the selected vertices values by entering a new value applied to all the vertices.

![Z_value_1](https://user-images.githubusercontent.com/7416892/133950304-8afa0fa4-6441-4ff7-9b5e-7830e33eaacb.gif)

If none vertex is selected, the Z value widget contains the default Z value of the application (defined in settings) or the last value enter by the user.

Another way to change the Z value of a vertex is to move a vertex and snap it on a vector layer feature with the Z value capability. If more than one vertex are selected, the Z value can't be changed in this way.

![Z_value_2](https://user-images.githubusercontent.com/7416892/133950315-935621fa-d0d5-4abc-aff8-cd10e4a1c425.gif)

The value contained by this Z value widget is also used when the user adds a new "free" vertex, that is, a vertex not included in a face or an edge of a face. Vertices included in a face or the edge of a face will have a Z value interpolated.

![Z_value_3](https://user-images.githubusercontent.com/7416892/133950333-467d257f-956d-451d-83d3-e5d7a16537ed.gif)

With CAD mode, mesh editing uses now the new constraint Z value:


If none vertex is selected, the mesh Z value widget is no more available.
When the mouse encounters a mesh vertex or snaps on a vector layer feature, the Z value of the CAD widget takes the Z value of the vertex or from the feature depending on the snap. The user can "capture" this Z value by locking it. Then this value can be used to add a new free vertex.
The user can also enter a Z value manually and lock it for new free vertices.

![Z_value_4](https://user-images.githubusercontent.com/7416892/133950339-58b7edc6-1868-432f-8b52-465507f590ef.gif)

If one or more vertices are selected, the mesh Z value widget is again available and allows to change the Z value of selected vertices as for standard mode.

When moving vertices, the Z value of the CAD widget is disabled. Indeed, the Z value can't be constraint by the dock widget when moving vertices. It is intentional to avoid constantly changing the Z value by simply moving vertices without changing it. The first intention was to use the Z value only when the Z constraint is locked, but that was not implemented. The mains reason is that the cad widget always gives default value when the cursor does not encounter vertex or not snap on a vector layer feature. When the point comes to the mesh edit tool through the event, maybe I am wrong, there is no information about this point comes from a lock constraint or not.

![Z_value_5](https://user-images.githubusercontent.com/7416892/133950344-adc172fc-1b51-4239-87fd-60f828d21064.gif)

@lbartoletti , if you can have a look at the changes int the CAD canvas dock widget