### PR TITLE
QgsApplication::init(): register QgsMapLayer* meta type (fixes #44095)

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -300,6 +300,7 @@ void QgsApplication::init( QString profileFolder )
 #endif
     qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
     qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
+    qRegisterMetaType<QList<QgsMapLayer *>>( "QList<QgsMapLayer*>" );
   } );
 
   ( void ) resolvePkgPath();


### PR DESCRIPTION
Otherwise when using QgsProject::addMapLayer() from Python, the
following warning is emitted:
```
Warning: QObject::connect: Cannot queue arguments of type 'QList<QgsMapLayer*>'
(Make sure 'QList<QgsMapLayer*>' is registered using qRegisterMetaType().)
```
