### PR TITLE
[ui] Fixing unmet expectations when hitting enter/return

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
@@ -97,6 +97,11 @@ Sets a ``filter`` string, used to filter out the contents of the view
 to matching algorithms.
 %End
 
+  protected:
+
+    virtual void keyPressEvent( QKeyEvent *event );
+
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsbrowsertreeview.sip.in
+++ b/python/gui/auto_generated/qgsbrowsertreeview.sip.in
@@ -48,6 +48,11 @@ Returns the browser model
 
     void setSettingsSection( const QString &section );
 
+  protected:
+
+    virtual void keyPressEvent( QKeyEvent *event );
+
+
   protected slots:
     virtual void rowsInserted( const QModelIndex &parentIndex, int start, int end );
 

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
@@ -16,6 +16,8 @@
 #include "qgsprocessingtoolboxtreeview.h"
 #include "qgsprocessingtoolboxmodel.h"
 
+#include <QKeyEvent>
+
 ///@cond PRIVATE
 
 QgsProcessingToolboxTreeView::QgsProcessingToolboxTreeView( QWidget *parent,
@@ -117,6 +119,14 @@ QModelIndex QgsProcessingToolboxTreeView::findFirstVisibleAlgorithm( const QMode
       return index;
   }
   return QModelIndex();
+}
+
+void QgsProcessingToolboxTreeView::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter )
+    emit doubleClicked( currentIndex() );
+  else
+    QTreeView::keyPressEvent( event );
 }
 
 ///@endcond

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.h
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.h
@@ -106,6 +106,10 @@ class GUI_EXPORT QgsProcessingToolboxTreeView : public QTreeView
      */
     void setFilterString( const QString &filter );
 
+  protected:
+
+    void keyPressEvent( QKeyEvent *event ) override;
+
   private:
 
     QgsProcessingToolboxProxyModel *mModel = nullptr;

--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -20,12 +20,22 @@
 #include "qgsguiutils.h"
 #include "qgsdataitem.h"
 
+#include <QKeyEvent>
+
 QgsBrowserTreeView::QgsBrowserTreeView( QWidget *parent )
   : QTreeView( parent )
   , mSettingsSection( QStringLiteral( "browser" ) )
 {
   setEditTriggers( QAbstractItemView::EditKeyPressed );
   setIndentation( QgsGuiUtils::scaleIconSize( 16 ) );
+}
+
+void QgsBrowserTreeView::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter )
+    emit doubleClicked( currentIndex() );
+  else
+    QTreeView::keyPressEvent( event );
 }
 
 void QgsBrowserTreeView::setModel( QAbstractItemModel *model )

--- a/src/gui/qgsbrowsertreeview.h
+++ b/src/gui/qgsbrowsertreeview.h
@@ -51,6 +51,10 @@ class GUI_EXPORT QgsBrowserTreeView : public QTreeView
     // Set section where to store settings (because we have 2 browser dock widgets)
     void setSettingsSection( const QString &section ) { mSettingsSection = section; }
 
+  protected:
+
+    void keyPressEvent( QKeyEvent *event ) override;
+
   protected slots:
     void rowsInserted( const QModelIndex &parentIndex, int start, int end ) override;
 


### PR DESCRIPTION
## Description

Title says it all: when hitting the enter/return key while navigating the browser panel or the processing toolbox panel, the expected action will be triggered (adding focused dataset, launching focused algorithm).