### PR TITLE
Fix updated parameter name

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -266,7 +266,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         while self.model().parameterDefinition(name):
             name = safeName.lower() + str(i)
             i += 1
-        parameter.setName(safeName)
+        parameter.setName(name)
 
     def addInput(self, paramType, pos=None):
         if paramType not in [param.id() for param in QgsApplication.instance().processingRegistry().parameterTypes()]:


### PR DESCRIPTION
## Description

Fix of #44378, it's the wrong variable that is used in the method.

However, it's possible that we could add characters (like '_') in allowed list or even, the name became case sensitive (actually, it is, but with this fix, it won't be anymore). I can't see all usages of the parameter name...