### PR TITLE
Take query parameters for url advertised in capabilities from the original request

### DIFF
--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -407,7 +407,7 @@ QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServ
   }
 
   // https://docs.qgis.org/3.16/en/docs/server_manual/services.html#wms-map
-  const QString map = request.parameter( QStringLiteral( "MAP" ) );
+  const QString map = QUrlQuery( request.originalUrl().query() ).queryItemValue( QStringLiteral( "MAP" ) );
   if ( ! map.isEmpty() )
   {
     QUrlQuery query;
@@ -418,6 +418,7 @@ QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServ
   {
     urlQUrl.setQuery( NULL );
   }
+
   return urlQUrl.url();
 }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -407,7 +407,8 @@ QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServ
   }
 
   // https://docs.qgis.org/3.16/en/docs/server_manual/services.html#wms-map
-  const QString map = QUrlQuery( request.originalUrl().query() ).queryItemValue( QStringLiteral( "MAP" ) );
+  const QString map = QUrlQuery( request.originalUrl().query().replace( QStringLiteral( "MAP" ), QStringLiteral( "MAP" ), Qt::CaseInsensitive ) ).queryItemValue( QStringLiteral( "MAP" ) );
+
   if ( ! map.isEmpty() )
   {
     QUrlQuery query;

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -33,6 +33,8 @@ from owslib.wms import WebMapService
 
 from test_qgsserver import QgsServerTestBase
 from qgis.core import QgsProject
+from qgis.server import QgsServer, QgsServerRequest, QgsBufferServerResponse
+from qgis.PyQt.QtCore import QUrl
 
 # Strip path and content length because path may vary
 RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|SERVICE=[^"]+|Content-Length: \\d+'
@@ -98,6 +100,27 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
     def test_getcapabilities_case_insensitive(self):
         self.wms_request_compare('getcapabilities', reference_file="getcapabilities-map")
         self.wms_request_compare('GETCAPABILITIES', reference_file="getcapabilities-map")
+
+    def test_getcapabilities_advertised_url(self):
+        server = QgsServer()
+        request = QgsServerRequest()
+        projectPath = os.path.join(self.testdata_path, 'test_project.qgs')
+        request.setUrl( QUrl('http://localhost/qgis_mapserv.fcgi?MAP=' + projectPath + '&SERVICE=WMS&REQUEST=GetCapabilities') )
+        request.setOriginalUrl( QUrl('http://localhost/wms/test_project') )
+        response = QgsBufferServerResponse()
+        server.handleRequest( request, response )
+        response.flush()
+
+        headers = []
+        rh = response.headers()
+        rk = sorted(rh.keys())
+        for k in rk:
+            headers.append(("%s: %s" % (k, rh[k])).encode('utf-8'))
+
+        reference_path = os.path.join(self.testdata_path, 'wms_getcapabilities_rewriting.txt')
+        f = open(reference_path, 'rb')
+        expected = f.read()
+        self.assertXMLEqual(b"\n".join(headers) + b"\n\n" + bytes(response.body()), expected )
 
     def test_getprojectsettings(self):
         self.wms_request_compare('GetProjectSettings')

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -105,10 +105,10 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         server = QgsServer()
         request = QgsServerRequest()
         projectPath = os.path.join(self.testdata_path, 'test_project.qgs')
-        request.setUrl( QUrl('http://localhost/qgis_mapserv.fcgi?MAP=' + projectPath + '&SERVICE=WMS&REQUEST=GetCapabilities') )
-        request.setOriginalUrl( QUrl('http://localhost/wms/test_project') )
+        request.setUrl(QUrl('http://localhost/qgis_mapserv.fcgi?MAP=' + projectPath + '&SERVICE=WMS&REQUEST=GetCapabilities'))
+        request.setOriginalUrl(QUrl('http://localhost/wms/test_project'))
         response = QgsBufferServerResponse()
-        server.handleRequest( request, response )
+        server.handleRequest(request, response)
         response.flush()
 
         headers = []
@@ -120,7 +120,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         reference_path = os.path.join(self.testdata_path, 'wms_getcapabilities_rewriting.txt')
         f = open(reference_path, 'rb')
         expected = f.read()
-        self.assertXMLEqual(b"\n".join(headers) + b"\n\n" + bytes(response.body()), expected )
+        self.assertXMLEqual(b"\n".join(headers) + b"\n\n" + bytes(response.body()), expected)
 
     def test_getprojectsettings(self):
         self.wms_request_compare('GetProjectSettings')

--- a/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
@@ -1,0 +1,328 @@
+Content-Length: 14317
+Content-Type: text/xml; charset=utf-8
+
+<?xml version="1.0" encoding="utf-8"?>
+<WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms http://localhost/wms/test_project?SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
+ <Service>
+  <Name>WMS</Name>
+  <Title>QGIS TestProject</Title>
+  <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+  <KeywordList>
+   <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+  </KeywordList>
+  <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+  <ContactInformation>
+   <ContactPersonPrimary>
+    <ContactPerson>Alessandro Pasotti</ContactPerson>
+    <ContactOrganization>QGIS dev team</ContactOrganization>
+   </ContactPersonPrimary>
+   <ContactElectronicMailAddress>elpaso@itopen.it</ContactElectronicMailAddress>
+  </ContactInformation>
+  <Fees>conditions unknown</Fees>
+  <AccessConstraints>None</AccessConstraints>
+ </Service>
+ <Capability>
+  <Request>
+   <GetCapabilities>
+    <Format>text/xml</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </GetCapabilities>
+   <GetMap>
+    <Format>image/jpeg</Format>
+    <Format>image/png</Format>
+    <Format>image/png; mode=16bit</Format>
+    <Format>image/png; mode=8bit</Format>
+    <Format>image/png; mode=1bit</Format>
+    <Format>application/dxf</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </GetMap>
+   <GetFeatureInfo>
+    <Format>text/plain</Format>
+    <Format>text/html</Format>
+    <Format>text/xml</Format>
+    <Format>application/vnd.ogc.gml</Format>
+    <Format>application/vnd.ogc.gml/3.1.1</Format>
+    <Format>application/json</Format>
+    <Format>application/geo+json</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </GetFeatureInfo>
+   <sld:GetLegendGraphic>
+    <Format>image/jpeg</Format>
+    <Format>image/png</Format>
+    <Format>application/json</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </sld:GetLegendGraphic>
+   <sld:DescribeLayer>
+    <Format>text/xml</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </sld:DescribeLayer>
+   <qgs:GetStyles>
+    <Format>text/xml</Format>
+    <DCPType>
+     <HTTP>
+      <Get>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </Get>
+     </HTTP>
+    </DCPType>
+   </qgs:GetStyles>
+  </Request>
+  <Exception>
+   <Format>XML</Format>
+  </Exception>
+  <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
+  <Layer queryable="1">
+   <Name>QGIS Test Project</Name>
+   <Title>QGIS TestProject</Title>
+   <Abstract><![CDATA[Some UTF8 text èòù]]></Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
+   <CRS>CRS:84</CRS>
+   <CRS>EPSG:4326</CRS>
+   <CRS>EPSG:3857</CRS>
+   <EX_GeographicBoundingBox>
+    <westBoundLongitude>8.203154</westBoundLongitude>
+    <eastBoundLongitude>8.204165</eastBoundLongitude>
+    <southBoundLatitude>44.901236</southBoundLatitude>
+    <northBoundLatitude>44.901599</northBoundLatitude>
+   </EX_GeographicBoundingBox>
+   <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
+   <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
+   <Layer queryable="1">
+    <Name>layer_with_short_name</Name>
+    <Title>A Layer with a short name</Title>
+    <Abstract>A Layer with an abstract</Abstract>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Style>
+     <Name>default</Name>
+     <Title>default</Title>
+     <LegendURL>
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=layer_with_short_name&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+     </LegendURL>
+    </Style>
+    <MetadataURL type="FGDC:1998">
+     <Format>text/plain</Format>
+     <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://my.other.url"/>
+    </MetadataURL>
+    <MetadataURL type="ISO19115:2003">
+     <Format>text/xml</Format>
+     <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://some.data.com"/>
+    </MetadataURL>
+   </Layer>
+   <Layer queryable="1">
+    <Name>landsat</Name>
+    <Title>landsat</Title>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>17.924273</westBoundLongitude>
+     <eastBoundLongitude>18.045658</eastBoundLongitude>
+     <southBoundLatitude>30.151856</southBoundLatitude>
+     <northBoundLatitude>30.257289</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="3536664.948" maxx="2008833.414" miny="3523084.517" CRS="EPSG:3857" minx="1995320.991"/>
+    <BoundingBox maxy="18.045658" maxx="30.257289" miny="17.924273" CRS="EPSG:4326" minx="30.151856"/>
+    <Style>
+     <Name>default</Name>
+     <Title>default</Title>
+     <LegendURL>
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=landsat&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+     </LegendURL>
+    </Style>
+   </Layer>
+   <Layer queryable="1">
+    <Name>testlayer èé</Name>
+    <Title>A test vector layer</Title>
+    <Abstract>A test vector layer with unicode òà</Abstract>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Style>
+     <Name>default</Name>
+     <Title>default</Title>
+     <LegendURL>
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer èé&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+     </LegendURL>
+    </Style>
+   </Layer>
+   <Layer queryable="1">
+    <Name>fields_alias</Name>
+    <Title>A test vector layer</Title>
+    <Abstract>A test vector layer with unicode òà</Abstract>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Style>
+     <Name>default</Name>
+     <Title>default</Title>
+     <LegendURL>
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=fields_alias&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+     </LegendURL>
+    </Style>
+   </Layer>
+   <Layer queryable="1">
+    <Name>exclude_attribute</Name>
+    <Title>A test vector layer</Title>
+    <Abstract>A test vector layer with unicode òà</Abstract>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203547</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+    <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Style>
+     <Name>default</Name>
+     <Title>default</Title>
+     <LegendURL>
+      <Format>image/png</Format>
+      <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=exclude_attribute&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+     </LegendURL>
+    </Style>
+   </Layer>
+   <Layer queryable="1">
+    <Name>group_name</Name>
+    <Title>Group title</Title>
+    <Abstract>Group abstract</Abstract>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
+    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Layer queryable="1">
+     <Name>testlayer2</Name>
+     <Title>testlayer2</Title>
+     <CRS>CRS:84</CRS>
+     <CRS>EPSG:4326</CRS>
+     <CRS>EPSG:3857</CRS>
+     <EX_GeographicBoundingBox>
+      <westBoundLongitude>8.203459</westBoundLongitude>
+      <eastBoundLongitude>8.203547</eastBoundLongitude>
+      <southBoundLatitude>44.901394</southBoundLatitude>
+      <northBoundLatitude>44.901483</northBoundLatitude>
+     </EX_GeographicBoundingBox>
+     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+     <Style>
+      <Name>default</Name>
+      <Title>default</Title>
+      <LegendURL>
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer2&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </LegendURL>
+     </Style>
+    </Layer>
+   </Layer>
+   <Layer queryable="0">
+    <Name>groupwithoutshortname</Name>
+    <Title>groupwithoutshortname</Title>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <EX_GeographicBoundingBox>
+     <westBoundLongitude>8.203459</westBoundLongitude>
+     <eastBoundLongitude>8.203548</eastBoundLongitude>
+     <southBoundLatitude>44.901394</southBoundLatitude>
+     <northBoundLatitude>44.901483</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox maxy="5606025.239" maxx="913214.676" miny="5606011.456" CRS="EPSG:3857" minx="913204.911"/>
+    <BoundingBox maxy="8.203548" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+    <Layer queryable="0">
+     <Name>testlayer3</Name>
+     <Title>testlayer3</Title>
+     <CRS>CRS:84</CRS>
+     <CRS>EPSG:4326</CRS>
+     <CRS>EPSG:3857</CRS>
+     <EX_GeographicBoundingBox>
+      <westBoundLongitude>8.203459</westBoundLongitude>
+      <eastBoundLongitude>8.203547</eastBoundLongitude>
+      <southBoundLatitude>44.901394</southBoundLatitude>
+      <northBoundLatitude>44.901483</northBoundLatitude>
+     </EX_GeographicBoundingBox>
+     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
+     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
+     <Style>
+      <Name>default</Name>
+      <Title>default</Title>
+      <LegendURL>
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer3&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+      </LegendURL>
+     </Style>
+    </Layer>
+   </Layer>
+  </Layer>
+ </Capability>
+</WMS_Capabilities>


### PR DESCRIPTION
If QGIS Server is accessed by a rewrite-rule, the original request usually does not contain the map parameter, however the rewritten request does. To decide if the map-parameter has to be added to the url advertised in GetCapabilities, the original request has to be considered (not the rewritten request).