### PR TITLE
Check for valid field index in QgsFieldFormatter::representValue

### DIFF
--- a/src/core/qgsfieldformatter.cpp
+++ b/src/core/qgsfieldformatter.cpp
@@ -26,6 +26,9 @@ QString QgsFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex
   Q_UNUSED( config )
   Q_UNUSED( cache )
 
+  if ( ! layer->fields().exists( fieldIndex ) )
+    return QString();
+
   QString defVal;
   if ( layer->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginProvider && layer->dataProvider() )
     defVal = layer->dataProvider()->defaultValueClause( layer->fields().fieldOriginIndex( fieldIndex ) );

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -660,6 +660,8 @@ class TestQgsFallbackFieldFormatter(unittest.TestCase):
                          '4')
         self.assertEqual(fieldFormatter.representValue(vl, 1, {}, None, "123"),
                          '123')
+        # bad field index
+        self.assertEqual(fieldFormatter.representValue(vl, 3, {}, None, 5), "")
 
 
 class TestQgsDateTimeFieldFormatter(unittest.TestCase):


### PR DESCRIPTION
Check for valid field index has been removed in this PR #45199 and [detected](https://github.com/qgis/QGIS/pull/45291#discussion_r717883659) while backporting, so I restore it.