### PR TITLE
QgsAttributeTableModel clears mFieldFormatters on loadAttributes

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -391,6 +391,7 @@ void QgsAttributeTableModel::loadAttributes()
   mWidgetFactories.clear();
   mAttributeWidgetCaches.clear();
   mWidgetConfigs.clear();
+  mFieldFormatters.clear();
 
   for ( int idx = 0; idx < fields.count(); ++idx )
   {


### PR DESCRIPTION
## Description

This PR ensures that `QgsAttributeTableModel::loadAttributes()` clears it's internal list of QgsFieldFormatters before appending field specific formatters.

fixes #45478 

