### PR TITLE
avoid detaching QSharedDataPointer<QgsMeshSpatialIndexData>

### DIFF
--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -428,6 +428,9 @@ void QgsMeshLayerRenderer::renderFaceMesh(
     if ( context.renderingStopped() )
       break;
 
+    if ( i >= faces.count() )
+      continue;
+
     const QgsMeshFace &face = faces[i];
     if ( face.size() < 2 )
       continue;

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -409,11 +409,11 @@ void QgsMeshSpatialIndex::addFace( int faceIndex, const QgsMesh &mesh )
   if ( !ok )
     return;
 
-  const QMutexLocker locker( &d->mMutex );
+  const QMutexLocker locker( &d.constData()->mMutex );
 
   try
   {
-    d->mRTree->insertData( 0, nullptr, r, faceIndex );
+    d.constData()->mRTree->insertData( 0, nullptr, r, faceIndex );
   }
   catch ( Tools::Exception &e )
   {
@@ -435,7 +435,7 @@ void QgsMeshSpatialIndex::removeFace( int faceIndex, const QgsMesh &mesh )
 {
   if ( mesh.face( faceIndex ).isEmpty() )
     return;
-  const QMutexLocker locker( &d->mMutex );
+  const QMutexLocker locker( &d.constData()->mMutex );
   bool ok = false;
-  d->mRTree->deleteData( faceToRegion( mesh, faceIndex, ok ), faceIndex );
+  d.constData()->mRTree->deleteData( faceToRegion( mesh, faceIndex, ok ), faceIndex );
 }

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -639,8 +639,11 @@ static QSet<int> _nativeElementsFromElements( const QList<int> &indexes, const Q
   QSet<int> nativeElements;
   for ( const int index : indexes )
   {
-    const int nativeIndex = elementToNativeElements[index];
-    nativeElements.insert( nativeIndex );
+    if ( index < elementToNativeElements.count() )
+    {
+      const int nativeIndex = elementToNativeElements[index];
+      nativeElements.insert( nativeIndex );
+    }
   }
   return nativeElements;
 }


### PR DESCRIPTION
This PR avoid the detaching of the mesh spatial index when add/remove faces in the spatial index. Without that, if the mesh is rendering, detaching the spatial index if add/remove face leads to clone the spatial index and to rebuild all the index.
With big mesh, if the user edit the mesh when the layer is rendering in another thread, the user will have to wait that the index is rebuilt even for a simple edit action, here adding a vertex in a face after a zoom:
![spatialIndex](https://user-images.githubusercontent.com/7416892/138208611-0fade2b8-096d-4a0f-a906-41dcfb503f5d.gif)



This PR fixes this bad user experience.

