### PR TITLE
Properly quote the delimiter in the processing aggregate algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/aggregate_quoted_delim.gfs
+++ b/python/plugins/processing/tests/testdata/expected/aggregate_quoted_delim.gfs
@@ -1,0 +1,22 @@
+s<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>aggregate_quoted_delim</Name>
+    <ElementPath>aggregate_quoted_delim</ElementPath>
+    <!--MULTILINESTRING-->
+    <GeometryType>5</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>1</FeatureCount>
+      <ExtentXMin>-1.00000</ExtentXMin>
+      <ExtentXMax>11.00000</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>5.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>fids</Name>
+      <ElementPath>fids</ElementPath>
+      <Type>String</Type>
+      <Width>55</Width>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/aggregate_quoted_delim.gml
+++ b/python/plugins/processing/tests/testdata/expected/aggregate_quoted_delim.gml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>11</gml:X><gml:Y>5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+  <gml:featureMember>
+    <ogr:aggregate_quoted_delim fid="aggregate_quoted_delim.0">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>-1,-1 1,-1</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>7,-3 10,-3</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>6,2 9,2 9,3 11,5</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>6,-3 10,1</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>3,1 5,1</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>2,0 2,2 3,2 3,3</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:fids>lines.0"','"lines.1"','"lines.2"','"lines.3"','"lines.4"','"lines.5"','"lines.6</ogr:fids>
+    </ogr:aggregate_quoted_delim>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
@@ -240,6 +240,31 @@ tests:
           geometry:
             ignore_part_order: True
 
+  - name: Aggregate with a quoted delimiter
+    algorithm: qgis:aggregate
+    params:
+      INPUT:
+        name: lines.gml
+        type: vector
+      GROUP_BY: 'NULL'
+      AGGREGATES:
+        [{
+          input: 'fid',
+          aggregate: 'concatenate',
+          delimiter: '"'',''"',
+          name: 'fids',
+          type: 10,
+          length: 255,
+          precision: 0
+        }]
+    results:
+      OUTPUT:
+        name: expected/aggregate_quoted_delim.gml
+        type: vector
+        compare:
+          geometry:
+            ignore_part_order: True
+
   - name: Delete Holes
     algorithm: native:deleteholes
     params:

--- a/src/analysis/processing/qgsalgorithmaggregate.cpp
+++ b/src/analysis/processing/qgsalgorithmaggregate.cpp
@@ -116,11 +116,11 @@ bool QgsAggregateAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
     }
     else if ( aggregateType == QLatin1String( "concatenate" ) || aggregateType == QLatin1String( "concatenate_unique" ) )
     {
-      expression = QStringLiteral( "%1(%2, %3, %4, \'%5\')" ).arg( aggregateType,
+      expression = QStringLiteral( "%1(%2, %3, %4, %5)" ).arg( aggregateType,
                    source,
                    mGroupBy,
                    QStringLiteral( "TRUE" ),
-                   delimiter );
+                   QgsExpression::quotedString( delimiter ) );
     }
     else
     {


### PR DESCRIPTION
If one tries to use the aggregate algorithm with `concatatenate` and puts single quotes as a delimiter, it causes a parse error when building the aggregate expression.  
