### PR TITLE
Save PostgreSQL user and use it when it is unknown (Fix #42439)

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -251,10 +251,20 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   };
   addDefaultTimeoutAndClientEncoding( expandedConnectionInfo );
 
+  QgsDataSourceUri expandedUri( expandedConnectionInfo );
+  static QString lastUser;
+
+  if ( !expandedUri.username().isEmpty() )
+    lastUser = expandedUri.username();
+  else if ( !getenv( "PGUSER" ) && !lastUser.isEmpty() )
+  {
+    QgsDebugMsgLevel( "Use saved user: " + lastUser, 2 );
+    expandedConnectionInfo += " user='" + lastUser + "'";
+  }
+
   mConn = PQconnectdb( expandedConnectionInfo.toUtf8() );
 
   // remove temporary cert/key/CA if they exist
-  QgsDataSourceUri expandedUri( expandedConnectionInfo );
   QStringList parameters;
   parameters << QStringLiteral( "sslcert" ) << QStringLiteral( "sslkey" ) << QStringLiteral( "sslrootcert" );
   const auto constParameters = parameters;


### PR DESCRIPTION


## Description

Fix https://github.com/qgis/QGIS/issues/42439

When a user configures a PostGIS connection and loads a QGIS project
from this database, then often the authcfg `id` in the saved project
is different from the local authcfg `id` with correct PostgreSQL credentials.

This is no problem when the `PGUSER` environment variable matches the
PostgreSQL user in the saved and local authcfg or the OS username matches.

This works because `PQconnectdb()` just needs a username (either explicit
or implicit from `PGUSER` or the OS username) when a previous
connect with the same username and a password was successful.

This patch saves a PostgreSQL username when one is supplied and uses
it when the username is not known. In most cases this prevents that the user
must enter his username in one or more Authentication dialogs.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
