### PR TITLE
fix aggregate functions with mesh virtual dataset group

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsMeshCalculator
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -392,6 +392,24 @@ Returns the dataset index of the dataset in a specific dataset group at ``time``
 :return: the dataset index
 %End
 
+    QList<QgsMeshDatasetIndex> datasetIndexInTimeInterval( const QDateTime &referenceTime,
+        int groupIndex,
+        qint64 time1,
+        qint64 time2 ) const;
+%Docstring
+Returns a list of dataset indexes of the dataset in a specific dataset group that are between ``time1`` and ``time2`` from the ``reference`` time
+
+:param referenceTime: the reference time from where to find the dataset
+:param groupIndex: the index of the dataset group
+:param time1: the first relative time of the time intervale from reference time
+:param time2: the second relative time of the time intervale from reference time
+
+:return: the dataset index
+
+
+.. versionadded:: 3.22
+%End
+
   protected:
 };
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -568,6 +568,26 @@ Dataset index is valid even the temporal properties is inactive. This method is 
 .. versionadded:: 3.16
 %End
 
+    QList<QgsMeshDatasetIndex> datasetIndexInRelativeTimeInterval( const QgsInterval &startRelativeTime, const QgsInterval &endRelativeTime, int datasetGroupIndex ) const;
+%Docstring
+Returns a list of dataset indexes from datasets group that are in a interval time from the layer reference time.
+Dataset index is valid even the temporal properties is inactive. This method is used for calculation on mesh layer.
+
+:param startRelativeTime: the start time of the relative interval from the reference time.
+:param endRelativeTime: the end time of the relative interval from the reference time.
+:param datasetGroupIndex: the index of the dataset group
+
+:return: dataset index
+
+.. note::
+
+   indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+   In the layer scope, those indexes are different from the data provider indexes.
+
+
+.. versionadded:: 3.22
+%End
+
     QgsMeshDatasetIndex activeScalarDatasetAtTime( const QgsDateTimeRange &timeRange ) const;
 %Docstring
 Returns dataset index from active scalar group depending on the time range.

--- a/src/core/mesh/qgsmeshcalcnode.h
+++ b/src/core/mesh/qgsmeshcalcnode.h
@@ -132,10 +132,16 @@ class CORE_EXPORT QgsMeshCalcNode
      * \param result destination dataset group for calculation results
      * \returns TRUE on success, FALSE on failure
      */
-    bool calculate( const QgsMeshCalcUtils &dsu, QgsMeshMemoryDatasetGroup &result ) const;
+    bool calculate( const QgsMeshCalcUtils &dsu, QgsMeshMemoryDatasetGroup &result, bool isAggregate = false ) const;
 
     //! Returns all dataset group names used in formula
     QStringList usedDatasetGroupNames() const;
+
+    //! Returns dataset group names used in formula involved in aggregate function
+    QStringList aggregatedUsedDatasetGroupNames() const;
+
+    //! Returns dataset group names used in formula not involved in aggregate function
+    QStringList notAggregatedUsedDatasetGroupNames() const;
 
     /**
      * Parses string to calculation node. Caller takes responsibility to delete the node

--- a/src/core/mesh/qgsmeshcalculator.cpp
+++ b/src/core/mesh/qgsmeshcalculator.cpp
@@ -19,9 +19,11 @@
 #include <limits>
 #include <memory>
 
+#include "qgsfeedback.h"
 #include "qgsmeshcalcnode.h"
 #include "qgsmeshcalculator.h"
 #include "qgsmeshcalcutils.h"
+#include "qgsmeshlayer.h"
 #include "qgsmeshmemorydataprovider.h"
 #include "qgsmeshvirtualdatasetgroup.h"
 #include "qgis.h"

--- a/src/core/mesh/qgsmeshcalculator.h
+++ b/src/core/mesh/qgsmeshcalculator.h
@@ -25,10 +25,12 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsrectangle.h"
-#include "qgsmeshlayer.h"
-#include "qgsmeshdataprovider.h"
+#include "qgsgeometry.h"
+#include "qgsmeshdataset.h"
 #include "qgsprovidermetadata.h"
-#include "qgsfeedback.h"
+
+class QgsMeshLayer;
+class QgsFeedback;
 
 /**
  * \ingroup core

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -72,6 +72,35 @@ QgsMeshDatasetIndex QgsMeshDatasetSourceInterface::datasetIndexAtTime(
   return QgsMeshDatasetIndex();
 }
 
+QList<QgsMeshDatasetIndex> QgsMeshDatasetSourceInterface::datasetIndexInTimeInterval( const QDateTime &referenceTime, int groupIndex, qint64 time1, qint64 time2 ) const
+{
+  const QDateTime requestDateTime = referenceTime.addMSecs( time1 );
+  qint64 providerTime1;
+  qint64 providerTime2;
+  const QDateTime providerReferenceTime = mTemporalCapabilities->referenceTime();
+  if ( mTemporalCapabilities->referenceTime().isValid() )
+  {
+    providerTime1 = providerReferenceTime.msecsTo( requestDateTime );
+    providerTime2 = providerTime1 - time1 + time2;
+  }
+  else
+  {
+    providerTime1 = time1;
+    providerTime2 = time2;
+  }
+
+  QList<QgsMeshDatasetIndex> ret;
+  for ( int i = 0; i < datasetCount( groupIndex ); ++i )
+  {
+    QgsMeshDatasetIndex datasetIndex( groupIndex, i );
+    qint64 time = mTemporalCapabilities->datasetTime( datasetIndex );
+    if ( time >= providerTime1 && time <= providerTime2 )
+      ret.append( datasetIndex );
+  }
+
+  return ret;
+}
+
 QgsMeshDatasetSourceInterface::QgsMeshDatasetSourceInterface():
   mTemporalCapabilities( std::make_unique<QgsMeshDataProviderTemporalCapabilities>() ) {}
 

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -401,6 +401,23 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
                                             qint64 time,
                                             QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod method ) const;
 
+    /**
+     * Returns a list of dataset indexes of the dataset in a specific dataset group that are between \a time1 and \a time2 from the \a reference time
+     *
+     * \param referenceTime the reference time from where to find the dataset
+     * \param groupIndex the index of the dataset group
+     * \param time1 the first relative time of the time intervale from reference time
+     * \param time2 the second relative time of the time intervale from reference time
+     *
+     * \return the dataset index
+     *
+     * \since QGIS 3.22
+     */
+    QList<QgsMeshDatasetIndex> datasetIndexInTimeInterval( const QDateTime &referenceTime,
+        int groupIndex,
+        qint64 time1,
+        qint64 time2 ) const;
+
   protected:
     std::unique_ptr<QgsMeshDataProviderTemporalCapabilities> mTemporalCapabilities;
 };

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -237,6 +237,28 @@ QgsMeshDatasetIndex QgsMeshDatasetGroupStore::datasetIndexAtTime(
                               group.first->datasetIndexAtTime( referenceTime, group.second, time, method ).dataset() );
 }
 
+QList<QgsMeshDatasetIndex> QgsMeshDatasetGroupStore::datasetIndexInTimeInterval(
+  qint64 time1,
+  qint64 time2,
+  int groupIndex ) const
+{
+  const QgsMeshDatasetGroupStore::DatasetGroup  group = datasetGroup( groupIndex );
+  if ( !group.first )
+    return QList<QgsMeshDatasetIndex>();
+
+  const QDateTime &referenceTime = mPersistentProvider ? mPersistentProvider->temporalCapabilities()->referenceTime() : QDateTime();
+
+  const QList<QgsMeshDatasetIndex> datasetIndexes = group.first->datasetIndexInTimeInterval( referenceTime, group.second, time1, time2 );
+
+  QList<QgsMeshDatasetIndex> ret;
+  ret.reserve( datasetIndexes.count() );
+
+  for ( const QgsMeshDatasetIndex &sourceDatasetIndex : datasetIndexes )
+    ret.append( QgsMeshDatasetIndex( groupIndex, sourceDatasetIndex.dataset() ) );
+
+  return ret;
+}
+
 qint64 QgsMeshDatasetGroupStore::datasetRelativeTime( const QgsMeshDatasetIndex &index ) const
 {
   QgsMeshDatasetGroupStore::DatasetGroup  group = datasetGroup( index.group() );

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -198,6 +198,13 @@ class QgsMeshDatasetGroupStore: public QObject
                                             int groupIndex,
                                             QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod method ) const;
 
+    /**
+     * Returns the global dataset index of the dataset int the dataset group with \a groupIndex, that is between relative times \a time1 and \a time2
+     *
+     * Since QGIS 3.22
+     */
+    QList<QgsMeshDatasetIndex> datasetIndexInTimeInterval( qint64 time1, qint64 time2, int groupIndex ) const;
+
     //! Returns the relative time of the dataset from the persistent provider reference time
     qint64 datasetRelativeTime( const QgsMeshDatasetIndex &index ) const;
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -588,6 +588,24 @@ QgsMeshDatasetIndex QgsMeshLayer::datasetIndexAtRelativeTime( const QgsInterval 
   return  mDatasetGroupStore->datasetIndexAtTime( relativeTime.seconds() * 1000, datasetGroupIndex, mTemporalProperties->matchingMethod() );
 }
 
+QList<QgsMeshDatasetIndex> QgsMeshLayer::datasetIndexInRelativeTimeInterval( const QgsInterval &startRelativeTime, const QgsInterval &endRelativeTime, int datasetGroupIndex ) const
+{
+  qint64 usedRelativeTime1 = startRelativeTime.seconds() * 1000;
+  qint64 usedRelativeTime2 = endRelativeTime.seconds() * 1000;
+
+  //adjust relative time if layer reference time is different from provider reference time
+  if ( mTemporalProperties->referenceTime().isValid() &&
+       mDataProvider &&
+       mDataProvider->isValid() &&
+       mTemporalProperties->referenceTime() != mDataProvider->temporalCapabilities()->referenceTime() )
+  {
+    usedRelativeTime1 = usedRelativeTime1 + mTemporalProperties->referenceTime().msecsTo( mDataProvider->temporalCapabilities()->referenceTime() );
+    usedRelativeTime2 = usedRelativeTime2 + mTemporalProperties->referenceTime().msecsTo( mDataProvider->temporalCapabilities()->referenceTime() );
+  }
+
+  return  mDatasetGroupStore->datasetIndexInTimeInterval( usedRelativeTime1, usedRelativeTime2, datasetGroupIndex );
+}
+
 void QgsMeshLayer::applyClassificationOnScalarSettings( const QgsMeshDatasetGroupMetadata &meta, QgsMeshRendererScalarSettings &scalarSettings ) const
 {
   if ( meta.extraOptions().contains( QStringLiteral( "classification" ) ) )

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -583,6 +583,22 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QgsMeshDatasetIndex datasetIndexAtRelativeTime( const QgsInterval &relativeTime, int datasetGroupIndex ) const;
 
     /**
+      * Returns a list of dataset indexes from datasets group that are in a interval time from the layer reference time.
+      * Dataset index is valid even the temporal properties is inactive. This method is used for calculation on mesh layer.
+      *
+      * \param startRelativeTime the start time of the relative interval from the reference time.
+      * \param endRelativeTime the end time of the relative interval from the reference time.
+      * \param datasetGroupIndex the index of the dataset group
+      * \returns dataset index
+      *
+      * \note indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+      * In the layer scope, those indexes are different from the data provider indexes.
+      *
+      * \since QGIS 3.22
+      */
+    QList<QgsMeshDatasetIndex> datasetIndexInRelativeTimeInterval( const QgsInterval &startRelativeTime, const QgsInterval &endRelativeTime, int datasetGroupIndex ) const;
+
+    /**
       * Returns dataset index from active scalar group depending on the time range.
       * If the temporal properties is not active, return the static dataset
       *

--- a/src/core/mesh/qgsmeshvirtualdatasetgroup.cpp
+++ b/src/core/mesh/qgsmeshvirtualdatasetgroup.cpp
@@ -40,8 +40,10 @@ void QgsMeshVirtualDatasetGroup::initialize()
   if ( !mCalcNode || !mLayer )
     return;
 
-  mDatasetGroupNameUsed = mCalcNode->usedDatasetGroupNames();
-  setDataType( QgsMeshCalcUtils::determineResultDataType( mLayer, mDatasetGroupNameUsed ) );
+  mDatasetGroupNameUsed = mCalcNode->notAggregatedUsedDatasetGroupNames();
+  mDatasetGroupNameUsedForAggregate = mCalcNode->aggregatedUsedDatasetGroupNames();
+  setDataType( QgsMeshCalcUtils::determineResultDataType( mLayer,
+               mDatasetGroupNameUsed + mDatasetGroupNameUsedForAggregate ) );
 
   //populate used group indexes
   QMap<QString, int> usedDatasetGroupindexes;
@@ -152,7 +154,12 @@ bool QgsMeshVirtualDatasetGroup::calculateDataset() const
   if ( !mLayer )
     return false;
 
-  const QgsMeshCalcUtils dsu( mLayer, mDatasetGroupNameUsed, QgsInterval( mDatasetTimes[mCurrentDatasetIndex] / 1000.0 ) );
+  const QgsMeshCalcUtils dsu( mLayer,
+                              mDatasetGroupNameUsed,
+                              mDatasetGroupNameUsedForAggregate,
+                              QgsInterval( mDatasetTimes[mCurrentDatasetIndex] / 1000.0 ),
+                              QgsInterval( mStartTime / 1000.0 ),
+                              QgsInterval( mEndTime / 1000.0 ) );
 
   if ( !dsu.isValid() )
     return false;

--- a/src/core/mesh/qgsmeshvirtualdatasetgroup.h
+++ b/src/core/mesh/qgsmeshvirtualdatasetgroup.h
@@ -66,9 +66,10 @@ class CORE_EXPORT QgsMeshVirtualDatasetGroup: public QgsMeshDatasetGroup
     QString mFormula;
     std::unique_ptr<QgsMeshCalcNode> mCalcNode;
     QgsMeshLayer *mLayer = nullptr;
-    qint64 mStartTime = 0.0;
-    qint64 mEndTime = 0.0;
+    qint64 mStartTime = 0;
+    qint64 mEndTime = 0;
     QStringList mDatasetGroupNameUsed;
+    QStringList mDatasetGroupNameUsedForAggregate;
     QList<qint64> mDatasetTimes;
 
     mutable std::shared_ptr<QgsMeshMemoryDataset> mCacheDataset;

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -362,6 +362,71 @@ void TestQgsMeshCalculator::virtualDatasetGroup()
   QCOMPARE( dataset->datasetValue( 2 ).scalar(), 7.0 );
   QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5.5 );
   QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4.0 );
+
+  formula = QStringLiteral( "\"VertexScalarDataset\" +  max_aggr (\"VertexScalarDataset\")" );
+  virtualDatasetGroup = QgsMeshVirtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 2 );
+
+  dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 3.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5.0 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 7.0 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5.0 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 3.0 );
+
+  dataset = virtualDatasetGroup.dataset( 1 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 4.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 6.0 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 8.0 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 6.0 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4.0 );
+
+  formula = QStringLiteral( "max_aggr (\"FaceScalarDataset\") + min_aggr (\"FaceScalarDataset\")" );
+  virtualDatasetGroup = QgsMeshVirtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 1 );
+
+  dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 2 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 3.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5.0 );
+
+  formula = QStringLiteral( "max_aggr (\"FaceScalarDataset\") + \"VertexScalarDataset\"" );
+  virtualDatasetGroup = QgsMeshVirtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 2 );
+
+  dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 3.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 4.5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 6.0 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 4.5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 3.0 );
+
+  dataset = virtualDatasetGroup.dataset( 1 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 4.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 7.0 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4.0 );
+
+  formula = QStringLiteral( "max_aggr (\"FaceScalarDataset\" + \"VertexScalarDataset\")" );
+  virtualDatasetGroup = QgsMeshVirtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 1 );
+
+  dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 4.0 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 7.0 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4.0 );
 }
 
 
@@ -378,6 +443,7 @@ void TestQgsMeshCalculator::test_dataset_group_dependency()
     {
       const std::shared_ptr<QgsMeshMemoryDataset> ds = std::make_shared<QgsMeshMemoryDataset>();
       ds->time = i / 3600.0;
+      ds->valid = true;
       for ( int v = 0; v < vertexCount; ++v )
         ds->values.append( QgsMeshDatasetValue( v / 2.0 + dsg ) );
 
@@ -396,7 +462,7 @@ void TestQgsMeshCalculator::test_dataset_group_dependency()
   formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + \"virtual_0\"" ) );
   formulas.append( QStringLiteral( " \"virtual_0\" + max_aggr ( \"VertexScalarDataset\")  + 1" ) );
   formulas.append( QStringLiteral( "if ( \"FaceScalarDataset\" = \"VertexScalarDataset\" , 0 , 1 )" ) ); //temporal one, must have several datasets
-  formulas.append( QStringLiteral( "if ( 2 = 1 , 0 , 1 )" ) ); //dtatic one, must have one dataset
+  formulas.append( QStringLiteral( "if ( 2 = 1 , 0 , 1 )" ) ); //static one, must have one dataset
   formulas.append( QStringLiteral( "if ( 2 = 1 , \"FaceScalarDataset\" , 1 )" ) ); //temporal one, must have several datasets
   QVector<int> sizes{10, 10, 2, 1, 1, 10, 10, 2, 1, 2};
 


### PR DESCRIPTION
This PR fixes the mesh virtual dataset group when using aggregate functions.
Indeed with formula containing aggr_Max, Aggr_Min,... the virtual dataset group contains wrong values, considering only one dataset (one time step) with aggregate function.

This PR fixes structural issues and make aggregate functions working fine.