### PR TITLE
Format date and datetime fields based on locale (#45617)

### DIFF
--- a/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -22,9 +22,9 @@ the field configuration.
 #include "qgsdatetimefieldformatter.h"
 %End
   public:
-    static const QString DATE_FORMAT;
+    static QString DATE_FORMAT;
     static const QString TIME_FORMAT;
-    static const QString DATETIME_FORMAT;
+    static QString DATETIME_FORMAT;
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
 
@@ -38,6 +38,11 @@ Default constructor of field formatter for a date time field.
 
     virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
 
+
+    static void applyLocaleChange();
+%Docstring
+Adjusts the date time formats according to locale.
+%End
 
     static QString defaultFormat( QVariant::Type type );
 %Docstring

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -113,6 +113,7 @@ typedef SInt32 SRefCon;
 
 #include "qgsuserprofilemanager.h"
 #include "qgsuserprofile.h"
+#include "qgsdatetimefieldformatter.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -1028,6 +1029,9 @@ int main( int argc, char *argv[] )
       currentLocale.setNumberOptions( currentLocale.numberOptions() |= QLocale::NumberOption::OmitGroupSeparator );
     }
     QLocale::setDefault( currentLocale );
+
+    // Date time settings
+    QgsDateTimeFieldFormatter::applyLocaleChange();
 
     QgsApplication::setTranslation( translationCode );
   }

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -20,9 +20,9 @@
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
 
-const QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
+QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
 const QString QgsDateTimeFieldFormatter::TIME_FORMAT = QStringLiteral( "HH:mm:ss" );
-const QString QgsDateTimeFieldFormatter::DATETIME_FORMAT = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
+QString QgsDateTimeFieldFormatter::DATETIME_FORMAT = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
 // we need to use Qt::ISODate rather than a string format definition in QDate::fromString
 const QString QgsDateTimeFieldFormatter::QT_ISO_FORMAT = QStringLiteral( "Qt ISO Date" );
 // but QDateTimeEdit::setDisplayFormat only accepts string formats, so use with time zone by default
@@ -62,6 +62,10 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
     // we always show time zones for datetime values
     showTimeZone = true;
   }
+  else if ( static_cast<QMetaType::Type>( value.type() ) == QMetaType::QTime )
+  {
+    return  value.toTime().toString( displayFormat );
+  }
   else
   {
     if ( fieldIsoFormat )
@@ -92,6 +96,13 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   }
 
   return result;
+}
+
+void QgsDateTimeFieldFormatter::applyLocaleChange()
+{
+  QString dateFormat = QLocale().dateFormat( QLocale::FormatType::ShortFormat );
+  QgsDateTimeFieldFormatter::DATETIME_FORMAT = QString( "%1 %2" ).arg( dateFormat, QgsDateTimeFieldFormatter::TIME_FORMAT );
+  QgsDateTimeFieldFormatter::DATE_FORMAT = dateFormat;
 }
 
 QString QgsDateTimeFieldFormatter::defaultFormat( QVariant::Type type )

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.h
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.h
@@ -31,9 +31,9 @@
 class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
 {
   public:
-    static const QString DATE_FORMAT;
+    static QString DATE_FORMAT;
     static const QString TIME_FORMAT;
-    static const QString DATETIME_FORMAT;
+    static QString DATETIME_FORMAT;
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
 
@@ -45,6 +45,9 @@ class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
     QString id() const override;
 
     QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const override;
+
+    //! Adjusts the date time formats according to locale.
+    static void applyLocaleChange();
 
     /**
      * Gets the default format in function of the type.

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -682,30 +682,63 @@ class TestQgsDateTimeFieldFormatter(unittest.TestCase):
         QLocale.setDefault(QLocale(QLocale.English))
 
     def test_representValue(self):
-        layer = QgsVectorLayer("point?field=int:integer&field=datetime:datetime&field=long:long",
+        layer = QgsVectorLayer("point?field=datetime:datetime&field=date:date&field=time:time",
                                "layer", "memory")
         self.assertTrue(layer.isValid())
         QgsProject.instance().addMapLayers([layer])
 
         field_formatter = QgsDateTimeFieldFormatter()
 
-        # default configuration should show timezone information
-        config = {}
-        self.assertEqual(field_formatter.representValue(layer, 1, config, None,
-                                                        QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.UTC)),
-                         '2020-03-04 12:13:14 (UTC)')
-        self.assertEqual(field_formatter.representValue(layer, 1, config, None,
-                                                        QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.OffsetFromUTC, 3600)),
-                         '2020-03-04 12:13:14 (UTC+01:00)')
-
         # if specific display format is set then use that
         config = {"display_format": "dd/MM/yyyy HH:mm:ss"}
-        self.assertEqual(field_formatter.representValue(layer, 1, config, None,
+        self.assertEqual(field_formatter.representValue(layer, 0, config, None,
                                                         QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.UTC)),
                          '04/03/2020 12:13:14')
-        self.assertEqual(field_formatter.representValue(layer, 1, config, None,
+        self.assertEqual(field_formatter.representValue(layer, 0, config, None,
                                                         QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.OffsetFromUTC, 3600)),
                          '04/03/2020 12:13:14')
+
+        locale_assertions = {
+            QLocale(QLocale.English): {
+                "date_format": 'M/d/yy',
+                "time_format": 'HH:mm:ss',
+                "datetime_format": 'M/d/yy HH:mm:ss',
+                "datetime_utc": '3/4/20 12:13:14 (UTC)',
+                "datetime_utc+1": '3/4/20 12:13:14 (UTC+01:00)'
+            },
+            QLocale(QLocale.Finnish): {
+                "date_format": 'd.M.yyyy',
+                "time_format": 'HH:mm:ss',
+                "datetime_format": 'd.M.yyyy HH:mm:ss',
+                "datetime_utc": '4.3.2020 12:13:14 (UTC)',
+                "datetime_utc+1": '4.3.2020 12:13:14 (UTC+01:00)'
+            },
+        }
+
+        for locale, assertions in locale_assertions.items():
+            QLocale().setDefault(locale)
+            QgsDateTimeFieldFormatter.applyLocaleChange()
+            field_formatter = QgsDateTimeFieldFormatter()
+
+            self.assertEqual(field_formatter.defaultFormat(QVariant.Date), assertions["date_format"], locale.name())
+            self.assertEqual(field_formatter.defaultFormat(QVariant.Time), assertions["time_format"], locale.name())
+            self.assertEqual(field_formatter.defaultFormat(QVariant.DateTime), assertions["datetime_format"], locale.name())
+
+            # default configuration should show timezone information
+            config = {}
+            self.assertEqual(field_formatter.representValue(layer, 0, config, None,
+                                                            QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.UTC)),
+                             assertions["datetime_utc"], locale.name())
+            self.assertEqual(field_formatter.representValue(layer, 0, config, None,
+                                                            QDateTime(QDate(2020, 3, 4), QTime(12, 13, 14), Qt.OffsetFromUTC, 3600)),
+                             assertions["datetime_utc+1"], locale.name())
+            self.assertEqual(field_formatter.representValue(layer, 1, config, None,
+                                                            QDate(2020, 3, 4)),
+                             assertions["datetime_utc"].split(" ")[0], locale.name())
+            config = {"display_format": "HH:mm:s"}
+            self.assertEqual(field_formatter.representValue(layer, 2, config, None,
+                                                            QTime(12, 13, 14)),
+                             assertions["datetime_utc"].split(" ")[1], locale.name())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR allows formatting date and datetime field values based on the selected locale.

WIP:
- [x] There is a special rule for english locale. This might have to be done differently.

Fixes #45617.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
