### PR TITLE
Ensure labeling map tools only try to affect labels from vector layers (3.16)

### DIFF
--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -74,7 +74,6 @@ bool QgsMapToolLabel::labelAtPosition( QMouseEvent *e, QgsLabelPosition &p )
         case QgsMapLayerType::MeshLayer:
         case QgsMapLayerType::VectorTileLayer:
         case QgsMapLayerType::AnnotationLayer:
-        case QgsMapLayerType::PointCloudLayer:
           return true;
       }
     }


### PR DESCRIPTION
Labels from other layer types (eg vector tiles) are unsupported,
which results in a crash.

Fixes #44486

Manual backport of https://github.com/qgis/QGIS/pull/45311
