### PR TITLE
Fix QgsImageCache [fix #43787]

### DIFF
--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -56,7 +56,7 @@ class TestQgsImageCache : public QObject
     void base64();
     void empty();
     void dpi();
-
+    void cachesize();
 };
 
 
@@ -316,6 +316,14 @@ void TestQgsImageCache::dpi()
   entry1.size = QSize( 100, 100 );
   entry2.size = QSize( 100, 100 );
   QVERIFY( entry1.isEqual( &entry2 ) );
+}
+
+void TestQgsImageCache::cachesize()
+{
+  uint cacheSize = 100000000;
+  QgsSettings().setValue( QStringLiteral( "/qgis/maxImageCacheSize" ), cacheSize );
+  QgsImageCache cache;
+  QCOMPARE( cache.mMaxCacheSize, cacheSize );
 }
 
 bool TestQgsImageCache::imageCheck( const QString &testName, QImage &image, int mismatchCount )


### PR DESCRIPTION
## Description

Fix QgsImageCache:

- Allow configuration of the max cache size from qgis settings.
- Fix size calculation as *bytes* instead of *bits* as stated from documentation.

The actual implementation allow only a max cache size of abount 2Mb,  this is totally inneficient when using layout images for with multiple composers that could be tens (even hundreds) of Mb for large printing output. In that case image are loaded  for each composer an may increase the memory footprint dramatically (see related issue).  

This is also a problem on serverside when GetPrint requests are enabled.

Fixes #43787
