### PR TITLE
Fixes #45228: QgsVectorLayer::featuresDeleted is only called once

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3475,7 +3475,15 @@ bool QgsVectorLayer::commitChanges( bool stopEditing )
   if ( !mAllowCommit )
     return false;
 
+  mCommitChangesActive = true;
   bool success = mEditBuffer->commitChanges( mCommitErrors );
+  mCommitChangesActive = false;
+
+  if ( !mDeletedFids.empty() )
+  {
+    emit featuresDeleted( mDeletedFids );
+    mDeletedFids.clear();
+  }
 
   if ( success )
   {
@@ -5286,7 +5294,7 @@ void QgsVectorLayer::onJoinedFieldsChanged()
 
 void QgsVectorLayer::onFeatureDeleted( QgsFeatureId fid )
 {
-  if ( mEditCommandActive )
+  if ( mEditCommandActive  || mCommitChangesActive )
   {
     mDeletedFids << fid;
   }

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2951,6 +2951,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! True while an undo command is active
     bool mEditCommandActive = false;
 
+    //! True while a commit is active
+    bool mCommitChangesActive = false;
+
     bool mReadExtentFromXml;
     QgsRectangle mXmlExtent;
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3660,6 +3660,32 @@ class TestQgsVectorLayerTransformContext(unittest.TestCase):
         self.assertEqual(layer.featureCount(), 0)
         self.assertEqual(layer.selectedFeatureIds(), [])
 
+        def testCommitChangesReportsDeletedFeatureIDs(self):
+            """
+            Tests if commitChanges emits "featuresDeleted" with all deleted feature IDs,
+            e.g. in case (negative) temporary FIDs are converted into (positive) persistent FIDs.
+            """
+            temp_fids = []
+
+            def onFeaturesDeleted(deleted_fids):
+                self.assertEqual(len(deleted_fids), len(temp_fids),
+                                 msg=f'featuresDeleted returned {len(deleted_fids)} instead of 2 deleted feature IDs: '
+                                     f'{deleted_fids}')
+                for d in deleted_fids:
+                    self.assertTrue(d in temp_fids)
+
+            layer = QgsVectorLayer("point?crs=epsg:4326&field=name:string", "Scratch point layer", "memory")
+            layer.featuresDeleted.connect(onFeaturesDeleted)
+
+            layer.startEditing()
+            layer.beginEditCommand(f'add 2 features')
+            layer.addFeature(QgsFeature(layer.fields()))
+            layer.addFeature(QgsFeature(layer.fields()))
+            layer.endEditCommand()
+            temp_fids.extend(layer.allFeatureIds())
+
+            layer.commitChanges()
+
     def testSubsetStringInvalidLayer(self):
         """
         Test that subset strings can be set on invalid layers, and retrieved later...

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3678,7 +3678,7 @@ class TestQgsVectorLayerTransformContext(unittest.TestCase):
             layer.featuresDeleted.connect(onFeaturesDeleted)
 
             layer.startEditing()
-            layer.beginEditCommand(f'add 2 features')
+            layer.beginEditCommand('add 2 features')
             layer.addFeature(QgsFeature(layer.fields()))
             layer.addFeature(QgsFeature(layer.fields()))
             layer.endEditCommand()


### PR DESCRIPTION
## Description

This PR provides a fix for #45228 to emit the `QgsVectorLayer::featuresDeleted` signal only once and with all deleted FIDs in case features are deleted during a `QgsVectorLayer::commitChanges` call.

A corresponding test was added to tests/src/python/test_qgsvectorlayer.py (testCommitChangesReportsDeletedFeatureIDs)

Fixes #45228
