### PR TITLE
Add active python plugins' version to the about QGIS dialog to further improve quality of issue reporting

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5553,7 +5553,7 @@ void QgisApp::about()
     {
       versionString += QStringLiteral( "</tr><tr><td colspan=\"4\">%1</td>" ).arg( tr( "Active Python plugins" ) );
       const QStringList activePlugins = mPythonUtils->listActivePlugins();
-      for ( const auto &plugin : activePlugins )
+      for ( const QString &plugin : activePlugins )
       {
         const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );
         versionString += QStringLiteral( "</tr><tr><td>%1</td><td colspan=\"3\">%2</td>" ).arg( plugin, version );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5551,8 +5551,13 @@ void QgisApp::about()
 #ifdef WITH_BINDINGS
     if ( mPythonUtils && mPythonUtils->isEnabled() )
     {
+      versionString += QStringLiteral( "</tr><tr><td colspan=\"4\">%1</td>" ).arg( tr( "Active Python plugins" ) );
       const QStringList activePlugins = mPythonUtils->listActivePlugins();
-      versionString += QStringLiteral( "</tr><tr><td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "Active Python plugins" ), activePlugins.join( "<br />" ) );
+      for ( const auto &plugin : activePlugins )
+      {
+        const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );
+        versionString += QStringLiteral( "</tr><tr><td>%1</td><td colspan=\"3\">%2</td>" ).arg( plugin, version );
+      }
     }
 #endif
 


### PR DESCRIPTION
## Description

This PR adds the version number of active python plugins in the About QGIS dialog:
![image](https://user-images.githubusercontent.com/1728657/135707858-7989bbd7-a102-4e59-9473-a5f3886853b5.png)

I was reviewing some reported issues and wished for this information to be available in the screenshot people attached of their own About QGIS dialog.