### PR TITLE
Add action info to the form d&d panel

### DIFF
--- a/python/core/auto_generated/qgsaction.sip.in
+++ b/python/core/auto_generated/qgsaction.sip.in
@@ -216,6 +216,13 @@ Returns an expression context scope used for running the action.
 .. versionadded:: 3.0
 %End
 
+    QString html( ) const;
+%Docstring
+Returns an HTML table with the basic information about this action.
+
+.. versionadded:: 3.24
+%End
+
 };
 
 

--- a/src/core/qgsaction.cpp
+++ b/src/core/qgsaction.cpp
@@ -163,4 +163,53 @@ void QgsAction::setExpressionContextScope( const QgsExpressionContextScope &scop
 QgsExpressionContextScope QgsAction::expressionContextScope() const
 {
   return mExpressionContextScope;
+}
+
+QString QgsAction::html() const
+{
+  QString typeText;
+  switch ( mType )
+  {
+    case Generic:
+    {
+      typeText = QObject::tr( "Generic" );
+      break;
+    }
+    case GenericPython:
+    {
+      typeText = QObject::tr( "Generic Python" );
+      break;
+    }
+    case Mac:
+    {
+      typeText = QObject::tr( "Mac" );
+      break;
+    }
+    case Windows:
+    {
+      typeText = QObject::tr( "Windows" );
+      break;
+    }
+    case Unix:
+    {
+      typeText = QObject::tr( "Unix" );
+      break;
+    }
+    case OpenUrl:
+    {
+      typeText = QObject::tr( "Open URL" );
+      break;
+    }
+  }
+  return { QObject::tr( R"html(
+<h2>Action Details</h2>
+<p>
+   <b>Description:</b> %1<br>
+   <b>Short title:</b> %2<br>
+   <b>Type:</b> %3<br>
+   <b>Scope:</b> %4<br>
+   <b>Action:</b><br>
+   <pre>%6</pre>
+</p>
+  )html" ).arg( mDescription, mShortTitle, typeText, actionScopes().values().join( QStringLiteral( ", " ) ), mCommand )};
 };

--- a/src/core/qgsaction.h
+++ b/src/core/qgsaction.h
@@ -247,6 +247,13 @@ class CORE_EXPORT QgsAction
      */
     QgsExpressionContextScope expressionContextScope() const;
 
+    /**
+     * Returns an HTML table with the basic information about this action.
+     *
+     * \since QGIS 3.24
+     */
+    QString html( ) const;
+
   private:
     ActionType mType = Generic;
     QString mDescription;

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -589,6 +589,8 @@ void QgsAttributesFormProperties::loadAttributeSpecificEditor( QgsAttributesDnDT
       case DnDTreeItemData::Action:
       {
         receiver->selectFirstMatchingItem( itemData );
+        const QgsAction action {mLayer->actions()->action( itemData.name() )};
+        loadInfoWidget( action.html() );
         break;
       }
       case DnDTreeItemData::QmlWidget:


### PR DESCRIPTION
Followup to https://github.com/qgis/QGIS/pull/44710 this PR adds some information about the selected action into the information panel on the right side of the d&d designer:


![qgis_form_actions_dd_info](https://user-images.githubusercontent.com/142164/136546012-42a22fdf-4b20-406c-b932-77568f7820f6.png)


