### PR TITLE
QgsOgrProvider: Ensure that QgsEditorWidgets are not removed by QgsVectorLayer::commitChanges() 

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2009,6 +2009,7 @@ bool QgsOgrProvider::addAttributes( const QList<QgsField> &attributes )
       mAttributeFields[ idx ].setType( it->type() );
       mAttributeFields[ idx ].setLength( it->length() );
       mAttributeFields[ idx ].setPrecision( it->precision() );
+      mAttributeFields[ idx ].setEditorWidgetSetup( it->editorWidgetSetup() );
     }
   }
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -26,6 +26,7 @@ from qgis.core import (
     QgsAuthMethodConfig,
     QgsApplication,
     QgsCoordinateTransformContext,
+    QgsEditorWidgetSetup,
     QgsProject,
     QgsField,
     QgsFields,
@@ -39,6 +40,7 @@ from qgis.core import (
     QgsVectorDataProvider,
     QgsVectorLayer,
     QgsVectorFileWriter,
+    QgsVectorLayerExporter,
     QgsWkbTypes,
     QgsNetworkAccessManager,
     QgsLayerMetadata,
@@ -47,6 +49,10 @@ from qgis.core import (
     QgsProviderSublayerDetails,
     Qgis,
     QgsDirectoryItem
+)
+
+from qgis.gui import (
+    QgsGui
 )
 from qgis.testing import start_app, unittest
 from qgis.utils import spatialite_connect
@@ -1502,6 +1508,53 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(enum_setup.type(), 'ValueMap')
         self.assertTrue(enum_setup.config()['map'], [{'one': '1'}, {'2': '2'}])
         self.assertEqual(vl.editorWidgetSetup(fields.lookupField('with_enum_domain')).type(), 'ValueMap')
+
+    def test_provider_editorWidgets(self):
+        if len(QgsGui.editorWidgetRegistry().factories()) == 0:
+            QgsGui.editorWidgetRegistry().initEditors()
+
+        editor_widget_type = 'Color'
+        factory = QgsGui.instance().editorWidgetRegistry().factory(editor_widget_type)
+        assert factory.name() == editor_widget_type
+
+        # 1. create a vector
+        uri = "point?crs=epsg:4326&field=id:integer"
+        layer = QgsVectorLayer(uri, "Scratch point layer", "memory")
+
+        path = '/vsimem/test.gpkg'
+        result, msg = QgsVectorLayerExporter.exportLayer(layer, path, 'ogr', layer.crs())
+        self.assertTrue(result == Qgis.VectorExportResult.Success, msg=msg)
+        layer = QgsVectorLayer(path)
+        self.assertTrue(layer.isValid())
+        self.assertTrue(layer.providerType() == 'ogr')
+
+        field1 = QgsField(name='field1', type=QVariant.String)
+        field2 = QgsField(name='field2', type=QVariant.String)
+        setup1 = QgsEditorWidgetSetup(editor_widget_type, {})
+        setup2 = QgsEditorWidgetSetup(editor_widget_type, {})
+
+        # 2. Add field, set editor widget after commitChanges()
+        assert layer.startEditing()
+        layer.addAttribute(field1)
+        assert layer.commitChanges(stopEditing=False)
+        i = layer.fields().lookupField(field1.name())
+        layer.setEditorWidgetSetup(i, setup1)
+
+        # 3. Add field, set editor widget before commitChanges()
+        field2.setEditorWidgetSetup(setup2)
+        layer.addAttribute(field2)
+        i = layer.fields().lookupField(field2.name())
+
+        # this is a workaround:
+        # layer.setEditorWidgetSetup(i, field2.editorWidgetSetup())
+        self.assertEqual(layer.editorWidgetSetup(i).type(), editor_widget_type)
+        self.assertTrue(layer.commitChanges())
+
+        # editor widget should not change by commitChanges
+        self.assertEqual(layer.editorWidgetSetup(i).type(),
+                         editor_widget_type,
+                         msg='QgsVectorLayer::commitChanged() changed QgsEditorWidgetSetup' +
+                             f'\nDriver: {layer.dataProvider().name()}')
 
     def test_provider_sublayer_details(self):
         """


### PR DESCRIPTION


## Description

This PR fixes #43261, which caused that calling `QgsVectorLayer:.commitChanges(...)` on a QgsOgrDataProvider source led to a reset of the QgsEditorWidget setups of the layer fields .

A new unit-test (`test_provider_editorWidgets(self)`) has been added to test_provider_ogr.py