### PR TITLE
Prefer cmake provided FindPostgreSQL scripts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ Following a summary of the required dependencies for building:
 
 Required build tools:
 
-* CMake >= 3.10.0
+* CMake >= 3.12.0
 * Flex >= 2.5.6
 * Bison >= 2.4
 * Python >= 3.7

--- a/cmake/FindPostgres.cmake
+++ b/cmake/FindPostgres.cmake
@@ -14,6 +14,18 @@
 #    POSTGRES_INCLUDE_DIR
 #    POSTGRES_LIBRARY
 
+# First try using the cmake native FindPostgreSQL script.
+# For cmake < 3.20 this also requires server components.
+# Once the minimum cmake version for QGIS is bumped to 3.20
+# we can get rid of our custom script
+find_package(PostgreSQL)
+if(${PostgreSQL_FOUND})
+  set(POSTGRES_INCLUDE_DIR ${PostgreSQL_INCLUDE_DIRS})
+  set(POSTGRES_LIBRARY ${PostgreSQL_LIBRARIES})
+  set(POSTGRES_FOUND TRUE)
+  return()
+endif()
+
 IF(ANDROID)
   SET(POSTGRES_INCLUDE_DIR ${POSTGRES_INCLUDE_DIR} CACHE STRING INTERNAL)
   SET(POSTGRES_LIBRARY ${PG_TMP}/libpq.so CACHE STRING INTERNAL)


### PR DESCRIPTION
This prefers the system script over our built-in one. This is helpful when building with a system like vcpkg which makes sure that the proper libraries are found through the default mechanisms.
Completely replacing our internal scripts is not possible at the moment because with cmake < 3.20 it always looks for serer libraries as well while we only need client libs for our case.