### PR TITLE
add missing text for mesh editing undo/redo

### DIFF
--- a/python/analysis/auto_generated/mesh/qgsmeshtriangulation.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshtriangulation.sip.in
@@ -139,6 +139,9 @@ a Delaunay triangulation on provided existing vertex.
 Constructor
 %End
 
+    virtual QString text() const;
+
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
@@ -58,6 +58,11 @@ Returns whether the advanced edit is finished,
 if not, this edit has to be applied again with :py:func:`QgsMeshEditor.advancedEdit()` until is finished returns ``True``
 %End
 
+    virtual QString text() const;
+%Docstring
+Returns a short text string describing what this advanced edit does. Default implementation return a void string.
+%End
+
   protected:
 
 };
@@ -85,6 +90,9 @@ Neighboring faces are triangulated to take account of the new vertex in the shar
 %Docstring
 Constructor
 %End
+
+    virtual QString text() const;
+
 
 };
 
@@ -122,6 +130,9 @@ expressionZ: "if( $vertex_x <= 100 , $vertex_z + 80 , $vertex_z - 150)"
 %Docstring
 Constructor
 %End
+
+    virtual QString text() const;
+
 
     void setExpressions( const QString &expressionX, const QString &expressionY, const QString &expressionZ );
 %Docstring

--- a/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshforcebypolylines.sip.in
@@ -88,6 +88,8 @@ before applying the edition with :py:func:`QgsMeshEditor.advancedEdit()`
 Constructor
 %End
 
+    virtual QString text() const;
+
     virtual bool isFinished() const;
 
 

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -337,6 +337,11 @@ int QgsMeshZValueDataset::valuesCount() const
 
 QgsMeshEditingDelaunayTriangulation::QgsMeshEditingDelaunayTriangulation() = default;
 
+QString QgsMeshEditingDelaunayTriangulation::text() const
+{
+  return QObject::tr( "Delaunay triangulation" );
+}
+
 QgsTopologicalMesh::Changes QgsMeshEditingDelaunayTriangulation::apply( QgsMeshEditor *meshEditor )
 {
   //use only vertices that are on boundary or free, if boundary

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -436,7 +436,7 @@ QgsTopologicalMesh::Changes QgsMeshEditingDelaunayTriangulation::apply( QgsMeshE
   Q_ASSERT( meshEditor->topologicalMesh().checkConsistency() == QgsMeshEditingError() );
 
   if ( !removedVerticesFromTriangulation.isEmpty() )
-    mMessage = QObject::tr( "%1 vertices have not been included in the triangulation" ).arg( removedVerticesFromTriangulation.count() );
+    mMessage = QObject::tr( "%n vertices have not been included in the triangulation", nullptr, removedVerticesFromTriangulation.count() );
 
   mIsFinished = true;
 

--- a/src/analysis/mesh/qgsmeshtriangulation.h
+++ b/src/analysis/mesh/qgsmeshtriangulation.h
@@ -181,6 +181,8 @@ class ANALYSIS_EXPORT QgsMeshEditingDelaunayTriangulation : public QgsMeshAdvanc
     //! Constructor
     QgsMeshEditingDelaunayTriangulation();
 
+    QString text() const override;
+
   private:
     QgsTopologicalMesh::Changes apply( QgsMeshEditor *meshEditor ) override;
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -15668,7 +15668,6 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectByForm->setEnabled( false );
       mActionOpenFieldCalc->setEnabled( false );
       mActionSaveLayerEdits->setEnabled( false );
-      mUndoDock->widget()->setEnabled( false );
       mActionSaveLayerDefinition->setEnabled( true );
       mActionLayerSaveAs->setEnabled( false );
       mActionAddFeature->setEnabled( false );
@@ -15707,6 +15706,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionToggleEditing->setChecked( canSupportEditing && isEditable );
       mActionSaveLayerEdits->setEnabled( canSupportEditing && isEditable && mlayer->isModified() );
       enableMeshEditingTools( isEditable );
+      mUndoDock->widget()->setEnabled( canSupportEditing && isEditable );
       mActionUndo->setEnabled( canSupportEditing && isEditable );
       mActionRedo->setEnabled( canSupportEditing && isEditable );
       updateUndoActions();

--- a/src/core/mesh/qgsmeshadvancedediting.cpp
+++ b/src/core/mesh/qgsmeshadvancedediting.cpp
@@ -57,6 +57,11 @@ bool QgsMeshAdvancedEditing::isFinished() const
   return mIsFinished;
 }
 
+QString QgsMeshAdvancedEditing::text() const
+{
+  return QString();
+}
+
 static int vertexPositionInFace( int vertexIndex, const QgsMeshFace &face )
 {
   return face.indexOf( vertexIndex );
@@ -604,6 +609,14 @@ bool QgsMeshEditRefineFaces::createNewBorderFaces( QgsMeshEditor *meshEditor,
   return true;
 }
 
+QString QgsMeshEditRefineFaces::text() const
+{
+  if ( mInputFaces.count() > 1 )
+    return QObject::tr( "refine %1 faces" ).arg( mInputFaces.count() );
+  else
+    return QObject::tr( "refine face" ).arg( mInputFaces.count() );
+}
+
 bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
 {
   if ( !layer || !layer->meshEditor() || !layer->nativeMesh() )
@@ -740,6 +753,14 @@ bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
 
   mNativeFacesIndexesGeometryChanged = qgis::setToList( concernedFaces );
   return layer->meshEditor()->canBeTransformed( mNativeFacesIndexesGeometryChanged, transformFunction );
+}
+
+QString QgsMeshTransformVerticesByExpression::text() const
+{
+  if ( mInputVertices.count() > 1 )
+    return QObject::tr( "transform %1 vertices by expression" ).arg( mInputFaces.count() );
+  else
+    return QObject::tr( "transform vertex by expression" ).arg( mInputFaces.count() );
 }
 
 void QgsMeshTransformVerticesByExpression::setExpressions( const QString &expressionX, const QString &expressionY, const QString &expressionZ )

--- a/src/core/mesh/qgsmeshadvancedediting.cpp
+++ b/src/core/mesh/qgsmeshadvancedediting.cpp
@@ -611,10 +611,7 @@ bool QgsMeshEditRefineFaces::createNewBorderFaces( QgsMeshEditor *meshEditor,
 
 QString QgsMeshEditRefineFaces::text() const
 {
-  if ( mInputFaces.count() > 1 )
-    return QObject::tr( "refine %1 faces" ).arg( mInputFaces.count() );
-  else
-    return QObject::tr( "refine face" ).arg( mInputFaces.count() );
+  return QObject::tr( "Refine %1 faces", nullptr, mInputFaces.count() );
 }
 
 bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
@@ -757,10 +754,7 @@ bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
 
 QString QgsMeshTransformVerticesByExpression::text() const
 {
-  if ( mInputVertices.count() > 1 )
-    return QObject::tr( "transform %1 vertices by expression" ).arg( mInputFaces.count() );
-  else
-    return QObject::tr( "transform vertex by expression" ).arg( mInputFaces.count() );
+  return QObject::tr( "Transform %n vertices by expression", nullptr, mInputVertices.count() );
 }
 
 void QgsMeshTransformVerticesByExpression::setExpressions( const QString &expressionX, const QString &expressionY, const QString &expressionZ )

--- a/src/core/mesh/qgsmeshadvancedediting.cpp
+++ b/src/core/mesh/qgsmeshadvancedediting.cpp
@@ -611,7 +611,7 @@ bool QgsMeshEditRefineFaces::createNewBorderFaces( QgsMeshEditor *meshEditor,
 
 QString QgsMeshEditRefineFaces::text() const
 {
-  return QObject::tr( "Refine %1 faces", nullptr, mInputFaces.count() );
+  return QObject::tr( "Refine %n faces", nullptr, mInputFaces.count() );
 }
 
 bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )

--- a/src/core/mesh/qgsmeshadvancedediting.h
+++ b/src/core/mesh/qgsmeshadvancedediting.h
@@ -62,6 +62,9 @@ class CORE_EXPORT QgsMeshAdvancedEditing : protected QgsTopologicalMesh::Changes
      */
     virtual bool isFinished() const;
 
+    //! Returns a short text string describing what this advanced edit does. Default implementation return a void string.
+    virtual QString text() const;
+
   protected:
     QList<int> mInputVertices;
     QList<int> mInputFaces;
@@ -96,6 +99,8 @@ class CORE_EXPORT QgsMeshEditRefineFaces : public QgsMeshAdvancedEditing
 
     //! Constructor
     QgsMeshEditRefineFaces();
+
+    QString text() const override;
 
   private:
     QgsTopologicalMesh::Changes apply( QgsMeshEditor *meshEditor ) override;
@@ -160,6 +165,8 @@ class CORE_EXPORT QgsMeshTransformVerticesByExpression : public QgsMeshAdvancedE
 
     //! Constructor
     QgsMeshTransformVerticesByExpression() = default;
+
+    QString text() const override;
 
     /**
      * Sets the expressions for the coordinates transformation.

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -776,7 +776,12 @@ QgsMeshLayerUndoCommandAddVertices::QgsMeshLayerUndoCommandAddVertices( QgsMeshE
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVertices( vertices )
   , mTolerance( tolerance )
-{}
+{
+  if ( mVertices.count() > 1 )
+    setText( QObject::tr( "add %1 vertices" ).arg( vertices.count() ) );
+  else
+    setText( QObject::tr( "add vertex" ) );
+}
 
 void QgsMeshLayerUndoCommandAddVertices::redo()
 {
@@ -804,7 +809,12 @@ QgsMeshLayerUndoCommandRemoveVertices::QgsMeshLayerUndoCommandRemoveVertices( Qg
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVerticesToRemoveIndexes( verticesToRemoveIndexes )
   , mFillHole( fillHole )
-{}
+{
+  if ( verticesToRemoveIndexes.count() > 1 )
+    setText( QObject::tr( "remove %1 vertices" ).arg( verticesToRemoveIndexes.count() ) );
+  else
+    setText( QObject::tr( "remove vertex" ) );
+}
 
 void QgsMeshLayerUndoCommandRemoveVertices::redo()
 {
@@ -837,7 +847,12 @@ void QgsMeshLayerUndoCommandRemoveVertices::redo()
 QgsMeshLayerUndoCommandAddFaces::QgsMeshLayerUndoCommandAddFaces( QgsMeshEditor *meshEditor, QgsTopologicalMesh::TopologicalFaces &faces )
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mFaces( faces )
-{}
+{
+  if ( faces.meshFaces().count() > 1 )
+    setText( QObject::tr( "add %1 faces" ).arg( faces.meshFaces().count() ) );
+  else
+    setText( QObject::tr( "add face" ) );
+}
 
 void QgsMeshLayerUndoCommandAddFaces::redo()
 {
@@ -859,7 +874,12 @@ void QgsMeshLayerUndoCommandAddFaces::redo()
 QgsMeshLayerUndoCommandRemoveFaces::QgsMeshLayerUndoCommandRemoveFaces( QgsMeshEditor *meshEditor, const QList<int> &facesToRemoveIndexes )
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mfacesToRemoveIndexes( facesToRemoveIndexes )
-{}
+{
+  if ( facesToRemoveIndexes.count() > 1 )
+    setText( QObject::tr( "remove %1 faces" ).arg( facesToRemoveIndexes.count() ) );
+  else
+    setText( QObject::tr( "remove face" ) );
+}
 
 void QgsMeshLayerUndoCommandRemoveFaces::redo()
 {
@@ -953,7 +973,12 @@ QgsMeshLayerUndoCommandChangeZValue::QgsMeshLayerUndoCommandChangeZValue( QgsMes
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVerticesIndexes( verticesIndexes )
   , mNewValues( newValues )
-{}
+{
+  if ( verticesIndexes.count() > 1 )
+    setText( QObject::tr( "change %1 vertices Z Value" ).arg( verticesIndexes.count() ) );
+  else
+    setText( QObject::tr( "change vertex Z Value" ) );
+}
 
 void QgsMeshLayerUndoCommandChangeZValue::redo()
 {
@@ -976,7 +1001,12 @@ QgsMeshLayerUndoCommandChangeXYValue::QgsMeshLayerUndoCommandChangeXYValue( QgsM
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVerticesIndexes( verticesIndexes )
   , mNewValues( newValues )
-{}
+{
+  if ( verticesIndexes.count() > 1 )
+    setText( QObject::tr( "move %1 vertices" ).arg( verticesIndexes.count() ) );
+  else
+    setText( QObject::tr( "move vertex" ) );
+}
 
 void QgsMeshLayerUndoCommandChangeXYValue::redo()
 {
@@ -1000,7 +1030,12 @@ QgsMeshLayerUndoCommandChangeCoordinates::QgsMeshLayerUndoCommandChangeCoordinat
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVerticesIndexes( verticesIndexes )
   , mNewCoordinates( newCoordinates )
-{}
+{
+  if ( verticesIndexes.count() > 1 )
+    setText( QObject::tr( "transform %1 vertices coordinates" ).arg( verticesIndexes.count() ) );
+  else
+    setText( QObject::tr( "transform vertex coordinates" ) );
+}
 
 void QgsMeshLayerUndoCommandChangeCoordinates::redo()
 {
@@ -1039,7 +1074,9 @@ QgsMeshLayerUndoCommandFlipEdge::QgsMeshLayerUndoCommandFlipEdge( QgsMeshEditor 
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVertexIndex1( vertexIndex1 )
   , mVertexIndex2( vertexIndex2 )
-{}
+{
+  setText( QObject::tr( "flip edge" ) );
+}
 
 void QgsMeshLayerUndoCommandFlipEdge::redo()
 {
@@ -1062,7 +1099,9 @@ QgsMeshLayerUndoCommandMerge::QgsMeshLayerUndoCommandMerge( QgsMeshEditor *meshE
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mVertexIndex1( vertexIndex1 )
   , mVertexIndex2( vertexIndex2 )
-{}
+{
+  setText( QObject::tr( "merge faces" ) );
+}
 
 void QgsMeshLayerUndoCommandMerge::redo()
 {
@@ -1084,7 +1123,12 @@ void QgsMeshLayerUndoCommandMerge::redo()
 QgsMeshLayerUndoCommandSplitFaces::QgsMeshLayerUndoCommandSplitFaces( QgsMeshEditor *meshEditor, const QList<int> &faceIndexes )
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mFaceIndexes( faceIndexes )
-{}
+{
+  if ( faceIndexes.count() > 1 )
+    setText( QObject::tr( "split %1 faces" ).arg( faceIndexes.count() ) );
+  else
+    setText( QObject::tr( "split face" ) );
+}
 
 void QgsMeshLayerUndoCommandSplitFaces::redo()
 {
@@ -1108,7 +1152,9 @@ void QgsMeshLayerUndoCommandSplitFaces::redo()
 QgsMeshLayerUndoCommandAdvancedEditing::QgsMeshLayerUndoCommandAdvancedEditing( QgsMeshEditor *meshEditor, QgsMeshAdvancedEditing *advancdEdit )
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mAdvancedEditing( advancdEdit )
-{}
+{
+  setText( advancdEdit->text() );
+}
 
 void QgsMeshLayerUndoCommandAdvancedEditing::redo()
 {

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -777,10 +777,7 @@ QgsMeshLayerUndoCommandAddVertices::QgsMeshLayerUndoCommandAddVertices( QgsMeshE
   , mVertices( vertices )
   , mTolerance( tolerance )
 {
-  if ( mVertices.count() > 1 )
-    setText( QObject::tr( "add %1 vertices" ).arg( vertices.count() ) );
-  else
-    setText( QObject::tr( "add vertex" ) );
+  setText( QObject::tr( "Add %n vertices", nullptr, mVertices.count() ) );
 }
 
 void QgsMeshLayerUndoCommandAddVertices::redo()
@@ -810,10 +807,7 @@ QgsMeshLayerUndoCommandRemoveVertices::QgsMeshLayerUndoCommandRemoveVertices( Qg
   , mVerticesToRemoveIndexes( verticesToRemoveIndexes )
   , mFillHole( fillHole )
 {
-  if ( verticesToRemoveIndexes.count() > 1 )
-    setText( QObject::tr( "remove %1 vertices" ).arg( verticesToRemoveIndexes.count() ) );
-  else
-    setText( QObject::tr( "remove vertex" ) );
+  setText( QObject::tr( "Remove %n vertices", nullptr, verticesToRemoveIndexes.count() ) ) ;
 }
 
 void QgsMeshLayerUndoCommandRemoveVertices::redo()
@@ -848,10 +842,7 @@ QgsMeshLayerUndoCommandAddFaces::QgsMeshLayerUndoCommandAddFaces( QgsMeshEditor 
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mFaces( faces )
 {
-  if ( faces.meshFaces().count() > 1 )
-    setText( QObject::tr( "add %1 faces" ).arg( faces.meshFaces().count() ) );
-  else
-    setText( QObject::tr( "add face" ) );
+  setText( QObject::tr( "Add %n faces", nullptr, faces.meshFaces().count() ) );
 }
 
 void QgsMeshLayerUndoCommandAddFaces::redo()
@@ -875,10 +866,7 @@ QgsMeshLayerUndoCommandRemoveFaces::QgsMeshLayerUndoCommandRemoveFaces( QgsMeshE
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mfacesToRemoveIndexes( facesToRemoveIndexes )
 {
-  if ( facesToRemoveIndexes.count() > 1 )
-    setText( QObject::tr( "remove %1 faces" ).arg( facesToRemoveIndexes.count() ) );
-  else
-    setText( QObject::tr( "remove face" ) );
+  setText( QObject::tr( "Remove %n faces", nullptr, facesToRemoveIndexes.count() ) );
 }
 
 void QgsMeshLayerUndoCommandRemoveFaces::redo()
@@ -974,10 +962,7 @@ QgsMeshLayerUndoCommandChangeZValue::QgsMeshLayerUndoCommandChangeZValue( QgsMes
   , mVerticesIndexes( verticesIndexes )
   , mNewValues( newValues )
 {
-  if ( verticesIndexes.count() > 1 )
-    setText( QObject::tr( "change %1 vertices Z Value" ).arg( verticesIndexes.count() ) );
-  else
-    setText( QObject::tr( "change vertex Z Value" ) );
+  setText( QObject::tr( "Change %n vertices Z Value", nullptr, verticesIndexes.count() ) );
 }
 
 void QgsMeshLayerUndoCommandChangeZValue::redo()
@@ -1002,10 +987,7 @@ QgsMeshLayerUndoCommandChangeXYValue::QgsMeshLayerUndoCommandChangeXYValue( QgsM
   , mVerticesIndexes( verticesIndexes )
   , mNewValues( newValues )
 {
-  if ( verticesIndexes.count() > 1 )
-    setText( QObject::tr( "move %1 vertices" ).arg( verticesIndexes.count() ) );
-  else
-    setText( QObject::tr( "move vertex" ) );
+  setText( QObject::tr( "Move %n vertices", nullptr, verticesIndexes.count() ) );
 }
 
 void QgsMeshLayerUndoCommandChangeXYValue::redo()
@@ -1031,10 +1013,7 @@ QgsMeshLayerUndoCommandChangeCoordinates::QgsMeshLayerUndoCommandChangeCoordinat
   , mVerticesIndexes( verticesIndexes )
   , mNewCoordinates( newCoordinates )
 {
-  if ( verticesIndexes.count() > 1 )
-    setText( QObject::tr( "transform %1 vertices coordinates" ).arg( verticesIndexes.count() ) );
-  else
-    setText( QObject::tr( "transform vertex coordinates" ) );
+  setText( QObject::tr( "Transform %n vertices coordinates", nullptr, verticesIndexes.count() ) );
 }
 
 void QgsMeshLayerUndoCommandChangeCoordinates::redo()
@@ -1075,7 +1054,7 @@ QgsMeshLayerUndoCommandFlipEdge::QgsMeshLayerUndoCommandFlipEdge( QgsMeshEditor 
   , mVertexIndex1( vertexIndex1 )
   , mVertexIndex2( vertexIndex2 )
 {
-  setText( QObject::tr( "flip edge" ) );
+  setText( QObject::tr( "Flip edge" ) );
 }
 
 void QgsMeshLayerUndoCommandFlipEdge::redo()
@@ -1100,7 +1079,7 @@ QgsMeshLayerUndoCommandMerge::QgsMeshLayerUndoCommandMerge( QgsMeshEditor *meshE
   , mVertexIndex1( vertexIndex1 )
   , mVertexIndex2( vertexIndex2 )
 {
-  setText( QObject::tr( "merge faces" ) );
+  setText( QObject::tr( "Merge faces" ) );
 }
 
 void QgsMeshLayerUndoCommandMerge::redo()
@@ -1124,10 +1103,7 @@ QgsMeshLayerUndoCommandSplitFaces::QgsMeshLayerUndoCommandSplitFaces( QgsMeshEdi
   : QgsMeshLayerUndoCommandMeshEdit( meshEditor )
   , mFaceIndexes( faceIndexes )
 {
-  if ( faceIndexes.count() > 1 )
-    setText( QObject::tr( "split %1 faces" ).arg( faceIndexes.count() ) );
-  else
-    setText( QObject::tr( "split face" ) );
+  setText( QObject::tr( "Split %n faces", nullptr, faceIndexes.count() ) );
 }
 
 void QgsMeshLayerUndoCommandSplitFaces::redo()

--- a/src/core/mesh/qgsmeshforcebypolylines.cpp
+++ b/src/core/mesh/qgsmeshforcebypolylines.cpp
@@ -1097,7 +1097,7 @@ bool QgsMeshEditForceByLine::finishForcingLine()
 
 QString QgsMeshEditForceByPolylines::text() const
 {
-  return QObject::tr( "force mesh by polyline" );
+  return QObject::tr( "Force mesh by polyline" );
 }
 
 bool QgsMeshEditForceByPolylines::isFinished() const

--- a/src/core/mesh/qgsmeshforcebypolylines.cpp
+++ b/src/core/mesh/qgsmeshforcebypolylines.cpp
@@ -1095,6 +1095,11 @@ bool QgsMeshEditForceByLine::finishForcingLine()
 }
 
 
+QString QgsMeshEditForceByPolylines::text() const
+{
+  return QObject::tr( "force mesh by polyline" );
+}
+
 bool QgsMeshEditForceByPolylines::isFinished() const
 {
   return mCurrentPolyline >= mPolylines.count() && QgsMeshEditForceByLine::isFinished();

--- a/src/core/mesh/qgsmeshforcebypolylines.h
+++ b/src/core/mesh/qgsmeshforcebypolylines.h
@@ -148,6 +148,7 @@ class CORE_EXPORT QgsMeshEditForceByPolylines : public QgsMeshEditForceByLine
     //! Constructor
     QgsMeshEditForceByPolylines() = default;
 
+    QString text() const override;
     bool isFinished() const override;
 
     /**


### PR DESCRIPTION
Before this PR, short  texts describing the mesh edition action were missing and undo/redo stack widget was void.