### PR TITLE
[Geometry Checker] Change parameter label

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.ui
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.ui
@@ -114,7 +114,7 @@
           <item row="1" column="0" colspan="3">
            <widget class="QCheckBox" name="checkBoxHighlight">
             <property name="text">
-             <string>Highlight contour of selected features</string>
+             <string>Highlight selected features</string>
             </property>
             <property name="checked">
              <bool>true</bool>


### PR DESCRIPTION
## Description

As @uclaros said, with the PR #45219, the parameter label `Highlight contour of selected features` should be changed to `Highlight selected features` for more meaning.