### PR TITLE
Make Postgres provider test idempotent

### DIFF
--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -902,6 +902,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertAlmostEqual(f['pk3'], 3.14159274)
         self.assertEqual(f['value'], 'test 2')
 
+        # Backup test table (will be edited)
+        self.backupTable('qgis_test', 'tb_test_composite_float_pk')
+
         # can we edit a field?
         vl.startEditing()
         vl.changeAttributeValue(f.id(), fields.indexOf('value'), 'Edited Test 2')
@@ -958,6 +961,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             got_feature = False
 
         self.assertFalse(got_feature)
+
+        # Restore test table
+        self.restoreTable('qgis_test', 'tb_test_composite_float_pk')
 
     def testPktFloatingPoint(self):
         """

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -829,6 +829,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(f['pk2'], 2)
         self.assertEqual(f['value'], 'test 2')
 
+        # Backup test table (will be edited)
+        self.backupTable('qgis_test', 'tb_test_compound_pk')
+
         # can we edit a field?
         vl.startEditing()
         vl.changeAttributeValue(f.id(), fields.indexOf('value'), 'Edited Test 2')
@@ -877,6 +880,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             got_feature = False
 
         self.assertFalse(got_feature)
+
+        # Restore test table
+        self.restoreTable('qgis_test', 'tb_test_compound_pk')
 
     def testPktCompositeFloat(self):
         """

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -720,6 +720,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             "bigint_pk", "postgres")
         flds = vl.fields()
 
+        # Backup test table (will be edited)
+        self.backupTable('qgis_test', 'bigint_pk')
+
         self.assertTrue(vl.isValid())
 
         vl.startEditing()
@@ -762,6 +765,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             elif ft['value'] == '-1th value':
                 statuses[3] = 1
         self.assertTrue(all(x == 1 for x in statuses))
+
+        # Restore test table
+        self.restoreTable('qgis_test', 'bigint_pk')
 
     def testPktUpdateBigintPkNonFirst(self):
         """Test if we can update objects with positive, zero and negative bigint PKs in tables whose PK is not the first field"""

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1146,13 +1146,15 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
     def testNestedInsert(self):
         tg = QgsTransactionGroup()
-        tg.addLayer(self.vl)
-        self.vl.startEditing()
-        it = self.vl.getFeatures()
+        l = self.getEditableLayer()
+        tg.addLayer(l)
+        l.startEditing()
+        it = l.getFeatures()
         f = next(it)
         f['pk'] = NULL
-        self.vl.addFeature(f)  # Should not deadlock during an active iteration
+        self.assertTrue(l.addFeature(f))  # Should not deadlock during an active iteration
         f = next(it)
+        l.commitChanges()
 
     def testTimeout(self):
         """

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -134,6 +134,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                             "(1, 100, 'Orange', 'oranGe', '1', TIMESTAMP '2020-05-03 12:13:14', '2020-05-03', '12:13:14', '0101000020E61000006891ED7C3F9551C085EB51B81E955040'),"
                             "(2, 200, 'Apple', 'Apple', '2', TIMESTAMP '2020-05-04 12:14:14', '2020-05-04', '12:14:14', '0101000020E6100000CDCCCCCCCC0C51C03333333333B35140'),"
                             "(4, 400, 'Honey', 'Honey', '4', TIMESTAMP '2021-05-04 13:13:14', '2021-05-04', '13:13:14', '0101000020E610000014AE47E17A5450C03333333333935340')")
+        self.execSQLCommand("SELECT setval('qgis_test.\"editData_pk_seq\"', 5, true)")
         vl = QgsVectorLayer(
             self.dbconn +
             ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."editData" (geom) sql=',

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -969,6 +969,11 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         """
         Check if we can handle floating point/numeric primary keys correctly
         """
+
+        # 0. Backup test table (will be edited)
+        self.backupTable('qgis_test', 'tb_test_float_pk')
+        self.backupTable('qgis_test', 'tb_test_double_pk')
+
         # 1. 32 bit float (PostgreSQL "REAL" type)
         vl = QgsVectorLayer(self.dbconn + ' sslmode=disable srid=4326 key="pk" table="qgis_test"."tb_test_float_pk" (geom)', "test_float_pk", "postgres")
         self.assertTrue(vl.isValid())
@@ -1083,6 +1088,10 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         # no NUMERIC/DECIMAL checks here. NUMERIC primary keys are unsupported.
         # TODO: implement NUMERIC primary keys/arbitrary precision arithmethics/fixed point math in QGIS.
+
+        # Restore test tables
+        self.restoreTable('qgis_test', 'tb_test_float_pk')
+        self.restoreTable('qgis_test', 'tb_test_double_pk')
 
     def testPktMapInsert(self):
         vl = QgsVectorLayer('{} table="qgis_test"."{}" key="obj_id" sql='.format(self.dbconn, 'oid_serial_table'),


### PR DESCRIPTION
See #45417 

TODO:

 - [x] testGeneratedFields
 - [x] testNonPkBigintField
 - [x] testPktComposite
 - [x] testPktCompositeFloat
 - [x] testPktFloatingPoint
 - [x] testPktUpdateBigintPk
 - [x] testPktUpdateBigintPkNonFirst
 - [x] testJson
 - [x] testNestedInsert
