### PR TITLE
Fix layout legend not showing WMS legend graphics unless image already cached

### DIFF
--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1250,6 +1250,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
 
   if ( ctx && ctx->painter )
   {
+    const QImage image = getLegendGraphic();
+
     switch ( settings.symbolAlignment() )
     {
       case Qt::AlignLeft:
@@ -1258,8 +1260,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
                                          ctx->top,
                                          settings.wmsLegendSize().width(),
                                          settings.wmsLegendSize().height() ),
-                                 mImage,
-                                 QRectF( QPointF( 0, 0 ), mImage.size() ) );
+                                 image,
+                                 QRectF( QPointF( 0, 0 ), image.size() ) );
         break;
 
       case Qt::AlignRight:
@@ -1267,8 +1269,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
                                          ctx->top,
                                          settings.wmsLegendSize().width(),
                                          settings.wmsLegendSize().height() ),
-                                 mImage,
-                                 QRectF( QPointF( 0, 0 ), mImage.size() ) );
+                                 image,
+                                 QRectF( QPointF( 0, 0 ), image.size() ) );
         break;
     }
   }

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -1067,6 +1067,7 @@ QgsLegendModel::QgsLegendModel( QgsLayerTree *rootNode, QObject *parent, QgsLayo
 {
   setFlag( QgsLayerTreeModel::AllowLegendChangeState, false );
   setFlag( QgsLayerTreeModel::AllowNodeReorder, true );
+  connect( this, &QgsLegendModel::dataChanged, this, &QgsLegendModel::refreshLegend );
 }
 
 QgsLegendModel::QgsLegendModel( QgsLayerTree *rootNode,  QgsLayoutItemLegend *layout )
@@ -1075,6 +1076,7 @@ QgsLegendModel::QgsLegendModel( QgsLayerTree *rootNode,  QgsLayoutItemLegend *la
 {
   setFlag( QgsLayerTreeModel::AllowLegendChangeState, false );
   setFlag( QgsLayerTreeModel::AllowNodeReorder, true );
+  connect( this, &QgsLegendModel::dataChanged, this, &QgsLegendModel::refreshLegend );
 }
 
 QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -971,7 +971,7 @@ bool QgsLayoutItemLegend::legendFilterOutAtlas() const
 
 void QgsLayoutItemLegend::onAtlasFeature()
 {
-  if ( !mLayout->reportContext().feature().isValid() )
+  if ( !mLayout || !mLayout->reportContext().feature().isValid() )
     return;
   mInAtlas = mFilterOutAtlas;
   updateFilterByMap();


### PR DESCRIPTION
Currently, a WMS legend graphics will not get displayed in the layout unless the image is already cached (by expanding the layer item in the canvas layer tree).