### PR TITLE
Fix regexp_replace using null

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1482,13 +1482,10 @@ static QVariant fcnReplace( const QVariantList &values, const QgsExpressionConte
 
 static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  if ( ! values.at( 2 ).isValid() )
-  {
-    return QVariant();
-  }
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+  bool isValid_after{ values.at( 2 ).isValid() };
 
   QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
@@ -1496,6 +1493,12 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );
     return QVariant();
   }
+
+  if ( ! isValid_after && str.contains( re ) ) // fix https://github.com/qgis/QGIS/issues/44274
+  {
+    return QVariant();
+  }
+
   return QVariant( str.replace( re, after ) );
 }
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1485,6 +1485,8 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+  if ( after.isNull() )
+    after = QStringLiteral( "" );
 
   QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )
@@ -6738,7 +6740,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "length3D" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ), fcnLength3D, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "replace" ), -1, fcnReplace, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "regexp_replace" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "input_string" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "regex" ) )
-                                            << QgsExpressionFunction::Parameter( QStringLiteral( "replacement" ) ), fcnRegexpReplace, QStringLiteral( "String" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "replacement" ) ), fcnRegexpReplace, QStringLiteral( "String" ),
+                                            QString(), false, QSet< QString >(), false, QStringList(), true )
         << new QgsStaticExpressionFunction( QStringLiteral( "regexp_substr" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "input_string" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "regex" ) ), fcnRegexpSubstr, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "substr" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "start" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "length" ), true ), fcnSubstr, QStringLiteral( "String" ), QString(),
                                             false, QSet< QString >(), false, QStringList(), true )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1482,6 +1482,10 @@ static QVariant fcnReplace( const QVariantList &values, const QgsExpressionConte
 
 static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+  if ( ! values.at( 2 ).isValid() )
+  {
+    return QVariant();
+  }
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1485,8 +1485,6 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
   QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
-  if ( after.isNull() )
-    after = QString( "" );
 
   QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1486,7 +1486,7 @@ static QVariant fcnRegexpReplace( const QVariantList &values, const QgsExpressio
   QString regexp = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
   QString after = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
   if ( after.isNull() )
-    after = QStringLiteral( "" );
+    after = QString( "" );
 
   QRegularExpression re( regexp, QRegularExpression::UseUnicodePropertiesOption );
   if ( !re.isValid() )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1404,9 +1404,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace non greedy" ) << "regexp_replace('HeLLo','(?<=H).*?L', '-')" << false << QVariant( "H-Lo" );
       QTest::newRow( "regexp_replace cap group" ) << "regexp_replace('HeLLo','(eL)', 'x\\\\1x')" << false << QVariant( "HxeLxLo" );
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
-      QTest::newRow( "regexp_replace match, with null" ) << "regexp_replace('aaaa','a',NULL)" << false << QVariant( "" );
-      QTest::newRow( "regexp_replace not full match, with null" ) << "regexp_replace('aaabbb','b',NULL)" << false << QVariant( "" );
-      QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( "zzz" ); // fix https://github.com/qgis/QGIS/issues/44274
+      QTest::newRow( "regexp_replace match, with null" ) << "regexp_replace('aaaa','a',NULL)" << false << QVariant( ); // fix https://github.com/qgis/QGIS/issues/44274
+      QTest::newRow( "regexp_replace not full match, with null" ) << "regexp_replace('aaabbb','b',NULL)" << false << QVariant( );
+      QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( );
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
       QTest::newRow( "substr named parameters" ) << "substr(string:='HeLLo',start:=3,length:=2)" << false << QVariant( "LL" );
       QTest::newRow( "substr negative start" ) << "substr('HeLLo', -4)" << false << QVariant( "eLLo" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1405,6 +1405,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace cap group" ) << "regexp_replace('HeLLo','(eL)', 'x\\\\1x')" << false << QVariant( "HxeLxLo" );
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
       QTest::newRow( "regexp_replace match, with null" ) << "regexp_replace('aaaa','a',NULL)" << false << QVariant( "" );
+      QTest::newRow( "regexp_replace not full match, with null" ) << "regexp_replace('aaabbb','b',NULL)" << false << QVariant( "" );
       QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( "zzz" ); // fix https://github.com/qgis/QGIS/issues/44274
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
       QTest::newRow( "substr named parameters" ) << "substr(string:='HeLLo',start:=3,length:=2)" << false << QVariant( "LL" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1404,6 +1404,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace non greedy" ) << "regexp_replace('HeLLo','(?<=H).*?L', '-')" << false << QVariant( "H-Lo" );
       QTest::newRow( "regexp_replace cap group" ) << "regexp_replace('HeLLo','(eL)', 'x\\\\1x')" << false << QVariant( "HxeLxLo" );
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
+      QTest::newRow( "regexp_replace match, with null" ) << "regexp_replace('aaaa','a',NULL)" << false << QVariant( "" );
+      QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( "zzz" ); // fix https://github.com/qgis/QGIS/issues/44274
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
       QTest::newRow( "substr named parameters" ) << "substr(string:='HeLLo',start:=3,length:=2)" << false << QVariant( "LL" );
       QTest::newRow( "substr negative start" ) << "substr('HeLLo', -4)" << false << QVariant( "eLLo" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1406,7 +1406,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
       QTest::newRow( "regexp_replace match, with null" ) << "regexp_replace('aaaa','a',NULL)" << false << QVariant( ); // fix https://github.com/qgis/QGIS/issues/44274
       QTest::newRow( "regexp_replace not full match, with null" ) << "regexp_replace('aaabbb','b',NULL)" << false << QVariant( );
-      QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( );
+      QTest::newRow( "regexp_replace no match with null" ) << "regexp_replace('zzz', 'b', NULL)" << false << QVariant( "zzz" );
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
       QTest::newRow( "substr named parameters" ) << "substr(string:='HeLLo',start:=3,length:=2)" << false << QVariant( "LL" );
       QTest::newRow( "substr negative start" ) << "substr('HeLLo', -4)" << false << QVariant( "eLLo" );


### PR DESCRIPTION
## Description

The expression regexp_replace does not handle null value and produce unwanted results when a field has one.

fixes #44274

