### PR TITLE
Emit customPropertyChanged when read from XML

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -774,7 +774,17 @@ void QgsMapLayer::resolveReferences( QgsProject *project )
 
 void QgsMapLayer::readCustomProperties( const QDomNode &layerNode, const QString &keyStartsWith )
 {
+  const QgsObjectCustomProperties oldKeys = mCustomProperties;
+
   mCustomProperties.readXml( layerNode, keyStartsWith );
+
+  for ( const QString key : mCustomProperties.keys() )
+  {
+    if ( !oldKeys.contains( key ) || mCustomProperties.value( key ) != oldKeys.value( key ) )
+    {
+      emit customPropertyChanged( key );
+    }
+  }
 }
 
 void QgsMapLayer::writeCustomProperties( QDomNode &layerNode, QDomDocument &doc ) const
@@ -1963,6 +1973,10 @@ void QgsMapLayer::setCustomProperty( const QString &key, const QVariant &value )
 void QgsMapLayer::setCustomProperties( const QgsObjectCustomProperties &properties )
 {
   mCustomProperties = properties;
+  for ( const QString key : mCustomProperties.keys() )
+  {
+    emit customPropertyChanged( key );
+  }
 }
 
 const QgsObjectCustomProperties &QgsMapLayer::customProperties() const

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -778,7 +778,7 @@ void QgsMapLayer::readCustomProperties( const QDomNode &layerNode, const QString
 
   mCustomProperties.readXml( layerNode, keyStartsWith );
 
-  for ( const QString key : mCustomProperties.keys() )
+  for ( const QString &key : mCustomProperties.keys() )
   {
     if ( !oldKeys.contains( key ) || mCustomProperties.value( key ) != oldKeys.value( key ) )
     {
@@ -1973,7 +1973,7 @@ void QgsMapLayer::setCustomProperty( const QString &key, const QVariant &value )
 void QgsMapLayer::setCustomProperties( const QgsObjectCustomProperties &properties )
 {
   mCustomProperties = properties;
-  for ( const QString key : mCustomProperties.keys() )
+  for ( const QString &key : mCustomProperties.keys() )
   {
     emit customPropertyChanged( key );
   }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -2111,6 +2111,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QString mLegendPlaceholderImage;
 
     friend class QgsVectorLayer;
+    friend class TestQgsMapLayer;
 };
 
 Q_DECLARE_METATYPE( QgsMapLayer * )


### PR DESCRIPTION
Fixes #44692 : We need to fire the signal *customPropertyChanged* when we read custom properties from XML so the icon could be displayed when copying style. 