### PR TITLE
Ensure labeling map tools only try to affect labels from vector layers

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -446,6 +446,18 @@ Emits signal scaleChanged to update scale in main window
 Returns the map layer at position index in the layer stack
 %End
 
+    QgsMapLayer *layer( const QString &id );
+%Docstring
+Returns the map layer with the matching ID, or ``None`` if no layers could be found.
+
+This method searches both layers associated with the map canvas (see :py:func:`~QgsMapCanvas.layers`)
+and layers from the :py:class:`QgsProject` associated with the canvas
+(which is current the :py:func:`QgsProject.instance()`). It can be used to resolve layer IDs to
+layers which may be visible in the canvas, but not associated with a :py:class:`QgsProject`.
+
+.. versionadded:: 3.22
+%End
+
     int layerCount() const;
 %Docstring
 Returns number of layers on the map

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -324,6 +324,17 @@ Transforms a ``rect`` from map coordinates to ``layer`` coordinates.
 Transforms a ``point`` from map coordinates to screen coordinates.
 %End
 
+    QgsMapLayer *layer( const QString &id );
+%Docstring
+Returns the map layer with the matching ID, or ``None`` if no layers could be found.
+
+This method searches both layers associated with the map canvas (see :py:func:`QgsMapCanvas.layers()`)
+and layers from the :py:class:`QgsProject` associated with the canvas. It can be used to resolve layer IDs to
+layers which may be visible in the canvas, but not associated with a :py:class:`QgsProject`.
+
+.. versionadded:: 3.22
+%End
+
     void setToolName( const QString &name );
 %Docstring
 Sets the tool's ``name``.
@@ -332,6 +343,7 @@ Sets the tool's ``name``.
 
 .. versionadded:: 3.20
 %End
+
 
 
 

--- a/src/app/labeling/qgslabelpropertydialog.cpp
+++ b/src/app/labeling/qgslabelpropertydialog.cpp
@@ -105,7 +105,7 @@ void QgsLabelPropertyDialog::buttonBox_clicked( QAbstractButton *button )
 void QgsLabelPropertyDialog::init( const QString &layerId, const QString &providerId, QgsFeatureId featureId, const QString &labelText )
 {
   //get feature attributes
-  QgsVectorLayer *vlayer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( layerId );
+  QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( mCanvas->layer( layerId ) );
   if ( !vlayer )
   {
     return;

--- a/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/labeling/qgsmaptoolchangelabelproperties.cpp
@@ -65,7 +65,7 @@ void QgsMapToolChangeLabelProperties::canvasPressEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  mCurrentLabel = LabelDetails( labelPos );
+  mCurrentLabel = LabelDetails( labelPos, canvas() );
   if ( !mCurrentLabel.valid || !mCurrentLabel.layer )
   {
     return;

--- a/src/app/labeling/qgsmaptoollabel.h
+++ b/src/app/labeling/qgsmaptoollabel.h
@@ -100,7 +100,7 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapToolAdvancedDigitizing
     struct APP_EXPORT LabelDetails
     {
       LabelDetails() = default;
-      explicit LabelDetails( const QgsLabelPosition &p );
+      explicit LabelDetails( const QgsLabelPosition &p, QgsMapCanvas *canvas );
       bool valid = false;
       QgsLabelPosition pos;
       QgsVectorLayer *layer = nullptr;

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -124,7 +124,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
       clearHoveredLabel();
 
-      QgsVectorLayer *vlayer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( mCurrentCallout.layerID );
+      QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( QgsMapTool::layer( mCurrentCallout.layerID ) );
       if ( !vlayer || xCol < 0 || yCol < 0 )
       {
         return;
@@ -174,7 +174,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
       clearHoveredLabel();
 
-      mCurrentLabel = LabelDetails( labelPos );
+      mCurrentLabel = LabelDetails( labelPos, canvas() );
 
       QgsVectorLayer *vlayer = mCurrentLabel.layer;
       if ( !vlayer )
@@ -275,7 +275,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
         deleteRubberBands();
 
-        QgsVectorLayer *vlayer = !isCalloutMove ? mCurrentLabel.layer : QgsProject::instance()->mapLayer<QgsVectorLayer *>( mCurrentCallout.layerID );
+        QgsVectorLayer *vlayer = !isCalloutMove ? mCurrentLabel.layer : qobject_cast< QgsVectorLayer * >( QgsMapTool::layer( mCurrentCallout.layerID ) );
         if ( !vlayer )
         {
           return;
@@ -452,7 +452,7 @@ void QgsMapToolMoveLabel::keyReleaseEvent( QKeyEvent *e )
 
         // delete the stored label/callout position
         const bool isCalloutMove = !mCurrentCallout.layerID.isEmpty();
-        QgsVectorLayer *vlayer = !isCalloutMove ? mCurrentLabel.layer : QgsProject::instance()->mapLayer<QgsVectorLayer *>( mCurrentCallout.layerID );
+        QgsVectorLayer *vlayer = !isCalloutMove ? mCurrentLabel.layer : qobject_cast< QgsVectorLayer * >( QgsMapTool::layer( mCurrentCallout.layerID ) );
         const QgsFeatureId featureId = !isCalloutMove ? mCurrentLabel.pos.featureId : mCurrentCallout.featureId;
         if ( vlayer )
         {
@@ -514,7 +514,7 @@ void QgsMapToolMoveLabel::keyReleaseEvent( QKeyEvent *e )
 
 bool QgsMapToolMoveLabel::canModifyCallout( const QgsCalloutPosition &pos, bool isOrigin, int &xCol, int &yCol )
 {
-  QgsVectorLayer *layer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( pos.layerID );
+  QgsVectorLayer *layer = qobject_cast< QgsVectorLayer * >( QgsMapTool::layer( pos.layerID ) );
   QgsPalLayerSettings settings;
   if ( layer && layer->labelsEnabled() )
   {
@@ -558,7 +558,7 @@ bool QgsMapToolMoveLabel::canModifyCallout( const QgsCalloutPosition &pos, bool 
 
 bool QgsMapToolMoveLabel::currentCalloutDataDefinedPosition( double &x, bool &xSuccess, double &y, bool &ySuccess, int &xCol, int &yCol )
 {
-  QgsVectorLayer *vlayer =  QgsProject::instance()->mapLayer<QgsVectorLayer *>( mCurrentCallout.layerID );
+  QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( QgsMapTool::layer( mCurrentCallout.layerID ) );
   const QgsFeatureId featureId = mCurrentCallout.featureId;
 
   xSuccess = false;

--- a/src/app/labeling/qgsmaptoolpinlabels.cpp
+++ b/src/app/labeling/qgsmaptoolpinlabels.cpp
@@ -196,7 +196,7 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
   QList<QgsLabelPosition>::const_iterator it;
   for ( const QgsLabelPosition &pos : labelPosList )
   {
-    mCurrentLabel = LabelDetails( pos );
+    mCurrentLabel = LabelDetails( pos, canvas() );
 
     if ( isPinned() )
     {
@@ -209,7 +209,7 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
       }
 
       QColor lblcolor = QColor( 54, 129, 255, 63 );
-      QgsMapLayer *layer = QgsProject::instance()->mapLayer( pos.layerID );
+      QgsMapLayer *layer = QgsMapTool::layer( pos.layerID );
       if ( !layer )
       {
         continue;
@@ -287,7 +287,7 @@ void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle &ext, QMouseEvent *
   {
     const QgsLabelPosition &pos = *it;
 
-    mCurrentLabel = LabelDetails( pos );
+    mCurrentLabel = LabelDetails( pos, canvas() );
 
     if ( !mCurrentLabel.valid )
     {

--- a/src/app/labeling/qgsmaptoolrotatelabel.cpp
+++ b/src/app/labeling/qgsmaptoolrotatelabel.cpp
@@ -99,7 +99,7 @@ void QgsMapToolRotateLabel::canvasPressEvent( QgsMapMouseEvent *e )
       return;
     }
 
-    mCurrentLabel = LabelDetails( labelPos );
+    mCurrentLabel = LabelDetails( labelPos, canvas() );
 
     if ( !mCurrentLabel.valid )
       return;

--- a/src/app/labeling/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/labeling/qgsmaptoolshowhidelabels.cpp
@@ -316,7 +316,7 @@ bool QgsMapToolShowHideLabels::selectedLabelFeatures( QgsVectorLayer *vlayer,
 
 bool QgsMapToolShowHideLabels::showHide( const QgsLabelPosition &pos, bool show )
 {
-  LabelDetails details = LabelDetails( pos );
+  LabelDetails details = LabelDetails( pos, canvas() );
 
   if ( !details.valid )
     return false;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -336,6 +336,21 @@ QgsMapLayer *QgsMapCanvas::layer( int index )
     return nullptr;
 }
 
+QgsMapLayer *QgsMapCanvas::layer( const QString &id )
+{
+  // first check for layers from canvas map settings
+  const QList<QgsMapLayer *> layers = mapSettings().layers();
+  for ( QgsMapLayer *layer : layers )
+  {
+    if ( layer && layer->id() == id )
+      return layer;
+  }
+
+  // else fallback to searching project layers
+  // TODO: allow a specific project to be associated with a canvas!
+  return QgsProject::instance()->mapLayer( id );
+}
+
 void QgsMapCanvas::setCurrentLayer( QgsMapLayer *layer )
 {
   if ( mCurrentLayer == layer )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -459,6 +459,18 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     //! Returns the map layer at position index in the layer stack
     QgsMapLayer *layer( int index );
 
+    /**
+     * Returns the map layer with the matching ID, or NULLPTR if no layers could be found.
+     *
+     * This method searches both layers associated with the map canvas (see layers())
+     * and layers from the QgsProject associated with the canvas
+     * (which is current the QgsProject::instance()). It can be used to resolve layer IDs to
+     * layers which may be visible in the canvas, but not associated with a QgsProject.
+     *
+     * \since QGIS 3.22
+     */
+    QgsMapLayer *layer( const QString &id );
+
     //! Returns number of layers on the map
     int layerCount() const;
 

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -81,6 +81,11 @@ QPoint QgsMapTool::toCanvasCoordinates( const QgsPointXY &point ) const
   return QPoint( std::round( x ), std::round( y ) );
 }
 
+QgsMapLayer *QgsMapTool::layer( const QString &id )
+{
+  return mCanvas->layer( id );
+}
+
 void QgsMapTool::setToolName( const QString &name )
 {
   mToolName = name;

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -299,6 +299,17 @@ class GUI_EXPORT QgsMapTool : public QObject
     QPoint toCanvasCoordinates( const QgsPointXY &point ) const;
 
     /**
+     * Returns the map layer with the matching ID, or NULLPTR if no layers could be found.
+     *
+     * This method searches both layers associated with the map canvas (see QgsMapCanvas::layers())
+     * and layers from the QgsProject associated with the canvas. It can be used to resolve layer IDs to
+     * layers which may be visible in the canvas, but not associated with a QgsProject.
+     *
+     * \since QGIS 3.22
+     */
+    QgsMapLayer *layer( const QString &id );
+
+    /**
      * Sets the tool's \a name.
      *
      * \see toolName()
@@ -326,6 +337,8 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     //! The translated name of the map tool
     QString mToolName;
+
+    friend class TestQgsMapToolEdit;
 
 };
 

--- a/tests/src/app/testqgsmaptoollabel.cpp
+++ b/tests/src/app/testqgsmaptoollabel.cpp
@@ -295,7 +295,7 @@ class TestQgsMapToolLabel : public QObject
       QVERIFY( tool->labelAtPosition( event.get(), pos ) );
       QCOMPARE( pos.layerID, vl1->id() );
       QCOMPARE( pos.labelText, QStringLiteral( "label" ) );
-      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos );
+      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos, canvas.get() );
 
       // defaults to bottom left
       QString hali, vali;
@@ -315,7 +315,7 @@ class TestQgsMapToolLabel : public QObject
       QVERIFY( tool->labelAtPosition( event.get(), pos ) );
       QCOMPARE( pos.layerID, vl1->id() );
       QCOMPARE( pos.labelText, QStringLiteral( "label" ) );
-      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos );
+      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos, canvas.get() );
 
       tool->currentAlignment( hali, vali );
       QCOMPARE( hali, QStringLiteral( "right" ) );
@@ -330,7 +330,7 @@ class TestQgsMapToolLabel : public QObject
       QVERIFY( tool->labelAtPosition( event.get(), pos ) );
       QCOMPARE( pos.layerID, vl1->id() );
       QCOMPARE( pos.labelText, QStringLiteral( "label" ) );
-      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos );
+      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos, canvas.get() );
 
       tool->currentAlignment( hali, vali );
       QCOMPARE( hali, QStringLiteral( "center" ) );
@@ -354,7 +354,7 @@ class TestQgsMapToolLabel : public QObject
       QVERIFY( tool->labelAtPosition( event.get(), pos ) );
       QCOMPARE( pos.layerID, vl1->id() );
       QCOMPARE( pos.labelText, QStringLiteral( "label" ) );
-      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos );
+      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos, canvas.get() );
 
       tool->currentAlignment( hali, vali );
       QCOMPARE( hali, QStringLiteral( "left" ) );
@@ -369,7 +369,7 @@ class TestQgsMapToolLabel : public QObject
       QVERIFY( tool->labelAtPosition( event.get(), pos ) );
       QCOMPARE( pos.layerID, vl1->id() );
       QCOMPARE( pos.labelText, QStringLiteral( "label" ) );
-      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos );
+      tool->mCurrentLabel = QgsMapToolLabel::LabelDetails( pos, canvas.get() );
 
       tool->currentAlignment( hali, vali );
       QCOMPARE( hali, QStringLiteral( "right" ) );


### PR DESCRIPTION
Labels from other layer types (eg vector tiles) are unsupported,
which results in a crash.

Fixes #44486
