### PR TITLE
Use a checkbox to create virtual mesh in mesh calculator

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -116,8 +116,8 @@ QgsMeshCalculatorDialog::QgsMeshCalculatorDialog( QgsMeshLayer *meshLayer, QWidg
   onOutputFormatChange();
   connect( mOutputDatasetFileWidget, &QgsFileWidget::fileChanged, this, &QgsMeshCalculatorDialog::updateInfoMessage );
 
-  connect( mOutputOnFileRadioButton, &QRadioButton::toggled, this, &QgsMeshCalculatorDialog::onOutputRadioButtonChange );
-  onOutputRadioButtonChange();
+  connect( mUseVirtualProviderCheckBox, &QCheckBox::clicked, this, &QgsMeshCalculatorDialog::onVirtualCheckboxChange );
+  onVirtualCheckboxChange();
 }
 
 QgsMeshCalculatorDialog::~QgsMeshCalculatorDialog() = default;
@@ -204,7 +204,7 @@ std::unique_ptr<QgsMeshCalculator> QgsMeshCalculatorDialog::calculator() const
   std::unique_ptr<QgsMeshCalculator> calc;
   QgsMeshDatasetGroup::Type destination = QgsMeshDatasetGroup::Persistent;
 
-  if ( mOutputVirtualRadioButton->isChecked() )
+  if ( mUseVirtualProviderCheckBox->isChecked() )
     destination = QgsMeshDatasetGroup::Virtual;
 
   switch ( destination )
@@ -304,7 +304,7 @@ void QgsMeshCalculatorDialog::updateInfoMessage()
   const bool expressionValid = result == QgsMeshCalculator::Success;
 
   // selected driver is appropriate
-  const bool notInFile = !mOutputOnFileRadioButton->isChecked();
+  const bool notInFile = mUseVirtualProviderCheckBox->isChecked();
   bool driverValid = false;
   if ( expressionValid )
   {
@@ -354,10 +354,10 @@ void QgsMeshCalculatorDialog::updateInfoMessage()
   }
 }
 
-void QgsMeshCalculatorDialog::onOutputRadioButtonChange()
+void QgsMeshCalculatorDialog::onVirtualCheckboxChange()
 {
-  mOutputDatasetFileWidget->setEnabled( mOutputOnFileRadioButton->isChecked() );
-  mOutputFormatComboBox->setEnabled( mOutputOnFileRadioButton->isChecked() );
+  mOutputDatasetFileWidget->setEnabled( !mUseVirtualProviderCheckBox->isChecked() );
+  mOutputFormatComboBox->setEnabled( !mUseVirtualProviderCheckBox->isChecked() );
   updateInfoMessage();
 }
 

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -356,8 +356,10 @@ void QgsMeshCalculatorDialog::updateInfoMessage()
 
 void QgsMeshCalculatorDialog::onVirtualCheckboxChange()
 {
-  mOutputDatasetFileWidget->setEnabled( !mUseVirtualProviderCheckBox->isChecked() );
-  mOutputFormatComboBox->setEnabled( !mUseVirtualProviderCheckBox->isChecked() );
+  mOutputDatasetFileWidget->setVisible( !mUseVirtualProviderCheckBox->isChecked() );
+  mOutputDatasetFileLabel->setVisible( !mUseVirtualProviderCheckBox->isChecked() );
+  mOutputFormatComboBox->setVisible( !mUseVirtualProviderCheckBox->isChecked() );
+  mOutputFormatLabel->setVisible( !mUseVirtualProviderCheckBox->isChecked() );
   updateInfoMessage();
 }
 

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -20,7 +20,6 @@
 
 #include "ui_qgsmeshcalculatordialogbase.h"
 #include "qgsmeshcalculator.h"
-#include "qgshelp.h"
 #include "qgis_app.h"
 
 //! A dialog to enter a mesh calculation expression
@@ -47,7 +46,8 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
     void mAllTimesButton_clicked();
     void toggleExtendMask();
     void updateInfoMessage();
-    void onOutputRadioButtonChange();
+    //! Disables some options that are not required if using Virtual Provider
+    void onVirtualCheckboxChange();
     void onOutputFormatChange();
 
     //calculator buttons

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -77,7 +77,7 @@
            <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="mOutputDatasetFileLabel">
             <property name="text">
              <string>Output file</string>
             </property>

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -40,6 +40,19 @@
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
          <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="0" colspan="3">
+           <widget class="QCheckBox" name="mUseVirtualProviderCheckBox">
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Create on-the-fly mesh instead of writing layer to disk</string>
+            </property>
+            <property name="tristate">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="mOutputFormatLabel_2">
             <property name="text">
@@ -54,35 +67,11 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="mOutputOnFileRadioButton">
-            <property name="text">
-             <string>On file</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1" colspan="2">
            <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="mOutputDatasetLabel">
-            <property name="text">
-             <string>Output dataset</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="1" colspan="2">
            <widget class="QComboBox" name="mOutputFormatComboBox"/>
-          </item>
-          <item row="0" column="2">
-           <widget class="QRadioButton" name="mOutputVirtualRadioButton">
-            <property name="text">
-             <string>Virtual</string>
-            </property>
-           </widget>
           </item>
           <item row="3" column="1" colspan="2">
            <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
@@ -685,8 +674,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>mDatasetsListWidget</tabstop>
-  <tabstop>mOutputOnFileRadioButton</tabstop>
-  <tabstop>mOutputVirtualRadioButton</tabstop>
+  <tabstop>mUseVirtualProviderCheckBox</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
   <tabstop>mOutputGroupNameLineEdit</tabstop>
   <tabstop>useExtentCb</tabstop>


### PR DESCRIPTION
instead of current radiobuttons (fixes #45246)
A more explicit label and it mimics the raster calculator dialog