### PR TITLE
MDAL update & FLO-2D bug fix

### DIFF
--- a/external/mdal/3rdparty/libplyxx.h
+++ b/external/mdal/3rdparty/libplyxx.h
@@ -1,0 +1,271 @@
+/*
+This file forked from https://github.com/srajotte/libplyxx
+
+Copyright (c) 2016 Simon Rajotte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Updated (c) 2021 Runette Software Ltd to make multiplatform, to complete the typemaps and add to voxel types.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#pragma once
+
+#include <vector>
+#include <array>
+#include <map>
+#include <unordered_map>
+#include <type_traits>
+#include <cassert>
+#include <memory>
+#include <functional>
+
+#include "textio.h"
+
+namespace libply
+{
+  enum class Type
+  {
+    INT8,
+    UINT8,
+    INT16,
+    UINT16,
+    INT32,
+    UINT32,
+    FLOAT32,
+    FLOAT64
+  };
+
+  class IProperty
+  {
+    public:
+      virtual ~IProperty() = default;
+
+      virtual IProperty &operator=( unsigned int value ) = 0;
+      virtual IProperty &operator=( int value ) = 0;
+      virtual IProperty &operator=( float value ) = 0;
+      virtual IProperty &operator=( double value ) = 0;
+
+      virtual operator unsigned int() = 0;
+      virtual operator int() = 0;
+      virtual operator float() = 0;
+      virtual operator double() = 0;
+
+      virtual bool isList() = 0;
+
+  };
+
+  template<typename InternalType>
+  class ScalarProperty: public IProperty
+  {
+    public :
+
+      virtual ~ScalarProperty() = default;
+
+      virtual ScalarProperty &operator=( unsigned int value ) override
+      {
+        m_value = static_cast<InternalType>( value );
+        return *this;
+      };
+      virtual ScalarProperty &operator=( int value ) override
+      {
+        m_value = static_cast<InternalType>( value );
+        return *this;
+      };
+      virtual ScalarProperty &operator=( float value ) override
+      {
+        m_value = static_cast<InternalType>( value );
+        return *this;
+      };
+      virtual ScalarProperty &operator=( double value ) override
+      {
+        m_value = static_cast<InternalType>( value );
+        return *this;
+      };
+
+      virtual operator unsigned int() override
+      {
+        return static_cast<unsigned int>( m_value );
+      };
+      virtual operator int() override
+      {
+        return static_cast<int>( m_value );
+      };
+      virtual operator float() override
+      {
+        return static_cast<float>( m_value );
+      };
+      virtual operator double() override
+      {
+        return static_cast<double>( m_value );
+      };
+
+      virtual bool isList() override { return false; }
+
+    public:
+      InternalType value() const { return m_value; };
+
+    private :
+      InternalType m_value;
+  };
+
+  class ListProperty : public IProperty
+  {
+    public:
+
+      IProperty &operator=( unsigned int value ) override { return *this; };
+      IProperty &operator=( int value ) override  { return *this; };
+      IProperty &operator=( float value ) override  { return *this; };
+      IProperty &operator=( double value ) override  { return *this; };
+
+      operator unsigned int() override { return 0; };
+      operator int() override { return 0; };
+      operator float() override { return 0; };
+      operator double() override { return 0; };
+
+      bool isList() override { return true; }
+
+      void define( Type type, size_t size );
+      size_t size() const { return list.size(); }
+
+      IProperty &value( size_t index );
+
+    private:
+      std::vector<std::unique_ptr<IProperty>> list;
+      std::unique_ptr<IProperty> getScalarProperty( Type type );
+  };
+
+  struct ElementDefinition;
+
+  class ElementBuffer
+  {
+    public:
+      ElementBuffer() = default;
+      ElementBuffer( const ElementDefinition &definition );
+
+    public:
+      size_t size() const { return properties.size(); };
+      IProperty &operator[]( size_t index );
+
+    private:
+      void appendScalarProperty( Type type );
+      void appendListProperty( Type type );
+      std::unique_ptr<IProperty> getScalarProperty( Type type );
+
+    private:
+      std::vector<std::unique_ptr<IProperty>> properties;
+  };
+
+  struct Property
+  {
+    Property( const std::string &name, Type type, bool isList )
+      : name( name ), type( type ), isList( isList ) {};
+
+    std::string name;
+    Type type;
+    bool isList;
+    size_t listCount;
+  };
+
+  typedef std::size_t ElementSize;
+
+  struct Element
+  {
+    Element( const std::string &name, ElementSize size, const std::vector<Property> &properties )
+      : name( name ), size( size ), properties( properties ) {};
+
+    std::string name;
+    ElementSize size;
+    std::vector<Property> properties;
+  };
+
+  typedef std::function< void( ElementBuffer & ) > ElementReadCallback;
+
+  class FileParser;
+
+  typedef std::vector<Element> ElementsDefinition;
+  typedef std::unordered_map<std::string, std::string> Metadata;
+
+  class File
+  {
+    public:
+      File( const std::string &filename );
+      ~File();
+
+      ElementsDefinition definitions() const;
+      Metadata metadata() const;
+      void setElementReadCallback( std::string elementName, ElementReadCallback &readCallback );
+      void read();
+
+    public:
+      enum class Format
+      {
+        ASCII,
+        BINARY_LITTLE_ENDIAN,
+        BINARY_BIG_ENDIAN
+      };
+
+    private:
+      std::string m_filename;
+      std::unique_ptr<FileParser> m_parser;
+  };
+
+
+  typedef std::function< void( ElementBuffer &, size_t index ) > ElementWriteCallback;
+
+  class FileOut
+  {
+    public:
+      FileOut( const std::string &filename, File::Format format );
+
+      void setElementsDefinition( const ElementsDefinition &definitions );
+      void setElementWriteCallback( const std::string &elementName, ElementWriteCallback &writeCallback );
+      void write();
+      Metadata metadata;
+
+    private:
+      void createFile();
+      void writeHeader();
+      void writeData();
+
+    private:
+      std::string m_filename;
+      File::Format m_format;
+      ElementsDefinition m_definitions;
+      std::map<std::string, ElementWriteCallback> m_writeCallbacks;
+  };
+}

--- a/external/mdal/3rdparty/libplyxx.h
+++ b/external/mdal/3rdparty/libplyxx.h
@@ -147,10 +147,10 @@ namespace libply
   {
     public:
 
-      IProperty &operator=( unsigned int value ) override { return *this; };
-      IProperty &operator=( int value ) override  { return *this; };
-      IProperty &operator=( float value ) override  { return *this; };
-      IProperty &operator=( double value ) override  { return *this; };
+      IProperty &operator=( unsigned int ) override { return *this; };
+      IProperty &operator=( int ) override  { return *this; };
+      IProperty &operator=( float ) override  { return *this; };
+      IProperty &operator=( double ) override  { return *this; };
 
       operator unsigned int() override { return 0; };
       operator int() override { return 0; };

--- a/external/mdal/3rdparty/libplyxx/libplyxx.cpp
+++ b/external/mdal/3rdparty/libplyxx/libplyxx.cpp
@@ -1,0 +1,708 @@
+/*
+This file forked from https://github.com/srajotte/libplyxx
+
+Copyright (c) 2016 Simon Rajotte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Updated (c) 2021 Runette Software Ltd to make multiplatform, to complete the typemaps and add to voxel types.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "libplyxx_internal.h"
+#include "mdal.h"
+
+#include <fstream>
+#include <string>
+#include <iostream>
+
+namespace libply
+{
+  File::File( const std::string &filename )
+    : m_filename( filename ),
+      m_parser( std::make_unique<FileParser>( filename ) )
+  {
+  }
+
+  File::~File() = default;
+
+  std::vector<Element> File::definitions() const
+  {
+    return m_parser->definitions();
+  }
+
+  Metadata File::metadata() const
+  {
+    return m_parser->metadata;
+  }
+
+
+  void File::setElementReadCallback( std::string elementName, ElementReadCallback &readCallback )
+  {
+    m_parser->setElementReadCallback( elementName, readCallback );
+  }
+
+  void File::read()
+  {
+    m_parser->read();
+  }
+
+  void addElementDefinition( const textio::Tokenizer::TokenList &tokens, std::vector<ElementDefinition> &elementDefinitions )
+  {
+    assert( std::string( tokens.at( 0 ) ) == "element" );
+    if ( tokens.size() != 3 || tokens.at( 2 ).size() == 0 )
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "PLY: Invalid Element Definition" );
+      elementDefinitions.emplace_back( );
+    }
+    else
+    {
+      size_t startLine = 0;
+      if ( !elementDefinitions.empty() )
+      {
+        const auto &previousElement = elementDefinitions.back();
+        startLine = previousElement.startLine + previousElement.size;
+      }
+      ElementSize elementCount = std::stoul( tokens.at( 2 ) );
+      elementDefinitions.emplace_back( tokens.at( 1 ), elementCount, startLine );
+    }
+  }
+
+  void addProperty( const textio::Tokenizer::TokenList &tokens, ElementDefinition &elementDefinition )
+  {
+    auto &properties = elementDefinition.properties;
+    if ( std::string( tokens.at( 1 ) ) == "list" )
+    {
+      if ( tokens.size() != 5 )
+      {
+        MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, std::string( "PLY: Invalid Property Definition : " ).append( textio::Tokenizer::toString( tokens ) ).c_str() );
+      }
+      else
+      {
+        properties.emplace_back( tokens.back(), TYPE_MAP.at( tokens.at( 3 ) ), true, TYPE_MAP.at( tokens.at( 2 ) ) );
+      }
+    }
+    else
+    {
+      if ( tokens.size() != 3 )
+      {
+        MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, std::string( "PLY: Invalid Property Definition : " ).append( textio::Tokenizer::toString( tokens ) ).c_str() );
+      }
+      else
+      {
+        properties.emplace_back( tokens.back(), TYPE_MAP.at( tokens.at( 1 ) ), false );
+      }
+    }
+  }
+
+  void addMetadata( const textio::SubString line, Metadata &metadata )
+  {
+    textio::SubString::const_iterator next = textio::find( line.begin(), line.end(), ' ' );
+    assert( std::string( textio::SubString( line.begin(), next ) ) == "comment" );
+    line.begin() = next;
+    next++;
+    textio::SubString::const_iterator comment = textio::find( next, line.end(), ':' );
+    if ( comment != line.end() )
+    {
+      metadata.emplace( std::string( textio::SubString( next, comment ) ), std::string( textio::SubString( comment + 1, line.end() ) ) );
+    }
+    else
+    {
+      int idx = 1;
+      while ( idx < 100 )
+      {
+        std::string keyword = "comment" + std::to_string( idx );
+        if ( metadata.find( keyword ) ==  metadata.end() )
+        {
+          metadata.emplace( keyword, std::string( textio::SubString( next, line.end() ) ) );
+          break;
+        }
+        idx++;
+      }
+    }
+  }
+
+  Property PropertyDefinition::getProperty() const
+  {
+    return Property( name, type, isList );
+  }
+
+  Element ElementDefinition::getElement() const
+  {
+    std::vector<Property> props;
+    for ( const PropertyDefinition &p : properties )
+    {
+      props.emplace_back( p.getProperty() );
+    }
+    return Element( name, size, props );
+  }
+
+  FileParser::FileParser( const std::string &filename )
+    : m_filename( filename ),
+      m_lineReader( filename ),
+      m_lineTokenizer( ' ' )
+  {
+    readHeader();
+  }
+
+  FileParser::~FileParser() = default;
+
+  std::vector<Element> FileParser::definitions() const
+  {
+    std::vector<Element> elements;
+    for ( const auto &e : m_elements )
+    {
+      elements.emplace_back( e.getElement() );
+    }
+    return elements;
+  }
+
+  void FileParser::readHeader()
+  {
+    // Read PLY magic number
+    std::string line = m_lineReader.getline();
+    if ( line != "ply" )
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_UnknownFormat, "Invalid file format." );
+      return;
+    }
+
+    // Read file format.
+    line = m_lineReader.getline();
+    if ( line == "format ascii 1.0" )
+    {
+      m_format = File::Format::ASCII;
+    }
+    else if ( line == "format binary_little_endian 1.0" )
+    {
+      m_format = File::Format::BINARY_LITTLE_ENDIAN;
+    }
+    else if ( line == "format binary_big_endian 1.0" )
+    {
+      m_format = File::Format::BINARY_BIG_ENDIAN;
+    }
+    else
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_UnknownFormat, "Unsupported PLY format" );
+      return;
+    }
+
+    // Read mesh elements properties.
+    textio::SubString line_substring;
+    line_substring = m_lineReader.getline();
+    line = line_substring;
+    textio::Tokenizer spaceTokenizer( ' ' );
+    auto tokens = spaceTokenizer.tokenize( line );
+    while ( std::string( tokens.at( 0 ) ) != "end_header" )
+    {
+      const std::string lineType = tokens.at( 0 );
+      if ( lineType == "element" )
+      {
+        addElementDefinition( tokens, m_elements );
+      }
+      else if ( lineType == "property" )
+      {
+        addProperty( tokens, m_elements.back() );
+      }
+      else if ( lineType == "comment" )
+      {
+        addMetadata( line_substring, metadata );
+      }
+      else
+      {
+        MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_UnknownFormat, "Invalid header line." );
+        return;
+      }
+
+      line_substring = m_lineReader.getline();
+      line = line_substring;
+      tokens = spaceTokenizer.tokenize( line );
+    }
+
+    m_dataOffset = m_lineReader.position( line_substring.end() ) + 1;
+  }
+
+  void FileParser::setElementReadCallback( std::string elementName, ElementReadCallback &callback )
+  {
+    m_readCallbackMap[elementName] = callback;
+  }
+
+  void FileParser::read()
+  {
+    std::size_t totalLines = 0;
+    for ( auto &e : m_elements )
+    {
+      totalLines += e.size;
+    }
+
+    std::vector<std::shared_ptr<ElementBuffer>> buffers;
+    for ( auto &e : m_elements )
+    {
+      buffers.emplace_back( std::make_shared<ElementBuffer>( e ) );
+    }
+
+    std::size_t lineIndex = 0;
+    std::size_t elementIndex = 0;
+    ElementReadCallback readCallback = m_readCallbackMap.at( m_elements.at( elementIndex ).name );
+    auto &elementDefinition = m_elements.at( elementIndex );
+    const std::size_t maxElementIndex = m_elements.size();
+
+    std::shared_ptr<ElementBuffer> buffer = buffers[elementIndex];
+
+    std::ifstream &filestream = m_lineReader.filestream();
+
+    if ( m_format == File::Format::BINARY_BIG_ENDIAN || m_format == File::Format::BINARY_LITTLE_ENDIAN )
+    {
+      filestream.clear();
+      filestream.seekg( m_dataOffset );
+    }
+
+    while ( lineIndex < totalLines )
+    {
+      const auto nextElementIndex = elementIndex + 1;
+      if ( nextElementIndex < maxElementIndex && lineIndex >= m_elements[nextElementIndex].startLine )
+      {
+        elementIndex = nextElementIndex;
+        readCallback = m_readCallbackMap.at( m_elements.at( elementIndex ).name );
+        elementDefinition = m_elements.at( elementIndex );
+
+        buffer = buffers[elementIndex];
+      }
+
+      if ( m_format == File::Format::ASCII )
+      {
+        auto line = m_lineReader.getline();
+        parseLine( line, elementDefinition, *buffer );
+      }
+      else
+      {
+        readBinaryElement( filestream, elementDefinition, *buffer );
+      }
+
+      readCallback( *buffer );
+      ++lineIndex;
+    }
+  }
+
+  void FileParser::parseLine( const textio::SubString &line, const ElementDefinition &elementDefinition, ElementBuffer &elementBuffer )
+  {
+    m_lineTokenizer.tokenize( line, m_tokens );
+    const std::vector<PropertyDefinition> properties = elementDefinition.properties;
+    size_t t_idx = 0;
+    size_t e_idx = 0;
+    for ( PropertyDefinition p : properties )
+    {
+      if ( t_idx == m_tokens.size() ||  e_idx == elementBuffer.size() )
+      {
+        MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "Incomplete Element" );
+        return;
+      }
+      if ( !p.isList )
+      {
+        p.conversionFunction( m_tokens[t_idx], elementBuffer[e_idx] );
+        t_idx++;
+        e_idx++;
+      }
+      else
+      {
+        const size_t listLength = std::stoi( m_tokens[t_idx] );
+        t_idx++;
+        ListProperty *lp = dynamic_cast<ListProperty *>( &elementBuffer[e_idx] );
+        lp->define( p.type, listLength );
+        for ( size_t i = 0; i < listLength; i++ )
+        {
+          if ( t_idx == m_tokens.size() )
+          {
+            MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "Incomplete Element" );
+            return;
+          }
+          p.conversionFunction( m_tokens[t_idx], lp->value( i ) );
+          t_idx++;
+        }
+        e_idx++;
+      }
+    }
+  }
+
+  void FileParser::readBinaryElement( std::ifstream &fs, const ElementDefinition &elementDefinition, ElementBuffer &elementBuffer )
+  {
+    const auto &properties = elementDefinition.properties;
+    const unsigned int MAX_PROPERTY_SIZE = 8;
+    char buffer[MAX_PROPERTY_SIZE];
+    size_t e_idx = 0;
+
+    for ( PropertyDefinition p : properties )
+    {
+      if ( !p.isList )
+      {
+        if ( e_idx == elementBuffer.size() ) return; //TODO throw an error
+        const auto size = TYPE_SIZE_MAP.at( p.type );
+        fs.read( buffer, size );
+        p.castFunction( buffer, elementBuffer[e_idx] );
+        e_idx++;
+      }
+      else
+      {
+        if ( e_idx == elementBuffer.size() ) return; //TODO throw an error
+        const auto lengthType = p.listLengthType;
+        const auto lengthTypeSize = TYPE_SIZE_MAP.at( lengthType );
+        fs.read( buffer, lengthTypeSize );
+        size_t listLength = static_cast<size_t>( *buffer );
+
+        ListProperty *lp = dynamic_cast<ListProperty *>( &elementBuffer[e_idx] );
+        lp->define( p.type, listLength );
+
+        const auto &castFunction = p.castFunction;
+        const auto size = TYPE_SIZE_MAP.at( p.type );
+        for ( size_t i = 0; i < listLength; i++ )
+        {
+          fs.read( buffer, size );
+          castFunction( buffer, lp->value( i ) );
+        }
+        e_idx++;
+      }
+    }
+  }
+
+  ElementBuffer::ElementBuffer( const ElementDefinition &definition )
+  {
+    auto &properties = definition.properties;
+    for ( auto &p : properties )
+    {
+      if ( p.isList )
+      {
+        appendListProperty( p.type );
+      }
+      else
+      {
+        appendScalarProperty( p.type );
+      }
+    }
+
+  }
+
+  IProperty &ElementBuffer::operator[]( size_t index )
+  {
+    return *properties[index];
+  }
+
+  void ElementBuffer::appendScalarProperty( Type type )
+  {
+    std::unique_ptr<IProperty> prop = getScalarProperty( type );
+    properties.push_back( std::move( prop ) );
+  }
+
+  void ElementBuffer::appendListProperty( Type type )
+  {
+    std::unique_ptr<IProperty> prop = std::make_unique<ListProperty>();
+    properties.push_back( std::move( prop ) );
+  }
+
+  std::unique_ptr<IProperty> ElementBuffer::getScalarProperty( Type type )
+  {
+    std::unique_ptr<IProperty> prop;
+    switch ( type )
+    {
+      case Type::INT8:
+        prop = std::make_unique<ScalarProperty<char>>();
+        break;
+      case Type::UINT8:
+        prop = std::make_unique<ScalarProperty<unsigned char>>();
+        break;
+      case Type::INT16:
+        prop = std::make_unique<ScalarProperty<short>>();
+        break;
+      case Type::UINT16:
+        prop = std::make_unique<ScalarProperty<unsigned short>>();
+        break;
+      case Type::UINT32:
+        prop = std::make_unique<ScalarProperty<unsigned int>>();
+        break;
+      case Type::INT32:
+        prop = std::make_unique<ScalarProperty<int>>();
+        break;
+      case Type::FLOAT32:
+        prop = std::make_unique<ScalarProperty<float>>();
+        break;
+      case Type::FLOAT64:
+        prop = std::make_unique<ScalarProperty<double>>();
+        break;
+    }
+    return prop;
+  }
+
+  std::string formatString( File::Format format )
+  {
+    switch ( format )
+    {
+      case File::Format::ASCII: return "ascii";
+      case File::Format::BINARY_BIG_ENDIAN: return "binary_big_endian";
+      case File::Format::BINARY_LITTLE_ENDIAN: return "binary_little_endian";
+    }
+    return "";
+  }
+
+  std::string typeString( Type type )
+  {
+    switch ( type )
+    {
+      case Type::INT8: return "char";
+      case Type::UINT8: return "uchar";
+      case Type::INT16: return "short";
+      case Type::UINT16: return "ushort";
+      case Type::UINT32: return "uint";
+      case Type::INT32: return "int";
+      case Type::FLOAT32: return "float";
+      case Type::FLOAT64: return "double";
+    }
+    return "";
+  }
+
+  void writePropertyDefinition( std::ofstream &file, const Property &propertyDefinition )
+  {
+    if ( propertyDefinition.isList )
+    {
+      file << "property list uchar ";
+    }
+    else
+    {
+      file << "property ";
+    }
+    file << typeString( propertyDefinition.type ) << " " << propertyDefinition.name << '\n';
+  }
+
+  void writeElementDefinition( std::ofstream &file, const Element &elementDefinition )
+  {
+    file << "element " << elementDefinition.name << " " << elementDefinition.size << '\n';
+    for ( const auto &prop : elementDefinition.properties )
+    {
+      writePropertyDefinition( file, prop );
+    }
+  }
+
+  void writeTextProperties( std::ofstream &file, ElementBuffer &buffer, const ElementDefinition &elementDefinition )
+  {
+    std::stringstream ss;
+    const std::vector<PropertyDefinition> properties = elementDefinition.properties;
+    size_t e_idx = 0;
+    for ( PropertyDefinition p : properties )
+    {
+      if ( !p.isList )
+      {
+        auto &convert = p.writeConvertFunction;
+        ss.clear();
+        ss.str( std::string() );
+        file << convert( buffer[e_idx], ss ).str() << " ";
+        e_idx++;
+      }
+      else
+      {
+        auto &convert = p.writeConvertFunction;
+        ListProperty *lp = dynamic_cast<ListProperty *>( &buffer[e_idx] );
+        file << lp->size() << " ";
+        for ( size_t i = 0; i < lp->size(); i++ )
+        {
+          ss.clear();
+          ss.str( std::string() );
+          file << convert( lp->value( i ), ss ).str() << " ";
+        }
+        e_idx++;
+        for ( size_t i = 0; i < buffer.size(); ++i )
+        {
+
+        }
+      }
+    }
+    file << '\n';
+  }
+
+  void writeBinaryProperties( std::ofstream &file, ElementBuffer &buffer, const ElementDefinition &elementDefinition )
+  {
+    const unsigned int MAX_PROPERTY_SIZE = 8;
+    char write_buffer[MAX_PROPERTY_SIZE];
+
+    if ( elementDefinition.properties.front().isList )
+    {
+      unsigned char list_size = static_cast<unsigned char>( buffer.size() );
+      file.write( reinterpret_cast<char *>( &list_size ), sizeof( list_size ) );
+
+      auto &cast = elementDefinition.properties.front().writeCastFunction;
+      for ( size_t i = 0; i < buffer.size(); ++i )
+      {
+        size_t write_size;
+        cast( buffer[i], write_buffer, write_size );
+        file.write( reinterpret_cast<char *>( write_buffer ), write_size );
+      }
+    }
+    else
+    {
+      for ( size_t i = 0; i < buffer.size(); ++i )
+      {
+        auto &cast = elementDefinition.properties.at( i ).writeCastFunction;
+        size_t write_size;
+        cast( buffer[i], write_buffer, write_size );
+        file.write( reinterpret_cast<char *>( write_buffer ), write_size );
+      }
+    }
+  }
+
+  void writeProperties( std::ofstream &file, ElementBuffer &buffer, size_t index, const ElementDefinition &elementDefinition, File::Format format, ElementWriteCallback &callback )
+  {
+    callback( buffer, index );
+    if ( format == File::Format::ASCII )
+    {
+      writeTextProperties( file, buffer, elementDefinition );
+    }
+    else
+    {
+      writeBinaryProperties( file, buffer, elementDefinition );
+    }
+  }
+
+  void writeElements( std::ofstream &file, const Element &elementDefinition, File::Format format, ElementWriteCallback &callback )
+  {
+    const size_t size = elementDefinition.size;
+    ElementBuffer buffer( elementDefinition );
+    //buffer.reset( elementDefinition.properties.size() );
+    for ( size_t i = 0; i < size; ++i )
+    {
+      writeProperties( file, buffer, i, elementDefinition, format, callback );
+    }
+  }
+
+  FileOut::FileOut( const std::string &filename, File::Format format )
+    : m_filename( filename ), m_format( format )
+  {
+    createFile();
+  }
+
+  void FileOut::setElementsDefinition( const ElementsDefinition &definitions )
+  {
+    m_definitions = definitions;
+  }
+
+  void FileOut::setElementWriteCallback( const std::string &elementName, ElementWriteCallback &writeCallback )
+  {
+    m_writeCallbacks[elementName] = writeCallback;
+  }
+
+  void FileOut::write()
+  {
+    writeHeader();
+    writeData();
+  }
+
+  void FileOut::createFile()
+  {
+    std::ofstream f( m_filename, std::ios::trunc );
+    f.close();
+  }
+
+  void FileOut::writeHeader()
+  {
+    std::ofstream file( m_filename, std::ios::out | std::ios::binary );
+
+    file << "ply" << std::endl;
+    file << "format " << formatString( m_format ) << " 1.0" << std::endl;
+    for ( const auto &def : m_definitions )
+    {
+      writeElementDefinition( file, def );
+    }
+    file << "end_header" << std::endl;
+
+    file.close();
+  }
+
+  void FileOut::writeData()
+  {
+    std::ofstream file( m_filename, std::ios::out | std::ios::binary | std::ios::app );
+    for ( const auto &elem : m_definitions )
+    {
+      writeElements( file, elem, m_format, m_writeCallbacks[elem.name] );
+    }
+    file.close();
+  }
+
+  IProperty &ListProperty::value( size_t index )
+  {
+    return *list[index];
+  }
+
+  void ListProperty::define( Type type, size_t isize )
+  {
+    list.clear();
+    for ( size_t i = 0; i < isize; i++ )
+    {
+      std::unique_ptr<IProperty> prop = getScalarProperty( type );
+      list.push_back( std::move( prop ) );
+    }
+  }
+
+  std::unique_ptr<IProperty> ListProperty::getScalarProperty( Type type )
+  {
+    std::unique_ptr<IProperty> prop;
+    switch ( type )
+    {
+      case Type::INT8:
+        prop = std::make_unique<ScalarProperty<char>>();
+        break;
+      case Type::UINT8:
+        prop = std::make_unique<ScalarProperty<unsigned char>>();
+        break;
+      case Type::INT16:
+        prop = std::make_unique<ScalarProperty<short>>();
+        break;
+      case Type::UINT16:
+        prop = std::make_unique<ScalarProperty<unsigned short>>();
+        break;
+      case Type::UINT32:
+        prop = std::make_unique<ScalarProperty<unsigned int>>();
+        break;
+      case Type::INT32:
+        prop = std::make_unique<ScalarProperty<int>>();
+        break;
+      case Type::FLOAT32:
+        prop = std::make_unique<ScalarProperty<float>>();
+        break;
+      case Type::FLOAT64:
+        prop = std::make_unique<ScalarProperty<double>>();
+        break;
+    }
+    return prop;
+  }
+
+}

--- a/external/mdal/3rdparty/libplyxx/libplyxx.cpp
+++ b/external/mdal/3rdparty/libplyxx/libplyxx.cpp
@@ -426,7 +426,7 @@ namespace libply
     properties.push_back( std::move( prop ) );
   }
 
-  void ElementBuffer::appendListProperty( Type type )
+  void ElementBuffer::appendListProperty( Type )
   {
     std::unique_ptr<IProperty> prop = std::make_unique<ListProperty>();
     properties.push_back( std::move( prop ) );

--- a/external/mdal/3rdparty/libplyxx/libplyxx_internal.h
+++ b/external/mdal/3rdparty/libplyxx/libplyxx_internal.h
@@ -1,0 +1,357 @@
+/*
+This file forked from https://github.com/srajotte/libplyxx
+
+Copyright (c) 2016 Simon Rajotte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Updated (c) 2021 Runette Software Ltd to make multiplatform, to complete the typemaps and add to voxel types.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#pragma once
+
+#include "libplyxx.h"
+#include <sstream>
+
+// a custom specialisation (and yes, you are allowed (and have to) put this in std)
+// from http://www.cplusplus.com/forum/general/238538/
+namespace std
+{
+  template<>
+  struct hash<libply::Type>
+  {
+    using argument_type = libply::Type;
+    using result_type = int;
+
+    result_type operator()( argument_type a ) const
+    {
+      return static_cast<result_type>( a );
+    }
+  };
+}
+
+namespace libply
+{
+  typedef std::unordered_map<std::string, Type> TypeMap;
+  const TypeMap TYPE_MAP =
+  {
+    { "char", Type::INT8 },
+    { "uchar", Type::UINT8 },
+    { "short", Type::INT16 },
+    { "ushort", Type::UINT16},
+    { "int", Type::INT32 },
+    { "uint", Type::UINT32},
+    { "float", Type::FLOAT32 },
+    { "double", Type::FLOAT64 },
+    { "int8", Type::INT8 },
+    { "uint8", Type::UINT8 },
+    { "int16", Type::INT16 },
+    { "uint16", Type::UINT16},
+    { "int32", Type::INT32 },
+    { "uint32", Type::UINT32},
+    { "float32", Type::FLOAT32 },
+    { "float64", Type::FLOAT64 }
+  };
+
+  typedef std::unordered_map<Type, unsigned int> TypeSizeMap;
+  const TypeSizeMap TYPE_SIZE_MAP =
+  {
+    { Type::INT8, 1 },
+    { Type::UINT8, 1},
+    { Type::INT16, 2},
+    { Type::UINT16, 2},
+    { Type::INT32, 4},
+    { Type::UINT32, 4},
+    { Type::FLOAT32, 4},
+    { Type::FLOAT64, 8}
+  };
+
+  /// Type conversion functions.
+
+  inline void convert_UINT( const textio::SubString &token, IProperty &property )
+  {
+    property = textio::stoi<int>( token );
+  }
+
+  inline void convert_INT( const textio::SubString &token, IProperty &property )
+  {
+    property = textio::stoi<int>( token );
+  }
+
+  inline void convert_FLOAT( const textio::SubString &token, IProperty &property )
+  {
+    property = textio::stor<float>( token );
+  }
+
+  inline void convert_DOUBLE( const textio::SubString &token, IProperty &property )
+  {
+    property = textio::stor<double>( token );
+  }
+
+  typedef void( *ConversionFunction )( const textio::SubString &, IProperty & );
+  typedef std::unordered_map<Type, ConversionFunction> ConversionFunctionMap;
+
+  const ConversionFunctionMap CONVERSION_MAP =
+  {
+    { Type::INT8, convert_INT },
+    { Type::UINT8, convert_UINT },
+    { Type::INT16, convert_INT },
+    { Type::UINT16, convert_UINT },
+    { Type::INT32, convert_INT },
+    { Type::UINT32, convert_UINT },
+    { Type::FLOAT32, convert_FLOAT },
+    { Type::FLOAT64, convert_DOUBLE }
+  };
+
+  /// Type casting functions.
+
+  inline void cast_UINT8( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<unsigned char *>( buffer );
+  }
+
+  inline void cast_INT8( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast< char *>( buffer );
+  }
+
+  inline void cast_UINT16( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<unsigned short *>( buffer );
+  }
+
+  inline void cast_INT16( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<short *>( buffer );
+  }
+
+  inline void cast_UINT32( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<unsigned int *>( buffer );
+  }
+
+  inline void cast_INT32( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<int *>( buffer );
+  }
+
+  inline void cast_FLOAT( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<float *>( buffer );
+  }
+
+  inline void cast_DOUBLE( char *buffer, IProperty &property )
+  {
+    property = *reinterpret_cast<double *>( buffer );
+  }
+
+  typedef void( *CastFunction )( char *buffer, IProperty & );
+  typedef std::unordered_map<Type, CastFunction> CastFunctionMap;
+
+  const CastFunctionMap CAST_MAP =
+  {
+    { Type::INT8, cast_INT8 },
+    { Type::UINT8, cast_UINT8 },
+    { Type::INT16, cast_INT16 },
+    { Type::UINT16, cast_UINT16 },
+    { Type::INT32, cast_INT32 },
+    { Type::UINT32, cast_UINT32 },
+    { Type::FLOAT32, cast_FLOAT },
+    { Type::FLOAT64, cast_DOUBLE }
+  };
+
+  inline std::stringstream &write_convert_UINT( IProperty &property, std::stringstream &ss )
+  {
+    ss << static_cast<unsigned int>( property );
+    return ss;
+  }
+
+  inline std::stringstream &write_convert_INT( IProperty &property, std::stringstream &ss )
+  {
+    ss << static_cast<int>( property );
+    return ss;
+  }
+
+  inline std::stringstream &write_convert_FLOAT( IProperty &property, std::stringstream &ss )
+  {
+    ss << static_cast<float>( property );
+    return ss;
+  }
+
+  inline std::stringstream &write_convert_DOUBLE( IProperty &property, std::stringstream &ss )
+  {
+    ss << static_cast<double>( property );
+    return ss;
+  }
+
+  typedef std::stringstream &( *WriteConvertFunction )( IProperty &, std::stringstream & );
+  typedef std::unordered_map<Type, WriteConvertFunction> WriteConvertFunctionMap;
+
+  const WriteConvertFunctionMap WRITE_CONVERT_MAP =
+  {
+    { Type::INT8, write_convert_INT },
+    { Type::UINT8, write_convert_UINT },
+    { Type::INT16, write_convert_INT },
+    { Type::UINT16, write_convert_UINT },
+    { Type::INT32, write_convert_INT },
+    { Type::UINT32, write_convert_UINT },
+    { Type::FLOAT32, write_convert_FLOAT },
+    { Type::FLOAT64, write_convert_DOUBLE }
+  };
+
+  inline void write_cast_UINT( IProperty &property, char *buffer, size_t &size )
+  {
+    *reinterpret_cast<unsigned int *>( buffer ) = static_cast<unsigned int>( property );
+    size = sizeof( unsigned char );
+  }
+
+  inline void write_cast_INT( IProperty &property, char *buffer, size_t &size )
+  {
+    *reinterpret_cast<int *>( buffer ) = static_cast<int>( property );
+    size = sizeof( int );
+  }
+
+  inline void write_cast_FLOAT( IProperty &property, char *buffer, size_t &size )
+  {
+    *reinterpret_cast<float *>( buffer ) = static_cast<float>( property );
+    size = sizeof( float );
+  }
+
+  inline void write_cast_DOUBLE( IProperty &property, char *buffer, size_t &size )
+  {
+    *reinterpret_cast<double *>( buffer ) = static_cast<double>( property );
+    size = sizeof( double );
+  }
+
+  typedef void( *WriteCastFunction )( IProperty &property, char *buffer, size_t &size );
+  typedef std::unordered_map<Type, WriteCastFunction> WriteCastFunctionMap;
+
+  const WriteCastFunctionMap WRITE_CAST_MAP =
+  {
+    { Type::INT8, write_cast_INT },
+    { Type::UINT8, write_cast_UINT },
+    { Type::INT16, write_cast_INT },
+    { Type::UINT16, write_cast_UINT },
+    { Type::INT32, write_cast_INT },
+    { Type::UINT32, write_cast_UINT },
+    { Type::FLOAT32, write_cast_FLOAT },
+    { Type::FLOAT64, write_cast_DOUBLE }
+  };
+
+  struct PropertyDefinition
+  {
+    PropertyDefinition( const std::string &name, Type type, bool isList, Type listLengthType = Type::UINT8 )
+      : name( name ), type( type ), isList( isList ), listLengthType( listLengthType ),
+        conversionFunction( CONVERSION_MAP.at( type ) ),
+        castFunction( CAST_MAP.at( type ) ),
+        writeConvertFunction( WRITE_CONVERT_MAP.at( type ) ),
+        writeCastFunction( WRITE_CAST_MAP.at( type ) )
+    {};
+    PropertyDefinition( const Property &p )
+      : PropertyDefinition( p.name, p.type, p.isList )
+    {};
+
+    Property getProperty() const;
+
+    std::string name;
+    Type type;
+    bool isList;
+    Type listLengthType;
+    ConversionFunction conversionFunction;
+    CastFunction castFunction;
+    WriteConvertFunction writeConvertFunction;
+    WriteCastFunction writeCastFunction;
+  };
+
+  struct ElementDefinition
+  {
+    ElementDefinition() : ElementDefinition( "", 0, 0 ) {};
+    ElementDefinition( const std::string &name, ElementSize size, std::size_t startLine )
+      : name( name ), size( size ), startLine( startLine ) {};
+    ElementDefinition( const Element &e )
+      : name( e.name ), size( e.size )
+    {
+      for ( const auto &p : e.properties )
+      {
+        properties.emplace_back( p );
+      }
+    };
+
+    Element getElement() const;
+
+    std::string name;
+    ElementSize size;
+    std::vector<PropertyDefinition> properties;
+    std::size_t startLine;
+  };
+
+  class FileParser
+  {
+    public:
+      explicit FileParser( const std::string &filename );
+      FileParser( const FileParser &other ) = delete;
+      ~FileParser();
+
+      std::vector<Element> definitions() const;
+      Metadata metadata;
+      //void setElementInserter(std::string elementName, IElementInserter* inserter);
+      void setElementReadCallback( std::string elementName, ElementReadCallback &readCallback );
+      void read();
+
+    private:
+      void readHeader();
+      void parseLine( const textio::SubString &substr, const ElementDefinition &elementDefinition, ElementBuffer &buffer );
+      void readBinaryElement( std::ifstream &fs, const ElementDefinition &elementDefinition, ElementBuffer &buffer );
+
+    private:
+      typedef std::map<std::string, ElementReadCallback> CallbackMap;
+
+    private:
+      std::string m_filename;
+      File::Format m_format;
+      std::streamsize m_dataOffset;
+      textio::LineReader m_lineReader;
+      textio::Tokenizer m_lineTokenizer;
+      textio::Tokenizer::TokenList m_tokens;
+      std::vector<ElementDefinition> m_elements;
+      CallbackMap m_readCallbackMap;
+  };
+
+  std::string formatString( File::Format format );
+  std::string typeString( Type type );
+}

--- a/external/mdal/3rdparty/textio.h
+++ b/external/mdal/3rdparty/textio.h
@@ -1,0 +1,409 @@
+/*
+This file forked from https://github.com/srajotte/libplyxx
+
+Copyright (c) 2016 Simon Rajotte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Updated (c) 2021 Runette Software Ltd to make multiplatform, to complete the typemaps and add to voxel types.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <fstream>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+
+namespace textio
+{
+  class SubString
+  {
+    public:
+      typedef std::string::const_iterator const_iterator;
+
+    public:
+      SubString() = default;
+      SubString( const std::string::const_iterator &begin, const std::string::const_iterator &end )
+        : m_begin( begin ), m_end( end ) {};
+
+      operator std::string() const { return std::string( m_begin, m_end ); };
+
+      const_iterator begin() const { return m_begin; };
+      const_iterator end() const { return m_end; };
+      int size() const { return m_end - m_begin; };
+
+    private:
+      const_iterator m_begin;
+      const_iterator m_end;
+  };
+
+  class Tokenizer
+  {
+    public:
+      typedef std::vector<SubString> TokenList;
+    public:
+      inline Tokenizer( char delimiter );
+
+      inline TokenList tokenize( const std::string &buffer ) const;
+      inline TokenList tokenize( const SubString &buffer ) const;
+      inline void tokenize( const SubString &buffer, TokenList &tokens ) const;
+
+      inline static std::string toString( const TokenList &tokens );
+
+    private:
+      char m_delimiter;
+  };
+
+  class LineReader
+  {
+    public:
+      template<typename PathString>
+      inline LineReader( const PathString &filename, bool textMode = false );
+
+      // Read next line from input file.
+      // Returned SubString is valid until the next call to getline()
+      inline SubString getline();
+      inline bool eof() const { return m_eof; };
+      inline std::ifstream &filestream() { return m_file; };
+      inline std::streamsize position( const std::string::const_iterator &workbuf_iter );
+
+    private:
+      //inline void readFileChunk(std::streamoff offset = 0);
+      inline std::streamsize readFileChunk( std::size_t overlap );
+      inline SubString findLine();
+
+    private:
+      typedef std::string WorkBuffer;
+
+    private:
+      std::ifstream m_file;
+
+      std::streamsize m_workBufSize;
+      std::streamsize m_workBufFileEndPosition;
+      WorkBuffer m_workBuf;
+      bool m_eof;
+
+      WorkBuffer::const_iterator m_begin;
+      WorkBuffer::const_iterator m_end;
+  };
+
+  // Convert string to floating point (real) type.
+  template<typename T>
+  T stor( const SubString &substr )
+  {
+    auto p = substr.begin();
+    auto end = substr.end();
+    T real = 0.0;
+    bool negative = false;
+    if ( p != end && *p == '-' )
+    {
+      negative = true;
+      ++p;
+    }
+    while ( p != end && *p >= '0' && *p <= '9' )
+    {
+      real = ( real * static_cast<T>( 10.0 ) ) + ( *p - '0' );
+      ++p;
+    }
+    if ( p != end && *p == '.' )
+    {
+      T frac = 0.0;
+      int n = 0;
+      ++p;
+      while ( p != end && *p >= '0' && *p <= '9' )
+      {
+        frac = ( frac * static_cast<T>( 10.0 ) ) + ( *p - '0' );
+        ++p;
+        ++n;
+      }
+      real += static_cast<T>( frac / std::pow( 10.0, n ) );
+    }
+    if ( p != end && ( *p == 'e' || *p == 'E' ) )
+    {
+      ++p;
+      T sign = 1.0;
+      if ( p != end && *p == '-' )
+      {
+        sign = -1.0;
+        ++p;
+      }
+      T exponent = 0.0;
+      while ( p != end && *p >= '0' && *p <= '9' )
+      {
+        exponent = ( exponent * static_cast<T>( 10.0 ) ) + ( *p - '0' );
+        ++p;
+      }
+      real = real * std::pow( static_cast<T>( 10.0 ), sign * exponent );
+    }
+    if ( negative )
+    {
+      real = -real;
+    }
+    return real;
+  }
+
+  template<typename T>
+  T stor( const std::string &str )
+  {
+    return stor<T>( SubString( str.cbegin(), str.cend() ) );
+  }
+
+  // Convert string to unsigned type.
+  template<typename T>
+  T stou( const SubString &substr )
+  {
+    static_assert( std::is_unsigned<T>::value, "Cannot use stou() with signed type." );
+    auto p = substr.begin();
+    auto end = substr.end();
+    T integer = 0;
+    assert( *p != '-' );
+    while ( p != end && *p >= '0' && *p <= '9' )
+    {
+      integer = ( integer * 10 ) + ( *p - '0' );
+      ++p;
+    }
+    return integer;
+  }
+
+  // Convert string to signed integer type.
+  template<typename T>
+  T stoi( const SubString &substr )
+  {
+    auto p = substr.begin();
+    auto end = substr.end();
+    T integer = 0;
+    bool negative = false;
+    if ( p != end && *p == '-' )
+    {
+      negative = true;
+      ++p;
+    }
+    while ( p != end && *p >= '0' && *p <= '9' )
+    {
+      integer = ( integer * 10 ) + ( *p - '0' );
+      ++p;
+    }
+    if ( negative )
+    {
+      integer = -integer;
+    }
+    return integer;
+  }
+
+  template<typename T>
+  T stou( const std::string &str )
+  {
+    return stou<T>( SubString( str.cbegin(), str.cend() ) );
+  }
+
+  Tokenizer::Tokenizer( char delimiter )
+    : m_delimiter( delimiter )
+  {
+
+  }
+
+  Tokenizer::TokenList Tokenizer::tokenize( const SubString &buffer ) const
+  {
+    TokenList tokens;
+    tokenize( buffer, tokens );
+    return tokens;
+  }
+
+  Tokenizer::TokenList Tokenizer::tokenize( const std::string &buffer ) const
+  {
+    return tokenize( SubString( buffer.cbegin(), buffer.cend() ) );
+  }
+
+  inline textio::SubString::const_iterator find( textio::SubString::const_iterator begin, textio::SubString::const_iterator end, char delimiter )
+  {
+    textio::SubString::const_iterator start = begin;
+    while ( start != end )
+    {
+      if ( *start == delimiter ) return start;
+      ++start;
+    }
+    return end;
+  }
+
+  inline textio::SubString::const_iterator findSIMD( textio::SubString::const_iterator begin, textio::SubString::const_iterator end, char delimiter )
+  {
+    uint64_t pattern;
+    switch ( delimiter )
+    {
+      case '\n': pattern = 0x0a0a0a0a0a0a0a0aULL; break;
+      case ' ': pattern = 0x2020202020202020ULL; break;
+      case '\r': pattern = 0x0d0d0d0d0d0d0d0dULL; break;
+      default: throw std::runtime_error( "Unsupported delimiter." ); //TODO
+    }
+
+    textio::SubString::const_iterator start = begin;
+    const int WORD_WIDTH = 8;
+    while ( end - start > WORD_WIDTH )
+    {
+      // Xor data with pattern to find the bit distance. Matching bytes will be 0x00, otherwise >0x00.
+      // When subtracting 0x01 to all bytes, only bytes at 0x00 will underflow to 0xff, i.e. bytes that match the pattern.
+      // Apply bitwise-and between that last result and 0x80, i.e. b10000000, to keep bytes >0x80. Since the last ASCII character is 0x79, only the matching bytes that underflowed are kept.
+      // Must also test with ~data, because subtraction at 0x00 cause borrowing from the adjacent byte, which might have cause an underflow at that byte.
+      uint64_t data = *( uint64_t * ) & ( *start );
+      data = data ^ pattern;
+      if ( ( data - 0x0101010101010101ULL ) & ~data & 0x8080808080808080 )
+      {
+        // Delimiter found in sequence.
+        return textio::find( start, end, delimiter );
+      }
+      else
+      {
+        start += WORD_WIDTH;
+      }
+    }
+    // Remaining data in sequence too small to run SIMD search.
+    return textio::find( begin, end, delimiter );
+  }
+
+  inline void Tokenizer::tokenize( const SubString &buffer, TokenList &tokens ) const
+  {
+    tokens.clear();
+    textio::SubString::const_iterator begin = buffer.begin();
+    const textio::SubString::const_iterator end = buffer.end();
+    textio::SubString::const_iterator eot = begin;
+    while ( eot != end )
+    {
+      // Skip all delimiters.
+      while ( begin != end && *begin == m_delimiter )
+      {
+        ++begin;
+      }
+      eot = textio::find( begin, end, m_delimiter );
+
+      tokens.emplace_back( begin, eot );
+      if ( eot != end )
+      {
+        // Move begin after delimiter.
+        begin = eot + 1;
+      }
+    }
+  }
+
+  inline std::string Tokenizer::toString( const TokenList &tokens )
+  {
+    std::string ret = "";
+    for ( textio::SubString token : tokens )
+    {
+      ret.append( token );
+    }
+    return ret;
+  }
+
+  template<typename PathString>
+  LineReader::LineReader( const PathString &filename, bool textMode )
+    : m_workBufSize( 1 * 1024 * 1024 ), m_workBufFileEndPosition( 0 ), m_eof( false )
+  {
+    std::ios_base::openmode mode = std::fstream::in;
+    if ( !textMode ) { mode |= std::fstream::binary; }
+    m_file.open( filename, mode );
+    if ( !m_file.is_open() )
+    {
+      throw std::runtime_error( "Could not open file." );
+    }
+    m_workBuf.resize( m_workBufSize );
+    readFileChunk( 0 );
+  }
+
+  SubString LineReader::getline()
+  {
+    return findLine();
+  }
+
+  std::streamsize LineReader::readFileChunk( std::size_t overlap )
+  {
+    char *bufferFront = &m_workBuf.front();
+    if ( overlap != 0 )
+    {
+      size_t offset = m_workBufSize - overlap;
+      std::memcpy( bufferFront, bufferFront + offset, overlap );
+    }
+    m_file.read( bufferFront + overlap, m_workBufSize - overlap );
+    m_begin = m_workBuf.cbegin();
+    m_end = m_workBuf.cbegin() + overlap + m_file.gcount();
+    m_workBufFileEndPosition += m_file.gcount();
+    return m_file.gcount();
+  }
+
+  SubString LineReader::findLine()
+  {
+    SubString::const_iterator nl = findSIMD( m_begin, m_end, '\n' );
+    SubString::const_iterator eol = findSIMD( m_begin, nl, '\r' );
+    if ( m_begin == m_workBuf.cbegin() && eol == m_end )
+    {
+      std::runtime_error( "Working buffer too small to fit single line." );
+    }
+    SubString lineSubstring( m_begin, eol );
+
+    // Reached the end of the work buffer (last character not a newline delimiter).
+    if ( eol == m_end )
+    {
+      auto count = readFileChunk( m_end - m_begin );
+      if ( count == 0 && m_file.eof() )
+      {
+        m_eof = true;
+        return lineSubstring;
+      }
+      else
+      {
+        lineSubstring = findLine();
+      }
+    }
+    // Line complete.
+    else
+    {
+      // Set begin pointer to the first character after the newline delimiter.
+      m_begin = nl + 1;
+    }
+    return lineSubstring;
+  }
+
+  std::streamsize LineReader::position( const std::string::const_iterator &workbuf_iter )
+  {
+    return m_workBufFileEndPosition - ( m_end - workbuf_iter );
+  }
+}

--- a/external/mdal/api/mdal.h
+++ b/external/mdal/api/mdal.h
@@ -332,6 +332,22 @@ MDAL_EXPORT void MDAL_M_addFaces( MDAL_MeshH mesh,
                                   int *vertexIndices );
 
 /**
+ * Adds edges to the mesh
+ * \param mesh the mesh which the faces are added
+ * \param edgeCount the count of edges
+ * \param startVertexIndices must be allocated to edgesCount items to store start vertex indices for edges
+ * \param endVertexIndices must be allocated to edgesCount items to store end vertex indices for edges
+ *
+ * \note to avoid incompatible datasets, adding edges removes all the existing dataset group
+ *
+ * \since MDAL 0.9.0
+ */
+MDAL_EXPORT void MDAL_M_addEdges( MDAL_MeshH mesh,
+                                  int edgesCount,
+                                  int *startVertexIndices,
+                                  int *endVertexIndices );
+
+/**
  * Returns vertex count for the mesh
  */
 MDAL_EXPORT int MDAL_M_vertexCount( MDAL_MeshH mesh );
@@ -368,7 +384,7 @@ MDAL_EXPORT void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
 MDAL_EXPORT int MDAL_M_metadataCount( MDAL_MeshH mesh );
 
 /**
- * Returns dataset metadata key
+ * Returns mesh metadata key
  * not thread-safe and valid only till next call
  *
  * \since MDAL 0.9.0
@@ -376,7 +392,7 @@ MDAL_EXPORT int MDAL_M_metadataCount( MDAL_MeshH mesh );
 MDAL_EXPORT const char *MDAL_M_metadataKey( MDAL_MeshH mesh, int index );
 
 /**
- * Returns dataset metadata value
+ * Returns mesh metadata value
  * not thread-safe and valid only till next call
  *
  * \since MDAL 0.9.0
@@ -647,6 +663,8 @@ MDAL_EXPORT MDAL_DatasetH MDAL_G_addDataset(
  * \param verticalExtrusion Double Array holding the vertical level values for the voxels
  *               Size must be Face count + Volume count
  * \returns empty pointer if not possible to create dataset (e.g. group opened in read mode), otherwise handle to new dataset
+ *
+ * \since MDAL 0.9.0
  */
 
 MDAL_EXPORT MDAL_DatasetH MDAL_G_addDataset3D(

--- a/external/mdal/cmake_templates/mdal_config.hpp.in
+++ b/external/mdal/cmake_templates/mdal_config.hpp.in
@@ -13,6 +13,8 @@
 
 #cmakedefine HAVE_SQLITE3
 
+#cmakedefine BUILD_PLY
+
 #endif // MDAL_CONFIG_HPP
 
  

--- a/external/mdal/frmts/mdal_dynamic_driver.cpp
+++ b/external/mdal/frmts/mdal_dynamic_driver.cpp
@@ -439,16 +439,22 @@ MDAL::DatasetDynamicDriver::DatasetDynamicDriver( int meshId, int groupIndex, in
   , mLibrary( library )
 {}
 
+MDAL::DatasetDynamicDriver::~DatasetDynamicDriver() = default;
+
 MDAL::DatasetDynamicDriver2D::DatasetDynamicDriver2D( MDAL::DatasetGroup *parentGroup, int meshId, int groupIndex, int datasetIndex, const MDAL::Library &library )
   : Dataset2D( parentGroup )
   , DatasetDynamicDriver( meshId, groupIndex, datasetIndex, library )
 {}
+
+MDAL::DatasetDynamicDriver2D::~DatasetDynamicDriver2D() = default;
 
 
 MDAL::DatasetDynamicDriver3D::DatasetDynamicDriver3D( MDAL::DatasetGroup *parentGroup, int meshId, int groupIndex, int datasetIndex, size_t volumes, size_t maxVerticalLevelCount, const MDAL::Library &library )
   : Dataset3D( parentGroup, volumes, maxVerticalLevelCount )
   , DatasetDynamicDriver( meshId, groupIndex, datasetIndex, library )
 {}
+
+MDAL::DatasetDynamicDriver3D::~DatasetDynamicDriver3D() = default;
 
 size_t MDAL::DatasetDynamicDriver3D::verticalLevelCountData( size_t indexStart, size_t count, int *buffer )
 {

--- a/external/mdal/frmts/mdal_dynamic_driver.hpp
+++ b/external/mdal/frmts/mdal_dynamic_driver.hpp
@@ -110,6 +110,7 @@ namespace MDAL
                             int groupIndex,
                             int datasetIndex,
                             const Library &library );
+      virtual ~DatasetDynamicDriver();
 
       virtual bool loadSymbol();
 
@@ -135,6 +136,7 @@ namespace MDAL
                               int groupIndex,
                               int datasetIndex,
                               const Library &library );
+      ~DatasetDynamicDriver2D() override;
 
       bool loadSymbol() override;
 
@@ -157,7 +159,7 @@ namespace MDAL
                               size_t volumes,
                               size_t maxVerticalLevelCount,
                               const Library &library );
-
+      ~DatasetDynamicDriver3D() override;
       bool loadSymbol() override;
 
       size_t verticalLevelCountData( size_t indexStart, size_t count, int *buffer ) override;

--- a/external/mdal/frmts/mdal_dynamic_driver.hpp
+++ b/external/mdal/frmts/mdal_dynamic_driver.hpp
@@ -102,25 +102,21 @@ namespace MDAL
       std::function<int ( int, int, int, int *, int * )> mEdgesFunction;
   };
 
-  class DatasetDynamicDriver: public Dataset2D
+
+  class DatasetDynamicDriver
   {
     public:
-      DatasetDynamicDriver( DatasetGroup *parentGroup,
-                            int meshId,
+      DatasetDynamicDriver( int meshId,
                             int groupIndex,
                             int datasetIndex,
                             const Library &library );
 
-      size_t scalarData( size_t indexStart, size_t count, double *buffer ) override;
-      size_t vectorData( size_t indexStart, size_t count, double *buffer ) override;
-      size_t activeData( size_t indexStart, size_t count, int *buffer ) override;
-
-      bool loadSymbol();
+      virtual bool loadSymbol();
 
       //! Removes stored data in memory (for drivers that support lazy loading)
       void unloadData();
 
-    private:
+    protected:
       int mMeshId = -1;
       int mGroupIndex = -1;
       int mDatasetIndex = -1;
@@ -128,8 +124,54 @@ namespace MDAL
 
       //************************************
       std::function<int ( int, int, int, int, int, double * )> mDataFunction;
-      std::function<int ( int, int, int, int, int, int * )> mActiveFlagsFunction;
       std::function<void( int, int, int )> mUnloadFunction;
+  };
+
+  class DatasetDynamicDriver2D: public Dataset2D, public DatasetDynamicDriver
+  {
+    public:
+      DatasetDynamicDriver2D( DatasetGroup *parentGroup,
+                              int meshId,
+                              int groupIndex,
+                              int datasetIndex,
+                              const Library &library );
+
+      bool loadSymbol() override;
+
+      size_t scalarData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t vectorData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t activeData( size_t indexStart, size_t count, int *buffer ) override;
+
+    private:
+
+      std::function<int ( int, int, int, int, int, int * )> mActiveFlagsFunction;
+  };
+
+  class DatasetDynamicDriver3D: public Dataset3D, public DatasetDynamicDriver
+  {
+    public:
+      DatasetDynamicDriver3D( DatasetGroup *parentGroup,
+                              int meshId,
+                              int groupIndex,
+                              int datasetIndex,
+                              size_t volumes,
+                              size_t maxVerticalLevelCount,
+                              const Library &library );
+
+      bool loadSymbol() override;
+
+      size_t verticalLevelCountData( size_t indexStart, size_t count, int *buffer ) override;
+      size_t verticalLevelData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t faceToVolumeData( size_t indexStart, size_t count, int *buffer ) override;
+      size_t scalarVolumesData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t vectorVolumesData( size_t indexStart, size_t count, double *buffer ) override;
+
+    private:
+
+      std::function<int ( int, int, int, int, int, int * )> mVerticalLevelCountDataFunction;
+      std::function<int ( int, int, int, int, int, double * )> mVerticalLevelDataFunction;
+      std::function<int ( int, int, int, int, int, int * )> mFaceToVolumeDataFunction;
+
   };
 
   class MeshDynamicDriver: public Mesh
@@ -178,6 +220,8 @@ namespace MDAL
       std::function < bool ( int, int, bool *, int *, int * )> mDatasetDescriptionFunction;
       std::function < double( int, int, int, bool * )> mDatasetTimeFunction;
       std::function<bool ( int, int, int )> mDatasetSupportActiveFlagFunction;
+      std::function<int ( int, int, int )> mDataset3DMaximumVerticalLevelCount;
+      std::function<int ( int, int, int )> mDataset3DVolumeCount;
 
       std::function<void ( int )> mCloseMeshFunction;
   };

--- a/external/mdal/frmts/mdal_flo2d.cpp
+++ b/external/mdal/frmts/mdal_flo2d.cpp
@@ -996,7 +996,7 @@ MDAL::DriverFlo2D::DriverFlo2D()
   : Driver(
       "FLO2D",
       "Flo2D",
-      "*.nc",
+      "*.nc;;*.DAT",
       Capability::ReadMesh | Capability::ReadDatasets | Capability::WriteDatasetsOnFaces )
 {
 

--- a/external/mdal/frmts/mdal_ply.cpp
+++ b/external/mdal/frmts/mdal_ply.cpp
@@ -23,6 +23,8 @@
 #include "mdal_logger.hpp"
 #include "mdal_data_model.hpp"
 #include "mdal_memory_data_model.hpp"
+#include "libplyxx.h"
+#include "mdal_driver_manager.hpp"
 
 #define DRIVER_NAME "PLY"
 
@@ -30,7 +32,12 @@ MDAL::DriverPly::DriverPly() :
   Driver( DRIVER_NAME,
           "Stanford PLY Ascii Mesh File",
           "*.ply",
-          Capability::ReadMesh
+          Capability::ReadMesh |
+          Capability::SaveMesh |
+          Capability::WriteDatasetsOnVertices |
+          Capability::WriteDatasetsOnFaces |
+          Capability::WriteDatasetsOnEdges |
+          Capability::WriteDatasetsOnVolumes
         )
 {
 }
@@ -42,9 +49,11 @@ MDAL::DriverPly *MDAL::DriverPly::create()
 
 MDAL::DriverPly::~DriverPly() = default;
 
-size_t MDAL::DriverPly::getIndex( std::vector<std::string> v, std::string in )
+size_t getIndex( std::vector<std::pair<std::string, bool>> v, std::string in )
 {
-  std::vector<std::string>::iterator it = std::find( v.begin(), v.end(), in );
+  auto is_equal = [ in ]( std::pair<std::string, bool> s ) { return  s.first == in; };
+
+  auto it = std::find_if( v.begin(), v.end(), is_equal );
   return ( size_t )std::distance( v.begin(), it );
 }
 
@@ -60,273 +69,236 @@ bool MDAL::DriverPly::canReadMesh( const std::string &uri )
   return true;
 }
 
+std::string MDAL::DriverPly::saveMeshOnFileSuffix() const
+{
+  return "ply";
+}
+
 std::unique_ptr<MDAL::Mesh> MDAL::DriverPly::load( const std::string &meshFile, const std::string & )
 {
   MDAL::Log::resetLastStatus();
-
-  std::ifstream in( meshFile, std::ifstream::in );
-  std::string line;
-
-  // Read header
-  size_t vertexCount = 0;
-  size_t faceCount = 0;
-  size_t edgeCount = 0;
-  std::vector<std::string> chunks;
-  std::vector<MDAL::DriverPly::element> elements; // we will decant the element specifications into here
-  std::string proj = "";
-
-  if ( !std::getline( in, line ) )
-  {
-    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " Header is corrupt" );
-    return nullptr;
-  }
-
-  /*
-  * The header is a format definition and a series of element definitions and/or comment lines
-  * cycle through these until end-header
-  */
-  do
-  {
-    /*
-    * iterate through all of the  element blocks in the header and enumerate the number of members and the properties
-    */
-    if ( startsWith( line, "element" ) )
-    {
-      chunks = split( line, ' ' );
-      if ( ( chunks.size() != 3 ) )
-      {
-        MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " invalid number of vertexes" );
-        return nullptr;
-      }
-      MDAL::DriverPly::element element;
-      element.name = chunks[1];
-      element.size = MDAL::toSizeT( chunks[2] );
-      do
-      {
-        if ( !std::getline( in, line ) )
-        {
-          MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " Header is corrupt" );
-          return nullptr;
-        }
-        if ( startsWith( line, "property" ) )
-        {
-          chunks = split( line, ' ' );
-          switch ( chunks.size() )
-          {
-            case 3:
-              element.properties.push_back( chunks[2] );
-              element.types.push_back( chunks[1] );
-              element.list.push_back( false );
-              break;
-            case 5:
-              element.properties.push_back( chunks[4] );
-              element.types.push_back( chunks[3] );
-              element.list.push_back( true );
-              break;
-            default:
-              MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " invalid element line" + line );
-              return nullptr;
-          }
-        }
-        else
-        {
-          break;
-        }
-      }
-      while ( true );
-      elements.push_back( element );
-    }
-
-    // if end - stop looping
-    else if ( startsWith( line, "end_header" ) )
-    {
-      break;
-    }
-
-    //if binary - give up
-
-    else if ( startsWith( line, "binary" ) )
-    {
-      MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " only ASCII format PLY files are supported" );
-      return nullptr;
-    }
-
-    // if "comment crs" assume that the rest is the crs data
-    else if ( startsWith( line, "comment crs " ) )
-    {
-      line.erase( 0, 12 );
-      proj = line;
-      if ( !std::getline( in, line ) )
-      {
-        MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " Header is corrupt" );
-        return nullptr;
-      }
-    }
-
-    // probably a comment line
-    else
-    {
-      if ( !std::getline( in, line ) )
-      {
-        MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " Header is corrupt" );
-        return nullptr;
-      }
-    }
-  }
-  while ( true );
-
   Vertices vertices( 0 );
   Faces faces( 0 );
   Edges edges( 0 );
   size_t maxSizeFace = 0;
-  size_t faceSize = 0;
 
-  //datastructures that will contain all of the datasets, categorised by vertex, face and edge datasets
-  std::vector<std::vector<double>> vertexDatasets; // conatins the data
-  std::vector<std::string> vProp2Ds; // contains the dataset names
+  size_t vertexCount = 0;
+  size_t faceCount = 0;
+  size_t edgeCount = 0;
+
+  //data structures that will contain all of the datasets, categorised by vertex, face and edge datasets
+  std::vector<std::vector<double>> vertexDatasets; // contains the data
+  std::vector<std::pair<std::string, bool>> vProp2Ds; // contains the dataset name and a flag for scalar / vector
   std::vector<std::vector<double>> faceDatasets;
-  std::vector<std::string> fProp2Ds;
+  std::vector<std::pair<std::string, bool>> fProp2Ds;
   std::vector<std::vector<double>> edgeDatasets;
-  std::vector<std::string> eProp2Ds;
+  std::vector<std::pair<std::string, bool>> eProp2Ds;
+  std::unordered_map<std::string, std::pair<std::vector<double>, std::vector<int>>> listProps; // contains the list datasets as vector of values and vector indices for each face into the vector of values
 
-  /*
-  * load the elements in order
-  */
-  if ( !std::getline( in, line ) )
+  libply::File file( meshFile );
+  if ( MDAL::Log::getLastStatus() != MDAL_Status::None ) { return nullptr; }
+  const libply::ElementsDefinition &definitions = file.definitions();
+  const libply::Metadata &metadata = file.metadata();
+  for ( const libply::Element &element : definitions )
   {
-    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " does not contain any definitions" );
-    return nullptr;
-  }
-  chunks = split( line, ' ' );
-
-  // configure the vectors to hold the data
-
-  for ( size_t elid = 0; elid < elements.size(); ++elid )
-  {
-    MDAL::DriverPly::element element = elements[elid];
     if ( element.name == "vertex" )
     {
       vertexCount = element.size;
-      vertices.resize( vertexCount );
-      for ( size_t i = 0; i < element.properties.size(); ++i )
-      {
-        if ( element.properties[i] != "x" &&
-             element.properties[i] != "y" &&
-             element.properties[i] != "z" &&
-             !element.list[i] )
-        {
-          vertexDatasets.push_back( * new std::vector<double> );
-          vProp2Ds.push_back( element.properties[i] );
-        }
-      }
     }
     else if ( element.name == "face" )
     {
       faceCount = element.size;
-      faces.resize( faceCount );
-      for ( size_t i = 0; i < element.properties.size(); ++i )
-      {
-        if ( element.properties[i] != "vertex_indices" &&
-             !element.list[i] )
-        {
-          faceDatasets.push_back( * new std::vector<double> );
-          fProp2Ds.push_back( element.properties[i] );
-        }
-      }
     }
     else if ( element.name == "edge" )
     {
       edgeCount = element.size;
-      edges.resize( edgeCount );
-      for ( size_t i = 0; i < element.properties.size(); ++i )
-      {
-        if ( element.properties[i] != "vertex1" &&
-             element.properties[i] != "vertex2" &&
-             !element.list[i] )
-        {
-          edgeDatasets.push_back( * new std::vector<double> );
-          eProp2Ds.push_back( element.properties[i] );
-        }
-      }
     }
-
-    // load the data
-    for ( size_t i = 0; i < element.size; ++i )
+    for ( const libply::Property &property : element.properties )
     {
-      /*
-      * set the line size - we will only deal with one list at the begining of the line
-      */
-      size_t nChunks = element.properties.size();
-      if ( element.list[0] ) nChunks += MDAL::toSizeT( chunks[0] );
-      if ( chunks.size() != nChunks )
+      if ( element.name == "vertex" &&
+           property.name != "X" &&
+           property.name != "x" &&
+           property.name != "Y" &&
+           property.name != "y" &&
+           property.name != "Z" &&
+           property.name != "z"
+         )
       {
-        MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " contains invalid line : " + line );
-        return nullptr;
+        vProp2Ds.emplace_back( property.name, property.isList );
+        vertexDatasets.push_back( std::vector<double>() );
+        if ( property.isList ) listProps.emplace( property.name, std::make_pair( std::vector<double>(), std::vector<int>() ) );
       }
-
-      /*
-      * Load the vertexes
-      */
-      if ( element.name == "vertex" )
+      else if ( element.name == "face" &&
+                property.name != "vertex_indices"
+              )
       {
-        Vertex &vertex = vertices[i];
-        vertex.x = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, "x" )] );
-        vertex.y = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, "y" )] );
-        vertex.z = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, "z" )] );
-        for ( size_t j = 0; j < vProp2Ds.size(); ++j )
-        {
-          double value = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, vProp2Ds[j] )] );
-          vertexDatasets[j].push_back( value );
-        }
+        fProp2Ds.emplace_back( property.name, property.isList );
+        faceDatasets.push_back( std::vector<double>() );
+        if ( property.isList ) listProps.emplace( property.name, std::make_pair( std::vector<double>(), std::vector<int>() ) );
       }
-
-      /*
-      *load the faces
-      */
-      else if ( element.name == "face" )
+      else if ( element.name == "edge" &&
+                property.name != "vertex1" &&
+                property.name != "vertex2"
+              )
       {
-        faceSize = MDAL::toSizeT( chunks[0] );
-        Face &face = faces[i];
-        face.resize( faceSize );
-        for ( size_t j = 0; j < faceSize; ++j )
-        {
-          face[j] = MDAL::toSizeT( chunks[j + 1] );
-        }
-        if ( faceSize > maxSizeFace ) maxSizeFace = faceSize;
-        for ( size_t j = 0; j < fProp2Ds.size(); ++j )
-        {
-          double value = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, fProp2Ds[j] ) + faceSize] );
-          faceDatasets[j].push_back( value );
-        }
+        eProp2Ds.emplace_back( property.name, property.isList );
+        edgeDatasets.push_back( std::vector<double>() );
+        if ( property.isList ) listProps.emplace( property.name, std::make_pair( std::vector<double>(), std::vector<int>() ) );
       }
-
-      /*
-      load the edges
-      */
-      else if ( element.name == "edge" )
-      {
-        Edge &edge = edges[i];
-        edge.startVertex = MDAL::toSizeT( chunks[MDAL::DriverPly::getIndex( element.properties, "vertex1" )] );
-        edge.endVertex = MDAL::toSizeT( chunks[MDAL::DriverPly::getIndex( element.properties, "vertex2" )] );
-        for ( size_t j = 0; j < eProp2Ds.size(); ++j )
-        {
-          double value = MDAL::toDouble( chunks[MDAL::DriverPly::getIndex( element.properties, eProp2Ds[j] )] );
-          edgeDatasets[j].push_back( value );
-        }
-      }
-
-      // any other element ignore and move to the next line
-      if ( !std::getline( in, line ) )
-      {
-        // if it is supposed to be the last line - don't look further
-        if ( elid != ( elements.size() - 1 ) && i != ( element.size - 1 ) )
-        {
-          MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, name(), meshFile + " does not contain enough definitions of type " + element.name );
-          return nullptr;
-        }
-      }
-      chunks = split( line, ' ' );
     }
+  }
+
+
+
+  for ( const libply::Element &el : definitions )
+  {
+    if ( el.name == "vertex" )
+    {
+      libply::ElementReadCallback vertexCallback = [&vertices, &el, &vProp2Ds, &vertexDatasets, &listProps]( libply::ElementBuffer & e )
+      {
+        Vertex vertex;
+        for ( size_t i = 0; i < el.properties.size(); i++ )
+        {
+          libply::Property p = el.properties[i];
+          if ( p.name == "X" || p.name == "x" )
+          {
+            vertex.x = e[i];
+          }
+          else if ( p.name == "Y" || p.name == "y" )
+          {
+            vertex.y = e[i];
+          }
+          else if ( p.name == "Z" || p.name == "z" )
+          {
+            vertex.z = e[i];
+          }
+          else
+          {
+            int dsIdx = getIndex( vProp2Ds, p.name );
+            if ( vProp2Ds[ dsIdx ].second )
+            {
+              const std::string name = vProp2Ds[ dsIdx ].first;
+              auto &vals = listProps.at( name );
+              libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i] );
+              vals.second.push_back( lp->size() );
+              for ( size_t j = 0; j < lp->size(); j++ )
+              {
+                vals.first.push_back( lp->value( j ) );
+              }
+            }
+            else
+            {
+              std::vector<double> &ds = vertexDatasets[dsIdx];
+              ds.push_back( e[i] );
+            }
+          }
+        }
+        vertices.push_back( vertex );
+      };
+      file.setElementReadCallback( "vertex", vertexCallback );
+    }
+    else if ( el.name == "face" )
+    {
+      libply::ElementReadCallback faceCallback = [&faces, &el, &maxSizeFace, &fProp2Ds, &faceDatasets, &listProps]( libply::ElementBuffer & e )
+      {
+        Face face;
+        for ( size_t i = 0; i < el.properties.size(); i++ )
+        {
+          libply::Property p = el.properties[i];
+          if ( p.name == "vertex_indices" )
+          {
+            if ( !p.isList )
+            {
+              MDAL::Log::error( MDAL_Status::Err_InvalidData, "PLY: the triangles are not a list" );
+            }
+            else
+            {
+              libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i] );
+              if ( maxSizeFace < lp->size() ) maxSizeFace = lp->size();
+              face.resize( lp->size() );
+              for ( size_t j = 0; j < lp->size(); j++ )
+              {
+                face[j] = int( lp->value( j ) );
+              }
+            }
+          }
+          else
+          {
+            int dsIdx = getIndex( fProp2Ds, p.name );
+            if ( fProp2Ds[ dsIdx ].second )
+            {
+              const std::string name = fProp2Ds[ dsIdx ].first;
+              auto &vals = listProps.at( name );
+              libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i] );
+              vals.second.push_back( lp->size() );
+              for ( size_t j = 0; j < lp->size(); j++ )
+              {
+                vals.first.push_back( lp->value( j ) );
+              }
+            }
+            else
+            {
+              std::vector<double> &ds = faceDatasets[dsIdx];
+              ds.push_back( e[i] );
+            }
+          }
+        }
+        faces.push_back( face );
+      };
+      file.setElementReadCallback( "face", faceCallback );
+    }
+    else if ( el.name == "edge" )
+    {
+      libply::ElementReadCallback edgeCallback = [&edges, &el, &eProp2Ds, &edgeDatasets, &listProps]( libply::ElementBuffer & e )
+      {
+        Edge edge;
+        for ( size_t i = 0; i < el.properties.size(); i++ )
+        {
+          libply::Property p = el.properties[i];
+          if ( p.name == "vertex1" )
+          {
+            edge.startVertex = int( e[i] );
+          }
+          else if ( p.name == "vertex2" )
+          {
+            edge.endVertex = int( e[i] );
+          }
+          else
+          {
+            int dsIdx = getIndex( eProp2Ds, p.name );
+            if ( eProp2Ds[ dsIdx ].second )
+            {
+              const std::string name = eProp2Ds[ dsIdx ].first;
+              auto &vals = listProps.at( name );
+              libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i] );
+              vals.second.push_back( lp->size() );
+              for ( size_t j = 0; j < lp->size(); j++ )
+              {
+                vals.first.push_back( lp->value( j ) );
+              }
+            }
+            else
+            {
+              std::vector<double> &ds = edgeDatasets[dsIdx];
+              ds.push_back( e[i] );
+            }
+          }
+        }
+        edges.push_back( edge );
+      };
+      file.setElementReadCallback( "edge", edgeCallback );
+    }
+  }
+
+  file.read();
+  if ( MDAL::Log::getLastStatus() != MDAL_Status::None ) { return nullptr; }
+  if ( vertices.size() != vertexCount ||
+       faces.size() != faceCount ||
+       edges.size() != edgeCount
+     )
+  {
+    MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "Incomplete Mesh" );
+    return nullptr;
   }
 
   std::unique_ptr< MemoryMesh > mesh(
@@ -339,27 +311,96 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverPly::load( const std::string &meshFile, 
   mesh->setFaces( std::move( faces ) );
   mesh->setVertices( std::move( vertices ) );
   mesh->setEdges( std::move( edges ) );
-  mesh->setSourceCrs( proj );
+  if ( metadata.find( "crs" ) != metadata.end() )
+  {
+    mesh->setSourceCrs( metadata.at( "crs" ) );
+  }
+
 
   // Add Bed Elevation
   MDAL::addBedElevationDatasetGroup( mesh.get(), mesh->vertices() );
 
+  // Add Vertex Datasets
   for ( size_t i = 0; i < vertexDatasets.size(); ++i )
   {
-    std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), vProp2Ds[i], DataOnVertices, true );
-    addDataset( group.get(), vertexDatasets[i] );
+    if ( vProp2Ds[i].second )
+    {
+      auto &vals = listProps.at( vProp2Ds[i].first );
+      vertexDatasets[i].clear();
+      auto it = vals.second.begin();
+      size_t idx = 0;
+      while ( idx < vals.first.size() )
+      {
+        vertexDatasets[i].push_back( vals.first[idx] );
+        vertexDatasets[i].push_back( vals.first[idx + 1] );
+        idx += *it;
+        it = std::next( it, 1 );
+      }
+      listProps.erase( vProp2Ds[i].first );
+    }
+    std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), vProp2Ds[i].first, DataOnVertices, !vProp2Ds[i].second );
+    addDataset2D( group.get(), vertexDatasets[i] );
   }
 
+  //Add face datasets and volume datasets
   for ( size_t i = 0; i < faceDatasets.size(); ++i )
   {
-    std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), fProp2Ds[i], DataOnFaces, true );
-    addDataset( group.get(), faceDatasets[i] );
+    if ( fProp2Ds[i].second )
+    {
+      std::string name = fProp2Ds[i].first;
+      if ( name.find( "__vols" ) != std::string::npos ) break;
+      auto &vals = listProps.at( name );
+      faceDatasets[i].clear();
+      auto it = vals.second.begin();
+      size_t idx = 0;
+      if ( listProps.find( name + "__vols" ) == listProps.end() )
+      {
+        while ( idx < vals.first.size() )
+        {
+          faceDatasets[i].push_back( vals.first[idx] );
+          faceDatasets[i].push_back( vals.first[idx + 1] );
+          idx += *it;
+          it = std::next( it, 1 );
+        }
+        std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), name, DataOnFaces, false );
+        addDataset2D( group.get(), faceDatasets[i] );
+      }
+      else
+      {
+        auto levels = listProps.at( name + "__vols" );
+        std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), name, DataOnVolumes, true );
+        addDataset3D( group.get(), vals.first, vals.second, levels.first, levels.second );
+        listProps.erase( name + "__vols" );
+      }
+      listProps.erase( name );
+    }
+    else
+    {
+      std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), fProp2Ds[i].first, DataOnFaces, true );
+      addDataset2D( group.get(), faceDatasets[i] );
+    }
   }
 
+  // Add Edge Datasets
   for ( size_t i = 0; i < edgeDatasets.size(); ++i )
   {
-    std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), eProp2Ds[i], DataOnEdges, true );
-    addDataset( group.get(), edgeDatasets[i] );
+    if ( eProp2Ds[i].second )
+    {
+      auto vals = listProps.at( eProp2Ds[i].first );
+      edgeDatasets[i].clear();
+      auto it = vals.second.begin();
+      size_t idx = 0;
+      while ( idx < vals.first.size() )
+      {
+        edgeDatasets[i].push_back( vals.first[idx] );
+        edgeDatasets[i].push_back( vals.first[idx + 1] );
+        idx += *it;
+        it = std::next( it, 1 );
+      }
+      listProps.erase( eProp2Ds[i].first );
+    }
+    std::shared_ptr<DatasetGroup> group = addDatasetGroup( mesh.get(), eProp2Ds[i].first, DataOnEdges, !eProp2Ds[i].second );
+    addDataset2D( group.get(), edgeDatasets[i] );
   }
 
   /*
@@ -403,10 +444,13 @@ std::shared_ptr< MDAL::DatasetGroup> MDAL::DriverPly::addDatasetGroup( MDAL::Mes
   return group;
 }
 
-void MDAL::DriverPly::addDataset( MDAL::DatasetGroup *group, const std::vector<double> &values )
+void MDAL::DriverPly::addDataset2D( MDAL::DatasetGroup *group, const std::vector<double> &values )
 {
   if ( !group )
     return;
+
+  size_t mult = 1;
+  if ( !group->isScalar() ) mult = 2;
 
   MDAL::Mesh *mesh = group->mesh();
 
@@ -418,19 +462,31 @@ void MDAL::DriverPly::addDataset( MDAL::DatasetGroup *group, const std::vector<d
 
   if ( group->dataLocation() == DataOnVertices )
   {
-    assert( values.size() == mesh->verticesCount() );
+    if ( values.size() != mesh->verticesCount()*mult )
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "PLY: Invalid Number of Data Values" );
+      return;
+    }
   }
 
   if ( group->dataLocation() == DataOnFaces )
   {
-    assert( values.size() == mesh->facesCount() );
+    if ( values.size() != mesh->facesCount()*mult )
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "PLY: Invalid Number of Data Values" );
+      return;
+    }
     if ( mesh->facesCount() == 0 )
       return;
   }
 
   if ( group->dataLocation() == DataOnEdges )
   {
-    assert( values.size() == mesh->edgesCount() );
+    if ( values.size() != mesh->edgesCount()*mult )
+    {
+      MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "PLY: Invalid Number of Data Values" );
+      return;
+    }
     if ( mesh->edgesCount() == 0 )
       return;
   }
@@ -441,4 +497,285 @@ void MDAL::DriverPly::addDataset( MDAL::DatasetGroup *group, const std::vector<d
   dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
   group->datasets.push_back( dataset );
   group->setStatistics( MDAL::calculateStatistics( group ) );
+}
+
+void MDAL::DriverPly::addDataset3D( MDAL::DatasetGroup *group,
+                                    const std::vector<double> &values,
+                                    const std::vector<int> &valueIndexes,
+                                    const std::vector<double> &levels,
+                                    const std::vector<int> &levelIndexes )
+{
+  if ( !group )
+    return;
+
+
+  MDAL::Mesh *mesh = group->mesh();
+
+  if ( values.empty() )
+    return;
+
+  if ( 0 == mesh->facesCount() )
+    return;
+
+  if ( valueIndexes.size() != mesh->facesCount() ||
+       levelIndexes.size() != mesh->facesCount() ||
+       levels.size() != values.size() + mesh->facesCount()
+     )
+  {
+    MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_InvalidData, "Incomplete Volume Dataset" );
+    return;
+  }
+
+  int maxVerticalLevelCount = * std::max_element( valueIndexes.begin(), valueIndexes.end() );
+
+  std::shared_ptr< MDAL::MemoryDataset3D > dataset = std::make_shared< MemoryDataset3D >( group, values.size(), maxVerticalLevelCount, valueIndexes.data(), levels.data() );
+  dataset->setTime( 0.0 );
+  memcpy( dataset->values(), values.data(), sizeof( double ) * values.size() );
+  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  group->datasets.push_back( dataset );
+  group->setStatistics( MDAL::calculateStatistics( group ) );
+}
+
+void MDAL::DriverPly::save( const std::string &fileName, const std::string &meshName, Mesh *mesh )
+{
+  MDAL::Log::resetLastStatus();
+
+  DatasetGroups groups = mesh->datasetGroups;
+
+  // vectors to hold the different types of group
+  DatasetGroups vgroups;
+  DatasetGroups fgroups;
+  DatasetGroups egroups;
+  DatasetGroups volGroups;
+
+  for ( std::shared_ptr<DatasetGroup> group : groups )
+  {
+    if ( group->dataLocation() == MDAL_DataLocation::DataOnVertices )
+    {
+      if ( group->name() != "Bed Elevation" ) vgroups.push_back( group );
+    }
+    else if ( group->dataLocation() == MDAL_DataLocation::DataOnFaces )
+    {
+      fgroups.push_back( group );
+    }
+    else if ( group->dataLocation() == MDAL_DataLocation::DataOnEdges )
+    {
+      egroups.push_back( group );
+    }
+    else if ( group->dataLocation() == MDAL_DataLocation::DataOnVolumes )
+    {
+      if ( group->isScalar() )
+      {
+        volGroups.push_back( group );
+      }
+      else
+      {
+        MDAL_SetStatus( MDAL_LogLevel::Warn, MDAL_Status::Err_IncompatibleDatasetGroup, "PLY: Vector Datasets on Volumes are not supported" );
+      }
+    }
+  }
+
+
+  libply::FileOut file( fileName, libply::File::Format::ASCII );
+  if ( MDAL::Log::getLastStatus() != MDAL_Status::None ) return;
+
+  libply::ElementsDefinition definitions;
+  std::vector<libply::Property> vproperties;
+  vproperties.emplace_back( "X", libply::Type::FLOAT64, false );
+  vproperties.emplace_back( "Y", libply::Type::FLOAT64, false );
+  vproperties.emplace_back( "Z", libply::Type::FLOAT64, false );
+  for ( std::shared_ptr<DatasetGroup> group : vgroups )
+  {
+    vproperties.emplace_back( group->name(), libply::Type::FLOAT64, ! group->isScalar() );
+  }
+
+  definitions.emplace_back( "vertex", mesh->verticesCount(), vproperties );
+  if ( mesh->facesCount() > 0 )
+  {
+    std::vector<libply::Property> fproperties;
+    fproperties.emplace_back( "vertex_indices", libply::Type::UINT32, true );
+    for ( std::shared_ptr<DatasetGroup> group : fgroups )
+    {
+      fproperties.emplace_back( group->name(), libply::Type::FLOAT64, ! group->isScalar() );
+    }
+    for ( std::shared_ptr<DatasetGroup> group : volGroups )
+    {
+      fproperties.emplace_back( group->name(), libply::Type::FLOAT64, true );
+      fproperties.emplace_back( group->name() + "__vols", libply::Type::FLOAT64, true );
+    }
+    definitions.emplace_back( "face", mesh->facesCount(), fproperties );
+  }
+
+  if ( mesh->edgesCount() > 0 )
+  {
+    std::vector<libply::Property> eproperties;
+    eproperties.emplace_back( "vertex1", libply::Type::UINT32, false );
+    eproperties.emplace_back( "vertex2", libply::Type::UINT32, false );
+    for ( std::shared_ptr<DatasetGroup> group : egroups )
+    {
+      eproperties.emplace_back( group->name(), libply::Type::FLOAT64, ! group->isScalar() );
+    }
+    definitions.emplace_back( "edge", mesh->edgesCount(), eproperties );
+  }
+  file.setElementsDefinition( definitions );
+
+  // write vertices
+  std::unique_ptr<MDAL::MeshVertexIterator> vertices = mesh->readVertices();
+
+
+  libply::ElementWriteCallback vertexCallback = [&vertices, &vgroups]( libply::ElementBuffer & e, size_t index )
+  {
+    double vertex[3];
+    vertices->next( 1, vertex );
+    e[0] = vertex[0];
+    e[1] = vertex[1];
+    e[2] = vertex[2];
+    for ( size_t i = 0; i < vgroups.size(); i++ )
+    {
+      if ( vgroups[i]->isScalar() )
+      {
+        double val[1];
+        vgroups[i]->datasets[0]->scalarData( index, 1, &val[0] );
+        e[i + 3] = val[0];
+      }
+      else
+      {
+        double val[2];
+        vgroups[i]->datasets[0]->vectorData( index, 1, &val[0] );
+        libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i + 3] );
+        lp->define( libply::Type::FLOAT64, 2 );
+        lp->value( 0 ) = val[0];
+        lp->value( 1 ) = val[1];
+      };
+    }
+  };
+
+
+  // write faces
+  std::vector<int> vertexIndices( mesh->faceVerticesMaximumCount() );
+  std::unique_ptr<MDAL::MeshFaceIterator> faces = mesh->readFaces();
+
+  libply::ElementWriteCallback faceCallback = [&faces, &fgroups, &vertexIndices, &volGroups]( libply::ElementBuffer & e, size_t index )
+  {
+    int idx = 0;
+    int faceOffsets[1];
+    faces->next( 1, faceOffsets, vertexIndices.size(), vertexIndices.data() );
+    libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[idx] );
+    lp->define( libply::Type::UINT32, faceOffsets[0] );
+    for ( int j = 0; j < faceOffsets[0]; ++j )
+    {
+      lp->value( j ) = vertexIndices[j];
+    };
+    idx++;
+    for ( size_t i = 0; i < fgroups.size(); i++ )
+    {
+      if ( fgroups[i]->isScalar() )
+      {
+        double val[1];
+        fgroups[i]->datasets[0]->scalarData( index, 1, &val[0] );
+        e[idx] = val[0];
+      }
+      else
+      {
+        double val[2];
+        fgroups[i]->datasets[0]->vectorData( index, 1, &val[0] );
+        libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[idx] );
+        lp->define( libply::Type::FLOAT64, 2 );
+        lp->value( 0 ) = val[0];
+        lp->value( 1 ) = val[1];
+      };
+      idx++;
+    }
+    int vCount[1];
+    int f2v[1];
+    for ( size_t i = 0; i < volGroups.size(); i++ )
+    {
+      std::shared_ptr<MDAL::MemoryDataset3D> ds = std::dynamic_pointer_cast<MDAL::MemoryDataset3D>( volGroups[i]->datasets[0] );
+      ds->verticalLevelCountData( index, 1, &vCount[0] );
+      const int count = vCount[0];
+      ds->faceToVolumeData( index, 1, &f2v[0] );
+      const int vindex = f2v[0];
+      std::vector<double> val( count, 0 );
+      ds->scalarVolumesData( vindex, count, val.data() );
+      libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[idx] );
+      lp->define( libply::Type::FLOAT64, count );
+
+      for ( int j = 0; j < count; ++j )
+      {
+        lp->value( j ) = val[j];
+      };
+      idx++;
+      std::vector<double> ex( count + 1, 0 );
+      ds->verticalLevelData( vindex + index, count + 1, ex.data() );
+      libply::ListProperty *lp1 = dynamic_cast<libply::ListProperty *>( &e[idx] );
+      lp1->define( libply::Type::FLOAT64, count + 1 );
+      for ( int j = 0; j < count + 1; ++j )
+      {
+        lp1->value( j ) = ex[j];
+      };
+      idx++;
+    }
+  };
+
+  // write edges
+
+  std::unique_ptr<MDAL::MeshEdgeIterator> edges = mesh->readEdges();
+
+  libply::ElementWriteCallback edgeCallback = [&edges, &egroups]( libply::ElementBuffer & e, size_t index )
+  {
+    int startIndex;
+    int endIndex;
+    edges->next( 1, &startIndex, &endIndex );
+    e[0] = startIndex;
+    e[1] = endIndex;
+    for ( size_t i = 0; i < egroups.size(); i++ )
+    {
+      if ( egroups[i]->isScalar() )
+      {
+        double val[1];
+        egroups[i]->datasets[0]->scalarData( index, 1, &val[0] );
+        e[i + 2] = val[0];
+      }
+      else
+      {
+        double val[2];
+        egroups[i]->datasets[0]->vectorData( index, 1, &val[0] );
+        libply::ListProperty *lp = dynamic_cast<libply::ListProperty *>( &e[i + 2] );
+        lp->define( libply::Type::FLOAT64, 2 );
+        lp->value( 0 ) = val[0];
+        lp->value( 1 ) = val[1];
+      };
+    }
+  };
+
+  file.setElementWriteCallback( "vertex", vertexCallback );
+  if ( mesh->facesCount() > 0 ) file.setElementWriteCallback( "face", faceCallback );
+  if ( mesh->edgesCount() > 0 ) file.setElementWriteCallback( "edge", edgeCallback );
+
+  file.write();
+
+
+  /*
+  * Clean up
+  */
+  for ( size_t i = 0; i < vgroups.size(); ++i )
+  {
+    vgroups.pop_back();
+  };
+
+  for ( size_t i = 0; i < fgroups.size(); ++i )
+  {
+    fgroups.pop_back();
+  };
+
+  for ( size_t i = 0; i < egroups.size(); ++i )
+  {
+    egroups.pop_back();
+  };
+}
+
+bool MDAL::DriverPly::persist( DatasetGroup *group )
+{
+  save( group->uri(), "", group->mesh() );
+  return false;
 }

--- a/external/mdal/frmts/mdal_ply.cpp
+++ b/external/mdal/frmts/mdal_ply.cpp
@@ -538,6 +538,8 @@ void MDAL::DriverPly::addDataset3D( MDAL::DatasetGroup *group,
 
 void MDAL::DriverPly::save( const std::string &fileName, const std::string &meshName, Mesh *mesh )
 {
+  MDAL_UNUSED( meshName );
+
   MDAL::Log::resetLastStatus();
 
   DatasetGroups groups = mesh->datasetGroups;

--- a/external/mdal/frmts/mdal_ply.hpp
+++ b/external/mdal/frmts/mdal_ply.hpp
@@ -28,31 +28,23 @@ namespace MDAL
       DriverPly *create() override;
 
       bool canReadMesh( const std::string &uri ) override;
+      int faceVerticesMaximumCount() const override {return 100;}
+
       std::unique_ptr< Mesh > load( const std::string &meshFile, const std::string &meshName = "" ) override;
+      void save( const std::string &fileName, const std::string &meshName, Mesh *mesh ) override;
+      bool persist( DatasetGroup *group ) override;
+
+      std::string saveMeshOnFileSuffix() const override;
 
     private:
       std::shared_ptr<DatasetGroup> addDatasetGroup( MDAL::Mesh *mesh, const std::string &name, const MDAL_DataLocation location, bool isScalar );
-      void addDataset( MDAL::DatasetGroup *group, const std::vector<double> &values );
+      void addDataset2D( MDAL::DatasetGroup *group, const std::vector<double> &values );
+      void addDataset3D( MDAL::DatasetGroup *group,
+                         const std::vector<double> &values,
+                         const std::vector<int> &valueIndexes,
+                         const std::vector<double> &levels,
+                         const std::vector<int> &levelIndexes );
 
-      /*
-      * Element specification. holds the name, size and arbitraily long vector of properties
-      */
-      struct element
-      {
-        public:
-          std::string name; // element name
-          std::vector<std::string> properties; // the name of each property
-          std::vector<std::string> types; // the type of each property
-          std::vector<bool> list; // is the property a list
-          size_t size; // element size
-
-          bool operator==( const std::string &rhs ) const
-          {
-            return name == rhs;
-          }
-      };
-
-      size_t getIndex( std::vector<std::string> v, std::string in );
   };
 
 } // namespace MDAL

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -21,7 +21,7 @@ static const char *EMPTY_STR = "";
 
 const char *MDAL_Version()
 {
-  return "0.8.92";
+  return "0.8.93";
 }
 
 MDAL_Status MDAL_LastStatus()
@@ -522,6 +522,7 @@ MDAL_DatasetGroupH MDAL_M_datasetGroup( MDAL_MeshH mesh, int index )
     return nullptr;
   }
   size_t i = static_cast<size_t>( index );
+
   return static_cast< MDAL_DatasetH >( m->datasetGroups[i].get() );
 }
 
@@ -1494,4 +1495,29 @@ void MDAL_M_setProjection( MDAL_MeshH mesh, const char *projection )
   }
 
   static_cast<MDAL::Mesh *>( mesh )->setSourceCrsFromWKT( std::string( projection ) );
+}
+
+void MDAL_M_addEdges( MDAL_MeshH mesh,
+                      int edgesCount,
+                      int *startVertexIndices,
+                      int *endVertexIndices )
+{
+  MDAL::Log::resetLastStatus();
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not valid (null)" );
+    return;
+  }
+
+  MDAL::Mesh *m = static_cast<MDAL::Mesh *>( mesh );
+
+  if ( ! m->isEditable() )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not editable" );
+  }
+
+  m->datasetGroups.clear();
+  std::shared_ptr<MDAL::Driver> driver = MDAL::DriverManager::instance().driver( m->driverName() );
+
+  m->addEdges( edgesCount, startVertexIndices, endVertexIndices );
 }

--- a/external/mdal/mdal_data_model.cpp
+++ b/external/mdal/mdal_data_model.cpp
@@ -431,6 +431,14 @@ void MDAL::Mesh::addFaces( size_t faceCount, size_t driverMaxVerticesPerFace, in
   MDAL_UNUSED( vertexIndices );
 }
 
+void MDAL::Mesh::addEdges( size_t edgeCount, int *startVertexIndices, int *endVertexIndices )
+{
+  MDAL_UNUSED( edgeCount );
+  MDAL_UNUSED( startVertexIndices );
+  MDAL_UNUSED( endVertexIndices );
+}
+
+
 MDAL::MeshVertexIterator::~MeshVertexIterator() = default;
 
 MDAL::MeshFaceIterator::~MeshFaceIterator() = default;

--- a/external/mdal/mdal_data_model.hpp
+++ b/external/mdal/mdal_data_model.hpp
@@ -279,6 +279,8 @@ namespace MDAL
 
       virtual void addVertices( size_t vertexCount, double *coordinates );
       virtual void addFaces( size_t faceCount, size_t driverMaxVerticesPerFace, int *faceSizes, int *vertexIndices );
+      virtual void addEdges( size_t edgeCount, int *startVertexIndices, int *endVertexIndices );
+
 
     protected:
       void setFaceVerticesMaximumCount( const size_t &faceVerticesMaximumCount );

--- a/external/mdal/mdal_driver_manager.cpp
+++ b/external/mdal/mdal_driver_manager.cpp
@@ -11,9 +11,12 @@
 #include "frmts/mdal_binary_dat.hpp"
 #include "frmts/mdal_selafin.hpp"
 #include "frmts/mdal_esri_tin.hpp"
-#include "frmts/mdal_ply.hpp"
 #include "frmts/mdal_dynamic_driver.hpp"
 #include "mdal_utils.hpp"
+
+#ifdef BUILD_PLY
+#include "frmts/mdal_ply.hpp"
+#endif
 
 #ifdef HAVE_HDF5
 #include "frmts/mdal_xmdf.hpp"
@@ -218,7 +221,10 @@ MDAL::DriverManager::DriverManager()
   mDrivers.push_back( std::make_shared<MDAL::DriverXmsTin>() );
   mDrivers.push_back( std::make_shared<MDAL::DriverSelafin>() );
   mDrivers.push_back( std::make_shared<MDAL::DriverEsriTin>() );
+
+#ifdef BUILD_PLY
   mDrivers.push_back( std::make_shared<MDAL::DriverPly>() );
+#endif
 
 #ifdef HAVE_HDF5
   mDrivers.push_back( std::make_shared<MDAL::DriverFlo2D>() );

--- a/external/mdal/mdal_memory_data_model.cpp
+++ b/external/mdal/mdal_memory_data_model.cpp
@@ -328,6 +328,24 @@ void MDAL::MemoryMesh::addFaces( size_t faceCount, size_t driverMaxVerticesPerFa
   std::move( newFaces.begin(), newFaces.end(), std::back_inserter( mFaces ) );
 }
 
+void MDAL::MemoryMesh::addEdges( size_t edgeCount, int *startVertexIndices, int *endVertexIndices )
+{
+  int maxVertex = mVertices.size();
+  for ( size_t edgeIndex = 0 ; edgeIndex < edgeCount; ++edgeIndex )
+  {
+    Edge edge;
+    if ( startVertexIndices[edgeIndex] >= maxVertex || endVertexIndices[edgeIndex] >= maxVertex )
+    {
+      MDAL::Log::error( Err_InvalidData, "Invalid vertex index when adding edges" );
+      return;
+    }
+    edge.startVertex = startVertexIndices[edgeIndex];
+    edge.endVertex = endVertexIndices[edgeIndex];
+
+    mEdges.push_back( std::move( edge ) );
+  }
+}
+
 MDAL::MemoryMesh::~MemoryMesh() = default;
 
 MDAL::MemoryMeshVertexIterator::MemoryMeshVertexIterator( const MDAL::MemoryMesh *mesh )

--- a/external/mdal/mdal_memory_data_model.hpp
+++ b/external/mdal/mdal_memory_data_model.hpp
@@ -320,6 +320,7 @@ namespace MDAL
       BBox extent() const override;
       void addVertices( size_t vertexCount, double *coordinates ) override;
       void addFaces( size_t faceCount, size_t driverMaxVerticesPerFace, int *faceSizes, int *vertexIndices ) override;
+      void addEdges( size_t edgeCount, int *startVertexIndices, int *endVertexIndices ) override;
 
       bool isEditable() const override {return true;}
 

--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -156,6 +156,7 @@ if (WITH_INTERNAL_MDAL)
 
 
   # create mdal_config.h
+  set (BUILD_PLY TRUE)
   configure_file(${CMAKE_SOURCE_DIR}/external/mdal/cmake_templates/mdal_config.hpp.in ${CMAKE_BINARY_DIR}/mdal_config.hpp)
   include_directories(${CMAKE_BINARY_DIR})
 

--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -27,6 +27,7 @@ if (WITH_INTERNAL_MDAL)
   include_directories(
     ${CMAKE_SOURCE_DIR}/external/mdal
     ${CMAKE_SOURCE_DIR}/external/mdal/api
+    ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty
   )
 
   set(MDAL_LIB_SRCS
@@ -47,6 +48,7 @@ if (WITH_INTERNAL_MDAL)
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_esri_tin.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_xms_tin.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_ply.cpp
+    ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/libplyxx/libplyxx.cpp
   )
 
   set(MDAL_LIB_HDRS
@@ -65,6 +67,9 @@ if (WITH_INTERNAL_MDAL)
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_esri_tin.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_xms_tin.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_ply.hpp
+    ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/libplyxx.h
+    ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/libplyxx/libplyxx_internal.h
+    ${CMAKE_SOURCE_DIR}/external/mdal/3rdparty/textio.h
   )
 
   if(HDF5_FOUND)

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -657,6 +657,7 @@ void QgsMdalProvider::fileMeshExtensions( QStringList &fileMeshExtensions,
       for ( auto ext : extensions )
       {
         ext.remove( QStringLiteral( "*." ) );
+        ext = ext.toLower();
         if ( isMeshDriver )
           fileMeshExtensions += ext;
         else


### PR DESCRIPTION
- update MDAL to 0.8.93 (RC for QGIS 3.22)
  - API for edges edits
  - data on volumes for dynamic drivers
  - WRITE support for PLY
- fix unreported bug for loading FLO-2D files introduced in https://github.com/qgis/QGIS/commit/04a735798ee336a51409315bc529f09b611aae2a  (MDAL didn't add DAT extention for FLO-2D format and therefore it was not possible to add it anymore (neither from data manager nor browser)
