### PR TITLE
Fix Z/M dimension URI via DB Manager. Fixes #34894

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -319,7 +319,7 @@ class PGVectorTable(PGTable, VectorTable):
         | LineStringZM | LineString  | 4       |
         """
         geometryType = self.geomType
-        if self.geomDim == 3 and not self.geomType[-1] == "M":
+        if self.geomDim == 3 and self.geomType[-1] != "M":
             geometryType += "Z"
         elif self.geomDim == 4:
             geometryType += "ZM"

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -308,6 +308,24 @@ class PGVectorTable(PGTable, VectorTable):
             return True
         return VectorTable.runAction(self, action)
 
+    def geometryType(self):
+        """ Returns the proper WKT type.
+        PostGIS records type like this:
+        | WKT Type     | geomType    | geomDim |
+        |--------------|-------------|---------|
+        | LineString   | LineString  | 2       |
+        | LineStringZ  | LineString  | 3       |
+        | LineStringM  | LineStringM | 3       |
+        | LineStringZM | LineString  | 4       |
+        """
+        geometryType = self.geomType
+        if self.geomDim == 3 and not self.geomType[-1] == "M":
+            geometryType += "Z"
+        elif self.geomDim == 4:
+            geometryType += "ZM"
+
+        return geometryType
+
 
 class PGRasterTable(PGTable, RasterTable):
 

--- a/python/plugins/db_manager/db_tree.py
+++ b/python/plugins/db_manager/db_tree.py
@@ -159,7 +159,7 @@ class DBTree(QTreeView):
     def addLayer(self):
         table = self.currentTable()
         if table is not None:
-            layer = table.toMapLayer()
+            layer = table.toMapLayer(table.geometryType())
             layers = QgsProject.instance().addMapLayers([layer])
             if len(layers) != 1:
                 QgsMessageLog.logMessage(


### PR DESCRIPTION
## Description

As described in #34894 the DB Manager adds postgis layer with a wrong wkb type. 

PostGIS records type like this:
| WKT Type     | geomType    | geomDim |
|--------------|-------------|---------|
| LineString   | LineString  | 2       |
| LineStringZ  | LineString  | 3       |
| LineStringM  | LineStringM | 3       |
| LineStringZM | LineString  | 4       |

So we have to enforce the `wkbtype` in the `uri`