### PR TITLE
Allow CAD dock to be used for geographic CRS for x/y/z/m only

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -159,6 +159,24 @@ Toggle lock mode
 Toggle relative mode
 %End
 
+        int precision() const;
+%Docstring
+Returns the numeric precision (decimal places) to show in the associated widget.
+
+.. seealso:: :py:func:`setPrecision`
+
+.. versionadded:: 3.22
+%End
+
+        void setPrecision( int precision );
+%Docstring
+Sets the numeric precision (decimal places) to show in the associated widget.
+
+.. seealso:: :py:func:`precision`
+
+.. versionadded:: 3.22
+%End
+
     };
 
     explicit QgsAdvancedDigitizingDockWidget( QgsMapCanvas *canvas, QWidget *parent = 0 );

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -31,6 +31,7 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
       AbsoluteAngle,
       RelativeAngle,
       RelativeCoordinates,
+      Distance,
     };
     typedef QFlags<QgsAdvancedDigitizingDockWidget::CadCapacity> CadCapacities;
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1410,6 +1410,9 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mDistanceLineEdit->setEnabled( false );
     mDistanceLineEdit->setToolTip( tr( "Distance constraint cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
 
+    mLabelX->setText( tr( "Long" ) );
+    mLabelY->setText( tr( "Lat" ) );
+
     mXConstraint->setPrecision( 8 );
     mYConstraint->setPrecision( 8 );
   }
@@ -1420,6 +1423,9 @@ void QgsAdvancedDigitizingDockWidget::enable()
 
     mDistanceLineEdit->setEnabled( true );
     mDistanceLineEdit->setToolTip( "<b>" + tr( "Distance" ) + "</b><br>(" + tr( "press d for quick access" ) + ")" );
+
+    mLabelX->setText( tr( "x" ) );
+    mLabelY->setText( tr( "y" ) );
 
     mXConstraint->setPrecision( 6 );
     mYConstraint->setPrecision( 6 );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1409,6 +1409,9 @@ void QgsAdvancedDigitizingDockWidget::enable()
 
     mDistanceLineEdit->setEnabled( false );
     mDistanceLineEdit->setToolTip( tr( "Distance constraint cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
+
+    mXConstraint->setPrecision( 8 );
+    mYConstraint->setPrecision( 8 );
   }
   else
   {
@@ -1417,6 +1420,9 @@ void QgsAdvancedDigitizingDockWidget::enable()
 
     mDistanceLineEdit->setEnabled( true );
     mDistanceLineEdit->setToolTip( "<b>" + tr( "Distance" ) + "</b><br>(" + tr( "press d for quick access" ) + ")" );
+
+    mXConstraint->setPrecision( 6 );
+    mYConstraint->setPrecision( 6 );
   }
 
   mEnableAction->setEnabled( true );
@@ -1546,7 +1552,7 @@ void QgsAdvancedDigitizingDockWidget::CadConstraint::setValue( double value, boo
 {
   mValue = value;
   if ( updateWidget && mLineEdit->isEnabled() )
-    mLineEdit->setText( QLocale().toString( value, 'f', 6 ) );
+    mLineEdit->setText( QLocale().toString( value, 'f', mPrecision ) );
 }
 
 void QgsAdvancedDigitizingDockWidget::CadConstraint::toggleLocked()
@@ -1557,6 +1563,13 @@ void QgsAdvancedDigitizingDockWidget::CadConstraint::toggleLocked()
 void QgsAdvancedDigitizingDockWidget::CadConstraint::toggleRelative()
 {
   setRelative( !mRelative );
+}
+
+void QgsAdvancedDigitizingDockWidget::CadConstraint::setPrecision( int precision )
+{
+  mPrecision = precision;
+  if ( mLineEdit->isEnabled() )
+    mLineEdit->setText( QLocale().toString( mValue, 'f', mPrecision ) );
 }
 
 QgsPoint QgsAdvancedDigitizingDockWidget::currentPointV2( bool *exist ) const

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1412,11 +1412,11 @@ void QgsAdvancedDigitizingDockWidget::enable()
   }
   else
   {
-    mAngleLineEdit->setEnabled( true );
-    mAngleLineEdit->setToolTip( tr( "xxx" ) );
+    mAngleLineEdit->setToolTip( "<b>" + tr( "Angle" ) + "</b><br>(" + tr( "press a for quick access" ) + ")" );
+    mAngleLineEdit->setToolTip( QString() );
 
     mDistanceLineEdit->setEnabled( true );
-    mDistanceLineEdit->setToolTip( tr( "xxx" ) );
+    mDistanceLineEdit->setToolTip( "<b>" + tr( "Distance" ) + "</b><br>(" + tr( "press d for quick access" ) + ")" );
   }
 
   mEnableAction->setEnabled( true );

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -195,6 +195,22 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
          */
         void toggleRelative();
 
+        /**
+         * Returns the numeric precision (decimal places) to show in the associated widget.
+         *
+         * \see setPrecision()
+         * \since QGIS 3.22
+         */
+        int precision() const { return mPrecision; }
+
+        /**
+         * Sets the numeric precision (decimal places) to show in the associated widget.
+         *
+         * \see precision()
+         * \since QGIS 3.22
+         */
+        void setPrecision( int precision );
+
       private:
         QLineEdit *mLineEdit = nullptr;
         QToolButton *mLockerButton = nullptr;
@@ -204,6 +220,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
         bool mRepeatingLock;
         bool mRelative;
         double mValue;
+        int mPrecision = 6;
     };
 
     /**

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -61,6 +61,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
       AbsoluteAngle = 1, //!< Azimuth
       RelativeAngle = 2, //!< Also for parallel and perpendicular
       RelativeCoordinates = 4, //!< This corresponds to distance and relative coordinates
+      Distance = 8, //!< Distance
     };
     Q_DECLARE_FLAGS( CadCapacities, CadCapacity )
     Q_FLAG( CadCapacities )

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>252</width>
-    <height>250</height>
+    <height>262</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -345,7 +345,7 @@
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="mLabelX">
               <property name="text">
                <string>x</string>
               </property>
@@ -399,7 +399,7 @@
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QLabel" name="label_4">
+             <widget class="QLabel" name="mLabelY">
               <property name="text">
                <string>y</string>
               </property>


### PR DESCRIPTION
Enables the CAD dock even when a geographic CRS is in use, but only allow the x/y/z/m constraints to be set (not distance or angle based constraints)
