### PR TITLE
[ogr] Insure that the connections pool always carry on open options

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -957,7 +957,17 @@ QString QgsOgrProviderUtils::connectionPoolId( const QString &dataSourceURI, boo
     QString filePath = dataSourceURI.left( dataSourceURI.indexOf( QLatin1Char( '|' ) ) );
     QFileInfo fi( filePath );
     if ( fi.isFile() )
-      return filePath;
+    {
+      // Preserve open options so pooled connections always carry those on
+      QString openOptions;
+      static thread_local QRegularExpression openOptionsRegex( QStringLiteral( "((?:\\|option:(?:[^|]*))+)" ) );
+      QRegularExpressionMatch match = openOptionsRegex.match( dataSourceURI );
+      if ( match.hasMatch() )
+      {
+        openOptions = match.captured( 1 );
+      }
+      return filePath + openOptions;
+    }
   }
   return dataSourceURI;
 }

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2351,6 +2351,24 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(features[1].attribute('B'), 'B')
         self.assertEqual(features[1].attribute('C'), 'C')
 
+    def test_provider_feature_iterator_options(self):
+        """Test issue GH #45534"""
+
+        datasource = os.path.join(self.basetestpath, 'testProviderFeatureIteratorOptions.csv')
+        with open(datasource, 'wt') as f:
+            f.write('id,Longitude,Latitude\n')
+            f.write('1,1.0,1.0\n')
+            f.write('2,2.0,2.0\n')
+
+        vl = QgsVectorLayer('{}|option:X_POSSIBLE_NAMES=Longitude|option:Y_POSSIBLE_NAMES=Latitude'.format(datasource), 'test', 'ogr')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), QgsWkbTypes.Point)
+
+        f = vl.getFeature(1)
+        self.assertEqual(f.geometry().asWkt(), 'Point (1 1)')
+        f = vl.getFeature(2)
+        self.assertEqual(f.geometry().asWkt(), 'Point (2 2)')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

This PR fixes #45534 by insuring open options within the data source URI are always passed onto the OGR connections pool. A test was added to cover this scenario.

Power to CSV datasets! :wink: