### PR TITLE
Remove line which decreases tile zoom by one.

### DIFF
--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -64,7 +64,6 @@ double QgsVectorTileUtils::scaleToZoom( double mapScale )
 {
   double s0 = 559082264.0287178;   // scale denominator at zoom level 0 of GoogleCRS84Quad
   double tileZoom2 = log( s0 / mapScale ) / log( 2 );
-  tileZoom2 -= 1;   // TODO: it seems that map scale is double (is that because of high-dpi screen?)
   return tileZoom2;
 }
 


### PR DESCRIPTION
## Description

This PR fixes #45000. It removes a line that decreases tile zoom level by one. Probably forgotten TODO during development.
After this PR, vector tiles in QGIS should display the same extent as when displaying vector tiles in a browser.