### PR TITLE
Fix very low dpi rendering of pdf files in layout picture items

### DIFF
--- a/python/core/auto_generated/qgsimagecache.sip.in
+++ b/python/core/auto_generated/qgsimagecache.sip.in
@@ -60,7 +60,7 @@ in the same thread to ensure provided the image. WARNING: the ``blocking`` param
 be ``True`` from GUI based applications (like the main QGIS application) or crashes will result. Only for
 use in external scripts or QGIS server.
 
-Since QGIS 3.22 the ``targetDpi`` argument can be used to specify an explict DPI to render the image
+Since QGIS 3.22 the ``targetDpi`` argument can be used to specify an explicit DPI to render the image
 at. This is used for some image formats (e.g. PDF) to ensure that content is rendered at the desired
 DPI. This argument is only used when an invalid ``size`` argument is specified. If a valid ``size`` is
 specified then the image will always be rendered at this size, regardless of the ``targetDpi``.

--- a/python/core/auto_generated/qgsimagecache.sip.in
+++ b/python/core/auto_generated/qgsimagecache.sip.in
@@ -35,7 +35,7 @@ reuse without incurring the cost of resampling on every render.
 Constructor for QgsImageCache, with the specified ``parent`` object.
 %End
 
-    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache /Out/, bool blocking = false );
+    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache /Out/, bool blocking = false, double targetDpi = 96 );
 %Docstring
 Returns the specified ``path`` rendered as an image. If possible, a pre-existing cached
 version of the image will be used. If not, the image is fetched and resampled to the desired
@@ -59,6 +59,11 @@ The ``blocking`` boolean forces to wait for loading before returning image. The 
 in the same thread to ensure provided the image. WARNING: the ``blocking`` parameter must NEVER
 be ``True`` from GUI based applications (like the main QGIS application) or crashes will result. Only for
 use in external scripts or QGIS server.
+
+Since QGIS 3.22 the ``targetDpi`` argument can be used to specify an explict DPI to render the image
+at. This is used for some image formats (e.g. PDF) to ensure that content is rendered at the desired
+DPI. This argument is only used when an invalid ``size`` argument is specified. If a valid ``size`` is
+specified then the image will always be rendered at this size, regardless of the ``targetDpi``.
 %End
 
     QSize originalSize( const QString &path, bool blocking = false ) const;

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -384,6 +384,7 @@ void QgsLayoutItemPicture::loadRemotePicture( const QString &url )
   if ( reply )
   {
     QImageReader imageReader( reply );
+    imageReader.setAutoTransform( true );
 
     if ( imageReader.format() == "pdf" )
     {
@@ -449,6 +450,7 @@ void QgsLayoutItemPicture::loadLocalPicture( const QString &path )
     {
       //try to open raster with QImageReader
       QImageReader imageReader( pic.fileName() );
+      imageReader.setAutoTransform( true );
 
       if ( imageReader.format() == "pdf" )
       {

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -463,7 +463,7 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
     {
       bool fitsInCache = false;
       bool isMissing = false;
-      mImage = QgsApplication::imageCache()->pathAsImage( path, QSize(), true, 1, fitsInCache, true, &isMissing );
+      mImage = QgsApplication::imageCache()->pathAsImage( path, QSize(), true, 1, fitsInCache, true, mLayout->renderContext().dpi(), &isMissing );
       if ( mImage.isNull() || isMissing )
         mMode = FormatUnknown;
       break;

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -200,6 +200,7 @@ QImage QgsImageCache::renderImage( const QString &path, QSize size, const bool k
   if ( !path.startsWith( QLatin1String( "base64:" ) ) && QFile::exists( path ) )
   {
     QImageReader reader( path );
+    reader.setAutoTransform( true );
 
     if ( reader.format() == "pdf" )
     {
@@ -278,6 +279,7 @@ QImage QgsImageCache::renderImage( const QString &path, QSize size, const bool k
       buffer.open( QIODevice::ReadOnly );
 
       QImageReader reader( &buffer );
+      reader.setAutoTransform( true );
 
       if ( reader.format() == "pdf" )
       {

--- a/src/core/qgsimagecache.h
+++ b/src/core/qgsimagecache.h
@@ -45,8 +45,10 @@ class CORE_EXPORT QgsImageCacheEntry : public QgsAbstractContentCacheEntry
      *
      * If \a keepAspectRatio is TRUE then the original raster aspect ratio will always be preserved
      * when resizing.
+     *
+     * The \a targetDpi argument is ignored if \a size is a valid size.
      */
-    QgsImageCacheEntry( const QString &path, QSize size, bool keepAspectRatio, double opacity ) ;
+    QgsImageCacheEntry( const QString &path, QSize size, bool keepAspectRatio, double opacity, double targetDpi ) ;
 
     //! Rendered image size
     QSize size;
@@ -66,6 +68,13 @@ class CORE_EXPORT QgsImageCacheEntry : public QgsAbstractContentCacheEntry
      * \since QGIS 3.14
      */
     bool isMissingImage = false;
+
+    /**
+     * Target DPI
+     *
+     * \since QGIS 3.22
+     */
+    double targetDpi = 96;
 
     int dataSize() const override;
     void dump() const override;
@@ -128,11 +137,16 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
      * in the same thread to ensure provided the image. WARNING: the \a blocking parameter must NEVER
      * be TRUE from GUI based applications (like the main QGIS application) or crashes will result. Only for
      * use in external scripts or QGIS server.
+     *
+     * Since QGIS 3.22 the \a targetDpi argument can be used to specify an explict DPI to render the image
+     * at. This is used for some image formats (e.g. PDF) to ensure that content is rendered at the desired
+     * DPI. This argument is only used when an invalid \a size argument is specified. If a valid \a size is
+     * specified then the image will always be rendered at this size, regardless of the \a targetDpi.
      */
 #ifndef SIP_RUN
-    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache SIP_OUT, bool blocking = false, bool *isMissing = nullptr );
+    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache SIP_OUT, bool blocking = false, double targetDpi = 96, bool *isMissing = nullptr );
 #else
-    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache SIP_OUT, bool blocking = false );
+    QImage pathAsImage( const QString &path, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache SIP_OUT, bool blocking = false, double targetDpi = 96 );
 #endif
 
     /**
@@ -161,7 +175,7 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
 
   private:
 
-    QImage renderImage( const QString &path, QSize size, const bool keepAspectRatio, const double opacity, bool &isBroken, bool blocking = false ) const;
+    QImage renderImage( const QString &path, QSize size, const bool keepAspectRatio, const double opacity, double targetDpi, bool &isBroken, bool blocking = false ) const;
 
     //! SVG content to be rendered if SVG file was not found.
     QByteArray mMissingSvg;

--- a/src/core/qgsimagecache.h
+++ b/src/core/qgsimagecache.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
      * be TRUE from GUI based applications (like the main QGIS application) or crashes will result. Only for
      * use in external scripts or QGIS server.
      *
-     * Since QGIS 3.22 the \a targetDpi argument can be used to specify an explict DPI to render the image
+     * Since QGIS 3.22 the \a targetDpi argument can be used to specify an explicit DPI to render the image
      * at. This is used for some image formats (e.g. PDF) to ensure that content is rendered at the desired
      * DPI. This argument is only used when an invalid \a size argument is specified. If a valid \a size is
      * specified then the image will always be rendered at this size, regardless of the \a targetDpi.

--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -55,6 +55,7 @@ class TestQgsImageCache : public QObject
     void opacity(); // check non-opaque image rendering
     void base64();
     void empty();
+    void dpi();
 
 };
 
@@ -144,12 +145,12 @@ void TestQgsImageCache::broken()
   QgsImageCache cache;
   bool inCache = false;
   bool missingImage = false;
-  const QImage img = cache.pathAsImage( QStringLiteral( "bbbbbbb" ), QSize( 200, 200 ), true, 1.0, inCache, false, &missingImage );
+  const QImage img = cache.pathAsImage( QStringLiteral( "bbbbbbb" ), QSize( 200, 200 ), true, 1.0, inCache, false, 96,  &missingImage );
   QVERIFY( missingImage );
-  cache.pathAsImage( QStringLiteral( "bbbbbbb" ), QSize( 200, 200 ), true, 1.0, inCache, false, &missingImage );
+  cache.pathAsImage( QStringLiteral( "bbbbbbb" ), QSize( 200, 200 ), true, 1.0, inCache, false, 96, &missingImage );
   QVERIFY( missingImage );
   const QString originalImage = TEST_DATA_DIR + QStringLiteral( "/sample_image.png" );
-  cache.pathAsImage( originalImage, QSize( 200, 200 ), true, 1.0, inCache, false, &missingImage );
+  cache.pathAsImage( originalImage, QSize( 200, 200 ), true, 1.0, inCache, false, 96, &missingImage );
   QVERIFY( !missingImage );
 }
 
@@ -301,6 +302,20 @@ void TestQgsImageCache::empty()
   QVERIFY( img.isNull() );
 
   QVERIFY( !cache.originalSize( QStringLiteral( " " ) ).isValid() );
+}
+
+void TestQgsImageCache::dpi()
+{
+  QgsImageCacheEntry entry1( QStringLiteral( "my path" ), QSize(), true, 1, 96 );
+  QgsImageCacheEntry entry2( QStringLiteral( "my path" ), QSize(), true, 1, 300 );
+  QVERIFY( !entry1.isEqual( &entry2 ) );
+  entry2.targetDpi = 96;
+  QVERIFY( entry1.isEqual( &entry2 ) );
+  entry2.targetDpi = 300;
+  // target dpi is ignored if a valid size is set
+  entry1.size = QSize( 100, 100 );
+  entry2.size = QSize( 100, 100 );
+  QVERIFY( entry1.isEqual( &entry2 ) );
 }
 
 bool TestQgsImageCache::imageCheck( const QString &testName, QImage &image, int mismatchCount )


### PR DESCRIPTION
For the PDF QImage driver we need to pass the desired target size onto the image reader so that it can correctly render the (vector) pdf content at the desired dpi. Otherwise it returns a very low resolution image (the driver assumes points == pixels!)

This PR adds the API required to handle this to QgsImageCache, and ensures that PDF content is rendered in a layout picture item in the same dpi as the layout settings.

This change also made it trivial to fix #38611, and ensure that layout picture items are correctly rotated to match the image exif tags.