### PR TITLE
Revert "Adapt mesh editing following new CAD Z value"

### DIFF
--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -153,15 +153,7 @@ Changes the Z values of the vertices with indexes in ``vertices`` indexes with t
     void changeXYValues( const QList<int> &verticesIndexes, const QList<QgsPointXY> &newValues );
 %Docstring
 Changes the (X,Y) coordinates values of the vertices with indexes in ``vertices`` indexes with the values in ``newValues``.
-The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
-New values are in layer CRS.
-%End
-
-    void changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
-%Docstring
-Changes the (X,Y,Z) coordinates values of the vertices with indexes in ``vertices`` indexes with the values in ``newValues``.
 The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
-New coordinates are in layer CRS.
 %End
 
     void advancedEdit( QgsMeshAdvancedEditing *editing );

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -221,20 +221,6 @@ Determines if Z or M will be enabled.
 .. versionadded:: 3.22
 %End
 
-    void setEnabledZ( bool enable );
-%Docstring
-Sets whether Z is enabled
-
-.. versionadded:: 3.22
-%End
-
-    void setEnabledM( bool enable );
-%Docstring
-Sets whether M is enabled
-
-.. versionadded:: 3.22
-%End
-
     bool constructionMode() const;
 %Docstring
 construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -188,8 +188,6 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     const QgsPointXY mapVertexXY( int index ) const;
     const QgsMeshFace nativeFace( int index ) const;
 
-    double currentZValue();
-
     void highLight( const QgsPointXY &mapPoint );
     void highlightCurrentHoveredFace( const QgsPointXY &mapPoint );
     void highlightCloseVertex( const QgsPointXY &mapPoint );
@@ -205,7 +203,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     void clearAll();
 
-    void addVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match &mapPointMatch );
+    void addVertex( const QgsPointXY &mapPoint, const QgsPointLocator::Match &mapPointMatch, Qt::KeyboardModifiers modifiers );
     void updateFreeVertices();
 
     //! Checks if we are closed to a vertex, if yes return the index of the vertex;
@@ -264,8 +262,9 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QList<int> mNewFaceCandidate;
     bool mDoubleClicks = false;
     QgsPointXY mFirstClickPoint; //the first click point when double clicks, we need it when the point is constraint by the cad tool, second click could not be constraint
-    double mFirstClickZValue;
-    double mUserZValue = 0;
+    double mOrdinaryZValue = 0;
+    bool mIsSelectedZValue = false;
+    double mSelectedZValue = 0;
 
     //! Rubber band used to highlight a face that is on mouse over and not dragging anything, own by map canvas
     QgsRubberBand *mFaceRubberBand = nullptr;

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -733,11 +733,6 @@ void QgsMeshEditor::changeXYValues( const QList<int> &verticesIndexes, const QLi
   mUndoStack->push( new QgsMeshLayerUndoCommandChangeXYValue( this, verticesIndexes, newValues ) );
 }
 
-void QgsMeshEditor::changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates )
-{
-  mUndoStack->push( new QgsMeshLayerUndoCommandChangeCoordinates( this, verticesIndexes, newCoordinates ) );
-}
-
 void QgsMeshEditor::advancedEdit( QgsMeshAdvancedEditing *editing )
 {
   mUndoStack->push( new QgsMeshLayerUndoCommandAdvancedEditing( this, editing ) );
@@ -994,45 +989,6 @@ void QgsMeshLayerUndoCommandChangeXYValue::redo()
       mMeshEditor->applyEdit( edit );
   }
 }
-
-
-QgsMeshLayerUndoCommandChangeCoordinates::QgsMeshLayerUndoCommandChangeCoordinates( QgsMeshEditor *meshEditor, const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates )
-  : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
-  , mVerticesIndexes( verticesIndexes )
-  , mNewCoordinates( newCoordinates )
-{}
-
-void QgsMeshLayerUndoCommandChangeCoordinates::redo()
-{
-  if ( !mVerticesIndexes.isEmpty() )
-  {
-    QgsMeshEditor::Edit editXY;
-    QList<QgsPointXY> newXY;
-    newXY.reserve( mNewCoordinates.count() );
-    QgsMeshEditor::Edit editZ;
-    QList<double> newZ;
-    newZ.reserve( mNewCoordinates.count() );
-
-    for ( const QgsPoint &pt : std::as_const( mNewCoordinates ) )
-    {
-      newXY.append( pt );
-      newZ.append( pt.z() );
-    }
-
-    mMeshEditor->applyChangeXYValue( editXY, mVerticesIndexes, newXY );
-    mEdits.append( editXY );
-    mMeshEditor->applyChangeZValue( editZ, mVerticesIndexes, newZ );
-    mEdits.append( editZ );
-    mVerticesIndexes.clear();
-    mNewCoordinates.clear();
-  }
-  else
-  {
-    for ( QgsMeshEditor::Edit &edit : mEdits )
-      mMeshEditor->applyEdit( edit );
-  }
-}
-
 
 
 QgsMeshLayerUndoCommandFlipEdge::QgsMeshLayerUndoCommandFlipEdge( QgsMeshEditor *meshEditor, int vertexIndex1, int vertexIndex2 )

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -176,17 +176,9 @@ class CORE_EXPORT QgsMeshEditor : public QObject
 
     /**
      * Changes the (X,Y) coordinates values of the vertices with indexes in \a vertices indexes with the values in \a newValues.
-     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
-     * New values are in layer CRS.
+     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
      */
     void changeXYValues( const QList<int> &verticesIndexes, const QList<QgsPointXY> &newValues );
-
-    /**
-     * Changes the (X,Y,Z) coordinates values of the vertices with indexes in \a vertices indexes with the values in \a newValues.
-     * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors
-     * New coordinates are in layer CRS.
-     */
-    void changeCoordinates( const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
 
     /**
      * Applies an advance editing on the edited mesh, see QgsMeshAdvancedEditing
@@ -303,7 +295,6 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     friend class QgsMeshLayerUndoCommandSetZValue;
     friend class QgsMeshLayerUndoCommandChangeZValue;
     friend class QgsMeshLayerUndoCommandChangeXYValue;
-    friend class QgsMeshLayerUndoCommandChangeCoordinates;
     friend class QgsMeshLayerUndoCommandFlipEdge;
     friend class QgsMeshLayerUndoCommandMerge;
     friend class QgsMeshLayerUndoCommandSplitFaces;
@@ -456,29 +447,6 @@ class QgsMeshLayerUndoCommandChangeXYValue : public QgsMeshLayerUndoCommandMeshE
   private:
     QList<int> mVerticesIndexes;
     QList<QgsPointXY> mNewValues;
-};
-
-/**
- * \ingroup core
- *
- * \brief  Class for undo/redo command for changing coordinate (X,Y,Z) values of vertices
- *
- * \since QGIS 3.22
- */
-class QgsMeshLayerUndoCommandChangeCoordinates : public QgsMeshLayerUndoCommandMeshEdit
-{
-  public:
-
-    /**
-     * Constructor with the associated \a meshEditor and indexes \a verticesIndexes of the vertices that will have
-     * the coordinate (X,Y,Z) values changed with \a newCoordinates
-     */
-    QgsMeshLayerUndoCommandChangeCoordinates( QgsMeshEditor *meshEditor, const QList<int> &verticesIndexes, const QList<QgsPoint> &newCoordinates );
-    void redo() override;
-
-  private:
-    QList<int> mVerticesIndexes;
-    QList<QgsPoint> mNewCoordinates;
 };
 
 /**

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -38,7 +38,6 @@
 #include "qgsproject.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmessagelog.h"
-#include "qgsmeshlayer.h"
 
 #include <QActionGroup>
 
@@ -320,47 +319,29 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 
 void QgsAdvancedDigitizingDockWidget::switchZM( )
 {
-  bool enableZ = false;
-  bool enableM = false;
 
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
-  if ( vlayer )
+  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() ) )
   {
     const QgsWkbTypes::Type type = vlayer->wkbType();
-    enableZ = QgsWkbTypes::hasZ( type );
-    enableM = QgsWkbTypes::hasM( type );
+    mRelativeZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+    mZLabel->setEnabled( QgsWkbTypes::hasZ( type ) );
+    mZLineEdit->setEnabled( QgsWkbTypes::hasZ( type ) );
+    if ( mZLineEdit->isEnabled() )
+      mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
+    else
+      mZLineEdit->clear();
+    mLockZButton->setEnabled( QgsWkbTypes::hasZ( type ) );
+
+    mRelativeMButton->setEnabled( QgsWkbTypes::hasM( type ) );
+    mMLabel->setEnabled( QgsWkbTypes::hasM( type ) );
+    mMLineEdit->setEnabled( QgsWkbTypes::hasM( type ) );
+    if ( mMLineEdit->isEnabled() )
+      mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
+    else
+      mMLineEdit->clear();
+    mLockMButton->setEnabled( QgsWkbTypes::hasM( type ) );
   }
 
-  QgsMeshLayer *mlayer = qobject_cast<QgsMeshLayer *>( mMapCanvas->currentLayer() );
-  if ( mlayer )
-    enableZ = mlayer->isEditable();
-
-  setEnabledZ( enableZ );
-  setEnabledM( enableM );
-}
-
-void QgsAdvancedDigitizingDockWidget::setEnabledZ( bool enable )
-{
-  mRelativeZButton->setEnabled( enable );
-  mZLabel->setEnabled( enable );
-  mZLineEdit->setEnabled( enable );
-  if ( mZLineEdit->isEnabled() )
-    mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
-  else
-    mZLineEdit->clear();
-  mLockZButton->setEnabled( enable );
-}
-
-void QgsAdvancedDigitizingDockWidget::setEnabledM( bool enable )
-{
-  mRelativeMButton->setEnabled( enable );
-  mMLabel->setEnabled( enable );
-  mMLineEdit->setEnabled( enable );
-  if ( mMLineEdit->isEnabled() )
-    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
-  else
-    mMLineEdit->clear();
-  mLockMButton->setEnabled( enable );
 }
 
 void QgsAdvancedDigitizingDockWidget::activateCad( bool enabled )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -256,18 +256,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void switchZM( );
 
-    /**
-     * Sets whether Z is enabled
-     * \since QGIS 3.22
-     */
-    void setEnabledZ( bool enable );
-
-    /**
-     * Sets whether M is enabled
-     * \since QGIS 3.22
-     */
-    void setEnabledM( bool enable );
-
     //! construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
     bool constructionMode() const { return mConstructionMode; }
 


### PR DESCRIPTION
Reverts qgis/QGIS#45140 -- this is  causing a floating "vertex z value" widget to show for non-related map tools, which never disappears (e.g. drawing a polygon annotation item)

ping @vcloarec 