### PR TITLE
Responsive cancellation of paint effects

### DIFF
--- a/python/core/auto_generated/effects/qgsimageoperation.sip.in
+++ b/python/core/auto_generated/effects/qgsimageoperation.sip.in
@@ -52,7 +52,7 @@ Convert a QImage to a grayscale image. Alpha channel is preserved.
 
 :param image: QImage to convert
 :param mode: mode to use during grayscale conversion
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 %End
 
     static void adjustBrightnessContrast( QImage &image, int brightness, double contrast, QgsFeedback *feedback = 0 );
@@ -66,7 +66,7 @@ Alter the brightness or contrast of a QImage.
 :param contrast: contrast value. Must be a positive or zero value. A value of 1.0 indicates no change
                  to the contrast, a value of 0 represents an image with 0 contrast, and a value > 1.0 will increase the
                  contrast of the image.
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 %End
 
     static void adjustHueSaturation( QImage &image, double saturation, const QColor &colorizeColor = QColor(),
@@ -79,7 +79,7 @@ Alter the hue or saturation of a QImage.
 :param colorizeColor: color to use for colorizing image. Set to an invalid QColor to disable
                       colorization.
 :param colorizeStrength: double between 0 and 1, where 0 = no colorization and 1.0 = full colorization
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 %End
 
     static void multiplyOpacity( QImage &image, double factor, QgsFeedback *feedback = 0 );
@@ -88,7 +88,7 @@ Multiplies opacity of image pixel values by a factor.
 
 :param image: QImage to alter
 :param factor: factor to multiple pixel's opacity by
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 %End
 
     static void overlayColor( QImage &image, const QColor &color );
@@ -120,7 +120,7 @@ using a color ramp.
 :param image: QImage to alter
 :param properties: DistanceTransformProperties object with parameters
                    for the distance transform operation
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 %End
 
     static void stackBlur( QImage &image, int radius, bool alphaOnly = false, QgsFeedback *feedback = 0 );
@@ -131,7 +131,7 @@ speed and blur quality.
 :param image: QImage to blur
 :param radius: blur radius in pixels, maximum value of 16
 :param alphaOnly: set to ``True`` to blur only the alpha component of the image
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 
 .. note::
 
@@ -146,7 +146,7 @@ quality blur.
 
 :param image: QImage to blur
 :param radius: blur radius in pixels
-:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
+:param feedback: optional feedback object for responsive cancellation (since QGIS 3.22)
 
 :return: blurred image
 

--- a/python/core/auto_generated/effects/qgsimageoperation.sip.in
+++ b/python/core/auto_generated/effects/qgsimageoperation.sip.in
@@ -118,7 +118,7 @@ using a color ramp.
                    for the distance transform operation
 %End
 
-    static void stackBlur( QImage &image, int radius, bool alphaOnly = false );
+    static void stackBlur( QImage &image, int radius, bool alphaOnly = false, QgsFeedback *feedback = 0 );
 %Docstring
 Performs a stack blur on an image. Stack blur represents a good balance between
 speed and blur quality.
@@ -126,6 +126,7 @@ speed and blur quality.
 :param image: QImage to blur
 :param radius: blur radius in pixels, maximum value of 16
 :param alphaOnly: set to ``True`` to blur only the alpha component of the image
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 
 .. note::
 
@@ -133,13 +134,14 @@ speed and blur quality.
    alphaOnly is set to ``False``, or ARGB32 if alphaOnly is ``True``
 %End
 
-    static QImage *gaussianBlur( QImage &image, int radius ) /Factory/;
+    static QImage *gaussianBlur( QImage &image, int radius, QgsFeedback *feedback = 0 ) /Factory/;
 %Docstring
 Performs a gaussian blur on an image. Gaussian blur is slower but results in a high
 quality blur.
 
 :param image: QImage to blur
 :param radius: blur radius in pixels
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 
 :return: blurred image
 

--- a/python/core/auto_generated/effects/qgsimageoperation.sip.in
+++ b/python/core/auto_generated/effects/qgsimageoperation.sip.in
@@ -46,15 +46,16 @@ on which is faster for the particular operation.
       FlipVertical
     };
 
-    static void convertToGrayscale( QImage &image, GrayscaleMode mode = GrayscaleLuminosity );
+    static void convertToGrayscale( QImage &image, GrayscaleMode mode = GrayscaleLuminosity, QgsFeedback *feedback = 0 );
 %Docstring
 Convert a QImage to a grayscale image. Alpha channel is preserved.
 
 :param image: QImage to convert
 :param mode: mode to use during grayscale conversion
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 %End
 
-    static void adjustBrightnessContrast( QImage &image, int brightness, double contrast );
+    static void adjustBrightnessContrast( QImage &image, int brightness, double contrast, QgsFeedback *feedback = 0 );
 %Docstring
 Alter the brightness or contrast of a QImage.
 
@@ -65,10 +66,11 @@ Alter the brightness or contrast of a QImage.
 :param contrast: contrast value. Must be a positive or zero value. A value of 1.0 indicates no change
                  to the contrast, a value of 0 represents an image with 0 contrast, and a value > 1.0 will increase the
                  contrast of the image.
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 %End
 
     static void adjustHueSaturation( QImage &image, double saturation, const QColor &colorizeColor = QColor(),
-                                     double colorizeStrength = 1.0 );
+                                     double colorizeStrength = 1.0, QgsFeedback *feedback = 0 );
 %Docstring
 Alter the hue or saturation of a QImage.
 
@@ -77,14 +79,16 @@ Alter the hue or saturation of a QImage.
 :param colorizeColor: color to use for colorizing image. Set to an invalid QColor to disable
                       colorization.
 :param colorizeStrength: double between 0 and 1, where 0 = no colorization and 1.0 = full colorization
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 %End
 
-    static void multiplyOpacity( QImage &image, double factor );
+    static void multiplyOpacity( QImage &image, double factor, QgsFeedback *feedback = 0 );
 %Docstring
 Multiplies opacity of image pixel values by a factor.
 
 :param image: QImage to alter
 :param factor: factor to multiple pixel's opacity by
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 %End
 
     static void overlayColor( QImage &image, const QColor &color );
@@ -108,7 +112,7 @@ original image, but replaces all image pixel colors with the specified color.
       QgsColorRamp *ramp;
     };
 
-    static void distanceTransform( QImage &image, const QgsImageOperation::DistanceTransformProperties &properties );
+    static void distanceTransform( QImage &image, const QgsImageOperation::DistanceTransformProperties &properties, QgsFeedback *feedback = 0 );
 %Docstring
 Performs a distance transform on the source image and shades the result
 using a color ramp.
@@ -116,6 +120,7 @@ using a color ramp.
 :param image: QImage to alter
 :param properties: DistanceTransformProperties object with parameters
                    for the distance transform operation
+:param feedback: optional feedback object for responsive cancelation (since QGIS 3.22)
 %End
 
     static void stackBlur( QImage &image, int radius, bool alphaOnly = false, QgsFeedback *feedback = 0 );

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -294,7 +294,36 @@ Returns the targeted DPI for rendering.
 Returns ``True`` if the rendering operation has been stopped and any ongoing
 rendering should be canceled immediately.
 
+.. note::
+
+   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancelation support.
+
 .. seealso:: :py:func:`setRenderingStopped`
+
+.. seealso:: :py:func:`feedback`
+%End
+
+    void setFeedback( QgsFeedback *feedback );
+%Docstring
+Attach a ``feedback`` object that can be queried regularly during rendering to check
+if rendering should be canceled.
+
+Ownership of ``feedback`` is NOT transferred, and the caller must take care that it exists
+for the lifetime of the render context.
+
+.. seealso:: :py:func:`feedback`
+
+.. versionadded:: 3.22
+%End
+
+    QgsFeedback *feedback() const;
+%Docstring
+Returns the feedback object that can be queried regularly during rendering to check
+if rendering should be canceled, if set. Maybe be ``None``.
+
+.. seealso:: :py:func:`setFeedback`
+
+.. versionadded:: 3.22
 %End
 
     bool forceVectorOutput() const;
@@ -436,7 +465,15 @@ Sets whether edit markers should be drawn during the render operation.
 Sets whether the rendering operation has been ``stopped`` and any ongoing
 rendering should be canceled immediately.
 
+.. note::
+
+   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancelation support.
+
 .. seealso:: :py:func:`renderingStopped`
+
+.. seealso:: :py:func:`feedback`
+
+.. seealso:: :py:func:`setFeedback`
 %End
 
     void setDistanceArea( const QgsDistanceArea &distanceArea );

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -296,7 +296,7 @@ rendering should be canceled immediately.
 
 .. note::
 
-   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancelation support.
+   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancellation support.
 
 .. seealso:: :py:func:`setRenderingStopped`
 
@@ -467,7 +467,7 @@ rendering should be canceled immediately.
 
 .. note::
 
-   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancelation support.
+   Since QGIS 3.22 the :py:func:`~QgsRenderContext.feedback` member exists as an alternative means of cancellation support.
 
 .. seealso:: :py:func:`renderingStopped`
 

--- a/src/core/effects/qgsblureffect.cpp
+++ b/src/core/effects/qgsblureffect.cpp
@@ -63,7 +63,7 @@ void QgsBlurEffect::drawGaussianBlur( QgsRenderContext &context )
 void QgsBlurEffect::drawBlurredImage( QgsRenderContext &context, QImage &image )
 {
   //opacity
-  QgsImageOperation::multiplyOpacity( image, mOpacity );
+  QgsImageOperation::multiplyOpacity( image, mOpacity, context.feedback() );
 
   QPainter *painter = context.painter();
   const QgsScopedQPainterState painterState( painter );

--- a/src/core/effects/qgsblureffect.cpp
+++ b/src/core/effects/qgsblureffect.cpp
@@ -47,7 +47,7 @@ void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 {
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   QImage im = sourceAsImage( context )->copy();
-  QgsImageOperation::stackBlur( im, blurLevel, context.feedback() );
+  QgsImageOperation::stackBlur( im, blurLevel, false, context.feedback() );
   drawBlurredImage( context, im );
 }
 

--- a/src/core/effects/qgsblureffect.cpp
+++ b/src/core/effects/qgsblureffect.cpp
@@ -47,15 +47,16 @@ void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 {
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   QImage im = sourceAsImage( context )->copy();
-  QgsImageOperation::stackBlur( im, blurLevel );
+  QgsImageOperation::stackBlur( im, blurLevel, context.feedback() );
   drawBlurredImage( context, im );
 }
 
 void QgsBlurEffect::drawGaussianBlur( QgsRenderContext &context )
 {
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  QImage *im = QgsImageOperation::gaussianBlur( *sourceAsImage( context ), blurLevel );
-  drawBlurredImage( context, *im );
+  QImage *im = QgsImageOperation::gaussianBlur( *sourceAsImage( context ), blurLevel, context.feedback() );
+  if ( !im->isNull() )
+    drawBlurredImage( context, *im );
   delete im;
 }
 

--- a/src/core/effects/qgscoloreffect.cpp
+++ b/src/core/effects/qgscoloreffect.cpp
@@ -43,14 +43,29 @@ void QgsColorEffect::draw( QgsRenderContext &context )
   //rasterize source and apply modifications
   QImage image = sourceAsImage( context )->copy();
 
-  QgsImageOperation::adjustBrightnessContrast( image, mBrightness, mContrast / 100.0 + 1 );
+  QgsImageOperation::adjustBrightnessContrast( image, mBrightness, mContrast / 100.0 + 1, context.feedback() );
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
   if ( mGrayscaleMode != QgsImageOperation::GrayscaleOff )
   {
-    QgsImageOperation::convertToGrayscale( image, static_cast< QgsImageOperation::GrayscaleMode >( mGrayscaleMode ) );
+    QgsImageOperation::convertToGrayscale( image, static_cast< QgsImageOperation::GrayscaleMode >( mGrayscaleMode ), context.feedback() );
   }
-  QgsImageOperation::adjustHueSaturation( image, mSaturation, mColorizeOn ? mColorizeColor : QColor(), mColorizeStrength / 100.0 );
 
-  QgsImageOperation::multiplyOpacity( image, mOpacity );
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
+  QgsImageOperation::adjustHueSaturation( image, mSaturation, mColorizeOn ? mColorizeColor : QColor(), mColorizeStrength / 100.0, context.feedback() );
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
+  QgsImageOperation::multiplyOpacity( image, mOpacity, context.feedback() );
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
   QgsScopedQPainterState painterState( painter );
   painter->setCompositionMode( mBlendMode );
   painter->drawImage( imageOffset( context ), image );

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -73,7 +73,7 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   if ( blurLevel <= 16 )
   {
-    QgsImageOperation::stackBlur( im, blurLevel, context.feedback() );
+    QgsImageOperation::stackBlur( im, blurLevel, false, context.feedback() );
   }
   else
   {

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -70,12 +70,13 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   if ( blurLevel <= 16 )
   {
-    QgsImageOperation::stackBlur( im, blurLevel );
+    QgsImageOperation::stackBlur( im, blurLevel, context.feedback() );
   }
   else
   {
-    QImage *imb = QgsImageOperation::gaussianBlur( im, blurLevel );
-    im = QImage( *imb );
+    QImage *imb = QgsImageOperation::gaussianBlur( im, blurLevel, context.feedback() );
+    if ( !imb->isNull() )
+      im = QImage( *imb );
     delete imb;
   }
 

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -65,7 +65,10 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
   dtProps.useMaxDistance = false;
   dtProps.shadeExterior = shadeExterior();
   dtProps.ramp = ramp;
-  QgsImageOperation::distanceTransform( im, dtProps );
+  QgsImageOperation::distanceTransform( im, dtProps, context.feedback() );
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
 
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   if ( blurLevel <= 16 )
@@ -80,7 +83,13 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
     delete imb;
   }
 
-  QgsImageOperation::multiplyOpacity( im, mOpacity );
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
+  QgsImageOperation::multiplyOpacity( im, mOpacity, context.feedback() );
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
 
   if ( !shadeExterior() )
   {

--- a/src/core/effects/qgsimageoperation.h
+++ b/src/core/effects/qgsimageoperation.h
@@ -73,7 +73,7 @@ class CORE_EXPORT QgsImageOperation
      * Convert a QImage to a grayscale image. Alpha channel is preserved.
      * \param image QImage to convert
      * \param mode mode to use during grayscale conversion
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      */
     static void convertToGrayscale( QImage &image, GrayscaleMode mode = GrayscaleLuminosity, QgsFeedback *feedback = nullptr );
 
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsImageOperation
      * \param contrast contrast value. Must be a positive or zero value. A value of 1.0 indicates no change
      * to the contrast, a value of 0 represents an image with 0 contrast, and a value > 1.0 will increase the
      * contrast of the image.
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      */
     static void adjustBrightnessContrast( QImage &image, int brightness, double contrast, QgsFeedback *feedback = nullptr );
 
@@ -97,7 +97,7 @@ class CORE_EXPORT QgsImageOperation
      * \param colorizeColor color to use for colorizing image. Set to an invalid QColor to disable
      * colorization.
      * \param colorizeStrength double between 0 and 1, where 0 = no colorization and 1.0 = full colorization
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      */
     static void adjustHueSaturation( QImage &image, double saturation, const QColor &colorizeColor = QColor(),
                                      double colorizeStrength = 1.0, QgsFeedback *feedback = nullptr );
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsImageOperation
      * Multiplies opacity of image pixel values by a factor.
      * \param image QImage to alter
      * \param factor factor to multiple pixel's opacity by
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      */
     static void multiplyOpacity( QImage &image, double factor, QgsFeedback *feedback = nullptr );
 
@@ -153,7 +153,7 @@ class CORE_EXPORT QgsImageOperation
      * \param image QImage to alter
      * \param properties DistanceTransformProperties object with parameters
      * for the distance transform operation
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      */
     static void distanceTransform( QImage &image, const QgsImageOperation::DistanceTransformProperties &properties, QgsFeedback *feedback = nullptr );
 
@@ -163,7 +163,7 @@ class CORE_EXPORT QgsImageOperation
      * \param image QImage to blur
      * \param radius blur radius in pixels, maximum value of 16
      * \param alphaOnly set to TRUE to blur only the alpha component of the image
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      * \note for fastest operation, ensure the source image is ARGB32_Premultiplied if
      * alphaOnly is set to FALSE, or ARGB32 if alphaOnly is TRUE
      */
@@ -174,7 +174,7 @@ class CORE_EXPORT QgsImageOperation
      * quality blur.
      * \param image QImage to blur
      * \param radius blur radius in pixels
-     * \param feedback optional feedback object for responsive cancelation (since QGIS 3.22)
+     * \param feedback optional feedback object for responsive cancellation (since QGIS 3.22)
      * \returns blurred image
      * \note for fastest operation, ensure the source image is ARGB32_Premultiplied
      */

--- a/src/core/effects/qgsimageoperation.h
+++ b/src/core/effects/qgsimageoperation.h
@@ -27,6 +27,7 @@
 #include <cmath>
 
 class QgsColorRamp;
+class QgsFeedback;
 
 /**
  * \ingroup core
@@ -442,6 +443,9 @@ class CORE_EXPORT QgsImageOperation
           p += increment;
           for ( int j = 1; j < lineLength; ++j, p += increment )
           {
+            if ( mFeedback && mFeedback->isCanceled() )
+              break;
+
             for ( int i = mi1; i <= mi2; ++i )
             {
               p[i] = ( rgba[i] += ( ( p[i] << 4 ) - rgba[i] ) * mAlpha / 16 ) >> 4;

--- a/src/core/effects/qgsimageoperation.h
+++ b/src/core/effects/qgsimageoperation.h
@@ -264,8 +264,8 @@ class CORE_EXPORT QgsImageOperation
     };
 
     //for linear operations
-    template <typename LineOperation> static void runLineOperation( QImage &image, LineOperation &operation );
-    template <class LineOperation> static void runLineOperationOnWholeImage( QImage &image, LineOperation &operation );
+    template <typename LineOperation> static void runLineOperation( QImage &image, LineOperation &operation, QgsFeedback *feedback = nullptr );
+    template <class LineOperation> static void runLineOperationOnWholeImage( QImage &image, LineOperation &operation, QgsFeedback *feedback = nullptr );
     template <class LineOperation>
     struct ProcessBlockUsingLineOperation
     {
@@ -437,6 +437,9 @@ class CORE_EXPORT QgsImageOperation
 
         void operator()( QRgb *startRef, int lineLength, int bytesPerLine )
         {
+          if ( mFeedback && mFeedback->isCanceled() )
+            return;
+
           unsigned char *p = reinterpret_cast< unsigned char * >( startRef );
           int rgba[4];
           int increment = ( mDirection == QgsImageOperation::ByRow ) ? 4 : bytesPerLine;

--- a/src/core/effects/qgspainteffect.cpp
+++ b/src/core/effects/qgspainteffect.cpp
@@ -221,7 +221,7 @@ void QgsDrawSourceEffect::draw( QgsRenderContext &context )
   {
     //rasterize source and apply modifications
     QImage image = sourceAsImage( context )->copy();
-    QgsImageOperation::multiplyOpacity( image, mOpacity );
+    QgsImageOperation::multiplyOpacity( image, mOpacity, context.feedback() );
     const QgsScopedQPainterState painterState( painter );
     painter->setCompositionMode( mBlendMode );
     painter->drawImage( imageOffset( context ), image );

--- a/src/core/effects/qgsshadoweffect.cpp
+++ b/src/core/effects/qgsshadoweffect.cpp
@@ -49,12 +49,13 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   if ( blurLevel <= 16 )
   {
-    QgsImageOperation::stackBlur( colorisedIm, blurLevel );
+    QgsImageOperation::stackBlur( colorisedIm, blurLevel, context.feedback() );
   }
   else
   {
-    QImage *imb = QgsImageOperation::gaussianBlur( colorisedIm, blurLevel );
-    colorisedIm = QImage( *imb );
+    QImage *imb = QgsImageOperation::gaussianBlur( colorisedIm, blurLevel, context.feedback() );
+    if ( !imb->isNull() )
+      colorisedIm = QImage( *imb );
     delete imb;
   }
 

--- a/src/core/effects/qgsshadoweffect.cpp
+++ b/src/core/effects/qgsshadoweffect.cpp
@@ -66,7 +66,7 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
                          -offsetDist * std::sin( angleRad + M_PI_2 ) );
 
   //transparency, scale
-  QgsImageOperation::multiplyOpacity( colorisedIm, mOpacity );
+  QgsImageOperation::multiplyOpacity( colorisedIm, mOpacity, context.feedback() );
 
   if ( !exteriorShadow() )
   {

--- a/src/core/effects/qgsshadoweffect.cpp
+++ b/src/core/effects/qgsshadoweffect.cpp
@@ -31,7 +31,13 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
   if ( !source() || !enabled() || !context.painter() )
     return;
 
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
+
   QImage colorisedIm = sourceAsImage( context )->copy();
+
+  if ( context.feedback() && context.feedback()->isCanceled() )
+    return;
 
   QPainter *painter = context.painter();
   const QgsScopedQPainterState painterState( painter );
@@ -49,7 +55,7 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
   const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
   if ( blurLevel <= 16 )
   {
-    QgsImageOperation::stackBlur( colorisedIm, blurLevel, context.feedback() );
+    QgsImageOperation::stackBlur( colorisedIm, blurLevel, false, context.feedback() );
   }
   else
   {

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -526,7 +526,10 @@ std::vector<LayerRenderJob> QgsMapRendererJob::prepareJobs( QPainter *painter, Q
     layerTime.start();
     job.renderer = ml->createMapRenderer( *( job.context() ) );
     if ( job.renderer )
+    {
       job.renderer->setLayerRenderingTimeHint( job.estimatedRenderingTime );
+      job.context()->setFeedback( job.renderer->feedback() );
+    }
 
     // If we are drawing with an alternative blending mode then we need to render to a separate image
     // before compositing this on the map. This effectively flattens the layer and prevents
@@ -744,6 +747,10 @@ std::vector< LayerRenderJob > QgsMapRendererJob::prepareSecondPassJobs( std::vec
     // the first pass job, would be to be able to call QgsMapLayerRenderer::render() with a QgsRenderContext.
     QgsVectorLayerRenderer *mapRenderer = static_cast<QgsVectorLayerRenderer *>( vl1->createMapRenderer( *job2.context() ) );
     job2.renderer = mapRenderer;
+    if ( job2.renderer )
+    {
+      job2.context()->setFeedback( job2.renderer->feedback() );
+    }
 
     // Modify the render context so that symbol layers get disabled as needed.
     // The map renderer stores a reference to the context, so we can modify it even after the map renderer creation (what we need here)

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -50,6 +50,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mOriginalMapExtent( rh.mOriginalMapExtent )
   , mMapToPixel( rh.mMapToPixel )
   , mRenderingStopped( rh.mRenderingStopped )
+  , mFeedback( rh.mFeedback )
   , mScaleFactor( rh.mScaleFactor )
   , mDpiTarget( rh.mDpiTarget )
   , mRendererScale( rh.mRendererScale )
@@ -89,6 +90,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mOriginalMapExtent = rh.mOriginalMapExtent;
   mMapToPixel = rh.mMapToPixel;
   mRenderingStopped = rh.mRenderingStopped;
+  mFeedback = rh.mFeedback;
   mScaleFactor = rh.mScaleFactor;
   mDpiTarget = rh.mDpiTarget;
   mRendererScale = rh.mRendererScale;
@@ -175,6 +177,16 @@ void QgsRenderContext::setTransformContext( const QgsCoordinateTransformContext 
 #ifdef QGISDEBUG
   mHasTransformContext = true;
 #endif
+}
+
+void QgsRenderContext::setFeedback( QgsFeedback *feedback )
+{
+  mFeedback = feedback;
+}
+
+QgsFeedback *QgsRenderContext::feedback() const
+{
+  return mFeedback;
 }
 
 void QgsRenderContext::setFlags( QgsRenderContext::Flags flags )

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -344,9 +344,35 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * Returns TRUE if the rendering operation has been stopped and any ongoing
      * rendering should be canceled immediately.
      *
+     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancelation support.
+     *
      * \see setRenderingStopped()
+     * \see feedback()
      */
     bool renderingStopped() const {return mRenderingStopped;}
+
+    /**
+     * Attach a \a feedback object that can be queried regularly during rendering to check
+     * if rendering should be canceled.
+     *
+     * Ownership of \a feedback is NOT transferred, and the caller must take care that it exists
+     * for the lifetime of the render context.
+     *
+     * \see feedback()
+     *
+     * \since QGIS 3.22
+     */
+    void setFeedback( QgsFeedback *feedback );
+
+    /**
+     * Returns the feedback object that can be queried regularly during rendering to check
+     * if rendering should be canceled, if set. Maybe be NULLPTR.
+     *
+     * \see setFeedback()
+     *
+     * \since QGIS 3.22
+     */
+    QgsFeedback *feedback() const;
 
     /**
      * Returns TRUE if rendering operations should use vector operations instead
@@ -482,7 +508,11 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * Sets whether the rendering operation has been \a stopped and any ongoing
      * rendering should be canceled immediately.
      *
+     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancelation support.
+     *
      * \see renderingStopped()
+     * \see feedback()
+     * \see setFeedback()
      */
     void setRenderingStopped( bool stopped ) {mRenderingStopped = stopped;}
 
@@ -974,6 +1004,9 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
 
     //! True if the rendering has been canceled
     bool mRenderingStopped = false;
+
+    //! Optional feedback object, as an alternative for mRenderingStopped for cancelation support
+    QgsFeedback *mFeedback = nullptr;
 
     //! Factor to scale line widths and point marker sizes
     double mScaleFactor = 1.0;

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -344,7 +344,7 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * Returns TRUE if the rendering operation has been stopped and any ongoing
      * rendering should be canceled immediately.
      *
-     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancelation support.
+     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancellation support.
      *
      * \see setRenderingStopped()
      * \see feedback()
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      * Sets whether the rendering operation has been \a stopped and any ongoing
      * rendering should be canceled immediately.
      *
-     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancelation support.
+     * \note Since QGIS 3.22 the feedback() member exists as an alternative means of cancellation support.
      *
      * \see renderingStopped()
      * \see feedback()
@@ -1005,7 +1005,7 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     //! True if the rendering has been canceled
     bool mRenderingStopped = false;
 
-    //! Optional feedback object, as an alternative for mRenderingStopped for cancelation support
+    //! Optional feedback object, as an alternative for mRenderingStopped for cancellation support
     QgsFeedback *mFeedback = nullptr;
 
     //! Factor to scale line widths and point marker sizes

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -37,6 +37,7 @@
 #include "qgssymbol.h"
 #include "qgsmarkersymbol.h"
 #include "qgslinesymbol.h"
+#include "qgsfeedback.h"
 
 #include <QPainter>
 #include <QFile>
@@ -1287,6 +1288,11 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
   int pointsHeight = static_cast< int >( std::round( points.boundingRect().height() ) );
   int imWidth = pointsWidth + ( sideBuffer * 2 );
   int imHeight = pointsHeight + ( sideBuffer * 2 );
+
+  // these are all potentially very expensive operations, so check regularly if the job is canceled and abort responsively
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
+
   std::unique_ptr< QImage > fillImage = std::make_unique< QImage >( imWidth,
                                         imHeight, QImage::Format_ARGB32_Premultiplied );
   if ( fillImage->isNull() )
@@ -1294,6 +1300,9 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
     QgsMessageLog::logMessage( QObject::tr( "Could not allocate sufficient memory for shapeburst fill" ) );
     return;
   }
+
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
 
   //also create an image to store the alpha channel
   std::unique_ptr< QImage > alphaImage = std::make_unique< QImage >( fillImage->width(), fillImage->height(), QImage::Format_ARGB32_Premultiplied );
@@ -1303,13 +1312,22 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
     return;
   }
 
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
+
   //Fill this image with black. Initially the distance transform is drawn in greyscale, where black pixels have zero distance from the
   //polygon boundary. Since we don't care about pixels which fall outside the polygon, we start with a black image and then draw over it the
   //polygon in white. The distance transform function then fills in the correct distance values for the white pixels.
   fillImage->fill( Qt::black );
 
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
+
   //initially fill the alpha channel image with a transparent color
   alphaImage->fill( Qt::transparent );
+
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
 
   //now, draw the polygon in the alpha channel image
   QPainter imgPainter;
@@ -1320,6 +1338,9 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
   imgPainter.translate( -points.boundingRect().left() + sideBuffer, - points.boundingRect().top() + sideBuffer );
   _renderPolygon( &imgPainter, points, rings, context );
   imgPainter.end();
+
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
 
   //now that we have a render of the polygon in white, draw this onto the shapeburst fill image too
   //(this avoids calling _renderPolygon twice, since that can be slow)
@@ -1339,6 +1360,9 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
     _renderPolygon( &imgPainter, points, nullptr, context );
   }
   imgPainter.end();
+
+  if ( context.renderContext().feedback() && context.renderContext().feedback()->isCanceled() )
+    return;
 
   //apply distance transform to image, uses the current color ramp to calculate final pixel colors
   double *dtArray = distanceTransform( fillImage.get(), context.renderContext() );

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -1357,7 +1357,7 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
   //apply blur if desired
   if ( blurRadius > 0 )
   {
-    QgsImageOperation::stackBlur( *fillImage, blurRadius, false );
+    QgsImageOperation::stackBlur( *fillImage, blurRadius, false, context.renderContext().feedback() );
   }
 
   //apply alpha channel to distance transform image, so that areas outside the polygon are transparent

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -1372,7 +1372,7 @@ void QgsShapeburstFillSymbolLayer::renderPolygon( const QPolygonF &points, const
                    context.renderContext(), useWholeShape, outputPixelMaxDist );
   if ( context.opacity() < 1 )
   {
-    QgsImageOperation::multiplyOpacity( *fillImage, context.opacity() );
+    QgsImageOperation::multiplyOpacity( *fillImage, context.opacity(), context.renderContext().feedback() );
   }
 
   //clean up some variables

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -2249,7 +2249,7 @@ void QgsSvgMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext
       usePict = false;
 
       if ( context.selected() )
-        QgsImageOperation::adjustHueSaturation( img, 1.0, context.renderContext().selectionColor(), 1.0 );
+        QgsImageOperation::adjustHueSaturation( img, 1.0, context.renderContext().selectionColor(), 1.0, context.renderContext().feedback() );
 
       //consider transparency
       if ( !qgsDoubleNear( context.opacity(), 1.0 ) )
@@ -2965,7 +2965,7 @@ void QgsRasterMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderCont
   if ( !img.isNull() )
   {
     if ( context.selected() )
-      QgsImageOperation::adjustHueSaturation( img, 1.0, context.renderContext().selectionColor(), 1.0 );
+      QgsImageOperation::adjustHueSaturation( img, 1.0, context.renderContext().selectionColor(), 1.0, context.renderContext().feedback() );
 
     p->drawImage( -img.width() / 2.0, -img.height() / 2.0, img );
   }

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -51,8 +51,6 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
   , mLayer( layer )
   , mFields( layer->fields() )
   , mSource( std::make_unique< QgsVectorLayerFeatureSource >( layer ) )
-  , mLabeling( false )
-  , mDiagrams( false )
 {
   std::unique_ptr< QgsFeatureRenderer > mainRenderer( layer->renderer() ? layer->renderer()->clone() : nullptr );
 

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -47,13 +47,13 @@
 
 QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
+  , mFeedback( std::make_unique< QgsFeedback >() )
   , mLayer( layer )
   , mFields( layer->fields() )
+  , mSource( std::make_unique< QgsVectorLayerFeatureSource >( layer ) )
   , mLabeling( false )
   , mDiagrams( false )
 {
-  mSource = std::make_unique< QgsVectorLayerFeatureSource >( layer );
-
   std::unique_ptr< QgsFeatureRenderer > mainRenderer( layer->renderer() ? layer->renderer()->clone() : nullptr );
 
   if ( !mainRenderer )
@@ -160,14 +160,10 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( context, layer );
 
-  for ( const std::unique_ptr< QgsFeatureRenderer > &renderer : mRenderers )
+  if ( std::any_of( mRenderers.begin(), mRenderers.end(), []( const auto & renderer ) { return renderer->forceRasterRender(); } ) )
   {
-    if ( renderer->forceRasterRender() )
-    {
-      //raster rendering is forced for this layer
-      mForceRasterRender = true;
-      break;
-    }
+    //raster rendering is forced for this layer
+    mForceRasterRender = true;
   }
 
   if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) &&
@@ -191,7 +187,7 @@ void QgsVectorLayerRenderer::setLayerRenderingTimeHint( int time )
 
 QgsFeedback *QgsVectorLayerRenderer::feedback() const
 {
-  return mInterruptionChecker.get();
+  return mFeedback.get();
 }
 
 bool QgsVectorLayerRenderer::forceRasterRender() const
@@ -250,8 +246,6 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
 
   QgsScopedQPainterState painterState( context.painter() );
 
-  // MUST be created in the thread doing the rendering
-  mInterruptionChecker = std::make_unique< QgsVectorLayerRendererInterruptionChecker >( context );
   bool usingEffect = false;
   if ( renderer->paintEffect() && renderer->paintEffect()->enabled() )
   {
@@ -394,17 +388,17 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
     context.setVectorSimplifyMethod( vectorMethod );
   }
 
-  featureRequest.setFeedback( mInterruptionChecker.get() );
+  featureRequest.setFeedback( mFeedback.get() );
   // also set the interruption checker for the expression context, in case the renderer uses some complex expression
   // which could benefit from early exit paths...
-  context.expressionContext().setFeedback( mInterruptionChecker.get() );
+  context.expressionContext().setFeedback( mFeedback.get() );
 
   QgsFeatureIterator fit = mSource->getFeatures( featureRequest );
   // Attach an interruption checker so that iterators that have potentially
   // slow fetchFeature() implementations, such as in the WFS provider, can
   // check it, instead of relying on just the mContext.renderingStopped() check
   // in drawRenderer()
-  fit.setInterruptionChecker( mInterruptionChecker.get() );
+  fit.setInterruptionChecker( mFeedback.get() );
 
   if ( ( renderer->capabilities() & QgsFeatureRenderer::SymbolLevels ) && renderer->usingSymbolLevels() )
     drawRendererLevels( renderer, fit );
@@ -422,7 +416,6 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
   }
 
   context.expressionContext().setFeedback( nullptr );
-  mInterruptionChecker.reset();
   return true;
 }
 
@@ -783,23 +776,3 @@ void QgsVectorLayerRenderer::prepareDiagrams( QgsVectorLayer *layer, QSet<QStrin
   }
 }
 
-/*  -----------------------------------------  */
-/*  QgsVectorLayerRendererInterruptionChecker  */
-/*  -----------------------------------------  */
-
-QgsVectorLayerRendererInterruptionChecker::QgsVectorLayerRendererInterruptionChecker
-( const QgsRenderContext &context )
-  : mContext( context )
-  , mTimer( new QTimer( this ) )
-{
-  connect( mTimer, &QTimer::timeout, this, [ = ]
-  {
-    if ( mContext.renderingStopped() )
-    {
-      mTimer->stop();
-      cancel();
-    }
-  } );
-  mTimer->start( 50 );
-
-}

--- a/src/core/vector/qgsvectorlayerrenderer.h
+++ b/src/core/vector/qgsvectorlayerrenderer.h
@@ -50,24 +50,6 @@ class QgsVectorLayerDiagramProvider;
 
 /**
  * \ingroup core
- * \brief Interruption checker used by QgsVectorLayerRenderer::render()
- * \note not available in Python bindings
- */
-class QgsVectorLayerRendererInterruptionChecker: public QgsFeedback
-{
-    Q_OBJECT
-
-  public:
-    //! Constructor
-    explicit QgsVectorLayerRendererInterruptionChecker( const QgsRenderContext &context );
-
-  private:
-    const QgsRenderContext &mContext;
-    QTimer *mTimer = nullptr;
-};
-
-/**
- * \ingroup core
  * \brief Implementation of threaded rendering for vector layers.
  *
  * \note not available in Python bindings
@@ -117,9 +99,10 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
 
     bool renderInternal( QgsFeatureRenderer *renderer );
-  protected:
 
-    std::unique_ptr< QgsVectorLayerRendererInterruptionChecker > mInterruptionChecker;
+  private:
+
+    std::unique_ptr<QgsFeedback> mFeedback = nullptr;
 
     //! The rendered layer
     QgsVectorLayer *mLayer = nullptr;

--- a/src/core/vector/qgsvectorlayerrenderer.h
+++ b/src/core/vector/qgsvectorlayerrenderer.h
@@ -127,11 +127,6 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
     QSet<QString> mAttrNames;
 
-    //! used with old labeling engine (QgsPalLabeling): whether labeling is enabled
-    bool mLabeling;
-    //! used with new labeling engine (QgsPalLabeling): whether diagrams are enabled
-    bool mDiagrams;
-
     /**
      * used with new labeling engine (QgsLabelingEngine): provider for labels.
      * may be NULLPTR. no need to delete: if exists it is owned by labeling engine


### PR DESCRIPTION
This PR adds support for responsive cancelation of paint effects. These can potentially be very expensive to calculate, especially when a user accidentally sets a too-large blur radius or similar. Previously this would cause QGIS to burn away cpu in background threads trying to calculate the paint effect, even for map render jobs which had been canceled.

Now, we proxy the map layer renderer's QgsFeedback object through QgsRenderContext to the QgsDrawEffect/QgsImageOperation methods, so that the expensive code paths in these classes have a way to test if the render is canceled and they should early exit.

Refs https://github.com/qgis/QGIS/issues/41149, but doesn't fix that issue (it's still possible to hang the UI for large periods of time if excessive blur radius are set for symbols, as the layer tree and symbol preview icon generation are run in the main thread and have no way to cancel these renders. In order to fully fix the bug we'd also need to implement limits on the blur sizes used for these symbol icons)