### PR TITLE
Pin Fedora version on CI

### DIFF
--- a/ms-windows/mingw/qgis3-build-deps-mingw.dockerfile
+++ b/ms-windows/mingw/qgis3-build-deps-mingw.dockerfile
@@ -1,6 +1,6 @@
 # MinGW build environment for QGIS / KADAS Albireo
 
-FROM fedora:rawhide
+FROM fedora:34
 
 MAINTAINER Sandro Mani <manisandro@gmail.com>
 
@@ -39,7 +39,6 @@ dnf install -y --nogpgcheck \
   mingw64-python3-pillow \
   mingw64-python3-psycopg2 \
   mingw64-python3-pygments \
-  mingw64-python3-PyQt-builder \
   mingw64-python3-pytz \
   mingw64-python3-pyyaml \
   mingw64-python3-qscintilla-qt5 \


### PR DESCRIPTION
This is a proposal to use Fedora 34 on CI instead of rawhide.
This should reduce potential sources of external reasons for test failures and give a more stable baseline system to test against.

I also tried with fedora 35 but got the same errors as with rawhide. 

@manisandro what do you think about that?
