### PR TITLE
Also reset field precision when converting merged field to string

### DIFF
--- a/src/analysis/processing/qgsalgorithmmergevector.cpp
+++ b/src/analysis/processing/qgsalgorithmmergevector.cpp
@@ -164,6 +164,7 @@ QVariantMap QgsMergeVectorAlgorithm::processAlgorithm( const QVariantMap &parame
             destField.setType( QVariant::String );
             destField.setSubType( QVariant::Invalid );
             destField.setLength( 0 );
+            destField.setPrecision( 0 );
           }
           break;
         }


### PR DESCRIPTION
## Description
Fix unreported bug:
On *Merge vector layers* algorithm, when a numeric field with a set precision is converted to string (due to different field types on some of the merged layers) then the resulting field becomes a *String* type with length 0 but it keeps the precision.
This causes the field to be exported as *String(1)* when exporting to geopackage causing trouble...
This PR properly resets the precision of the merged field, however there is probably something that could also be improved in the *export to geopackage* logic, since the same behavior could be triggered by some other malformed field.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
