### PR TITLE
 Don't reset mesh layer styling when changing data source for layer

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -94,6 +94,8 @@ Constructor for LayerOptions with optional ``transformContext``.
 
       QgsCoordinateTransformContext transformContext;
 
+      bool loadDefaultStyle;
+
       bool skipCrsValidation;
     };
 
@@ -160,6 +162,8 @@ QgsMeshLayer cannot be copied.
     virtual bool isEditable() const;
 
     virtual bool supportsEditing() const;
+
+    virtual QString loadDefaultStyle( bool &resultFlag /Out/ ) ${SIP_FINAL};
 
 
     QString providerType() const;

--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -91,6 +91,22 @@ Sets the method used to match dataset from temporal capabilities
 :param matchingMethod: the matching method
 %End
 
+    bool isValid() const;
+%Docstring
+Returns whether the instance is valid
+
+.. versionadded:: 3.22
+%End
+
+    void setIsValid( bool isValid );
+%Docstring
+Sets whether the instance is valid
+
+:param isValid: whether the instance is valid
+
+.. versionadded:: 3.22
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -749,6 +749,13 @@ Sets the active vector dataset group
 .. versionadded:: 3.14
 %End
 
+    bool hasSettings( int datasetGroupIndex ) const;
+%Docstring
+Returns whether the group with ``index`` has render settings (scalar or vector)
+
+.. versionadded:: 3.22
+%End
+
 };
 
 /************************************************************************

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -50,6 +50,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerlabeling.h"
 #include "qgsxmlutils.h"
+#include "qgsmeshlayer.h"
 
 
 QgsAppLayerTreeViewMenuProvider::QgsAppLayerTreeViewMenuProvider( QgsLayerTreeView *view, QgsMapCanvas *canvas )
@@ -153,6 +154,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer );
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
       QgsPointCloudLayer *pcLayer = qobject_cast<QgsPointCloudLayer * >( layer );
+      QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer * >( layer );
 
       if ( layer && layer->isSpatial() )
       {
@@ -363,8 +365,8 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( tr( "&Filter…" ), QgisApp::instance(), qOverload<>( &QgisApp::layerSubsetString ) );
       }
 
-      // change data source is only supported for vectors and rasters, point clouds
-      if ( vlayer || rlayer || pcLayer )
+      // change data source is only supported for vectors, rasters, point clouds, mesh
+      if ( vlayer || rlayer || pcLayer || meshLayer )
       {
 
         QAction *a = new QAction( layer->isValid() ? tr( "C&hange Data Source…" ) : tr( "Repair Data Source…" ), menu );

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -343,6 +343,16 @@ void QgsMeshDatasetGroupStore::readXml( const QDomElement &storeElem, const QgsR
     setDatasetGroupTreeItem( new QgsMeshDatasetGroupTreeItem( rootTreeItemElem, context ) );
 }
 
+int QgsMeshDatasetGroupStore::globalDatasetGroupIndexInSource( QgsMeshDatasetSourceInterface *source, int nativeGroupIndex ) const
+{
+  for ( QMap<int, DatasetGroup>::const_iterator it = mRegistery.cbegin(); it != mRegistery.cend(); ++it )
+  {
+    if ( it.value().first == source && it.value().second == nativeGroupIndex )
+      return it.key();
+  }
+
+  return -1;
+}
 
 bool QgsMeshDatasetGroupStore::saveDatasetGroup( QString filePath, int groupIndex, QString driver )
 {

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -210,6 +210,14 @@ class QgsMeshDatasetGroupStore: public QObject
     //! Reads the store's information from a DOM document
     void readXml( const QDomElement &storeElem, const QgsReadWriteContext &context );
 
+    /**
+     * Returns the global dataset group index of the dataset group with native index \a globalGroupIndex in the \a source
+     * Returns -1 if the group or the source is not registered
+     *
+     * Since QGIS 3.22
+     */
+    int globalDatasetGroupIndexInSource( QgsMeshDatasetSourceInterface *source, int nativeGroupIndex ) const;
+
   signals:
     //! Emitted after dataset groups are added
     void datasetGroupsAdded( QList<int> indexes );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -49,8 +49,8 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &providerKey,
                             const QgsMeshLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath ),
-    mDatasetGroupStore( new QgsMeshDatasetGroupStore( this ) )
-
+    mDatasetGroupStore( new QgsMeshDatasetGroupStore( this ) ),
+    mTemporalProperties( new QgsMeshLayerTemporalProperties( this ) )
 {
   mShouldValidateCrs = !options.skipCrsValidation;
 
@@ -1159,7 +1159,6 @@ void QgsMeshLayer::setDataSourcePrivate( const QString &dataSource, const QStrin
 
   if ( !mDataSource.isEmpty() && !provider.isEmpty() )
     setDataProvider( provider, options, flags );
-
 }
 
 QgsPointXY QgsMeshLayer::snapOnElement( QgsMesh::ElementType elementType, const QgsPointXY &point, double searchRadius )
@@ -1497,8 +1496,6 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
   else
     mDatasetGroupStore->readXml( elemDatasetGroupsStore, context );
 
-  mTemporalProperties = new QgsMeshLayerTemporalProperties( this );
-
   setDataProvider( mProviderKey, providerOptions, flags );
 
   QString errorMsg;
@@ -1706,9 +1703,8 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
     return false;
   }
 
-  if ( !mTemporalProperties )
+  if ( !mTemporalProperties->isValid() )
   {
-    mTemporalProperties = new QgsMeshLayerTemporalProperties( this );
     mTemporalProperties->setDefaultsFromDataProviderTemporalCapabilities( dataProvider()->temporalCapabilities() );
   }
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -112,7 +112,16 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
         : transformContext( transformContext )
       {}
 
+      /**
+       * Coordinate transform context
+       */
       QgsCoordinateTransformContext transformContext;
+
+      /**
+       * Set to TRUE if the default layer style should be loaded.
+       * \since QGIS 3.22
+       */
+      bool loadDefaultStyle = true;
 
       /**
        * Controls whether the layer is allowed to have an invalid/unknown CRS.
@@ -182,6 +191,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QString htmlMetadata() const override;
     bool isEditable() const override;
     bool supportsEditing() const override;
+    QString loadDefaultStyle( bool &resultFlag SIP_OUT ) FINAL;
 
     //! Returns the provider type for this layer
     QString providerType() const;

--- a/src/core/mesh/qgsmeshlayertemporalproperties.cpp
+++ b/src/core/mesh/qgsmeshlayertemporalproperties.cpp
@@ -61,6 +61,7 @@ bool QgsMeshLayerTemporalProperties::readXml( const QDomElement &element, const 
   mMatchingMethod = static_cast<QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod>(
                       temporalElement.attribute( QStringLiteral( "matching-method" ) ).toInt() );
 
+  mIsValid = true;
   return true;
 }
 
@@ -74,6 +75,8 @@ void QgsMeshLayerTemporalProperties::setDefaultsFromDataProviderTemporalCapabili
 
   if ( mReferenceTime.isValid() )
     mTimeExtent = temporalCapabilities->timeExtent();
+
+  mIsValid = true;
 }
 
 QgsDateTimeRange QgsMeshLayerTemporalProperties::calculateTemporalExtent( QgsMapLayer * ) const
@@ -111,4 +114,14 @@ QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod QgsMeshLa
 void QgsMeshLayerTemporalProperties::setMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod )
 {
   mMatchingMethod = matchingMethod;
+}
+
+bool QgsMeshLayerTemporalProperties::isValid() const
+{
+  return mIsValid;
+}
+
+void QgsMeshLayerTemporalProperties::setIsValid( bool isValid )
+{
+  mIsValid = isValid;
 }

--- a/src/core/mesh/qgsmeshlayertemporalproperties.h
+++ b/src/core/mesh/qgsmeshlayertemporalproperties.h
@@ -100,11 +100,28 @@ class CORE_EXPORT QgsMeshLayerTemporalProperties : public QgsMapLayerTemporalPro
      */
     void setMatchingMethod( const QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod &matchingMethod );
 
+    /**
+     * Returns whether the instance is valid
+     *
+     * \since QGIS 3.22
+     */
+    bool isValid() const;
+
+    /**
+     * Sets whether the instance is valid
+     *
+     * \param isValid whether the instance is valid
+     *
+     * \since QGIS 3.22
+     */
+    void setIsValid( bool isValid );
+
   private:
     QDateTime mReferenceTime;
     QgsDateTimeRange mTimeExtent;
     QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod mMatchingMethod =
       QgsMeshDataProviderTemporalCapabilities::FindClosestDatasetBeforeStartRangeTime;
+    bool mIsValid = false;
 };
 
 #endif // QGSMESHLAYERTEMPORALPROPERTIES_H

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -740,3 +740,7 @@ void QgsMeshRendererVectorTracesSettings::setParticlesCount( int value )
   mParticlesCount = value;
 }
 
+bool QgsMeshRendererSettings::hasSettings( int datasetGroupIndex ) const
+{
+  return mRendererScalarSettings.contains( datasetGroupIndex ) || mRendererVectorSettings.contains( datasetGroupIndex );
+}

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -673,6 +673,13 @@ class CORE_EXPORT QgsMeshRendererSettings
      */
     void setActiveVectorDatasetGroup( int activeVectorDatasetGroup );
 
+    /**
+    * Returns whether the group with \a index has render settings (scalar or vector)
+    *
+    * \since QGIS 3.22
+    */
+    bool hasSettings( int datasetGroupIndex ) const;
+
   private:
     QgsMeshRendererMeshSettings mRendererNativeMeshSettings;
     QgsMeshRendererMeshSettings mRendererTriangularMeshSettings;

--- a/src/core/qgsmaplayerfactory.cpp
+++ b/src/core/qgsmaplayerfactory.cpp
@@ -91,6 +91,7 @@ QgsMapLayer *QgsMapLayerFactory::createLayer( const QString &uri, const QString 
     {
       QgsMeshLayer::LayerOptions meshOptions;
       meshOptions.transformContext = options.transformContext;
+      meshOptions.loadDefaultStyle = options.loadDefaultStyle;
       return new QgsMeshLayer( uri, name, provider, meshOptions );
     }
 


### PR DESCRIPTION
This breaks fixing mesh layer paths when restoring projects with
broken mesh layers -- fixing the path causes the existing style
to be lost.

Fixes #45391