### PR TITLE
Promote QgsCoordinateTransform::TransformDirection to enum class, move to Qgis

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -761,3 +761,14 @@ QgsRasterDataProviderTemporalCapabilities.FindClosestMatchToEndOfRange.__doc__ =
 Qgis.TemporalIntervalMatchMethod.__doc__ = 'Method to use when resolving a temporal range to a data provider layer or band.\n\n.. versionadded:: 3.22\n\n' + '* ``MatchUsingWholeRange``: ' + Qgis.TemporalIntervalMatchMethod.MatchUsingWholeRange.__doc__ + '\n' + '* ``MatchExactUsingStartOfRange``: ' + Qgis.TemporalIntervalMatchMethod.MatchExactUsingStartOfRange.__doc__ + '\n' + '* ``MatchExactUsingEndOfRange``: ' + Qgis.TemporalIntervalMatchMethod.MatchExactUsingEndOfRange.__doc__ + '\n' + '* ``FindClosestMatchToStartOfRange``: ' + Qgis.TemporalIntervalMatchMethod.FindClosestMatchToStartOfRange.__doc__ + '\n' + '* ``FindClosestMatchToEndOfRange``: ' + Qgis.TemporalIntervalMatchMethod.FindClosestMatchToEndOfRange.__doc__
 # --
 Qgis.TemporalIntervalMatchMethod.baseClass = Qgis
+QgsCoordinateTransform.TransformDirection = Qgis.TransformDirection
+# monkey patching scoped based enum
+QgsCoordinateTransform.ForwardTransform = Qgis.TransformDirection.Forward
+QgsCoordinateTransform.ForwardTransform.is_monkey_patched = True
+QgsCoordinateTransform.ForwardTransform.__doc__ = "Forward transform (from source to destination)"
+QgsCoordinateTransform.ReverseTransform = Qgis.TransformDirection.Reverse
+QgsCoordinateTransform.ReverseTransform.is_monkey_patched = True
+QgsCoordinateTransform.ReverseTransform.__doc__ = "Reverse/inverse transform (from destination to source)"
+Qgis.TransformDirection.__doc__ = 'Indicates the direction (forward or inverse) of a transform.\n\n.. versionadded:: 3.22\n\n' + '* ``ForwardTransform``: ' + Qgis.TransformDirection.Forward.__doc__ + '\n' + '* ``ReverseTransform``: ' + Qgis.TransformDirection.Reverse.__doc__
+# --
+Qgis.TransformDirection.baseClass = Qgis

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -318,7 +318,7 @@ Returns a KML representation of the geometry.
 
 
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException ) = 0;
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException ) = 0;
 %Docstring
 Transforms the geometry using a coordinate transform
 

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -154,7 +154,7 @@ Appends the contents of another circular ``string`` to the end of this circular 
 
     virtual void draw( QPainter &p ) const;
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -142,7 +142,7 @@ Converts the vertex at the given position from/to circular
 
     virtual void draw( QPainter &p ) const;
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false )  throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false )  throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -202,7 +202,7 @@ direction.
 
     virtual void draw( QPainter &p ) const;
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -869,7 +869,7 @@ Translates this geometry by dx, dy, dz and dm.
 :return: OperationResult a result code: success or reason of failure
 %End
 
-    Qgis::GeometryOperationResult transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection direction = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
+    Qgis::GeometryOperationResult transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException );
 %Docstring
 Transforms this geometry as described by the coordinate transform ``ct``.
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -153,7 +153,7 @@ Removes a geometry from the collection by index.
 %End
 
     void normalize() final /HoldGIL/;
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -666,7 +666,7 @@ of the curve.
     virtual void draw( QPainter &p ) const;
 
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false )  throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false )  throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -401,7 +401,7 @@ Example
 
     virtual QPainterPath asQPainterPath() const;
 
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) throw( QgsCsException );
 
     virtual void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 );
 

--- a/python/core/auto_generated/layertree/qgslegendpatchshape.sip.in
+++ b/python/core/auto_generated/layertree/qgslegendpatchshape.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsLegendPatchShape
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -45,12 +45,6 @@ transforms coordinates from the layer's coordinate system to the map canvas.
 %End
   public:
 
-    enum TransformDirection
-    {
-      ForwardTransform,
-      ReverseTransform
-    };
-
     QgsCoordinateTransform();
 %Docstring
 Default constructor, creates an invalid QgsCoordinateTransform.
@@ -212,7 +206,7 @@ transform coordinates to.
 .. seealso:: :py:func:`sourceCrs`
 %End
 
-    QgsPointXY transform( const QgsPointXY &point, TransformDirection direction = ForwardTransform ) const throw( QgsCsException );
+    QgsPointXY transform( const QgsPointXY &point, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const throw( QgsCsException );
 %Docstring
 Transform the point from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -224,7 +218,7 @@ otherwise points are transformed from destination to source CRS.
 :return: transformed point
 %End
 
-    QgsPointXY transform( double x, double y, TransformDirection direction = ForwardTransform ) const;
+    QgsPointXY transform( double x, double y, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const;
 %Docstring
 Transform the point specified by x,y from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -237,7 +231,7 @@ otherwise points are transformed from destination to source CRS.
 :return: transformed point
 %End
 
-    QgsVector3D transform( const QgsVector3D &point, TransformDirection direction = ForwardTransform ) const;
+    QgsVector3D transform( const QgsVector3D &point, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const;
 %Docstring
 Transform the point specified in 3D coordinates from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -251,7 +245,7 @@ otherwise points are transformed from destination to source CRS.
 .. versionadded:: 3.18
 %End
 
-    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, bool handle180Crossover = false ) const throw( QgsCsException );
+    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward, bool handle180Crossover = false ) const throw( QgsCsException );
 %Docstring
 Transforms a rectangle from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -268,7 +262,7 @@ the returned rectangle.
 :return: rectangle in destination CRS
 %End
 
-    void transformInPlace( double &x, double &y, double &z, TransformDirection direction = ForwardTransform ) const throw( QgsCsException );
+    void transformInPlace( double &x, double &y, double &z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const throw( QgsCsException );
 %Docstring
 Transforms an array of x, y and z double coordinates in place, from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -286,7 +280,7 @@ otherwise points are transformed from destination to source CRS.
 
 
 
-    void transformPolygon( QPolygonF &polygon, TransformDirection direction = ForwardTransform ) const throw( QgsCsException );
+    void transformPolygon( QPolygonF &polygon, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const throw( QgsCsException );
 %Docstring
 Transforms a polygon to the destination coordinate system.
 
@@ -294,7 +288,7 @@ Transforms a polygon to the destination coordinate system.
 :param direction: transform direction (defaults to forward transformation)
 %End
 
-    QgsRectangle transform( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform ) const throw( QgsCsException );
+    QgsRectangle transform( const QgsRectangle &rectangle, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const throw( QgsCsException );
 %Docstring
 Transforms a rectangle to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -306,7 +300,7 @@ otherwise points are transformed from destination to source CRS.
 :return: transformed rectangle
 %End
 
-    void transformCoords( int numPoint, double *x, double *y, double *z, TransformDirection direction = ForwardTransform ) const throw( QgsCsException );
+    void transformCoords( int numPoint, double *x, double *y, double *z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const throw( QgsCsException );
 %Docstring
 Transform an array of coordinates to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -545,6 +545,12 @@ The development version
       FindClosestMatchToEndOfRange
     };
 
+    enum class TransformDirection
+      {
+      Forward,
+      Reverse
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsScopedExpressionFunction : QgsExpressionFunction
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsFeatureRequest
 {
 %Docstring(signature="appended")

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -115,7 +115,7 @@ void QgsMeshTriangulation::addVerticesFromFeature( const QgsFeature &feature, in
   QgsGeometry geom = feature.geometry();
   try
   {
-    geom.transform( transform, QgsCoordinateTransform::ForwardTransform, true );
+    geom.transform( transform, Qgis::TransformDirection::Forward, true );
   }
   catch ( QgsCsException &cse )
   {
@@ -155,7 +155,7 @@ void QgsMeshTriangulation::addBreakLinesFromFeature( const QgsFeature &feature, 
   QgsGeometry geom = feature.geometry();
   try
   {
-    geom.transform( transform, QgsCoordinateTransform::ForwardTransform, true );
+    geom.transform( transform, Qgis::TransformDirection::Forward, true );
   }
   catch ( QgsCsException &cse )
   {

--- a/src/analysis/processing/qgsalgorithmdrape.cpp
+++ b/src/analysis/processing/qgsalgorithmdrape.cpp
@@ -104,7 +104,7 @@ QgsFeatureList QgsDrapeAlgorithmBase::processFeature( const QgsFeature &feature,
     // whether individual vector geometries are actually covered by the raster
     try
     {
-      mRasterExtent = mTransform.transform( mRasterExtent, QgsCoordinateTransform::ReverseTransform );
+      mRasterExtent = mTransform.transform( mRasterExtent, Qgis::TransformDirection::Reverse );
     }
     catch ( QgsCsException & )
     {

--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -22,6 +22,7 @@
 #include "qgsfeedback.h"
 #include "qgsogrutils.h"
 #include "qgsmessagelog.h"
+#include "qgsconfig.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -22,6 +22,7 @@
 #include "gdal.h"
 #include "qgis_analysis.h"
 #include "qgsogrutils.h"
+#include "qgsconfig.h"
 
 class QgsFeedback;
 

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -20,6 +20,7 @@
 
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include <QString>
 #include <QVector>
 #include "gdal.h"

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -239,7 +239,7 @@ QgsGeometryCheckerUtils::LayerFeatures::LayerFeatures( const QMap<QString, QgsFe
     if ( geometryTypes.contains( featurePool->geometryType() ) )
     {
       const QgsCoordinateTransform ct( featurePool->crs(), context->mapCrs, context->transformContext );
-      mFeatureIds.insert( layerId, featurePool->getIntersects( ct.transform( extent, QgsCoordinateTransform::ReverseTransform ) ) );
+      mFeatureIds.insert( layerId, featurePool->getIntersects( ct.transform( extent, Qgis::TransformDirection::Reverse ) ) );
     }
     else
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -315,7 +315,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( const QMap<QString, QgsFeaturePool 
     QgsFeaturePool *featurePool = featurePools.value( layerId );
     std::unique_ptr<QgsAbstractGeometry> errLayerGeom( errGeometry->clone() );
     const QgsCoordinateTransform ct( featurePool->crs(), mContext->mapCrs, mContext->transformContext );
-    errLayerGeom->transform( ct, QgsCoordinateTransform::ReverseTransform );
+    errLayerGeom->transform( ct, Qgis::TransformDirection::Reverse );
 
     const auto featureIds = err->neighbors().value( layerId );
 
@@ -406,7 +406,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( const QMap<QString, QgsFeaturePool 
   QgsFeaturePool *featurePool = featurePools[ mergeLayerId ];
   std::unique_ptr<QgsAbstractGeometry> errLayerGeom( snappedErrGeom->clone() );
   const QgsCoordinateTransform ct( featurePool->crs(), mContext->mapCrs, mContext->transformContext );
-  errLayerGeom->transform( ct, QgsCoordinateTransform::ReverseTransform );
+  errLayerGeom->transform( ct, Qgis::TransformDirection::Reverse );
   const QgsGeometry mergeFeatureGeom = mergeFeature.geometry();
   const QgsAbstractGeometry *mergeGeom = mergeFeatureGeom.constGet();
   std::unique_ptr< QgsGeometryEngine > geomEngine = QgsGeometryCheckerUtils::createGeomEngine( errLayerGeom.get(), 0 );

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
@@ -184,7 +184,7 @@ void QgsGeometryOverlapCheck::fixError( const QMap<QString, QgsFeaturePool *> &f
       if ( shared1 < shared2 )
       {
         const QgsCoordinateTransform ct( featurePoolA->crs(), mContext->mapCrs, mContext->transformContext );
-        diff1->transform( ct, QgsCoordinateTransform::ReverseTransform );
+        diff1->transform( ct, Qgis::TransformDirection::Reverse );
         featureA.setGeometry( QgsGeometry( std::move( diff1 ) ) );
 
         changes[error->layerId()][featureA.id()].append( Change( ChangeFeature, ChangeChanged ) );
@@ -193,7 +193,7 @@ void QgsGeometryOverlapCheck::fixError( const QMap<QString, QgsFeaturePool *> &f
       else
       {
         const QgsCoordinateTransform ct( featurePoolB->crs(), mContext->mapCrs, mContext->transformContext );
-        diff2->transform( ct, QgsCoordinateTransform::ReverseTransform );
+        diff2->transform( ct, Qgis::TransformDirection::Reverse );
         featureB.setGeometry( QgsGeometry( std::move( diff2 ) ) );
 
         changes[overlapError->overlappedFeature().layerId()][featureB.id()].append( Change( ChangeFeature, ChangeChanged ) );

--- a/src/app/dwg/qgsdwgimporter.cpp
+++ b/src/app/dwg/qgsdwgimporter.cpp
@@ -30,6 +30,7 @@
 #include "qgspolygon.h"
 #include "qgsgeometry.h"
 #include "qgsogrutils.h"
+#include "qgscoordinatereferencesystem.h"
 
 #include <QString>
 #include <QStringList>

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -602,7 +602,7 @@ void QgsGpsInformationWidget::recenter()
 {
   try
   {
-    const QgsPointXY center = mCanvasToWgs84Transform.transform( mLastGpsPosition, QgsCoordinateTransform::ReverseTransform );
+    const QgsPointXY center = mCanvasToWgs84Transform.transform( mLastGpsPosition, Qgis::TransformDirection::Reverse );
     mMapCanvas->setCenter( center );
     mMapCanvas->refresh();
   }
@@ -989,7 +989,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     {
       try
       {
-        const QgsPointXY myPoint = mCanvasToWgs84Transform.transform( myNewCenter, QgsCoordinateTransform::ReverseTransform );
+        const QgsPointXY myPoint = mCanvasToWgs84Transform.transform( myNewCenter, Qgis::TransformDirection::Reverse );
         //keep the extent the same just center the map canvas in the display so our feature is in the middle
         const QgsRectangle myRect( myPoint, myPoint );  // empty rect can be used to set new extent that is centered on the point used to construct the rect
 
@@ -1154,7 +1154,7 @@ void QgsGpsInformationWidget::addVertex()
   QgsPointXY myPoint;
   if ( mMapCanvas )
   {
-    myPoint = mCanvasToWgs84Transform.transform( mLastGpsPosition, QgsCoordinateTransform::ReverseTransform );
+    myPoint = mCanvasToWgs84Transform.transform( mLastGpsPosition, Qgis::TransformDirection::Reverse );
   }
   else
   {

--- a/src/app/qgsmaptooloffsetpointsymbol.h
+++ b/src/app/qgsmaptooloffsetpointsymbol.h
@@ -17,6 +17,7 @@
 #define QGSMAPTOOLOFFSETPOINTSYMBOL_H
 
 #include "qgsmaptoolpointsymbol.h"
+#include "qgsunittypes.h"
 #include "qgis_app.h"
 
 class QgsMarkerSymbol;

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -26,6 +26,7 @@
 #include "qgis_app.h"
 #include "qgsdockwidget.h"
 #include "qgspoint.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QLabel;
 class QTableView;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -560,7 +560,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       {
         QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( vlayer );
         if ( ct.isValid() )
-          layerRubberBandGeometry.transform( ct, QgsCoordinateTransform::ReverseTransform );
+          layerRubberBandGeometry.transform( ct, Qgis::TransformDirection::Reverse );
       }
       catch ( QgsCsException & )
       {

--- a/src/core/annotations/qgsannotationmarkeritem.cpp
+++ b/src/core/annotations/qgsannotationmarkeritem.cpp
@@ -192,7 +192,7 @@ QgsRectangle QgsAnnotationMarkerItem::boundingBox( QgsRenderContext &context ) c
   const QgsPointXY bottomRight = context.mapToPixel().toMapCoordinates( boundsInPixels.right(), boundsInPixels.bottom() );
 
   const QgsRectangle boundsMapUnits = QgsRectangle( topLeft.x(), bottomLeft.y(), bottomRight.x(), topRight.y() );
-  return context.coordinateTransform().transformBoundingBox( boundsMapUnits, QgsCoordinateTransform::ReverseTransform );
+  return context.coordinateTransform().transformBoundingBox( boundsMapUnits, Qgis::TransformDirection::Reverse );
 }
 
 const QgsMarkerSymbol *QgsAnnotationMarkerItem::symbol() const

--- a/src/core/callouts/qgscallout.h
+++ b/src/core/callouts/qgscallout.h
@@ -25,6 +25,7 @@
 #include "qgsmapunitscale.h"
 #include "qgscalloutposition.h"
 #include "qgsmargins.h"
+#include "qgscoordinatetransform.h"
 
 #include <QPainter>
 #include <QString>

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -663,7 +663,7 @@ void QgsDxfExport::writeEntities()
     const QgsCoordinateTransform ct( job->crs, mMapSettings.destinationCrs(), mMapSettings.transformContext() );
 
     QgsFeatureRequest request = QgsFeatureRequest().setSubsetOfAttributes( job->attributes, job->fields ).setExpressionContext( job->renderContext.expressionContext() );
-    request.setFilterRect( ct.transformBoundingBox( mExtent, QgsCoordinateTransform::ReverseTransform ) );
+    request.setFilterRect( ct.transformBoundingBox( mExtent, Qgis::TransformDirection::Reverse ) );
 
     QgsFeatureIterator featureIt = job->featureSource.getFeatures( request );
 

--- a/src/core/geocoding/qgsgooglemapsgeocoder.cpp
+++ b/src/core/geocoding/qgsgooglemapsgeocoder.cpp
@@ -19,6 +19,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsblockingnetworkrequest.h"
 #include "qgsreadwritelocker.h"
+#include "qgscoordinatetransform.h"
 #include <QUrl>
 #include <QUrlQuery>
 #include <QNetworkRequest>

--- a/src/core/geocoding/qgsnominatimgeocoder.cpp
+++ b/src/core/geocoding/qgsnominatimgeocoder.cpp
@@ -18,6 +18,7 @@
 #include "qgsgeocodercontext.h"
 #include "qgslogger.h"
 #include "qgsnetworkaccessmanager.h"
+#include "qgscoordinatetransform.h"
 #include <QDateTime>
 #include <QUrl>
 #include <QUrlQuery>

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -22,7 +22,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include <QString>
 
 #include "qgis_core.h"
-#include "qgscoordinatetransform.h"
+#include "qgis.h"
 #include "qgswkbtypes.h"
 #include "qgswkbptr.h"
 
@@ -47,6 +47,9 @@ class QgsConstWkbPtr;
 class QPainterPath;
 class QgsAbstractGeometryTransformer;
 class QgsFeedback;
+class QgsCoordinateTransform;
+class QgsPoint;
+class QgsRectangle;
 
 typedef QVector< QgsPoint > QgsPointSequence;
 #ifndef SIP_RUN
@@ -373,7 +376,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * units (generally meters). If FALSE, then z coordinates will not be changed by the
      * transform.
      */
-    virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) SIP_THROW( QgsCsException ) = 0;
+    virtual void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) SIP_THROW( QgsCsException ) = 0;
 
     /**
      * Transforms the x and y components of the geometry using a QTransform object \a t.

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -1108,7 +1108,7 @@ void QgsCircularString::draw( QPainter &p ) const
   p.drawPath( path );
 }
 
-void QgsCircularString::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsCircularString::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   clearCache();
 

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     bool removeDuplicateNodes( double epsilon = 4 * std::numeric_limits<double>::epsilon(), bool useZValues = false ) override;
 
     void draw( QPainter &p ) const override;
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
     void addToPainterPath( QPainterPath &path ) const override;
     void drawAsPolygon( QPainter &p ) const override;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -706,7 +706,7 @@ void QgsCompoundCurve::draw( QPainter &p ) const
   }
 }
 
-void QgsCompoundCurve::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsCompoundCurve::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   for ( QgsCurve *curve : std::as_const( mCurves ) )
   {

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -127,7 +127,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     bool toggleCircularAtVertex( QgsVertexId position );
 
     void draw( QPainter &p ) const override;
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override  SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override  SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
     void addToPainterPath( QPainterPath &path ) const override;
     void drawAsPolygon( QPainter &p ) const override;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -870,7 +870,7 @@ void QgsCurvePolygon::draw( QPainter &p ) const
   }
 }
 
-void QgsCurvePolygon::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsCurvePolygon::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   if ( mExteriorRing )
   {

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -248,7 +248,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
 
     QPainterPath asQPainterPath() const override;
     void draw( QPainter &p ) const override;
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
 
     bool insertVertex( QgsVertexId position, const QgsPoint &vertex ) override;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3045,7 +3045,7 @@ bool QgsGeometry::requiresConversionToStraightSegments() const
   return d->geometry->hasCurvedSegments();
 }
 
-Qgis::GeometryOperationResult QgsGeometry::transform( const QgsCoordinateTransform &ct, const QgsCoordinateTransform::TransformDirection direction, const bool transformZ )
+Qgis::GeometryOperationResult QgsGeometry::transform( const QgsCoordinateTransform &ct, const Qgis::TransformDirection direction, const bool transformZ )
 {
   if ( !d->geometry )
   {

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -918,7 +918,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \returns OperationResult a result code: success or reason of failure
      */
-    Qgis::GeometryOperationResult transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection direction = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) SIP_THROW( QgsCsException );
+    Qgis::GeometryOperationResult transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward, bool transformZ = false ) SIP_THROW( QgsCsException );
 
     /**
      * Transforms the x and y components of the geometry using a QTransform object \a t.

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -323,7 +323,7 @@ QString QgsGeometryCollection::geometryType() const
   return QStringLiteral( "GeometryCollection" );
 }
 
-void QgsGeometryCollection::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsGeometryCollection::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   for ( QgsAbstractGeometry *g : std::as_const( mGeometries ) )
   {

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -22,6 +22,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
+#include "qgsrectangle.h"
 
 class QgsPoint;
 
@@ -180,7 +181,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 #endif
 
     void normalize() final SIP_HOLDGIL;
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
 
     void draw( QPainter &p ) const override;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1546,7 +1546,7 @@ int QgsLineString::dimension() const
  * See details in QEP #17
  ****************************************************************************/
 
-void QgsLineString::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsLineString::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   double *zArray = nullptr;
   bool hasZ = is3D();

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -835,7 +835,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 
     void draw( QPainter &p ) const override;
 
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override  SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override  SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
 
     void addToPainterPath( QPainterPath &path ) const override;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -379,7 +379,7 @@ void QgsPoint::clear()
  * See details in QEP #17
  ****************************************************************************/
 
-void QgsPoint::transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d, bool transformZ )
+void QgsPoint::transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d, bool transformZ )
 {
   clearCache();
   if ( transformZ )

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -513,7 +513,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     QString asKml( int precision = 17 ) const override;
     void draw( QPainter &p ) const override;
     QPainterPath asQPainterPath() const override;
-    void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) override SIP_THROW( QgsCsException );
+    void transform( const QgsCoordinateTransform &ct, Qgis::TransformDirection d = Qgis::TransformDirection::Forward, bool transformZ = false ) override SIP_THROW( QgsCsException );
     void transform( const QTransform &t, double zTranslate = 0.0, double zScale = 1.0, double mTranslate = 0.0, double mScale = 1.0 ) override;
     QgsCoordinateSequence coordinateSequence() const override;
     int nCoordinates() const override SIP_HOLDGIL;

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -149,7 +149,7 @@ QList<QgsLabelFeature *> QgsVectorLayerLabelProvider::labelFeatures( QgsRenderCo
 
   QgsRectangle layerExtent = ctx.extent();
   if ( mSettings.ct.isValid() && !mSettings.ct.isShortCircuited() )
-    layerExtent = mSettings.ct.transformBoundingBox( ctx.extent(), QgsCoordinateTransform::ReverseTransform );
+    layerExtent = mSettings.ct.transformBoundingBox( ctx.extent(), Qgis::TransformDirection::Reverse );
 
   QgsFeatureRequest request;
   request.setFilterRect( layerExtent );
@@ -268,7 +268,7 @@ QgsGeometry QgsVectorLayerLabelProvider::getPointObstacleGeometry( QgsFeature &f
     {
       try
       {
-        boundLineString->transform( context.coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+        boundLineString->transform( context.coordinateTransform(), Qgis::TransformDirection::Reverse );
       }
       catch ( QgsCsException & )
       {

--- a/src/core/layertree/qgslegendpatchshape.h
+++ b/src/core/layertree/qgslegendpatchshape.h
@@ -22,6 +22,8 @@ email                : nyall dot dawson at gmail dot com
 #include "qgis.h"
 #include "qgsgeometry.h"
 
+class QgsReadWriteContext;
+
 /**
  * \ingroup core
  * \brief Represents a patch shape for use in map legends.

--- a/src/core/layout/qgscompositionconverter.h
+++ b/src/core/layout/qgscompositionconverter.h
@@ -45,6 +45,7 @@ class QgsLayoutItemHtml;
 class QgsLayoutItemAttributeTable;
 class QgsLayoutItemGroup;
 class QgsLayoutAtlas;
+class QgsProject;
 
 /**
  * \brief QgsCompositionConverter class converts a QGIS 2.x composition to a QGIS 3.x layout

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -434,8 +434,8 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
     QgsCoordinateTransform coordTransform( layer->crs(), mMap->crs(), mLayout->project() );
     try
     {
-      selectionRect = coordTransform.transformBoundingBox( selectionRect, QgsCoordinateTransform::ReverseTransform );
-      visibleRegion.transform( coordTransform, QgsCoordinateTransform::ReverseTransform );
+      selectionRect = coordTransform.transformBoundingBox( selectionRect, Qgis::TransformDirection::Reverse );
+      visibleRegion.transform( coordTransform, Qgis::TransformDirection::Reverse );
     }
     catch ( QgsCsException &cse )
     {

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -2605,7 +2605,7 @@ int QgsLayoutItemMapGrid::crsGridParams( QgsRectangle &crsRect, QgsCoordinateTra
       if ( lowerLeft.x() > upperRight.x() )
       {
         //we've crossed the line
-        crsRect = tr.transformBoundingBox( mapBoundingRect, QgsCoordinateTransform::ForwardTransform, true );
+        crsRect = tr.transformBoundingBox( mapBoundingRect, Qgis::TransformDirection::Forward, true );
       }
       else
       {

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -280,8 +280,8 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
         // if we transform from a projected coordinate system check
         // check if transforming back roughly returns the input
         // extend - otherwise render the world.
-        QgsRectangle extent1 = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
-        QgsRectangle extent2 = approxTransform.transformBoundingBox( extent1, QgsCoordinateTransform::ForwardTransform );
+        QgsRectangle extent1 = approxTransform.transformBoundingBox( extent, Qgis::TransformDirection::Reverse );
+        QgsRectangle extent2 = approxTransform.transformBoundingBox( extent1, Qgis::TransformDirection::Forward );
 
         QgsDebugMsgLevel( QStringLiteral( "\n0:%1 %2x%3\n1:%4\n2:%5 %6x%7 (w:%8 h:%9)" )
                           .arg( extent.toString() ).arg( extent.width() ).arg( extent.height() )
@@ -309,15 +309,15 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
       {
         // Note: ll = lower left point
         QgsPointXY ll = approxTransform.transform( extent.xMinimum(), extent.yMinimum(),
-                        QgsCoordinateTransform::ReverseTransform );
+                        Qgis::TransformDirection::Reverse );
 
         //   and ur = upper right point
         QgsPointXY ur = approxTransform.transform( extent.xMaximum(), extent.yMaximum(),
-                        QgsCoordinateTransform::ReverseTransform );
+                        Qgis::TransformDirection::Reverse );
 
         QgsDebugMsgLevel( QStringLiteral( "in:%1 (ll:%2 ur:%3)" ).arg( extent.toString(), ll.toString(), ur.toString() ), 4 );
 
-        extent = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+        extent = approxTransform.transformBoundingBox( extent, Qgis::TransformDirection::Reverse );
 
         QgsDebugMsgLevel( QStringLiteral( "out:%1 (w:%2 h:%3)" ).arg( extent.toString() ).arg( extent.width() ).arg( extent.height() ), 4 );
 
@@ -354,7 +354,7 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
         res = false;
       }
       else
-        extent = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+        extent = approxTransform.transformBoundingBox( extent, Qgis::TransformDirection::Reverse );
     }
   }
   catch ( QgsCsException & )

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -120,7 +120,7 @@ void QgsTriangularMesh::triangulate( const QgsMeshFace &face, int nativeIndex )
   triangulateFaces( face, nativeIndex, mTriangularMesh.faces, mTrianglesToNativeFaces, mTriangularMesh );
 }
 
-QgsMeshVertex QgsTriangularMesh::transformVertex( const QgsMeshVertex &vertex, QgsCoordinateTransform::TransformDirection direction ) const
+QgsMeshVertex QgsTriangularMesh::transformVertex( const QgsMeshVertex &vertex, Qgis::TransformDirection direction ) const
 {
   QgsMeshVertex transformedVertex = vertex;
 
@@ -276,12 +276,12 @@ void QgsTriangularMesh::finalizeTriangles()
 
 QgsMeshVertex QgsTriangularMesh::nativeToTriangularCoordinates( const QgsMeshVertex &vertex ) const
 {
-  return transformVertex( vertex, QgsCoordinateTransform::ForwardTransform );
+  return transformVertex( vertex, Qgis::TransformDirection::Forward );
 }
 
 QgsMeshVertex QgsTriangularMesh::triangularToNativeCoordinates( const QgsMeshVertex &vertex ) const
 {
-  return transformVertex( vertex, QgsCoordinateTransform::ReverseTransform );
+  return transformVertex( vertex, Qgis::TransformDirection::Reverse );
 }
 
 QgsRectangle QgsTriangularMesh::nativeExtent()
@@ -291,7 +291,7 @@ QgsRectangle QgsTriangularMesh::nativeExtent()
   {
     try
     {
-      nativeExtent = mCoordinateTransform.transform( extent(), QgsCoordinateTransform::ReverseTransform );
+      nativeExtent = mCoordinateTransform.transform( extent(), Qgis::TransformDirection::Reverse );
     }
     catch ( QgsCsException &cse )
     {

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -31,9 +31,9 @@
 #include "qgsgeometry.h"
 #include "qgsmeshspatialindex.h"
 #include "qgstopologicalmesh.h"
+#include "qgscoordinatetransform.h"
 
 class QgsRenderContext;
-class QgsCoordinateTransform;
 class QgsRectangle;
 
 /**
@@ -337,7 +337,7 @@ class CORE_EXPORT QgsTriangularMesh // TODO rename to QgsRendererMesh in QGIS 4
 
     void addVertex( const QgsMeshVertex &vertex );
 
-    QgsMeshVertex transformVertex( const QgsMeshVertex &vertex, QgsCoordinateTransform::TransformDirection direction ) const;
+    QgsMeshVertex transformVertex( const QgsMeshVertex &vertex, Qgis::TransformDirection direction ) const;
 
     // calculate the centroid of the native mesh, mNativeMeshCentroids container must have the emplacment for the corresponding centroid before calling this method
     QgsMeshVertex calculateCentroid( const QgsMeshFace &nativeFace );

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -270,7 +270,7 @@ QVector<QVariantMap> QgsPointCloudRenderer::identify( QgsPointCloudLayer *layer,
   // selection geometry must be in layer CRS for QgsPointCloudDataProvider::identify
   try
   {
-    selectionGeometry.transform( renderContext.coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+    selectionGeometry.transform( renderContext.coordinateTransform(), Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException & )
   {

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -25,6 +25,7 @@
 #include "qgsproject.h"
 #include "qgsreadwritelocker.h"
 #include "qgsvector3d.h"
+#include "qgis.h"
 
 //qt includes
 #include <QDomNode>
@@ -209,7 +210,7 @@ QgsCoordinateReferenceSystem QgsCoordinateTransform::destinationCrs() const
   return d->mDestCRS;
 }
 
-QgsPointXY QgsCoordinateTransform::transform( const QgsPointXY &point, TransformDirection direction ) const
+QgsPointXY QgsCoordinateTransform::transform( const QgsPointXY &point, Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return point;
@@ -233,7 +234,7 @@ QgsPointXY QgsCoordinateTransform::transform( const QgsPointXY &point, Transform
 }
 
 
-QgsPointXY QgsCoordinateTransform::transform( const double theX, const double theY = 0.0, TransformDirection direction ) const
+QgsPointXY QgsCoordinateTransform::transform( const double theX, const double theY = 0.0, Qgis::TransformDirection direction ) const
 {
   try
   {
@@ -247,7 +248,7 @@ QgsPointXY QgsCoordinateTransform::transform( const double theX, const double th
   }
 }
 
-QgsRectangle QgsCoordinateTransform::transform( const QgsRectangle &rect, TransformDirection direction ) const
+QgsRectangle QgsCoordinateTransform::transform( const QgsRectangle &rect, Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return rect;
@@ -283,7 +284,7 @@ QgsRectangle QgsCoordinateTransform::transform( const QgsRectangle &rect, Transf
   return QgsRectangle( x1, y1, x2, y2 );
 }
 
-QgsVector3D QgsCoordinateTransform::transform( const QgsVector3D &point, TransformDirection direction ) const
+QgsVector3D QgsCoordinateTransform::transform( const QgsVector3D &point, Qgis::TransformDirection direction ) const
 {
   double x = point.x();
   double y = point.y();
@@ -302,7 +303,7 @@ QgsVector3D QgsCoordinateTransform::transform( const QgsVector3D &point, Transfo
 }
 
 void QgsCoordinateTransform::transformInPlace( double &x, double &y, double &z,
-    TransformDirection direction ) const
+    Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return;
@@ -323,7 +324,7 @@ void QgsCoordinateTransform::transformInPlace( double &x, double &y, double &z,
 }
 
 void QgsCoordinateTransform::transformInPlace( float &x, float &y, double &z,
-    TransformDirection direction ) const
+    Qgis::TransformDirection direction ) const
 {
   double xd = static_cast< double >( x ), yd = static_cast< double >( y );
   transformInPlace( xd, yd, z, direction );
@@ -332,7 +333,7 @@ void QgsCoordinateTransform::transformInPlace( float &x, float &y, double &z,
 }
 
 void QgsCoordinateTransform::transformInPlace( float &x, float &y, float &z,
-    TransformDirection direction ) const
+    Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return;
@@ -358,7 +359,7 @@ void QgsCoordinateTransform::transformInPlace( float &x, float &y, float &z,
   }
 }
 
-void QgsCoordinateTransform::transformPolygon( QPolygonF &poly, TransformDirection direction ) const
+void QgsCoordinateTransform::transformPolygon( QPolygonF &poly, Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
   {
@@ -410,9 +411,8 @@ void QgsCoordinateTransform::transformPolygon( QPolygonF &poly, TransformDirecti
     throw QgsCsException( err );
 }
 
-void QgsCoordinateTransform::transformInPlace(
-  QVector<double> &x, QVector<double> &y, QVector<double> &z,
-  TransformDirection direction ) const
+void QgsCoordinateTransform::transformInPlace( QVector<double> &x, QVector<double> &y, QVector<double> &z,
+    Qgis::TransformDirection direction ) const
 {
 
   if ( !d->mIsValid || d->mShortCircuit )
@@ -438,9 +438,8 @@ void QgsCoordinateTransform::transformInPlace(
 }
 
 
-void QgsCoordinateTransform::transformInPlace(
-  QVector<float> &x, QVector<float> &y, QVector<float> &z,
-  TransformDirection direction ) const
+void QgsCoordinateTransform::transformInPlace( QVector<float> &x, QVector<float> &y, QVector<float> &z,
+    Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return;
@@ -499,7 +498,7 @@ void QgsCoordinateTransform::transformInPlace(
   }
 }
 
-QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &rect, TransformDirection direction, const bool handle180Crossover ) const
+QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &rect, Qgis::TransformDirection direction, const bool handle180Crossover ) const
 {
   // Calculate the bounding box of a QgsRectangle in the source CRS
   // when projected to the destination CRS (or the inverse).
@@ -618,7 +617,7 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
   return bb_rect;
 }
 
-void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *y, double *z, TransformDirection direction ) const
+void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *y, double *z, Qgis::TransformDirection direction ) const
 {
   if ( !d->mIsValid || d->mShortCircuit )
     return;
@@ -677,7 +676,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   int projResult = 0;
 
   proj_errno_reset( projData );
-  proj_trans_generic( projData, ( direction == ForwardTransform && !d->mIsReversed ) || ( direction == ReverseTransform && d->mIsReversed ) ? PJ_FWD : PJ_INV,
+  proj_trans_generic( projData, ( direction == Qgis::TransformDirection::Forward && !d->mIsReversed ) || ( direction == Qgis::TransformDirection::Reverse && d->mIsReversed ) ? PJ_FWD : PJ_INV,
                       x, sizeof( double ), numPoints,
                       y, sizeof( double ), numPoints,
                       z, sizeof( double ), numPoints,
@@ -722,7 +721,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     {
       projResult = 0;
       proj_errno_reset( transform );
-      proj_trans_generic( transform, direction == ForwardTransform ? PJ_FWD : PJ_INV,
+      proj_trans_generic( transform, direction == Qgis::TransformDirection::Forward ? PJ_FWD : PJ_INV,
                           xprev.data(), sizeof( double ), numPoints,
                           yprev.data(), sizeof( double ), numPoints,
                           zprev.data(), sizeof( double ), numPoints,
@@ -775,7 +774,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     for ( int i = 0; i < numPoints; ++i )
     {
-      if ( direction == ForwardTransform )
+      if ( direction == Qgis::TransformDirection::Forward )
       {
         points += QStringLiteral( "(%1, %2)\n" ).arg( x[i], 0, 'f' ).arg( y[i], 0, 'f' );
       }
@@ -785,7 +784,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       }
     }
 
-    const QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
+    const QString dir = ( direction == Qgis::TransformDirection::Forward ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
     const QString msg = QObject::tr( "%1 of\n"
                                      "%2"

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -59,13 +59,6 @@ class CORE_EXPORT QgsCoordinateTransform
 
   public:
 
-    //! Enum used to indicate the direction (forward or inverse) of the transform
-    enum TransformDirection
-    {
-      ForwardTransform,     //!< Transform from source to destination CRS.
-      ReverseTransform      //!< Transform from destination to source CRS.
-    };
-
     //! Default constructor, creates an invalid QgsCoordinateTransform.
     QgsCoordinateTransform();
 
@@ -212,7 +205,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \returns transformed point
      */
-    QgsPointXY transform( const QgsPointXY &point, TransformDirection direction = ForwardTransform ) const SIP_THROW( QgsCsException );
+    QgsPointXY transform( const QgsPointXY &point, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_THROW( QgsCsException );
 
     /**
      * Transform the point specified by x,y from the source CRS to the destination CRS.
@@ -223,7 +216,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \returns transformed point
      */
-    QgsPointXY transform( double x, double y, TransformDirection direction = ForwardTransform ) const;
+    QgsPointXY transform( double x, double y, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const;
 
     /**
      * Transform the point specified in 3D coordinates from the source CRS to the destination CRS.
@@ -234,7 +227,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \returns transformed point
      * \since QGIS 3.18
      */
-    QgsVector3D transform( const QgsVector3D &point, TransformDirection direction = ForwardTransform ) const;
+    QgsVector3D transform( const QgsVector3D &point, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const;
 
     /**
      * Transforms a rectangle from the source CRS to the destination CRS.
@@ -249,7 +242,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * crossing the 180 degree longitude line is required
      * \returns rectangle in destination CRS
      */
-    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, bool handle180Crossover = false ) const SIP_THROW( QgsCsException );
+    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward, bool handle180Crossover = false ) const SIP_THROW( QgsCsException );
 
     /**
      * Transforms an array of x, y and z double coordinates in place, from the source CRS to the destination CRS.
@@ -262,7 +255,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * heights) and must be expressed in its vertical units (generally meters)
      * \param direction transform direction (defaults to ForwardTransform)
      */
-    void transformInPlace( double &x, double &y, double &z, TransformDirection direction = ForwardTransform ) const SIP_THROW( QgsCsException );
+    void transformInPlace( double &x, double &y, double &z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_THROW( QgsCsException );
 
     /**
      * Transforms an array of x, y and z float coordinates in place, from the source CRS to the destination CRS.
@@ -276,7 +269,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \note not available in Python bindings
      */
-    void transformInPlace( float &x, float &y, double &z, TransformDirection direction = ForwardTransform ) const SIP_SKIP;
+    void transformInPlace( float &x, float &y, double &z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_SKIP;
 
     /**
      * Transforms an array of x, y and z float coordinates in place, from the source CRS to the destination CRS.
@@ -290,7 +283,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \note not available in Python bindings
      */
-    void transformInPlace( float &x, float &y, float &z, TransformDirection direction = ForwardTransform ) const SIP_SKIP;
+    void transformInPlace( float &x, float &y, float &z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_SKIP;
 
     /**
      * Transforms a vector of x, y and z float coordinates in place, from the source CRS to the destination CRS.
@@ -305,7 +298,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \note not available in Python bindings
      */
     void transformInPlace( QVector<float> &x, QVector<float> &y, QVector<float> &z,
-                           TransformDirection direction = ForwardTransform ) const SIP_SKIP;
+                           Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_SKIP;
 
     /**
      * Transforms a vector of x, y and z double coordinates in place, from the source CRS to the destination CRS.
@@ -320,14 +313,14 @@ class CORE_EXPORT QgsCoordinateTransform
      * \note not available in Python bindings
      */
     void transformInPlace( QVector<double> &x, QVector<double> &y, QVector<double> &z,
-                           TransformDirection direction = ForwardTransform ) const SIP_SKIP;
+                           Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_SKIP;
 
     /**
      * Transforms a polygon to the destination coordinate system.
      * \param polygon polygon to transform (occurs in place)
      * \param direction transform direction (defaults to forward transformation)
      */
-    void transformPolygon( QPolygonF &polygon, TransformDirection direction = ForwardTransform ) const SIP_THROW( QgsCsException );
+    void transformPolygon( QPolygonF &polygon, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_THROW( QgsCsException );
 
     /**
      * Transforms a rectangle to the destination CRS.
@@ -337,7 +330,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \returns transformed rectangle
      */
-    QgsRectangle transform( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform ) const SIP_THROW( QgsCsException );
+    QgsRectangle transform( const QgsRectangle &rectangle, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_THROW( QgsCsException );
 
     /**
      * Transform an array of coordinates to the destination CRS.
@@ -349,7 +342,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param z array of z coordinates to transform
      * \param direction transform direction (defaults to ForwardTransform)
      */
-    void transformCoords( int numPoint, double *x, double *y, double *z, TransformDirection direction = ForwardTransform ) const SIP_THROW( QgsCsException );
+    void transformCoords( int numPoint, double *x, double *y, double *z, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward ) const SIP_THROW( QgsCsException );
 
     /**
      * Returns TRUE if the transform short circuits because the source and destination are equivalent.

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -21,6 +21,7 @@
 #include "qgsapplication.h"
 #include "qgsmessagelog.h"
 #include "qgsauthmanager.h"
+#include "qgscoordinatetransform.h"
 
 #include <QUrl>
 #include <QUrlQuery>

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.h
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.h
@@ -21,6 +21,7 @@
 #include "qgsexpressioncontext.h"
 #include "qgsfields.h"
 #include "qgsgeometry.h"
+#include "qgscoordinatetransform.h"
 
 ///@cond PRIVATE
 

--- a/src/core/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.h
@@ -19,6 +19,7 @@
 #include "qgsogrconnpool.h"
 #include "qgsfields.h"
 #include "qgsogrutils.h"
+#include "qgscoordinatetransform.h"
 
 #include <ogr_api.h>
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -872,6 +872,18 @@ class CORE_EXPORT Qgis
     Q_ENUM( TemporalIntervalMatchMethod )
 
     /**
+     * Indicates the direction (forward or inverse) of a transform.
+     *
+     * \since QGIS 3.22
+     */
+    enum class TransformDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateTransform, TransformDirection ) : int
+      {
+      Forward SIP_MONKEYPATCH_COMPAT_NAME( ForwardTransform ), //!< Forward transform (from source to destination)
+      Reverse SIP_MONKEYPATCH_COMPAT_NAME( ReverseTransform ) //!< Reverse/inverse transform (from destination to source)
+    };
+    Q_ENUM( TransformDirection )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -26,6 +26,7 @@
 #include "qgsfeature.h"
 #include "qgsabstractmetadatabase.h"
 #include "qgspolygon.h"
+#include "qgscoordinatereferencesystem.h"
 
 #define SIP_NO_FILE
 

--- a/src/core/qgsbearingutils.cpp
+++ b/src/core/qgsbearingutils.cpp
@@ -43,7 +43,7 @@ double QgsBearingUtils::bearingTrueNorth( const QgsCoordinateReferenceSystem &cr
   p2.setY( p2.y() + 0.000001 );
 
   //transform back
-  const QgsPointXY p3 = transform.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  const QgsPointXY p3 = transform.transform( p2, Qgis::TransformDirection::Reverse );
 
   // find bearing from point to p3
   return point.azimuth( p3 );

--- a/src/core/qgscachedfeatureiterator.h
+++ b/src/core/qgscachedfeatureiterator.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgsfeature.h"
 #include "qgsfeatureiterator.h"
+#include "qgscoordinatetransform.h"
 
 class QgsVectorLayerCache;
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -613,9 +613,9 @@ QgsGeometry QgsDistanceArea::splitGeometryAtAntimeridian( const QgsGeometry &geo
 
           QgsPointXY antiMeridianPoint;
           if ( prevLon < -120 )
-            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( -180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( -180, lat180 ), Qgis::TransformDirection::Reverse );
           else
-            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( 180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( 180, lat180 ), Qgis::TransformDirection::Reverse );
 
           QgsPoint newPoint( antiMeridianPoint );
           if ( line->is3D() )
@@ -633,9 +633,9 @@ QgsGeometry QgsDistanceArea::splitGeometryAtAntimeridian( const QgsGeometry &geo
           newPoints.reserve( line->numPoints() - i + 1 );
 
           if ( lon < -120 )
-            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( -180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( -180, lat180 ), Qgis::TransformDirection::Reverse );
           else
-            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( 180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+            antiMeridianPoint = mCoordTransform.transform( QgsPointXY( 180, lat180 ), Qgis::TransformDirection::Reverse );
 
           if ( std::isfinite( antiMeridianPoint.x() ) && std::isfinite( antiMeridianPoint.y() ) )
           {
@@ -732,9 +732,9 @@ QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &
       {
         QgsPointXY p;
         if ( prevLon < -120 )
-          p = mCoordTransform.transform( QgsPointXY( -180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+          p = mCoordTransform.transform( QgsPointXY( -180, lat180 ), Qgis::TransformDirection::Reverse );
         else
-          p = mCoordTransform.transform( QgsPointXY( 180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+          p = mCoordTransform.transform( QgsPointXY( 180, lat180 ), Qgis::TransformDirection::Reverse );
 
         if ( std::isfinite( p.x() ) && std::isfinite( p.y() ) )
           currentPart << p;
@@ -750,9 +750,9 @@ QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &
       {
         QgsPointXY p;
         if ( lon < -120 )
-          p = mCoordTransform.transform( QgsPointXY( -180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+          p = mCoordTransform.transform( QgsPointXY( -180, lat180 ), Qgis::TransformDirection::Reverse );
         else
-          p = mCoordTransform.transform( QgsPointXY( 180, lat180 ), QgsCoordinateTransform::ReverseTransform );
+          p = mCoordTransform.transform( QgsPointXY( 180, lat180 ), Qgis::TransformDirection::Reverse );
 
         if ( std::isfinite( p.x() ) && std::isfinite( p.y() ) )
           currentPart << p;
@@ -769,7 +769,7 @@ QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &
 
     try
     {
-      currentPart << mCoordTransform.transform( QgsPointXY( lon, lat ), QgsCoordinateTransform::ReverseTransform );
+      currentPart << mCoordTransform.transform( QgsPointXY( lon, lat ), Qgis::TransformDirection::Reverse );
     }
     catch ( QgsCsException & )
     {

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -25,6 +25,8 @@
 #include "qgsexpressionfunction.h"
 #include "qgsfeature.h"
 
+class QgsReadWriteContext;
+
 /**
  * \ingroup core
  * \class QgsScopedExpressionFunction

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -19,6 +19,7 @@
 #include "qgsexception.h"
 #include "qgsexpressionsorter.h"
 #include "qgsfeedback.h"
+#include "qgscoordinatetransform.h"
 
 QgsAbstractFeatureIterator::QgsAbstractFeatureIterator( const QgsFeatureRequest &request )
   : mRequest( request )
@@ -124,7 +125,7 @@ QgsRectangle QgsAbstractFeatureIterator::filterRectToSourceCrs( const QgsCoordin
   if ( mRequest.filterRect().isNull() )
     return QgsRectangle();
 
-  return transform.transformBoundingBox( mRequest.filterRect(), QgsCoordinateTransform::ReverseTransform );
+  return transform.transformBoundingBox( mRequest.filterRect(), Qgis::TransformDirection::Reverse );
 }
 
 void QgsAbstractFeatureIterator::ref()

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -27,7 +27,8 @@
 #include "qgsexpression.h"
 #include "qgsexpressioncontext.h"
 #include "qgssimplifymethod.h"
-
+#include "qgscoordinatetransformcontext.h"
+#include "qgscoordinatereferencesystem.h"
 
 
 /**

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -17,6 +17,7 @@
 #include "qgslogger.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgssettings.h"
+#include "qgscoordinatereferencesystem.h"
 
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include "gdal.h"

--- a/src/core/qgsmapclippingutils.cpp
+++ b/src/core/qgsmapclippingutils.cpp
@@ -66,7 +66,7 @@ QgsGeometry QgsMapClippingUtils::calculateFeatureRequestGeometry( const QList< Q
   // lastly transform back to layer CRS
   try
   {
-    result.transform( context.coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+    result.transform( context.coordinateTransform(), Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException & )
   {
@@ -112,7 +112,7 @@ QgsGeometry QgsMapClippingUtils::calculateFeatureIntersectionGeometry( const QLi
   // lastly transform back to layer CRS
   try
   {
-    result.transform( context.coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+    result.transform( context.coordinateTransform(), Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException & )
   {
@@ -216,7 +216,7 @@ QgsGeometry QgsMapClippingUtils::calculateLabelIntersectionGeometry( const QList
   // lastly transform back to layer CRS
   try
   {
-    result.transform( context.coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+    result.transform( context.coordinateTransform(), Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException & )
   {

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -533,7 +533,7 @@ QgsRectangle QgsMapSettings::outputExtentToLayerExtent( const QgsMapLayer *layer
       QgsDebugMsgLevel( QStringLiteral( "sourceCrs = %1" ).arg( ct.sourceCrs().authid() ), 3 );
       QgsDebugMsgLevel( QStringLiteral( "destCRS = %1" ).arg( ct.destinationCrs().authid() ), 3 );
       QgsDebugMsgLevel( QStringLiteral( "extent = %1" ).arg( extent.toString() ), 3 );
-      extent = ct.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+      extent = ct.transformBoundingBox( extent, Qgis::TransformDirection::Reverse );
     }
   }
   catch ( QgsCsException &cse )
@@ -553,7 +553,7 @@ QgsPointXY QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, QgsP
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      point = ct.transform( point, QgsCoordinateTransform::ForwardTransform );
+      point = ct.transform( point, Qgis::TransformDirection::Forward );
   }
   catch ( QgsCsException &cse )
   {
@@ -574,7 +574,7 @@ QgsPoint QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, const 
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      ct.transformInPlace( x, y, z, QgsCoordinateTransform::ForwardTransform );
+      ct.transformInPlace( x, y, z, Qgis::TransformDirection::Forward );
   }
   catch ( QgsCsException &cse )
   {
@@ -591,7 +591,7 @@ QgsRectangle QgsMapSettings::layerToMapCoordinates( const QgsMapLayer *layer, Qg
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      rect = ct.transform( rect, QgsCoordinateTransform::ForwardTransform );
+      rect = ct.transform( rect, Qgis::TransformDirection::Forward );
   }
   catch ( QgsCsException &cse )
   {
@@ -608,7 +608,7 @@ QgsPointXY QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, QgsP
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      point = ct.transform( point, QgsCoordinateTransform::ReverseTransform );
+      point = ct.transform( point, Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException &cse )
   {
@@ -629,7 +629,7 @@ QgsPoint QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, const 
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      ct.transformInPlace( x, y, z, QgsCoordinateTransform::ReverseTransform );
+      ct.transformInPlace( x, y, z, Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException &cse )
   {
@@ -646,7 +646,7 @@ QgsRectangle QgsMapSettings::mapToLayerCoordinates( const QgsMapLayer *layer, Qg
   {
     const QgsCoordinateTransform ct = layerTransform( layer );
     if ( ct.isValid() )
-      rect = ct.transform( rect, QgsCoordinateTransform::ReverseTransform );
+      rect = ct.transform( rect, Qgis::TransformDirection::Reverse );
   }
   catch ( QgsCsException &cse )
   {

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -37,6 +37,7 @@ class QgsVectorLayer;
 #include "qgsexpressionnode.h"
 #include "qgsexpressionnodeimpl.h"
 #include "qgssqlstatement.h"
+#include "qgscoordinatetransformcontext.h"
 
 /**
  * \ingroup core

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -27,6 +27,8 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
+class QgsCoordinateReferenceSystem;
+
 class QTextCodec;
 
 namespace gdal

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -1025,7 +1025,7 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
     {
       try
       {
-        rect = mTransform.transformBoundingBox( rect, QgsCoordinateTransform::ReverseTransform );
+        rect = mTransform.transformBoundingBox( rect, Qgis::TransformDirection::Reverse );
       }
       catch ( const QgsException &e )
       {

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -22,6 +22,7 @@
 #include "qgis.h"
 #include "qgsfeaturesink.h"
 #include "qgsproperty.h"
+#include "qgscoordinatetransform.h"
 
 /**
  * \class QgsRemappingSinkDefinition

--- a/src/core/qgstracer.h
+++ b/src/core/qgstracer.h
@@ -25,6 +25,7 @@ class QgsVectorLayer;
 
 #include "qgsfeatureid.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgsrectangle.h"
 #include "qgsgeometry.h"
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3107,7 +3107,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
       try
       {
         // map filter rect back from destination CRS to layer CRS
-        filterRect = options.ct.transformBoundingBox( filterRect, QgsCoordinateTransform::ReverseTransform );
+        filterRect = options.ct.transformBoundingBox( filterRect, Qgis::TransformDirection::Reverse );
       }
       catch ( QgsCsException & )
       {

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -695,7 +695,7 @@ bool ProjectorData::checkCols( const QgsCoordinateTransform &ct )
       }
       try
       {
-        const QgsPointXY myDestApprox = ct.transform( mySrcApprox, QgsCoordinateTransform::ReverseTransform );
+        const QgsPointXY myDestApprox = ct.transform( mySrcApprox, Qgis::TransformDirection::Reverse );
         const double mySqrDist = myDestApprox.sqrDist( myDestPoint );
         if ( mySqrDist > mSqrTolerance )
         {
@@ -740,7 +740,7 @@ bool ProjectorData::checkRows( const QgsCoordinateTransform &ct )
       }
       try
       {
-        const QgsPointXY myDestApprox = ct.transform( mySrcApprox, QgsCoordinateTransform::ReverseTransform );
+        const QgsPointXY myDestApprox = ct.transform( mySrcApprox, Qgis::TransformDirection::Reverse );
         const double mySqrDist = myDestApprox.sqrDist( myDestPoint );
         if ( mySqrDist > mSqrTolerance )
         {

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -330,7 +330,7 @@ void QgsGeometryGeneratorSymbolLayer::render( QgsSymbolRenderContext &context, Q
     // also need to apply the coordinate transform from the render context
     try
     {
-      geom.transform( context.renderContext().coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+      geom.transform( context.renderContext().coordinateTransform(), Qgis::TransformDirection::Reverse );
     }
     catch ( QgsCsException & )
     {

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -378,7 +378,7 @@ void QgsGeometryGeneratorSymbolLayer::render( QgsSymbolRenderContext &context, Q
 
         // transform geometry back from screen units to layer crs
         geom.transform( mapToPixel.inverted() );
-        geom.transform( context.renderContext().coordinateTransform(), QgsCoordinateTransform::ReverseTransform );
+        geom.transform( context.renderContext().coordinateTransform(), Qgis::TransformDirection::Reverse );
 
         f.setGeometry( geom );
         break;

--- a/src/core/vector/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/vector/qgsvectorlayerdiagramprovider.cpp
@@ -73,7 +73,7 @@ QList<QgsLabelFeature *> QgsVectorLayerDiagramProvider::labelFeatures( QgsRender
 
   QgsRectangle layerExtent = context.extent();
   if ( mSettings.coordinateTransform().isValid() )
-    layerExtent = mSettings.coordinateTransform().transformBoundingBox( context.extent(), QgsCoordinateTransform::ReverseTransform );
+    layerExtent = mSettings.coordinateTransform().transformBoundingBox( context.extent(), Qgis::TransformDirection::Reverse );
 
   QgsFeatureRequest request;
   request.setFilterRect( layerExtent );

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -22,6 +22,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsfeaturesource.h"
 #include "qgsexpressioncontextscopegenerator.h"
+#include "qgscoordinatetransform.h"
 
 #include <QPointer>
 #include <QSet>

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -165,7 +165,7 @@ void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QgsFeedback *feed
   QgsRectangle layerTileExtent = mTileExtent;
   try
   {
-    layerTileExtent = ct.transformBoundingBox( layerTileExtent, QgsCoordinateTransform::ReverseTransform );
+    layerTileExtent = ct.transformBoundingBox( layerTileExtent, Qgis::TransformDirection::Reverse );
     if ( !layerTileExtent.intersects( layer->extent() ) )
     {
       return;  // tile is completely outside of the layer'e extent

--- a/src/core/vectortile/qgsvectortilemvtencoder.h
+++ b/src/core/vectortile/qgsvectortilemvtencoder.h
@@ -21,7 +21,7 @@
 #include "qgstiles.h"
 #include "qgsvectortilerenderer.h"
 #include "vector_tile.pb.h"
-
+#include "qgscoordinatetransform.h"
 
 /**
  * \ingroup core

--- a/src/core/vectortile/qgsvectortilerenderer.h
+++ b/src/core/vectortile/qgsvectortilerenderer.h
@@ -23,6 +23,8 @@
 #include "qgstiles.h"
 
 class QgsRenderContext;
+class QgsReadWriteContext;
+class QgsProject;
 
 //! Features of a vector tile, grouped by sub-layer names (key of the map)
 typedef QMap<QString, QVector<QgsFeature> > QgsVectorTileFeatures SIP_SKIP;

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -85,7 +85,7 @@ void QgsMapMouseEvent::snapToGrid( double precision, const QgsCoordinateReferenc
     pt.setX( std::round( pt.x() / precision ) * precision );
     pt.setY( std::round( pt.y() / precision ) * precision );
 
-    pt = ct.transform( pt, QgsCoordinateTransform::ReverseTransform );
+    pt = ct.transform( pt, Qgis::TransformDirection::Reverse );
 
     setMapPoint( pt );
   }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -696,7 +696,7 @@ int QgsMapToolCapture::addCurve( QgsCurve *c )
   const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( layer() );
   if ( ct.isValid() )
   {
-    c->transform( ct, QgsCoordinateTransform::ReverseTransform );
+    c->transform( ct, Qgis::TransformDirection::Reverse );
   }
   const int countBefore = mCaptureCurve.vertexCount();
   //if there is only one point, this the first digitized point that are in the this first curve added --> remove the point

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -542,7 +542,7 @@ void QgsRasterLayerSaveAsDialog::setResolution( double xRes, double yRes, const 
 
     QgsPointXY center = outputRectangle().center();
     QgsCoordinateTransform ct( srcCrs, outputCrs(), QgsProject::instance() );
-    QgsPointXY srsCenter = ct.transform( center, QgsCoordinateTransform::ReverseTransform );
+    QgsPointXY srsCenter = ct.transform( center, Qgis::TransformDirection::Reverse );
 
     QgsRectangle srcExtent( srsCenter.x() - xRes / 2, srsCenter.y() - yRes / 2, srsCenter.x() + xRes / 2, srsCenter.y() + yRes / 2 );
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -18,6 +18,7 @@
 #include "qgsmapcanvasitem.h"
 #include "qgis_sip.h"
 #include "qgsgeometry.h"
+#include "qgscoordinatetransform.h"
 
 #include <QBrush>
 #include <QVector>

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -43,8 +43,8 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
 
   try
   {
-    const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, QgsCoordinateTransform::ReverseTransform );
-    const QgsPointXY layerPt = mTransform.transform( mPoint, QgsCoordinateTransform::ReverseTransform );
+    const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, Qgis::TransformDirection::Reverse );
+    const QgsPointXY layerPt = mTransform.transform( mPoint, Qgis::TransformDirection::Reverse );
 
     const double gridXMin = std::ceil( layerExtent.xMinimum() / mPrecision ) * mPrecision;
     const double gridXMax = std::ceil( layerExtent.xMaximum() / mPrecision ) * mPrecision;
@@ -153,8 +153,8 @@ void QgsSnapToGridCanvasItem::updateZoomFactor()
     const QgsPointXY pt2 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( canvasCenter.x() + threshold ),
                            static_cast<int>( canvasCenter.y() + threshold ) );
 
-    const QgsPointXY layerPt1 = mTransform.transform( pt1, QgsCoordinateTransform::ReverseTransform );
-    const QgsPointXY layerPt2 = mTransform.transform( pt2, QgsCoordinateTransform::ReverseTransform );
+    const QgsPointXY layerPt1 = mTransform.transform( pt1, Qgis::TransformDirection::Reverse );
+    const QgsPointXY layerPt2 = mTransform.transform( pt2, Qgis::TransformDirection::Reverse );
 
     const double dist = layerPt1.distance( layerPt2 );
 

--- a/src/plugins/grass/qgsgrassregion.cpp
+++ b/src/plugins/grass/qgsgrassregion.cpp
@@ -128,7 +128,7 @@ void QgsGrassRegionEdit::setTransform()
   }
 }
 
-void QgsGrassRegionEdit::transform( QgsMapCanvas *, QVector<QgsPointXY> &points, const QgsCoordinateTransform &coordinateTransform, QgsCoordinateTransform::TransformDirection direction )
+void QgsGrassRegionEdit::transform( QgsMapCanvas *, QVector<QgsPointXY> &points, const QgsCoordinateTransform &coordinateTransform, Qgis::TransformDirection direction )
 {
   //! Coordinate transform
   //QgsDebugMsg ( "srcCrs = " +  coordinateTransform->sourceCrs().toWkt() );

--- a/src/plugins/grass/qgsgrassregion.h
+++ b/src/plugins/grass/qgsgrassregion.h
@@ -160,7 +160,7 @@ class QgsGrassRegionEdit : public QgsMapTool
 
     static void drawRegion( QgsMapCanvas *canvas, QgsRubberBand *rubberBand, const QgsRectangle &rect, const QgsCoordinateTransform &coordinateTransform = QgsCoordinateTransform(), bool isPolygon = false );
     void calcSrcRegion();
-    static void transform( QgsMapCanvas *canvas, QVector<QgsPointXY> &points, const QgsCoordinateTransform &coordinateTransform, QgsCoordinateTransform::TransformDirection direction = QgsCoordinateTransform::ForwardTransform );
+    static void transform( QgsMapCanvas *canvas, QVector<QgsPointXY> &points, const QgsCoordinateTransform &coordinateTransform, Qgis::TransformDirection direction = Qgis::TransformDirection::Forward );
 
   signals:
     void captureStarted();

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -17,6 +17,7 @@
 
 #include "qgsfeatureiterator.h"
 #include "qgsafsshareddata.h"
+#include "qgscoordinatetransform.h"
 #include <memory>
 
 class QgsSpatialIndex;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -21,6 +21,7 @@
 #include "qgsfields.h"
 #include "qgsfeature.h"
 #include "qgsdatasourceuri.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QgsFeedback;
 

--- a/src/providers/db2/qgsdb2featureiterator.h
+++ b/src/providers/db2/qgsdb2featureiterator.h
@@ -20,6 +20,7 @@
 
 #include "qgsfields.h"
 #include "qgsfeatureiterator.h"
+#include "qgscoordinatetransform.h"
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -19,6 +19,7 @@
 #include "qgsfeatureiterator.h"
 #include "qgsfeature.h"
 #include "qgsexpressioncontext.h"
+#include "qgscoordinatetransform.h"
 
 #include "qgsdelimitedtextprovider.h"
 

--- a/src/providers/gpx/qgsgpxfeatureiterator.h
+++ b/src/providers/gpx/qgsgpxfeatureiterator.h
@@ -19,6 +19,7 @@
 
 #include "gpsdata.h"
 #include "qgsgpxprovider.h"
+#include "qgscoordinatetransform.h"
 
 class QgsGPXProvider;
 

--- a/src/providers/hana/qgshanafeatureiterator.h
+++ b/src/providers/hana/qgshanafeatureiterator.h
@@ -22,6 +22,7 @@
 #include "qgshanaprimarykeys.h"
 #include "qgshanaprovider.h"
 #include "qgshanaresultset.h"
+#include "qgscoordinatetransform.h"
 
 #include "odbc/Forwards.h"
 

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -24,6 +24,7 @@
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
+#include "qgscoordinatetransform.h"
 
 #include "qgsmssqlprovider.h"
 

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -23,6 +23,7 @@
 #include <QSqlQuery>
 
 #include "qgsoracleprovider.h"
+#include "qgscoordinatetransform.h"
 
 class QgsOracleConn;
 class QgsOracleProvider;

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -20,6 +20,7 @@
 #include <QQueue>
 
 #include "qgspostgresprovider.h"
+#include "qgscoordinatetransform.h"
 
 class QgsPostgresProvider;
 class QgsPostgresResult;

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -17,6 +17,7 @@
 
 #include "qgsfeatureiterator.h"
 #include "qgsfields.h"
+#include "qgscoordinatetransform.h"
 
 extern "C"
 {

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.h
@@ -21,6 +21,7 @@ email                : hugo dot mercier at oslandia dot com
 #include "qgsvirtuallayerprovider.h"
 #include "qgsfeatureiterator.h"
 #include "qgsgeometryengine.h"
+#include "qgscoordinatetransform.h"
 
 #include <memory>
 #include <QPointer>

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -18,6 +18,7 @@ email                : hugo dot mercier at oslandia dot com
 #define QGSVIRTUAL_LAYER_PROVIDER_H
 
 #include "qgsvectordataprovider.h"
+#include "qgsconfig.h"
 
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvirtuallayerdefinition.h"

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1136,7 +1136,7 @@ bool QgsWcsProvider::calculateExtent() const
     // Convert to the user's CRS as required
     try
     {
-      mCoverageExtent = mCoordinateTransform.transformBoundingBox( mCoverageSummary.wgs84BoundingBox, QgsCoordinateTransform::ForwardTransform );
+      mCoverageExtent = mCoordinateTransform.transformBoundingBox( mCoverageSummary.wgs84BoundingBox, Qgis::TransformDirection::Forward );
     }
     catch ( QgsCsException &cse )
     {

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
@@ -20,6 +20,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsspatialindex.h"
 #include "qgsvectordataprovider.h"
+#include "qgscoordinatetransform.h"
 
 class QDataStream;
 class QFile;

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -21,6 +21,7 @@
 #include "qgsmessagelog.h"
 #include "qgsogcutils.h"
 #include "qgssettings.h"
+#include "qgscoordinatetransform.h"
 
 #include <cpl_minixml.h>
 
@@ -548,9 +549,9 @@ void QgsWfsCapabilities::capabilitiesReplyFinished()
           QgsCoordinateTransform ct( crsWGS84, crs, mOptions.transformContext );
 
           QgsPointXY ptMin( featureType.bbox.xMinimum(), featureType.bbox.yMinimum() );
-          QgsPointXY ptMinBack( ct.transform( ct.transform( ptMin, QgsCoordinateTransform::ForwardTransform ), QgsCoordinateTransform::ReverseTransform ) );
+          QgsPointXY ptMinBack( ct.transform( ct.transform( ptMin, Qgis::TransformDirection::Forward ), Qgis::TransformDirection::Reverse ) );
           QgsPointXY ptMax( featureType.bbox.xMaximum(), featureType.bbox.yMaximum() );
-          QgsPointXY ptMaxBack( ct.transform( ct.transform( ptMax, QgsCoordinateTransform::ForwardTransform ), QgsCoordinateTransform::ReverseTransform ) );
+          QgsPointXY ptMaxBack( ct.transform( ct.transform( ptMax, Qgis::TransformDirection::Forward ), Qgis::TransformDirection::Reverse ) );
 
           QgsDebugMsg( featureType.bbox.toString() );
           QgsDebugMsg( ptMinBack.toString() );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1912,7 +1912,7 @@ bool QgsWFSProvider::getCapabilities()
           QgsDebugMsgLevel( "src:" + src.authid(), 4 );
           QgsDebugMsgLevel( "dst:" + mShared->mSourceCrs.authid(), 4 );
 
-          mShared->mCapabilityExtent = ct.transformBoundingBox( r, QgsCoordinateTransform::ForwardTransform );
+          mShared->mCapabilityExtent = ct.transformBoundingBox( r, Qgis::TransformDirection::Forward );
         }
         else
         {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1919,7 +1919,7 @@ bool QgsWmsProvider::calculateExtent() const
 
           try
           {
-            QgsRectangle extent = ct.transformBoundingBox( mTileLayer->boundingBoxes.at( i ).box, QgsCoordinateTransform::ForwardTransform );
+            QgsRectangle extent = ct.transformBoundingBox( mTileLayer->boundingBoxes.at( i ).box, Qgis::TransformDirection::Forward );
 
             //make sure extent does not contain 'inf' or 'nan'
             if ( extent.isFinite() )

--- a/src/quickgui/qgsquickcoordinatetransformer.h
+++ b/src/quickgui/qgsquickcoordinatetransformer.h
@@ -23,6 +23,7 @@
 #include "qgis_quick.h"
 #include "qgscoordinatetransformcontext.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransform.h"
 #include "qgspoint.h"
 
 /**

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -229,7 +229,7 @@ namespace QgsWms
 
       QgsCoordinateTransform tr = mapSettings.layerTransform( vl );
       context.setCoordinateTransform( tr );
-      context.setExtent( tr.transformBoundingBox( mapSettings.extent(), QgsCoordinateTransform::ReverseTransform ) );
+      context.setExtent( tr.transformBoundingBox( mapSettings.extent(), Qgis::TransformDirection::Reverse ) );
 
       SymbolSet &usedSymbols = hitTest[vl];
       runHitTestLayer( vl, usedSymbols, context );

--- a/tests/src/core/geometry/testqgscircularstring.cpp
+++ b/tests/src/core/geometry/testqgscircularstring.cpp
@@ -700,7 +700,7 @@ void TestQgsCircularString::circularString()
   QgsCircularString l21;
   l21.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
                  << QgsPoint( 6474985, -3526584 ) );
-  l21.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  l21.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( l21.pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( l21.pointN( 0 ).y(), -39.724, 0.001 );
   QGSCOMPARENEAR( l21.pointN( 1 ).x(), 176.959, 0.001 );
@@ -714,7 +714,7 @@ void TestQgsCircularString::circularString()
   QgsCircularString l22;
   l22.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
                  << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 3, 4 ) );
-  l22.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  l22.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( l22.pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 0 ).y(), -39.724, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1.0, 0.001 );
@@ -725,7 +725,7 @@ void TestQgsCircularString::circularString()
   QCOMPARE( l22.pointN( 1 ).m(), 4.0 );
 
   //reverse transform
-  l22.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  l22.transform( tr, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( l22.pointN( 0 ).x(), 6374985, 0.01 );
   QGSCOMPARENEAR( l22.pointN( 0 ).y(), -3626584, 0.01 );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1, 0.001 );
@@ -737,10 +737,10 @@ void TestQgsCircularString::circularString()
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  l22.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  l22.transform( tr, Qgis::TransformDirection::Forward, true );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), -19.249066, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 1 ).z(), -21.092128, 0.001 );
-  l22.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  l22.transform( tr, Qgis::TransformDirection::Reverse, true );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1.0, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 1 ).z(), 3.0, 0.001 );
 #endif

--- a/tests/src/core/geometry/testqgscompoundcurve.cpp
+++ b/tests/src/core/geometry/testqgscompoundcurve.cpp
@@ -871,7 +871,7 @@ void TestQgsCompoundCurve::compoundCurve()
   ls21.setPoints( QgsPointSequence() << QgsPoint( 6474985, -3526584 )
                   << QgsPoint( 6504985, -3526584 ) );
   c21.addCurve( ls21.clone() );
-  c21.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  c21.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( c21.xAt( 0 ), 175.771, 0.001 );
   QGSCOMPARENEAR( c21.yAt( 0 ), -39.724, 0.001 );
   QGSCOMPARENEAR( c21.xAt( 1 ), 176.959, 0.001 );
@@ -891,7 +891,7 @@ void TestQgsCompoundCurve::compoundCurve()
   ls21.setPoints( QgsPointSequence() << QgsPoint( 6474985, -3526584, 3, 4 )
                   << QgsPoint( 6504985, -3526584, 5, 6 ) );
   c22.addCurve( ls21.clone() );
-  c22.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  c22.transform( tr, Qgis::TransformDirection::Forward );
   QgsPoint pt;
   QgsVertexId::VertexType v;
   c22.pointAt( 0, pt, v );
@@ -911,7 +911,7 @@ void TestQgsCompoundCurve::compoundCurve()
   QCOMPARE( pt.m(), 6.0 );
 
   //reverse transform
-  c22.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  c22.transform( tr, Qgis::TransformDirection::Reverse );
   c22.pointAt( 0, pt, v );
   QGSCOMPARENEAR( pt.x(), 6374985, 100 );
   QGSCOMPARENEAR( pt.y(), -3626584, 100 );
@@ -930,7 +930,7 @@ void TestQgsCompoundCurve::compoundCurve()
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  c22.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  c22.transform( tr, Qgis::TransformDirection::Forward, true );
   c22.pointAt( 0, pt, v );
   QGSCOMPARENEAR( pt.z(), -19.249066, 0.001 );
   c22.pointAt( 1, pt, v );
@@ -938,7 +938,7 @@ void TestQgsCompoundCurve::compoundCurve()
   c22.pointAt( 2, pt, v );
   QGSCOMPARENEAR( pt.z(), -19.370485, 0.001 );
 
-  c22.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  c22.transform( tr, Qgis::TransformDirection::Reverse, true );
   c22.pointAt( 0, pt, v );
   QGSCOMPARENEAR( pt.z(), 1, 0.001 );
   c22.pointAt( 1, pt, v );

--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -541,7 +541,7 @@ void TestQgsGeometryCollection::geometryCollection()
                  << QgsPoint( 6374985, -3626584 ) );
   pTransform.addGeometry( l21.clone() );
   pTransform.addGeometry( l21.clone() );
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward );
   const QgsLineString *extR = static_cast< const QgsLineString * >( pTransform.geometryN( 0 ) );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -578,7 +578,7 @@ void TestQgsGeometryCollection::geometryCollection()
   pTransform.clear();
   pTransform.addGeometry( l22.clone() );
   pTransform.addGeometry( l22.clone() );
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward );
   extR = static_cast< const QgsLineString * >( pTransform.geometryN( 0 ) );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -623,7 +623,7 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->boundingBox().yMaximum(), -38.7999, 0.001 );
 
   //reverse transform
-  pTransform.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Reverse );
   extR = static_cast< const QgsLineString * >( pTransform.geometryN( 0 ) );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 6374984, 100 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -3626584, 100 );
@@ -669,7 +669,7 @@ void TestQgsGeometryCollection::geometryCollection()
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward, true );
   extR = static_cast< const QgsLineString * >( pTransform.geometryN( 0 ) );
   QGSCOMPARENEAR( extR->pointN( 0 ).z(), -19.249066, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 1 ).z(), -19.148357, 0.001 );
@@ -680,7 +680,7 @@ void TestQgsGeometryCollection::geometryCollection()
   QGSCOMPARENEAR( intR->pointN( 1 ).z(), -19.148357, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 2 ).z(), -19.092128, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 3 ).z(), -19.249066, 0.001 );
-  pTransform.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  pTransform.transform( tr, Qgis::TransformDirection::Reverse, true );
   extR = static_cast< const QgsLineString * >( pTransform.geometryN( 0 ) );
   QGSCOMPARENEAR( extR->pointN( 0 ).z(), 1, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 1 ).z(), 3, 0.001 );

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -1078,7 +1078,7 @@ void TestQgsLineString::lineString()
   QgsLineString l21;
   l21.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
                  << QgsPoint( 6474985, -3526584 ) );
-  l21.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  l21.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( l21.pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( l21.pointN( 0 ).y(), -39.724, 0.001 );
   QGSCOMPARENEAR( l21.pointN( 1 ).x(), 176.959, 0.001 );
@@ -1092,7 +1092,7 @@ void TestQgsLineString::lineString()
   QgsLineString l22;
   l22.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
                  << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 3, 4 ) );
-  l22.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  l22.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( l22.pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 0 ).y(), -39.724, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1.0, 0.001 );
@@ -1103,7 +1103,7 @@ void TestQgsLineString::lineString()
   QCOMPARE( l22.pointN( 1 ).m(), 4.0 );
 
   //reverse transform
-  l22.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  l22.transform( tr, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( l22.pointN( 0 ).x(), 6374985, 0.01 );
   QGSCOMPARENEAR( l22.pointN( 0 ).y(), -3626584, 0.01 );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1, 0.001 );
@@ -1115,10 +1115,10 @@ void TestQgsLineString::lineString()
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  l22.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  l22.transform( tr, Qgis::TransformDirection::Forward, true );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), -19.249066, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 1 ).z(), -21.092128, 0.001 );
-  l22.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  l22.transform( tr, Qgis::TransformDirection::Reverse, true );
   QGSCOMPARENEAR( l22.pointN( 0 ).z(), 1.0, 0.001 );
   QGSCOMPARENEAR( l22.pointN( 1 ).z(), 3.0, 0.001 );
 #endif

--- a/tests/src/core/geometry/testqgspoint.cpp
+++ b/tests/src/core/geometry/testqgspoint.cpp
@@ -358,21 +358,21 @@ void TestQgsPoint::point()
   QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
   QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
   QgsPoint p16( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 );
-  p16.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  p16.transform( tr, Qgis::TransformDirection::Forward );
   QGSCOMPARENEAR( p16.x(), 175.771, 0.001 );
   QGSCOMPARENEAR( p16.y(), -39.724, 0.001 );
   QGSCOMPARENEAR( p16.z(), 1.0, 0.001 );
   QCOMPARE( p16.m(), 2.0 );
-  p16.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  p16.transform( tr, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p16.x(), 6374985, 1 );
   QGSCOMPARENEAR( p16.y(), -3626584, 1 );
   QGSCOMPARENEAR( p16.z(), 1.0, 0.001 );
   QCOMPARE( p16.m(), 2.0 );
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //test with z transform
-  p16.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  p16.transform( tr, Qgis::TransformDirection::Forward, true );
   QGSCOMPARENEAR( p16.z(), -19.249, 0.001 );
-  p16.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  p16.transform( tr, Qgis::TransformDirection::Reverse, true );
   QGSCOMPARENEAR( p16.z(), 1.0, 0.001 );
 #endif
   //QTransform transform

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -970,7 +970,7 @@ void TestQgsPolygon::polygon()
                  << QgsPoint( 6374985, -3626584 ) );
   pTransform.setExteriorRing( l21.clone() );
   pTransform.addInteriorRing( l21.clone() );
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward );
   const QgsLineString *extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -1007,7 +1007,7 @@ void TestQgsPolygon::polygon()
   pTransform.clear();
   pTransform.setExteriorRing( l22.clone() );
   pTransform.addInteriorRing( l22.clone() );
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward );
   extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
@@ -1052,7 +1052,7 @@ void TestQgsPolygon::polygon()
   QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
 
   //reverse transform
-  pTransform.transform( tr, QgsCoordinateTransform::ReverseTransform );
+  pTransform.transform( tr, Qgis::TransformDirection::Reverse );
   extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
   QGSCOMPARENEAR( extR->pointN( 0 ).x(), 6374984, 100 );
   QGSCOMPARENEAR( extR->pointN( 0 ).y(), -3626584, 100 );
@@ -1098,7 +1098,7 @@ void TestQgsPolygon::polygon()
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  pTransform.transform( tr, QgsCoordinateTransform::ForwardTransform, true );
+  pTransform.transform( tr, Qgis::TransformDirection::Forward, true );
   extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
   QGSCOMPARENEAR( extR->pointN( 0 ).z(), -19.249066, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 1 ).z(), -19.148357, 0.001 );
@@ -1109,7 +1109,7 @@ void TestQgsPolygon::polygon()
   QGSCOMPARENEAR( intR->pointN( 1 ).z(), -19.148357, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 2 ).z(), -19.092128, 0.001 );
   QGSCOMPARENEAR( intR->pointN( 3 ).z(), -19.249066, 0.001 );
-  pTransform.transform( tr, QgsCoordinateTransform::ReverseTransform, true );
+  pTransform.transform( tr, Qgis::TransformDirection::Reverse, true );
   extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
   QGSCOMPARENEAR( extR->pointN( 0 ).z(), 1, 0.001 );
   QGSCOMPARENEAR( extR->pointN( 1 ).z(), 3, 0.001 );

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -274,71 +274,71 @@ void TestQgsCoordinateTransform::transform_data()
   QTest::newRow( "To geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 2545059.0 << 2393190.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.512750 << -37.961375 << 0.000015;
+      << 2545059.0 << 2393190.0 << static_cast< int >( Qgis::TransformDirection::Forward ) << 145.512750 << -37.961375 << 0.000015;
   QTest::newRow( "From geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
-      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 2545059.0 << 2393190.0 << 1.5;
+      << 145.512750 <<  -37.961375 << static_cast< int >( Qgis::TransformDirection::Forward ) << 2545059.0 << 2393190.0 << 1.5;
   QTest::newRow( "From geographic to geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )
-      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.510966 <<  -37.961741 << 0.0001;
+      << 145.512750 <<  -37.961375 << static_cast< int >( Qgis::TransformDirection::Forward ) << 145.510966 <<  -37.961741 << 0.0001;
   QTest::newRow( "To geographic (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 2545059.0 << 2393190.0 << 1.5;
+      << 145.512750 <<  -37.961375 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 2545059.0 << 2393190.0 << 1.5;
   QTest::newRow( "From geographic (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
-      << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 145.512750 << -37.961375 << 0.000015;
+      << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 145.512750 << -37.961375 << 0.000015;
   QTest::newRow( "From geographic to geographic reverse" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )
-      << 145.510966 <<  -37.961741 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) <<  145.512750 <<  -37.961375 << 0.0001;
+      << 145.510966 <<  -37.961741 << static_cast< int >( Qgis::TransformDirection::Reverse ) <<  145.512750 <<  -37.961375 << 0.0001;
   QTest::newRow( "From LKS92/TM to Baltic93/TM" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3059 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 25884 )
-      << 725865.850 << 198519.947 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 725865.850 << 6198519.947 << 0.001;
+      << 725865.850 << 198519.947 << static_cast< int >( Qgis::TransformDirection::Forward ) << 725865.850 << 6198519.947 << 0.001;
   QTest::newRow( "From LKS92/TM to Baltic93/TM (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3059 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 25884 )
-      << 725865.850 << 6198519.947 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 725865.850 << 198519.947 << 0.001;
+      << 725865.850 << 6198519.947 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 725865.850 << 198519.947 << 0.001;
   QTest::newRow( "From LKS92/TM to WGS84" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3059 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 725865.850 << 198519.947 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 27.61113711 << 55.87910378 << 0.00000001;
+      << 725865.850 << 198519.947 << static_cast< int >( Qgis::TransformDirection::Forward ) << 27.61113711 << 55.87910378 << 0.00000001;
   QTest::newRow( "From LKS92/TM to WGS84 (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3059 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 27.61113711 << 55.87910378 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 725865.850 << 198519.947 << 0.001;
+      << 27.61113711 << 55.87910378 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 725865.850 << 198519.947 << 0.001;
   QTest::newRow( "From BNG to WGS84" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 7467023.96 << -5527971.74 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 51.400222 << 0.000025 << 0.4;
+      << 7467023.96 << -5527971.74 << static_cast< int >( Qgis::TransformDirection::Forward ) << 51.400222 << 0.000025 << 0.4;
   QTest::newRow( "From BNG to WGS84 2" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 246909.0 << 54108.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << -4.153951 <<  50.366908  << 0.4;
+      << 246909.0 << 54108.0 << static_cast< int >( Qgis::TransformDirection::Forward ) << -4.153951 <<  50.366908  << 0.4;
   QTest::newRow( "From BNG to WGS84 (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 51.400222 << 0.000025 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 7467023.96 << -5527971.74 << 22000.0;
+      << 51.400222 << 0.000025 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 7467023.96 << -5527971.74 << 22000.0;
   QTest::newRow( "From WGS84 to BNG (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
-      << 7467023.96 << -5527971.74 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 51.400222 << 0.000025 << 0.4;
+      << 7467023.96 << -5527971.74 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 51.400222 << 0.000025 << 0.4;
   QTest::newRow( "From WGS84 to BNG" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
-      << 51.400222 << 0.000025 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 7467023.96 << -5527971.74 << 22000.0;
+      << 51.400222 << 0.000025 << static_cast< int >( Qgis::TransformDirection::Forward ) << 7467023.96 << -5527971.74 << 22000.0;
   QTest::newRow( "From BNG to 3857" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3857 )
-      << 7467023.96 << -5527971.74 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 5721846.47 << 2.78 << 43000.0;
+      << 7467023.96 << -5527971.74 << static_cast< int >( Qgis::TransformDirection::Forward ) << 5721846.47 << 2.78 << 43000.0;
   QTest::newRow( "From BNG to 3857 (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 27700 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3857 )
-      << 5721846.47 << 2.78 << static_cast< int >( QgsCoordinateTransform::ReverseTransform )  << 7467023.96 << -5527971.74 << 22000.0;
+      << 5721846.47 << 2.78 << static_cast< int >( Qgis::TransformDirection::Reverse )  << 7467023.96 << -5527971.74 << 22000.0;
 }
 
 void TestQgsCoordinateTransform::transform()
@@ -355,7 +355,7 @@ void TestQgsCoordinateTransform::transform()
   double z = 0;
   const QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
 
-  ct.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
+  ct.transformInPlace( x, y, z, static_cast<  Qgis::TransformDirection >( direction ) );
   QGSCOMPARENEAR( x, outX, precision );
   QGSCOMPARENEAR( y, outY, precision );
 }
@@ -379,56 +379,56 @@ void TestQgsCoordinateTransform::transformEpoch_data()
       << std::numeric_limits< double >::quiet_NaN()
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2020.0
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 150.0 << -30.0 << 0.0000000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Forward ) << 150.0 << -30.0 << 0.0000000001;
 
   QTest::newRow( "GDA2020 to ITRF at central epoch (reverse) -- no coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2020.0
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 150.0 << -30.0 << 0.0000000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 150.0 << -30.0 << 0.0000000001;
 
   QTest::newRow( "ITRF at central epoch to GDA2020 -- no coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2020.0
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 150.0 << -30.0 << 0.0000000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Forward ) << 150.0 << -30.0 << 0.0000000001;
 
   QTest::newRow( "ITRF at central epoch to GDA2020 (reverse) -- no coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2020.0
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 150.0 << -30.0 << 0.0000000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 150.0 << -30.0 << 0.0000000001;
 
   QTest::newRow( "GDA2020 to ITRF at 2030 -- coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2030.0
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 150.0000022212 << -29.9999950478 << 0.0000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Forward ) << 150.0000022212 << -29.9999950478 << 0.0000001;
 
   QTest::newRow( "GDA2020 to ITRF at 2030 (reverse) -- coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2030.0
-      << 150.0000022212 << -29.9999950478 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 150.0 << -30.0 << 0.0000001;
+      << 150.0000022212 << -29.9999950478 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 150.0 << -30.0 << 0.0000001;
 
   QTest::newRow( "ITRF at 2030 to GDA2020-- coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2030.0
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
-      << 150.0000022212 << -29.9999950478 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 150.0 << -30.0 << 0.0000001;
+      << 150.0000022212 << -29.9999950478 << static_cast< int >( Qgis::TransformDirection::Forward ) << 150.0 << -30.0 << 0.0000001;
 
   QTest::newRow( "ITRF at 2030 to GDA2020 (reverse) -- coordinate change expected" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 9000 ) // ITRF2014
       << 2030.0
       << QgsCoordinateReferenceSystem::fromEpsgId( 7844 ) // GDA2020
       << std::numeric_limits< double >::quiet_NaN()
-      << 150.0 << -30.0 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 150.0000022212 << -29.9999950478 << 0.0000001;
+      << 150.0 << -30.0 << static_cast< int >( Qgis::TransformDirection::Reverse ) << 150.0000022212 << -29.9999950478 << 0.0000001;
 }
 
 void TestQgsCoordinateTransform::transformEpoch()
@@ -528,7 +528,7 @@ void TestQgsCoordinateTransform::transformBoundingBox()
 
   QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
   const QgsRectangle crossingRect( 6374985, -3626584, 7021195, -3272435 );
-  QgsRectangle resultRect = tr.transformBoundingBox( crossingRect, QgsCoordinateTransform::ForwardTransform, true );
+  QgsRectangle resultRect = tr.transformBoundingBox( crossingRect, Qgis::TransformDirection::Forward, true );
   QgsRectangle expectedRect;
   expectedRect.setXMinimum( 175.771 );
   expectedRect.setYMinimum( -39.7222 );
@@ -576,7 +576,7 @@ void TestQgsCoordinateTransform::transformLKS()
 
   QPolygonF sPoly = QgsGeometry::fromWkt( QStringLiteral( "Polygon (( 725865.850 198519.947, 363511.181 263208.769, 717694.697 333650.333, 725865.850 198519.947 ))" ) ).asQPolygonF();
 
-  Lks2Balt.transformPolygon( sPoly, QgsCoordinateTransform::ForwardTransform );
+  Lks2Balt.transformPolygon( sPoly, Qgis::TransformDirection::Forward );
 
   QGSCOMPARENEAR( sPoly.at( 0 ).x(), 725865.850, 0.001 );
   QGSCOMPARENEAR( sPoly.at( 0 ).y(), 6198519.947, 0.001 );
@@ -600,7 +600,7 @@ void TestQgsCoordinateTransform::transformContextNormalize()
   QGSCOMPARENEAR( p2.x(), 245424.604645, 0.01 );
   QGSCOMPARENEAR( p2.y(), 54016.813093, 0.01 );
 
-  p = ct.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  p = ct.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p.x(), -4.17477, 0.01 );
   QGSCOMPARENEAR( p.y(), 50.3657, 0.01 );
 
@@ -611,7 +611,7 @@ void TestQgsCoordinateTransform::transformContextNormalize()
   QGSCOMPARENEAR( p2.x(), -4.17477, 0.01 );
   QGSCOMPARENEAR( p2.y(), 50.3657, 0.01 );
 
-  p = ct2.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  p = ct2.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p.x(), 245424.604645, 0.01 );
   QGSCOMPARENEAR( p.y(), 54016.813093, 0.01 );
 }
@@ -689,7 +689,7 @@ void TestQgsCoordinateTransform::testDeprecated4240to4326()
   QGSCOMPARENEAR( p2.x(), 102.494938, 0.000001 );
   QGSCOMPARENEAR( p2.y(), 7.502624, 0.000001 );
 
-  QgsPointXY p3 = defaultTransform.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  QgsPointXY p3 = defaultTransform.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p3.x(), 102.5, 0.000001 );
   QGSCOMPARENEAR( p3.y(), 7.5, 0.000001 );
 
@@ -704,7 +704,7 @@ void TestQgsCoordinateTransform::testDeprecated4240to4326()
   QGSCOMPARENEAR( p2.x(), 102.5, 0.000001 );
   QGSCOMPARENEAR( p2.y(), 7.5, 0.000001 );
 
-  p3 = defaultTransformRev.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  p3 = defaultTransformRev.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p3.x(), 102.494938, 0.000001 );
   QGSCOMPARENEAR( p3.y(), 7.502624, 0.000001 );
 
@@ -721,7 +721,7 @@ void TestQgsCoordinateTransform::testDeprecated4240to4326()
   QGSCOMPARENEAR( p2.x(), 102.496547, 0.000001 );
   QGSCOMPARENEAR( p2.y(), 7.502139, 0.000001 );
 
-  p3 = deprecatedTransform.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  p3 = deprecatedTransform.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p3.x(), 102.5, 0.000001 );
   QGSCOMPARENEAR( p3.y(), 7.5, 0.000001 );
 
@@ -735,7 +735,7 @@ void TestQgsCoordinateTransform::testDeprecated4240to4326()
   QGSCOMPARENEAR( p2.x(), 102.5, 0.000001 );
   QGSCOMPARENEAR( p2.y(), 7.5, 0.000001 );
 
-  p3 = deprecatedTransformRev.transform( p2, QgsCoordinateTransform::ReverseTransform );
+  p3 = deprecatedTransformRev.transform( p2, Qgis::TransformDirection::Reverse );
   QGSCOMPARENEAR( p3.x(), 102.496547, 0.000001 );
   QGSCOMPARENEAR( p3.y(), 7.502139, 0.000001 );
 }

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -452,7 +452,7 @@ void TestQgsCoordinateTransform::transformEpoch()
 
   double x = srcX;
   double y = srcY;
-  ct.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
+  ct.transformInPlace( x, y, z, static_cast< Qgis::TransformDirection >( direction ) );
   QGSCOMPARENEAR( x, outX, precision );
   QGSCOMPARENEAR( y, outY, precision );
 
@@ -460,7 +460,7 @@ void TestQgsCoordinateTransform::transformEpoch()
   QgsCoordinateTransform ct2( sourceCrs, destCrs, QgsProject::instance() );
   x = srcX;
   y = srcY;
-  ct2.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
+  ct2.transformInPlace( x, y, z, static_cast< Qgis::TransformDirection >( direction ) );
   QGSCOMPARENEAR( x, outX, precision );
   QGSCOMPARENEAR( y, outY, precision );
 }

--- a/tests/src/core/testqgsgml.cpp
+++ b/tests/src/core/testqgsgml.cpp
@@ -24,6 +24,7 @@
 #include <qgsgml.h>
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgscoordinatereferencesystem.h"
 
 /**
  * \ingroup UnitTests


### PR DESCRIPTION
This enum was forcing an include of qgscoordinatetransform.h within the
widely used qgsabstractgeometry.h header, causing an absolute explosion
of includes of a bunch of very heavy header classes all across QGIS. By
removing the forced include we can avoid a ton of unwanted includes
and make wider use of forward declarations...
