### PR TITLE
Group widgets in mesh/raster calculator dialogs

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -65,6 +65,7 @@ QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidg
 
   connect( useMaskCb, &QRadioButton::toggled, this, &QgsMeshCalculatorDialog::toggleExtendMask );
   maskBox->setVisible( false );
+  useMaskCb->setEnabled( cboLayerMask->count() );
 
   mXMaxSpinBox->setShowClearButton( false );
   mXMinSpinBox->setShowClearButton( false );

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -63,8 +63,7 @@ QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidg
   connect( mAllTimesButton, &QPushButton::clicked, this, &QgsMeshCalculatorDialog::mAllTimesButton_clicked );
   connect( mExpressionTextEdit, &QTextEdit::textChanged, this, &QgsMeshCalculatorDialog::updateInfoMessage );
 
-  connect( useMaskCb, &QCheckBox::stateChanged, this, &QgsMeshCalculatorDialog::toggleExtendMask );
-  connect( useExtentCb, &QCheckBox::stateChanged, this, &QgsMeshCalculatorDialog::toggleExtendMask );
+  connect( useMaskCb, &QRadioButton::toggled, this, &QgsMeshCalculatorDialog::toggleExtendMask );
   maskBox->setVisible( false );
 
   mXMaxSpinBox->setShowClearButton( false );
@@ -279,19 +278,11 @@ void QgsMeshCalculatorDialog::datasetGroupEntry( const QModelIndex &index )
   mExpressionTextEdit->insertPlainText( QStringLiteral( " %1 " ).arg( group ) );
 }
 
-void QgsMeshCalculatorDialog::toggleExtendMask( int state )
+void QgsMeshCalculatorDialog::toggleExtendMask()
 {
-  Q_UNUSED( state )
-  if ( useMaskCb->checkState() == Qt::Checked )
-  {
-    extendBox->setVisible( false );
-    maskBox->setVisible( true );
-  }
-  else
-  {
-    extendBox->setVisible( true );
-    maskBox->setVisible( false );
-  }
+  bool visible = useMaskCb->isChecked();
+  extendBox->setVisible( !visible );
+  maskBox->setVisible( visible );
 }
 
 void QgsMeshCalculatorDialog::updateInfoMessage()

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -45,7 +45,7 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
     void datasetGroupEntry( const QModelIndex &index );
     void mCurrentLayerExtentButton_clicked();
     void mAllTimesButton_clicked();
-    void toggleExtendMask( int state );
+    void toggleExtendMask();
     void updateInfoMessage();
     void onOutputRadioButtonChange();
     void onOutputFormatChange();

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -100,7 +100,7 @@
          <widget class="QWidget" name="horizontalWidget" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_5">
            <item>
-            <widget class="QCheckBox" name="useExtentCb">
+            <widget class="QRadioButton" name="useExtentCb">
              <property name="text">
               <string>Current extent</string>
              </property>
@@ -113,7 +113,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="useMaskCb">
+            <widget class="QRadioButton" name="useMaskCb">
              <property name="text">
               <string>Mask layer</string>
              </property>

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>912</width>
-    <height>864</height>
+    <height>902</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,234 +97,296 @@
          </layout>
         </item>
         <item>
-         <widget class="QWidget" name="horizontalWidget" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <widget class="QGroupBox" name="groupBox_3">
+          <property name="title">
+           <string>Spatial Extent</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
-            <widget class="QRadioButton" name="useExtentCb">
-             <property name="text">
-              <string>Current extent</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">buttonGroup</string>
-             </attribute>
+            <widget class="QWidget" name="horizontalWidget" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QRadioButton" name="useExtentCb">
+                <property name="text">
+                 <string>Custom extent</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">buttonGroup</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="useMaskCb">
+                <property name="toolTip">
+                 <string>Clips the datasets using features from vector polygon layer.</string>
+                </property>
+                <property name="text">
+                 <string>Mask layer</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">buttonGroup</string>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
-            <widget class="QRadioButton" name="useMaskCb">
-             <property name="text">
-              <string>Mask layer</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">buttonGroup</string>
-             </attribute>
+            <widget class="QWidget" name="maskBox" native="true">
+             <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="label_3">
+                <property name="minimumSize">
+                 <size>
+                  <width>206</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Mask layer</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QgsMapLayerComboBox" name="cboLayerMask">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="editable">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="maskBox" native="true">
-          <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
            <item>
-            <widget class="QLabel" name="label_3">
-             <property name="minimumSize">
-              <size>
-               <width>206</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Mask layer</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsMapLayerComboBox" name="cboLayerMask">
+            <widget class="QWidget" name="extendBox" native="true">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="editable">
-              <bool>false</bool>
-             </property>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="2" column="4">
+               <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-999999999.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>999999999.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="mYMinLabel">
+                <property name="text">
+                 <string>Y min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QLabel" name="mXMaxLabel">
+                <property name="text">
+                 <string>X max</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-999999999.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>999999999.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QLabel" name="mYMaxLabel">
+                <property name="text">
+                 <string>Y max</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-999999999.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>999999999.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-999999999.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>999999999.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="mXMinLabel">
+                <property name="text">
+                 <string>X min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="5">
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <item>
+                 <widget class="QPushButton" name="mCurrentLayerExtentButton">
+                  <property name="text">
+                   <string>Use Selected Layer Extent</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="2">
+               <spacer name="horizontalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </widget>
            </item>
           </layout>
          </widget>
         </item>
         <item>
-         <widget class="QWidget" name="extendBox" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Temporal Extent</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="1" column="0">
-            <widget class="QLabel" name="mXMinLabel">
-             <property name="text">
-              <string>X min</string>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <item row="1" column="2">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
              </property>
-            </widget>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
            <item row="1" column="3">
-            <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
-             <property name="decimals">
-              <number>5</number>
-             </property>
-             <property name="minimum">
-              <double>-999999999.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>999999999.000000000000000</double>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>End time</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="mXMaxLabel">
+           <item row="1" column="0">
+            <widget class="QLabel" name="label">
              <property name="text">
-              <string>X max</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="QLabel" name="mYMaxLabel">
-             <property name="text">
-              <string>Y max</string>
+              <string>Start time</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
-             <property name="decimals">
-              <number>5</number>
-             </property>
-             <property name="minimum">
-              <double>-999999999.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>999999999.000000000000000</double>
-             </property>
-            </widget>
+            <widget class="QComboBox" name="mStartTimeComboBox"/>
            </item>
-           <item row="2" column="3">
-            <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
-             <property name="decimals">
-              <number>5</number>
-             </property>
-             <property name="minimum">
-              <double>-999999999.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>999999999.000000000000000</double>
-             </property>
-            </widget>
+           <item row="1" column="4">
+            <widget class="QComboBox" name="mEndTimeComboBox"/>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="mYMinLabel">
-             <property name="text">
-              <string>Y min</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
-             <property name="decimals">
-              <number>5</number>
-             </property>
-             <property name="minimum">
-              <double>-999999999.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>999999999.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0" colspan="2">
-            <widget class="QPushButton" name="mCurrentLayerExtentButton">
-             <property name="text">
-              <string>Use Selected Layer Extent</string>
-             </property>
-            </widget>
+           <item row="0" column="0" colspan="5">
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QPushButton" name="mAllTimesButton">
+               <property name="text">
+                <string>Use all Selected Dataset Times</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QPushButton" name="mAllTimesButton">
-            <property name="text">
-             <string>Use all Selected Dataset Times</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="0" column="4">
-           <widget class="QComboBox" name="mEndTimeComboBox"/>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>End time</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Start time</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>10</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="mStartTimeComboBox"/>
-          </item>
-         </layout>
         </item>
         <item>
          <spacer name="verticalSpacer">
@@ -340,9 +402,6 @@
          </spacer>
         </item>
        </layout>
-       <zorder>maskBox</zorder>
-       <zorder>extendBox</zorder>
-       <zorder>horizontalWidget</zorder>
       </widget>
      </widget>
      <widget class="QWidget" name="verticalLayoutWidget">

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -543,14 +543,14 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0" colspan="6">
+           <widget class="QPushButton" name="mNoDataButton">
+            <property name="text">
+             <string>NODATA</string>
+            </property>
+           </widget>
+          </item>
          </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="mNoDataButton">
-         <property name="text">
-          <string>NODATA</string>
-         </property>
         </widget>
        </item>
        <item>

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>756</width>
-    <height>687</height>
+    <height>779</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,165 +38,6 @@
         <string>Result Layer</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0,0">
-        <item row="3" column="1" colspan="3">
-         <widget class="QComboBox" name="mOutputFormatComboBox"/>
-        </item>
-        <item row="6" column="1" colspan="3">
-         <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
-          <property name="focusPolicy">
-           <enum>Qt::StrongFocus</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0" colspan="4">
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="3">
-           <widget class="QLabel" name="mRowsLabel">
-            <property name="text">
-             <string>Rows</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QgsSpinBox" name="mNRowsSpinBox">
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-999999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mYMinLabel">
-            <property name="text">
-             <string>Y min</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="mXMinLabel">
-            <property name="text">
-             <string>X min</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="mXMaxLabel">
-            <property name="text">
-             <string>X max</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mColumnsLabel">
-            <property name="text">
-             <string>Columns</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsSpinBox" name="mNColumnsSpinBox">
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QLabel" name="mYMaxLabel">
-            <property name="text">
-             <string>Y max</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-999999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-999999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-999999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>10</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item row="7" column="0" colspan="4">
-         <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
-          <property name="text">
-           <string>Add result to project</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Output CRS</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="mOutputLayerLabel">
-          <property name="text">
-           <string>Output layer</string>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="0">
          <widget class="QLabel" name="mOutputFormatLabel">
           <property name="text">
@@ -204,7 +45,136 @@
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
+        <item row="4" column="0" colspan="4">
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Spatial Extent</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="2" column="1">
+            <widget class="QgsDoubleSpinBox" name="mXMinSpinBox">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+             <property name="minimum">
+              <double>-999999999.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>999999999.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QLabel" name="mXMaxLabel">
+             <property name="text">
+              <string>X max</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="mYMinLabel">
+             <property name="text">
+              <string>Y min</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="mXMinLabel">
+             <property name="text">
+              <string>X min</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="2" column="4">
+            <widget class="QgsDoubleSpinBox" name="mXMaxSpinBox">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+             <property name="minimum">
+              <double>-999999999.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>999999999.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QgsDoubleSpinBox" name="mYMinSpinBox">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+             <property name="minimum">
+              <double>-999999999.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>999999999.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <widget class="QLabel" name="mYMaxLabel">
+             <property name="text">
+              <string>Y max</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="4">
+            <widget class="QgsDoubleSpinBox" name="mYMaxSpinBox">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+             <property name="minimum">
+              <double>-999999999.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>999999999.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0" rowspan="2" colspan="5">
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="1" rowspan="2" colspan="4">
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="0" column="0" rowspan="2">
+              <widget class="QPushButton" name="mCurrentLayerExtentButton">
+               <property name="text">
+                <string>Use Selected Layer Extent</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="3">
+         <widget class="QComboBox" name="mOutputFormatComboBox"/>
+        </item>
+        <item row="9" column="0">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -216,6 +186,20 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item row="7" column="1" colspan="3">
+         <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="mOutputLayerLabel">
+          <property name="text">
+           <string>Output layer</string>
+          </property>
+         </widget>
         </item>
         <item row="0" column="0" colspan="4">
          <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
@@ -230,22 +214,32 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QPushButton" name="mCurrentLayerExtentButton">
-          <property name="text">
-           <string>Use Selected Layer Extent</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1" colspan="3">
-         <widget class="QgsFileWidget" name="mOutputLayer" native="true"/>
-        </item>
         <item row="1" column="0">
          <widget class="QLabel" name="mVirtualLayerLabel">
           <property name="text">
            <string>Layer name</string>
           </property>
          </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Output CRS</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0" colspan="4">
+         <widget class="QCheckBox" name="mAddResultToProjectCheckBox">
+          <property name="text">
+           <string>Add result to project</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1" colspan="3">
+         <widget class="QgsFileWidget" name="mOutputLayer" native="true"/>
         </item>
         <item row="1" column="1" colspan="3">
          <widget class="QLineEdit" name="mVirtualLayerName">
@@ -255,6 +249,56 @@
           <property name="placeholderText">
            <string>Autogenerated from expression</string>
           </property>
+         </widget>
+        </item>
+        <item row="6" column="0" colspan="4">
+         <widget class="QGroupBox" name="groupBox_3">
+          <property name="title">
+           <string>Resolution</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLabel" name="mColumnsLabel">
+             <property name="text">
+              <string>Columns</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsSpinBox" name="mNColumnsSpinBox">
+             <property name="maximum">
+              <number>999999999</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="mRowsLabel">
+             <property name="text">
+              <string>Rows</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsSpinBox" name="mNRowsSpinBox">
+             <property name="maximum">
+              <number>999999999</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
Trying to make the dialogs clearer: spatial, temporal and resolution related options are grouped together.

In the mesh calculator dialog, this PR also:
* turns into radiobuttons the current extent vs mask layer options: they are mutually exclusive so radiobuttons seem more appropriate. I "relabeled" the "current extent" option but I'm not satisfied with the new name (but I don't find the elder more explicit either)
* move the NODATA button into the operators group to make it constrained also by the horizontal spacer
* disable the mask layer option when there's no polygon layer in the project: currently it's possible to switch to the mask layer option with an empty combobox (and the OK button enabled)
![image](https://user-images.githubusercontent.com/7983394/135306448-8a5e5ff2-503d-4a35-8449-1e9635ee4876.png)
![image](https://user-images.githubusercontent.com/7983394/135306394-23d39e63-3815-47c7-a2c3-41e23918e424.png)
![image](https://user-images.githubusercontent.com/7983394/135306558-d5e89c41-2f78-42f2-b6eb-03cdba9d3316.png)
