### PR TITLE
Add a return value to reloadPlugin()

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -581,11 +581,12 @@ def reloadPlugin(packageName: str):
     """ unload and start again a plugin """
     global active_plugins
     if packageName not in active_plugins:
-        return  # it's not active
+        return False  # it's not active
 
     unloadPlugin(packageName)
     loadPlugin(packageName)
-    startPlugin(packageName)
+    started = startPlugin(packageName)
+    return started
 
 
 def showPluginHelp(packageName: str = None, filename: str = "index", section: str = ""):

--- a/python/utils.py
+++ b/python/utils.py
@@ -577,7 +577,7 @@ def isPluginLoaded(packageName: str) -> bool:
     return (packageName in active_plugins)
 
 
-def reloadPlugin(packageName: str):
+def reloadPlugin(packageName: str) -> bool:
     """ unload and start again a plugin """
     global active_plugins
     if packageName not in active_plugins:


### PR DESCRIPTION
## Description

`qgis.utils.reloadPlugin()` doesn't return any value currently. The idea is to output `True`/`False` depending on the result of `startPlugin()` runned inside in order to know whether or not the plugin has been successfully reloaded.

I looked into this because of the plugin **[Plugin Reloader](https://github.com/borysiasty/plugin_reloader)** which uses the reloadPlugin() function.

It's really not a big deal considering that reloadPlugin() can easily be rewrited inside Plugin Reloader, but why doing so if the native function could do the job?