### PR TITLE
Fix area, length and perimeter expression functions and Identify Features map tool area measurement for CircularString and CurvePolygon type entities

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1373,7 +1373,7 @@ static QVariant fcnLength( const QVariantList &values, const QgsExpressionContex
     if ( geom.type() != QgsWkbTypes::LineGeometry )
       return QVariant();
 
-    return QVariant( geom.length() );
+    return QVariant( geom.constGet()->length() );
   }
 
   //otherwise fall back to string variant
@@ -3331,7 +3331,7 @@ static QVariant fcnGeomArea( const QVariantList &, const QgsExpressionContext *c
   }
   else
   {
-    return QVariant( f.geometry().area() );
+    return QVariant( f.geometry().constGet()->area() );
   }
 }
 
@@ -3342,7 +3342,7 @@ static QVariant fcnArea( const QVariantList &values, const QgsExpressionContext 
   if ( geom.type() != QgsWkbTypes::PolygonGeometry )
     return QVariant();
 
-  return QVariant( geom.area() );
+  return QVariant( geom.constGet()->area() );
 }
 
 static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -3358,7 +3358,7 @@ static QVariant fcnGeomLength( const QVariantList &, const QgsExpressionContext 
   }
   else
   {
-    return QVariant( f.geometry().length() );
+    return QVariant( f.geometry().constGet()->length() );
   }
 }
 
@@ -3387,7 +3387,7 @@ static QVariant fcnPerimeter( const QVariantList &values, const QgsExpressionCon
     return QVariant();
 
   //length for polygons = perimeter
-  return QVariant( geom.length() );
+  return QVariant( geom.constGet()->perimeter() );
 }
 
 static QVariant fcnGeomNumPoints( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -865,6 +865,8 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   }
   else if ( geometryType == QgsWkbTypes::PolygonGeometry )
   {
+    const QgsAbstractGeometry *geom = feature.geometry().constGet();
+
     double area = calc.measureArea( feature.geometry() );
     area = calc.convertAreaMeasurement( area, displayAreaUnits() );
     QString str;
@@ -873,7 +875,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
       str = formatArea( area );
       derivedAttributes.insert( tr( "Area (Ellipsoidal — %1)" ).arg( ellipsoid ), str );
     }
-    str = formatArea( feature.geometry().area()
+    str = formatArea( geom->area()
                       * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::distanceToAreaUnit( layer->crs().mapUnits() ), cartesianAreaUnits ), cartesianAreaUnits );
     derivedAttributes.insert( tr( "Area (Cartesian)" ), str );
 
@@ -884,7 +886,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
       str = formatDistance( perimeter );
       derivedAttributes.insert( tr( "Perimeter (Ellipsoidal — %1)" ).arg( ellipsoid ), str );
     }
-    str = formatDistance( feature.geometry().constGet()->perimeter()
+    str = formatDistance( geom->perimeter()
                           * QgsUnitTypes::fromUnitToUnitFactor( layer->crs().mapUnits(), cartesianDistanceUnits ), cartesianDistanceUnits );
     derivedAttributes.insert( tr( "Perimeter (Cartesian)" ), str );
 


### PR DESCRIPTION
## Description

Fixes area, length and perimeter expression functions and the Identify Features map tool area measurement, replacing the use of QgsGeometry class functions area() and length() with the QgsAbstractGeometry class functions area(), length() and perimeter(), in order to return more accurate Cartesian measurements in case of geometries containing CircularString or CurvePolygon type entities.

See https://lists.osgeo.org/pipermail/qgis-developer/2021-October/064159.html.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
