### PR TITLE
Fix quasi-hangs when excessively large sizes are used in symbol preview icons for draw effects

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -889,3 +889,11 @@ QgsRenderContext.TextFormatAlwaysText.__doc__ = "Always render text as text obje
 Qgis.TextRenderFormat.__doc__ = 'Options for rendering text.\n\n.. versionadded:: 3.22\n\n' + '* ``TextFormatAlwaysOutlines``: ' + Qgis.TextRenderFormat.AlwaysOutlines.__doc__ + '\n' + '* ``TextFormatAlwaysText``: ' + Qgis.TextRenderFormat.AlwaysText.__doc__
 # --
 Qgis.TextRenderFormat.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.RenderSubcomponentProperty.Generic.__doc__ = "Generic subcomponent property"
+Qgis.RenderSubcomponentProperty.ShadowOffset.__doc__ = "Shadow offset"
+Qgis.RenderSubcomponentProperty.BlurSize.__doc__ = "Blur size"
+Qgis.RenderSubcomponentProperty.GlowSpread.__doc__ = "Glow spread size"
+Qgis.RenderSubcomponentProperty.__doc__ = 'Rendering subcomponent properties.\n\n.. versionadded:: 3.22\n\n' + '* ``Generic``: ' + Qgis.RenderSubcomponentProperty.Generic.__doc__ + '\n' + '* ``ShadowOffset``: ' + Qgis.RenderSubcomponentProperty.ShadowOffset.__doc__ + '\n' + '* ``BlurSize``: ' + Qgis.RenderSubcomponentProperty.BlurSize.__doc__ + '\n' + '* ``GlowSpread``: ' + Qgis.RenderSubcomponentProperty.GlowSpread.__doc__
+# --
+Qgis.RenderSubcomponentProperty.baseClass = Qgis

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -601,6 +601,14 @@ The development version
       AlwaysText,
     };
 
+    enum class RenderSubcomponentProperty
+    {
+      Generic,
+      ShadowOffset,
+      BlurSize,
+      GlowSpread,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -23,6 +23,13 @@ This class can convert device coordinates to map coordinates and vice versa.
 %End
   public:
 
+    QgsMapToPixel();
+%Docstring
+Constructor for an invalid QgsMapToPixel.
+
+A manual call to :py:func:`~QgsMapToPixel.setParameters` is required to initialise the object.
+%End
+
     QgsMapToPixel( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );
 %Docstring
 Constructor
@@ -57,16 +64,17 @@ Returns a new QgsMapToPixel created using a specified ``scale`` and distance uni
 .. versionadded:: 3.0
 %End
 
-    QgsMapToPixel();
+    bool isValid() const;
 %Docstring
-Constructor
+Returns ``True`` if the object is valid (i.e. it has parameters set), or ``False`` if the object is default constructed
+with no parameters set.
 
-Use setParameters to fill
+.. versionadded:: 3.22
 %End
 
     QgsPointXY transform( const QgsPointXY &p ) const;
 %Docstring
-Transform the point ``p`` from map (world) coordinates to device coordinates.
+Transforms a point ``p`` from map (world) coordinates to device coordinates.
 
 :param p: Point to transform
 
@@ -75,15 +83,14 @@ Transform the point ``p`` from map (world) coordinates to device coordinates.
 
     void transform( QgsPointXY *p ) const;
 %Docstring
-Transform the point ``p`` from map (world) coordinates to device coordinates in place.
+Transforms a point ``p`` from map (world) coordinates to device coordinates in place.
 %End
 
     QgsPointXY transform( qreal x, qreal y ) const;
 %Docstring
-Transform the point specified by x,y from map (world)
-coordinates to device coordinates
+Transforms the point specified by x,y from map (world) coordinates to device coordinates.
 
-:param x: x coordinate o point to transform
+:param x: x coordinate of point to transform
 :param y: y coordinate of point to transform
 
 :return: :py:class:`QgsPointXY` in device coordinates
@@ -91,8 +98,9 @@ coordinates to device coordinates
 
     void transformInPlace( double &x, double &y ) const;
 %Docstring
-Transforms device coordinates to map coordinates. Modifies the
-given coordinates in place. Intended as a fast way to do the
+Transforms device coordinates to map coordinates.
+
+This method modifies the given coordinates in place. It is intended as a fast way to do the
 transform.
 %End
 
@@ -100,17 +108,17 @@ transform.
 
     QgsPointXY toMapCoordinates( int x, int y ) const;
 %Docstring
-Transform device coordinates to map (world) coordinates
+Transforms device coordinates to map (world) coordinates.
 %End
 
     QgsPointXY toMapCoordinates( double x, double y ) const /PyName=toMapCoordinatesF/;
 %Docstring
-Transform device coordinates to map (world) coordinates
+Transforms device coordinates to map (world) coordinates.
 %End
 
     QgsPointXY toMapCoordinates( QPoint p ) const;
 %Docstring
-Transform device coordinates to map (world) coordinates
+Transforms device coordinates to map (world) coordinates.
 
 :param p: Point to be converted to map cooordinates
 
@@ -119,7 +127,7 @@ Transform device coordinates to map (world) coordinates
 
  QgsPointXY toMapPoint( double x, double y ) const /Deprecated/;
 %Docstring
-Transform device coordinates to map (world) coordinates
+Transforms device coordinates to map (world) coordinates.
 
 .. deprecated:: QGIS 3.4
    use toMapCoordinates instead
@@ -127,20 +135,29 @@ Transform device coordinates to map (world) coordinates
 
     void setMapUnitsPerPixel( double mapUnitsPerPixel );
 %Docstring
-Set map units per pixel
+Sets the map units per pixel.
+
+Calling this method will automatically set the object as valid.
 
 :param mapUnitsPerPixel: Map units per pixel
+
+.. seealso:: :py:func:`mapUnitsPerPixel`
 %End
 
     double mapUnitsPerPixel() const;
 %Docstring
-Returns current map units per pixel
+Returns the current map units per pixel.
+
+.. seealso:: :py:func:`setMapUnitsPerPixel`
 %End
 
     int mapWidth() const;
 %Docstring
-Returns current map width in pixels
-The information is only known if setRotation was used
+Returns the current map width in pixels.
+
+The information is only known if setRotation was used.
+
+.. seealso:: :py:func:`mapHeight`
 
 .. versionadded:: 2.8
 %End
@@ -149,30 +166,40 @@ The information is only known if setRotation was used
 %Docstring
 Returns current map height in pixels
 
+.. seealso:: :py:func:`mapWidth`
+
 .. versionadded:: 2.8
 %End
 
     void setMapRotation( double degrees, double cx, double cy );
 %Docstring
-Set map rotation in degrees (clockwise)
+Sets map rotation in ``degrees`` (clockwise).
+
+Calling this method will automatically set the object as valid.
 
 :param degrees: clockwise rotation in degrees
 :param cx: X ordinate of map center in geographical units
 :param cy: Y ordinate of map center in geographical units
+
+.. seealso:: :py:func:`mapRotation`
 
 .. versionadded:: 2.8
 %End
 
     double mapRotation() const;
 %Docstring
-Returns current map rotation in degrees (clockwise)
+Returns the current map rotation in degrees (clockwise).
+
+.. seealso:: :py:func:`setMapRotation`
 
 .. versionadded:: 2.8
 %End
 
     void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );
 %Docstring
-Set parameters for use in transforming coordinates
+Sets parameters for use in transforming coordinates.
+
+Calling this method will automatically set the object as valid.
 
 :param mapUnitsPerPixel: Map units per pixel
 :param centerX: X coordinate of map center, in geographical units
@@ -191,7 +218,7 @@ Set parameters for use in transforming coordinates
 
     QString showParameters() const;
 %Docstring
-String representation of the parameters used in the transform
+Returns a string representation of the parameters used in the transform.
 %End
 
     QTransform transform() const;

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -27,7 +27,7 @@ This class can convert device coordinates to map coordinates and vice versa.
 %Docstring
 Constructor for an invalid QgsMapToPixel.
 
-A manual call to :py:func:`~QgsMapToPixel.setParameters` is required to initialise the object.
+A manual call to :py:func:`~QgsMapToPixel.setParameters` is required to initialize the object.
 %End
 
     QgsMapToPixel( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -688,10 +688,14 @@ Gets segmentation tolerance type (maximum angle or maximum difference between cu
 %End
 
 
-    double convertToPainterUnits( double size, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &scale = QgsMapUnitScale() ) const;
+    double convertToPainterUnits( double size, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &scale = QgsMapUnitScale(), Qgis::RenderSubcomponentProperty property = Qgis::RenderSubcomponentProperty::Generic ) const;
 %Docstring
 Converts a size from the specified units to painter units (pixels). The conversion respects the limits
 specified by the optional scale parameter.
+
+Since QGIS 3.22 the optional ``property`` argument can be used to specify the associated property. This
+is used in some contexts to refine the converted size. For example, a Qgis.RenderSubcomponentProperty.BlurSize
+property will be limited to a suitably fast range when the render context has the Qgis.RenderContextFlag.RenderSymbolPreview set.
 
 .. seealso:: :py:func:`convertToMapUnits`
 

--- a/src/core/effects/qgsblureffect.cpp
+++ b/src/core/effects/qgsblureffect.cpp
@@ -45,13 +45,7 @@ void QgsBlurEffect::draw( QgsRenderContext &context )
 
 void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 {
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-  }
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
 
   QImage im = sourceAsImage( context )->copy();
   QgsImageOperation::stackBlur( im, blurLevel, false, context.feedback() );
@@ -60,13 +54,7 @@ void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 
 void QgsBlurEffect::drawGaussianBlur( QgsRenderContext &context )
 {
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-  }
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
 
   QImage *im = QgsImageOperation::gaussianBlur( *sourceAsImage( context ), blurLevel, context.feedback() );
   if ( !im->isNull() )
@@ -153,14 +141,7 @@ QgsBlurEffect *QgsBlurEffect::clone() const
 
 QRectF QgsBlurEffect::boundingRect( const QRectF &rect, const QgsRenderContext &context ) const
 {
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-  }
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
 
   //plus possible extension due to blur, with a couple of extra pixels thrown in for safety
   const double spread = blurLevel * 2.0 + 10;

--- a/src/core/effects/qgsblureffect.cpp
+++ b/src/core/effects/qgsblureffect.cpp
@@ -45,7 +45,14 @@ void QgsBlurEffect::draw( QgsRenderContext &context )
 
 void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 {
-  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
+  {
+    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
+    // for just a preview icon
+    blurLevel = std::min( blurLevel, 30 );
+  }
+
   QImage im = sourceAsImage( context )->copy();
   QgsImageOperation::stackBlur( im, blurLevel, false, context.feedback() );
   drawBlurredImage( context, im );
@@ -53,7 +60,14 @@ void QgsBlurEffect::drawStackBlur( QgsRenderContext &context )
 
 void QgsBlurEffect::drawGaussianBlur( QgsRenderContext &context )
 {
-  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
+  {
+    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
+    // for just a preview icon
+    blurLevel = std::min( blurLevel, 30 );
+  }
+
   QImage *im = QgsImageOperation::gaussianBlur( *sourceAsImage( context ), blurLevel, context.feedback() );
   if ( !im->isNull() )
     drawBlurredImage( context, *im );
@@ -139,7 +153,15 @@ QgsBlurEffect *QgsBlurEffect::clone() const
 
 QRectF QgsBlurEffect::boundingRect( const QRectF &rect, const QgsRenderContext &context ) const
 {
-  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+
+  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
+  {
+    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
+    // for just a preview icon
+    blurLevel = std::min( blurLevel, 30 );
+  }
+
   //plus possible extension due to blur, with a couple of extra pixels thrown in for safety
   const double spread = blurLevel * 2.0 + 10;
   return rect.adjusted( -spread, -spread, spread, spread );

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -60,16 +60,8 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
     ramp = tempRamp.get();
   }
 
-  double spread = context.convertToPainterUnits( mSpread, mSpreadUnit, mSpreadMapUnitScale );
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessive spread in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    spread = std::min( spread, 50.0 );
-  }
-
   QgsImageOperation::DistanceTransformProperties dtProps;
-  dtProps.spread = context.convertToPainterUnits( mSpread, mSpreadUnit, mSpreadMapUnitScale );
+  dtProps.spread = context.convertToPainterUnits( mSpread, mSpreadUnit, mSpreadMapUnitScale, Qgis::RenderSubcomponentProperty::GlowSpread );
   dtProps.useMaxDistance = false;
   dtProps.shadeExterior = shadeExterior();
   dtProps.ramp = ramp;
@@ -78,14 +70,7 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
   if ( context.feedback() && context.feedback()->isCanceled() )
     return;
 
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessive blur in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-  }
-
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
   if ( blurLevel <= 16 )
   {
     QgsImageOperation::stackBlur( im, blurLevel, false, context.feedback() );
@@ -248,16 +233,8 @@ QgsGlowEffect &QgsGlowEffect::operator=( const QgsGlowEffect &rhs )
 QRectF QgsGlowEffect::boundingRect( const QRectF &rect, const QgsRenderContext &context ) const
 {
   //blur radius and spread size
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  double spread = context.convertToPainterUnits( mSpread, mSpreadUnit, mSpreadMapUnitScale );
-
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur or spread in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-    spread = std::min( spread, 50.0 );
-  }
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
+  double spread = context.convertToPainterUnits( mSpread, mSpreadUnit, mSpreadMapUnitScale, Qgis::RenderSubcomponentProperty::GlowSpread );
 
   //plus possible extension due to blur, with a couple of extra pixels thrown in for safety
   spread += blurLevel * 2 + 10;

--- a/src/core/effects/qgsimageoperation.cpp
+++ b/src/core/effects/qgsimageoperation.cpp
@@ -717,6 +717,9 @@ void QgsImageOperation::GaussianBlurOperation::operator()( QgsImageOperation::Im
       destRef = reinterpret_cast< QRgb * >( outputLineRef );
       for ( int x = 0; x < width; ++x, ++destRef, sourceRef += 4 )
       {
+        if ( mFeedback && mFeedback->isCanceled() )
+          break;
+
         *destRef = gaussianBlurVertical( y, sourceRef, sourceBpl, height );
       }
     }
@@ -732,6 +735,9 @@ void QgsImageOperation::GaussianBlurOperation::operator()( QgsImageOperation::Im
       destRef = reinterpret_cast< QRgb * >( outputLineRef );
       for ( int x = 0; x < width; ++x, ++destRef )
       {
+        if ( mFeedback && mFeedback->isCanceled() )
+          break;
+
         *destRef = gaussianBlurHorizontal( x, sourceRef, width );
       }
     }

--- a/src/core/effects/qgsshadoweffect.cpp
+++ b/src/core/effects/qgsshadoweffect.cpp
@@ -52,14 +52,7 @@ void QgsShadowEffect::draw( QgsRenderContext &context )
 
   QgsImageOperation::overlayColor( colorisedIm, mColor );
 
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-  }
-
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
   if ( blurLevel <= 16 )
   {
     QgsImageOperation::stackBlur( colorisedIm, blurLevel, false, context.feedback() );
@@ -181,17 +174,10 @@ void QgsShadowEffect::readProperties( const QVariantMap &props )
 QRectF QgsShadowEffect::boundingRect( const QRectF &rect, const QgsRenderContext &context ) const
 {
   //blur radius and offset distance
-  int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale ) );
+  const int blurLevel = std::round( context.convertToPainterUnits( mBlurLevel, mBlurUnit, mBlurMapUnitScale, Qgis::RenderSubcomponentProperty::BlurSize ) );
 
-  double spread = context.convertToPainterUnits( mOffsetDist, mOffsetUnit, mOffsetMapUnitScale );
-
-  if ( context.flags() & QgsRenderContext::Flag::RenderSymbolPreview )
-  {
-    // avoid excessively large blur or offset in symbol preview icons -- it's too slow to calculate, and unnecessary
-    // for just a preview icon
-    blurLevel = std::min( blurLevel, 30 );
-    spread = std::min( spread, 100.0 );
-  }
+  // spread is initially the shadow offset size
+  double spread = context.convertToPainterUnits( mOffsetDist, mOffsetUnit, mOffsetMapUnitScale, Qgis::RenderSubcomponentProperty::ShadowOffset );
 
   //plus possible extension due to blur, with a couple of extra pixels thrown in for safety
   spread += blurLevel * 2 + 10;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -968,6 +968,20 @@ class CORE_EXPORT Qgis
     Q_ENUM( TextRenderFormat )
 
     /**
+     * Rendering subcomponent properties.
+     *
+     * \since QGIS 3.22
+     */
+    enum class RenderSubcomponentProperty : int
+    {
+      Generic, //!< Generic subcomponent property
+      ShadowOffset, //!< Shadow offset
+      BlurSize, //!< Blur size
+      GlowSpread, //!< Glow spread size
+    };
+    Q_ENUM( RenderSubcomponentProperty )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -31,7 +31,8 @@ QgsMapToPixel::QgsMapToPixel( double mapUnitsPerPixel,
                               int width,
                               int height,
                               double rotation )
-  : mMapUnitsPerPixel( mapUnitsPerPixel )
+  : mValid( true )
+  , mMapUnitsPerPixel( mapUnitsPerPixel )
   , mWidth( width )
   , mHeight( height )
   , mRotation( rotation )
@@ -45,7 +46,8 @@ QgsMapToPixel::QgsMapToPixel( double mapUnitsPerPixel,
 }
 
 QgsMapToPixel::QgsMapToPixel( double mapUnitsPerPixel )
-  : mMapUnitsPerPixel( mapUnitsPerPixel )
+  : mValid( true )
+  , mMapUnitsPerPixel( mapUnitsPerPixel )
   , mWidth( 0 )
   , mHeight( 0 )
   , mXCenter( 0 )
@@ -80,6 +82,8 @@ bool QgsMapToPixel::updateMatrix()
 
 void QgsMapToPixel::setMapUnitsPerPixel( double mapUnitsPerPixel )
 {
+  mValid = true;
+
   const double oldUnits = mMapUnitsPerPixel;
   mMapUnitsPerPixel = mapUnitsPerPixel;
   if ( !updateMatrix() )
@@ -90,6 +94,8 @@ void QgsMapToPixel::setMapUnitsPerPixel( double mapUnitsPerPixel )
 
 void QgsMapToPixel::setMapRotation( double degrees, double cx, double cy )
 {
+  mValid = true;
+
   const double oldRotation = mRotation;
   const double oldXCenter = mXCenter;
   const double oldYCenter = mYCenter;
@@ -121,6 +127,8 @@ void QgsMapToPixel::setParameters( double mapUnitsPerPixel,
                                    double rotation,
                                    bool *ok )
 {
+  mValid = true;
+
   const double oldMUPP = mMapUnitsPerPixel;
   const double oldXCenter = mXCenter;
   const double oldYCenter = mYCenter;
@@ -164,6 +172,7 @@ void QgsMapToPixel::setParameters( double mapUnitsPerPixel,
                                    int height,
                                    double rotation )
 {
+  mValid = true;
   bool ok;
   setParameters( mapUnitsPerPixel, xc, yc, width, height, rotation, &ok );
 }

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -40,6 +40,13 @@ class CORE_EXPORT QgsMapToPixel
   public:
 
     /**
+     * Constructor for an invalid QgsMapToPixel.
+     *
+     * A manual call to setParameters() is required to initialise the object.
+     */
+    QgsMapToPixel();
+
+    /**
      * Constructor
      * \param mapUnitsPerPixel Map units per pixel
      * \param centerX X coordinate of map center, in geographical units
@@ -68,14 +75,15 @@ class CORE_EXPORT QgsMapToPixel
     static QgsMapToPixel fromScale( double scale, QgsUnitTypes::DistanceUnit mapUnits, double dpi = 96 );
 
     /**
-     * Constructor
+     * Returns TRUE if the object is valid (i.e. it has parameters set), or FALSE if the object is default constructed
+     * with no parameters set.
      *
-     * Use setParameters to fill
+     * \since QGIS 3.22
      */
-    QgsMapToPixel();
+    bool isValid() const { return mValid; }
 
     /**
-     * Transform the point \a p from map (world) coordinates to device coordinates.
+     * Transforms a point \a p from map (world) coordinates to device coordinates.
      * \param p Point to transform
      * \returns QgsPointXY in device coordinates
      */
@@ -88,7 +96,7 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transform the point \a p from map (world) coordinates to device coordinates in place.
+     * Transforms a point \a p from map (world) coordinates to device coordinates in place.
      */
     void transform( QgsPointXY *p ) const
     {
@@ -99,9 +107,9 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transform the point specified by x,y from map (world)
-     * coordinates to device coordinates
-     * \param x x coordinate o point to transform
+     * Transforms the point specified by x,y from map (world) coordinates to device coordinates.
+     *
+     * \param x x coordinate of point to transform
      * \param y y coordinate of point to transform
      * \returns QgsPointXY in device coordinates
      */
@@ -112,8 +120,9 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transforms device coordinates to map coordinates. Modifies the
-     * given coordinates in place. Intended as a fast way to do the
+     * Transforms device coordinates to map coordinates.
+     *
+     * This method modifies the given coordinates in place. It is intended as a fast way to do the
      * transform.
      */
     void transformInPlace( double &x, double &y ) const
@@ -125,9 +134,11 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transforms device coordinates to map coordinates. Modifies the
-     * given coordinates in place. Intended as a fast way to do the
+     * Transforms device coordinates to map coordinates.
+     *
+     * This method modifies the given coordinates in place. It is intended as a fast way to do the
      * transform.
+     *
      * \note Not available in Python bindings
      */
     void transformInPlace( float &x, float &y ) const SIP_SKIP
@@ -141,8 +152,9 @@ class CORE_EXPORT QgsMapToPixel
 #ifndef SIP_RUN
 
     /**
-     * Transform device coordinates to map coordinates. Modifies the
-     * given coordinates in place. Intended as a fast way to do the
+     * Transforms device coordinates to map coordinates.
+     *
+     * This method modifies the given coordinates in place. It is intended as a fast way to do the
      * transform.
      * \note not available in Python bindings
      */
@@ -155,13 +167,17 @@ class CORE_EXPORT QgsMapToPixel
     }
 #endif
 
-    //! Transform device coordinates to map (world) coordinates
+    /**
+     * Transforms device coordinates to map (world) coordinates.
+     */
     QgsPointXY toMapCoordinates( int x, int y ) const
     {
       return toMapCoordinates( static_cast<double>( x ), static_cast<double>( y ) );
     }
 
-    //! Transform device coordinates to map (world) coordinates
+    /**
+     * Transforms device coordinates to map (world) coordinates.
+     */
     QgsPointXY toMapCoordinates( double x, double y ) const SIP_PYNAME( toMapCoordinatesF )
     {
       bool invertible;
@@ -173,7 +189,8 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transform device coordinates to map (world) coordinates
+     * Transforms device coordinates to map (world) coordinates.
+     *
      * \param p Point to be converted to map cooordinates
      * \returns QgsPointXY in map coorndiates
      */
@@ -184,7 +201,8 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Transform device coordinates to map (world) coordinates
+     * Transforms device coordinates to map (world) coordinates.
+     *
      * \deprecated since QGIS 3.4 use toMapCoordinates instead
      */
     Q_DECL_DEPRECATED QgsPointXY toMapPoint( double x, double y ) const SIP_DEPRECATED
@@ -193,44 +211,68 @@ class CORE_EXPORT QgsMapToPixel
     }
 
     /**
-     * Set map units per pixel
+     * Sets the map units per pixel.
+     *
+     * Calling this method will automatically set the object as valid.
+     *
      * \param mapUnitsPerPixel Map units per pixel
+     *
+     * \see mapUnitsPerPixel()
      */
     void setMapUnitsPerPixel( double mapUnitsPerPixel );
 
-    //! Returns current map units per pixel
+    /**
+     * Returns the current map units per pixel.
+     *
+     * \see setMapUnitsPerPixel()
+     */
     double mapUnitsPerPixel() const { return mMapUnitsPerPixel; }
 
     /**
-     * Returns current map width in pixels
-     * The information is only known if setRotation was used
+     * Returns the current map width in pixels.
+     *
+     * The information is only known if setRotation was used.
+     *
+     * \see mapHeight()
      * \since QGIS 2.8
      */
     int mapWidth() const { return mWidth; }
 
     /**
      * Returns current map height in pixels
+     *
+     * \see mapWidth()
      * \since QGIS 2.8
      */
     int mapHeight() const { return mHeight; }
 
     /**
-     * Set map rotation in degrees (clockwise)
+     * Sets map rotation in \a degrees (clockwise).
+     *
+     * Calling this method will automatically set the object as valid.
+     *
      * \param degrees clockwise rotation in degrees
      * \param cx X ordinate of map center in geographical units
      * \param cy Y ordinate of map center in geographical units
+     *
+     * \see mapRotation()
      * \since QGIS 2.8
      */
     void setMapRotation( double degrees, double cx, double cy );
 
     /**
-     * Returns current map rotation in degrees (clockwise)
+     * Returns the current map rotation in degrees (clockwise).
+     *
+     * \see setMapRotation()
      * \since QGIS 2.8
      */
     double mapRotation() const { return mRotation; }
 
     /**
-     * Set parameters for use in transforming coordinates
+     * Sets parameters for use in transforming coordinates.
+     *
+     * Calling this method will automatically set the object as valid.
+     *
      * \param mapUnitsPerPixel Map units per pixel
      * \param centerX X coordinate of map center, in geographical units
      * \param centerY Y coordinate of map center, in geographical units
@@ -244,7 +286,10 @@ class CORE_EXPORT QgsMapToPixel
     void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation );
 
     /**
-     * Set parameters for use in transforming coordinates
+     * Sets parameters for use in transforming coordinates.
+     *
+     * Calling this method will automatically set the object as valid.
+     *
      * \param mapUnitsPerPixel Map units per pixel
      * \param centerX X coordinate of map center, in geographical units
      * \param centerY Y coordinate of map center, in geographical units
@@ -257,7 +302,9 @@ class CORE_EXPORT QgsMapToPixel
      */
     void setParameters( double mapUnitsPerPixel, double centerX, double centerY, int widthPixels, int heightPixels, double rotation, bool *ok ) SIP_SKIP;
 
-    //! String representation of the parameters used in the transform
+    /**
+     * Returns a string representation of the parameters used in the transform.
+     */
     QString showParameters() const;
 
     /**
@@ -281,7 +328,8 @@ class CORE_EXPORT QgsMapToPixel
 
     bool operator==( const QgsMapToPixel &other ) const
     {
-      return mMapUnitsPerPixel == other.mMapUnitsPerPixel
+      return mValid == other.mValid
+             && mMapUnitsPerPixel == other.mMapUnitsPerPixel
              && mWidth == other.mWidth
              && mHeight == other.mHeight
              && mRotation == other.mRotation
@@ -297,6 +345,7 @@ class CORE_EXPORT QgsMapToPixel
     }
 
   private:
+    bool mValid = false;
     double mMapUnitsPerPixel = 1;
     int mWidth = 1;
     int mHeight = 1;

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsMapToPixel
     /**
      * Constructor for an invalid QgsMapToPixel.
      *
-     * A manual call to setParameters() is required to initialise the object.
+     * A manual call to setParameters() is required to initialize the object.
      */
     QgsMapToPixel();
 

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -427,7 +427,7 @@ double QgsRenderContext::convertToPainterUnits( double size, QgsUnitTypes::Rende
         break;
 
       case Qgis::RenderSubcomponentProperty::ShadowOffset:
-        // excessively large shadow offset in symbol preview icons is too slow to calculate
+        // excessively large shadow offset in symbol preview icons is undesirable -- it pushes the shadow outside of view
         convertedSize = std::min( convertedSize, 100.0 );
         break;
       case Qgis::RenderSubcomponentProperty::BlurSize:

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -670,10 +670,15 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     /**
      * Converts a size from the specified units to painter units (pixels). The conversion respects the limits
      * specified by the optional scale parameter.
+     *
+     * Since QGIS 3.22 the optional \a property argument can be used to specify the associated property. This
+     * is used in some contexts to refine the converted size. For example, a Qgis::RenderSubcomponentProperty::BlurSize
+     * property will be limited to a suitably fast range when the render context has the Qgis::RenderContextFlag::RenderSymbolPreview set.
+     *
      * \see convertToMapUnits()
      * \since QGIS 3.0
      */
-    double convertToPainterUnits( double size, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &scale = QgsMapUnitScale() ) const;
+    double convertToPainterUnits( double size, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &scale = QgsMapUnitScale(), Qgis::RenderSubcomponentProperty property = Qgis::RenderSubcomponentProperty::Generic ) const;
 
     /**
      * Converts a size from the specified units to map units. The conversion respects the limits

--- a/src/gui/effects/qgseffectstackpropertieswidget.cpp
+++ b/src/gui/effects/qgseffectstackpropertieswidget.cpp
@@ -211,7 +211,7 @@ void QgsEffectStackPropertiesWidget::updatePreview()
   painter.begin( &previewImage );
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext context = QgsRenderContext::fromQPainter( &painter );
-  context.setFlag( QgsRenderContext::RenderSymbolPreview, true );
+  context.setFlag( Qgis::RenderContextFlag::RenderSymbolPreview, true );
   if ( mPreviewPicture.isNull() )
   {
     QPicture previewPic;

--- a/src/gui/effects/qgseffectstackpropertieswidget.cpp
+++ b/src/gui/effects/qgseffectstackpropertieswidget.cpp
@@ -211,6 +211,7 @@ void QgsEffectStackPropertiesWidget::updatePreview()
   painter.begin( &previewImage );
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext context = QgsRenderContext::fromQPainter( &painter );
+  context.setFlag( QgsRenderContext::RenderSymbolPreview, true );
   if ( mPreviewPicture.isNull() )
   {
     QPicture previewPic;

--- a/tests/src/core/testqgsmaptopixel.cpp
+++ b/tests/src/core/testqgsmaptopixel.cpp
@@ -25,12 +25,47 @@ class TestQgsMapToPixel: public QObject
 {
     Q_OBJECT
   private slots:
+    void isValid();
     void rotation();
     void getters();
     void fromScale();
     void equality();
     void toMapCoordinates();
 };
+
+void TestQgsMapToPixel::isValid()
+{
+  // test QgsMapToPixel::isValid()
+
+  // constructors with parameters should result in valid QgsMapToPixel
+  QgsMapToPixel m2p( 1, 5, 5, 10, 10, 90 );
+  QVERIFY( m2p.isValid() );
+  m2p = QgsMapToPixel( 90 );
+  QVERIFY( m2p.isValid() );
+  m2p = QgsMapToPixel::fromScale( 90, QgsUnitTypes::DistanceMeters );
+  QVERIFY( m2p.isValid() );
+
+  // default constructor should result in invalid m2p
+  m2p = QgsMapToPixel();
+  QVERIFY( !m2p.isValid() );
+
+  // but setting parameters on an invalid m2p should turn it valid
+  m2p.setMapUnitsPerPixel( 90 );
+  QVERIFY( m2p.isValid() );
+
+  m2p = QgsMapToPixel();
+  m2p.setMapRotation( 90, 1, 2 );
+  QVERIFY( m2p.isValid() );
+
+  m2p = QgsMapToPixel();
+  m2p.setParameters( 90, 1, 2, 50, 70, 0 );
+  QVERIFY( m2p.isValid() );
+
+  m2p = QgsMapToPixel();
+  bool ok = false;
+  m2p.setParameters( 90, 1, 2, 50, 70, 0, &ok );
+  QVERIFY( m2p.isValid() );
+}
 
 void TestQgsMapToPixel::rotation()
 {

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -240,21 +240,18 @@ class TestQgsRenderContext(unittest.TestCase):
         da_wsg84.setSourceCrs(crs_wsg84, QgsProject.instance().transformContext())
         if (da_wsg84.sourceCrs().isGeographic()):
             da_wsg84.setEllipsoid(da_wsg84.sourceCrs().ellipsoidAcronym())
-        length_meter_mapunits = da_wsg84.measureLineProjected(point_berlin_wsg84, 1.0, (math.pi / 2))
         meters_test_mapunits = meters_test * length_wsg84_mapunits
-        meters_test_pixel = meters_test * length_wsg84_mapunits
         ms = QgsMapSettings()
         ms.setDestinationCrs(crs_wsg84)
         ms.setExtent(rt_extent)
+        ms.setOutputSize(QSize(50, 50))
         r = QgsRenderContext.fromMapSettings(ms)
         r.setExtent(rt_extent)
         self.assertEqual(r.extent().center().toString(7), point_berlin_wsg84.toString(7))
         c = QgsMapUnitScale()
         r.setDistanceArea(da_wsg84)
         result_test_painterunits = r.convertToPainterUnits(meters_test, QgsUnitTypes.RenderMetersInMapUnits, c)
-        self.assertEqual(
-            QgsDistanceArea.formatDistance(result_test_painterunits, 7, QgsUnitTypes.DistanceUnknownUnit, True),
-            QgsDistanceArea.formatDistance(meters_test_mapunits, 7, QgsUnitTypes.DistanceUnknownUnit, True))
+        self.assertAlmostEqual(result_test_painterunits, 60.0203759, 1)
         result_test_mapunits = r.convertToMapUnits(meters_test, QgsUnitTypes.RenderMetersInMapUnits, c)
         self.assertEqual(QgsDistanceArea.formatDistance(result_test_mapunits, 7, QgsUnitTypes.DistanceDegrees, True),
                          QgsDistanceArea.formatDistance(meters_test_mapunits, 7, QgsUnitTypes.DistanceDegrees, True))
@@ -265,7 +262,7 @@ class TestQgsRenderContext(unittest.TestCase):
         # attempting to convert to meters in map units when no extent is available should fallback to a very
         # approximate degrees -> meters conversion
         r.setExtent(QgsRectangle())
-        self.assertAlmostEqual(r.convertToPainterUnits(5555, QgsUnitTypes.RenderMetersInMapUnits), 0.0499, 3)
+        self.assertAlmostEqual(r.convertToPainterUnits(5555, QgsUnitTypes.RenderMetersInMapUnits), 84692, -10)
 
     def testConvertSingleUnit(self):
         ms = QgsMapSettings()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -415,7 +415,7 @@ class TestQgsRenderContext(unittest.TestCase):
         Test converting map unit based sizes to painter units when render context has NO map to pixel set
         """
         r = QgsRenderContext()
-        r.setScaleFactor(300 / 25.4) # 300 dpi, to match above test
+        r.setScaleFactor(300 / 25.4)  # 300 dpi, to match above test
 
         # start with no min/max scale
         c = QgsMapUnitScale()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -67,6 +67,9 @@ class TestQgsRenderContext(unittest.TestCase):
         c.setSymbologyReferenceScale(1000)
         self.assertEqual(c.symbologyReferenceScale(), 1000)
 
+        # should have an invalid mapToPixel by default
+        self.assertFalse(c.mapToPixel().isValid())
+
     def testCopyConstructor(self):
         """
         Test the copy constructor
@@ -113,6 +116,9 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertEqual(c.testFlag(QgsRenderContext.LosslessImageRendering), False)
         self.assertAlmostEqual(c.scaleFactor(), 88 / 25.4, 3)
 
+        # should have an invalid mapToPixel by default
+        self.assertFalse(c.mapToPixel().isValid())
+
         im = QImage(1000, 600, QImage.Format_RGB32)
         dots_per_m = 300 / 25.4 * 1000  # 300 dpi to dots per m
         im.setDotsPerMeterX(dots_per_m)
@@ -152,6 +158,9 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertTrue(rc.testFlag(QgsRenderContext.Render3DMap))
         self.assertEqual(ms.zRange(), QgsDoubleRange(1, 10))
         self.assertEqual(rc.symbologyReferenceScale(), -1)
+
+        # should have an valid mapToPixel
+        self.assertTrue(rc.mapToPixel().isValid())
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         ms.setZRange(QgsDoubleRange())


### PR DESCRIPTION
This PR implements so handling to prevent the quasi-hang descripted in #41149. Specifically we now have special logic in place to handle symbol sizes in map units when rendered in a context with no associated map scale (e.g. symbol preview icons). 

Fixes #41149

Also fixes #42668