### PR TITLE
Add check for empty geom in QgsGeos::closestPoint

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2510,7 +2510,7 @@ QgsGeometry QgsGeos::mergeLines( QString *errorMsg ) const
 
 QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg ) const
 {
-  if ( !mGeos || isEmpty() || other.isEmpty() || other.isNull() )
+  if ( !mGeos || isEmpty() || other.isEmpty() )
   {
     return QgsGeometry();
   }

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2510,7 +2510,7 @@ QgsGeometry QgsGeos::mergeLines( QString *errorMsg ) const
 
 QgsGeometry QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg ) const
 {
-  if ( !mGeos || isEmpty() || other.isNull() )
+  if ( !mGeos || isEmpty() || other.isEmpty() || other.isNull() )
   {
     return QgsGeometry();
   }


### PR DESCRIPTION
This relates to #36142. 

It's still possible to trigger a QGIS crash by passing an empty geometry to `QgsGeometry::nearestPoint`. This adds a check that exists early if this is the case.

