### PR TITLE
Reduce GEOS conversions and preparations of geometries

### DIFF
--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -405,6 +405,7 @@ will use the same CRS as the source layer/provider.
 .. versionadded:: 3.22
 %End
 
+
     double distanceWithin() const;
 %Docstring
 Returns the maximum distance from the :py:func:`~QgsFeatureRequest.referenceGeometry` of fetched

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -70,11 +70,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mSpatialFilter = rh.mSpatialFilter;
   mFilterRect = rh.mFilterRect;
   mReferenceGeometry = rh.mReferenceGeometry;
-  if ( !mReferenceGeometry.isEmpty() )
-  {
-    mReferenceGeometryEngine.reset( QgsGeometry::createGeometryEngine( mReferenceGeometry.constGet() ) );
-    mReferenceGeometryEngine->prepareGeometry();
-  }
+  mReferenceGeometryEngine = rh.mReferenceGeometryEngine;
   mDistanceWithin = rh.mDistanceWithin;
   mFilterFid = rh.mFilterFid;
   mFilterFids = rh.mFilterFids;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -947,7 +947,7 @@ class CORE_EXPORT QgsFeatureRequest
     /**
      * Prepared geometry engine for mReferenceGeometry.
      */
-    std::unique_ptr< QgsGeometryEngine > mReferenceGeometryEngine;
+    std::shared_ptr< QgsGeometryEngine > mReferenceGeometryEngine;
 
     /**
      * Maximum distance from reference geometry.

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -408,6 +408,16 @@ class CORE_EXPORT QgsFeatureRequest
     QgsGeometry referenceGeometry() const { return mReferenceGeometry; }
 
     /**
+     * Returns the reference geometry engine used for spatial filtering of features.
+     *
+     * This is to avoid re-creating the engine.
+     *
+     * \see referenceGeometry()
+     * \since QGIS 3.22
+     */
+    std::shared_ptr< QgsGeometryEngine > referenceGeometryEngine() const SIP_SKIP { return mReferenceGeometryEngine; }
+
+    /**
      * Returns the maximum distance from the referenceGeometry() of fetched
      * features, if spatialFilterType() is Qgis::SpatialFilterType::DistanceWithin.
      *

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -151,7 +151,7 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
       if ( !mRequest.referenceGeometry().isEmpty() )
       {
         mDistanceWithinGeom = mRequest.referenceGeometry();
-        mDistanceWithinEngine.reset( QgsGeometry::createGeometryEngine( mDistanceWithinGeom.constGet() ) );
+        mDistanceWithinEngine = mRequest.referenceGeometryEngine();
         mDistanceWithinEngine->prepareGeometry();
         mDistanceWithin = mRequest.distanceWithin();
       }

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -272,7 +272,7 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsCoordinateTransform mTransform;
 
     QgsGeometry mDistanceWithinGeom;
-    std::unique_ptr< QgsGeometryEngine > mDistanceWithinEngine;
+    std::shared_ptr< QgsGeometryEngine > mDistanceWithinEngine;
     double mDistanceWithin = 0;
 
     // only related to editing


### PR DESCRIPTION
This is a spin-off of PR #45057 which surfaced a problem with duplicated GEOS conversions and preparations.

In this PR the aim is to reduce the number of GEOS preparation as much as possible.
For testing I'm using a polygon layer containing 310 features and running the "Extract Within Distance" processing algorithm to extract features being within 10 units distance from features of a 1-feature point layer.

It was found, in https://github.com/qgis/QGIS/pull/45057#issuecomment-921852873 that QGIS is running 1550 prepare operations.

The first commit in this PR (using shared_ptr for the GeometryEngine member of QgsFeatureRequest) reduces the preparation to  620 (less than half).

The 620 number probably means that for each of the 310 polygons we're re-preparing the same POINT from the points layer.


