### PR TITLE
Add shortcut path when a line symbol is being rendered with a dash pattern which is all 0 lengths

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -419,6 +419,24 @@ void QgsSimpleLineSymbolLayer::renderPolyline( const QPolygonF &pts, QgsSymbolRe
   applyDataDefinedSymbology( context, mPen, mSelPen, offset );
 
   const QPen pen = context.selected() ? mSelPen : mPen;
+
+  if ( !pen.dashPattern().isEmpty() )
+  {
+    // check for a null (all 0) dash component, and shortcut out early if so -- these lines are rendered as "no pen"
+    const QVector<double> pattern = pen.dashPattern();
+    bool foundNonNull = false;
+    for ( int i = 0; i < pattern.size(); ++i )
+    {
+      if ( i % 2 == 0  && !qgsDoubleNear( pattern[i], 0 ) )
+      {
+        foundNonNull = true;
+        break;
+      }
+    }
+    if ( !foundNonNull )
+      return;
+  }
+
   p->setBrush( Qt::NoBrush );
 
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext (We known that it must have least #2 points).


### PR DESCRIPTION
This is rendered as no line, so we can skip out early

Refs #41994
