### PR TITLE
Fix word wrap regression

### DIFF
--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -633,17 +633,17 @@ QString QgsStringUtils::wordWrap( const QString &string, const int length, const
       if ( useMaxLineLength )
       {
         //first try to locate delimiter backwards
-        strHit = lines.at( i ).lastIndexOf( rx, strCurrent + length );
+        strHit = ( strCurrent + length >= strLength ) ? -1 : lines.at( i ).lastIndexOf( rx, strCurrent + length );
         if ( strHit == lastHit || strHit == -1 )
         {
           //if no new backward delimiter found, try to locate forward
-          strHit = lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
+          strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
         }
         lastHit = strHit;
       }
       else
       {
-        strHit = lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
+        strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
       }
       if ( strHit > -1 )
       {

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -621,7 +621,16 @@ QString QgsStringUtils::wordWrap( const QString &string, const int length, const
 
   for ( int i = 0; i < lines.size(); i++ )
   {
-    strLength = lines.at( i ).length();
+    const QString line = lines.at( i );
+    strLength = line.length();
+    if ( strLength <= length )
+    {
+      // shortcut, no wrapping required
+      newstr.append( line );
+      if ( i < lines.size() - 1 )
+        newstr.append( '\n' );
+      continue;
+    }
     strCurrent = 0;
     strHit = 0;
     lastHit = 0;
@@ -633,24 +642,24 @@ QString QgsStringUtils::wordWrap( const QString &string, const int length, const
       if ( useMaxLineLength )
       {
         //first try to locate delimiter backwards
-        strHit = ( strCurrent + length >= strLength ) ? -1 : lines.at( i ).lastIndexOf( rx, strCurrent + length );
+        strHit = ( strCurrent + length >= strLength ) ? -1 : line.lastIndexOf( rx, strCurrent + length );
         if ( strHit == lastHit || strHit == -1 )
         {
           //if no new backward delimiter found, try to locate forward
-          strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
+          strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : line.indexOf( rx, strCurrent + std::abs( length ) );
         }
         lastHit = strHit;
       }
       else
       {
-        strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : lines.at( i ).indexOf( rx, strCurrent + std::abs( length ) );
+        strHit = ( strCurrent + std::abs( length ) >= strLength ) ? -1 : line.indexOf( rx, strCurrent + std::abs( length ) );
       }
       if ( strHit > -1 )
       {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 2)
-        newstr.append( lines.at( i ).midRef( strCurrent, strHit - strCurrent ) );
+        newstr.append( line.midRef( strCurrent, strHit - strCurrent ) );
 #else
-        newstr.append( QStringView {lines.at( i )} .mid( strCurrent, strHit - strCurrent ) );
+        newstr.append( QStringView {line} .mid( strCurrent, strHit - strCurrent ) );
 #endif
         newstr.append( '\n' );
         strCurrent = strHit + delimiterLength;
@@ -658,9 +667,9 @@ QString QgsStringUtils::wordWrap( const QString &string, const int length, const
       else
       {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 2)
-        newstr.append( lines.at( i ).midRef( strCurrent ) );
+        newstr.append( line.midRef( strCurrent ) );
 #else
-        newstr.append( QStringView {lines.at( i )}.mid( strCurrent ) );
+        newstr.append( QStringView {line}.mid( strCurrent ) );
 #endif
         strCurrent = strLength;
       }

--- a/tests/src/core/testqgspallabeling.cpp
+++ b/tests/src/core/testqgspallabeling.cpp
@@ -85,7 +85,10 @@ void TestQgsPalLabeling::wrapChar()
   QCOMPARE( QgsPalLabeling::splitToLines( "with auto wrap", QString(), 6, false ), QStringList() << "with auto" << "wrap" );
 
   // manual wrap character should take precedence
-  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with" << "auto" << "wrap and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with automatic-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with" << "automatic" << "wrap and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with automatic-wrap and manual-wrap" ), QStringLiteral( "-" ), 6, true ), QStringList() << "with" << "automatic" << "wrap" << "and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, false ), QStringList() << "with auto" << "wrap and manual" << "wrap" );
   QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 6, false ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
 }
 

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -239,6 +239,8 @@ void TestQgsStringUtils::wordWrap_data()
   QTest::addColumn<QString>( "expected" );
 
   QTest::newRow( "wordwrap" ) << "university of qgis" << 13 << true << QString() << "university of\nqgis";
+  QTest::newRow( "wordwrap not possible" ) << "universityofqgis" << 13 << true << QString() << "universityofqgis";
+  QTest::newRow( "wordwrap not required" ) << "uni of qgis" << 13 << true << QString() << "uni of qgis";
   QTest::newRow( "optional parameters unspecified" ) << "test string" << 5 << true << QString() << "test\nstring";
   QTest::newRow( "wordwrap with delim" ) << "university of qgis" << 13 << true << QStringLiteral( " " ) << "university of\nqgis";
   QTest::newRow( "wordwrap min" ) << "university of qgis" << 3 << false << QStringLiteral( " " ) << "university\nof qgis";


### PR DESCRIPTION
The switch to QRegularExpression mean that word wrapping was ALWAYS
being applied, even when the string was short enough to not require it