### PR TITLE
Add a since QGIS 3.22 note to the AttributeEditorType enum's AeTypeAction

### DIFF
--- a/src/core/editform/qgsattributeeditorelement.h
+++ b/src/core/editform/qgsattributeeditorelement.h
@@ -67,7 +67,7 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
       AeTypeInvalid,   //!< Invalid
       AeTypeQmlElement, //!< A QML element
       AeTypeHtmlElement, //!< A HTML element
-      AeTypeAction //!< A layer action element
+      AeTypeAction //!< A layer action element (since QGIS 3.22)
     };
 
     /**


### PR DESCRIPTION
## Description

@elpaso , a quick documentation follow up to your attribute editor action feature.