### PR TITLE
Add API in expression to set help string on a variable

### DIFF
--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -607,6 +607,23 @@ Returns a string list of search tags for a specified function.
 .. versionadded:: 3.12
 %End
 
+    static bool addVariableHelpText( const QString name, const QString &description );
+%Docstring
+Adds a help string for a custom variable.
+
+The specified variable ``name`` should not have an existing help string set. If a help string is already present then
+``False`` will be returned and no changes will occur.
+
+:param name: variable name
+:param description: the help string to add. This is user visible, and should be a translated string.
+
+:return: ``True`` if the help string was successfully added
+
+.. seealso:: :py:func:`variableHelpText`
+
+.. versionadded:: 3.22
+%End
+
     static QString variableHelpText( const QString &variableName );
 %Docstring
 Returns the help text for a specified variable.
@@ -614,6 +631,8 @@ Returns the help text for a specified variable.
 :param variableName: name of variable
 
 .. seealso:: :py:func:`helpText`
+
+.. seealso:: :py:func:`addVariableHelpText`
 
 .. versionadded:: 2.12
 %End

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -900,6 +900,17 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "form_mode" ), QCoreApplication::translate( "form_mode", "What the form is used for, like AddFeatureMode, SingleEditMode, MultiEditMode, SearchMode, AggregateSearchMode or IdentifyMode as string." ) );
 }
 
+
+bool QgsExpression::addVariableHelpText( const QString name, const QString &description )
+{
+  if ( sVariableHelpTexts()->contains( name ) )
+  {
+    return false;
+  }
+  sVariableHelpTexts()->insert( name, description );
+  return true;
+}
+
 QString QgsExpression::variableHelpText( const QString &variableName )
 {
   QgsExpression::initVariableHelp();

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -604,9 +604,24 @@ class CORE_EXPORT QgsExpression
     static QStringList tags( const QString &name );
 
     /**
+     * Adds a help string for a custom variable.
+     *
+     * The specified variable \a name should not have an existing help string set. If a help string is already present then
+     * FALSE will be returned and no changes will occur.
+     *
+     * \param name variable name
+     * \param description the help string to add. This is user visible, and should be a translated string.
+     * \returns TRUE if the help string was successfully added
+     * \see variableHelpText()
+     * \since QGIS 3.22
+     */
+    static bool addVariableHelpText( const QString name, const QString &description );
+
+    /**
      * Returns the help text for a specified variable.
      * \param variableName name of variable
      * \see helpText()
+     * \see addVariableHelpText()
      * \since QGIS 2.12
      */
     static QString variableHelpText( const QString &variableName );

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -83,7 +83,8 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         args = function.params()
         self.assertEqual(args, 3)
 
-    def testHelp(self):
+    def testHelpPythonFunction(self):
+        """Test help about python function."""
         QgsExpression.registerFunction(self.help_with_variable)
         html = ('<h3>help_with_variable function</h3><br>'
                 'The help comes from a variable.')
@@ -93,6 +94,12 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         html = ('<h3>help_with_docstring function</h3><br>'
                 'The help comes from the python docstring.')
         self.assertEqual(self.help_with_docstring.helpText(), html)
+
+    def testHelpString(self):
+        """Test add custom help string."""
+        self.assertTrue(QgsExpression.addVariableHelpText("custom_variable_help", "custom help 1"))
+        self.assertFalse(QgsExpression.addVariableHelpText("custom_variable_help", "other help 2"))
+        self.assertEqual(QgsExpression.variableHelpText("custom_variable_help"), "custom help 1")
 
     def testAutoArgsAreExpanded(self):
         function = self.expandargs


### PR DESCRIPTION
Plugins will be able to register their help string if they add a variable in a project or layer.

Example : 
![Screenshot from 2021-10-11 18-41-53](https://user-images.githubusercontent.com/1609292/136826061-4f7825a8-5046-471e-bd41-b5803cb0a5f5.png)

I was wondering if I should check or not if the key exist or not. It's low probability, we don't want to alter existing help string from a plugin.