### PR TITLE
Fix deleteholes processing

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/removed_holes.gml
+++ b/python/plugins/processing/tests/testdata/expected/removed_holes.gml
@@ -34,7 +34,7 @@
   </gml:featureMember>
   <gml:featureMember>
     <ogr:removed_holes fid="remove_holes.3">
-      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,6 2,3 10,3 10,6 2,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,6 10,6 10,3 2,3 2,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
     </ogr:removed_holes>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/removed_holes_min_area.gml
+++ b/python/plugins/processing/tests/testdata/expected/removed_holes_min_area.gml
@@ -34,7 +34,7 @@
   </gml:featureMember>
   <gml:featureMember>
     <ogr:removed_holes_min_area fid="remove_holes.3">
-      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,6 2,3 10,3 10,6 2,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>2.5,5.6 2.5,3.5 5.6,3.5 5.6,5.6 2.5,5.6</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,6 10,6 10,3 2,3 2,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>2.5,5.6 2.5,3.5 5.6,3.5 5.6,5.6 2.5,5.6</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
     </ogr:removed_holes_min_area>
   </gml:featureMember>
 </ogr:FeatureCollection>

--- a/src/analysis/processing/qgsalgorithmremoveholes.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveholes.cpp
@@ -111,7 +111,7 @@ QgsFeatureList QgsRemoveHolesAlgorithm::processFeature( const QgsFeature &featur
     if ( mDynamicMinArea )
       minArea = mMinAreaProperty.valueAsDouble( context.expressionContext(), minArea );
 
-    f.setGeometry( geometry.removeInteriorRings( minArea > 0 ? minArea : -1 ) );
+    f.setGeometry( geometry.removeInteriorRings( minArea > 0 ? minArea : -1 ).buffer( 0, 0 ) );
   }
   return QgsFeatureList() << f;
 }


### PR DESCRIPTION
## Description

`native:deleteholes` (and `QgsGeometry::removeInteriorRings`) can return invalid geometry as described in #44424

One solution is to apply the magic `buffer(0)` which will fix the invalid geometry and put the order of the rings in the right direction in the OGC meaning.
