### PR TITLE
fix reference time for memory mesh provider

### DIFF
--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
@@ -262,9 +262,9 @@ bool QgsMeshMemoryDataProvider::addDatasetGroupMetadata( const QString &def, Qgs
   for ( int i = 0; i < metadataLines.size(); ++i )
   {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    const QStringList keyVal = metadataLines[i].split( ':', QString::SkipEmptyParts );
+    const QStringList keyVal = metadataLines[i].split( QStringLiteral( ": " ), QString::SkipEmptyParts );
 #else
-    const QStringList keyVal = metadataLines[i].split( ':', Qt::SkipEmptyParts );
+    const QStringList keyVal = metadataLines[i].split( QStringLiteral( ": " ), Qt::SkipEmptyParts );
 #endif
     if ( keyVal.size() != 2 )
     {
@@ -405,6 +405,13 @@ void QgsMeshMemoryDataProvider::addGroupToTemporalCapabilities( int groupIndex, 
 
   if ( group.datasetCount() > 1 ) //non temporal dataset groups (count=1) have no time in the capabilities
   {
+    QString timeReferenceString = group.extraMetadata().value( QStringLiteral( "reference_time" ) );
+    if ( !timeReferenceString.isEmpty() )
+    {
+      timeReferenceString.append( 'Z' );//For now provider doesn't support time zone and return always in local time, force UTC
+      const QDateTime referenceTime = QDateTime::fromString( timeReferenceString, Qt::ISODate );
+      tempCap->addGroupReferenceDateTime( groupIndex, referenceTime );
+    }
     for ( int i = 0; i < group.memoryDatasets.count(); ++i )
       if ( group.memoryDatasets.at( i ) )
         tempCap->addDatasetTime( groupIndex, group.memoryDatasets.at( i )->time );

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsMeshMemoryDataProvider final: public QgsMeshDataProvider
      *
      * Data string contains simple definition of datasets
      * Each entry is separated by "\n" sign and section deliminer "---"
-     * First section defines the dataset group: Vertex/Edge/Face Vector/Scalar Name
+     * First section defines the dataset group: vertex/edge/face vector/scalar Name
      * Second section defines the group metadata: key: value pairs
      * Third section defines the datasets (timesteps). First line is time,
      * other lines are values (one value on line). For vectors separated by comma
@@ -111,7 +111,7 @@ class CORE_EXPORT QgsMeshMemoryDataProvider final: public QgsMeshDataProvider
      *
      *  \code
      *    QString uri(
-     *      "Vertex Vector MyVertexVectorDataset\n" \
+     *      "vertex vector MyVertexVectorDataset\n" \
      *      "---"
      *      "description: My great dataset \n" \
      *      "reference_time: Midnight  \n" \

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -138,6 +138,8 @@ void TestQgsMeshLayer::initTestCase()
   QCOMPARE( mMemoryLayer->datasetGroupTreeRootItem()->childCount(), 5 );
   QVERIFY( mMemoryLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
   QVERIFY( mMemoryLayer->temporalProperties()->isActive() );
+  QDateTime referenceTime = mMemoryLayer->dataProvider()->temporalCapabilities()->referenceTime();
+  QCOMPARE( referenceTime, QDateTime( QDate( 2017, 2, 27 ), QTime( 1, 2, 3 ), Qt::UTC ) );
   QVERIFY( !mMemoryLayer->supportsEditing() );
   QgsProject::instance()->addMapLayers(
     QList<QgsMapLayer *>() << mMemoryLayer );

--- a/tests/testdata/mesh/quad_and_triangle_face_scalar.txt
+++ b/tests/testdata/mesh/quad_and_triangle_face_scalar.txt
@@ -1,6 +1,7 @@
 Face Scalar FaceScalarDataset
 ---
 description: Face Scalar Dataset
+reference_time: 2017-02-27T01:02:03
 ---
 0
 1


### PR DESCRIPTION
Before this PR, it was not possible to set the reference time for memory mesh provider  dataset groups