### PR TITLE
Fix QgsRendererRasterPropertiesWidget().syncToLayer

### DIFF
--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -296,7 +296,7 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
       const QgsRectangle myExtent = mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
       if ( oldWidget )
       {
-        QgsRasterRenderer *oldRenderer = oldWidget->renderer();
+        std::unique_ptr< QgsRasterRenderer > oldRenderer( oldWidget->renderer() );
         if ( !oldRenderer || oldRenderer->type() != rendererName )
         {
           if ( rendererName == QLatin1String( "singlebandgray" ) )
@@ -310,7 +310,6 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
             whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
           }
         }
-        delete oldRenderer;
       }
       mRasterLayer->renderer()->setAlphaBand( alphaBand );
       mRasterLayer->renderer()->setOpacity( opacity );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -296,16 +296,21 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
       const QgsRectangle myExtent = mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
       if ( oldWidget )
       {
-        if ( rendererName == QLatin1String( "singlebandgray" ) )
+        QgsRasterRenderer *oldRenderer = oldWidget->renderer();
+        if (!oldRenderer || oldRenderer->type() != rendererName)
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
-          whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
+            if ( rendererName == QLatin1String( "singlebandgray" ) )
+            {
+              whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
+              whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
+            }
+            else if ( rendererName == QLatin1String( "multibandcolor" ) )
+            {
+              whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
+              whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
+            }
         }
-        else if ( rendererName == QLatin1String( "multibandcolor" ) )
-        {
-          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
-          whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
-        }
+        delete oldRenderer;
       }
       mRasterLayer->renderer()->setAlphaBand( alphaBand );
       mRasterLayer->renderer()->setOpacity( opacity );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -297,18 +297,18 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
       if ( oldWidget )
       {
         QgsRasterRenderer *oldRenderer = oldWidget->renderer();
-        if (!oldRenderer || oldRenderer->type() != rendererName)
+        if ( !oldRenderer || oldRenderer->type() != rendererName )
         {
-            if ( rendererName == QLatin1String( "singlebandgray" ) )
-            {
-              whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
-              whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
-            }
-            else if ( rendererName == QLatin1String( "multibandcolor" ) )
-            {
-              whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
-              whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
-            }
+          if ( rendererName == QLatin1String( "singlebandgray" ) )
+          {
+            whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::SingleBandGray, mRasterLayer->dataProvider() ) );
+            whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
+          }
+          else if ( rendererName == QLatin1String( "multibandcolor" ) )
+          {
+            whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( QgsRaster::MultiBandColor, mRasterLayer->dataProvider() ) );
+            whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
+          }
         }
         delete oldRenderer;
       }

--- a/tests/src/python/test_qgsrendererrasterpropertieswidget.py
+++ b/tests/src/python/test_qgsrendererrasterpropertieswidget.py
@@ -30,14 +30,14 @@ class QgsRendererRasterPropertiesTestCases(TestCase):
     def test_syncToLayer_SingleBandGray(self):
 
         lyr = self.multibandRasterLayer()
-        lyr.setRenderer(QgsSingleBandGrayRenderer(lyr.dataProvider(), 1))
+        lyr.setRenderer(QgsSingleBandGrayRenderer(lyr.dataProvider(), 2))
         c = QgsMapCanvas()
         w = QgsRendererRasterPropertiesWidget(lyr, c)
         assert isinstance(w.currentRenderWidget().renderer(), QgsSingleBandGrayRenderer)
-        assert w.currentRenderWidget().renderer().grayBand() == 1
-        lyr.renderer().setGrayBand(2)
-        w.syncToLayer(lyr)
         assert w.currentRenderWidget().renderer().grayBand() == 2
+        lyr.renderer().setGrayBand(1)
+        w.syncToLayer(lyr)
+        assert w.currentRenderWidget().renderer().grayBand() == 1
 
     def test_syncToLayer_MultiBand(self):
 


### PR DESCRIPTION
## Description

This PR fixes #34602 which caused that `QgsRendererRasterPropertiesWidget::syncToLayer()` replaced existing QgsMultiBandColorRenderer or QgsSingleBandGrayRenderer renderers. This, for example, led to a reset of band numbers.

src/python/test_qgsrendererrasterpropertieswidget.py was modified to control that band numbers are maintained.
