### PR TITLE
fix mesh editing context menu

### DIFF
--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -817,7 +817,7 @@ void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
           // With the selection handler, if we can know if the selecting polygon change, that means the first case appears,
           // we can't know if a feature is found or not (if the user do not choose a feature, nothing happen like if no feature was found).
           // The workaround is to check if a feature exist under the mouse before sending the event to the selection handler.
-          // This is not ideal because that leads to a double search but no better idea for now to allow the editing context menu whith selecting by polygon
+          // This is not ideal because that leads to a double search but no better idea for now to allow the editing context menu with selecting by polygon
 
           bool hasSelectableFeature = !searchFeatureOnMap( e, mCanvas, QList<QgsWkbTypes::GeometryType>() << QgsWkbTypes::PolygonGeometry ).isEmpty();
 

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -308,6 +308,7 @@ QgsMapToolEditMeshFrame::QgsMapToolEditMeshFrame( QgsMapCanvas *canvas )
 
   connect( mSelectionHandler.get(), &QgsMapToolSelectionHandler::geometryChanged, this, [this]( Qt::KeyboardModifiers modifiers )
   {
+    mIsSelectingPolygonInProgress = false;
     selectByGeometry( mSelectionHandler->selectedGeometry(), modifiers );
   } );
 
@@ -622,6 +623,7 @@ bool QgsMapToolEditMeshFrame::populateContextMenuWithEvent( QMenu *menu, QgsMapM
   switch ( mCurrentState )
   {
     case Digitizing:
+    case SelectingByPolygon:
     {
       QList<QAction * >  newActions;
       QList<QAction * >  lastActions;
@@ -634,7 +636,8 @@ bool QgsMapToolEditMeshFrame::populateContextMenuWithEvent( QMenu *menu, QgsMapM
         newActions << mActionRemoveVerticesFillingHole << mActionRemoveVerticesWithoutFillingHole;
       }
 
-      if ( !mSelectedFaces.isEmpty() || mCurrentFaceIndex != -1 )
+      if ( !mSelectedFaces.isEmpty() ||
+           ( mCurrentFaceIndex != -1 && mCurrentState == Digitizing ) )
       {
         newActions << mActionRemoveFaces;
         lastActions << mActionFacesRefinement;
@@ -670,7 +673,6 @@ bool QgsMapToolEditMeshFrame::populateContextMenuWithEvent( QMenu *menu, QgsMapM
     case AddingNewFace:
     case Selecting:
     case MovingSelection:
-    case SelectingByPolygon:
     case ForceByLines:
       return false;
   }
@@ -683,7 +685,7 @@ QgsMapTool::Flags QgsMapToolEditMeshFrame::flags() const
   switch ( mCurrentState )
   {
     case Digitizing:
-      if ( !mSelectedVertices.isEmpty() )
+      if ( !mCadDockWidget->cadEnabled() || !mSelectedVertices.isEmpty() || mCurrentFaceIndex != -1 )
         return QgsMapTool::Flags() | QgsMapTool::ShowContextMenu;
       FALLTHROUGH
     case AddingNewFace:
@@ -696,6 +698,87 @@ QgsMapTool::Flags QgsMapToolEditMeshFrame::flags() const
   }
 
   return QgsMapTool::Flags();
+}
+
+static QList<QgsMapToolIdentify::IdentifyResult> searchFeatureOnMap( QgsMapMouseEvent *e, QgsMapCanvas *canvas, const QList<QgsWkbTypes::GeometryType> &geomType )
+{
+  QList<QgsMapToolIdentify::IdentifyResult> results;
+  const QMap< QString, QString > derivedAttributes;
+
+  QgsPointXY mapPoint = e->mapPoint();
+  double x = mapPoint.x(), y = mapPoint.y();
+  const double sr = QgsMapTool::searchRadiusMU( canvas );
+
+  const QList<QgsMapLayer *> layers = canvas->layers();
+  for ( QgsMapLayer *layer : layers )
+  {
+    if ( layer->type() == QgsMapLayerType::VectorLayer )
+    {
+      QgsVectorLayer *vectorLayer = static_cast<QgsVectorLayer *>( layer );
+
+      bool typeIsSelectable = false;
+      for ( const QgsWkbTypes::GeometryType &type : geomType )
+        if ( vectorLayer->geometryType() == type )
+        {
+          typeIsSelectable = true;
+          break;
+        }
+      if ( typeIsSelectable )
+      {
+        QgsRectangle rect( x - sr, y - sr, x + sr, y + sr );
+        QgsCoordinateTransform transform = canvas->mapSettings().layerTransform( vectorLayer );
+
+        try
+        {
+          rect = transform.transformBoundingBox( rect, Qgis::TransformDirection::Reverse );
+        }
+        catch ( QgsCsException &exception )
+        {
+          QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+        }
+
+        QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest()
+                                 .setFilterRect( rect )
+                                 .setFlags( QgsFeatureRequest::ExactIntersect ) );
+        QgsFeature f;
+        while ( fit.nextFeature( f ) )
+        {
+          results << QgsMapToolIdentify::IdentifyResult( vectorLayer, f, derivedAttributes );
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+void QgsMapToolEditMeshFrame::forceByLineBySelectedFeature( QgsMapMouseEvent *e )
+{
+  const QList<QgsMapToolIdentify::IdentifyResult> &results =
+    searchFeatureOnMap( e, mCanvas, QList<QgsWkbTypes::GeometryType>() << QgsWkbTypes::PolygonGeometry << QgsWkbTypes::LineGeometry );
+
+  QgsIdentifyMenu *menu = new QgsIdentifyMenu( mCanvas );
+  menu->setExecWithSingleResult( true );
+  const QPoint globalPos = mCanvas->mapToGlobal( QPoint( e->pos().x() + 5, e->pos().y() + 5 ) );
+  const QList<QgsMapToolIdentify::IdentifyResult> selectedFeatures = menu->exec( results, globalPos );
+  menu->deleteLater();
+
+  if ( !selectedFeatures.empty() && selectedFeatures[0].mFeature.hasGeometry() )
+  {
+    QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( selectedFeatures.at( 0 ).mLayer );
+    QgsGeometry geom = selectedFeatures[0].mFeature.geometry();
+    try
+    {
+      geom.transform( transform );
+    }
+    catch ( QgsCsException &exception )
+    {
+      QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
+    }
+    forceByLine( geom );
+  }
+
+  return;
 }
 
 void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
@@ -723,7 +806,37 @@ void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
       break;
     case SelectingByPolygon:
       if ( mSelectionHandler )
-        mSelectionHandler->canvasPressEvent( e );
+      {
+        if ( e->button() == Qt::RightButton )
+        {
+          // here, quite tricky because 3 possibilities:
+          // - a polygon has started to be digitized for selection -> right click validate the selection
+          // - right click on an existing vector layer feature -> a menu is executed to choose a feature
+          // - other case -> context menu of mesh editing to apply an edit on selected element
+          // The last case is launched only if the other cases do not appears
+          // With the selection handler, if we can know if the selecting polygon change, that means the first case appears,
+          // we can't know if a feature is found or not (if the user do not choose a feature, nothing happen like if no feature was found).
+          // The workaround is to check if a feature exist under the mouse before sending the event to the selection handler.
+          // This is not ideal because that leads to a double search but no better idea for now to allow the editing context menu whith selecting by polygon
+
+          bool hasSelectableFeature = !searchFeatureOnMap( e, mCanvas, QList<QgsWkbTypes::GeometryType>() << QgsWkbTypes::PolygonGeometry ).isEmpty();
+
+          if ( hasSelectableFeature || mIsSelectingPolygonInProgress )
+            mSelectionHandler->canvasPressEvent( e );
+          else
+          {
+            QMenu menu;
+            populateContextMenuWithEvent( &menu, e );
+            menu.exec( e->globalPos() );
+          }
+        }
+        else
+        {
+          mIsSelectingPolygonInProgress = true;
+          mSelectionHandler->canvasPressEvent( e );
+        }
+      }
+
       break;
   }
 
@@ -1177,6 +1290,11 @@ void QgsMapToolEditMeshFrame::keyPressEvent( QKeyEvent *e )
       break;
     case Selecting:
     case SelectingByPolygon:
+      if ( e->key() == Qt::Key_Escape )
+      {
+        clearSelection();
+        consumned = true;
+      }
       break;
   }
 
@@ -2191,72 +2309,6 @@ void QgsMapToolEditMeshFrame::forceByLineReleaseEvent( QgsMapMouseEvent *e )
     mForceByLineRubberBand->reset( QgsWkbTypes::LineGeometry );
     mForcingLineZValue.clear();
   }
-}
-
-void QgsMapToolEditMeshFrame::forceByLineBySelectedFeature( QgsMapMouseEvent *e )
-{
-  QList<QgsMapToolIdentify::IdentifyResult> results;
-  const QMap< QString, QString > derivedAttributes;
-
-  QgsPointXY mapPoint = e->mapPoint();
-  double x = mapPoint.x(), y = mapPoint.y();
-  const double sr = QgsMapTool::searchRadiusMU( mCanvas );
-
-  const QList<QgsMapLayer *> layers = mCanvas->layers();
-  for ( QgsMapLayer *layer : layers )
-  {
-    if ( layer->type() == QgsMapLayerType::VectorLayer )
-    {
-      QgsVectorLayer *vectorLayer = static_cast<QgsVectorLayer *>( layer );
-      if ( vectorLayer->geometryType() == QgsWkbTypes::PolygonGeometry ||
-           vectorLayer->geometryType() == QgsWkbTypes::LineGeometry )
-      {
-        QgsRectangle rect( x - sr, y - sr, x + sr, y + sr );
-        QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( vectorLayer );
-
-        try
-        {
-          rect = transform.transformBoundingBox( rect, Qgis::TransformDirection::Reverse );
-        }
-        catch ( QgsCsException &exception )
-        {
-          QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
-        }
-
-        QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest()
-                                 .setFilterRect( rect )
-                                 .setFlags( QgsFeatureRequest::ExactIntersect ) );
-        QgsFeature f;
-        while ( fit.nextFeature( f ) )
-        {
-          results << QgsMapToolIdentify::IdentifyResult( vectorLayer, f, derivedAttributes );
-        }
-      }
-    }
-  }
-
-  QgsIdentifyMenu *menu = new QgsIdentifyMenu( mCanvas );
-  menu->setExecWithSingleResult( true );
-  const QPoint globalPos = mCanvas->mapToGlobal( QPoint( e->pos().x() + 5, e->pos().y() + 5 ) );
-  const QList<QgsMapToolIdentify::IdentifyResult> selectedFeatures = menu->exec( results, globalPos );
-  menu->deleteLater();
-
-  if ( !selectedFeatures.empty() && selectedFeatures[0].mFeature.hasGeometry() )
-  {
-    QgsCoordinateTransform transform = mCanvas->mapSettings().layerTransform( selectedFeatures.at( 0 ).mLayer );
-    QgsGeometry geom = selectedFeatures[0].mFeature.geometry();
-    try
-    {
-      geom.transform( transform );
-    }
-    catch ( QgsCsException &exception )
-    {
-      QgsDebugMsg( QStringLiteral( "Could not transform geometry to layer CRS" ) );
-    }
-    forceByLine( geom );
-  }
-
-  return;
 }
 
 void QgsMapToolEditMeshFrame::forceByLine( const QgsGeometry &lineGeometry )

--- a/src/app/mesh/qgsmaptooleditmeshframe.h
+++ b/src/app/mesh/qgsmaptooleditmeshframe.h
@@ -245,7 +245,6 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
     void forceByLineBySelectedFeature( QgsMapMouseEvent *e );
     void forceByLine( const QgsGeometry &lineGeometry );
 
-
     // members
     struct SelectedVertexData
     {
@@ -339,6 +338,7 @@ class APP_EXPORT QgsMapToolEditMeshFrame : public QgsMapToolAdvancedDigitizing
 
     QAction *mActionSelectByPolygon = nullptr;
     std::unique_ptr<QgsMapToolSelectionHandler> mSelectionHandler;
+    bool mIsSelectingPolygonInProgress = false;
 
     QAction *mActionTransformCoordinates = nullptr;
 


### PR DESCRIPTION
This PR fixes two point related to mesh editing context menu:
- when nothing is selected, the context menu for the current face was broken. Current face is the face under the mouse button even it is not selected
- that was not possible to call the edit mesh context menu whit the select by polygon tool. I think that was a very bad user experience to not be able to operate mesh edition on selected element just after the selection. This PR allow this context menu with select by polygon.