### PR TITLE
Cad dock z/m follow up fixes

### DIFF
--- a/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -70,6 +70,15 @@ Unregisters this maptool from the cad dock widget
 
     QgsAdvancedDigitizingDockWidget *cadDockWidget() const;
 
+    virtual QgsMapLayer *layer() const;
+%Docstring
+Returns the layer associated with the map tool.
+
+By default this returns the map canvas' :py:func:`QgsMapCanvas.currentLayer()`.
+
+.. versionadded:: 3.22
+%End
+
     bool isAdvancedDigitizingAllowed() const;
 %Docstring
 Returns whether functionality of advanced digitizing dock widget is currently allowed.

--- a/python/gui/auto_generated/qgsmaptoolcapture.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolcapture.sip.in
@@ -304,16 +304,6 @@ Set the points on which to work
 Close an open polygon
 %End
 
-    virtual QgsMapLayer *layer() const;
-%Docstring
-Returns the map layer associated with the geometry being captured.
-
-The base class implementation always returns the current map canvas layer, but
-subclasses can override this if they need to be associated with a specific layer.
-
-.. versionadded:: 3.22
-%End
-
   protected slots:
 
     void stopCapturing();

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -30,6 +30,46 @@
 ///@cond PRIVATE
 
 //
+// QgsMapToolCaptureAnnotationItem
+//
+
+QgsMapToolCaptureAnnotationItem::QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
+  : QgsMapToolCapture( canvas, cadDockWidget, mode )
+{
+
+}
+
+QgsCreateAnnotationItemMapToolHandler *QgsMapToolCaptureAnnotationItem::handler()
+{
+  return mHandler;
+}
+
+QgsMapTool *QgsMapToolCaptureAnnotationItem::mapTool()
+{
+  return this;
+}
+
+QgsMapLayer *QgsMapToolCaptureAnnotationItem::layer() const
+{
+  return mHandler->targetLayer();
+}
+
+
+QgsMapToolCapture::Capabilities QgsMapToolCaptureAnnotationItem::capabilities() const
+{
+  // no geometry validation!
+  return SupportsCurves;
+}
+
+bool QgsMapToolCaptureAnnotationItem::supportsTechnique( CaptureTechnique ) const
+{
+  return true;
+}
+
+
+
+
+//
 // QgsCreatePointTextItemMapTool
 //
 
@@ -75,13 +115,10 @@ QgsMapTool *QgsCreatePointTextItemMapTool::mapTool()
 //
 
 QgsCreateMarkerItemMapTool::QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
-  : QgsMapToolCapture( canvas, cadDockWidget, CapturePoint )
-  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
+  : QgsMapToolCaptureAnnotationItem( canvas, cadDockWidget, CapturePoint )
 {
-
+  mHandler = new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget, this );
 }
-
-QgsCreateMarkerItemMapTool::~QgsCreateMarkerItemMapTool() = default;
 
 void QgsCreateMarkerItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *event )
 {
@@ -101,52 +138,14 @@ void QgsCreateMarkerItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *event 
   cadDockWidget()->clearPoints();
 }
 
-QgsCreateAnnotationItemMapToolHandler *QgsCreateMarkerItemMapTool::handler()
-{
-  return mHandler;
-}
-
-QgsMapTool *QgsCreateMarkerItemMapTool::mapTool()
-{
-  return this;
-}
-
-QgsMapLayer *QgsCreateMarkerItemMapTool::layer() const
-{
-  return mHandler->targetLayer();
-}
-
-//
-// QgsMapToolCaptureAnnotationItem
-//
-
-QgsMapToolCaptureAnnotationItem::QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
-  : QgsMapToolCapture( canvas, cadDockWidget, mode )
-{
-
-}
-
-QgsMapToolCapture::Capabilities QgsMapToolCaptureAnnotationItem::capabilities() const
-{
-  // no geometry validation!
-  return SupportsCurves;
-}
-
-bool QgsMapToolCaptureAnnotationItem::supportsTechnique( CaptureTechnique ) const
-{
-  return true;
-}
-
-
 //
 // QgsCreateLineMapTool
 //
 
 QgsCreateLineItemMapTool::QgsCreateLineItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolCaptureAnnotationItem( canvas, cadDockWidget, CaptureLine )
-  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
 {
-
+  mHandler = new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget, this );
 }
 
 void QgsCreateLineItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
@@ -190,34 +189,14 @@ void QgsCreateLineItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
 }
 
-QgsCreateLineItemMapTool::~QgsCreateLineItemMapTool() = default;
-
-QgsCreateAnnotationItemMapToolHandler *QgsCreateLineItemMapTool::handler()
-{
-  return mHandler;
-}
-
-QgsMapTool *QgsCreateLineItemMapTool::mapTool()
-{
-  return this;
-}
-
-QgsMapLayer *QgsCreateLineItemMapTool::layer() const
-{
-  return mHandler->targetLayer();
-}
-
-
-
 //
 // QgsCreatePolygonItemMapTool
 //
 
 QgsCreatePolygonItemMapTool::QgsCreatePolygonItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolCaptureAnnotationItem( canvas, cadDockWidget, CapturePolygon )
-  , mHandler( new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget ) )
 {
-
+  mHandler = new QgsCreateAnnotationItemMapToolHandler( canvas, cadDockWidget, this );
 }
 
 void QgsCreatePolygonItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
@@ -264,21 +243,5 @@ void QgsCreatePolygonItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
 }
 
-QgsCreatePolygonItemMapTool::~QgsCreatePolygonItemMapTool() = default;
-
-QgsCreateAnnotationItemMapToolHandler *QgsCreatePolygonItemMapTool::handler()
-{
-  return mHandler;
-}
-
-QgsMapTool *QgsCreatePolygonItemMapTool::mapTool()
-{
-  return this;
-}
-
-QgsMapLayer *QgsCreatePolygonItemMapTool::layer() const
-{
-  return mHandler->targetLayer();
-}
-
 ///@endcond PRIVATE
+

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -24,6 +24,23 @@
 
 ///@cond PRIVATE
 
+class QgsMapToolCaptureAnnotationItem: public QgsMapToolCapture, public QgsCreateAnnotationItemMapToolInterface
+{
+    Q_OBJECT
+  public:
+    QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
+    QgsCreateAnnotationItemMapToolHandler *handler() override;
+    QgsMapTool *mapTool() override;
+    QgsMapLayer *layer() const override;
+    QgsMapToolCapture::Capabilities capabilities() const override;
+    bool supportsTechnique( CaptureTechnique technique ) const override;
+
+  protected:
+
+    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
+
+};
+
 class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public QgsCreateAnnotationItemMapToolInterface
 {
     Q_OBJECT
@@ -43,74 +60,40 @@ class QgsCreatePointTextItemMapTool: public QgsMapToolAdvancedDigitizing, public
 
 };
 
-class QgsCreateMarkerItemMapTool: public QgsMapToolCapture, public QgsCreateAnnotationItemMapToolInterface
+
+class QgsCreateMarkerItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
 
     QgsCreateMarkerItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
-    ~QgsCreateMarkerItemMapTool() override;
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
-    QgsMapTool *mapTool() override;
-    QgsMapLayer *layer() const override;
-
-  private:
-
-    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
 };
 
-class QgsMapToolCaptureAnnotationItem : public QgsMapToolCapture
-{
-    Q_OBJECT
-  public:
-    QgsMapToolCaptureAnnotationItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
-
-    QgsMapToolCapture::Capabilities capabilities() const override;
-    bool supportsTechnique( CaptureTechnique technique ) const override;
-
-};
-
-class QgsCreateLineItemMapTool: public QgsMapToolCaptureAnnotationItem, public QgsCreateAnnotationItemMapToolInterface
+class QgsCreateLineItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
 
     QgsCreateLineItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
-    ~QgsCreateLineItemMapTool() override;
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
-    QgsMapTool *mapTool() override;
-    QgsMapLayer *layer() const override;
-
-  private:
-
-    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
 };
 
-class QgsCreatePolygonItemMapTool: public QgsMapToolCaptureAnnotationItem, public QgsCreateAnnotationItemMapToolInterface
+class QgsCreatePolygonItemMapTool: public QgsMapToolCaptureAnnotationItem
 {
     Q_OBJECT
 
   public:
 
     QgsCreatePolygonItemMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
-    ~QgsCreatePolygonItemMapTool() override;
 
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
-    QgsCreateAnnotationItemMapToolHandler *handler() override;
-    QgsMapTool *mapTool() override;
-    QgsMapLayer *layer() const override;
-
-  private:
-
-    QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
 };
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -349,6 +349,7 @@ void QgsAdvancedDigitizingDockWidget::setEnabledZ( bool enable )
   else
     mZLineEdit->clear();
   mLockZButton->setEnabled( enable );
+  emit enabledChangedZ( enable );
 }
 
 void QgsAdvancedDigitizingDockWidget::setEnabledM( bool enable )
@@ -361,6 +362,7 @@ void QgsAdvancedDigitizingDockWidget::setEnabledM( bool enable )
   else
     mMLineEdit->clear();
   mLockMButton->setEnabled( enable );
+  emit enabledChangedM( enable );
 }
 
 void QgsAdvancedDigitizingDockWidget::activateCad( bool enabled )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -857,6 +857,12 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void settingsButtonTriggered( QAction *action );
 
   private:
+
+    /**
+     * Returns the layer currently associated with the map tool using the dock widget.
+     */
+    QgsMapLayer *targetLayer();
+
     //! updates the UI depending on activation of the tools and clear points / release locks.
     void setCadEnabled( bool enabled );
 

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -142,6 +142,11 @@ void QgsMapToolAdvancedDigitizing::deactivate()
   mSnapToGridCanvasItem = nullptr;
 }
 
+QgsMapLayer *QgsMapToolAdvancedDigitizing::layer() const
+{
+  return canvas()->currentLayer();
+}
+
 void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )
 {
   Q_UNUSED( point )

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -65,6 +65,15 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     QgsAdvancedDigitizingDockWidget *cadDockWidget() const { return mCadDockWidget; }
 
     /**
+     * Returns the layer associated with the map tool.
+     *
+     * By default this returns the map canvas' QgsMapCanvas::currentLayer().
+     *
+     * \since QGIS 3.22
+     */
+    virtual QgsMapLayer *layer() const;
+
+    /**
      * Returns whether functionality of advanced digitizing dock widget is currently allowed.
      *
      * Tools may decide to switch this support on/off based on the current state of the map tool.

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -873,11 +873,6 @@ void QgsMapToolCapture::closePolygon()
   updateExtraSnapLayer();
 }
 
-QgsMapLayer *QgsMapToolCapture::layer() const
-{
-  return canvas()->currentLayer();
-}
-
 void QgsMapToolCapture::validateGeometry()
 {
   if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries.value() == 0

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -391,16 +391,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     void closePolygon();
 
-    /**
-     * Returns the map layer associated with the geometry being captured.
-     *
-     * The base class implementation always returns the current map canvas layer, but
-     * subclasses can override this if they need to be associated with a specific layer.
-     *
-     * \since QGIS 3.22
-     */
-    virtual QgsMapLayer *layer() const;
-
   protected slots:
 
     /**


### PR DESCRIPTION
Together these changes ensure that the z/m support is correctly disabled/enabled in both the dock widget and the dock widget floater when a map tool which doesn't support z/m is active