### PR TITLE
Coerce geometry generators to required geometry type when the result doesn't match symbol type

### DIFF
--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -143,6 +143,12 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
      */
     QgsGeometry evaluateGeometryInPainterUnits( const QgsGeometry &input, const QgsFeature &feature, const QgsRenderContext &renderContext, QgsExpressionContext &expressionContext ) const;
 
+    /**
+     * Tries to coerce the geometry output by the generator expression into
+     * a type usable by the symbol.
+     */
+    QgsGeometry coerceToExpectedType( const QgsGeometry &geometry ) const;
+
     std::unique_ptr<QgsExpression> mExpression;
     std::unique_ptr<QgsFillSymbol> mFillSymbol;
     std::unique_ptr<QgsLineSymbol> mLineSymbol;


### PR DESCRIPTION
When a geometry generator expression result is an incorrect geometry type for the generator symbol, try to coerce the result geometry to the correct type

E.g. if the generator is set to a line symbol type but the expression gives a polygon result, then take the rings of the polygon as the geometry and render using the line symbol

At worst this is better then rendering absolutely nothing (which can be very confusing!!), and at best is desirable behaviour anyway.
