### PR TITLE
Fix crash when opening symbology properties of a layer set to embedded renderer which is not compatible with embedded renderers

### DIFF
--- a/src/app/maptools/qgsappmaptools.cpp
+++ b/src/app/maptools/qgsappmaptools.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsappmaptools.h"
+#include "qgisapp.h"
 #include "qgsmaptool.h"
 #include "qgsmaptoolselect.h"
 #include "qgsmaptoolidentifyaction.h"
@@ -101,7 +102,7 @@ QgsStreamDigitizingSettingsAction::QgsStreamDigitizingSettingsAction( QWidget *p
     QgsSettingsRegistryCore::settingsDigitizingStreamTolerance.setValue( value );
   } );
 
-  QWidget *w = new QWidget();
+  QWidget *w = new QWidget( parent );
   w->setLayout( gLayout );
   setDefaultWidget( w );
 }
@@ -181,7 +182,7 @@ QgsAppMapTools::QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockW
   mTools.insert( Tool::EditMeshFrame, new QgsMapToolEditMeshFrame( canvas ) );
   mTools.insert( Tool::AnnotationEdit, new QgsMapToolModifyAnnotation( canvas, cadDock ) );
 
-  mStreamDigitizingSettingsAction = new QgsStreamDigitizingSettingsAction();
+  mStreamDigitizingSettingsAction = new QgsStreamDigitizingSettingsAction( QgisApp::instance() );
 }
 
 QgsAppMapTools::~QgsAppMapTools()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1914,6 +1914,8 @@ QgisApp::~QgisApp()
   mSnappingUtils = nullptr;
   delete mUserInputDockWidget;
   mUserInputDockWidget = nullptr;
+  delete mMapStylingDock;
+  mMapStylingDock = nullptr;
 
   QgsGui::instance()->nativePlatformInterface()->cleanup();
 
@@ -3372,7 +3374,7 @@ void QgisApp::createToolBars()
 
   mDigitizeModeToolButton = new QToolButton();
   mDigitizeModeToolButton->setPopupMode( QToolButton::MenuButtonPopup );
-  QMenu *digitizeMenu = new QMenu();
+  QMenu *digitizeMenu = new QMenu( mDigitizeModeToolButton );
   digitizeMenu->addAction( mActionDigitizeWithCurve );
   digitizeMenu->addAction( mActionStreamDigitize );
   digitizeMenu->addSeparator();
@@ -3854,7 +3856,7 @@ void QgisApp::createToolBars()
 
     QToolButton *meshForceByLinesToolButton = new QToolButton();
     meshForceByLinesToolButton->setPopupMode( QToolButton::MenuButtonPopup );
-    QMenu *meshForceByLineMenu = new QMenu();
+    QMenu *meshForceByLineMenu = new QMenu( meshForceByLinesToolButton );
 
     //meshForceByLineMenu->addActions( editMeshMapTool->forceByLinesActions() );
     meshForceByLinesToolButton->setDefaultAction( editMeshMapTool->defaultForceAction() );
@@ -3875,7 +3877,7 @@ void QgisApp::createToolBars()
 
   QToolButton *annotationLayerToolButton = new QToolButton();
   annotationLayerToolButton->setPopupMode( QToolButton::MenuButtonPopup );
-  QMenu *annotationLayerMenu = new QMenu();
+  QMenu *annotationLayerMenu = new QMenu( annotationLayerToolButton );
   annotationLayerMenu->addAction( mActionCreateAnnotationLayer );
   annotationLayerMenu->addAction( mMainAnnotationLayerProperties );
   annotationLayerToolButton->setMenu( annotationLayerMenu );

--- a/src/core/gps/qgsbabelformatregistry.cpp
+++ b/src/core/gps/qgsbabelformatregistry.cpp
@@ -294,6 +294,9 @@ void QgsBabelFormatRegistry::reloadFromSettings()
     const QString trkDownload = settings.value( QStringLiteral( "%1/trkdownload" ).arg( baseKey ), QVariant(), section ).toString();
     const QString trkUpload = settings.value( QStringLiteral( "%1/trkupload" ).arg( baseKey ), QVariant(), section ).toString();
 
+    // don't leak memory if there's already a device with this name...
+    delete mDevices.value( device );
+
     mDevices[device] = new QgsBabelGpsDeviceFormat( wptDownload,
         wptUpload,
         rteDownload,

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -2652,6 +2652,7 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   delete mSourceCache;
   delete mCalloutRegistry;
   delete mSymbolLayerRegistry;
+  delete mExternalStorageRegistry;
   delete mTaskManager;
   delete mNetworkContentFetcherRegistry;
   delete mClassificationMethodRegistry;

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -326,15 +326,14 @@ void QgsOptionsDialogBase::setCurrentPage( const QString &page )
 
 void QgsOptionsDialogBase::addPage( const QString &title, const QString &tooltip, const QIcon &icon, QWidget *widget, const QStringList &path )
 {
-  QListWidgetItem *item = new QListWidgetItem();
-  item->setIcon( icon );
-  item->setText( title );
-  item->setToolTip( tooltip );
-
   int newPage = -1;
 
   if ( mOptListWidget )
   {
+    QListWidgetItem *item = new QListWidgetItem();
+    item->setIcon( icon );
+    item->setText( title );
+    item->setToolTip( tooltip );
     mOptListWidget->addItem( item );
   }
   else if ( mOptTreeModel )
@@ -409,13 +408,12 @@ void QgsOptionsDialogBase::insertPage( const QString &title, const QString &tool
     {
       //found the "before" page
 
-      QListWidgetItem *item = new QListWidgetItem();
-      item->setIcon( icon );
-      item->setText( title );
-      item->setToolTip( tooltip );
-
       if ( mOptListWidget )
       {
+        QListWidgetItem *item = new QListWidgetItem();
+        item->setIcon( icon );
+        item->setText( title );
+        item->setToolTip( tooltip );
         mOptListWidget->insertItem( page, item );
       }
       else if ( mOptTreeModel )

--- a/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
@@ -49,6 +49,7 @@ QgsEmbeddedSymbolRendererWidget::QgsEmbeddedSymbolRendererWidget( QgsVectorLayer
                                 .arg( layer->name() ), this );
     this->setLayout( layout );
     layout->addWidget( label );
+    mDefaultSymbolToolButton = nullptr;
     return;
   }
   setupUi( this );


### PR DESCRIPTION
Fixes #45159