### PR TITLE
[server] Allow better control of the response flow chain from server filters.

### DIFF
--- a/python/server/auto_generated/qgsserverfilter.sip.in
+++ b/python/server/auto_generated/qgsserverfilter.sip.in
@@ -44,20 +44,32 @@ and must be passed to QgsServerFilter instances.
 Returns the :py:class:`QgsServerInterface` instance
 %End
 
-    virtual void requestReady();
+ virtual void requestReady() /Deprecated/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` is ready and populated with
 parameters, just before entering the main switch for core services.
+
+This method is considered as deprecated and :py:func:`onRequestReady` should
+be used instead.
+
+.. deprecated::
+   Will be removed in QGIS 4.0
 %End
 
-    virtual void responseComplete();
+ virtual void responseComplete() /Deprecated/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` processing has done and
 the response is ready, just after the main switch for core services
-and before final sending response to FCGI stdout.
+and before final sending response.
+
+This method is considered as deprecated and :py:func:`onResponseComplete` should
+be used instead.
+
+.. deprecated::
+   Will be removed in QGIS 4.0
 %End
 
-    virtual void sendResponse();
+ virtual void sendResponse() /Deprecated/;
 %Docstring
 Method called when the :py:class:`QgsRequestHandler` sends its data to FCGI stdout.
 This normally occurs at the end of core services processing just after
@@ -65,7 +77,50 @@ the :py:func:`~QgsServerFilter.responseComplete` plugin hook. For streaming serv
 getFeature requests, :py:func:`~QgsServerFilter.sendResponse` might have been called several times
 before the response is complete: in this particular case, :py:func:`~QgsServerFilter.sendResponse`
 is called once for each feature before hitting :py:func:`~QgsServerFilter.responseComplete`
+
+This method is considered as deprecated and :py:func:`onSendResponse` should
+be used instead.
+
+.. deprecated::
+   Will be removed in QGIS 4.0
 %End
+
+    virtual bool onRequestReady();
+%Docstring
+Method called when the :py:class:`QgsRequestHandler` is ready and populated with
+parameters, just before entering the main switch for core services.
+
+:return: true if the call must propagate to the subsequent filters, false otherwise
+
+.. versionadded:: 3.24
+%End
+
+    virtual bool onResponseComplete();
+%Docstring
+Method called when the :py:class:`QgsRequestHandler` processing has done and
+the response is ready, just after the main switch for core services
+and before final sending response to FCGI stdout.
+
+:return: true if the call must propagate to the subsequent filters, false otherwise
+
+.. versionadded:: 3.24
+%End
+
+    virtual bool onSendResponse();
+%Docstring
+Method called when the :py:class:`QgsRequestHandler` sends its data to FCGI stdout.
+This normally occurs at the end of core services processing just after
+the :py:func:`~QgsServerFilter.responseComplete` plugin hook. For streaming services (like WFS on
+getFeature requests, :py:func:`~QgsServerFilter.sendResponse` might have been called several times
+before the response is complete: in this particular case, :py:func:`~QgsServerFilter.sendResponse`
+is called once for each feature before hitting :py:func:`~QgsServerFilter.responseComplete`
+
+:return: true if the call must propagate to the subsequent filters, false otherwise
+
+.. versionadded:: 3.22
+%End
+
+
 
 };
 

--- a/src/server/qgsserverfilter.cpp
+++ b/src/server/qgsserverfilter.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsserverfilter.h"
 #include "qgslogger.h"
+#include "qgis.h"
 
 /**
  * QgsServerFilter
@@ -42,8 +43,33 @@ void QgsServerFilter::responseComplete()
   QgsDebugMsg( QStringLiteral( "QgsServerFilter plugin default responseComplete called" ) );
 }
 
-
 void QgsServerFilter::sendResponse()
 {
   QgsDebugMsg( QStringLiteral( "QgsServerFilter plugin default sendResponse called" ) );
 }
+
+bool QgsServerFilter::onRequestReady()
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  requestReady();
+  Q_NOWARN_DEPRECATED_POP
+  return true;
+}
+
+bool QgsServerFilter::onResponseComplete()
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  responseComplete();
+  Q_NOWARN_DEPRECATED_POP
+  return true;
+}
+
+bool QgsServerFilter::onSendResponse()
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  sendResponse();
+  Q_NOWARN_DEPRECATED_POP
+  return true;
+}
+
+

--- a/src/server/qgsserverfilter.h
+++ b/src/server/qgsserverfilter.h
@@ -59,16 +59,26 @@ class SERVER_EXPORT QgsServerFilter
 
     /**
      * Method called when the QgsRequestHandler is ready and populated with
-    * parameters, just before entering the main switch for core services.
-    */
-    virtual void requestReady();
+     * parameters, just before entering the main switch for core services.
+     *
+     * This method is considered as deprecated and \see onRequestReady should
+     * be used instead.
+     *
+     * \deprecated Will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED virtual void requestReady() SIP_DEPRECATED;
 
     /**
      * Method called when the QgsRequestHandler processing has done and
      * the response is ready, just after the main switch for core services
-     * and before final sending response to FCGI stdout.
+     * and before final sending response.
+     *
+     * This method is considered as deprecated and \see onResponseComplete should
+     * be used instead.
+     *
+     * \deprecated Will be removed in QGIS 4.0
      */
-    virtual void responseComplete();
+    Q_DECL_DEPRECATED virtual void responseComplete() SIP_DEPRECATED;
 
     /**
      * Method called when the QgsRequestHandler sends its data to FCGI stdout.
@@ -77,11 +87,52 @@ class SERVER_EXPORT QgsServerFilter
      * getFeature requests, sendResponse() might have been called several times
      * before the response is complete: in this particular case, sendResponse()
      * is called once for each feature before hitting responseComplete()
+     *
+     * This method is considered as deprecated and \see onSendResponse should
+     * be used instead.
+     *
+     * \deprecated Will be removed in QGIS 4.0
      */
-    virtual void sendResponse();
+    Q_DECL_DEPRECATED virtual void sendResponse() SIP_DEPRECATED;
+
+    /**
+     * Method called when the QgsRequestHandler is ready and populated with
+     * parameters, just before entering the main switch for core services.
+     *
+     * \return true if the call must propagate to the subsequent filters, false otherwise
+     *
+     * \since QGIS 3.24
+     */
+    virtual bool onRequestReady();
+
+    /**
+     * Method called when the QgsRequestHandler processing has done and
+     * the response is ready, just after the main switch for core services
+     * and before final sending response to FCGI stdout.
+     *
+     * \return true if the call must propagate to the subsequent filters, false otherwise
+     *
+     * \since QGIS 3.24
+     */
+    virtual bool onResponseComplete();
+
+    /**
+     * Method called when the QgsRequestHandler sends its data to FCGI stdout.
+     * This normally occurs at the end of core services processing just after
+     * the responseComplete() plugin hook. For streaming services (like WFS on
+     * getFeature requests, sendResponse() might have been called several times
+     * before the response is complete: in this particular case, sendResponse()
+     * is called once for each feature before hitting responseComplete()
+     *
+     * \return true if the call must propagate to the subsequent filters, false otherwise
+     *
+     * \since QGIS 3.22
+     */
+    virtual bool onSendResponse();
+
+
 
   private:
-
     QgsServerInterface *mServerInterface = nullptr;
 
 };


### PR DESCRIPTION
## Description

Allow  better control the response flow for server filters.  

Consider the following use case: 

A plugin need to collect all chunks from the response (i.e a WFS GetFeature request) in order to rebuild the whole response for applying transformation before forwarding the new body.

This filter will clear each chunk in order not to send the wrong data.

While this may be ok most of the time, it becomes a problem when a filter must rebuild the whole response before inspecting or applying transformation to the complete response: in order to reconstruct a response from streamed chunks one must retrieve partial content then clear the body to prevent the original content to be flushed.  

As side effect, the `flush` method is called with empty chunks .   In this case this behavior is not desirable since, since some response backend implementation may interpret this as a stream terminator. 
Also no subsequent filters should be notified because they will receive nothing, otherwise they have to check the validity of the date and eventually abort processing - this is not really api friendly.

This PR allow filters to control the call chain by implementing new filter callbacks that allow returning a control value for stopping propagation. This allow for a better control of streamed data but also of the whole response flow.
## Changes

-  Deprecate `bool QgsFilter::onRequestReady()`,  `bool QgsFilter::onSendResponse()`,  `bool QgsFilter::onResponseComplete()` 
-  Add new methods  `bool QgsFilter::onRequestReady()`,  `bool QgsFilter::onSendResponse()`,  `bool QgsFilter::onResponseComplete()` which return boolean controlling data flow.
- Handle flow control in `QgsFilterResponseDecorator::flush()`
- New Tests
 