### PR TITLE
Mesh editing fixes

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6887,7 +6887,13 @@ void QgisApp::showRasterCalculator()
 
 void QgisApp::showMeshCalculator()
 {
-  QgsMeshCalculatorDialog d( qobject_cast<QgsMeshLayer *>( activeLayer() ), this );
+  QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( activeLayer() );
+  if ( meshLayer && meshLayer->isEditable() )
+  {
+    QMessageBox::information( this, tr( "Mesh Calculator" ), tr( "Mesh calculator with mesh layer in edit mode is not supported." ) );
+    return;
+  }
+  QgsMeshCalculatorDialog d( meshLayer, this );
   if ( d.exec() == QDialog::Accepted )
   {
     //invoke analysis library

--- a/src/core/mesh/qgsmeshdataset.cpp
+++ b/src/core/mesh/qgsmeshdataset.cpp
@@ -1111,9 +1111,10 @@ QgsMeshDataBlock QgsMeshVerticesElevationDataset::datasetValues( bool isScalar, 
     return QgsMeshDataBlock();
 
   QgsMeshDataBlock block( QgsMeshDataBlock::ScalarDouble, count );
-  QVector<double> values( std::min( count, ( mMesh->vertexCount() - valueIndex ) ) );
-  for ( int i = 0; i < values.count(); ++i )
-    values[i] = mMesh->vertex( i ).z();
+  int effectiveValueCount = std::min( count, ( mMesh->vertexCount() - valueIndex ) );
+  QVector<double> values( effectiveValueCount );
+  for ( int i = valueIndex; i < effectiveValueCount; ++i )
+    values[i] = mMesh->vertex( i - valueIndex ).z();
   block.setValues( values );
   block.setValid( true );
   return block;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -964,6 +964,8 @@ bool QgsMeshLayer::startFrameEditing( const QgsCoordinateTransform &transform )
     return false;
   }
 
+  mSimplificationSettings.setEnabled( false );
+
   updateTriangularMesh( transform );
 
   mMeshEditor = new QgsMeshEditor( this );

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -216,8 +216,10 @@ void QgsMeshLayerProperties::syncToLayer()
     w->syncToLayer( mMeshLayer );
 
   QgsDebugMsgLevel( QStringLiteral( "populate rendering tab" ), 4 );
-  QgsMeshSimplificationSettings simplifySettings = mMeshLayer->meshSimplificationSettings();
+  if ( mMeshLayer->isEditable() )
+    mSimplifyMeshGroupBox->setEnabled( false );
 
+  QgsMeshSimplificationSettings simplifySettings = mMeshLayer->meshSimplificationSettings();
   mSimplifyMeshGroupBox->setChecked( simplifySettings.isEnabled() );
   mSimplifyReductionFactorSpinBox->setValue( simplifySettings.reductionFactor() );
   mSimplifyMeshResolutionSpinBox->setValue( simplifySettings.meshResolution() );


### PR DESCRIPTION
Other fixes related to mesh editing:
- fix the virtual dataset used to display vertex Z value (`QgsMeshVerticesElevationDataset`)
- disable mesh simplification during mesh editing, otherwise leads to crash
- fix process algorithm: do not run some if in edit mode, for other build own triangular mesh to void interaction with the layer one
- do not open mesh calculator if layer is in edit mode