### PR TITLE
invalid value for memory mesh layer dataset

### DIFF
--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
@@ -314,7 +314,9 @@ bool QgsMeshMemoryDataProvider::addDatasetValues( const QString &def, std::share
       }
       else
       {
-        point.setX( values[0].toDouble() );
+        bool ok;
+        double val = values.at( 0 ).toDouble( &ok );
+        point.setX( ok ? val : std::numeric_limits<double>::quiet_NaN() );
       }
     }
     else
@@ -327,8 +329,11 @@ bool QgsMeshMemoryDataProvider::addDatasetValues( const QString &def, std::share
       }
       else
       {
-        point.setX( values[0].toDouble() );
-        point.setY( values[1].toDouble() );
+        bool ok;
+        double val = values.at( 0 ).toDouble( &ok );
+        point.setX( ok ? val : std::numeric_limits<double>::quiet_NaN() );
+        val = values.at( 1 ).toDouble( &ok );
+        point.setY( ok ? val : std::numeric_limits<double>::quiet_NaN() );
       }
     }
 

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -51,13 +51,13 @@ class TestQgsMeshLayer : public QObject
     QgsMeshLayer *mMemory1DLayer = nullptr;
     QgsMeshLayer *mMdal1DLayer = nullptr;
     QgsMeshLayer *mMdal3DLayer = nullptr;
+    QString readFile( const QString &fname ) const;
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
     void cleanupTestCase();// will be called after the last testfunction was executed.
     void init() {} // will be called before each testfunction is executed.
     void cleanup() {} // will be called after every testfunction.
-    QString readFile( const QString &fname ) const;
 
     void test_write_read_project();
 
@@ -92,6 +92,8 @@ class TestQgsMeshLayer : public QObject
 
     void test_memory_dataset_group();
     void test_memory_dataset_group_1d();
+
+    void test_memoryproviderdataset_invalid_values();
 
     void test_setDataSource();
 
@@ -1492,6 +1494,34 @@ void TestQgsMeshLayer::test_memory_dataset_group_1d()
 
   QCOMPARE( mMdal1DLayer->datasetGroupCount(), 7 );
   QCOMPARE( mMdal1DLayer->extraDatasetGroupCount(), 2 );
+}
+
+void TestQgsMeshLayer::test_memoryproviderdataset_invalid_values()
+{
+  std::unique_ptr<QgsMeshLayer> memoryLayer = std::make_unique<QgsMeshLayer>( readFile( "/quad_and_triangle.txt" ), "Triangle and Quad Memory", "mesh_memory" );
+  memoryLayer->addDatasets( readFile( "/quad_and_triangle_face_scalar_invalid_values.txt" ) );
+  memoryLayer->addDatasets( readFile( "/quad_and_triangle_face_vector_invalid_values.txt" ) );
+
+  QCOMPARE( 2, memoryLayer->datasetGroupCount() );
+
+  QgsMeshDatasetIndex dsi( 0, 0 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 0 ).scalar(), 0 );
+  QVERIFY( std::isnan( memoryLayer->datasetValue( dsi, 1 ).scalar() ) );
+  dsi = QgsMeshDatasetIndex( 0, 1 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 1 ).scalar(), 2 );
+  QVERIFY( std::isnan( memoryLayer->datasetValue( dsi, 0 ).scalar() ) );
+
+  dsi = QgsMeshDatasetIndex( 1, 0 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 1 ).x(), 2 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 1 ).y(), 2 );
+  QVERIFY( std::isnan( memoryLayer->datasetValue( dsi, 0 ).x() ) );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 0 ).y(), 1 );
+
+  dsi = QgsMeshDatasetIndex( 1, 1 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 0 ).x(), 2 );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 0 ).y(), 2 );
+  QVERIFY( std::isnan( memoryLayer->datasetValue( dsi, 1 ).y() ) );
+  QCOMPARE( memoryLayer->datasetValue( dsi, 1 ).x(), 3 );
 }
 
 void TestQgsMeshLayer::test_setDataSource()

--- a/tests/testdata/mesh/quad_and_triangle_face_scalar_invalid_values.txt
+++ b/tests/testdata/mesh/quad_and_triangle_face_scalar_invalid_values.txt
@@ -1,0 +1,11 @@
+Face Scalar FaceScalarDatasetWithInvalidValues
+---
+description: Face Scalar Dataset
+---
+0
+0
+*
+---
+1
+*
+2

--- a/tests/testdata/mesh/quad_and_triangle_face_vector_invalid_values.txt
+++ b/tests/testdata/mesh/quad_and_triangle_face_vector_invalid_values.txt
@@ -1,0 +1,11 @@
+Face Vector FaceVectorDatasetInvalidValues
+---
+description: Face Vector Dataset
+---
+0
+*, 1
+2, 2
+---
+1
+2, 2
+3, *


### PR DESCRIPTION
With memory mesh data provider, dataset values come from strings in the uri. If some string are not number, these strings are converted to zero value despite the value are not really valid. That could leads to confusion as zero is a valid value.

With this PR, not number strings are converted to NaN value.