### PR TITLE
[ui] Properly fix UI state restoration on QGIS launch

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1070,7 +1070,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     */
     void legendLayerStretchUsingCurrentExtent();
 
-    //! Watch for QFileOpenEvent.
+    //! Watches for QFileOpenEvent.
     bool event( QEvent *event ) override;
 
     //! Sets the CRS of the current legend group
@@ -1276,7 +1276,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsAttributeEditorContext createAttributeEditorContext();
 
   protected:
-    void showEvent( QShowEvent *event ) override;
+
+    //! Listens to resize event in order to properly restore UI upon re-launching QGIS
+    void resizeEvent( QResizeEvent *resizeEvent ) override;
 
     //! Handle state changes (WindowTitleChange)
     void changeEvent( QEvent *event ) override;
@@ -2731,6 +2733,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     };
     int mFreezeCount = 0;
     friend class QgsCanvasRefreshBlocker;
+
+    bool mRestoreStateOnResize = false;
 
     friend class TestQgisAppPython;
     friend class QgisAppInterface;


### PR DESCRIPTION
## Description

Qt 5.15 suffers from a regression on linux that messes with UI state restoration (i.e. panel visibility, size, etc.). @nyalldawson came up with a good fix that prevented docked panels from shrinking horizontally, but that wasn't properly handling height restoration of those panels.

This PR provides an alternative fix that successfully restores both width and height of docked panels. All credit goes to @tsdgeos.