### PR TITLE
fix performance issue of snapping when adding features

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -944,11 +944,11 @@ bool QgsPointLocator::init( int maxFeaturesToIndex, bool relaxed )
        || !mLayer->dataProvider()->isValid() )
     return false;
 
-  mRenderer.reset( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
   mSource.reset( new QgsVectorLayerFeatureSource( mLayer ) );
 
   if ( mContext )
   {
+    mRenderer.reset( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
     mContext->expressionContext() << QgsExpressionContextUtils::layerScope( mLayer );
   }
 


### PR DESCRIPTION
## Description

How to reproduce: Select no feature on map(This is important) to enable the snapping(so QgsPointLocator are created properly), and start to adding(or relocating) vector feature to layer. It will take more time(few seconds) to finish as the number of features goes up.

The following is a time profile on this issue, i used API to keep adding and removing features(about 300) on a interval of 20HZ, the UI stuck since it can not completed drawing it on map within 50ms.

(1)
<img width="949" alt="Screen Shot 2021-10-03 at 22 35 11" src="https://user-images.githubusercontent.com/5885946/136304748-5c706ac1-e29f-49b3-9fbc-f1def316ef9c.png">

(2)
<img width="964" alt="Screen Shot 2021-10-03 at 22 30 49" src="https://user-images.githubusercontent.com/5885946/136304636-3649595c-f8f2-42a9-b7f7-2b939dc8cd5e.png">

(3)
<img width="964" alt="Screen Shot 2021-10-03 at 22 30 49" src="https://user-images.githubusercontent.com/5885946/136304783-e2841160-45fe-4955-a085-bdb225acfc0b.png">


My debugging showed that it takes a lots of time on QgsPointLocator::init, especially the clone of layer's render. Though the cached mechanism for snap indexing has performance issues either, that for another topic.

This fix will bybass the clone of render if not been used, such as no-snapping on any feature but with snapping enabled, or enabling snap on invisible feature.
