### PR TITLE
fix face/vertex count during editing

### DIFF
--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -212,14 +212,14 @@ Returns ``True`` if an edge of face is closest than the tolerance from the ``poi
 Returns also the face index and the edge position in ``faceIndex`` and ``edgePosition``
 %End
 
-    int effectiveFacesCount() const;
+    int validFacesCount() const;
 %Docstring
-Returns the effective count of faces, that is non void faces in the mesh
+Returns the count of valid faces, that is non void faces in the mesh
 %End
 
-    int effectiveVerticesCount() const;
+    int validVerticesCount() const;
 %Docstring
-Returns the effective count of vertices, that is non void vertices in the mesh
+Returns the count of valid vertices, that is non void vertices in the mesh
 %End
 
   signals:

--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -212,6 +212,16 @@ Returns ``True`` if an edge of face is closest than the tolerance from the ``poi
 Returns also the face index and the edge position in ``faceIndex`` and ``edgePosition``
 %End
 
+    int effectiveFacesCount() const;
+%Docstring
+Returns the effective count of faces, that is non void faces in the mesh
+%End
+
+    int effectiveVerticesCount() const;
+%Docstring
+Returns the effective count of vertices, that is non void vertices in the mesh
+%End
+
   signals:
     void meshEdited();
 %Docstring

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -808,12 +808,20 @@ Returns whether the mesh contains at mesh elements of given type
 %Docstring
 Returns the vertices count of the mesh frame
 
+.. note::
+
+   during mesh editing, some vertices can be void and are not included in this returned value
+
 .. versionadded:: 3.22
 %End
 
     int meshFaceCount() const;
 %Docstring
 Returns the faces count of the mesh frame
+
+.. note::
+
+   during mesh editing, some faces can be void and are not included in this returned value
 
 .. versionadded:: 3.22
 %End

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -65,8 +65,8 @@ QgsMeshEditingError QgsMeshEditor::initialize()
 {
   QgsMeshEditingError error;
   mTopologicalMesh = QgsTopologicalMesh::createTopologicalMesh( mMesh, mMaximumVerticesPerFace, error );
-  mEffectiveFacesCount = mMesh->faceCount();
-  mEffectiveVerticesCount = mMesh->vertexCount();
+  mValidFacesCount = mMesh->faceCount();
+  mValidVerticesCount = mMesh->vertexCount();
   return error;
 }
 
@@ -337,14 +337,14 @@ void QgsMeshEditor::updateElementsCount( const QgsTopologicalMesh::Changes &chan
 {
   if ( apply )
   {
-    mEffectiveFacesCount += changes.addedFaces().count() - changes.removedFaces().count();
-    mEffectiveVerticesCount += changes.addedVertices().count() - changes.verticesToRemoveIndexes().count();
+    mValidFacesCount += changes.addedFaces().count() - changes.removedFaces().count();
+    mValidVerticesCount += changes.addedVertices().count() - changes.verticesToRemoveIndexes().count();
   }
   else
   {
     //reverse
-    mEffectiveFacesCount -= changes.addedFaces().count() - changes.removedFaces().count();
-    mEffectiveVerticesCount -= changes.addedVertices().count() - changes.verticesToRemoveIndexes().count();
+    mValidFacesCount -= changes.addedFaces().count() - changes.removedFaces().count();
+    mValidVerticesCount -= changes.addedVertices().count() - changes.verticesToRemoveIndexes().count();
   }
 }
 
@@ -419,14 +419,14 @@ bool QgsMeshEditor::edgeIsClose( QgsPointXY point, double tolerance, int &faceIn
 
 }
 
-int QgsMeshEditor::effectiveFacesCount() const
+int QgsMeshEditor::validFacesCount() const
 {
-  return mEffectiveFacesCount;
+  return mValidFacesCount;
 }
 
-int QgsMeshEditor::effectiveVerticesCount() const
+int QgsMeshEditor::validVerticesCount() const
 {
-  return mEffectiveVerticesCount;
+  return mValidVerticesCount;
 }
 
 QgsMeshEditingError QgsMeshEditor::removeFaces( const QList<int> &facesToRemove )
@@ -895,8 +895,8 @@ bool QgsMeshEditor::reindex( bool renumbering )
   mTopologicalMesh.reindex();
   mUndoStack->clear();
   QgsMeshEditingError error = initialize();
-  mEffectiveFacesCount = mMesh->faceCount();
-  mEffectiveVerticesCount = mMesh->vertexCount();
+  mValidFacesCount = mMesh->faceCount();
+  mValidVerticesCount = mMesh->vertexCount();
 
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return false;

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -238,6 +238,12 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      */
     bool edgeIsClose( QgsPointXY point, double tolerance, int &faceIndex, int &edgePosition );
 
+    //! Returns the effective count of faces, that is non void faces in the mesh
+    int effectiveFacesCount() const;
+
+    //! Returns the effective count of vertices, that is non void vertices in the mesh
+    int effectiveVerticesCount() const;
+
   signals:
     //! Emitted when the mesh is edited
     void meshEdited();
@@ -248,6 +254,8 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     QgsTriangularMesh *mTriangularMesh = nullptr;
     int mMaximumVerticesPerFace = 0;
     QgsMeshDatasetGroup *mZValueDatasetGroup = nullptr;
+    int mEffectiveVerticesCount = 0;
+    int mEffectiveFacesCount = 0;
 
     QVector<QgsMeshFace> prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error );
 
@@ -275,6 +283,8 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     void applyAdvancedEdit( Edit &edit, QgsMeshAdvancedEditing *editing );
 
     void applyEditOnTriangularMesh( Edit &edit, const QgsTopologicalMesh::Changes &topologicChanges );
+
+    void updateElementsCount( const QgsTopologicalMesh::Changes &changes, bool apply = true );
 
     friend class TestQgsMeshEditor;
     friend class QgsMeshLayerUndoCommandMeshEdit;

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -238,11 +238,11 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      */
     bool edgeIsClose( QgsPointXY point, double tolerance, int &faceIndex, int &edgePosition );
 
-    //! Returns the effective count of faces, that is non void faces in the mesh
-    int effectiveFacesCount() const;
+    //! Returns the count of valid faces, that is non void faces in the mesh
+    int validFacesCount() const;
 
-    //! Returns the effective count of vertices, that is non void vertices in the mesh
-    int effectiveVerticesCount() const;
+    //! Returns the count of valid vertices, that is non void vertices in the mesh
+    int validVerticesCount() const;
 
   signals:
     //! Emitted when the mesh is edited
@@ -254,8 +254,8 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     QgsTriangularMesh *mTriangularMesh = nullptr;
     int mMaximumVerticesPerFace = 0;
     QgsMeshDatasetGroup *mZValueDatasetGroup = nullptr;
-    int mEffectiveVerticesCount = 0;
-    int mEffectiveFacesCount = 0;
+    int mValidVerticesCount = 0;
+    int mValidFacesCount = 0;
 
     QVector<QgsMeshFace> prepareFaces( const QVector<QgsMeshFace> &faces, QgsMeshEditingError &error );
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1060,7 +1060,7 @@ bool QgsMeshLayer::contains( const QgsMesh::ElementType &type ) const
 int QgsMeshLayer::meshVertexCount() const
 {
   if ( mMeshEditor )
-    return mNativeMesh->vertexCount();
+    return mMeshEditor->effectiveVerticesCount();
   else if ( mDataProvider )
     return mDataProvider->vertexCount();
   else return 0;
@@ -1069,7 +1069,7 @@ int QgsMeshLayer::meshVertexCount() const
 int QgsMeshLayer::meshFaceCount() const
 {
   if ( mMeshEditor )
-    return mNativeMesh->faceCount();
+    return mMeshEditor->effectiveFacesCount();
   else if ( mDataProvider )
     return mDataProvider->faceCount();
   else return 0;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1060,7 +1060,7 @@ bool QgsMeshLayer::contains( const QgsMesh::ElementType &type ) const
 int QgsMeshLayer::meshVertexCount() const
 {
   if ( mMeshEditor )
-    return mMeshEditor->effectiveVerticesCount();
+    return mMeshEditor->validVerticesCount();
   else if ( mDataProvider )
     return mDataProvider->vertexCount();
   else return 0;
@@ -1069,7 +1069,7 @@ int QgsMeshLayer::meshVertexCount() const
 int QgsMeshLayer::meshFaceCount() const
 {
   if ( mMeshEditor )
-    return mMeshEditor->effectiveFacesCount();
+    return mMeshEditor->validFacesCount();
   else if ( mDataProvider )
     return mDataProvider->faceCount();
   else return 0;

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -813,12 +813,16 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     /**
     * Returns the vertices count of the mesh frame
     *
+    * \note during mesh editing, some vertices can be void and are not included in this returned value
+    *
     *  \since QGIS 3.22
     */
     int meshVertexCount() const;
 
     /**
     * Returns the faces count of the mesh frame
+    *
+    * \note during mesh editing, some faces can be void and are not included in this returned value
     *
     * \since QGIS 3.22
     */

--- a/tests/src/app/testqgsmaptooleditmesh.cpp
+++ b/tests/src/app/testqgsmaptooleditmesh.cpp
@@ -85,7 +85,7 @@ void TestQgsMapToolEditMesh::editMesh()
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
 
   tool.mouseDoubleClick( 1500, 2800, Qt::LeftButton ); //add a vertex on the face 0
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 8 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 9 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
 
@@ -103,19 +103,19 @@ void TestQgsMapToolEditMesh::editMesh()
 
   // redo
   tool.mouseDoubleClick( 1500, 2800, Qt::LeftButton );
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 8 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 9 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
 
   // attempt to add a vertex on place of existing one
   tool.mouseDoubleClick( 2500, 2500, Qt::LeftButton );
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 8 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 9 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
 
   // add a free vertex
   tool.mouseDoubleClick( 2500, 3500, Qt::LeftButton );  // 9
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 8 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 10 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 1 );
 
@@ -130,7 +130,7 @@ void TestQgsMapToolEditMesh::editMesh()
   tool.mouseClick( 2495, 2500, Qt::LeftButton ); // click near the vertex
   tool.mouseClick( 5000, 5000, Qt::RightButton ); // valid the face
 
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 10 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
 
   // Remove vertex 7 and 9
   tool.mouseMove( 1500, 3250 );

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -137,7 +137,7 @@ void TestQgsMeshEditor::startStopEditing()
   QgsMeshEditor *editor = meshLayerQuadTriangle->meshEditor();
   QCOMPARE( editor->addVertices( {QgsMeshVertex( 1500, 2500, 0 )}, 10 ), 1 );
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 6 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 6 );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 5 );
 
   // roll back editing and continue editing
   QVERIFY( meshLayerQuadTriangle->isModified() );
@@ -161,7 +161,7 @@ void TestQgsMeshEditor::startStopEditing()
 
   QCOMPARE( editor->addVertices( {QgsMeshVertex( 1500, 2500, 0 )}, 10 ), 1 );
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 6 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 6 );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 5 );
 
   // roll back editing and stop editing
   QVERIFY( meshLayerQuadTriangle->isModified() );
@@ -1084,14 +1084,14 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   // Add vertices under the tolerance from the edge inside the face
   editor->addVertices( {{2500, 2002, 0}}, 10 );
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 8 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 4 );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 3 );
   QCOMPARE( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().count(), 2 );
   meshLayerQuadTriangle->undoStack()->undo();
 
   // Add vertices under the tolerance from the edge outside the face
   editor->addVertices( {{2500, 1998, 0}}, 10 );
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 8 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 4 );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 3 );
   QCOMPARE( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().count(), 2 );
   meshLayerQuadTriangle->undoStack()->undo();
 
@@ -1176,8 +1176,8 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
 
   editor->removeFaces( {2, 3} );
 
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 4 ); //removed faces are still present but empty
-  QVERIFY( meshLayerQuadTriangle->nativeMesh()->face( 2 ).isEmpty() );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 2 );
+  QVERIFY( meshLayerQuadTriangle->nativeMesh()->face( 2 ).isEmpty() ); //removed faces are still present but empty
   QVERIFY( meshLayerQuadTriangle->nativeMesh()->face( 3 ).isEmpty() );
 
   QCOMPARE( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().count(), 2 );
@@ -1212,7 +1212,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   }, 10 );
 
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 9 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 8 ); // vertex on a quad face : 4 faces created, 1 removed, removed are still present but void
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 7 ); // vertex on a quad face : 4 faces created, 1 removed, removed are still present but void and not counted
   QVERIFY( meshLayerQuadTriangle->nativeMesh()->face( 0 ).isEmpty() );
   QVERIFY( QgsMesh::compareFaces( meshLayerQuadTriangle->nativeMesh()->face( 4 ), {0, 1, 7} ) );
   QVERIFY( QgsMesh::compareFaces( meshLayerQuadTriangle->nativeMesh()->face( 5 ), {1, 3, 7} ) );
@@ -1313,7 +1313,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   QVERIFY( centroid.compare( QgsPointXY( 1833.33333333, 2600 ), 1e-6 ) );
 
   QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 9 );
-  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 8 );
+  QCOMPARE( meshLayerQuadTriangle->meshFaceCount(), 7 );
 
   QCOMPARE( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().count(), 1 );
   QVERIFY( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().contains( 8 ) );
@@ -1329,7 +1329,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   centroid = meshLayerQuadTriangle->snapOnElement( QgsMesh::Face, QgsPoint( 1950, 2700, 0 ), 10 );
   QVERIFY( centroid.isEmpty() );
 
-  QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 9 ); //empty vertex still presents
+  QCOMPARE( meshLayerQuadTriangle->meshVertexCount(), 8 ); //empty vertex still presents but not counted
 
   snappedPoint = meshLayerQuadTriangle->snapOnElement( QgsMesh::Vertex, QgsPoint( 1498, 3505, 0 ), 10 );
   QVERIFY( snappedPoint.isEmpty() );
@@ -1388,23 +1388,23 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   meshLayerQuadFlower->startFrameEditing( transform );
   editor = meshLayerQuadFlower->meshEditor();
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1500, 2800, -10 )}, 10 ), 1 ); // 8
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 9 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 8 );
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1800, 2700, -10 )}, 10 ), 1 ); // 9
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 12 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 10 );
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1400, 2300, -10 ), QgsPoint( 1500, 2200, -10 )}, 10 ), 2 ); // 10 & 11
 
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 18 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 14 );
   QVERIFY( editor->checkConsistency() );
 
   // attempt to add a vertex under tolerance next existing one
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1499, 2801, -10 )}, 10 ), 0 );
 
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 18 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 14 );
 
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 700, 1750, 0 )}, 10 ), 1 ); // 12
 
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 18 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 14 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 13 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 1 );
   QVERIFY( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().contains( 12 ) );
@@ -1417,7 +1417,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1400, 2200, -10 )}, 10 ), 1 ); // 13
 
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 22 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 17 );
   QVERIFY( editor->checkConsistency() );
 
   QCOMPARE( meshLayerQuadFlower->datasetValue( QgsMeshDatasetIndex( 0, 0 ), QgsPointXY( 1420, 2220 ), 10 ).x(), -10 );
@@ -1505,8 +1505,8 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   QVERIFY( editor->removeVertices( {7}, true ) == QgsMeshEditingError() );
 
-  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 57 );
-  QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 16 );
+  QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 5 );
+  QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 7 );
   QVERIFY( editor->checkConsistency() );
 
   meshLayerQuadFlower->commitFrameEditing( transform, true );


### PR DESCRIPTION
During mesh editing, some faces and vertices can be void and are still in the mesh until the end of editing or a re indexing. When the count of faces or vertices are requested to the mesh layer, the return value includes all the elements, even the void one. That leads to a false information for the user, for example in the mesh layer properties (information tab).

With this PR, only the non void faces /vertices are included in the count.