### PR TITLE
Improve robustness of mesh editing

### DIFF
--- a/python/core/auto_generated/mesh/qgsmesheditor.sip.in
+++ b/python/core/auto_generated/mesh/qgsmesheditor.sip.in
@@ -137,12 +137,20 @@ The method returns the number of vertices effectivly added.
    if the mesh hasn't topological error before this operation, the toological operation always succeed
 %End
 
-    QgsMeshEditingError removeVertices( const QList<int> &verticesToRemoveIndexes, bool fillHoles = false );
+    QgsMeshEditingError removeVerticesWithoutFillHoles( const QList<int> &verticesToRemoveIndexes );
 %Docstring
-Removes vertices with indexes in the list ``verticesToRemoveIndexes`` in the mesh
-if ``fillHoles`` is set to ``True``, this operation will fill holes created in the mesh, if not remove the surrounding faces
+Removes vertices with indexes in the list ``verticesToRemoveIndexes`` in the mesh removing the surrounding faces without filling the freed space.
 
-If removing these vertices leads to a topological errors, the method will return the corresponding error and the operatio is canceled
+If removing these vertices leads to a topological errors, the method will return the corresponding error and the operation is canceled
+%End
+
+    QList<int> removeVerticesFillHoles( const QList<int> &verticesToRemoveIndexes );
+%Docstring
+Removes vertices with indexes in the list ``verticesToRemoveIndexes`` in the mesh the surrounding faces AND fills the freed space.
+
+This operation fills holes by a Delaunay triangulation using the surrounding vertices.
+Some vertices could no be deleted to avoid topological error even with hole filling (can not be detected before execution).
+A list of the remaining vertex indexes is returned.
 %End
 
     void changeZValues( const QList<int> &verticesIndexes, const QList<double> &newValues );
@@ -152,7 +160,7 @@ Changes the Z values of the vertices with indexes in ``vertices`` indexes with t
 
     void changeXYValues( const QList<int> &verticesIndexes, const QList<QgsPointXY> &newValues );
 %Docstring
-Changes the (X,Y) coordinates values of the vertices with indexes in ``vertices`` indexes with the values in ``newValues``.
+Changes the (X,Y) coordinates values of the vertices with indexes in ``verticesIndexes`` with the values in ``newValues``.
 The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
 New values are in layer CRS.
 %End
@@ -209,7 +217,7 @@ Returns whether the vertex with index ``vertexIndex`` is on a boundary
 Returns whether the vertex with index ``vertexIndex`` is a free vertex
 %End
 
-    bool checkConsistency() const;
+    bool checkConsistency( QgsMeshEditingError &error ) const;
 %Docstring
 Return ``True`` if the edited mesh is consistent
 %End
@@ -228,6 +236,11 @@ Returns the count of valid faces, that is non void faces in the mesh
     int validVerticesCount() const;
 %Docstring
 Returns the count of valid vertices, that is non void vertices in the mesh
+%End
+
+    int maximumVerticesPerFace() const;
+%Docstring
+Returns the maximum count of vertices per face that the mesh can support
 %End
 
   signals:

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -401,7 +401,7 @@ QgsTopologicalMesh::Changes QgsMeshEditingDelaunayTriangulation::apply( QgsMeshE
       topologicFaces = meshEditor->topologicalMesh().createNewTopologicalFaces( destinationFaces, true, error );
 
       if ( error == QgsMeshEditingError() )
-        error = meshEditor->topologicalMesh().canFacesBeAdded( topologicFaces );
+        error = meshEditor->topologicalMesh().facesCanBeAdded( topologicFaces );
 
       switch ( error.errorType )
       {

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1709,12 +1709,27 @@ void QgsMapToolEditMeshFrame::setSelectedFaces( const QList<int> newSelectedFace
 
 void QgsMapToolEditMeshFrame::removeSelectedVerticesFromMesh( bool fillHole )
 {
-  QgsMeshEditingError error = mCurrentEditor->removeVertices( mSelectedVertices.keys(), fillHole );
-  if ( error != QgsMeshEditingError() )
+  if ( fillHole )
   {
-    QgisApp::instance()->messageBar()->pushWarning(
-      tr( "Mesh editing" ),
-      tr( "removing the vertex %1 leads to a topological error, operation canceled." ).arg( error.elementIndex ) );
+
+    QList<int> remainingVertex = mCurrentEditor->removeVerticesFillHoles( mSelectedVertices.keys() );
+
+    if ( !remainingVertex.isEmpty() )
+    {
+      QgisApp::instance()->messageBar()->pushWarning(
+        tr( "Mesh editing" ),
+        tr( "%n vertices were not removed", nullptr, remainingVertex.count() ) );
+    }
+  }
+  else
+  {
+    QgsMeshEditingError error = mCurrentEditor->removeVerticesWithoutFillHoles( mSelectedVertices.keys() );
+    if ( error != QgsMeshEditingError() )
+    {
+      QgisApp::instance()->messageBar()->pushWarning(
+        tr( "Mesh editing" ),
+        tr( "removing the vertex %1 leads to a topological error, operation canceled." ).arg( error.elementIndex ) );
+    }
   }
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11482,7 +11482,11 @@ bool QgisApp::toggleEditingMeshLayer( QgsMeshLayer *mlayer, bool allowCancel )
     mActionToggleEditing->setChecked( res );
 
     if ( !res )
-      QgsMessageLog::logMessage( tr( "Unable to start mesh editing for layer \"%1\"" ).arg( mlayer->name() ) );
+    {
+      visibleMessageBar()->pushWarning(
+        tr( "Mesh editing" ),
+        tr( "Unable to start mesh editing for layer \"%1\"" ).arg( mlayer->name() ) );
+    }
   }
   else if ( mlayer->isModified() )
   {
@@ -11504,6 +11508,9 @@ bool QgisApp::toggleEditingMeshLayer( QgsMeshLayer *mlayer, bool allowCancel )
         QgsCanvasRefreshBlocker refreshBlocker;
         if ( !mlayer->commitFrameEditing( transform, false ) )
         {
+          visibleMessageBar()->pushWarning(
+            tr( "Mesh editing" ),
+            tr( "Unable to save editing for layer \"%1\"" ).arg( mlayer->name() ) );
           res = false;
         }
 
@@ -11606,7 +11613,11 @@ void QgisApp::saveMeshLayerEdits( QgsMapLayer *layer, bool leaveEditable, bool t
 
   QgsCanvasRefreshBlocker refreshBlocker;
   QgsCoordinateTransform transform( mlayer->crs(), mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
-  mlayer->commitFrameEditing( transform, leaveEditable );
+
+  if ( !mlayer->commitFrameEditing( transform, leaveEditable ) )
+    visibleMessageBar()->pushWarning(
+      tr( "Mesh editing" ),
+      tr( "Unable to save editing for layer \"%1\"" ).arg( mlayer->name() ) );
 
   if ( triggerRepaint )
   {

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -348,9 +348,10 @@ void QgsMeshEditor::updateElementsCount( const QgsTopologicalMesh::Changes &chan
   }
 }
 
-bool QgsMeshEditor::checkConsistency() const
+bool QgsMeshEditor::checkConsistency( QgsMeshEditingError &error ) const
 {
-  switch ( mTopologicalMesh.checkConsistency().errorType )
+  error = mTopologicalMesh.checkConsistency();
+  switch ( error.errorType )
   {
     case Qgis::MeshEditingErrorType::NoError:
       break;

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -176,7 +176,7 @@ bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face )
 
   // Check if there is topological error with the mesh
   QgsTopologicalMesh::TopologicalFaces topologicalFaces = mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
-  error = mTopologicalMesh.canFacesBeAdded( topologicalFaces );
+  error = mTopologicalMesh.facesCanBeAdded( topologicalFaces );
 
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return false;
@@ -431,7 +431,7 @@ int QgsMeshEditor::validVerticesCount() const
 
 QgsMeshEditingError QgsMeshEditor::removeFaces( const QList<int> &facesToRemove )
 {
-  QgsMeshEditingError error = mTopologicalMesh.canFacesBeRemoved( facesToRemove );
+  QgsMeshEditingError error = mTopologicalMesh.facesCanBeRemoved( facesToRemove );
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return error;
 
@@ -468,7 +468,7 @@ void QgsMeshEditor::merge( int vertexIndex1, int vertexIndex2 )
 
 bool QgsMeshEditor::faceCanBeSplit( int faceIndex ) const
 {
-  return mTopologicalMesh.faceCanBeSplit( faceIndex );
+  return mTopologicalMesh.canBeSplit( faceIndex );
 }
 
 int QgsMeshEditor::splitFaces( const QList<int> &faceIndexes )
@@ -520,7 +520,7 @@ QgsMeshEditingError QgsMeshEditor::addFaces( const QVector<QVector<int> > &faces
 
   QgsTopologicalMesh::TopologicalFaces topologicalFaces = mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
 
-  error = mTopologicalMesh.canFacesBeAdded( topologicalFaces );
+  error = mTopologicalMesh.facesCanBeAdded( topologicalFaces );
 
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return error;
@@ -595,7 +595,7 @@ QgsMeshEditingError QgsMeshEditor::removeVertices( const QList<int> &verticesToR
     for ( const int vi : std::as_const( verticesIndexes ) )
       concernedNativeFaces.unite( qgis::listToSet( mTopologicalMesh.facesAroundVertex( vi ) ) );
 
-    error = mTopologicalMesh.canFacesBeRemoved( concernedNativeFaces.values() );
+    error = mTopologicalMesh.facesCanBeRemoved( concernedNativeFaces.values() );
     if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
       return error;
   }

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -377,6 +377,7 @@ class QgsMeshLayerUndoCommandAddVertices : public QgsMeshLayerUndoCommandMeshEdi
 class QgsMeshLayerUndoCommandRemoveVerticesWithoutFillHoles : public QgsMeshLayerUndoCommandMeshEdit
 {
   public:
+
     /**
      * Constructor with the associated \a meshEditor and \a vertices that will be removed
      */
@@ -397,11 +398,12 @@ class QgsMeshLayerUndoCommandRemoveVerticesWithoutFillHoles : public QgsMeshLaye
 class QgsMeshLayerUndoCommandRemoveVerticesFillHoles : public QgsMeshLayerUndoCommandMeshEdit
 {
   public:
+
     /**
      * Constructor with the associated \a meshEditor and \a vertices that will be removed
      *
      * The pointer \a remainingVertex is used to know the remaining vertex that have not been removed by the operation
-     * afer the command was pushed in the undo/redo stack. The list pointed by \a remainingVertexPointer must not be
+     * after the command was pushed in the undo/redo stack. The list pointed by \a remainingVertexPointer must not be
      * destructed until the command is pushed to an undo/redo stack or the redo() method is called.
      *
      */

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -46,9 +46,9 @@ class CORE_EXPORT QgsMeshEditingError
     //! Constructor with eht error \a type and the index of the element \a elementIndex
     QgsMeshEditingError( Qgis::MeshEditingErrorType type, int elementIndex );
 
-    Qgis::MeshEditingErrorType errorType;
+    Qgis::MeshEditingErrorType errorType = Qgis::MeshEditingErrorType::NoError;
 
-    int elementIndex;
+    int elementIndex = -1;
 
     bool operator==( const QgsMeshEditingError &other ) const {return ( other.errorType == errorType && other.elementIndex == elementIndex );}
     bool operator!=( const QgsMeshEditingError &other ) const {return !operator==( other );}
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
     QgsTriangularMesh *triangularMesh(); SIP_SKIP
 
     //! Return TRUE if the edited mesh is consistent
-    bool checkConsistency() const;
+    bool checkConsistency( QgsMeshEditingError &error ) const;
 
     /**
      * Returns TRUE if an edge of face is closest than the tolerance from the \a point in triangular mesh coordinate

--- a/src/core/mesh/qgsmesheditor.h
+++ b/src/core/mesh/qgsmesheditor.h
@@ -152,7 +152,7 @@ class CORE_EXPORT QgsMeshEditor : public QObject
      *  Removes vertices with indexes in the list \a verticesToRemoveIndexes in the mesh
      *  if \a fillHoles is set to TRUE, this operation will fill holes created in the mesh, if not remove the surrounding faces
      *
-     *  If removing these vertices leads to a topological errors, the method will return the corresponding error and the operatio is canceled
+     *  If removing these vertices leads to a topological errors, the method will return the corresponding error and the operation is canceled
      */
     QgsMeshEditingError removeVertices( const QList<int> &verticesToRemoveIndexes, bool fillHoles = false );
 
@@ -163,19 +163,19 @@ class CORE_EXPORT QgsMeshEditor : public QObject
 
     /**
      * Returns TRUE if faces with index in \a transformedFaces can be transformed without obtaining topologic or geometrical errors
-     * condidering the transform function \a transformFunction
+     * considering the transform function \a transformFunction
      *
      * The transform function takes a vertex index in parameter and return a QgsMeshVertex object with transformed coordinates.
      * This transformation is done in layer coordinates
      *
-     * \note Even only the faces with indexes in \a transformdFaces are checked to avoid testing all the mesh,
+     * \note Even only the faces with indexes in \a facesToCheck are checked to avoid testing all the mesh,
      * all the mesh are supposed to path through this transform function (but it is possible that transform function is not able to transform all vertices).
-     * Moving free vertices of the mesh are also checked.
+     * Moving free vertices of the mesh is also checked.
      */
     bool canBeTransformed( const QList<int> &facesToCheck, const std::function<const QgsMeshVertex( int )> &transformFunction ) const; SIP_SKIP
 
     /**
-     * Changes the (X,Y) coordinates values of the vertices with indexes in \a vertices indexes with the values in \a newValues.
+     * Changes the (X,Y) coordinates values of the vertices with indexes in \a verticesIndexes with the values in \a newValues.
      * The caller has the responsibility to check if changing the vertices coordinates does not lead to topological errors.
      * New values are in layer CRS.
      */

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -966,7 +966,8 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
 
 bool QgsMeshLayer::commitFrameEditing( const QgsCoordinateTransform &transform, bool continueEditing )
 {
-  if ( !mMeshEditor->checkConsistency() )
+  QgsMeshEditingError error;
+  if ( !mMeshEditor->checkConsistency( error ) )
   {
     QgsMessageLog::logMessage( QObject::tr( "Mesh layer \"%1\" not support mesh editing" ).arg( name() ), QString(), Qgis::MessageLevel::Critical );
     return false;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -919,6 +919,37 @@ qint64 QgsMeshLayer::datasetRelativeTimeInMilliseconds( const QgsMeshDatasetInde
   return mDatasetGroupStore->datasetRelativeTime( index );
 }
 
+static QString detailsErrorMessage( const QgsMeshEditingError &error )
+{
+  QString message;
+
+  switch ( error.errorType )
+  {
+    case Qgis::MeshEditingErrorType::NoError:
+      break;
+    case Qgis::MeshEditingErrorType::InvalidFace:
+      message = QObject::tr( "Face %1 invalid" ).arg( error.elementIndex );
+      break;
+    case Qgis::MeshEditingErrorType::TooManyVerticesInFace:
+      message =  QObject::tr( "Too many vertices for face %1" ).arg( error.elementIndex );
+      break;
+    case Qgis::MeshEditingErrorType::FlatFace:
+      message =  QObject::tr( "Face %1 is flat" ).arg( error.elementIndex );
+      break;
+    case Qgis::MeshEditingErrorType::UniqueSharedVertex:
+      message =  QObject::tr( "Vertex %1 is a unique shared vertex" ).arg( error.elementIndex );
+      break;
+    case Qgis::MeshEditingErrorType::InvalidVertex:
+      message =  QObject::tr( "Vertex %1 is invalid" ).arg( error.elementIndex );
+      break;
+    case Qgis::MeshEditingErrorType::ManifoldFace:
+      message =  QObject::tr( "Face %1 is manifold" ).arg( error.elementIndex );
+      break;
+  }
+
+  return message;
+}
+
 bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
 {
   if ( !supportsEditing() )
@@ -943,7 +974,9 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
   {
     mMeshEditor->deleteLater();
     mMeshEditor = nullptr;
-    QgsMessageLog::logMessage( QObject::tr( "Unable to start editing of mesh layer \"%1\"." ).arg( name() ), QString(), Qgis::MessageLevel::Critical );
+
+    QgsMessageLog::logMessage( QObject::tr( "Unable to start editing of mesh layer \"%1\": %2" ).
+                               arg( name(), detailsErrorMessage( error ) ), QString(), Qgis::MessageLevel::Critical );
     return false;
   }
 
@@ -967,9 +1000,22 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
 bool QgsMeshLayer::commitFrameEditing( const QgsCoordinateTransform &transform, bool continueEditing )
 {
   QgsMeshEditingError error;
+  QString detailsError;
   if ( !mMeshEditor->checkConsistency( error ) )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Mesh layer \"%1\" not support mesh editing" ).arg( name() ), QString(), Qgis::MessageLevel::Critical );
+    if ( error.errorType == Qgis::MeshEditingErrorType::NoError )
+      detailsError = tr( "Unknown inconsistent mesh error" );
+  }
+  else
+  {
+    error = QgsTopologicalMesh::checkTopology( *mNativeMesh, mMeshEditor->maximumVerticesPerFace() );
+    detailsError = detailsErrorMessage( error );
+  }
+
+  if ( !detailsError.isEmpty() )
+  {
+    QgsMessageLog::logMessage( QObject::tr( "Edited mesh layer \"%1\" can't be save due to an error: %2" ).
+                               arg( name(), detailsError ), QString(), Qgis::MessageLevel::Critical );
     return false;
   }
 

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -1680,7 +1680,7 @@ QList<int> QgsTopologicalMesh::facesAroundVertex( int vertexIndex ) const
   return circ.facesAround();
 }
 
-QgsMeshEditingError QgsTopologicalMesh::canFacesBeRemoved( const QList<int> facesIndexes )
+QgsMeshEditingError QgsTopologicalMesh::facesCanBeRemoved( const QList<int> facesIndexes )
 {
   QSet<int> removedFaces = qgis::listToSet( facesIndexes );
   QSet<int> concernedFaces = concernedFacesBy( facesIndexes );
@@ -2072,7 +2072,7 @@ QgsTopologicalMesh::Changes QgsTopologicalMesh::merge( int vertexIndex1, int ver
   return changes;
 }
 
-bool QgsTopologicalMesh::faceCanBeSplit( int faceIndex ) const
+bool QgsTopologicalMesh::canBeSplit( int faceIndex ) const
 {
   const QgsMeshFace face = mMesh->face( faceIndex );
 

--- a/src/core/mesh/qgstopologicalmesh.cpp
+++ b/src/core/mesh/qgstopologicalmesh.cpp
@@ -1059,6 +1059,28 @@ QList<int> QgsTopologicalMesh::Changes::nativeFacesIndexesGeometryChanged() cons
   return mNativeFacesIndexesGeometryChanged;
 }
 
+bool QgsTopologicalMesh::Changes::isEmpty() const
+{
+  return ( mFaceIndexesToRemove.isEmpty() &&
+           mFacesToAdd.isEmpty() &&
+           mFacesNeighborhoodToAdd.isEmpty() &&
+           mFacesToRemove.isEmpty() &&
+           mFacesNeighborhoodToRemove.isEmpty() &&
+           mNeighborhoodChanges.isEmpty() &&
+           mVerticesToAdd.isEmpty() &&
+           mVertexToFaceToAdd.isEmpty() &&
+           mVerticesToRemoveIndexes.isEmpty() &&
+           mRemovedVertices.isEmpty() &&
+           mVerticesToFaceRemoved.isEmpty() &&
+           mVerticesToFaceChanges.isEmpty() &&
+           mChangeCoordinateVerticesIndexes.isEmpty() &&
+           mNewZValues.isEmpty() &&
+           mOldZValues.isEmpty() &&
+           mNewXYValues.isEmpty() &&
+           mOldXYValues.isEmpty() &&
+           mNativeFacesIndexesGeometryChanged.isEmpty() );
+}
+
 QList<int> QgsTopologicalMesh::Changes::verticesToRemoveIndexes() const
 {
   return mVerticesToRemoveIndexes;
@@ -1122,7 +1144,8 @@ QgsTopologicalMesh::Changes QgsTopologicalMesh::addFreeVertex( const QgsMeshVert
 static double vertexPolygonOrientation( const QgsMesh &mesh, const QList<int> &vertexIndexes )
 {
   if ( vertexIndexes.count() < 3 )
-    return 0;
+    return 0.0;
+
   int hullDomainVertexPos = -1;
   double xMin = std::numeric_limits<double>::max();
   double yMin = std::numeric_limits<double>::max();
@@ -1146,9 +1169,8 @@ static double vertexPolygonOrientation( const QgsMesh &mesh, const QList<int> &v
     return cp;
   }
 
-  return 0;
+  return 0.0;
 }
-
 
 QgsTopologicalMesh::Changes QgsTopologicalMesh::removeVertexFillHole( int vertexIndex )
 {

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -311,6 +311,9 @@ class CORE_EXPORT QgsTopologicalMesh
     //! Checks the consistency of the topological mesh and return FALSE if there is a consistency issue
     QgsMeshEditingError checkConsistency() const;
 
+    //! Checks the topology of the mesh \mesh, if error occurs, this mesh can't be edited
+    static QgsMeshEditingError checkTopology( const QgsMesh &mesh, int maxVerticesPerFace );
+
   private:
 
     //! Creates topological faces from mesh faces

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -314,7 +314,7 @@ class CORE_EXPORT QgsTopologicalMesh
     //! Checks the consistency of the topological mesh and return FALSE if there is a consistency issue
     QgsMeshEditingError checkConsistency() const;
 
-    //! Checks the topology of the mesh \mesh, if error occurs, this mesh can't be edited
+    //! Checks the topology of the mesh \a mesh, if error occurs, this mesh can't be edited
     static QgsMeshEditingError checkTopology( const QgsMesh &mesh, int maxVerticesPerFace );
 
   private:

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -121,6 +121,9 @@ class CORE_EXPORT QgsTopologicalMesh
         //! Returns a list of the native face indexes that have a geometry changed
         QList<int> nativeFacesIndexesGeometryChanged() const;
 
+        //! Returns whether changes are empty, that there is nothing to change
+        bool isEmpty() const;
+
       protected:
         int mAddedFacesFirstIndex = 0;
         QList<int> mFaceIndexesToRemove; // the removed faces indexes in the mesh

--- a/src/core/mesh/qgstopologicalmesh.h
+++ b/src/core/mesh/qgstopologicalmesh.h
@@ -192,7 +192,7 @@ class CORE_EXPORT QgsTopologicalMesh
     //----------- editing methods
 
     //! Returns whether the faces can be added to the mesh
-    QgsMeshEditingError canFacesBeAdded( const TopologicalFaces &topologicalFaces ) const;
+    QgsMeshEditingError facesCanBeAdded( const TopologicalFaces &topologicalFaces ) const;
 
     /**
      * Adds faces \a topologicFaces to the topologic mesh.
@@ -204,7 +204,7 @@ class CORE_EXPORT QgsTopologicalMesh
      * Returns whether faces with index in \a faceIndexes can be removed/
      * The method an error object with type QgsMeshEditingError::NoError if the faces can be removed, otherwise returns the corresponding error
      */
-    QgsMeshEditingError canFacesBeRemoved( const QList<int> facesIndexes );
+    QgsMeshEditingError facesCanBeRemoved( const QList<int> facesIndexes );
 
     /**
      * Removes faces with index in \a faceIndexes.
@@ -237,7 +237,7 @@ class CORE_EXPORT QgsTopologicalMesh
     /**
      * Returns TRUE if face with index \a faceIndex can be split
      */
-    bool faceCanBeSplit( int faceIndex ) const;
+    bool canBeSplit( int faceIndex ) const;
 
     /**
      * Splits face with index \a faceIndex

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -252,10 +252,10 @@ void TestQgsMeshEditor::editTopologicMesh()
   QVERIFY( !topologicalMesh.edgeCanBeFlipped( 1, 2 ) );
   QVERIFY( !topologicalMesh.edgeCanBeFlipped( 1, 4 ) );
 
-  QVERIFY( topologicalMesh.faceCanBeSplit( 0 ) );
-  QVERIFY( !topologicalMesh.faceCanBeSplit( 1 ) );
-  QVERIFY( !topologicalMesh.faceCanBeSplit( 2 ) );
-  QVERIFY( !topologicalMesh.faceCanBeSplit( 3 ) );
+  QVERIFY( topologicalMesh.canBeSplit( 0 ) );
+  QVERIFY( !topologicalMesh.canBeSplit( 1 ) );
+  QVERIFY( !topologicalMesh.canBeSplit( 2 ) );
+  QVERIFY( !topologicalMesh.canBeSplit( 3 ) );
 
   QVector<QgsTopologicalMesh::Changes> topologicalChanges;
 
@@ -281,12 +281,12 @@ void TestQgsMeshEditor::editTopologicMesh()
   QVector<QgsMeshFace> faces;
   faces = {{5, 7, 6}};
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) ==
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) ==
            QgsMeshEditingError( Qgis::MeshEditingErrorType::UniqueSharedVertex, 5 ) );
 
   faces = {{5, 7, 6, 4}};
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
   faces =
   {
@@ -301,7 +301,7 @@ void TestQgsMeshEditor::editTopologicMesh()
 
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
 
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
   faces =
   {
@@ -315,7 +315,7 @@ void TestQgsMeshEditor::editTopologicMesh()
   };
 
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ).errorType ==  Qgis::MeshEditingErrorType::UniqueSharedVertex );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ).errorType ==  Qgis::MeshEditingErrorType::UniqueSharedVertex );
   QCOMPARE( topologicalMesh.freeVerticesIndexes().count(), 6 );
 
   faces =
@@ -331,7 +331,7 @@ void TestQgsMeshEditor::editTopologicMesh()
   };
 
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
   faces =
   {
@@ -345,12 +345,12 @@ void TestQgsMeshEditor::editTopologicMesh()
 
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
   QVERIFY( error == QgsMeshEditingError() );
-  error = topologicalMesh.canFacesBeAdded( topologicFaces );
+  error = topologicalMesh.facesCanBeAdded( topologicFaces );
   QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 0 ) );
 
   faces = {{5, 7, 6, 4}};
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
   topologicalChanges.append( topologicalMesh.addFaces( topologicFaces ) ) ;
 
   QCOMPARE( topologicalMesh.freeVerticesIndexes().count(), 4 );
@@ -392,7 +392,7 @@ void TestQgsMeshEditor::editTopologicMesh()
   };
 
   topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
-  QVERIFY( topologicalMesh.canFacesBeAdded( topologicFaces ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
   topologicalChanges.append( topologicalMesh.addFaces( topologicFaces ) ) ;
 
   QCOMPARE( topologicalMesh.freeVerticesIndexes().count(), 0 );
@@ -470,28 +470,28 @@ void TestQgsMeshEditor::editTopologicMesh()
 
   QList<int> faceToRemove;
   faceToRemove = {2, 3};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
 
   faceToRemove = {0, 1, 2, 3};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
 
   faceToRemove = {0, 9};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ) == QgsMeshEditingError() );
 
   faceToRemove = {8, 0, 9, 10};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ) == QgsMeshEditingError() );
 
   faceToRemove = {1, 2, 3, 4, 5};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ) == QgsMeshEditingError() );
 
   faceToRemove = {0, 1, 2, 3, 4, 5};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ).errorType == Qgis::MeshEditingErrorType::UniqueSharedVertex );
 
   faceToRemove = {9, 0, 1, 2, 3, 4, 5};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ) == QgsMeshEditingError() );
 
   faceToRemove = {0, 6, 7, 8};
-  QVERIFY( topologicalMesh.canFacesBeRemoved( faceToRemove ) == QgsMeshEditingError() );
+  QVERIFY( topologicalMesh.facesCanBeRemoved( faceToRemove ) == QgsMeshEditingError() );
 
   topologicalChanges.append( topologicalMesh.removeFaces( {0, 9} ) );
 
@@ -562,7 +562,7 @@ void TestQgsMeshEditor::editTopologicMesh()
   QVERIFY( checkFacesAround( topologicalMesh, 3, {16, 25, 22, 10} ) );
   QVERIFY( topologicalMesh.checkConsistency() == QgsMeshEditingError() );
 
-  QVERIFY( topologicalMesh.faceCanBeSplit( 25 ) );
+  QVERIFY( topologicalMesh.canBeSplit( 25 ) );
   topologicalChanges.append( topologicalMesh.splitFace( 25 ) );
   QVERIFY( checkFacesAround( topologicalMesh, 12, {11, 12, 20, 22, 26, 27} ) );
   QVERIFY( checkFacesAround( topologicalMesh, 8, {18, 20, 27} ) );
@@ -928,7 +928,7 @@ void TestQgsMeshEditor::particularCases()
 
     const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
     QVERIFY( error == QgsMeshEditingError() );
-    error = meshEditor.mTopologicalMesh.canFacesBeAdded( topologicFaces );
+    error = meshEditor.mTopologicalMesh.facesCanBeAdded( topologicFaces );
     QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 2 ) );
   }
 
@@ -960,7 +960,7 @@ void TestQgsMeshEditor::particularCases()
 
     const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
     QVERIFY( error == QgsMeshEditingError() );
-    error = meshEditor.mTopologicalMesh.canFacesBeAdded( topologicFaces );
+    error = meshEditor.mTopologicalMesh.facesCanBeAdded( topologicFaces );
     QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 4 ) );
 
     QVERIFY( !meshEditor.isFaceGeometricallyCompatible( {1, 3, 2} ) );

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -1104,7 +1104,7 @@ void TestQgsMeshEditor::particularCases()
     QCOMPARE( mesh.vertexCount(), 10 );
     QCOMPARE( mesh.faceCount(), 8 );
 
-    // with the intersecting vertex completly out
+    // with the intersecting vertex completely out
     mesh.vertices[2] = QgsMeshVertex( 4, 5, 0 );
 
     changes = topologicMesh.removeVertexFillHole( 5 );

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -858,7 +858,7 @@ void TestQgsMeshEditor::particularCases()
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
     QVERIFY( meshEditor.checkConsistency( error ) );
 
-    QVERIFY( meshEditor.removeVertices( {5, 1}, false ) == QgsMeshEditingError() );
+    QVERIFY( meshEditor.removeVerticesWithoutFillHoles( {5, 1} ) == QgsMeshEditingError() );
     QVERIFY( meshEditor.checkConsistency( error ) );
 
     meshEditor.mUndoStack->undo();
@@ -867,7 +867,7 @@ void TestQgsMeshEditor::particularCases()
 
     QVERIFY( meshEditor.checkConsistency( error ) );
 
-    QVERIFY( meshEditor.removeVertices( {6}, false ) == QgsMeshEditingError() );
+    QVERIFY( meshEditor.removeVerticesWithoutFillHoles( {6} ) == QgsMeshEditingError() );
 
     meshEditor.stopEditing();
 
@@ -899,7 +899,7 @@ void TestQgsMeshEditor::particularCases()
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
     QVERIFY( meshEditor.checkConsistency( error ) );
 
-    QVERIFY( meshEditor.removeVertices( {5}, true ) == QgsMeshEditingError() );
+    QVERIFY( meshEditor.removeVerticesFillHoles( {5} ) == QList<int>() );
   }
 
   {
@@ -1031,7 +1031,7 @@ void TestQgsMeshEditor::particularCases()
         if ( j > 1 && j < sideSize - 2 && i < sideSize - 20 )
           verticesToRemove.append( i * sideSize + j );
 
-    QVERIFY( meshEditor.removeVertices( verticesToRemove, false ) == QgsMeshEditingError() );
+    QVERIFY( meshEditor.removeVerticesWithoutFillHoles( verticesToRemove ) == QgsMeshEditingError() );
     QVERIFY( meshEditor.checkConsistency( error ) );
 
     // just create a valid different transform to update the vertices of the triangular mesh
@@ -1596,7 +1596,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadTriangle()
   QCOMPARE( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().count(), 1 );
   QVERIFY( meshLayerQuadTriangle->meshEditor()->freeVerticesIndexes().contains( 8 ) );
 
-  editor->removeVertices( {7} );
+  editor->removeVerticesWithoutFillHoles( {7} );
 
   centroid = meshLayerQuadTriangle->snapOnElement( QgsMesh::Face, QgsPoint( 1400, 2050, 0 ), 10 );
   QVERIFY( centroid.isEmpty() );
@@ -1702,11 +1702,11 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   QCOMPARE( meshLayerQuadFlower->datasetValue( QgsMeshDatasetIndex( 0, 0 ), QgsPointXY( 1420, 2220 ), 10 ).x(), -10 );
 
-  QVERIFY( editor->removeVertices( {0}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {0} ) == QList<int>() );
 
   meshLayerQuadFlower->undoStack()->undo();
 
-  QVERIFY( editor->removeVertices( {0} ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesWithoutFillHoles( {0} ) == QgsMeshEditingError() );
   QVERIFY( editor->checkConsistency( error ) );
 
   QgsPointXY centroid = meshLayerQuadFlower->snapOnElement( QgsMesh::Face, QgsPoint( 1200, 2500, 0 ), 10 );
@@ -1756,12 +1756,12 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QVERIFY( !editor->edgeCanBeFlipped( 8, 9 ) );
   QVERIFY( !editor->edgeCanBeFlipped( 10, 17 ) );
 
-  QVERIFY( editor->removeVertices( {10}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {10} ) == QList<int>() );
   QVERIFY( editor->checkConsistency( error ) );
 
   editor->mUndoStack->undo();
 
-  QVERIFY( editor->removeVertices( {10}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {10} ) == QList<int>() );
 
   centroid = meshLayerQuadFlower->snapOnElement( QgsMesh::Face, QgsPoint( 1330, 2500, 0 ), 10 );
   QVERIFY( centroid.compare( QgsPointXY( 1400, 2500 ), 1e-2 ) );
@@ -1771,19 +1771,19 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   editor->mUndoStack->undo();
 
-  QVERIFY( editor->removeVertices( {13}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {13} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {11}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {11} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {9}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {9} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {8}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {8} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {15}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {15} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {14}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {14} ) == QList<int>() );
 
-  QVERIFY( editor->removeVertices( {7}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {7} ) == QList<int>() );
 
   QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 5 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 7 );
@@ -1798,13 +1798,13 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 7 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
 
-  QVERIFY( editor->removeVertices( {3}, false ).errorType != Qgis::MeshEditingErrorType::NoError ); // leads to a topological error
+  QVERIFY( editor->removeVerticesWithoutFillHoles( {3} ).errorType != Qgis::MeshEditingErrorType::NoError ); // leads to a topological error
   QCOMPARE( meshLayerQuadFlower->meshEditor()->addVertices( {{4000, 4000, 0}, {4000, 4100, 0}, {4100, 4000, 0}, {4100, 4100, 0}}, 10 ), 4 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 4 );
 
   //QVERIFY( editor->removeVertices( {3}, true ).errorType != Qgis::MeshEditingErrorType::NoError ); // filling after removing boundary not supported, so not fill and leads to a topological error
 
-  QVERIFY( editor->removeVertices( {4}, true ) == QgsMeshEditingError() );
+  QVERIFY( editor->removeVerticesFillHoles( {4} ) == QList<int>() );
   QVERIFY( editor->checkConsistency( error ) );
 
   meshLayerQuadFlower->commitFrameEditing( transform, true );

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -723,6 +723,8 @@ void TestQgsMeshEditor::meshEditorSimpleEdition()
                                           QgsPoint( 1.0, 0.0, 0.0 ), // 3
                                           QgsPoint( )} );            // 4
 
+  QgsMeshEditingError error;
+
   meshEditor.addVertices( vertices, 0.01 );
 
   for ( int i = 0; i < 5; ++i )
@@ -742,7 +744,7 @@ void TestQgsMeshEditor::meshEditorSimpleEdition()
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 0.6, 0.5 ) ), 1 );
   QCOMPARE( triangularMesh.faceIndexesForRectangle( QgsRectangle( 0.1, 0.1, 0.7, 0.7 ) ).count(), 2 );
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 1, 0.5 ) ), -1 );
-  QVERIFY( meshEditor.checkConsistency() );
+  QVERIFY( meshEditor.checkConsistency( error ) );
 
   QCOMPARE( meshEditor.mTopologicalMesh.neighborsOfFace( 0 ), QVector<int>( {-1, -1, -1, -1} ) );
   for ( int i = 0; i < 4; ++i )
@@ -757,7 +759,7 @@ void TestQgsMeshEditor::meshEditorSimpleEdition()
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 0.6, 0.5 ) ), -1 );
   QCOMPARE( triangularMesh.faceIndexesForRectangle( QgsRectangle( 0.1, 0.1, 0.7, 0.7 ) ).count(), 0 );
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 1, 0.5 ) ), -1 );
-  QVERIFY( meshEditor.checkConsistency() );
+  QVERIFY( meshEditor.checkConsistency( error ) );
 
   // redo edition
   meshEditor.mUndoStack->redo();
@@ -767,7 +769,7 @@ void TestQgsMeshEditor::meshEditorSimpleEdition()
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 0.6, 0.5 ) ), 1 );
   QCOMPARE( triangularMesh.faceIndexesForRectangle( QgsRectangle( 0.1, 0.1, 0.7, 0.7 ) ).count(), 2 );
   QCOMPARE( triangularMesh.faceIndexForPoint_v2( QgsPointXY( 1, 0.5 ) ), -1 );
-  QVERIFY( meshEditor.checkConsistency() );
+  QVERIFY( meshEditor.checkConsistency( error ) );
 
   QCOMPARE( meshEditor.mTopologicalMesh.neighborsOfFace( 0 ), QVector<int>( {-1, -1, -1, -1} ) );
   for ( int i = 0; i < 4; ++i )
@@ -824,6 +826,7 @@ void TestQgsMeshEditor::particularCases()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     mesh.vertices.append( QgsMeshVertex( 0, 0, 0 ) );
     mesh.vertices.append( QgsMeshVertex( 100, 0, 0 ) );
@@ -853,16 +856,16 @@ void TestQgsMeshEditor::particularCases()
     const QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     QVERIFY( meshEditor.removeVertices( {5, 1}, false ) == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     meshEditor.mUndoStack->undo();
     meshEditor.mUndoStack->redo();
     meshEditor.mUndoStack->undo();
 
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     QVERIFY( meshEditor.removeVertices( {6}, false ) == QgsMeshEditingError() );
 
@@ -877,6 +880,7 @@ void TestQgsMeshEditor::particularCases()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     mesh.vertices.append( QgsMeshVertex( 0, 0, 0 ) );
     mesh.vertices.append( QgsMeshVertex( 100, 0, 0 ) );
@@ -893,7 +897,7 @@ void TestQgsMeshEditor::particularCases()
     const QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     QVERIFY( meshEditor.removeVertices( {5}, true ) == QgsMeshEditingError() );
   }
@@ -902,6 +906,7 @@ void TestQgsMeshEditor::particularCases()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     mesh.vertices.append( QgsMeshVertex( 100, 100, 0 ) ); // 0
     mesh.vertices.append( QgsMeshVertex( 200, 110, 0 ) ); // 1
@@ -919,11 +924,10 @@ void TestQgsMeshEditor::particularCases()
     const QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     QVERIFY( meshEditor.isFaceGeometricallyCompatible( {1, 3, 2} ) );
 
-    QgsMeshEditingError error;
     const QVector<QgsMeshFace> facesToAdd( {{0, 1, 2}, {0, 2, 6}, {1, 3, 2}, {2, 3, 4}} );
 
     const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
@@ -936,6 +940,7 @@ void TestQgsMeshEditor::particularCases()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     mesh.vertices.append( QgsMeshVertex( 100, 100, 0 ) ); // 0
     mesh.vertices.append( QgsMeshVertex( 200, 110, 0 ) ); // 1
@@ -953,9 +958,8 @@ void TestQgsMeshEditor::particularCases()
     const QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
-    QgsMeshEditingError error;
     const QVector<QgsMeshFace> facesToAdd( {{1, 6, 0}, {1, 2, 6}, {2, 3, 6}, {3, 4, 6 }, {1, 3, 2} } );
 
     const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
@@ -971,6 +975,7 @@ void TestQgsMeshEditor::particularCases()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     const int sideSize = 40;
 
@@ -1027,7 +1032,7 @@ void TestQgsMeshEditor::particularCases()
           verticesToRemove.append( i * sideSize + j );
 
     QVERIFY( meshEditor.removeVertices( verticesToRemove, false ) == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     // just create a valid different transform to update the vertices of the triangular mesh
     transform = QgsCoordinateTransform( QgsCoordinateReferenceSystem( "EPSG:32620" ),
@@ -1035,7 +1040,7 @@ void TestQgsMeshEditor::particularCases()
                                         QgsCoordinateTransformContext() );
     triangularMesh.update( &mesh, transform );
     meshEditor.mUndoStack->undo();
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
     meshEditor.mUndoStack->redo();
   }
 }
@@ -1385,6 +1390,8 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QVERIFY( editor );
   editor->mMaximumVerticesPerFace = 5; //for testing
 
+  QgsMeshEditingError error;
+
   meshLayerQuadFlower->startFrameEditing( transform );
   editor = meshLayerQuadFlower->meshEditor();
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1500, 2800, -10 )}, 10 ), 1 ); // 8
@@ -1395,7 +1402,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
   QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 14 );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   // attempt to add a vertex under tolerance next existing one
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1499, 2801, -10 )}, 10 ), 0 );
@@ -1408,17 +1415,17 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 13 );
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 1 );
   QVERIFY( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().contains( 12 ) );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   QVERIFY( editor->addFace( {0, 6, 12} ) == QgsMeshEditingError() );
 
   QCOMPARE( meshLayerQuadFlower->meshEditor()->freeVerticesIndexes().count(), 0 );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   QCOMPARE( editor->addPointsAsVertices( {QgsPoint( 1400, 2200, -10 )}, 10 ), 1 ); // 13
 
   QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 17 );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   QCOMPARE( meshLayerQuadFlower->datasetValue( QgsMeshDatasetIndex( 0, 0 ), QgsPointXY( 1420, 2220 ), 10 ).x(), -10 );
 
@@ -1427,7 +1434,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   meshLayerQuadFlower->undoStack()->undo();
 
   QVERIFY( editor->removeVertices( {0} ) == QgsMeshEditingError() );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   QgsPointXY centroid = meshLayerQuadFlower->snapOnElement( QgsMesh::Face, QgsPoint( 1200, 2500, 0 ), 10 );
   QVERIFY( centroid.isEmpty() );
@@ -1477,7 +1484,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QVERIFY( !editor->edgeCanBeFlipped( 10, 17 ) );
 
   QVERIFY( editor->removeVertices( {10}, true ) == QgsMeshEditingError() );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   editor->mUndoStack->undo();
 
@@ -1507,10 +1514,10 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
 
   QCOMPARE( meshLayerQuadFlower->meshFaceCount(), 5 );
   QCOMPARE( meshLayerQuadFlower->meshVertexCount(), 7 );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   meshLayerQuadFlower->commitFrameEditing( transform, true );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   QVERIFY( meshLayerQuadFlower->meshEditor() == editor );
 
@@ -1525,7 +1532,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   //QVERIFY( editor->removeVertices( {3}, true ).errorType != Qgis::MeshEditingErrorType::NoError ); // filling after removing boundary not supported, so not fill and leads to a topological error
 
   QVERIFY( editor->removeVertices( {4}, true ) == QgsMeshEditingError() );
-  QVERIFY( editor->checkConsistency() );
+  QVERIFY( editor->checkConsistency( error ) );
 
   meshLayerQuadFlower->commitFrameEditing( transform, true );
 
@@ -1584,6 +1591,7 @@ void TestQgsMeshEditor::refineMesh()
     QgsMesh mesh;
     QgsTriangularMesh triangularMesh;
     QgsMeshEditor meshEditor( &mesh, &triangularMesh );
+    QgsMeshEditingError error;
 
     mesh.vertices.append( QgsMeshVertex( 100, 300, 0 ) ); // 0
     mesh.vertices.append( QgsMeshVertex( 100, 250, 0 ) ); // 1
@@ -1611,7 +1619,7 @@ void TestQgsMeshEditor::refineMesh()
     const QgsCoordinateTransform transform;
     triangularMesh.update( &mesh, transform );
     QVERIFY( meshEditor.initialize() == QgsMeshEditingError() );
-    QVERIFY( meshEditor.checkConsistency() );
+    QVERIFY( meshEditor.checkConsistency( error ) );
 
     QList<int> facesList;
     facesList << 2 << 3 << 4;
@@ -1869,6 +1877,7 @@ void TestQgsMeshEditor::forceByLine()
 {
   QString uri( mDataDir + "/refined_quad_flower.2dm" );
   std::unique_ptr<QgsMeshLayer> meshLayer = std::make_unique<QgsMeshLayer>( uri, "mesh layer", "mdal" );
+  QgsMeshEditingError error;
 
   QVERIFY( meshLayer->isValid() );
   QgsCoordinateTransform transform;
@@ -1904,7 +1913,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 750, 2251, 0 ), QgsPoint( 2250, 2249, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 2 );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount );
 
@@ -1914,7 +1923,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 500, 3001, 0 ), QgsPoint( 2000, 1499, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 4 );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount );
 
@@ -1924,7 +1933,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 500, 3001, 0 ), QgsPoint( 2000, 1499, 0 ), 2, true );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 8 );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
 
@@ -1934,7 +1943,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1000, 1751, 0 ), QgsPoint( 2250, 2999, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 8 );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
 
@@ -1944,7 +1953,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 999, 2251, 0 ), QgsPoint( 2250, 3000, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 1 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 13 );
 
@@ -1954,7 +1963,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1010, 2251, 0 ), QgsPoint( 2500, 2249, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 1 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 4 );
 
@@ -1964,7 +1973,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1250, 2250, 0 ), QgsPoint( 2250, 3250, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 1 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 10 );
 
@@ -1974,7 +1983,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1250, 2250, 0 ), QgsPoint( 2250, 3250, 0 ), 2, true );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 12 );
 
@@ -1984,7 +1993,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1250, 2250, 0 ), QgsPoint( 1950, 2950, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 12 );
 
@@ -1994,7 +2003,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1250, 2250, 0 ), QgsPoint( 1850, 3050, 0 ), 2, false );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 18 );
 
@@ -2004,7 +2013,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1250, 2250, 0 ), QgsPoint( 1850, 3050, 0 ), 2, true );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 8 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 30 );
 
@@ -2014,7 +2023,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 1200, 2350, 0 ), QgsPoint( 1350, 2150, 0 ), 2, true );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 2 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 7 );
 
@@ -2023,7 +2032,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByLine.setInputLine( QgsPoint( 3170, 2210, 0 ), QgsPoint( 4775, 2680, 0 ), 10, true );
   meshLayer->meshEditor()->advancedEdit( &forceByLine );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 3 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 12 );
 
@@ -2040,7 +2049,7 @@ void TestQgsMeshEditor::forceByLine()
 
   meshLayer->meshEditor()->advancedEdit( &forceByPolyline1 );
 
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 3 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 21 );
 
@@ -2056,7 +2065,7 @@ void TestQgsMeshEditor::forceByLine()
   forceByPolyline2.setAddVertexOnIntersection( true );
 
   meshLayer->meshEditor()->advancedEdit( &forceByPolyline2 );
-  QVERIFY( meshLayer->meshEditor()->checkConsistency() );
+  QVERIFY( meshLayer->meshEditor()->checkConsistency( error ) );
   QCOMPARE( meshLayer->nativeMesh()->vertexCount(), initialVertexCount + 8 );
   QCOMPARE( meshLayer->nativeMesh()->faceCount(), initialFaceCount + 31 );
 


### PR DESCRIPTION
In this PR, the following points are treated:

- some renaming and typo fix

- now, the mesh is checked before starting or saving to see if there is some errors in the mesh. A mesh with error can't be opened and can't be save. Indeed, editing a mesh with errors can lead to undefined behavior. So, if editing creates some errors, the mesh will not be saved to prevent that the user could not start editing this mesh later. The user has the possibility to fix errors and retry to save, depending of their types. To help the user, if there is an error, when trying to save, a message is sent with the type of error and the index of the element that creates this error.

- removing vertex filling hole has some issues that are fixed here. Also some changes / refactorization of the code related to remove vertex.