### PR TITLE
drop project backward compatibility for symbology with QGIS 3.16 and older

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -3171,19 +3171,6 @@ QVariantMap QgsSymbolLayerUtils::parseProperties( const QDomElement &element )
 void QgsSymbolLayerUtils::saveProperties( QVariantMap props, QDomDocument &doc, QDomElement &element )
 {
   element.appendChild( QgsXmlUtils::writeVariant( props, doc ) );
-
-  // -----
-  // let's do this to try to keep some backward compatibility
-  // to open a project saved on 3.18+ in QGIS <= 3.16
-  // TODO QGIS 4: remove
-  for ( QVariantMap::iterator it = props.begin(); it != props.end(); ++it )
-  {
-    QDomElement propEl = doc.createElement( QStringLiteral( "prop" ) );
-    propEl.setAttribute( QStringLiteral( "k" ), it.key() );
-    propEl.setAttribute( QStringLiteral( "v" ), it.value().toString() );
-    element.appendChild( propEl );
-  }
-  // -----
 }
 
 QgsSymbolMap QgsSymbolLayerUtils::loadSymbols( QDomElement &element, const QgsReadWriteContext &context )

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -30,6 +30,7 @@
 #include "qgslayoutmanager.h"
 #include "qgsmarkersymbol.h"
 
+
 class TestQgsProject : public QObject
 {
     Q_OBJECT
@@ -223,18 +224,9 @@ static QHash<QString, QString> _parseSvgPathsForLayers( const QString &projectFi
   while ( !layerElem.isNull() )
   {
     const QString layerName = layerElem.firstChildElement( QStringLiteral( "layername" ) ).text();
-    QString svgPath;
     const QDomElement symbolElem = layerElem.firstChildElement( QStringLiteral( "renderer-v2" ) ).firstChildElement( QStringLiteral( "symbols" ) ).firstChildElement( QStringLiteral( "symbol" ) ).firstChildElement( QStringLiteral( "layer" ) );
-    QDomElement propElem = symbolElem.firstChildElement( QStringLiteral( "prop" ) );
-    while ( !propElem.isNull() )
-    {
-      if ( propElem.attribute( QStringLiteral( "k" ) ) == QLatin1String( "name" ) )
-      {
-        svgPath = propElem.attribute( QStringLiteral( "v" ) );
-        break;
-      }
-      propElem = propElem.nextSiblingElement( QStringLiteral( "prop" ) );
-    }
+    QVariantMap props = QgsSymbolLayerUtils::parseProperties( symbolElem );
+    QString svgPath = props.value( QLatin1String( "name" ) ).toString();
     projectFileSvgPaths[layerName] = svgPath;
     layerElem = layerElem.nextSiblingElement();
   }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2133,8 +2133,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(errorMsg, "")
 
         qml, errmsg = vl.getStyleFromDatabase("1")
-        self.assertTrue('v="\u001E"' in qml)
         self.assertEqual(errmsg, "")
+        self.assertTrue('v="\u001E"' in qml, f"record separator character (\u001E) not found in qml: {qml}")
 
         # Test loadStyle from metadata
         md = QgsProviderRegistry.instance().providerMetadata('postgres')

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2134,13 +2134,19 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         qml, errmsg = vl.getStyleFromDatabase("1")
         self.assertEqual(errmsg, "")
-        self.assertTrue('value="\u001E" name="chr"' in qml, f"record separator character (\u001E) not found in qml: {qml}")
+        
+        found = False
+        for line in qml.split('\n'):
+            found = 'value="\u001E"' in qml and 'name="chr"' in qml
+            if found:
+                break
+        self.assertTrue(found, f"record separator character (\u001E) not found in qml: {qml}")
 
         # Test loadStyle from metadata
         md = QgsProviderRegistry.instance().providerMetadata('postgres')
         qml = md.loadStyle(self.dbconn + " type=POINT table=\"qgis_test\".\"editData\" (geom)", 'fontSymbol')
         self.assertTrue(qml.startswith('<!DOCTYPE qgi'), qml)
-        self.assertTrue('v="\u001E"' in qml)
+        self.assertTrue('value="\u001E"' in qml)
 
     def testHasMetadata(self):
         # views don't have metadata

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2134,7 +2134,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         qml, errmsg = vl.getStyleFromDatabase("1")
         self.assertEqual(errmsg, "")
-        
+
         found = False
         for line in qml.split('\n'):
             found = 'value="\u001E"' in qml and 'name="chr"' in qml

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2134,7 +2134,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         qml, errmsg = vl.getStyleFromDatabase("1")
         self.assertEqual(errmsg, "")
-        self.assertTrue('v="\u001E"' in qml, f"record separator character (\u001E) not found in qml: {qml}")
+        self.assertTrue('value="\u001E" name="chr"' in qml, f"record separator character (\u001E) not found in qml: {qml}")
 
         # Test loadStyle from metadata
         md = QgsProviderRegistry.instance().providerMetadata('postgres')


### PR DESCRIPTION
This part of the codes writes the symbology with backward compatibility so the project can be **open** under QGIS 3.16 and older
This is making the XML code much bigger.

Since next release will become the new LTR, I would be in favor of dropping this.
But I have no strong opinion if we should wait one more cycle.

This was added in #40716