### PR TITLE
Add roundness method to curve polygon

### DIFF
--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -79,6 +79,8 @@ Curve polygon geometry type
 %Docstring
 Returns the roundness of the curve polygon.
 The returned value is between 0 and 1.
+
+.. versionadded:: 3.24
 %End
 
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -75,7 +75,7 @@ Curve polygon geometry type
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
 
-    double roundness() const /Factory/;
+    double roundness() const;
 %Docstring
 Returns the roundness of the curve polygon.
 The returned value is between 0 and 1.

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -75,6 +75,12 @@ Curve polygon geometry type
     virtual bool boundingBoxIntersects( const QgsRectangle &rectangle ) const /HoldGIL/;
 
 
+    double roundness() const /Factory/;
+%Docstring
+Returns the roundness of the curve polygon.
+The returned value is between 0 and 1.
+%End
+
 
     int numInteriorRings() const /HoldGIL/;
 %Docstring

--- a/resources/function_help/json/roundness
+++ b/resources/function_help/json/roundness
@@ -2,7 +2,7 @@
   "name": "roundness",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Calculates how close the polygon shape is to a circle. The function returns 1 when the polygon shape is a perfect circle and 0 when it is completely flat.",
+  "description": "Calculates how close a polygon shape is to a circle. The function returns 1 when the polygon shape is a perfect circle and 0 when it is completely flat.",
   "arguments": [
     {"arg":"geometry","description":"a polygon"}],
   "examples": [

--- a/resources/function_help/json/roundness
+++ b/resources/function_help/json/roundness
@@ -1,0 +1,12 @@
+{
+  "name": "roundness",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Calculates how close the polygon shape is to a circle. The function returns 1 when the polygon shape is a perfect circle and 0 when it is completely flat.",
+  "arguments": [
+    {"arg":"geometry","description":"a polygon"}],
+  "examples": [
+    { "expression":"round(roundness(geom_from_wkt('POLYGON(( 0 0, 0 1, 1 1, 1 0, 0 0))')), 3)", "returns":"0.785"},
+    { "expression":"round(roundness(geom_from_wkt('POLYGON(( 0 0, 0 0.1, 1 0.1, 1 0, 0 0))')), 3)", "returns":"0.260"}
+  ]
+}

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -173,6 +173,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmrescaleraster.cpp
   processing/qgsalgorithmreverselinedirection.cpp
   processing/qgsalgorithmrotate.cpp
+  processing/qgsalgorithmroundness.cpp
   processing/qgsalgorithmroundrastervalues.cpp
   processing/qgsalgorithmruggedness.cpp
   processing/qgsalgorithmsavefeatures.cpp

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -57,7 +57,7 @@ QString QgsRoundnessAlgorithm::shortHelpString() const
 
 QString QgsRoundnessAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Calculates how close each feature shape is to a circle in a polygon vector layer." );
+  return QObject::tr( "Calculates the roundness of polygon features." );
 }
 
 QgsRoundnessAlgorithm *QgsRoundnessAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -27,7 +27,7 @@ QString QgsRoundnessAlgorithm::name() const
 
 QString QgsRoundnessAlgorithm::displayName() const
 {
-  return QObject::tr( "Roundess" );
+  return QObject::tr( "Roundness" );
 }
 
 QStringList QgsRoundnessAlgorithm::tags() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -53,12 +53,12 @@ QString QgsRoundnessAlgorithm::outputName() const
 
 QString QgsRoundnessAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "TODO" );
+  return QObject::tr( "Adds in the attribute table the roundness of each feature. The input vector layer must contain polygons." );
 }
 
 QString QgsRoundnessAlgorithm::shortDescription() const
 {
-  return QObject::tr( "TODO" );
+  return QObject::tr( "Calculate the roundness of each feature in a polygon vector layer." );
 }
 
 QgsRoundnessAlgorithm *QgsRoundnessAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -85,16 +85,25 @@ QgsFields QgsRoundnessAlgorithm::outputFields( const QgsFields &inputFields ) co
 QgsFeatureList QgsRoundnessAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
+  QgsAttributes attributes = f.attributes();
   if ( f.hasGeometry() )
   {
     QgsGeometry geom = f.geometry();
-    const QgsCurvePolygon *poly = qgsgeometry_cast< const QgsCurvePolygon * >( geom.constGet() );
-
-    double roundness = poly->roundness();
-    QgsAttributes attributes = f.attributes();
-    attributes << QVariant( roundness );
-    f.setAttributes( attributes );
+    if ( const QgsCurvePolygon *poly = qgsgeometry_cast< const QgsCurvePolygon * >( geom.constGet()->simplifiedTypeRef() ) )
+    {
+        double roundness = poly->roundness();
+        attributes << QVariant( roundness );
+     }
+     else
+     {
+        attributes << QVariant();
+     }
   }
+  else
+  {
+     attributes << QVariant();
+  }
+  f.setAttributes( attributes );
   return QgsFeatureList() << f;
 }
 

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -52,7 +52,8 @@ QString QgsRoundnessAlgorithm::outputName() const
 
 QString QgsRoundnessAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Adds in the attribute table the roundness of each feature. The input vector layer must contain polygons." );
+  return QObject::tr( "Calculates the roundness of each feature and stores it as a new field. The input vector layer must contain polygons.\n\n"
+                                  "The roundness of a polygon is defined as 4π × polygon area / perimeter². The roundness value varies between 0 and 1. A perfect circle has a roundness of 1, while a completely flat polygon has a roundness of 0." );
 }
 
 QString QgsRoundnessAlgorithm::shortDescription() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -32,7 +32,7 @@ QString QgsRoundnessAlgorithm::displayName() const
 
 QStringList QgsRoundnessAlgorithm::tags() const
 {
-  return QObject::tr( "roundess" ).split( ',' );
+  return QObject::tr( "roundness,circle" ).split( ',' );
 }
 
 QString QgsRoundnessAlgorithm::group() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -1,0 +1,104 @@
+/***************************************************************************
+                         qgsalgorithmroundness.cpp
+                         ---------------------
+    begin                : Septembre 2021
+    copyright            : (C) 2021 by Antoine Facchini
+    email                : antoine dot facchini @oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmroundness.h"
+#include "qgscurvepolygon.h"
+#include "qgsvectorlayer.h"
+
+///@cond PRIVATE
+
+QString QgsRoundnessAlgorithm::name() const
+{
+  return QStringLiteral( "roundess" );
+}
+
+QString QgsRoundnessAlgorithm::displayName() const
+{
+  return QObject::tr( "Roundess" );
+}
+
+QStringList QgsRoundnessAlgorithm::tags() const
+{
+  return QObject::tr( "roundess" ).split( ',' );
+}
+
+QString QgsRoundnessAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsRoundnessAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeometry" );
+}
+
+QString QgsRoundnessAlgorithm::outputName() const
+{
+  return QObject::tr( "Roundess" );
+}
+
+QString QgsRoundnessAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "TODO" );
+}
+
+QString QgsRoundnessAlgorithm::shortDescription() const
+{
+  return QObject::tr( "TODO" );
+}
+
+QgsRoundnessAlgorithm *QgsRoundnessAlgorithm::createInstance() const
+{
+  return new QgsRoundnessAlgorithm();
+}
+
+QList<int> QgsRoundnessAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVectorPolygon;
+}
+
+QgsProcessing::SourceType QgsRoundnessAlgorithm::outputLayerType() const
+{
+  return QgsProcessing::TypeVectorPolygon;
+}
+
+QgsFields QgsRoundnessAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  QgsFields outputFields = inputFields;
+  outputFields.append( QgsField( QStringLiteral( "roundness" ), QVariant::Double ) );
+  return outputFields;
+}
+
+QgsFeatureList QgsRoundnessAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() )
+  {
+    QgsGeometry geom = f.geometry();
+    const QgsCurvePolygon *poly = qgsgeometry_cast< const QgsCurvePolygon * >( geom.constGet() );
+
+    double roundness = poly->roundness();
+    QgsAttributes attributes = f.attributes();
+    attributes << QVariant( roundness );
+    f.setAttributes( attributes );
+  }
+  return QgsFeatureList() << f;
+}
+
+///@endcond
+
+

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
                          qgsalgorithmroundness.cpp
                          ---------------------
-    begin                : Septembre 2021
+    begin                : September 2021
     copyright            : (C) 2021 by Antoine Facchini
     email                : antoine dot facchini @oslandia dot com
  ***************************************************************************/

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -53,7 +53,7 @@ QString QgsRoundnessAlgorithm::outputName() const
 QString QgsRoundnessAlgorithm::shortHelpString() const
 {
   return QObject::tr( "Calculates the roundness of each feature and stores it as a new field. The input vector layer must contain polygons.\n\n"
-                                  "The roundness of a polygon is defined as 4π × polygon area / perimeter². The roundness value varies between 0 and 1. A perfect circle has a roundness of 1, while a completely flat polygon has a roundness of 0." );
+                      "The roundness of a polygon is defined as 4π × polygon area / perimeter². The roundness value varies between 0 and 1. A perfect circle has a roundness of 1, while a completely flat polygon has a roundness of 0." );
 }
 
 QString QgsRoundnessAlgorithm::shortDescription() const
@@ -92,17 +92,17 @@ QgsFeatureList QgsRoundnessAlgorithm::processFeature( const QgsFeature &feature,
     QgsGeometry geom = f.geometry();
     if ( const QgsCurvePolygon *poly = qgsgeometry_cast< const QgsCurvePolygon * >( geom.constGet()->simplifiedTypeRef() ) )
     {
-        double roundness = poly->roundness();
-        attributes << QVariant( roundness );
-     }
-     else
-     {
-        attributes << QVariant();
-     }
+      double roundness = poly->roundness();
+      attributes << QVariant( roundness );
+    }
+    else
+    {
+      attributes << QVariant();
+    }
   }
   else
   {
-     attributes << QVariant();
+    attributes << QVariant();
   }
   f.setAttributes( attributes );
   return QgsFeatureList() << f;

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -47,7 +47,7 @@ QString QgsRoundnessAlgorithm::groupId() const
 
 QString QgsRoundnessAlgorithm::outputName() const
 {
-  return QObject::tr( "Roundess" );
+  return QObject::tr( "Roundness" );
 }
 
 QString QgsRoundnessAlgorithm::shortHelpString() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -57,7 +57,7 @@ QString QgsRoundnessAlgorithm::shortHelpString() const
 
 QString QgsRoundnessAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Calculates the roundness of each feature in a polygon vector layer." );
+  return QObject::tr( "Calculates how close each feature shape is to a circle in a polygon vector layer." );
 }
 
 QgsRoundnessAlgorithm *QgsRoundnessAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsalgorithmroundness.h"
 #include "qgscurvepolygon.h"
-#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 
@@ -58,7 +57,7 @@ QString QgsRoundnessAlgorithm::shortHelpString() const
 
 QString QgsRoundnessAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Calculate the roundness of each feature in a polygon vector layer." );
+  return QObject::tr( "Calculates the roundness of each feature in a polygon vector layer." );
 }
 
 QgsRoundnessAlgorithm *QgsRoundnessAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -23,7 +23,7 @@
 
 QString QgsRoundnessAlgorithm::name() const
 {
-  return QStringLiteral( "roundess" );
+  return QStringLiteral( "roundness" );
 }
 
 QString QgsRoundnessAlgorithm::displayName() const

--- a/src/analysis/processing/qgsalgorithmroundness.h
+++ b/src/analysis/processing/qgsalgorithmroundness.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+                         qgsalgorithmroundness.h
+                         ---------------------
+    begin                : Septembre 2021
+    copyright            : (C) 2021 by Antoine Facchini
+    email                : antoine dot facchini @oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMROUNDNESS_H
+#define QGSALGORITHMROUNDNESS_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native roundness algorithm.
+ */
+class QgsRoundnessAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsRoundnessAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsRoundnessAlgorithm *createInstance() const override SIP_FACTORY;
+    QList<int> inputLayerTypes() const override;
+
+  protected:
+    QString outputName() const override;
+    QgsProcessing::SourceType outputLayerType() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMROUNDNESS_H
+
+

--- a/src/analysis/processing/qgsalgorithmroundness.h
+++ b/src/analysis/processing/qgsalgorithmroundness.h
@@ -1,7 +1,7 @@
 /***************************************************************************
                          qgsalgorithmroundness.h
                          ---------------------
-    begin                : Septembre 2021
+    begin                : September 2021
     copyright            : (C) 2021 by Antoine Facchini
     email                : antoine dot facchini @oslandia dot com
  ***************************************************************************/

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -161,6 +161,7 @@
 #include "qgsalgorithmrescaleraster.h"
 #include "qgsalgorithmreverselinedirection.h"
 #include "qgsalgorithmrotate.h"
+#include "qgsalgorithmroundness.h"
 #include "qgsalgorithmroundrastervalues.h"
 #include "qgsalgorithmruggedness.h"
 #include "qgsalgorithmsavefeatures.h"
@@ -437,6 +438,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsRetainTableFieldsAlgorithm() );
   addAlgorithm( new QgsReverseLineDirectionAlgorithm() );
   addAlgorithm( new QgsRotateFeaturesAlgorithm() );
+  addAlgorithm( new QgsRoundnessAlgorithm() );
   addAlgorithm( new QgsRoundRasterValuesAlgorithm() );
   addAlgorithm( new QgsRuggednessAlgorithm() );
   addAlgorithm( new QgsSaveFeaturesAlgorithm() );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3664,6 +3664,9 @@ static QVariant fcnRoundness( const QVariantList &values, const QgsExpressionCon
   return QVariant( poly->roundness() );
 }
 
+
+
+static QVariant fcnFlipCoordinates( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3650,9 +3650,20 @@ static QVariant fcnStraightDistance2d( const QVariantList &values, const QgsExpr
   return QVariant( curve->straightDistance2d() );
 }
 
+static QVariant fcnRoundness( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  const QgsCurvePolygon *poly = geom.constGet() ? qgsgeometry_cast< const QgsCurvePolygon * >( geom.constGet()->simplifiedTypeRef() ) : nullptr;
 
+  if ( !poly )
+  {
+    parent->setEvalErrorString( QObject::tr( "Function `roundness` requires a polygon geometry or a multi polygon geometry with a single part." ) );
+    return QVariant();
+  }
 
-static QVariant fcnFlipCoordinates( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+  return QVariant( poly->roundness() );
+}
+
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   if ( geom.isNull() )
@@ -6859,6 +6870,10 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     functions << perimeterFunc;
 
     functions << new QgsStaticExpressionFunction( QStringLiteral( "perimeter" ),  QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ), fcnPerimeter, QStringLiteral( "GeometryGroup" ) );
+
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "roundness" ),
+              QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ),
+              fcnRoundness, QStringLiteral( "GeometryGroup" ) );
 
     QgsStaticExpressionFunction *xFunc = new QgsStaticExpressionFunction( QStringLiteral( "$x" ), 0, fcnX, QStringLiteral( "GeometryGroup" ), QString(), true );
     xFunc->setIsStatic( false );

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -529,7 +529,7 @@ double QgsCurvePolygon::perimeter() const
 
 double QgsCurvePolygon::roundness() const
 {
-  if ( perimeter() == 0 )
+  if ( qgsDoubleNear( perimeter(), 0.0 ) )
     return 0.0;
 
   return 4 * M_PI * area() / pow( perimeter(), 2 );

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -529,10 +529,11 @@ double QgsCurvePolygon::perimeter() const
 
 double QgsCurvePolygon::roundness() const
 {
-  if ( qgsDoubleNear( perimeter(), 0.0 ) )
+  const double p = perimeter();
+  if ( qgsDoubleNear( p, 0.0 ) )
     return 0.0;
 
-  return 4.0 * M_PI * area() / pow( perimeter(), 2.0 );
+  return 4.0 * M_PI * area() / pow( p, 2.0 );
 }
 
 QgsPolygon *QgsCurvePolygon::surfaceToPolygon() const

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -532,7 +532,7 @@ double QgsCurvePolygon::roundness() const
   if ( qgsDoubleNear( perimeter(), 0.0 ) )
     return 0.0;
 
-  return 4 * M_PI * area() / pow( perimeter(), 2 );
+  return 4.0 * M_PI * area() / pow( perimeter(), 2.0 );
 }
 
 QgsPolygon *QgsCurvePolygon::surfaceToPolygon() const

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -527,6 +527,14 @@ double QgsCurvePolygon::perimeter() const
   return perimeter;
 }
 
+double QgsCurvePolygon::roundness() const
+{
+  if ( perimeter() == 0 )
+    return 0.0;
+
+  return 4 * M_PI * area() / pow( perimeter(), 2 );
+}
+
 QgsPolygon *QgsCurvePolygon::surfaceToPolygon() const
 {
   std::unique_ptr< QgsPolygon > polygon( new QgsPolygon() );

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -65,10 +65,15 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     double perimeter() const override SIP_HOLDGIL;
     QgsPolygon *surfaceToPolygon() const override SIP_FACTORY;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
-    double roundness() const SIP_FACTORY;
     QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;
+
+    /**
+     * Returns the roundness of the curve polygon.
+     * The returned value is between 0 and 1.
+     */
+    double roundness() const SIP_FACTORY;
 
     //curve polygon interface
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -72,6 +72,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     /**
      * Returns the roundness of the curve polygon.
      * The returned value is between 0 and 1.
+     * \since QGIS 3.24
      */
     double roundness() const SIP_FACTORY;
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
      * The returned value is between 0 and 1.
      * \since QGIS 3.24
      */
-    double roundness() const SIP_FACTORY;
+    double roundness() const;
 
     //curve polygon interface
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     double perimeter() const override SIP_HOLDGIL;
     QgsPolygon *surfaceToPolygon() const override SIP_FACTORY;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
+    double roundness() const SIP_FACTORY;
     QgsCurvePolygon *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
     bool boundingBoxIntersects( const QgsRectangle &rectangle ) const override SIP_HOLDGIL;

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -1476,7 +1476,7 @@ void TestQgsProcessingAlgs::roundness()
   const QgsFeature result = runForFeature( alg, feature, QStringLiteral( "Polygon" ) );
 
   const double roundnessResult = result.attribute( QStringLiteral( "roundness" ) ).toDouble();
-  QGSCOMPARENEAR( roundnessResult, expectedAttribute , 0.001 );
+  QGSCOMPARENEAR( roundnessResult, expectedAttribute, 0.001 );
 }
 
 Q_DECLARE_METATYPE( Qgis::DataType )

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -1475,7 +1475,7 @@ void TestQgsProcessingAlgs::roundness()
 
   const QgsFeature result = runForFeature( alg, feature, QStringLiteral( "Polygon" ) );
 
-  double roundnessResult = result.attribute( QStringLiteral( "roundness" ) ).toDouble();
+  const double roundnessResult = result.attribute( QStringLiteral( "roundness" ) ).toDouble();
   QCOMPARE( std::round( roundnessResult * 1000 ) / 1000, expectedAttribute );
 }
 

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -1476,7 +1476,7 @@ void TestQgsProcessingAlgs::roundness()
   const QgsFeature result = runForFeature( alg, feature, QStringLiteral( "Polygon" ) );
 
   const double roundnessResult = result.attribute( QStringLiteral( "roundness" ) ).toDouble();
-  QCOMPARE( std::round( roundnessResult * 1000 ) / 1000, expectedAttribute );
+  QGSCOMPARENEAR( roundnessResult, expectedAttribute , 0.001 );
 }
 
 Q_DECLARE_METATYPE( Qgis::DataType )

--- a/tests/src/core/geometry/testqgscurvepolygon.cpp
+++ b/tests/src/core/geometry/testqgscurvepolygon.cpp
@@ -54,6 +54,7 @@ class TestQgsCurvePolygon: public QObject
     void testClosestSegment();
     void testBoundary();
     void testBoundingBox();
+    void testRoundness();
     void testDropZValue();
     void testDropMValue();
     void testToPolygon();
@@ -1250,6 +1251,30 @@ void TestQgsCurvePolygon::testBoundingBox()
   QGSCOMPARENEAR( bBox.xMaximum(), 1.012344, 0.001 );
   QGSCOMPARENEAR( bBox.yMinimum(), 0.000000, 0.001 );
   QGSCOMPARENEAR( bBox.yMaximum(), 18, 0.001 );
+}
+
+void TestQgsCurvePolygon::testRoundness()
+{
+  QgsCurvePolygon poly;
+
+  //empty
+  QCOMPARE( poly.roundness(), 0 );
+
+  QgsCircularString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 1 )
+                 << QgsPoint( 1, 1 ) << QgsPoint( 1, 0 ) << QgsPoint( 0, 0 ) );
+  poly.setExteriorRing( ext.clone() );
+
+  QCOMPARE( poly.roundness(), 1.0 );
+
+  //with  Z
+  QgsLineString extLine;
+  extLine.setPoints( QgsPointSequence() << QgsPoint( 0, 0, 5 )
+                     << QgsPoint( 0, 0.01, 4 ) << QgsPoint( 1, 0.01, 2 )
+                     << QgsPoint( 1, 0, 10 ) << QgsPoint( 0, 0, 5 ) );
+  poly.setExteriorRing( extLine.clone() );
+
+  QGSCOMPARENEAR( poly.roundness(), 0.031, 0.001 );
 }
 
 void TestQgsCurvePolygon::testDropZValue()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1381,6 +1381,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "straight_distance_2d linestring" ) << "round(straight_distance_2d(geom_from_wkt('LINESTRING(1 4, 3 5, 5 0)')), 3)" << false << QVariant( 5.657 );
       QTest::newRow( "straight_distance_2d closed linestring" ) << "straight_distance_2d(geom_from_wkt('LINESTRING(2 2, 3 6, 2 2)'))" << false << QVariant( 0.0 );
       QTest::newRow( "straight_distance_2d circularstring" ) << "round(straight_distance_2d(geom_from_wkt('CircularString (20 30, 50 30, 10 50)')), 3)" << false << QVariant( 22.361 );
+      QTest::newRow( "roundness not geom" ) << "roundness('r')" << true << QVariant();
+      QTest::newRow( "roundness null" ) << "roundness(NULL)" << false << QVariant();
+      QTest::newRow( "roundness not polygon" ) << "roundness(geom_from_wkt('POINT(1 2)'))" << true << QVariant();
+      QTest::newRow( "roundness polygon" ) << "round(roundness(geom_from_wkt('POLYGON(( 0 0, 0 1, 1 1, 1 0, 0 0))')), 3)" << false << QVariant( 0.785 );
+      QTest::newRow( "roundness single part multi polygon" ) << "round(roundness(geom_from_wkt('MULTIPOLYGON (((0 0, 0 1, 1 1, 1 0, 0 0)))')), 3)" << false << QVariant( 0.785 );
+      QTest::newRow( "roundness multi polygon" ) << "round(roundness(geom_from_wkt('MULTIPOLYGON( ((0 0, 0 1, 1 1, 1 0, 0 0)), ((5 2, 4 9, 5 9, 6 5, 5 2)) )')))" << true << QVariant();
+      QTest::newRow( "roundness thin polygon" ) << "roundness(geom_from_wkt('POLYGON(( 0 0, 0.5 0, 1 0, 0.6 0, 0 0))'))" << false << QVariant( 0.0 );
+      QTest::newRow( "roundness circle polygon" ) << "roundness(geom_from_wkt('CurvePolygon (CompoundCurve (CircularString (0 0, 0 1, 1 1, 1 0, 0 0)))'))" << false << QVariant( 1.0 );
 
       // string functions
       QTest::newRow( "format_number" ) << "format_number(1999.567,2)" << false << QVariant( "1,999.57" );


### PR DESCRIPTION
## Description

This PR adds the roundness method in `QgsCurvePolygon` then adds the expression and the processing. The processing creates a new layer with the roundness of each feature in a new field.  

The definition I used is : 
`Roundness = (4 * pi * Area) / Perimeter^2`

I don't explain what roundness is and the definition used in documentation, I don't know if I should.