### PR TITLE
Harmonize raster and mesh calculator operators order

### DIFF
--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Mesh calculator</string>
+   <string>Mesh Calculator</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
@@ -258,25 +258,12 @@
            <item row="0" column="0" colspan="2">
             <widget class="QPushButton" name="mCurrentLayerExtentButton">
              <property name="text">
-              <string>Selected Layer Extent</string>
+              <string>Use Selected Layer Extent</string>
              </property>
             </widget>
            </item>
           </layout>
          </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <spacer name="verticalSpacer">
@@ -317,24 +304,24 @@
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout_4">
-          <item row="2" column="4">
+          <item row="0" column="4">
            <widget class="QComboBox" name="mEndTimeComboBox"/>
           </item>
-          <item row="2" column="3">
+          <item row="0" column="3">
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string>End time</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="0" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Start time</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
+          <item row="0" column="2">
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -347,7 +334,7 @@
             </property>
            </spacer>
           </item>
-          <item row="2" column="1">
+          <item row="0" column="1">
            <widget class="QComboBox" name="mStartTimeComboBox"/>
           </item>
          </layout>
@@ -374,6 +361,199 @@
      <widget class="QWidget" name="verticalLayoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
+         <property name="title">
+          <string>Operators</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QPushButton" name="mPlusPushButton">
+            <property name="text">
+             <string>+</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="mMultiplyPushButton">
+            <property name="text">
+             <string>*</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="mOpenBracketPushButton">
+            <property name="text">
+             <string>(</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QPushButton" name="mMinButton">
+            <property name="text">
+             <string>min</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QPushButton" name="mIfButton">
+            <property name="text">
+             <string>IF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QPushButton" name="mSumAggrButton">
+            <property name="text">
+             <string>sum (aggr)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QPushButton" name="mMinusPushButton">
+            <property name="text">
+             <string>-</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="mDividePushButton">
+            <property name="text">
+             <string>/</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="mCloseBracketPushButton">
+            <property name="text">
+             <string>)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="mMaxButton">
+            <property name="text">
+             <string>max</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QPushButton" name="mAndButton">
+            <property name="text">
+             <string>AND</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="5">
+           <widget class="QPushButton" name="mMaxAggrButton">
+            <property name="text">
+             <string>max (aggr)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="mLessButton">
+            <property name="text">
+             <string>&lt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="mGreaterButton">
+            <property name="text">
+             <string>&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="mEqualButton">
+            <property name="text">
+             <string>=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QPushButton" name="mAbsButton">
+            <property name="text">
+             <string>abs</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QPushButton" name="mOrButton">
+            <property name="text">
+             <string>OR</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QPushButton" name="mMinAggrButton">
+            <property name="text">
+             <string>min (aggr)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QPushButton" name="mLesserEqualButton">
+            <property name="text">
+             <string>&lt;=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="mGreaterEqualButton">
+            <property name="text">
+             <string>&gt;=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QPushButton" name="mNotEqualButton">
+            <property name="text">
+             <string>!=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QPushButton" name="mPowButton">
+            <property name="text">
+             <string>^</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QPushButton" name="mNotButton">
+            <property name="text">
+             <string>NOT</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="5">
+           <widget class="QPushButton" name="mAverageAggrButton">
+            <property name="text">
+             <string>average (aggr)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="mNoDataButton">
+         <property name="text">
+          <string>NODATA</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Mesh Calculator Expression</string>
@@ -388,199 +568,6 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item>
-           <widget class="QgsCollapsibleGroupBox" name="mOperatorsGroupBox">
-            <property name="title">
-             <string>Operators</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="3" column="0">
-              <widget class="QPushButton" name="mLesserEqualButton">
-               <property name="text">
-                <string>&lt;=</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QPushButton" name="mGreaterEqualButton">
-               <property name="text">
-                <string>&gt;=</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QPushButton" name="mDividePushButton">
-               <property name="text">
-                <string>/</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QPushButton" name="mMultiplyPushButton">
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QPushButton" name="mPlusPushButton">
-               <property name="text">
-                <string>+</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="5">
-              <widget class="QPushButton" name="mMaxButton">
-               <property name="text">
-                <string>max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="4">
-              <widget class="QPushButton" name="mEqualButton">
-               <property name="text">
-                <string>=</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QPushButton" name="mGreaterButton">
-               <property name="text">
-                <string>&gt;</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QPushButton" name="mLessButton">
-               <property name="text">
-                <string>&lt;</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="5">
-              <widget class="QPushButton" name="mAbsButton">
-               <property name="text">
-                <string>abs</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="4">
-              <widget class="QPushButton" name="mNotEqualButton">
-               <property name="text">
-                <string>!=</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="5">
-              <widget class="QPushButton" name="mMinButton">
-               <property name="text">
-                <string>min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="4">
-              <widget class="QPushButton" name="mOpenBracketPushButton">
-               <property name="text">
-                <string>(</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="4">
-              <widget class="QPushButton" name="mCloseBracketPushButton">
-               <property name="text">
-                <string>)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="6">
-              <widget class="QPushButton" name="mIfButton">
-               <property name="text">
-                <string>IF</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="6">
-              <widget class="QPushButton" name="mAndButton">
-               <property name="text">
-                <string>AND</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="6">
-              <widget class="QPushButton" name="mOrButton">
-               <property name="text">
-                <string>OR</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="6">
-              <widget class="QPushButton" name="mNotButton">
-               <property name="text">
-                <string>NOT</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="5">
-              <widget class="QPushButton" name="mPowButton">
-               <property name="text">
-                <string>^</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="13">
-              <widget class="QPushButton" name="mSumAggrButton">
-               <property name="text">
-                <string>sum (aggr)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="13">
-              <widget class="QPushButton" name="mMaxAggrButton">
-               <property name="text">
-                <string>max (aggr)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="13">
-              <widget class="QPushButton" name="mMinAggrButton">
-               <property name="text">
-                <string>min (aggr)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="13">
-              <widget class="QPushButton" name="mAverageAggrButton">
-               <property name="text">
-                <string>average (aggr)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QPushButton" name="mMinusPushButton">
-               <property name="text">
-                <string>-</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="mNoDataButton">
-            <property name="text">
-             <string>NODATA</string>
-            </property>
-           </widget>
-          </item>
           <item>
            <widget class="QTextEdit" name="mExpressionTextEdit"/>
           </item>
@@ -680,6 +667,7 @@
   <tabstop>mAverageAggrButton</tabstop>
   <tabstop>mNoDataButton</tabstop>
   <tabstop>mExpressionTextEdit</tabstop>
+  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -43,21 +43,21 @@
           <item row="3" column="0">
            <widget class="QLabel" name="mOutputFormatLabel_2">
             <property name="text">
-             <string>Group Name</string>
+             <string>Group name</string>
             </property>
            </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="mOutputFormatLabel">
             <property name="text">
-             <string>Output Format</string>
+             <string>Output format</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
            <widget class="QRadioButton" name="mOutputOnFileRadioButton">
             <property name="text">
-             <string>On File</string>
+             <string>On file</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -70,7 +70,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="mOutputDatasetLabel">
             <property name="text">
-             <string>Output Dataset</string>
+             <string>Output dataset</string>
             </property>
            </widget>
           </item>
@@ -90,7 +90,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Output File</string>
+             <string>Output file</string>
             </property>
            </widget>
           </item>
@@ -102,7 +102,7 @@
            <item>
             <widget class="QCheckBox" name="useExtentCb">
              <property name="text">
-              <string>Current Extent</string>
+              <string>Current extent</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -115,7 +115,7 @@
            <item>
             <widget class="QCheckBox" name="useMaskCb">
              <property name="text">
-              <string>Mask Layer</string>
+              <string>Mask layer</string>
              </property>
              <attribute name="buttonGroup">
               <string notr="true">buttonGroup</string>
@@ -146,7 +146,7 @@
               </size>
              </property>
              <property name="text">
-              <string>Mask Layer       </string>
+              <string>Mask layer</string>
              </property>
             </widget>
            </item>
@@ -270,12 +270,12 @@
           <item>
            <widget class="QPushButton" name="mAllTimesButton">
             <property name="text">
-             <string>All Selected Dataset Times </string>
+             <string>Use all Selected Dataset Times</string>
             </property>
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_4">
+           <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -403,6 +403,19 @@
              <string>sum (aggr)</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="6">
+           <spacer name="horizontalSpacer_1">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="1" column="0">
            <widget class="QPushButton" name="mMinusPushButton">

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -266,19 +266,6 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QPushButton" name="mAllTimesButton">
@@ -340,7 +327,7 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalSpacer_2">
+         <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -50,21 +50,21 @@
         </item>
         <item row="5" column="0" colspan="4">
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="3">
+          <item row="2" column="3">
            <widget class="QLabel" name="mRowsLabel">
             <property name="text">
              <string>Rows</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
+          <item row="2" column="4">
            <widget class="QgsSpinBox" name="mNRowsSpinBox">
             <property name="maximum">
              <number>999999999</number>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="1" column="1">
            <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
             <property name="decimals">
              <number>5</number>
@@ -77,49 +77,49 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="mYMinLabel">
             <property name="text">
              <string>Y min</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="0" column="0">
            <widget class="QLabel" name="mXMinLabel">
             <property name="text">
              <string>X min</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="3">
+          <item row="0" column="3">
            <widget class="QLabel" name="mXMaxLabel">
             <property name="text">
              <string>X max</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="mColumnsLabel">
             <property name="text">
              <string>Columns</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QgsSpinBox" name="mNColumnsSpinBox">
             <property name="maximum">
              <number>999999999</number>
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
+          <item row="1" column="3">
            <widget class="QLabel" name="mYMaxLabel">
             <property name="text">
              <string>Y max</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
+          <item row="1" column="4">
            <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
             <property name="decimals">
              <number>5</number>
@@ -132,7 +132,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="0" column="1">
            <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
             <property name="decimals">
              <number>5</number>
@@ -145,7 +145,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
+          <item row="0" column="4">
            <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
             <property name="decimals">
              <number>5</number>
@@ -158,7 +158,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="0" column="2">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -246,7 +246,7 @@
         <item row="4" column="0">
          <widget class="QPushButton" name="mCurrentLayerExtentButton">
           <property name="text">
-           <string>Selected Layer Extent</string>
+           <string>Use Selected Layer Extent</string>
           </property>
          </widget>
         </item>
@@ -290,62 +290,6 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
-          <item row="2" column="11">
-           <widget class="QPushButton" name="mOrButton">
-            <property name="text">
-             <string notr="true">OR</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="10">
-           <widget class="QPushButton" name="mLnButton">
-            <property name="text">
-             <string notr="true">ln</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="6">
-           <widget class="QPushButton" name="mLesserEqualButton">
-            <property name="text">
-             <string notr="true">&lt;=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="10">
-           <widget class="QPushButton" name="mAndButton">
-            <property name="text">
-             <string notr="true">AND</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="10">
-           <widget class="QPushButton" name="mLogButton">
-            <property name="text">
-             <string notr="true">log10</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QPushButton" name="mLessButton">
-            <property name="text">
-             <string notr="true">&lt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="8">
-           <widget class="QPushButton" name="mGreaterEqualButton">
-            <property name="text">
-             <string notr="true">&gt;=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="8">
-           <widget class="QPushButton" name="mTanButton">
-            <property name="text">
-             <string notr="true">tan</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QPushButton" name="mPlusPushButton">
             <property name="text">
@@ -360,21 +304,42 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="mOpenBracketPushButton">
+            <property name="text">
+             <string notr="true">(</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QPushButton" name="mMinButton">
+            <property name="text">
+             <string notr="true">min</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="4">
+           <widget class="QPushButton" name="mConditionalStatButton">
+            <property name="text">
+             <string notr="true">if</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
            <widget class="QPushButton" name="mCosButton">
             <property name="text">
              <string notr="true">cos</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="mGreaterButton">
+          <item row="0" column="6">
+           <widget class="QPushButton" name="mACosButton">
             <property name="text">
-             <string notr="true">&gt;</string>
+             <string notr="true">acos</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="14">
+          <item row="0" column="7">
            <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -387,59 +352,10 @@
             </property>
            </spacer>
           </item>
-          <item row="1" column="8">
-           <widget class="QPushButton" name="mATanButton">
-            <property name="text">
-             <string notr="true">atan</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QPushButton" name="mACosButton">
-            <property name="text">
-             <string notr="true">acos</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="6">
-           <widget class="QPushButton" name="mASinButton">
-            <property name="text">
-             <string notr="true">asin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QPushButton" name="mNotEqualButton">
-            <property name="text">
-             <string notr="true">!=</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="11">
-           <widget class="QPushButton" name="mCloseBracketPushButton">
-            <property name="text">
-             <string notr="true">)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QPushButton" name="mEqualButton">
-            <property name="text">
-             <string notr="true">=</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QPushButton" name="mMinusPushButton">
             <property name="text">
              <string notr="true">-</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="11">
-           <widget class="QPushButton" name="mOpenBracketPushButton">
-            <property name="text">
-             <string notr="true">(</string>
             </property>
            </widget>
           </item>
@@ -451,51 +367,135 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QPushButton" name="mExpButton">
+           <widget class="QPushButton" name="mCloseBracketPushButton">
             <property name="text">
-             <string notr="true">^</string>
+             <string notr="true">)</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="6">
-           <widget class="QPushButton" name="mSinButton">
-            <property name="text">
-             <string notr="true">sin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="mSqrtButton">
-            <property name="text">
-             <string notr="true">sqrt</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QPushButton" name="mAbsButton">
-            <property name="text">
-             <string notr="true">abs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QPushButton" name="mMinButton">
-            <property name="text">
-             <string notr="true">min</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
+          <item row="1" column="3">
            <widget class="QPushButton" name="mMaxButton">
             <property name="text">
              <string notr="true">max</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
-           <widget class="QPushButton" name="mConditionalStatButton">
+          <item row="1" column="4">
+           <widget class="QPushButton" name="mAndButton">
             <property name="text">
-             <string notr="true">if</string>
+             <string notr="true">AND</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="5">
+           <widget class="QPushButton" name="mSinButton">
+            <property name="text">
+             <string notr="true">sin</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QPushButton" name="mASinButton">
+            <property name="text">
+             <string notr="true">asin</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="mLessButton">
+            <property name="text">
+             <string notr="true">&lt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="mGreaterButton">
+            <property name="text">
+             <string notr="true">&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="mEqualButton">
+            <property name="text">
+             <string notr="true">=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QPushButton" name="mAbsButton">
+            <property name="text">
+             <string notr="true">abs</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QPushButton" name="mOrButton">
+            <property name="text">
+             <string notr="true">OR</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QPushButton" name="mTanButton">
+            <property name="text">
+             <string notr="true">tan</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="6">
+           <widget class="QPushButton" name="mATanButton">
+            <property name="text">
+             <string notr="true">atan</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QPushButton" name="mLesserEqualButton">
+            <property name="text">
+             <string notr="true">&lt;=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="mGreaterEqualButton">
+            <property name="text">
+             <string notr="true">&gt;=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QPushButton" name="mNotEqualButton">
+            <property name="text">
+             <string notr="true">!=</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QPushButton" name="mExpButton">
+            <property name="text">
+             <string notr="true">^</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QPushButton" name="mSqrtButton">
+            <property name="text">
+             <string notr="true">sqrt</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="5">
+           <widget class="QPushButton" name="mLogButton">
+            <property name="text">
+             <string notr="true">log10</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="6">
+           <widget class="QPushButton" name="mLnButton">
+            <property name="text">
+             <string notr="true">ln</string>
             </property>
            </widget>
           </item>
@@ -581,6 +581,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mRasterBandsListWidget</tabstop>
+  <tabstop>mUseVirtualProviderCheckBox</tabstop>
+  <tabstop>mVirtualLayerName</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
   <tabstop>mCurrentLayerExtentButton</tabstop>
   <tabstop>mXMinSpinBox</tabstop>
@@ -593,32 +595,34 @@
   <tabstop>mAddResultToProjectCheckBox</tabstop>
   <tabstop>mPlusPushButton</tabstop>
   <tabstop>mMultiplyPushButton</tabstop>
-  <tabstop>mSqrtButton</tabstop>
-  <tabstop>mCosButton</tabstop>
-  <tabstop>mSinButton</tabstop>
-  <tabstop>mTanButton</tabstop>
-  <tabstop>mLogButton</tabstop>
   <tabstop>mOpenBracketPushButton</tabstop>
+  <tabstop>mMinButton</tabstop>
+  <tabstop>mConditionalStatButton</tabstop>
+  <tabstop>mCosButton</tabstop>
+  <tabstop>mACosButton</tabstop>
   <tabstop>mMinusPushButton</tabstop>
   <tabstop>mDividePushButton</tabstop>
-  <tabstop>mExpButton</tabstop>
-  <tabstop>mACosButton</tabstop>
-  <tabstop>mASinButton</tabstop>
-  <tabstop>mATanButton</tabstop>
-  <tabstop>mLnButton</tabstop>
   <tabstop>mCloseBracketPushButton</tabstop>
+  <tabstop>mMaxButton</tabstop>
+  <tabstop>mAndButton</tabstop>
+  <tabstop>mSinButton</tabstop>
+  <tabstop>mASinButton</tabstop>
   <tabstop>mLessButton</tabstop>
   <tabstop>mGreaterButton</tabstop>
   <tabstop>mEqualButton</tabstop>
-  <tabstop>mNotEqualButton</tabstop>
+  <tabstop>mAbsButton</tabstop>
+  <tabstop>mOrButton</tabstop>
+  <tabstop>mTanButton</tabstop>
+  <tabstop>mATanButton</tabstop>
   <tabstop>mLesserEqualButton</tabstop>
   <tabstop>mGreaterEqualButton</tabstop>
-  <tabstop>mAndButton</tabstop>
-  <tabstop>mOrButton</tabstop>
-  <tabstop>mAbsButton</tabstop>
-  <tabstop>mMinButton</tabstop>
-  <tabstop>mMaxButton</tabstop>
+  <tabstop>mNotEqualButton</tabstop>
+  <tabstop>mExpButton</tabstop>
+  <tabstop>mSqrtButton</tabstop>
+  <tabstop>mLogButton</tabstop>
+  <tabstop>mLnButton</tabstop>
   <tabstop>mExpressionTextEdit</tabstop>
+  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -173,7 +173,7 @@
           </item>
          </layout>
         </item>
-        <item row="8" column="0" colspan="4">
+        <item row="7" column="0" colspan="4">
          <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
           <property name="text">
            <string>Add result to project</string>
@@ -204,8 +204,8 @@
           </property>
          </widget>
         </item>
-        <item row="9" column="0">
-         <spacer name="verticalSpacer_2">
+        <item row="8" column="0">
+         <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -229,19 +229,6 @@
            <bool>false</bool>
           </property>
          </widget>
-        </item>
-        <item row="7" column="1">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item row="4" column="0">
          <widget class="QPushButton" name="mCurrentLayerExtentButton">

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -321,7 +321,7 @@
           <item row="0" column="4">
            <widget class="QPushButton" name="mConditionalStatButton">
             <property name="text">
-             <string notr="true">if</string>
+             <string notr="true">IF</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Just a first step that covers:
- Reorder the raster calc operators to match the mesh calc ones
- Order mesh calc expression group to follow the raster ones 
- Fix title case, empty widgets and tabstops
- Rename option to make it more obvious

Before:
![image](https://user-images.githubusercontent.com/7983394/134675167-f88a1f0b-5b4b-4895-a53a-574e8bcbfc99.png)

After (from Qt Designer):
![image](https://user-images.githubusercontent.com/7983394/134682645-2a81f580-c7fa-41c9-a8e5-6a11c210d0c5.png)

![image](https://user-images.githubusercontent.com/7983394/134681774-bf4f9daf-48f8-42e7-8b64-d76f9f19730d.png)

I'm still uncertain how to handle:
- [ ] should I remove the horizontal spacer at the right of the raster calc operators and let the button enlarge or move the mesh ones the other way?
- [ ] the vertical spacers around the "Add result to project" and the "time related options": remove the upper one? for both? The time options would probably need to be grouped but I didn't test the options yet.
