### PR TITLE
Improve mesh editing force by line UI and fixes

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
@@ -94,11 +94,21 @@ Constructor
     void addLineFromGeometry( const QgsGeometry &geom );
 %Docstring
 Adds a input forcing line geometry in rendering coordinates
+
+.. note::
+
+   if the geometry is not 3D, the default Z value will be used for the Z value of the geometry's vertices.
+   This default Z value has to be set before adding the geometry (:py:func:`setDefaultZValue`
 %End
 
     void addLinesFromGeometries( const QList<QgsGeometry> geometries );
 %Docstring
 Adds a list of input forcing lines geometry in rendering coordinates
+
+.. note::
+
+   if the geometry is not 3D, the default Z value will be used for the Z value of the geometry's vertices.
+   This default Z value has to be set before adding the geometry (:py:func:`setDefaultZValue`
 %End
 
 };

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -44,16 +44,19 @@
 #include "qgsunitselectionwidget.h"
 #include "qgssettingsregistrycore.h"
 
-
-//
-// QgsZValueWidget
-//
-
 #include "qgsexpressionbuilderwidget.h"
 #include "qgsmeshselectbyexpressiondialog.h"
 #include "qgsexpressioncontext.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsexpressionutils.h"
+#include "qgssettingsregistrycore.h"
+#include "qgsmaptoolidentify.h"
+#include "qgsidentifymenu.h"
+
+
+//
+// QgsZValueWidget
+//
 
 
 QgsZValueWidget::QgsZValueWidget( const QString &label, QWidget *parent ): QWidget( parent )
@@ -145,7 +148,7 @@ QgsMeshEditForceByLineAction::QgsMeshEditForceByLineAction( QObject *parent )
                                  QgsUnitTypes::RenderMetersInMapUnits <<
                                  QgsUnitTypes::RenderMapUnits );
 
-  QgsUnitTypes::RenderUnit toleranceUnit = settings.enumValue( QStringLiteral( "UI/Mesh/ForceByLineToleranceValue" ), QgsUnitTypes::RenderMapUnits );
+  QgsUnitTypes::RenderUnit toleranceUnit = settings.enumValue( QStringLiteral( "UI/Mesh/ForceByLineToleranceUnit" ), QgsUnitTypes::RenderMapUnits );
   mUnitSelecionWidget->setUnit( toleranceUnit );
 
   gLayout->addWidget( mCheckBoxNewVertex, 1, 0, 1, 4 );
@@ -198,7 +201,7 @@ void QgsMeshEditForceByLineAction::updateSettings()
   settings.setEnumValue( QStringLiteral( "UI/Mesh/ForceByLineInterpolateFrom" ),
                          static_cast<IntepolationMode>( mComboInterpolateFrom->currentData().toInt() ) );
   settings.setValue( QStringLiteral( "UI/Mesh/ForceByLineToleranceValue" ), mToleranceSpinBox->value() );
-  settings.setEnumValue( QStringLiteral( "UI/Mesh/ForceByLineToleranceValue" ), mUnitSelecionWidget->unit() );
+  settings.setEnumValue( QStringLiteral( "UI/Mesh/ForceByLineToleranceUnit" ), mUnitSelecionWidget->unit() );
 }
 
 //
@@ -226,8 +229,8 @@ QgsMapToolEditMeshFrame::QgsMapToolEditMeshFrame( QgsMapCanvas *canvas )
   mActionTransformCoordinates = new QAction( QgsApplication::getThemePixmap( QStringLiteral( "/mActionMeshTransformByExpression.svg" ) ), tr( "Transform Vertices Coordinates" ), this );
   mActionTransformCoordinates->setCheckable( true );
 
-  mActionForceByVectorLayerGeometries = new QAction( QgsApplication::getThemePixmap( QStringLiteral( "/mActionMeshEditForceByVectorLines.svg" ) ), tr( "Force by Selected Geometries" ), this );
-  mActionForceByVectorLayerGeometries->setEnabled( areGeometriesSelectedInVectorLayer() );
+  mActionForceByLines = new QAction( QgsApplication::getThemePixmap( QStringLiteral( "/mActionMeshEditForceByVectorLines.svg" ) ), tr( "Force by Selected Geometries" ), this );
+  mActionForceByLines->setCheckable( true );
 
   mWidgetActionForceByLine = new QgsMeshEditForceByLineAction( this );
   mWidgetActionForceByLine->setMapCanvas( canvas );
@@ -273,7 +276,6 @@ QgsMapToolEditMeshFrame::QgsMapToolEditMeshFrame( QgsMapCanvas *canvas )
 
   connect( mActionSelectByExpression, &QAction::triggered, this, &QgsMapToolEditMeshFrame::showSelectByExpressionDialog );
   connect( mActionTransformCoordinates, &QAction::triggered, this, &QgsMapToolEditMeshFrame::triggerTransformCoordinatesDockWidget );
-  connect( mActionForceByVectorLayerGeometries, &QAction::triggered, this, &QgsMapToolEditMeshFrame::forceBySelectedLayerPolyline );
   connect( mActionReindexMesh, &QAction::triggered, this, &QgsMapToolEditMeshFrame::reindexMesh );
   connect( mActionDelaunayTriangulation, &QAction::triggered, this, [this]
   {
@@ -309,10 +311,17 @@ QgsMapToolEditMeshFrame::QgsMapToolEditMeshFrame( QgsMapCanvas *canvas )
     selectByGeometry( mSelectionHandler->selectedGeometry(), modifiers );
   } );
 
-  connect( canvas, &QgsMapCanvas::selectionChanged, this, [this]
+  connect( mActionForceByLines, &QAction::toggled, this, [this]( bool checked )
   {
-    bool enable = areGeometriesSelectedInVectorLayer() && ( mCurrentEditor != nullptr );
-    mActionForceByVectorLayerGeometries->setEnabled( enable );
+    if ( mIsInitialized )
+      mForceByLineRubberBand->reset( QgsWkbTypes::LineGeometry );
+    mForcingLineZValue.clear();
+    if ( checked )
+    {
+      onEditingStarted();
+      clearCanvasHelpers();
+      activateWithState( ForceByLines );
+    }
   } );
 
   connect( cadDockWidget(), &QgsAdvancedDigitizingDockWidget::cadEnabledChanged, this, [this]( bool enable )
@@ -356,14 +365,14 @@ void QgsMapToolEditMeshFrame::setActionsEnable( bool enable )
       << mActionSelectByPolygon
       << mActionSelectByExpression
       << mActionTransformCoordinates
-      << mActionForceByVectorLayerGeometries
+      << mActionForceByLines
       << mActionReindexMesh;
 
   for ( QAction *action : std::as_const( actions ) )
     action->setEnabled( enable );
 
-  bool areGeometriesSelected = areGeometriesSelectedInVectorLayer();
-  mActionForceByVectorLayerGeometries->setEnabled( enable && areGeometriesSelected );
+//  bool areGeometriesSelected = areGeometriesSelectedInVectorLayer();
+//  mActionForceByLines->setEnabled( enable && areGeometriesSelected );
 }
 
 
@@ -371,7 +380,8 @@ QList<QAction *> QgsMapToolEditMeshFrame::mapToolActions()
 {
   return  QList<QAction *>()
           << mActionDigitizing
-          << mActionSelectByPolygon;
+          << mActionSelectByPolygon
+          << mActionForceByLines;
 }
 
 QAction *QgsMapToolEditMeshFrame::digitizeAction() const
@@ -404,12 +414,12 @@ QAction *QgsMapToolEditMeshFrame::transformAction() const
 QList<QAction *> QgsMapToolEditMeshFrame::forceByLinesActions() const
 {
   return  QList<QAction *>()
-          << mActionForceByVectorLayerGeometries;
+          << mActionForceByLines;
 }
 
 QAction *QgsMapToolEditMeshFrame::defaultForceAction() const
 {
-  return mActionForceByVectorLayerGeometries;
+  return mActionForceByLines;
 }
 
 QWidgetAction *QgsMapToolEditMeshFrame::forceByLineWidgetActionSettings() const
@@ -537,6 +547,9 @@ void QgsMapToolEditMeshFrame::initialize()
   mMergeFaceMarker->setPenWidth( 3 );
   mMergeFaceMarker->setZValue( 10 );
 
+  if ( !mForceByLineRubberBand )
+    mForceByLineRubberBand = createRubberBand( QgsWkbTypes::LineGeometry );
+
   connect( mCanvas, &QgsMapCanvas::currentLayerChanged, this, &QgsMapToolEditMeshFrame::setCurrentLayer );
 
   mUserZValue = defaultZValue();
@@ -658,6 +671,7 @@ bool QgsMapToolEditMeshFrame::populateContextMenuWithEvent( QMenu *menu, QgsMapM
     case Selecting:
     case MovingSelection:
     case SelectingByPolygon:
+    case ForceByLines:
       return false;
   }
 
@@ -669,12 +683,18 @@ QgsMapTool::Flags QgsMapToolEditMeshFrame::flags() const
   switch ( mCurrentState )
   {
     case Digitizing:
-      return QgsMapTool::Flags() | QgsMapTool::ShowContextMenu;
+      if ( !mSelectedVertices.isEmpty() )
+      {
+        return QgsMapTool::Flags() | QgsMapTool::ShowContextMenu;
+        break;
+      }
     case AddingNewFace:
     case Selecting:
     case MovingSelection:
     case SelectingByPolygon:
+    case ForceByLines:
       return QgsMapTool::Flags();
+      break;
   }
 
   return QgsMapTool::Flags();
@@ -699,6 +719,7 @@ void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
     case AddingNewFace:
     case Selecting:
     case MovingSelection:
+    case ForceByLines:
       if ( e->button() == Qt::LeftButton )
         mSelectionBand->reset( QgsWkbTypes::PolygonGeometry );
       break;
@@ -720,9 +741,7 @@ void QgsMapToolEditMeshFrame::cadCanvasMoveEvent( QgsMapMouseEvent *e )
 
   mSnapIndicator->setMatch( e->mapPointMatch() );
 
-  if ( mLeftButtonPressed &&
-       mCurrentState != AddingNewFace &&
-       mCurrentState != SelectingByPolygon )
+  if ( mLeftButtonPressed && mCurrentState == Digitizing )
   {
     mCurrentState = Selecting;
   }
@@ -754,6 +773,31 @@ void QgsMapToolEditMeshFrame::cadCanvasMoveEvent( QgsMapMouseEvent *e )
     case SelectingByPolygon:
       if ( mSelectionHandler )
         mSelectionHandler->canvasMoveEvent( e );
+      break;
+    case ForceByLines:
+      searchFace( mapPoint );
+      searchEdge( mapPoint );
+      highlightCloseVertex( mapPoint );
+
+      const QgsPointLocator::Match &matchPoint = e->mapPointMatch();
+
+      if ( mCurrentVertexIndex != -1 )
+      {
+        mForceByLineRubberBand->movePoint( mapVertexXY( mCurrentVertexIndex ) );
+        if ( mZValueWidget )
+          mZValueWidget->setZValue( mapVertex( mCurrentVertexIndex ).z() );
+      }
+      else if ( matchPoint.isValid() && matchPoint.layer() && QgsWkbTypes::hasZ( matchPoint.layer()->wkbType() ) )
+      {
+        if ( mZValueWidget )
+          mZValueWidget->setZValue( e->mapPointMatch().interpolatedPoint().z() );
+      }
+      else
+      {
+        mForceByLineRubberBand->movePoint( mapPoint );
+        if ( mZValueWidget )
+          mZValueWidget->setZValue( mUserZValue );
+      }
       break;
   }
 
@@ -919,6 +963,9 @@ void QgsMapToolEditMeshFrame::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     case SelectingByPolygon:
       if ( mSelectionHandler )
         mSelectionHandler->canvasReleaseEvent( e );
+      break;
+    case ForceByLines:
+      forceByLineReleaseEvent( e );
       break;
   }
   mDoubleClicks = false;
@@ -1108,11 +1155,27 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
     }
     break;
     case MovingSelection:
-      mCurrentState = Digitizing;
-      mMovingEdgesRubberband->reset( QgsWkbTypes::LineGeometry );
-      mMovingFacesRubberband->reset( QgsWkbTypes::PolygonGeometry );
-      mMovingFreeVertexRubberband->reset( QgsWkbTypes::PointGeometry );
-      mCadDockWidget->setEnabledZ( mCadDockWidget->cadEnabled() );
+      if ( e->key() == Qt::Key_Escape )
+      {
+        mCurrentState = Digitizing;
+        mMovingEdgesRubberband->reset( QgsWkbTypes::LineGeometry );
+        mMovingFacesRubberband->reset( QgsWkbTypes::PolygonGeometry );
+        mMovingFreeVertexRubberband->reset( QgsWkbTypes::PointGeometry );
+        mCadDockWidget->setEnabledZ( mCadDockWidget->cadEnabled() );
+      }
+      break;
+    case ForceByLines:
+      if ( e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter )
+      {
+        if ( !mCadDockWidget->cadEnabled() )
+          mUserZValue = currentZValue();
+      }
+
+      if ( e->key() == Qt::Key_Escape )
+      {
+        mForceByLineRubberBand->reset( QgsWkbTypes::LineGeometry );
+        mForcingLineZValue.clear();
+      }
       break;
     case Selecting:
     case SelectingByPolygon:
@@ -1147,6 +1210,7 @@ void QgsMapToolEditMeshFrame::keyReleaseEvent( QKeyEvent *e )
       break;
     case Selecting:
     case MovingSelection:
+    case ForceByLines:
       break;
   }
 
@@ -1205,9 +1269,58 @@ double QgsMapToolEditMeshFrame::currentZValue()
   return defaultZValue();
 }
 
+void QgsMapToolEditMeshFrame::searchFace( const QgsPointXY &mapPoint )
+{
+  if ( !mCurrentLayer.isNull() && mCurrentLayer->triangularMesh() )
+    mCurrentFaceIndex = mCurrentLayer->triangularMesh()->nativeFaceIndexForPoint( mapPoint );
+}
+
+void QgsMapToolEditMeshFrame::searchEdge( const QgsPointXY &mapPoint )
+{
+  mCurrentEdge = {-1, -1};
+  double tolerance = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
+
+  QList<int> candidateFaceIndexes;
+
+  if ( mCurrentFaceIndex != -1 )
+  {
+    candidateFaceIndexes.append( mCurrentFaceIndex );
+  }
+  else
+  {
+    const QgsRectangle searchRect( mapPoint.x() - tolerance, mapPoint.y() - tolerance, mapPoint.x() + tolerance, mapPoint.y() + tolerance );
+    candidateFaceIndexes = mCurrentLayer->triangularMesh()->nativeFaceIndexForRectangle( searchRect );
+  }
+
+  double minimumDistance = std::numeric_limits<double>::max();
+  for ( const int faceIndex : std::as_const( candidateFaceIndexes ) )
+  {
+    const QgsMeshFace &face = nativeFace( faceIndex );
+    int faceSize = face.count();
+    for ( int i = 0; i < faceSize; ++i )
+    {
+      int iv1 = face.at( i );
+      int iv2 = face.at( ( i + 1 ) % faceSize );
+
+      QgsPointXY pt1 = mapVertexXY( iv1 );
+      QgsPointXY pt2 = mapVertexXY( iv2 );
+
+      QgsPointXY pointOneEdge;
+      double distance = sqrt( mapPoint.sqrDistToSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), pointOneEdge ) );
+      if ( distance < tolerance && distance < minimumDistance && edgeCanBeInteractive( iv1, iv2 ) )
+      {
+        mCurrentEdge = {faceIndex, iv2};
+        minimumDistance = distance;
+      }
+    }
+  }
+}
+
 void QgsMapToolEditMeshFrame::highLight( const QgsPointXY &mapPoint )
 {
+  searchFace( mapPoint );
   highlightCurrentHoveredFace( mapPoint );
+  searchEdge( mapPoint );
   highlightCloseVertex( mapPoint );
   highlightCloseEdge( mapPoint );
 }
@@ -1663,34 +1776,6 @@ void QgsMapToolEditMeshFrame::triggerTransformCoordinatesDockWidget( bool checke
 
 }
 
-void QgsMapToolEditMeshFrame::forceBySelectedLayerPolyline()
-{
-  const QList<QgsGeometry> geoms = selectedGeometriesInVectorLayers();
-  if ( geoms.isEmpty() )
-    return;
-
-  onEditingStarted();
-
-  QgsMeshEditForceByPolylines forceByPolylinesEdit;
-
-  double tolerance = QgsTolerance::toleranceInMapUnits( mWidgetActionForceByLine->toleranceValue(),
-                     nullptr,
-                     canvas()->mapSettings(),
-                     QgsTolerance::ProjectUnits );
-
-  forceByPolylinesEdit.setTolerance( tolerance );
-  forceByPolylinesEdit.setAddVertexOnIntersection( mWidgetActionForceByLine->newVertexOnIntersectingEdge() );
-  forceByPolylinesEdit.setDefaultZValue( currentZValue() );
-  forceByPolylinesEdit.setInterpolateZValueOnMesh(
-    mWidgetActionForceByLine->interpolationMode() == QgsMeshEditForceByLineAction::Mesh );
-
-  for ( const QgsGeometry &geom : geoms )
-    forceByPolylinesEdit.addLineFromGeometry( geom );
-
-  mCurrentEditor->advancedEdit( &forceByPolylinesEdit );
-}
-
-
 void QgsMapToolEditMeshFrame::reindexMesh()
 {
   onEditingStarted();
@@ -2062,68 +2147,141 @@ bool QgsMapToolEditMeshFrame::isSelectionGrapped( QgsPointXY &grappedPoint )
   return false;
 }
 
-QList<QgsGeometry> QgsMapToolEditMeshFrame::selectedGeometriesInVectorLayers() const
+void QgsMapToolEditMeshFrame::forceByLineReleaseEvent( QgsMapMouseEvent *e )
 {
-  const QList<QgsMapLayer *> layers = canvas()->layers();
+  QgsPointXY mapPoint = e->mapPoint();
 
-  QList<QgsGeometry> geomList;
+  if ( e->button() == Qt::LeftButton )
+  {
+    if ( mCurrentVertexIndex != -1 )
+    {
+      const QgsPointXY currentPoint =   mapVertexXY( mCurrentVertexIndex );
+      mForceByLineRubberBand->addPoint( currentPoint );
+      mCadDockWidget->setZ( QString::number( mapVertex( mCurrentVertexIndex ).z(), 'f' ), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited );
+      mCadDockWidget->setPoints( QList < QgsPointXY>() << currentPoint << currentPoint );
+    }
+    else
+    {
+      mForceByLineRubberBand->addPoint( mapPoint );
+    }
 
+    mForcingLineZValue.append( currentZValue() );
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    if ( mForceByLineRubberBand->numberOfVertices() == 0 )
+    {
+      forceByLineBySelectedFeature( e );
+      return;
+    }
+
+    QVector<QgsPoint> points;
+    QgsPolylineXY rubbergandLines = mForceByLineRubberBand->asGeometry().asPolyline();
+    double defaultValue = currentZValue();
+
+    if ( std::isnan( defaultValue ) )
+      defaultValue = defaultZValue();
+
+    for ( int i = 0; i < rubbergandLines.count() - 1; ++i )
+    {
+      points.append( QgsPoint( rubbergandLines.at( i ).x(),
+                               rubbergandLines.at( i ).y(),
+                               mForcingLineZValue.isEmpty() ? defaultValue : mForcingLineZValue.at( i ) ) );
+    }
+    std::unique_ptr<QgsLineString> forcingLine = std::make_unique<QgsLineString>( points );
+    forceByLine( QgsGeometry( forcingLine.release() ) );
+    mForceByLineRubberBand->reset( QgsWkbTypes::LineGeometry );
+    mForcingLineZValue.clear();
+  }
+}
+
+void QgsMapToolEditMeshFrame::forceByLineBySelectedFeature( QgsMapMouseEvent *e )
+{
+  QList<QgsMapToolIdentify::IdentifyResult> results;
+  const QMap< QString, QString > derivedAttributes;
+
+  QgsPointXY mapPoint = e->mapPoint();
+  double x = mapPoint.x(), y = mapPoint.y();
+  const double sr = QgsMapTool::searchRadiusMU( mCanvas );
+
+  const QList<QgsMapLayer *> layers = mCanvas->layers();
   for ( QgsMapLayer *layer : layers )
   {
-    QgsVectorLayer *vectoLayer = qobject_cast<QgsVectorLayer *>( layer );
-
-    if ( vectoLayer )
+    if ( layer->type() == QgsMapLayerType::VectorLayer )
     {
-      const QgsFeatureList &features = vectoLayer->selectedFeatures();
-
-      QgsCoordinateTransform transform = canvas()->mapSettings().layerTransform( vectoLayer );
-      for ( const QgsFeature &feat : features )
+      QgsVectorLayer *vectorLayer = static_cast<QgsVectorLayer *>( layer );
+      if ( vectorLayer->geometryType() == QgsWkbTypes::PolygonGeometry ||
+           vectorLayer->geometryType() == QgsWkbTypes::LineGeometry )
       {
-        QgsGeometry geom = feat.geometry();
+        QgsRectangle rect( x - sr, y - sr, x + sr, y + sr );
+        QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( vectorLayer );
 
         try
         {
-          geom.transform( transform );
+          rect = transform.transformBoundingBox( rect, QgsCoordinateTransform::ReverseTransform );
         }
-        catch ( QgsCsException &e )
+        catch ( QgsCsException &exception )
         {
-          Q_UNUSED( e );
-          continue;
+          QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
         }
-        geomList.append( geom );
+
+        QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest()
+                                 .setFilterRect( rect )
+                                 .setFlags( QgsFeatureRequest::ExactIntersect ) );
+        QgsFeature f;
+        while ( fit.nextFeature( f ) )
+        {
+          results << QgsMapToolIdentify::IdentifyResult( vectorLayer, f, derivedAttributes );
+        }
       }
     }
   }
 
-  return geomList;
-}
+  QgsIdentifyMenu *menu = new QgsIdentifyMenu( mCanvas );
+  menu->setExecWithSingleResult( true );
+  const QPoint globalPos = mCanvas->mapToGlobal( QPoint( e->pos().x() + 5, e->pos().y() + 5 ) );
+  const QList<QgsMapToolIdentify::IdentifyResult> selectedFeatures = menu->exec( results, globalPos );
+  menu->deleteLater();
 
-bool QgsMapToolEditMeshFrame::areGeometriesSelectedInVectorLayer() const
-{
-  const QList<QgsMapLayer *> layers = canvas()->layers();
-
-  QList<QgsGeometry> geomList;
-
-  for ( QgsMapLayer *layer : layers )
+  if ( !selectedFeatures.empty() && selectedFeatures[0].mFeature.hasGeometry() )
   {
-    QgsVectorLayer *vectoLayer = qobject_cast<QgsVectorLayer *>( layer );
-
-    if ( vectoLayer )
+    QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( selectedFeatures.at( 0 ).mLayer );
+    QgsGeometry geom = selectedFeatures[0].mFeature.geometry();
+    try
     {
-      if ( vectoLayer->selectedFeatureCount() > 0 )
-        return true;
+      geom.transform( transform );
     }
+    catch ( QgsCsException &exception )
+    {
+      QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+    }
+    forceByLine( geom );
   }
 
-  return false;
+  return;
 }
+
+void QgsMapToolEditMeshFrame::forceByLine( const QgsGeometry &lineGeometry )
+{
+  QgsMeshEditForceByPolylines forceByPolyline;
+
+  double defaultValue = currentZValue();
+  if ( std::isnan( defaultValue ) )
+    defaultValue = defaultZValue();
+
+  forceByPolyline.setDefaultZValue( defaultValue );
+  forceByPolyline.addLineFromGeometry( lineGeometry );
+  forceByPolyline.setAddVertexOnIntersection( mWidgetActionForceByLine->newVertexOnIntersectingEdge() );
+  forceByPolyline.setInterpolateZValueOnMesh( mWidgetActionForceByLine->interpolationMode() == QgsMeshEditForceByLineAction::Mesh );
+  forceByPolyline.setTolerance( mWidgetActionForceByLine->toleranceValue() );
+
+  mCurrentEditor->advancedEdit( &forceByPolyline );
+}
+
 
 void QgsMapToolEditMeshFrame::highlightCurrentHoveredFace( const QgsPointXY &mapPoint )
 {
-  int faceIndex = -1;
-  if ( !mCurrentLayer.isNull() && mCurrentLayer->triangularMesh() )
-    faceIndex = mCurrentLayer->triangularMesh()->nativeFaceIndexForPoint( mapPoint );
-
+  searchFace( mapPoint );
   if ( mSelectFaceMarker->isVisible() )
   {
     double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
@@ -2139,9 +2297,7 @@ void QgsMapToolEditMeshFrame::highlightCurrentHoveredFace( const QgsPointXY &map
     }
   }
 
-  mCurrentFaceIndex = faceIndex;
-
-  QgsPointSequence faceGeometry = nativeFaceGeometry( faceIndex );
+  QgsPointSequence faceGeometry = nativeFaceGeometry( mCurrentFaceIndex );
   mFaceRubberBand->reset( QgsWkbTypes::PolygonGeometry );
   mFaceVerticesBand->reset( QgsWkbTypes::PointGeometry );
   for ( const QgsPoint &pt : faceGeometry )
@@ -2150,9 +2306,9 @@ void QgsMapToolEditMeshFrame::highlightCurrentHoveredFace( const QgsPointXY &map
     mFaceVerticesBand->addPoint( pt );
   }
 
-  if ( faceIndex != -1 && faceCanBeInteractive( faceIndex ) )
+  if ( mCurrentFaceIndex != -1 && faceCanBeInteractive( mCurrentFaceIndex ) )
   {
-    mSelectFaceMarker->setCenter( mCurrentLayer->triangularMesh()->faceCentroids().at( faceIndex ) );
+    mSelectFaceMarker->setCenter( mCurrentLayer->triangularMesh()->faceCentroids().at( mCurrentFaceIndex ) );
     mSelectFaceMarker->setVisible( true );
   }
   else
@@ -2166,7 +2322,8 @@ void QgsMapToolEditMeshFrame::highlightCloseVertex( const QgsPointXY &mapPoint )
   if ( !mCurrentEditor )
     return;
 
-  if ( mNewFaceMarker->isVisible() )
+
+  if ( mCurrentState == Digitizing && mNewFaceMarker->isVisible() )
   {
     double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
     if ( mapPoint.distance( mNewFaceMarker->center() ) < tol )
@@ -2258,42 +2415,7 @@ void QgsMapToolEditMeshFrame::highlightCloseEdge( const QgsPointXY &mapPoint )
       mMergeFaceMarker->setColor( Qt::gray );
   }
 
-  mCurrentEdge = {-1, -1};
-
-  QList<int> candidateFaceIndexes;
-
-  if ( mCurrentFaceIndex != -1 )
-  {
-    candidateFaceIndexes.append( mCurrentFaceIndex );
-  }
-  else
-  {
-    const QgsRectangle searchRect( mapPoint.x() - tolerance, mapPoint.y() - tolerance, mapPoint.x() + tolerance, mapPoint.y() + tolerance );
-    candidateFaceIndexes = mCurrentLayer->triangularMesh()->nativeFaceIndexForRectangle( searchRect );
-  }
-
-  double minimumDistance = std::numeric_limits<double>::max();
-  for ( const int faceIndex : std::as_const( candidateFaceIndexes ) )
-  {
-    const QgsMeshFace &face = nativeFace( faceIndex );
-    int faceSize = face.count();
-    for ( int i = 0; i < faceSize; ++i )
-    {
-      int iv1 = face.at( i );
-      int iv2 = face.at( ( i + 1 ) % faceSize );
-
-      QgsPointXY pt1 = mapVertexXY( iv1 );
-      QgsPointXY pt2 = mapVertexXY( iv2 );
-
-      QgsPointXY pointOneEdge;
-      double distance = sqrt( mapPoint.sqrDistToSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), pointOneEdge ) );
-      if ( distance < tolerance && distance < minimumDistance && edgeCanBeInteractive( iv1, iv2 ) )
-      {
-        mCurrentEdge = {faceIndex, iv2};
-        minimumDistance = distance;
-      }
-    }
-  }
+  searchEdge( mapPoint );
 
   mEdgeBand->reset();
   mFlipEdgeMarker->setVisible( false );

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -684,10 +684,8 @@ QgsMapTool::Flags QgsMapToolEditMeshFrame::flags() const
   {
     case Digitizing:
       if ( !mSelectedVertices.isEmpty() )
-      {
         return QgsMapTool::Flags() | QgsMapTool::ShowContextMenu;
-        break;
-      }
+      FALLTHROUGH
     case AddingNewFace:
     case Selecting:
     case MovingSelection:

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -164,7 +164,6 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     void showSelectByExpressionDialog();
     void selectByExpression( const QString &textExpression, Qgis::SelectBehavior behavior, QgsMesh::ElementType elementType );
     void onZoomToSelected();
-    void forceBySelectedLayerPolyline();
     void reindexMesh();
 
   private:
@@ -176,6 +175,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
       Selecting, //!< Selection is in process
       MovingSelection, //!< Moving vertex or vertices is processing
       SelectingByPolygon, //!< Selection elements by polygon is in progress
+      ForceByLines, //!< Force by a lines drawn or selected by users
     };
 
     typedef QPair<int, int> Edge; //first face index, second the vertex index corresponding to the end extremity (ccw)
@@ -190,10 +190,12 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     double currentZValue();
 
+    void searchFace( const QgsPointXY &mapPoint );
+    void searchEdge( const QgsPointXY &mapPoint );
     void highLight( const QgsPointXY &mapPoint );
     void highlightCurrentHoveredFace( const QgsPointXY &mapPoint );
-    void highlightCloseVertex( const QgsPointXY &mapPoint );
     void highlightCloseEdge( const QgsPointXY &mapPoint );
+    void highlightCloseVertex( const QgsPointXY &mapPoint );
     bool edgeCanBeInteractive( int vertexIndex1, int vertexIndex2 ) const;
     bool faceCanBeInteractive( int faceIndex ) const;
 
@@ -239,8 +241,10 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     void setMovingRubberBandValidity( bool valid );
     bool isSelectionGrapped( QgsPointXY &grappedPoint );
 
-    QList<QgsGeometry> selectedGeometriesInVectorLayers() const;
-    bool areGeometriesSelectedInVectorLayer() const;
+    void forceByLineReleaseEvent( QgsMapMouseEvent *e );
+    void forceByLineBySelectedFeature( QgsMapMouseEvent *e );
+    void forceByLine( const QgsGeometry &lineGeometry );
+
 
     // members
     struct SelectedVertexData
@@ -306,6 +310,9 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QgsRubberBand *mMovingFreeVertexRubberband = nullptr; //own by map canvas
     bool mIsMovingAllowed = false;
 
+    QgsRubberBand *mForceByLineRubberBand = nullptr; //own by map canvas
+    QList<double> mForcingLineZValue;
+
     //! members for edge flip
     QgsVertexMarker *mFlipEdgeMarker = nullptr; //own by map canvas
 
@@ -336,7 +343,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     QAction *mActionTransformCoordinates = nullptr;
 
     QAction *mActionSelectByExpression = nullptr;
-    QAction *mActionForceByVectorLayerGeometries = nullptr;
+    QAction *mActionForceByLines = nullptr;
 
     QgsMeshEditForceByLineAction *mWidgetActionForceByLine = nullptr;
     QAction *mActionReindexMesh = nullptr;

--- a/src/core/mesh/qgsmeshforcebypolylines.cpp
+++ b/src/core/mesh/qgsmeshforcebypolylines.cpp
@@ -328,7 +328,7 @@ void QgsMeshEditForceByLine::interpolateZValueOnMesh( QgsPoint &point ) const
   }
 }
 
-void QgsMeshEditForceByLine::interPolateZValue( QgsMeshVertex &point, const QgsPoint &otherPoint1, const QgsPoint &otherPoint2 )
+void QgsMeshEditForceByLine::interpolateZValue( QgsMeshVertex &point, const QgsPoint &otherPoint1, const QgsPoint &otherPoint2 )
 {
   double distPoint = point.distance( otherPoint1 );
   double totalDistance = otherPoint1.distance( otherPoint2 );
@@ -439,11 +439,11 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
             mNewVerticesIndexesOnLine.append( mVerticesToAdd.count() );
             if ( mInterpolateZValueOnMesh )
-              interPolateZValue( intersectionPoint,
+              interpolateZValue( intersectionPoint,
                                  triangularMesh->vertices().at( iv1 ),
                                  triangularMesh->vertices().at( iv2 ) );
             else
-              interPolateZValue( intersectionPoint, mPoint1, mPoint2 );
+              interpolateZValue( intersectionPoint, mPoint1, mPoint2 );
             mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersectionPoint ) );
           }
 
@@ -460,11 +460,11 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             {
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersectionPoint,
+                interpolateZValue( intersectionPoint,
                                    triangularMesh->vertices().at( iv1 ),
                                    triangularMesh->vertices().at( iv2 ) );
               else
-                interPolateZValue( intersectionPoint, mPoint1, mPoint2 );
+                interpolateZValue( intersectionPoint, mPoint1, mPoint2 );
               mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersectionPoint ) );
             }
             else
@@ -544,11 +544,11 @@ bool QgsMeshEditForceByLine::buildForcedElements()
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               mNewVerticesIndexesOnLine.append( mVerticesToAdd.count() );
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersection,
+                interpolateZValue( intersection,
                                    triangularMesh->vertices().at( iv1 ),
                                    triangularMesh->vertices().at( iv2 ) );
               else
-                interPolateZValue( intersection, mPoint1, mPoint2 );
+                interpolateZValue( intersection, mPoint1, mPoint2 );
               mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersection ) );
             }
           }
@@ -597,11 +597,11 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             {
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersection,
+                interpolateZValue( intersection,
                                    triangularMesh->vertices().at( iv1 ),
                                    triangularMesh->vertices().at( iv2 ) );
               else
-                interPolateZValue( intersection, mPoint1, mPoint2 );
+                interpolateZValue( intersection, mPoint1, mPoint2 );
               mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersection ) );
             }
             else
@@ -713,11 +713,11 @@ bool QgsMeshEditForceByLine::buildForcedElements()
           currentEdge = {mHoleOnLeft.last(), mHoleOnRight.last()};
 
           if ( mInterpolateZValueOnMesh )
-            interPolateZValue( closestIntersectionPoint,
+            interpolateZValue( closestIntersectionPoint,
                                triangularMesh->vertices().at( mHoleOnLeft.last() ),
                                triangularMesh->vertices().at( mHoleOnRight.last() ) );
           else
-            interPolateZValue( closestIntersectionPoint, mPoint1, mPoint2 );
+            interpolateZValue( closestIntersectionPoint, mPoint1, mPoint2 );
 
           mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( closestIntersectionPoint ) );
 

--- a/src/core/mesh/qgsmeshforcebypolylines.cpp
+++ b/src/core/mesh/qgsmeshforcebypolylines.cpp
@@ -370,7 +370,7 @@ bool QgsMeshEditForceByLine::buildForcedElements()
       QgsPoint intersectionPoint( 0, 0, 0 );
       int edgePosition = -1;
 
-      bool result = searchIntersectionEdgeFromSnappedVertex_v2(
+      bool result = searchIntersectionEdgeFromSnappedVertex(
                       intersectionFaceIndex,
                       previousSnappedVertex,
                       mCurrentSnappedVertex,
@@ -439,10 +439,12 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
             mNewVerticesIndexesOnLine.append( mVerticesToAdd.count() );
             if ( mInterpolateZValueOnMesh )
-              interPolateZValue( intersectionPoint, mesh->vertex( iv1 ), mesh->vertex( iv2 ) );
+              interPolateZValue( intersectionPoint,
+                                 triangularMesh->vertices().at( iv1 ),
+                                 triangularMesh->vertices().at( iv2 ) );
             else
               interPolateZValue( intersectionPoint, mPoint1, mPoint2 );
-            mVerticesToAdd.append( intersectionPoint );
+            mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersectionPoint ) );
           }
 
           if ( nextCutFace != -1 )
@@ -458,10 +460,12 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             {
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersectionPoint, mesh->vertex( iv1 ), mesh->vertex( iv2 ) );
+                interPolateZValue( intersectionPoint,
+                                   triangularMesh->vertices().at( iv1 ),
+                                   triangularMesh->vertices().at( iv2 ) );
               else
                 interPolateZValue( intersectionPoint, mPoint1, mPoint2 );
-              mVerticesToAdd.append( intersectionPoint );
+              mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersectionPoint ) );
             }
             else
               mNewVerticesIndexesOnLine.removeLast();
@@ -540,10 +544,12 @@ bool QgsMeshEditForceByLine::buildForcedElements()
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               mNewVerticesIndexesOnLine.append( mVerticesToAdd.count() );
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersection, mesh->vertex( iv1 ), mesh->vertex( iv2 ) );
+                interPolateZValue( intersection,
+                                   triangularMesh->vertices().at( iv1 ),
+                                   triangularMesh->vertices().at( iv2 ) );
               else
                 interPolateZValue( intersection, mPoint1, mPoint2 );
-              mVerticesToAdd.append( intersection );
+              mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersection ) );
             }
           }
 
@@ -591,10 +597,12 @@ bool QgsMeshEditForceByLine::buildForcedElements()
             {
               currentAddedVertex = startingVertexIndex + mVerticesToAdd.count();
               if ( mInterpolateZValueOnMesh )
-                interPolateZValue( intersection, mesh->vertex( iv1 ), mesh->vertex( iv2 ) );
+                interPolateZValue( intersection,
+                                   triangularMesh->vertices().at( iv1 ),
+                                   triangularMesh->vertices().at( iv2 ) );
               else
                 interPolateZValue( intersection, mPoint1, mPoint2 );
-              mVerticesToAdd.append( intersection );
+              mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( intersection ) );
             }
             else
               mNewVerticesIndexesOnLine.removeLast();
@@ -705,11 +713,13 @@ bool QgsMeshEditForceByLine::buildForcedElements()
           currentEdge = {mHoleOnLeft.last(), mHoleOnRight.last()};
 
           if ( mInterpolateZValueOnMesh )
-            interPolateZValue( closestIntersectionPoint, mesh->vertex( mHoleOnLeft.last() ), mesh->vertex( mHoleOnRight.last() ) );
+            interPolateZValue( closestIntersectionPoint,
+                               triangularMesh->vertices().at( mHoleOnLeft.last() ),
+                               triangularMesh->vertices().at( mHoleOnRight.last() ) );
           else
             interPolateZValue( closestIntersectionPoint, mPoint1, mPoint2 );
 
-          mVerticesToAdd.append( closestIntersectionPoint );
+          mVerticesToAdd.append( triangularMesh->triangularToNativeCoordinates( closestIntersectionPoint ) );
 
         }
       }
@@ -748,7 +758,7 @@ bool QgsMeshEditForceByLine::buildForcedElements()
 }
 
 
-bool QgsMeshEditForceByLine::searchIntersectionEdgeFromSnappedVertex_v2
+bool QgsMeshEditForceByLine::searchIntersectionEdgeFromSnappedVertex
 ( int &intersectionFaceIndex,
   int &previousSnappedVertex,
   int &currentSnappedVertexIndex,
@@ -762,7 +772,7 @@ bool QgsMeshEditForceByLine::searchIntersectionEdgeFromSnappedVertex_v2
   while ( true )
   {
     treatedVertices.insert( currentSnappedVertexIndex );
-    QList<int> facesAround = mEditor->topologicalMesh().facesAroundVertex( currentSnappedVertexIndex );
+    const QList<int> facesAround = mEditor->topologicalMesh().facesAroundVertex( currentSnappedVertexIndex );
 
     bool foundSomething = false;
     for ( const int faceIndex : std::as_const( facesAround ) )

--- a/src/core/mesh/qgsmeshforcebypolylines.h
+++ b/src/core/mesh/qgsmeshforcebypolylines.h
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsMeshEditForceByLine : public QgsMeshAdvancedEditing
 
     void interpolateZValueOnMesh( QgsPoint &point ) const;
     void interpolateZValueOnMesh( int faceIndex, QgsPoint &point ) const;
-    void interPolateZValue( QgsMeshVertex &point, const QgsPoint &otherPoint1, const QgsPoint &otherPoint2 );
+    void interpolateZValue( QgsMeshVertex &point, const QgsPoint &otherPoint1, const QgsPoint &otherPoint2 );
 
 
     bool buildForcedElements();
@@ -150,10 +150,20 @@ class CORE_EXPORT QgsMeshEditForceByPolylines : public QgsMeshEditForceByLine
 
     bool isFinished() const override;
 
-    //! Adds a input forcing line geometry in rendering coordinates
+    /**
+     * Adds a input forcing line geometry in rendering coordinates
+     *
+     * \note if the geometry is not 3D, the default Z value will be used for the Z value of the geometry's vertices.
+     *       This default Z value has to be set before adding the geometry (\see setDefaultZValue()
+     */
     void addLineFromGeometry( const QgsGeometry &geom );
 
-    //! Adds a list of input forcing lines geometry in rendering coordinates
+    /**
+     * Adds a list of input forcing lines geometry in rendering coordinates
+     *
+     * \note if the geometry is not 3D, the default Z value will be used for the Z value of the geometry's vertices.
+     *       This default Z value has to be set before adding the geometry (\see setDefaultZValue()
+     */
     void addLinesFromGeometries( const QList<QgsGeometry> geometries );
 
   private:

--- a/src/core/mesh/qgsmeshforcebypolylines.h
+++ b/src/core/mesh/qgsmeshforcebypolylines.h
@@ -103,7 +103,7 @@ class CORE_EXPORT QgsMeshEditForceByLine : public QgsMeshAdvancedEditing
                            QgsPoint &intersectionPoint,
                            bool outAllowed );
 
-    bool searchIntersectionEdgeFromSnappedVertex_v2(
+    bool searchIntersectionEdgeFromSnappedVertex(
       int &intersectionFaceIndex,
       int &previousSnappedVertex,
       int &currentSnappedVertexIndex,

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -102,8 +102,7 @@ int QgsMeshVertexCirculator::turnCounterClockwise() const
   else
   {
     int currentPos = positionInCurrentFace();
-    if ( currentPos == -1 )
-      return -1;
+    Q_ASSERT( currentPos != -1 );
 
     const QgsMeshFace &currentFace = mFaces.at( mCurrentFace );
     int faceSize = currentFace.size();
@@ -121,8 +120,7 @@ int QgsMeshVertexCirculator::turnClockwise() const
   else
   {
     int currentPos = positionInCurrentFace();
-    if ( currentPos == -1 )
-      return -1;
+    Q_ASSERT( currentPos != -1 );
 
     const QgsMeshFace &currentFace = mFaces.at( mCurrentFace );
     int faceSize = currentFace.size();
@@ -570,6 +568,9 @@ QgsMeshEditingError QgsTopologicalMesh::checkConsistency() const
     if ( mVertexToFace.at( vertexIndex ) != -1 )
     {
       if ( !mMesh->face( mVertexToFace.at( vertexIndex ) ).contains( vertexIndex ) )
+        return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, vertexIndex );
+
+      if ( facesAroundVertex( vertexIndex ).count() == 0 )
         return QgsMeshEditingError( Qgis::MeshEditingErrorType::InvalidVertex, vertexIndex );
     }
   }


### PR DESCRIPTION
Following the PR #44962 that introduced the force by line tool for mesh editing, this PR aims to:
- fix force by line algorithm when layer CRS/ map CRS are different
- improve the UI and make it more consistent with other parts of QGIS.
- make the tool working with the new CAD Z value

To force by line, the user can either draw a line on the map canvas or select a vector layer feature on the map canvas by right click (same principle as select by polygon, but polyline can be selected).

There are several options that can be used to adapt the behavior. These settings are available in an action widget from the toolbar (existing in the first PR):
- whether vertices are added in the intersection of edge of faces with the forcing line
- either the new vertices have their Z value taken from the mesh (interpolated from the including face) or from the forcing line (interpolated between vertices of the line)
- Tolerance: if existing vertices are at a distance from the forcing line less than this tolerance, the existing vertices will be on result of the forcing line.

When new vertices have their Z value interpolated from the forcing line's vertices, the Z values of the forcing line depend on how the forcing line is entered.

When new vertices have their Z value interpolated from the forcing line's vertices, the Z values of the forcing line depend on how the forcing line is entered.

- forcing line drawn on the map canvas
each vertex will have the Z value of the Z value widget (on the top right of the map canvas) in standard mode or the Z value of the CAD dock widget in advanced digitizing mode.
If the mouse snaps on a mesh vertex or a vector layer feature vertex, Z value widget or CAD dock widget takes the value of snapped vertex and then will be used for the next vertex of the forcing line.

![forceLine_1](https://user-images.githubusercontent.com/7416892/134280004-5c3d9aa9-11d2-4f6f-adf8-eb1c1cdffbf7.gif)

- forcing line from an existing vector layer feature
If the geometry is 3D, the Z values of the geometry will be used. If not, the Z value will be the Z value of the Z value widget.

![forceLine_2](https://user-images.githubusercontent.com/7416892/134280015-cbed9edb-02fa-4da9-b4ee-93e2d8f75d8d.gif)


