### PR TITLE
[vector tile] Add encodeUri/decodeUri functions, fix bad layer handler's browse button not working for vector tile layers

### DIFF
--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -53,6 +53,7 @@ void QgsVectorTileLayer::setDataSourcePrivate( const QString &dataSource, const 
 {
   mDataSource = dataSource;
   mLayerName = baseName;
+  mDataProvider.reset();
 
   setValid( loadDataSource() );
 }
@@ -128,7 +129,7 @@ bool QgsVectorTileLayer::loadDataSource()
 
   setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
 
-  const QgsDataProvider::ProviderOptions providerOptions;
+  const QgsDataProvider::ProviderOptions providerOptions { transformContext() };
   const QgsDataProvider::ReadFlags flags;
   mDataProvider.reset( new QgsVectorTileDataProvider( providerOptions, flags ) );
   mProviderKey = mDataProvider->name();

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -628,20 +628,7 @@ QString QgsVectorTileLayer::htmlMetadata() const
 
   QString info = QStringLiteral( "<html><head></head>\n<body>\n" );
 
-  info += QStringLiteral( "<h1>" ) + tr( "Information from provider" ) + QStringLiteral( "</h1>\n<hr>\n" ) %
-          QStringLiteral( "<table class=\"list-view\">\n" );
-
-  // name
-  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Name" ) % QStringLiteral( "</td><td>" ) % name() % QStringLiteral( "</td></tr>\n" );
-
-  // local path
-  const QString url = sourcePath();
-  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Path" ) % QStringLiteral( "</td><td>%1" ).arg( QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl( url ).toString(), sourcePath() ) ) + QStringLiteral( "</td></tr>\n" );
-
-  // data source
-  info += QStringLiteral( "<tr><td class=\"highlight\">" ) % tr( "Source" ) % QStringLiteral( "</td><td>" ) % source() % QStringLiteral( "</td></tr>\n" );
-
-  info += QLatin1String( "</table>\n<br>" );
+  info += generalHtmlMetadata();
 
   info += QStringLiteral( "<h1>" ) + tr( "Information from provider" ) + QStringLiteral( "</h1>\n<hr>\n" ) %
           QStringLiteral( "<table class=\"list-view\">\n" );

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -198,6 +198,10 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     std::unique_ptr< QgsDataProvider > mDataProvider;
 
     bool setupArcgisVectorTileServiceConnection( const QString &uri, const QgsDataSourceUri &dataSourceUri );
+
+    void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
+                               const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags ) override;
+
 };
 
 #ifndef SIP_RUN

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -67,7 +67,12 @@ QVariantMap QgsVectorTileProviderMetadata::decodeUri( const QString &uri ) const
 
   QVariantMap uriComponents;
   uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
-  if ( uriComponents[ QStringLiteral( "type" ) ] == QStringLiteral( "mbtiles" ) )
+  if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
+    uriComponents.insert( QStringLiteral( "serviceType" ), dsUri.param( QStringLiteral( "serviceType" ) ) );
+
+  if ( uriComponents[ QStringLiteral( "type" ) ] == QStringLiteral( "mbtiles" ) ||
+       ( uriComponents[ QStringLiteral( "type" ) ] == QStringLiteral( "xyz" ) &&
+         !dsUri.param( QStringLiteral( "url" ) ).startsWith( QStringLiteral( "http" ) ) ) )
   {
     uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
   }
@@ -75,6 +80,21 @@ QVariantMap QgsVectorTileProviderMetadata::decodeUri( const QString &uri ) const
   {
     uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
   }
+
+  if ( dsUri.hasParam( QStringLiteral( "zmin" ) ) )
+    uriComponents.insert( QStringLiteral( "zmin" ), dsUri.param( QStringLiteral( "zmin" ) ) );
+  if ( dsUri.hasParam( QStringLiteral( "zmax" ) ) )
+    uriComponents.insert( QStringLiteral( "zmax" ), dsUri.param( QStringLiteral( "zmax" ) ) );
+
+  if ( dsUri.hasParam( QStringLiteral( "referer" ) ) )
+    uriComponents.insert( QStringLiteral( "referer" ), dsUri.param( QStringLiteral( "referer" ) ) );
+  if ( dsUri.hasParam( QStringLiteral( "styleUrl" ) ) )
+    uriComponents.insert( QStringLiteral( "styleUrl" ), dsUri.param( QStringLiteral( "styleUrl" ) ) );
+
+  const QString authcfg = dsUri.authConfigId();
+  if ( !authcfg.isEmpty() )
+    uriComponents.insert( QStringLiteral( "authcfg" ), authcfg );
+
   return uriComponents;
 }
 
@@ -82,7 +102,23 @@ QString QgsVectorTileProviderMetadata::encodeUri( const QVariantMap &parts ) con
 {
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
+  if ( parts.contains( QStringLiteral( "serviceType" ) ) )
+    dsUri.setParam( QStringLiteral( "serviceType" ), parts[ QStringLiteral( "serviceType" ) ].toString() );
   dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
+
+  if ( parts.contains( QStringLiteral( "zmin" ) ) )
+    dsUri.setParam( QStringLiteral( "zmin" ), parts[ QStringLiteral( "zmin" ) ].toString() );
+  if ( parts.contains( QStringLiteral( "zmax" ) ) )
+    dsUri.setParam( QStringLiteral( "zmax" ), parts[ QStringLiteral( "zmax" ) ].toString() );
+
+  if ( parts.contains( QStringLiteral( "referer" ) ) )
+    dsUri.setParam( QStringLiteral( "referer" ), parts[ QStringLiteral( "referer" ) ].toString() );
+  if ( parts.contains( QStringLiteral( "styleUrl" ) ) )
+    dsUri.setParam( QStringLiteral( "styleUrl" ), parts[ QStringLiteral( "styleUrl" ) ].toString() );
+
+  if ( parts.contains( QStringLiteral( "authcfg" ) ) )
+    dsUri.setAuthConfigId( parts[ QStringLiteral( "authcfg" ) ].toString() );
+
   return dsUri.encodedUri();
 }
 

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -55,4 +55,35 @@ void QgsVectorTileProviderMetadata::saveConnection( const QgsAbstractProviderCon
   saveConnectionProtected( connection, name );
 }
 
+QgsProviderMetadata::ProviderCapabilities QgsVectorTileProviderMetadata::providerCapabilities() const
+{
+  return FileBasedUris;
+}
+
+QVariantMap QgsVectorTileProviderMetadata::decodeUri( const QString &uri ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setEncodedUri( uri );
+
+  QVariantMap uriComponents;
+  uriComponents.insert( QStringLiteral( "type" ), dsUri.param( QStringLiteral( "type" ) ) );
+  if ( uriComponents[ QStringLiteral( "type" ) ] == QStringLiteral( "mbtiles" ) )
+  {
+    uriComponents.insert( QStringLiteral( "path" ), dsUri.param( QStringLiteral( "url" ) ) );
+  }
+  else
+  {
+    uriComponents.insert( QStringLiteral( "url" ), dsUri.param( QStringLiteral( "url" ) ) );
+  }
+  return uriComponents;
+}
+
+QString QgsVectorTileProviderMetadata::encodeUri( const QVariantMap &parts ) const
+{
+  QgsDataSourceUri dsUri;
+  dsUri.setParam( QStringLiteral( "type" ), parts.value( QStringLiteral( "type" ) ).toString() );
+  dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
+  return dsUri.encodedUri();
+}
+
 ///@endcond

--- a/src/core/vectortile/qgsvectortileprovidermetadata.h
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.h
@@ -40,6 +40,11 @@ class QgsVectorTileProviderMetadata : public QgsProviderMetadata
     void deleteConnection( const QString &name ) override;
     void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) override;
 
+    ProviderCapabilities providerCapabilities() const override;
+
+    QVariantMap decodeUri( const QString &uri ) const override;
+    QString encodeUri( const QVariantMap &parts ) const override;
+
 };
 
 ///@endcond


### PR DESCRIPTION
## Description

This PR implements a encodeUri/decodeUri pair of functions to the vector tile provider metatada class, as well as the vector tile layer's setDataSourcePrivate function. Among other things, this fixes the broken [ browse ] button in the bad layer handler dialog for vector tile layers:

https://user-images.githubusercontent.com/1728657/134641253-f6c79c41-022c-479e-b0b7-5bbb9661d3f2.mp4

In addition, alongside @nyalldawson 's recent addition of an hyper simple vector tile data provider, it greatly improves handling of data source via python scripts. E.g., plugins which would iterate over a list of map layers and fetch file-based datasets can now easily capture file-based vector tile layers. :partying_face: 