### PR TITLE
Update of virtual fields considering values of the same form fix #43900

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -594,23 +594,11 @@ void QgsAttributeForm::updateValuesDependenciesVirtualFields( const int originId
 
     for ( int i = 0; i < dstVars.count(); i++ )
     {
-      if ( !qgsVariantEqual( dstVars[i], srcVars[i] ) && srcVars[i].isValid() && fieldIsEditable( fieldIndexes[i] ) )
+      if ( !qgsVariantEqual( dstVars[i], srcVars[i] ) && srcVars[i].isValid() )
         featureAttributes[fieldIndexes[i]] = srcVars[i];
     }
   }
   updatedFeature.setAttributes( featureAttributes );
-
-  // If originIdx is a virtual field make sure it is up to date
-  {
-    QString expressionField = mLayer->expressionField( originIdx );
-    if ( ! expressionField.isEmpty() )
-    {
-      QgsExpressionContext context = createExpressionContext( updatedFeature );
-      QgsExpression exp( expressionField );
-      QVariant value = exp.evaluate( &context );
-      updatedFeature.setAttribute( originIdx, value );
-    }
-  }
 
   // go through depending fields and update the virtual field with its expression
   QList<QgsWidgetWrapper *> relevantWidgets = mVirtualFieldsDependencies.values( originIdx );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -596,7 +596,7 @@ void QgsAttributeForm::updateVirtualFields( const int originIdx )
     }
   }
 
-  // go through depending fields and update the fields with virtual field
+// go through depending fields and update the virtual field with its expression
   QList<QgsWidgetWrapper *> relevantWidgets = mVirtualFieldsDependencies.values( originIdx );
   for ( QgsWidgetWrapper *ww : std::as_const( relevantWidgets ) )
   {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -414,7 +414,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! update the default values in the fields after a referenced field changed
     bool updateDefaultValues( const int originIdx );
 
-    //! update the virtual fields values in the fields after a referenced field changed
+//! update the value in the virtual fields after a referenced field changed
     void updateVirtualFields( const int originIdx );
 
     void clearMultiEditMessages();

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -377,9 +377,9 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     bool fieldIsEditable( const QgsVectorLayer &layer, int fieldIndex, QgsFeatureId fid ) const;
 
-    void updateDefaultValueDependencies();
-
-    void updateVirtualFieldsDependencies();
+    void updateFieldDependencies();
+    void updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapper *eww );
+    void updateFieldDependenciesVirtualFields( QgsEditorWidgetWrapper *eww );
 
     struct WidgetInfo
     {
@@ -408,14 +408,10 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! Save single feature or add feature edits
     bool saveEdits( QString *error );
 
-    //! fill up dependency map for default values
-    void createDefaultValueDependencies();
-
-    //! update the default values in the fields after a referenced field changed
-    bool updateDefaultValues( const int originIdx );
-
-//! update the value in the virtual fields after a referenced field changed
-    void updateVirtualFields( const int originIdx );
+    //! update the default values and virtual fields in the fields after a referenced field changed
+    void updateValuesDependencies( const int originIdx );
+    void updateValuesDependenciesDefaultValues( const int originIdx );
+    void updateValuesDependenciesVirtualFields( const int originIdx );
 
     void clearMultiEditMessages();
     void pushSelectedFeaturesMessage();

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -379,6 +379,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void updateDefaultValueDependencies();
 
+    void updateVirtualFieldsDependencies();
+
     struct WidgetInfo
     {
       QWidget *widget = nullptr;
@@ -411,6 +413,9 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     //! update the default values in the fields after a referenced field changed
     bool updateDefaultValues( const int originIdx );
+
+    //! update the virtual fields values in the fields after a referenced field changed
+    void updateVirtualFields( const int originIdx );
 
     void clearMultiEditMessages();
     void pushSelectedFeaturesMessage();
@@ -517,6 +522,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * Attribute indexes will be added multiple times if more than one widget depends on them.
      */
     QMap<int, QgsWidgetWrapper *> mDefaultValueDependencies;
+
+    /**
+     * Dependency map for values from virtual fields. Attribute index -> widget wrapper.
+     * Attribute indexes will be added multiple times if more than one widget depends on them.
+     */
+    QMap<int, QgsWidgetWrapper *> mVirtualFieldsDependencies;
 
     //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;


### PR DESCRIPTION
Similar to the default values handling, a reference list (widget->field) is built to decide which virtual field widget must be updated.
Fix #43900