### PR TITLE
Add new authentication method that supports HTTP headers

### DIFF
--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(esritoken)
 add_subdirectory(identcert)
 add_subdirectory(pkipaths)
 add_subdirectory(pkipkcs12)
+add_subdirectory(apiheader)
 
 if (WITH_OAUTH2_PLUGIN)
   add_subdirectory(oauth2)

--- a/src/auth/apiheader/CMakeLists.txt
+++ b/src/auth/apiheader/CMakeLists.txt
@@ -1,0 +1,74 @@
+set(AUTH_APIHEADER_SRCS
+  core/qgsauthapiheadermethod.cpp
+)
+
+set(AUTH_APIHEADER_HDRS
+  core/qgsauthapiheadermethod.h
+)
+
+set(AUTH_APIHEADER_UIS_H "")
+
+if (WITH_GUI)
+  set(AUTH_APIHEADER_SRCS ${AUTH_APIHEADER_SRCS}
+    gui/qgsauthapiheaderedit.cpp
+  )
+  set(AUTH_APIHEADER_HDRS ${AUTH_APIHEADER_HDRS}
+    gui/qgsauthapiheaderedit.h
+  )
+  set(AUTH_APIHEADER_UIS gui/qgsauthapiheaderedit.ui)
+  if (WITH_QT6)
+    QT6_WRAP_UI(AUTH_APIHEADER_UIS_H ${AUTH_APIHEADER_UIS})
+  else()
+    QT5_WRAP_UI(AUTH_APIHEADER_UIS_H ${AUTH_APIHEADER_UIS})
+  endif()
+endif()
+
+
+# static library
+add_library(authmethod_apiheader_a STATIC ${AUTH_APIHEADER_SRCS} ${AUTH_APIHEADER_HDRS} ${AUTH_APIHEADER_UIS_H})
+
+target_include_directories(authmethod_apiheader_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/apiheader/core)
+
+# require c++17
+target_compile_features(authmethod_apiheader_a PRIVATE cxx_std_17)
+
+target_link_libraries(authmethod_apiheader_a qgis_core)
+
+if (WITH_GUI)
+  target_include_directories(authmethod_apiheader_a PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/auth/apiheader/gui
+    ${CMAKE_BINARY_DIR}/src/auth/apiheader
+  )
+  target_link_libraries (authmethod_apiheader_a qgis_gui)
+endif()
+
+target_compile_definitions(authmethod_apiheader_a PRIVATE "-DQT_NO_FOREACH")
+
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS authmethod_apiheader_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+else()
+  # dynamically loaded module
+  add_library(authmethod_apiheader MODULE ${AUTH_APIHEADER_SRCS} ${AUTH_APIHEADER_HDRS} ${AUTH_APIHEADER_UIS_H})
+
+  # require c++17
+  target_compile_features(authmethod_apiheader PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_apiheader qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_apiheader PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/apiheader/gui
+      ${CMAKE_BINARY_DIR}/src/auth/apiheader
+    )
+    target_link_libraries (authmethod_apiheader qgis_gui)
+    add_dependencies(authmethod_apiheader ui)
+  endif()
+
+  target_compile_definitions(authmethod_apiheader PRIVATE "-DQT_NO_FOREACH")
+
+  install (TARGETS authmethod_apiheader
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -19,6 +19,7 @@
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgsapplication.h"
+#include "qgsmessagelog.h"
 
 #ifdef HAVE_GUI
 #include "qgsauthapiheaderedit.h"
@@ -72,13 +73,28 @@ bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, con
     return false;
   }
 
-  const QString headerKey = mconfig.config( QStringLiteral( "headerKey" ) );
-  const QString headerValue = mconfig.config( QStringLiteral( "headerValue" ) );
-
-  if ( !headerKey.isEmpty() && !headerValue.isEmpty() )
+  QMapIterator<QString, QString> i( mconfig.configMap() );
+  while ( i.hasNext() )
   {
-    request.setRawHeader( QStringLiteral( "%1" ).arg( headerKey ).toLocal8Bit(),  QStringLiteral( "%1" ).arg( headerValue ).toLocal8Bit() );
+    i.next();
+
+    const QString headerKey = i.key();
+    const QString headerValue = i.value();
+
+    QgsDebugMsg( QStringLiteral( "HTTP Header: %1=%2" ).arg( headerKey ).arg( headerValue ) );
+
+    if ( !headerKey.isEmpty() )
+    {
+      request.setRawHeader( QStringLiteral( "%1" ).arg( headerKey ).toLocal8Bit(),
+                            QStringLiteral( "%1" ).arg( headerValue ).toLocal8Bit() );
+    }
+    else
+    {
+      const QString msg = "The header key was empty, we shouldn't have empty header keys at this point";
+      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+    }
   }
+
   return true;
 }
 

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -105,12 +105,8 @@ void QgsAuthApiHeaderMethod::clearCachedConfig( const QString &authcfg )
 
 void QgsAuthApiHeaderMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
-  if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
-  {
-    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
-  }
-
-  // NOTE: add updates as method version() increases due to config storage changes
+    Q_UNUSED( mconfig );
+    // NOTE: add updates as method version() increases due to config storage changes
 }
 
 QgsAuthMethodConfig QgsAuthApiHeaderMethod::getMethodConfig( const QString &authcfg, bool fullconfig )

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -66,14 +66,14 @@ bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, con
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  const QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
-  if ( !mconfig.isValid() )
+  const QgsAuthMethodConfig config = getMethodConfig( authcfg );
+  if ( !config.isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
     return false;
   }
 
-  QMapIterator<QString, QString> i( mconfig.configMap() );
+  QMapIterator<QString, QString> i( config.configMap() );
   while ( i.hasNext() )
   {
     i.next();
@@ -81,7 +81,7 @@ bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, con
     const QString headerKey = i.key();
     const QString headerValue = i.value();
 
-    QgsDebugMsg( QStringLiteral( "HTTP Header: %1=%2" ).arg( headerKey ).arg( headerValue ) );
+    QgsDebugMsgLevel( QStringLiteral( "HTTP Header: %1=%2" ).arg( headerKey ).arg( headerValue ), 2 );
 
     if ( !headerKey.isEmpty() )
     {
@@ -90,8 +90,7 @@ bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, con
     }
     else
     {
-      const QString msg = "The header key was empty, we shouldn't have empty header keys at this point";
-      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+      QgsDebugMsg( QStringLiteral( "The header key was empty, we shouldn't have empty header keys at this point" ) );
     }
   }
 
@@ -103,43 +102,43 @@ void QgsAuthApiHeaderMethod::clearCachedConfig( const QString &authcfg )
   removeMethodConfig( authcfg );
 }
 
-void QgsAuthApiHeaderMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
+void QgsAuthApiHeaderMethod::updateMethodConfig( QgsAuthMethodConfig &config )
 {
-    Q_UNUSED( mconfig );
-    // NOTE: add updates as method version() increases due to config storage changes
+  Q_UNUSED( config );
+  // NOTE: add updates as method version() increases due to config storage changes
 }
 
 QgsAuthMethodConfig QgsAuthApiHeaderMethod::getMethodConfig( const QString &authcfg, bool fullconfig )
 {
   const QMutexLocker locker( &mMutex );
-  QgsAuthMethodConfig mconfig;
+  QgsAuthMethodConfig config;
 
   // check if it is cached
   if ( sAuthConfigCache.contains( authcfg ) )
   {
-    mconfig = sAuthConfigCache.value( authcfg );
-    QgsDebugMsg( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ) );
-    return mconfig;
+    config = sAuthConfigCache.value( authcfg );
+    QgsDebugMsgLevel( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ), 2 );
+    return config;
   }
 
   // else build basic bundle
-  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, config, fullconfig ) )
   {
     QgsDebugMsg( QStringLiteral( "Retrieve config FAILED for authcfg: %1" ).arg( authcfg ) );
     return QgsAuthMethodConfig();
   }
 
   // cache bundle
-  putMethodConfig( authcfg, mconfig );
+  putMethodConfig( authcfg, config );
 
-  return mconfig;
+  return config;
 }
 
-void QgsAuthApiHeaderMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
+void QgsAuthApiHeaderMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &config )
 {
   const QMutexLocker locker( &mMutex );
-  QgsDebugMsg( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ) );
-  sAuthConfigCache.insert( authcfg, mconfig );
+  QgsDebugMsgLevel( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ), 2 );
+  sAuthConfigCache.insert( authcfg, config );
 }
 
 void QgsAuthApiHeaderMethod::removeMethodConfig( const QString &authcfg )
@@ -148,7 +147,7 @@ void QgsAuthApiHeaderMethod::removeMethodConfig( const QString &authcfg )
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );
-    QgsDebugMsg( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
 

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -2,9 +2,9 @@
     qgsauthapiheadermethod.cpp
     --------------------------
     begin                : October 2021
-    copyright            : (C) 2021 by Nyall Dawson
-    author               : Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2021 by Tom Cummins
+    author               : Tom Cummins
+    email                : tom cumminsc9 at googlemail dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -40,6 +40,9 @@ QgsAuthApiHeaderMethod::QgsAuthApiHeaderMethod()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest );
   setDataProviders( QStringList()
+                    << QStringLiteral( "ows" )
+                    << QStringLiteral( "wfs" )  // convert to lowercase
+                    << QStringLiteral( "wcs" )
                     << QStringLiteral( "wms" ) );
 }
 

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+    qgsauthapiheadermethod.cpp
+    --------------------------
+    begin                : October 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    author               : Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsauthapiheadermethod.h"
+
+#include "qgsauthmanager.h"
+#include "qgslogger.h"
+#include "qgsapplication.h"
+
+#ifdef HAVE_GUI
+#include "qgsauthapiheaderedit.h"
+#endif
+
+#include <QNetworkProxy>
+#include <QMutexLocker>
+#include <QUuid>
+
+const QString QgsAuthApiHeaderMethod::AUTH_METHOD_KEY = QStringLiteral( "APIHeader" );
+const QString QgsAuthApiHeaderMethod::AUTH_METHOD_DESCRIPTION = QStringLiteral( "API Header" );
+const QString QgsAuthApiHeaderMethod::AUTH_METHOD_DISPLAY_DESCRIPTION = tr( "API Header" );
+
+QMap<QString, QgsAuthMethodConfig> QgsAuthApiHeaderMethod::sAuthConfigCache = QMap<QString, QgsAuthMethodConfig>();
+
+
+QgsAuthApiHeaderMethod::QgsAuthApiHeaderMethod()
+{
+  setVersion( 2 );
+  setExpansions( QgsAuthMethod::NetworkRequest );
+  setDataProviders( QStringList()
+                    << QStringLiteral( "wms" ) );
+}
+
+QString QgsAuthApiHeaderMethod::key() const
+{
+  return AUTH_METHOD_KEY;
+}
+
+QString QgsAuthApiHeaderMethod::description() const
+{
+  return AUTH_METHOD_DESCRIPTION;
+}
+
+QString QgsAuthApiHeaderMethod::displayDescription() const
+{
+  return AUTH_METHOD_DISPLAY_DESCRIPTION;
+}
+
+bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
+    const QString &dataprovider )
+{
+  Q_UNUSED( dataprovider )
+  const QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
+  if ( !mconfig.isValid() )
+  {
+    QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
+    return false;
+  }
+
+  const QString headerKey = mconfig.config( QStringLiteral( "headerKey" ) );
+  const QString headerValue = mconfig.config( QStringLiteral( "headerValue" ) );
+
+  if ( !headerKey.isEmpty() && !headerValue.isEmpty() )
+  {
+    request.setRawHeader( QStringLiteral( "%1" ).arg( headerKey ).toLocal8Bit(),  QStringLiteral( "%1" ).arg( headerValue ).toLocal8Bit() );
+  }
+  return true;
+}
+
+void QgsAuthApiHeaderMethod::clearCachedConfig( const QString &authcfg )
+{
+  removeMethodConfig( authcfg );
+}
+
+void QgsAuthApiHeaderMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
+{
+  if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
+  }
+
+  // NOTE: add updates as method version() increases due to config storage changes
+}
+
+QgsAuthMethodConfig QgsAuthApiHeaderMethod::getMethodConfig( const QString &authcfg, bool fullconfig )
+{
+  const QMutexLocker locker( &mMutex );
+  QgsAuthMethodConfig mconfig;
+
+  // check if it is cached
+  if ( sAuthConfigCache.contains( authcfg ) )
+  {
+    mconfig = sAuthConfigCache.value( authcfg );
+    QgsDebugMsg( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ) );
+    return mconfig;
+  }
+
+  // else build basic bundle
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Retrieve config FAILED for authcfg: %1" ).arg( authcfg ) );
+    return QgsAuthMethodConfig();
+  }
+
+  // cache bundle
+  putMethodConfig( authcfg, mconfig );
+
+  return mconfig;
+}
+
+void QgsAuthApiHeaderMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
+{
+  const QMutexLocker locker( &mMutex );
+  QgsDebugMsg( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ) );
+  sAuthConfigCache.insert( authcfg, mconfig );
+}
+
+void QgsAuthApiHeaderMethod::removeMethodConfig( const QString &authcfg )
+{
+  const QMutexLocker locker( &mMutex );
+  if ( sAuthConfigCache.contains( authcfg ) )
+  {
+    sAuthConfigCache.remove( authcfg );
+    QgsDebugMsg( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ) );
+  }
+}
+
+#ifdef HAVE_GUI
+QWidget *QgsAuthApiHeaderMethod::editWidget( QWidget *parent ) const
+{
+  return new QgsAuthApiHeaderEdit( parent );
+}
+#endif
+
+//////////////////////////////////////////////
+// Plugin externals
+//////////////////////////////////////////////
+
+
+#ifndef HAVE_STATIC_PROVIDERS
+QGISEXTERN QgsAuthMethodMetadata *authMethodMetadataFactory()
+{
+  return new QgsAuthApiHeaderMethodMetadata();
+}
+#endif

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.h
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgsauthapiheadermethod.h
+    ---------------------
+    begin                : October 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAUTHAPIHEADERMETHOD_H
+#define QGSAUTHAPIHEADERMETHOD_H
+
+#include <QObject>
+#include <QMutex>
+
+#include "qgsauthconfig.h"
+#include "qgsauthmethod.h"
+#include "qgsauthmethodmetadata.h"
+
+
+class QgsAuthApiHeaderMethod : public QgsAuthMethod
+{
+    Q_OBJECT
+
+  public:
+
+    static const QString AUTH_METHOD_KEY;
+    static const QString AUTH_METHOD_DESCRIPTION;
+    static const QString AUTH_METHOD_DISPLAY_DESCRIPTION;
+
+    explicit QgsAuthApiHeaderMethod();
+
+    // QgsAuthMethod interface
+    QString key() const override;
+
+    QString description() const override;
+
+    QString displayDescription() const override;
+
+    bool updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
+                               const QString &dataprovider = QString() ) override;
+
+    void clearCachedConfig( const QString &authcfg ) override;
+    void updateMethodConfig( QgsAuthMethodConfig &mconfig ) override;
+
+#ifdef HAVE_GUI
+    QWidget *editWidget( QWidget *parent )const override;
+#endif
+
+  private:
+    QgsAuthMethodConfig getMethodConfig( const QString &authcfg, bool fullconfig = true );
+
+    void putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig );
+
+    void removeMethodConfig( const QString &authcfg );
+
+    static QMap<QString, QgsAuthMethodConfig> sAuthConfigCache;
+
+};
+
+
+class QgsAuthApiHeaderMethodMetadata : public QgsAuthMethodMetadata
+{
+  public:
+    QgsAuthApiHeaderMethodMetadata()
+      : QgsAuthMethodMetadata( QgsAuthApiHeaderMethod::AUTH_METHOD_KEY, QgsAuthApiHeaderMethod::AUTH_METHOD_DESCRIPTION )
+    {}
+    QgsAuthApiHeaderMethod *createAuthMethod() const override {return new QgsAuthApiHeaderMethod;}
+    //QStringList supportedDataProviders() const override;
+};
+
+#endif // QGSAUTHAPIHEADERMETHOD_H

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.h
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.h
@@ -48,7 +48,7 @@ class QgsAuthApiHeaderMethod : public QgsAuthMethod
                                const QString &dataprovider = QString() ) override;
 
     void clearCachedConfig( const QString &authcfg ) override;
-    void updateMethodConfig( QgsAuthMethodConfig &mconfig ) override;
+    void updateMethodConfig( QgsAuthMethodConfig &config ) override;
 
 #ifdef HAVE_GUI
     QWidget *editWidget( QWidget *parent )const override;
@@ -57,7 +57,7 @@ class QgsAuthApiHeaderMethod : public QgsAuthMethod
   private:
     QgsAuthMethodConfig getMethodConfig( const QString &authcfg, bool fullconfig = true );
 
-    void putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig );
+    void putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &config );
 
     void removeMethodConfig( const QString &authcfg );
 

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.h
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.h
@@ -1,9 +1,10 @@
 /***************************************************************************
     qgsauthapiheadermethod.h
-    ---------------------
+    ------------------------
     begin                : October 2021
-    copyright            : (C) 2021 by Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2021 by Tom Cummins
+    author               : Tom Cummins
+    email                : tom cumminsc9 at googlemail dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
@@ -17,17 +17,24 @@
 #include "qgsauthapiheaderedit.h"
 #include "ui_qgsauthapiheaderedit.h"
 
+#include "qgsapplication.h"
 
 QgsAuthApiHeaderEdit::QgsAuthApiHeaderEdit( QWidget *parent )
   : QgsAuthMethodEdit( parent )
 {
   setupUi( this );
-  connect( headerKeyEdit, &QLineEdit::textChanged, this, &QgsAuthApiHeaderEdit::textChanged );
+
+  connect( tblwdgHeaderPairs, &QTableWidget::itemSelectionChanged, this, &QgsAuthApiHeaderEdit::headerTableSelectionChanged );
+  connect( tblwdgHeaderPairs, &QTableWidget::cellChanged, this, &QgsAuthApiHeaderEdit::headerTableCellChanged );
+
+  connect( btnAddHeaderPair, &QToolButton::clicked, this, &QgsAuthApiHeaderEdit::addHeaderPair );
+  connect( btnRemoveHeaderPair, &QToolButton::clicked, this, &QgsAuthApiHeaderEdit::removeHeaderPair );
 }
+
 
 bool QgsAuthApiHeaderEdit::validateConfig()
 {
-  const bool curvalid = !headerKeyEdit->text().isEmpty();
+  const bool curvalid = !emptyHeadersKeysPresent() && tblwdgHeaderPairs->rowCount() != 0;
   if ( mValid != curvalid )
   {
     mValid = curvalid;
@@ -36,39 +43,144 @@ bool QgsAuthApiHeaderEdit::validateConfig()
   return curvalid;
 }
 
+
 QgsStringMap QgsAuthApiHeaderEdit::configMap() const
 {
-  QgsStringMap config;
-  config.insert( QStringLiteral( "headerKey" ), headerKeyEdit->text() );
-  config.insert( QStringLiteral( "headerValue" ), headerValueEdit->toPlainText() );
-
-  return config;
+  return headerPairs();
 }
+
 
 void QgsAuthApiHeaderEdit::loadConfig( const QgsStringMap &configmap )
 {
   clearConfig();
 
   mConfigMap = configmap;
-  headerKeyEdit->setText( configmap.value( QStringLiteral( "headerKey" ) ) );
-  headerValueEdit->setPlainText( configmap.value( QStringLiteral( "headerValue" ) ) );
+
+  populateHeaderPairs( configmap );
 
   validateConfig();
 }
+
 
 void QgsAuthApiHeaderEdit::resetConfig()
 {
   loadConfig( mConfigMap );
 }
 
+
 void QgsAuthApiHeaderEdit::clearConfig()
 {
-  headerKeyEdit->clear();
-  headerValueEdit->clear();
+  clearHeaderPairs();
 }
 
-void QgsAuthApiHeaderEdit::textChanged( const QString &txt )
+
+void QgsAuthApiHeaderEdit::addHeaderPair()
 {
-  Q_UNUSED( txt )
+  addHeaderPairRow( QString(), QString() );
+  tblwdgHeaderPairs->setFocus();
+  tblwdgHeaderPairs->setCurrentCell( tblwdgHeaderPairs->rowCount() - 1, 0 );
+  tblwdgHeaderPairs->edit( tblwdgHeaderPairs->currentIndex() );
+}
+
+
+void QgsAuthApiHeaderEdit::removeHeaderPair()
+{
+  tblwdgHeaderPairs->removeRow( tblwdgHeaderPairs->currentRow() );
   validateConfig();
+}
+
+
+void QgsAuthApiHeaderEdit::clearHeaderPairs()
+{
+  for ( int i = tblwdgHeaderPairs->rowCount(); i > 0 ; --i )
+  {
+    tblwdgHeaderPairs->removeRow( i - 1 );
+  }
+  validateConfig();
+}
+
+
+void QgsAuthApiHeaderEdit::populateHeaderPairs( const QgsStringMap &headerpairs, bool append )
+{
+  if ( !append )
+  {
+    clearHeaderPairs();
+  }
+
+  QgsStringMap::const_iterator i = headerpairs.constBegin();
+  while ( i != headerpairs.constEnd() )
+  {
+    addHeaderPairRow( i.key(), i.value() );
+    ++i;
+  }
+}
+
+
+void QgsAuthApiHeaderEdit::headerTableSelectionChanged()
+{
+  const bool hasPair = tblwdgHeaderPairs->selectedItems().count() > 0;
+  btnRemoveHeaderPair->setEnabled( hasPair );
+  validateConfig();
+}
+
+
+void QgsAuthApiHeaderEdit::headerTableCellChanged( const int row, const int column )
+{
+  QgsDebugMsg( QStringLiteral( "Cell updated: row %1 column %2" ).arg( row ).arg( column ) );
+  validateConfig();
+}
+
+
+bool QgsAuthApiHeaderEdit::emptyHeadersKeysPresent()
+{
+  const int rowCount = tblwdgHeaderPairs->rowCount();
+  QgsDebugMsg( QStringLiteral( "Validate header table contains valid header keys for %1 rows" ).arg( rowCount ) );
+
+  for ( int i = 0; i < rowCount; ++i )
+  {
+    if ( tblwdgHeaderPairs->item( i, 0 )->text().isEmpty() )
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+void QgsAuthApiHeaderEdit::addHeaderPairRow( const QString &key, const QString &val )
+{
+  const int rowCnt = tblwdgHeaderPairs->rowCount();
+  tblwdgHeaderPairs->insertRow( rowCnt );
+
+  const Qt::ItemFlags itmFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
+                                 | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
+
+  QTableWidgetItem *keyItm = new QTableWidgetItem( key );
+  keyItm->setFlags( itmFlags );
+  tblwdgHeaderPairs->setItem( rowCnt, 0, keyItm );
+
+  QTableWidgetItem *valItm = new QTableWidgetItem( val );
+  keyItm->setFlags( itmFlags );
+  tblwdgHeaderPairs->setItem( rowCnt, 1, valItm );
+
+  validateConfig();
+}
+
+
+QgsStringMap QgsAuthApiHeaderEdit::headerPairs() const
+{
+  QgsStringMap headerPairs;
+  for ( int i = 0; i < tblwdgHeaderPairs->rowCount(); ++i )
+  {
+    if ( tblwdgHeaderPairs->item( i, 0 )->text().isEmpty() )
+    {
+      continue;
+    }
+
+    const QString headerKey = tblwdgHeaderPairs->item( i, 0 )->text();
+    const QString headerValue = tblwdgHeaderPairs->item( i, 1 )->text();
+    headerPairs.insert( headerKey, headerValue );
+  }
+  return headerPairs;
 }

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
@@ -136,7 +136,7 @@ void QgsAuthApiHeaderEdit::headerTableCellChanged( const int row, const int colu
 bool QgsAuthApiHeaderEdit::emptyHeadersKeysPresent()
 {
   const int rowCount = tblwdgHeaderPairs->rowCount();
-  QgsDebugMsg( QStringLiteral( "Validate header table contains valid header keys for %1 rows" ).arg( rowCount ) );
+  QgsDebugMsgLevel( QStringLiteral( "Validate header table contains valid header keys for %1 rows" ).arg( rowCount ), 2 );
 
   for ( int i = 0; i < rowCount; ++i )
   {
@@ -152,19 +152,19 @@ bool QgsAuthApiHeaderEdit::emptyHeadersKeysPresent()
 
 void QgsAuthApiHeaderEdit::addHeaderPairRow( const QString &key, const QString &val )
 {
-  const int rowCnt = tblwdgHeaderPairs->rowCount();
-  tblwdgHeaderPairs->insertRow( rowCnt );
+  const int rowCount = tblwdgHeaderPairs->rowCount();
+  tblwdgHeaderPairs->insertRow( rowCount );
 
-  const Qt::ItemFlags itmFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
-                                 | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
+  const Qt::ItemFlags itemFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable
+                                  | Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
 
-  QTableWidgetItem *keyItm = new QTableWidgetItem( key );
-  keyItm->setFlags( itmFlags );
-  tblwdgHeaderPairs->setItem( rowCnt, 0, keyItm );
+  QTableWidgetItem *keyItem = new QTableWidgetItem( key );
+  keyItem->setFlags( itemFlags );
+  tblwdgHeaderPairs->setItem( rowCount, 0, keyItem );
 
-  QTableWidgetItem *valItm = new QTableWidgetItem( val );
-  keyItm->setFlags( itmFlags );
-  tblwdgHeaderPairs->setItem( rowCnt, 1, valItm );
+  QTableWidgetItem *valueItem = new QTableWidgetItem( val );
+  keyItem->setFlags( itemFlags );
+  tblwdgHeaderPairs->setItem( rowCount, 1, valueItem );
 
   validateConfig();
 }

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+    qgsauthapiheaderedit.cpp
+    ------------------------
+    begin                : October 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    author               : Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsauthapiheaderedit.h"
+#include "ui_qgsauthapiheaderedit.h"
+
+
+QgsAuthApiHeaderEdit::QgsAuthApiHeaderEdit( QWidget *parent )
+  : QgsAuthMethodEdit( parent )
+{
+  setupUi( this );
+  connect( headerKeyEdit, &QLineEdit::textChanged, this, &QgsAuthApiHeaderEdit::textChanged );
+}
+
+bool QgsAuthApiHeaderEdit::validateConfig()
+{
+  const bool curvalid = !headerKeyEdit->text().isEmpty();
+  if ( mValid != curvalid )
+  {
+    mValid = curvalid;
+    emit validityChanged( curvalid );
+  }
+  return curvalid;
+}
+
+QgsStringMap QgsAuthApiHeaderEdit::configMap() const
+{
+  QgsStringMap config;
+  config.insert( QStringLiteral( "headerKey" ), headerKeyEdit->text() );
+  config.insert( QStringLiteral( "headerValue" ), headerValueEdit->toPlainText() );
+
+  return config;
+}
+
+void QgsAuthApiHeaderEdit::loadConfig( const QgsStringMap &configmap )
+{
+  clearConfig();
+
+  mConfigMap = configmap;
+  headerKeyEdit->setText( configmap.value( QStringLiteral( "headerKey" ) ) );
+  headerValueEdit->setPlainText( configmap.value( QStringLiteral( "headerValue" ) ) );
+
+  validateConfig();
+}
+
+void QgsAuthApiHeaderEdit::resetConfig()
+{
+  loadConfig( mConfigMap );
+}
+
+void QgsAuthApiHeaderEdit::clearConfig()
+{
+  headerKeyEdit->clear();
+  headerValueEdit->clear();
+}
+
+void QgsAuthApiHeaderEdit::textChanged( const QString &txt )
+{
+  Q_UNUSED( txt )
+  validateConfig();
+}

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
@@ -2,9 +2,9 @@
     qgsauthapiheaderedit.cpp
     ------------------------
     begin                : October 2021
-    copyright            : (C) 2021 by Nyall Dawson
-    author               : Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2021 by Tom Cummins
+    author               : Tom Cummins
+    email                : tom cumminsc9 at googlemail dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.cpp
@@ -126,7 +126,9 @@ void QgsAuthApiHeaderEdit::headerTableSelectionChanged()
 
 void QgsAuthApiHeaderEdit::headerTableCellChanged( const int row, const int column )
 {
-  QgsDebugMsg( QStringLiteral( "Cell updated: row %1 column %2" ).arg( row ).arg( column ) );
+  Q_UNUSED( row );
+  Q_UNUSED( column );
+
   validateConfig();
 }
 

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.h
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsauthapiheaderedit.h
+    ---------------------
+    begin                : October 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    author               : Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAUTHAPIHEADEREDIT_H
+#define QGSAUTHAPIHEADEREDIT_H
+
+#include <QWidget>
+#include "qgsauthmethodedit.h"
+#include "ui_qgsauthapiheaderedit.h"
+
+#include "qgsauthconfig.h"
+
+
+class QgsAuthApiHeaderEdit : public QgsAuthMethodEdit, private Ui::QgsAuthApiHeaderEdit
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsAuthApiHeaderEdit( QWidget *parent = nullptr );
+
+    bool validateConfig() override;
+
+    QgsStringMap configMap() const override;
+
+  public slots:
+    void loadConfig( const QgsStringMap &configmap ) override;
+
+    void resetConfig() override;
+
+    void clearConfig() override;
+
+  private slots:
+    void textChanged( const QString &txt );
+
+  private:
+    QgsStringMap mConfigMap;
+    bool mValid = false;
+};
+
+#endif // QGSAUTHAPIHEADEREDIT_H

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.h
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.h
@@ -1,10 +1,10 @@
 /***************************************************************************
     qgsauthapiheaderedit.h
-    ---------------------
+    ----------------------
     begin                : October 2021
-    copyright            : (C) 2021 by Nyall Dawson
-    author               : Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2021 by Tom Cummins
+    author               : Tom Cummins
+    email                : tom cumminsc9 at googlemail dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.h
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.h
@@ -43,11 +43,27 @@ class QgsAuthApiHeaderEdit : public QgsAuthMethodEdit, private Ui::QgsAuthApiHea
     void clearConfig() override;
 
   private slots:
-    void textChanged( const QString &txt );
+    void addHeaderPair();
+
+    void removeHeaderPair();
+
+    void clearHeaderPairs();
+
+    void populateHeaderPairs( const QgsStringMap &headerpairs, bool append = false );
+
+    void headerTableSelectionChanged();
+
+    void headerTableCellChanged( const int row, const int column );
 
   private:
     QgsStringMap mConfigMap;
     bool mValid = false;
+
+    bool emptyHeadersKeysPresent();
+
+    void addHeaderPairRow( const QString &key, const QString &val );
+
+    QgsStringMap headerPairs() const;
 };
 
 #endif // QGSAUTHAPIHEADEREDIT_H

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>538</width>
-        <height>498</height>
+        <width>532</width>
+        <height>492</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -139,15 +139,16 @@
                <bold>true</bold>
               </font>
              </property>
-             <property name="text">
-              <string notr="true">+</string>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QToolButton" name="btnRemoveHeaderPair">
              <property name="enabled">
-              <bool>true</bool>
+              <bool>false</bool>
              </property>
              <property name="minimumSize">
               <size>
@@ -161,8 +162,9 @@
                <bold>true</bold>
               </font>
              </property>
-             <property name="text">
-              <string notr="true">–</string>
+             <property name="icon">
+              <iconset>
+               <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
              </property>
             </widget>
            </item>

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAuthApiHeaderEdit</class>
+ <widget class="QWidget" name="QgsAuthApiHeaderEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>446</width>
+    <height>284</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="2" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="headerKeyEdit">
+       <property name="placeholderText">
+        <string>Required</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblHeaderKey">
+       <property name="text">
+        <string>Header key</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblHeaderValue">
+       <property name="text">
+        <string>Header value</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="headerValueEdit"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
@@ -6,50 +6,186 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>284</height>
+    <width>550</width>
+    <height>510</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>6</number>
-   </property>
-   <property name="topMargin">
-    <number>6</number>
-   </property>
-   <property name="rightMargin">
-    <number>6</number>
-   </property>
-   <property name="bottomMargin">
-    <number>6</number>
-   </property>
-   <item row="2" column="0">
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="headerKeyEdit">
-       <property name="placeholderText">
-        <string>Required</string>
+   <item row="0" column="0">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>538</width>
+        <height>498</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="lblHeaderKey">
-       <property name="text">
-        <string>Header key</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblHeaderValue">
-       <property name="text">
-        <string>Header value</string>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QPlainTextEdit" name="headerValueEdit"/>
-     </item>
-    </layout>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item>
+          <widget class="QTableWidget" name="tblwdgHeaderPairs">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::AllEditTriggers</set>
+           </property>
+           <property name="tabKeyNavigation">
+            <bool>true</bool>
+           </property>
+           <property name="dragEnabled">
+            <bool>true</bool>
+           </property>
+           <property name="dragDropOverwriteMode">
+            <bool>true</bool>
+           </property>
+           <property name="dragDropMode">
+            <enum>QAbstractItemView::DragOnly</enum>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SingleSelection</enum>
+           </property>
+           <property name="sortingEnabled">
+            <bool>true</bool>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+           <property name="cornerButtonEnabled">
+            <bool>true</bool>
+           </property>
+           <attribute name="horizontalHeaderMinimumSectionSize">
+            <number>120</number>
+           </attribute>
+           <attribute name="horizontalHeaderDefaultSectionSize">
+            <number>160</number>
+           </attribute>
+           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+            <bool>true</bool>
+           </attribute>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
+           </attribute>
+           <attribute name="verticalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>Header key (required)</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Header value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+           <property name="spacing">
+            <number>3</number>
+           </property>
+           <item>
+            <widget class="QToolButton" name="btnAddHeaderPair">
+             <property name="minimumSize">
+              <size>
+               <width>24</width>
+               <height>24</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string notr="true">+</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="btnRemoveHeaderPair">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>24</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string notr="true">–</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Description
This intends to add a new authentication method that supports a custom HTTP header.

**For example** 
An WMS supplies an API key that is to be used in a HTTP header with the header key being `X-API-KEY` and the header value being a string, without this authentication method we are unable to authenticate against the WMS endpoint.

The first screenshot shows a list of all authentication method, which includes the new APIHeader authentication method plugin as a possible authentication method for WMS only currently.
![0](https://user-images.githubusercontent.com/10427953/136379545-1e09269e-3d59-4753-8170-a54923cc3d92.png)

Adding a new authentication method for the API Header is the same flow by clicking on the + Icon and selecting "API Header" from the authentication options. Once selected you can enter values into the two present input fields, with the Header key being a required field.

![1](https://user-images.githubusercontent.com/10427953/136379546-994f7843-e6eb-48c9-9dab-07bb0599c046.png)
(the header value string is a random string and not a real token)

As it is based on the authentication method plugins, the flow remains the same, with clearing the forms, deleting the authentication method configuration and selecting it on the required WMS authentication connection.

![2](https://user-images.githubusercontent.com/10427953/136379550-68698cad-cc26-49f8-9280-55df88c67f47.png)

Feedback is welcome, and if any further details are required just ask away! :)
