### PR TITLE
Fix Check Geometries plugin crash

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -333,8 +333,7 @@ void QgsGeometryCheckerResultTab::highlightErrors( bool current )
 
   if ( current )
   {
-    QTableWidgetItem *item = ui.tableWidgetErrors->currentItem();
-    if ( item )
+    if ( QTableWidgetItem *item = ui.tableWidgetErrors->currentItem() )
     {
       items.append( item );
     }

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -333,7 +333,11 @@ void QgsGeometryCheckerResultTab::highlightErrors( bool current )
 
   if ( current )
   {
-    items.append( ui.tableWidgetErrors->currentItem() );
+    QTableWidgetItem *item = ui.tableWidgetErrors->currentItem();
+    if ( item )
+    {
+      items.append( item );
+    }
   }
   else
   {


### PR DESCRIPTION
## Description

This PR fixes the issue #44244. `currentItem()` can return a NULL pointer. So, before adding it in the `QList`, check it.