### PR TITLE
Don't expose an outline subsymbol for SVG fill symbol layers

### DIFF
--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -818,11 +818,6 @@ Base class for polygon renderers generating texture images
     virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
 
 
-    virtual QgsSymbol *subSymbol();
-
-    virtual bool setSubSymbol( QgsSymbol *symbol /Transfer/ );
-
-
     void setStrokeWidthUnit( QgsUnitTypes::RenderUnit unit );
 %Docstring
 Sets the ``units`` fo the symbol's stroke width.
@@ -893,28 +888,19 @@ fill is positioned relative to the feature.
 
     virtual QgsMapUnitScale mapUnitScale() const;
 
-    virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
-
     virtual double dxfWidth( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const;
-
-    virtual QColor dxfColor( QgsSymbolRenderContext &context ) const;
 
     virtual Qt::PenStyle dxfPenStyle() const;
 
-    virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
-
     virtual QVariantMap properties() const;
-
-    virtual bool hasDataDefinedProperties() const;
 
 
   protected:
 
 
-
     virtual void applyDataDefinedSettings( QgsSymbolRenderContext &context );
 %Docstring
-Custom stroke
+Applies data defined settings prior to generating the fill symbol brush.
 %End
 
     virtual bool applyBrushTransformFromContext( QgsSymbolRenderContext *context = 0 ) const;
@@ -1256,6 +1242,8 @@ Used internally when reading/writing symbols.
 
     virtual void stopRender( QgsSymbolRenderContext &context );
 
+    virtual void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context );
+
     virtual QVariantMap properties() const;
 
     virtual QgsSVGFillSymbolLayer *clone() const /Factory/;
@@ -1263,6 +1251,18 @@ Used internally when reading/writing symbols.
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const;
 
     virtual bool usesMapUnits() const;
+
+    virtual QgsSymbol *subSymbol();
+
+    virtual bool setSubSymbol( QgsSymbol *symbol /Transfer/ );
+
+    virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
+
+    virtual QColor dxfColor( QgsSymbolRenderContext &context ) const;
+
+    virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
+
+    virtual bool hasDataDefinedProperties() const;
 
 
     void setSvgFilePath( const QString &svgPath );

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -783,9 +783,6 @@ class CORE_EXPORT QgsImageFillSymbolLayer: public QgsFillSymbolLayer
 
     void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context ) override;
 
-    QgsSymbol *subSymbol() override;
-    bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
-
     /**
      * Sets the \a units fo the symbol's stroke width.
      * \see strokeWidthUnit()
@@ -840,13 +837,9 @@ class CORE_EXPORT QgsImageFillSymbolLayer: public QgsFillSymbolLayer
     QgsUnitTypes::RenderUnit outputUnit() const override;
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
-    double estimateMaxBleed( const QgsRenderContext &context ) const override;
     double dxfWidth( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const override;
-    QColor dxfColor( QgsSymbolRenderContext &context ) const override;
     Qt::PenStyle dxfPenStyle() const override;
-    QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     QVariantMap properties() const override;
-    bool hasDataDefinedProperties() const override;
 
   protected:
     QBrush mBrush;
@@ -858,9 +851,9 @@ class CORE_EXPORT QgsImageFillSymbolLayer: public QgsFillSymbolLayer
     QgsUnitTypes::RenderUnit mStrokeWidthUnit = QgsUnitTypes::RenderMillimeters;
     QgsMapUnitScale mStrokeWidthMapUnitScale;
 
-    //! Custom stroke
-    std::unique_ptr< QgsLineSymbol > mStroke;
-
+    /**
+     * Applies data defined settings prior to generating the fill symbol brush.
+     */
     virtual void applyDataDefinedSettings( QgsSymbolRenderContext &context ) { Q_UNUSED( context ) }
 
     /**
@@ -1143,10 +1136,17 @@ class CORE_EXPORT QgsSVGFillSymbolLayer: public QgsImageFillSymbolLayer
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
     void stopRender( QgsSymbolRenderContext &context ) override;
+    void renderPolygon( const QPolygonF &points, const QVector<QPolygonF> *rings, QgsSymbolRenderContext &context ) override;
     QVariantMap properties() const override;
     QgsSVGFillSymbolLayer *clone() const override SIP_FACTORY;
     void toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const override;
     bool usesMapUnits() const override;
+    QgsSymbol *subSymbol() override;
+    bool setSubSymbol( QgsSymbol *symbol SIP_TRANSFER ) override;
+    double estimateMaxBleed( const QgsRenderContext &context ) const override;
+    QColor dxfColor( QgsSymbolRenderContext &context ) const override;
+    QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
+    bool hasDataDefinedProperties() const override;
 
     /**
      * Sets the path to the SVG file to render in the fill.
@@ -1371,6 +1371,9 @@ class CORE_EXPORT QgsSVGFillSymbolLayer: public QgsImageFillSymbolLayer
     double mSvgStrokeWidth = 0.2;
     QgsUnitTypes::RenderUnit mSvgStrokeWidthUnit = QgsUnitTypes::RenderMillimeters;
     QgsMapUnitScale mSvgStrokeWidthMapUnitScale;
+
+    //! Custom stroke -- here for historic reasons only
+    std::unique_ptr< QgsLineSymbol > mStroke;
 
     //! Helper function that gets the view box from the byte array
     void storeViewBox();

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -2126,7 +2126,7 @@ bool QgsSymbolLayerUtils::fillFromSld( QDomElement &element, Qt::BrushStyle &bru
     QgsStringMap svgParams = getSvgParameterList( element );
     for ( QgsStringMap::iterator it = svgParams.begin(); it != svgParams.end(); ++it )
     {
-      QgsDebugMsg( QStringLiteral( "found SvgParameter %1: %2" ).arg( it.key(), it.value() ) );
+      QgsDebugMsgLevel( QStringLiteral( "found SvgParameter %1: %2" ).arg( it.key(), it.value() ), 2 );
 
       if ( it.key() == QLatin1String( "fill" ) )
         color = QColor( it.value() );
@@ -2272,7 +2272,7 @@ bool QgsSymbolLayerUtils::lineFromSld( QDomElement &element,
   QgsStringMap svgParams = getSvgParameterList( element );
   for ( QgsStringMap::iterator it = svgParams.begin(); it != svgParams.end(); ++it )
   {
-    QgsDebugMsg( QStringLiteral( "found SvgParameter %1: %2" ).arg( it.key(), it.value() ) );
+    QgsDebugMsgLevel( QStringLiteral( "found SvgParameter %1: %2" ).arg( it.key(), it.value() ), 2 );
 
     if ( it.key() == QLatin1String( "stroke" ) )
     {
@@ -2356,7 +2356,7 @@ bool QgsSymbolLayerUtils::lineFromSld( QDomElement &element,
           }
           else
           {
-            QgsDebugMsg( QStringLiteral( "custom dash pattern required but not provided. Using default dash pattern." ) );
+            QgsDebugMsgLevel( QStringLiteral( "custom dash pattern required but not provided. Using default dash pattern." ), 2 );
             penStyle = Qt::DashLine;
           }
         }
@@ -2612,7 +2612,7 @@ bool QgsSymbolLayerUtils::wellKnownMarkerFromSld( QDomElement &element,
   if ( !wellKnownNameElem.isNull() )
   {
     name = wellKnownNameElem.firstChild().nodeValue();
-    QgsDebugMsg( "found Mark with well known name: " + name );
+    QgsDebugMsgLevel( "found Mark with well known name: " + name, 2 );
   }
 
   // <Fill>
@@ -3028,7 +3028,7 @@ QgsStringMap QgsSymbolLayerUtils::getSvgParameterList( QDomElement &element )
         if ( paramElem.firstChild().nodeType() == QDomNode::ElementNode &&
              paramElem.firstChild().localName() == QLatin1String( "Literal" ) )
         {
-          QgsDebugMsg( paramElem.firstChild().localName() );
+          QgsDebugMsgLevel( paramElem.firstChild().localName(), 3 );
           value = paramElem.firstChild().firstChild().nodeValue();
         }
         else
@@ -4612,7 +4612,7 @@ QList<double> QgsSymbolLayerUtils::prettyBreaks( double minimum, double maximum,
   {
     end = end + 1;
   }
-  QgsDebugMsg( QStringLiteral( "pretty classes: %1" ).arg( end ) );
+  QgsDebugMsgLevel( QStringLiteral( "pretty classes: %1" ).arg( end ), 3 );
 
   // If we don't have quite enough labels, extend the range out
   // to make more (these labels are beyond the data :()

--- a/tests/src/python/test_qgssymbollayer_createsld.py
+++ b/tests/src/python/test_qgssymbollayer_createsld.py
@@ -30,7 +30,8 @@ from qgis.core import (
     QgsFontMarkerSymbolLayer, QgsEllipseSymbolLayer, QgsSimpleLineSymbolLayer,
     QgsMarkerLineSymbolLayer, QgsMarkerSymbol, QgsSimpleFillSymbolLayer, QgsSVGFillSymbolLayer,
     QgsLinePatternFillSymbolLayer, QgsPointPatternFillSymbolLayer, QgsVectorLayer, QgsVectorLayerSimpleLabeling,
-    QgsTextBufferSettings, QgsPalLayerSettings, QgsTextBackgroundSettings, QgsRuleBasedLabeling)
+    QgsTextBufferSettings, QgsPalLayerSettings, QgsTextBackgroundSettings, QgsRuleBasedLabeling,
+    QgsLineSymbol)
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
 
@@ -293,6 +294,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
         symbol.setSvgFillColor(QColor('blue'))
         symbol.setSvgStrokeWidth(3)
         symbol.setSvgStrokeColor(QColor('yellow'))
+        symbol.setSubSymbol(QgsLineSymbol())
         symbol.subSymbol().setWidth(10)
 
         dom, root = self.symbolToSld(symbol)
@@ -313,6 +315,7 @@ class TestQgsSymbolLayerCreateSld(unittest.TestCase):
 
     def testSvgFillPixel(self):
         symbol = QgsSVGFillSymbolLayer('test/star.svg', 10, 45)
+        symbol.setSubSymbol(QgsLineSymbol())
         symbol.setSvgFillColor(QColor('blue'))
         symbol.setSvgStrokeWidth(3)
         symbol.setSvgStrokeColor(QColor('black'))


### PR DESCRIPTION
This is inconsistent with all other fill types, which don't
have a special outline subsymbol. Users should be creating
outline layers when they want an outline instead.

When reading an SVG fill symbol layer from XML, automatically
upgrade any outline subsymbol which is used by the fill to
be separate symbol layers for the parent fill symbol so
that existing symbols will appear as designed in older QGIS
versions.

Fixes #14103
