### PR TITLE
Keep order for external storage items

### DIFF
--- a/src/core/externalstorage/qgsexternalstorageregistry.cpp
+++ b/src/core/externalstorage/qgsexternalstorageregistry.cpp
@@ -32,20 +32,30 @@ QgsExternalStorageRegistry::~QgsExternalStorageRegistry()
 
 QgsExternalStorage *QgsExternalStorageRegistry::externalStorageFromType( const QString &type ) const
 {
-  return mBackends.value( type );
+  auto it = std::find_if( mBackends.begin(), mBackends.end(), [ = ]( QgsExternalStorage * storage )
+  {
+    return storage->type() == type;
+  } );
+
+  return it != mBackends.end() ? *it : nullptr;
 }
 
 QList<QgsExternalStorage *> QgsExternalStorageRegistry::externalStorages() const
 {
-  return mBackends.values();
+  return mBackends;
 }
 
 void QgsExternalStorageRegistry::registerExternalStorage( QgsExternalStorage *storage )
 {
-  mBackends.insert( storage->type(), storage );
+  if ( !mBackends.contains( storage ) )
+    mBackends.append( storage );
 }
 
 void QgsExternalStorageRegistry::unregisterExternalStorage( QgsExternalStorage *storage )
 {
-  delete mBackends.take( storage->type() );
+  const int index = mBackends.indexOf( storage );
+  if ( index >= 0 )
+  {
+    delete mBackends.takeAt( index );
+  }
 }

--- a/src/core/externalstorage/qgsexternalstorageregistry.h
+++ b/src/core/externalstorage/qgsexternalstorageregistry.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsExternalStorageRegistry
     void unregisterExternalStorage( QgsExternalStorage *storage );
 
   private:
-    QHash<QString, QgsExternalStorage *> mBackends;
+    QList< QgsExternalStorage * > mBackends;
 };
 
 #endif // QGSEXTERNALSTORAGEREGISTRY_H

--- a/tests/src/python/test_qgsexternalstorage_base.py
+++ b/tests/src/python/test_qgsexternalstorage_base.py
@@ -60,16 +60,17 @@ class TestPyQgsExternalStorageBase():
         assert(cls.authm.storeAuthenticationConfig(cls.auth_config)[0])
         assert cls.auth_config.isValid()
 
-        registry = QgsApplication.instance().externalStorageRegistry()
-        assert registry
+        cls.registry = QgsApplication.instance().externalStorageRegistry()
+        assert cls.registry
 
-        cls.storage = registry.externalStorageFromType(cls.storageType)
+        cls.storage = cls.registry.externalStorageFromType(cls.storageType)
         assert cls.storage
 
     @classmethod
     def tearDownClass(cls):
         """Run after all tests"""
-        pass
+        cls.registry.unregisterExternalStorage(cls.storage)
+        assert not cls.storageType in cls.registry.externalStorages()
 
     def setUp(self):
         """Run before each test."""
@@ -91,6 +92,13 @@ class TestPyQgsExternalStorageBase():
         f = open(file_path, 'r')
         self.assertTrue(f.read(), b"New content")
         f.close()
+
+    def testStorageList(self):
+        """
+        Check that storage list in in correct order
+        """
+        self.assertEqual([storage.type() for storage in self.registry.externalStorages()],
+                         ["SimpleCopy", "WebDAV"])
 
     def testStoreFetchFileLater(self):
         """

--- a/tests/src/python/test_qgsexternalstorage_base.py
+++ b/tests/src/python/test_qgsexternalstorage_base.py
@@ -70,7 +70,7 @@ class TestPyQgsExternalStorageBase():
     def tearDownClass(cls):
         """Run after all tests"""
         cls.registry.unregisterExternalStorage(cls.storage)
-        assert not cls.storageType in cls.registry.externalStorages()
+        assert cls.storageType not in cls.registry.externalStorages()
 
     def setUp(self):
         """Run before each test."""


### PR DESCRIPTION
This PR keeps the same order for external storage backends as the one used when registering. It's related to this [comment](https://github.com/qgis/QGIS-Documentation/pull/6914#discussion_r710290492)