### PR TITLE
 QgisApp::closeProject(): cancel canvas jobs before closing the project, ...

### DIFF
--- a/external/laz-perf/io.hpp
+++ b/external/laz-perf/io.hpp
@@ -599,7 +599,7 @@ namespace laszip {
 							//
 							laszipFound = true;
 
-							std::unique_ptr<char> buffer(
+							std::unique_ptr<char[]> buffer(
                                 new char[vlr_header.record_length]);
 
 							f_.read(buffer.get(), vlr_header.record_length);
@@ -977,7 +977,7 @@ namespace laszip {
 					//
 					laz_vlr vlr = laz_vlr::from_schema(schema_, chunk_size_);
 
-                    std::unique_ptr<char> vlrbuf(new char[vlr.size()]);
+                    std::unique_ptr<char[]> vlrbuf(new char[vlr.size()]);
                     vlr.extract(vlrbuf.get());
                     f_.write(vlrbuf.get(), vlr.size());
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -149,6 +149,7 @@ Make sure to remove any rendered images from cache (does nothing if cache is not
 .. versionadded:: 2.4
 %End
 
+
     void waitWhileRendering();
 %Docstring
 Blocks until the rendering job has finished.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13988,6 +13988,7 @@ void QgisApp::closeProject()
   // clear out any stuff from project
   mMapCanvas->setLayers( QList<QgsMapLayer *>() );
   mMapCanvas->clearCache();
+  mMapCanvas->cancelJobs();
   mOverviewCanvas->setLayers( QList<QgsMapLayer *>() );
 
   // Avoid unnecessary layer changed handling for each layer removed - instead,

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -201,6 +201,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     void clearCache();
 
     /**
+     * Cancel any rendering job, in a blocking way. Used for application closing.
+     * \note not available in Python bindings
+     */
+    void cancelJobs() SIP_SKIP;
+
+    /**
      * Blocks until the rendering job has finished.
      *
      * In almost all cases you do NOT want to call this, as it will hang the UI


### PR DESCRIPTION
...  to avoid rendering jobs to access deleted objects (fixes #44144)