### PR TITLE
Fix several dangling references in grid decoration

### DIFF
--- a/src/app/decorations/qgsdecorationgrid.cpp
+++ b/src/app/decorations/qgsdecorationgrid.cpp
@@ -451,9 +451,9 @@ int QgsDecorationGrid::xGridLines( const QgsMapSettings &mapSettings, QList< QPa
   if ( mGridIntervalY / mapSettings.mapUnitsPerPixel() < 1 )
     return 1;
 
-  const QPolygonF &canvasPoly = canvasPolygon( mapSettings );
-  const QPolygonF &mapPolygon = canvasExtent( mapSettings );
-  const QRectF &mapBoundingRect = mapPolygon.boundingRect();
+  const QPolygonF canvasPoly = canvasPolygon( mapSettings );
+  const QPolygonF mapPolygon = canvasExtent( mapSettings );
+  const QRectF mapBoundingRect = mapPolygon.boundingRect();
   const QLineF lineEast( mapPolygon[2], mapPolygon[1] );
   const QLineF lineWest( mapPolygon[3], mapPolygon[0] );
 
@@ -496,15 +496,15 @@ int QgsDecorationGrid::yGridLines( const QgsMapSettings &mapSettings, QList< QPa
   if ( mGridIntervalX / mapSettings.mapUnitsPerPixel() < 1 )
     return 1;
 
-  const QPolygonF &canvasPoly = canvasPolygon( mapSettings );
-  const QPolygonF &mapPolygon = canvasExtent( mapSettings );
+  const QPolygonF canvasPoly = canvasPolygon( mapSettings );
+  const QPolygonF mapPolygon = canvasExtent( mapSettings );
   const QLineF lineSouth( mapPolygon[3], mapPolygon[2] );
   const QLineF lineNorth( mapPolygon[0], mapPolygon[1] );
 
   const double len = lineSouth.length();
   Q_ASSERT( std::fabs( len - lineNorth.length() ) < 1e-6 ); // no shear
 
-  const QRectF &mapBoundingRect = mapPolygon.boundingRect();
+  const QRectF mapBoundingRect = mapPolygon.boundingRect();
   const double roundCorrection = mapBoundingRect.left() > 0 ? 1.0 : 0.0;
   double dist = static_cast< int >( ( mapBoundingRect.left() - mGridOffsetX ) / mGridIntervalX + roundCorrection ) * mGridIntervalX + mGridOffsetX;
   dist = dist - mapBoundingRect.left();


### PR DESCRIPTION
## Description

The functions in question all return values, not references, so we need to store those values somewhere.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
