### PR TITLE
Fix error highlight in geometry checker

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -349,7 +349,9 @@ void QgsGeometryCheckerResultTab::highlightErrors( bool current )
       QgsRubberBand *featureRubberBand = new QgsRubberBand( mIface->mapCanvas() );
       featureRubberBand->setToGeometry( geom, nullptr );
       featureRubberBand->setWidth( 5 );
-      featureRubberBand->setColor( Qt::yellow );
+      QColor color( Qt::yellow );
+      color.setAlpha( 43 );
+      featureRubberBand->setColor( color );
       mCurrentRubberBands.append( featureRubberBand );
     }
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -347,7 +347,7 @@ void QgsGeometryCheckerResultTab::highlightErrors( bool current )
     if ( ui.checkBoxHighlight->isChecked() && !geom.isNull() )
     {
       QgsRubberBand *featureRubberBand = new QgsRubberBand( mIface->mapCanvas() );
-      featureRubberBand->addGeometry( geom, nullptr );
+      featureRubberBand->setToGeometry( geom, nullptr );
       featureRubberBand->setWidth( 5 );
       featureRubberBand->setColor( Qt::yellow );
       mCurrentRubberBands.append( featureRubberBand );


### PR DESCRIPTION
## Description

Fix the issue #44245. There are 2 problems, the geometry type of the `QgsRubberBand` object isn't update. The second one is that the alpha channel isn't set.

Before:

![Screenshot_20210923_111115](https://user-images.githubusercontent.com/37629967/134483348-f7df2595-85a2-4711-a812-de4d2228ccf7.png) ![Screenshot_20210923_111151](https://user-images.githubusercontent.com/37629967/134483365-e169e699-5d8a-46a0-9f64-5589b175e88b.png)


After:
![Screenshot_20210923_110452](https://user-images.githubusercontent.com/37629967/134483377-2213e7f1-f855-4997-a7ad-f8a77fd331ad.png) ![Screenshot_20210923_110416](https://user-images.githubusercontent.com/37629967/134483385-099b9b0d-b0ef-4221-b34d-f14d710ab6ca.png)


