### PR TITLE
[Backport queued_ltr] QgisApp::closeProject(): cancel canvas jobs before closing the project, to avoid rendering jobs to access deleted objects (fixes #44144)

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -133,6 +133,7 @@ Make sure to remove any rendered images from cache (does nothing if cache is not
 .. versionadded:: 2.4
 %End
 
+
     void waitWhileRendering();
 %Docstring
 Blocks until the rendering job has finished.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13387,6 +13387,7 @@ void QgisApp::closeProject()
   // clear out any stuff from project
   mMapCanvas->setLayers( QList<QgsMapLayer *>() );
   mMapCanvas->clearCache();
+  mMapCanvas->cancelJobs();
   mOverviewCanvas->setLayers( QList<QgsMapLayer *>() );
 
   // Avoid unnecessary layer changed handling for each layer removed - instead,

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -242,23 +242,7 @@ QgsMapCanvas::~QgsMapCanvas()
   }
   mLastNonZoomMapTool = nullptr;
 
-  // rendering job may still end up writing into canvas map item
-  // so kill it before deleting canvas items
-  if ( mJob )
-  {
-    whileBlocking( mJob )->cancel();
-    delete mJob;
-  }
-
-  QList< QgsMapRendererQImageJob * >::const_iterator previewJob = mPreviewJobs.constBegin();
-  for ( ; previewJob != mPreviewJobs.constEnd(); ++previewJob )
-  {
-    if ( *previewJob )
-    {
-      whileBlocking( *previewJob )->cancel();
-      delete *previewJob;
-    }
-  }
+  cancelJobs();
 
   // delete canvas items prior to deleting the canvas
   // because they might try to update canvas when it's
@@ -270,6 +254,31 @@ QgsMapCanvas::~QgsMapCanvas()
   delete mCache;
   delete mLabelingResults;
 }
+
+
+void QgsMapCanvas::cancelJobs()
+{
+
+  // rendering job may still end up writing into canvas map item
+  // so kill it before deleting canvas items
+  if ( mJob )
+  {
+    whileBlocking( mJob )->cancel();
+    delete mJob;
+    mJob = nullptr;
+  }
+
+  QList< QgsMapRendererQImageJob * >::const_iterator previewJob = mPreviewJobs.constBegin();
+  for ( ; previewJob != mPreviewJobs.constEnd(); ++previewJob )
+  {
+    if ( *previewJob )
+    {
+      whileBlocking( *previewJob )->cancel();
+      delete *previewJob;
+    }
+  }
+}
+
 
 void QgsMapCanvas::setMagnificationFactor( double factor, const QgsPointXY *center )
 {

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -184,6 +184,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     void clearCache();
 
     /**
+     * Cancel any rendering job, in a blocking way. Used for application closing.
+     * \note not available in Python bindings
+     */
+    void cancelJobs() SIP_SKIP;
+
+    /**
      * Blocks until the rendering job has finished.
      *
      * In almost all cases you do NOT want to call this, as it will hang the UI


### PR DESCRIPTION
Backport of PR #45227