### PR TITLE
message box to warn user mesh edit removes dataset groups

### DIFF
--- a/src/app/mesh/qgsnewmeshlayerdialog.cpp
+++ b/src/app/mesh/qgsnewmeshlayerdialog.cpp
@@ -81,10 +81,11 @@ void QgsNewMeshLayerDialog::setCrs( const QgsCoordinateReferenceSystem &crs )
   mProjectionSelectionWidget->setCrs( crs );
 }
 
-void QgsNewMeshLayerDialog::setSourceMeshLayer( QgsMeshLayer *meshLayer )
+void QgsNewMeshLayerDialog::setSourceMeshLayer( QgsMeshLayer *meshLayer, bool fromExistingAsDefault )
 {
   mMeshProjectComboBox->setLayer( meshLayer );
   mMeshProjectRadioButton->setChecked( true );
+  mInitializeMeshGroupBox->setChecked( fromExistingAsDefault );
 }
 
 void QgsNewMeshLayerDialog::accept()
@@ -263,12 +264,20 @@ bool QgsNewMeshLayerDialog::apply()
         newMeshLayer->setCrs( crs );
 
       if ( newMeshLayer->isValid() )
+      {
+        mNewLayer = newMeshLayer.get();
         QgsProject::instance()->addMapLayer( newMeshLayer.release(), true, true );
-      return true;
+        return true;
+      }
     }
   }
 
   QMessageBox::warning( this, windowTitle(), tr( "Unable to create a new mesh layer with format \"%1\"" ).arg( mFormatComboBox->currentText() ) );
   return false;
+}
+
+QgsMeshLayer *QgsNewMeshLayerDialog::newLayer() const
+{
+  return mNewLayer;
 }
 

--- a/src/app/mesh/qgsnewmeshlayerdialog.h
+++ b/src/app/mesh/qgsnewmeshlayerdialog.h
@@ -41,7 +41,10 @@ class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshL
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 
     //! Sets a mesh layer that could be used as base for the new mesh
-    void setSourceMeshLayer( QgsMeshLayer *meshLayer );
+    void setSourceMeshLayer( QgsMeshLayer *meshLayer, bool fromExistingAsDefault = false );
+
+    //! Returns a pointer to the new created mesh layer
+    QgsMeshLayer *newLayer() const;
 
   private slots:
     void updateDialog();
@@ -57,6 +60,8 @@ class APP_EXPORT QgsNewMeshLayerDialog : public QDialog, private Ui::QgsNewMeshL
     bool mSourceMeshFrameReady;
     QMap<QString, QString> mDriverSuffixes;
     QMap<QString, QString> mDriverFileFilters;
+
+    QgsMeshLayer *mNewLayer = nullptr;
 };
 
 #endif // QGSNEWMESHLAYERDIALOG_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11409,7 +11409,15 @@ bool QgisApp::toggleEditingMeshLayer( QgsMeshLayer *mlayer, bool allowCancel )
     return false;
 
   if ( !mlayer->supportsEditing() )
-    return false; //TODO: when adapted widget will be ready, ask the user if he want to create a new one based on this one
+    return false;
+
+  if ( QMessageBox::warning( this, tr( "Start Mesh Frame Edit" ), tr( "Starting editing the frame of this mesh layer will remove all dataset groups.\n"
+                             "Alternatively, you can create a new mesh layer from that one.\n\n"
+                             "Do you want to start edit this mesh layer?" ), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Cancel )
+  {
+    mActionToggleEditing->setChecked( false );
+    return false;
+  }
 
   bool res = false;
 


### PR DESCRIPTION
When edit layer action is toggled with an editable mesh layer:

![image](https://user-images.githubusercontent.com/7416892/136482053-bd3ce5c5-c4e3-493e-b82d-d85ec1549208.png)
