### PR TITLE
Make QgsGeos::prepareGeometry and QgsGeos::cacheGeos idempotent

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -212,7 +212,11 @@ void QgsGeos::geometryChanged()
 
 void QgsGeos::prepareGeometry()
 {
-  mGeosPrepared.reset();
+  if ( mGeosPrepared )
+  {
+    // Already prepared
+    return;
+  }
   if ( mGeos )
   {
     mGeosPrepared.reset( GEOSPrepare_r( geosinit()->ctxt, mGeos.get() ) );
@@ -221,6 +225,11 @@ void QgsGeos::prepareGeometry()
 
 void QgsGeos::cacheGeos() const
 {
+  if ( mGeos )
+  {
+    // Already cached
+    return;
+  }
   if ( !mGeometry )
   {
     return;


### PR DESCRIPTION
Rather than re-preparing or re-converting geometries on every call.
The "geometryChanged" method will reset the caches.
