### PR TITLE
Fix PG error when failing to update geom & constrained field

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3479,7 +3479,9 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
 
         result = conn->PQexecPrepared( QStringLiteral( "updatefeature" ), params );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
+        {
           throw PGException( result );
+        }
 
         conn->PQexecNR( QStringLiteral( "DEALLOCATE updatefeature" ) );
       }
@@ -3511,6 +3513,7 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
   {
     pushError( tr( "PostGIS error while changing attributes: %1" ).arg( e.errorMessage() ) );
     conn->rollback();
+    conn->PQexecNR( QStringLiteral( "DEALLOCATE updatefeature" ) );
     returnvalue = false;
   }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3480,6 +3480,8 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
         result = conn->PQexecPrepared( QStringLiteral( "updatefeature" ), params );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
         {
+          conn->rollback();
+          conn->PQexecNR( QStringLiteral( "DEALLOCATE updatefeature" ) );
           throw PGException( result );
         }
 
@@ -3513,7 +3515,6 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
   {
     pushError( tr( "PostGIS error while changing attributes: %1" ).arg( e.errorMessage() ) );
     conn->rollback();
-    conn->PQexecNR( QStringLiteral( "DEALLOCATE updatefeature" ) );
     returnvalue = false;
   }
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2065,6 +2065,18 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         vl2.readLayerXml(elem, QgsReadWriteContext())
         self.assertEqual(vl2.extent(), originalExtent)
 
+    def testPreparedFailure(self):
+        """Test error from issue GH #45100"""
+
+        layer = self.getEditableLayerWithCheckConstraint()
+        self.assertTrue(layer.startEditing())
+        old_value = layer.getFeature(1).attribute('i_will_fail_on_no_name')
+        layer.changeAttributeValue(1, 1, 'no name')
+        layer.changeGeometry(1, QgsGeometry.fromWkt('point(7 45)'))
+        self.assertFalse(layer.commitChanges())
+        layer.changeAttributeValue(1, 1, old_value)
+        self.assertTrue(layer.commitChanges())
+        
     def testDeterminePkey(self):
         """Test primary key auto-determination"""
 
@@ -3386,18 +3398,6 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         feat = vl.getFeature(fid)
         self.assertTrue(feat.isValid())
         self.assertEqual(feat["name"], "test")
-
-    def testPreparedFailure(self):
-        """Test error from issue GH #45100"""
-
-        layer = self.getEditableLayerWithCheckConstraint()
-        self.assertTrue(layer.startEditing())
-        old_value = layer.getFeature(1).attribute('i_will_fail_on_no_name')
-        layer.changeAttributeValue(1, 1, 'no name')
-        layer.changeGeometry(1, QgsGeometry.fromWkt('point(7 45)'))
-        self.assertFalse(layer.commitChanges())
-        layer.changeAttributeValue(1, 1, old_value)
-        self.assertTrue(layer.commitChanges())
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -3387,6 +3387,18 @@ class TestPyQgsPostgresProviderBigintSinglePk(unittest.TestCase, ProviderTestCas
         self.assertTrue(feat.isValid())
         self.assertEqual(feat["name"], "test")
 
+    def testPreparedFailure(self):
+        """Test error from issue GH #45100"""
+
+        layer = self.getEditableLayerWithCheckConstraint()
+        self.assertTrue(layer.startEditing())
+        old_value = layer.getFeature(1).attribute('i_will_fail_on_no_name')
+        layer.changeAttributeValue(1, 1, 'no name')
+        layer.changeGeometry(1, QgsGeometry.fromWkt('point(7 45)'))
+        self.assertFalse(layer.commitChanges())
+        layer.changeAttributeValue(1, 1, old_value)
+        self.assertTrue(layer.commitChanges())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2076,7 +2076,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(layer.commitChanges())
         layer.changeAttributeValue(1, 1, old_value)
         self.assertTrue(layer.commitChanges())
-        
+
     def testDeterminePkey(self):
         """Test primary key auto-determination"""
 


### PR DESCRIPTION
The problem was that throwing an exception the prepared statement
was not deallocated.

Fix #45100
