### PR TITLE
Don't use ugly colors for newly created gradient color ramps

### DIFF
--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -137,8 +137,10 @@ class CORE_EXPORT QgsGradientStop
 //! List of gradient stops
 typedef QList<QgsGradientStop> QgsGradientStopsList;
 
-#define DEFAULT_GRADIENT_COLOR1 QColor(0,0,255)
-#define DEFAULT_GRADIENT_COLOR2 QColor(0,255,0)
+// these are the QGIS branding colors, exaggerated a bit to make a default ramp with greater color variation
+// then the official QGIS color gradient!
+#define DEFAULT_GRADIENT_COLOR1 QColor(69, 116, 40)
+#define DEFAULT_GRADIENT_COLOR2 QColor(188, 220, 60)
 
 /**
  * \ingroup core

--- a/tests/src/core/testqgsimageoperation.cpp
+++ b/tests/src/core/testqgsimageoperation.cpp
@@ -286,7 +286,7 @@ void TestQgsImageOperation::overlayColor()
 void TestQgsImageOperation::distanceTransformMaxDist()
 {
   QImage image( mTransparentSampleImage );
-  QgsGradientColorRamp ramp;
+  QgsGradientColorRamp ramp( QColor( 0, 0, 255 ), QColor( 0, 255, 0 ) );
   QgsImageOperation::DistanceTransformProperties props;
   props.useMaxDistance = true;
   props.ramp = &ramp;
@@ -301,7 +301,7 @@ void TestQgsImageOperation::distanceTransformMaxDist()
 void TestQgsImageOperation::distanceTransformSetSpread()
 {
   QImage image( mTransparentSampleImage );
-  QgsGradientColorRamp ramp;
+  QgsGradientColorRamp ramp( QColor( 0, 0, 255 ), QColor( 0, 255, 0 ) );
   QgsImageOperation::DistanceTransformProperties props;
   props.useMaxDistance = false;
   props.spread = 10;
@@ -317,7 +317,7 @@ void TestQgsImageOperation::distanceTransformSetSpread()
 void TestQgsImageOperation::distanceTransformInterior()
 {
   QImage image( mTransparentSampleImage );
-  QgsGradientColorRamp ramp;
+  QgsGradientColorRamp ramp( QColor( 0, 0, 255 ), QColor( 0, 255, 0 ) );
   QgsImageOperation::DistanceTransformProperties props;
   props.useMaxDistance = true;
   props.ramp = &ramp;
@@ -344,7 +344,7 @@ void TestQgsImageOperation::distanceTransformMisc()
   //zero spread
   QImage image2( mSampleImage );
   QgsImageOperation::DistanceTransformProperties props2;
-  QgsGradientColorRamp ramp;
+  QgsGradientColorRamp ramp( QColor( 0, 0, 255 ), QColor( 0, 255, 0 ) );
   props2.useMaxDistance = false;
   props2.spread = 0;
   props2.ramp = &ramp;


### PR DESCRIPTION
Because NO ONE EVER wanted a bright blue->bright green color ramp!

Before:
![image](https://user-images.githubusercontent.com/1829991/138004574-472d056a-8379-47f7-9e1f-d6f3e5c834da.png)

After:
![image](https://user-images.githubusercontent.com/1829991/138023947-8e350a60-b7d8-4bd3-a2c2-c26e97318031.png)
