### PR TITLE
Multiedit support for relation editor

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -246,6 +246,15 @@ Forward the signal to the embedded form
     virtual void setFeature( const QgsFeature &feature );
 
 
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+%Docstring
+Set multiple feature to edit simultaneously.
+
+:param fids: Multiple Id of features to edit
+
+.. versionadded:: 3.22
+%End
+
     void setVisible( bool visible );
 %Docstring
 Sets the visibility of the wrapper's widget.

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -252,7 +252,7 @@ Set multiple feature to edit simultaneously.
 
 :param fids: Multiple Id of features to edit
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
     void setVisible( bool visible );

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -82,7 +82,7 @@ Set multiple feature to edit simultaneously.
 
 :param fids: Multiple Id of features to edit
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
     virtual void setEditorContext( const QgsAttributeEditorContext &context );
@@ -188,7 +188,9 @@ Saves the current modifications in the relation
 
     QgsFeatureIds addFeature( const QgsGeometry &geometry = QgsGeometry() );
 %Docstring
-Adds a new feature with given ``geometry``
+Adds new features with given ``geometry``
+
+.. versionadded:: 3.24
 %End
 
     void deleteFeature( QgsFeatureId fid = QgsFeatureId() );
@@ -225,7 +227,7 @@ Duplicates features
 %Docstring
 Return true if editing multiple features at a time
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
   protected:

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -167,6 +167,13 @@ Returns the widget configuration
 Defines the widget configuration
 %End
 
+    bool multiEditModeActive() const;
+%Docstring
+Returns true if editing multiple features at a time
+
+.. versionadded:: 3.24
+%End
+
   public slots:
 
     virtual void parentFormValueChanged( const QString &attribute, const QVariant &newValue ) = 0;
@@ -221,13 +228,6 @@ Duplicates a feature
     void duplicateFeatures( const QgsFeatureIds &fids );
 %Docstring
 Duplicates features
-%End
-
-    bool multiEditModeActive() const;
-%Docstring
-Returns true if editing multiple features at a time
-
-.. versionadded:: 3.24
 %End
 
   protected:

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -186,7 +186,7 @@ Toggles editing state of the widget
 Saves the current modifications in the relation
 %End
 
-    void addFeature( const QgsGeometry &geometry = QgsGeometry() );
+    QgsFeatureIds addFeature( const QgsGeometry &geometry = QgsGeometry() );
 %Docstring
 Adds a new feature with given ``geometry``
 %End

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -225,7 +225,7 @@ Duplicates features
 
     bool multiEditModeActive() const;
 %Docstring
-Return true if editing multiple features at a time
+Returns true if editing multiple features at a time
 
 .. versionadded:: 3.24
 %End

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -76,6 +76,15 @@ Returns the nm relation
 Sets the ``feature`` being edited and updates the UI unless ``update`` is set to ``False``
 %End
 
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+%Docstring
+Set multiple feature to edit simultaneously.
+
+:param fids: Multiple Id of features to edit
+
+.. versionadded:: 3.22
+%End
+
     virtual void setEditorContext( const QgsAttributeEditorContext &context );
 %Docstring
 Sets the editor ``context``

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -221,6 +221,13 @@ Duplicates a feature
 Duplicates features
 %End
 
+    bool multiEditModeActive() const;
+%Docstring
+Return true if editing multiple features at a time
+
+.. versionadded:: 3.22
+%End
+
   protected:
 
 

--- a/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
@@ -34,6 +34,15 @@ Constructor
     virtual QString currentFilterExpression() const;
 
 
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+%Docstring
+Set multiple feature to edit simultaneously.
+
+:param fids: Multiple Id of features to edit
+
+.. versionadded:: 3.22
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
@@ -40,7 +40,7 @@ Set multiple feature to edit simultaneously.
 
 :param fids: Multiple Id of features to edit
 
-.. versionadded:: 3.22
+.. versionadded:: 3.24
 %End
 
 };

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.h
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsrelationreferenceconfigdlgbase.h
+    qgsrelationreferenceconfigdlg.h
      --------------------------------------
     Date                 : 21.4.2013
     Copyright            : (C) 2013 Matthias Kuhn

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -59,6 +59,12 @@ void QgsRelationWidgetWrapper::setFeature( const QgsFeature &feature )
     mWidget->setFeature( feature );
 }
 
+void QgsRelationWidgetWrapper::setMultiEditFeatureIds( const QgsFeatureIds &fids )
+{
+  if ( mWidget && mRelation.isValid() )
+    mWidget->setMultiEditFeatureIds( fids );
+}
+
 void QgsRelationWidgetWrapper::setVisible( bool visible )
 {
   if ( mWidget )

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -214,6 +214,13 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     void setFeature( const QgsFeature &feature ) override;
 
     /**
+     * Set multiple feature to edit simultaneously.
+     * \param fids Multiple Id of features to edit
+     * \since QGIS 3.22
+     */
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+
+    /**
      * Sets the visibility of the wrapper's widget.
      * \param visible set to TRUE to show widget, FALSE to hide widget
      * \since QGIS 2.16

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -216,7 +216,7 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     /**
      * Set multiple feature to edit simultaneously.
      * \param fids Multiple Id of features to edit
-     * \since QGIS 3.22
+     * \since QGIS 3.24
      */
     void setMultiEditFeatureIds( const QgsFeatureIds &fids );
 

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -107,7 +107,6 @@ void QgsAbstractRelationEditorWidget::setFeature( const QgsFeature &feature, boo
   mFeatureList.clear();
   mFeatureList.append( feature );
 
-  // Is this OK???
   mEditorContext.setFormFeature( feature );
 
   if ( update )
@@ -122,6 +121,9 @@ void QgsAbstractRelationEditorWidget::setMultiEditFeatureIds( const QgsFeatureId
   QgsFeature feature;
   while ( featureIterator.nextFeature( feature ) )
     mFeatureList.append( feature );
+
+  if ( ! mFeatureList.isEmpty() )
+    mEditorContext.setFormFeature( mFeatureList.first() );
 }
 
 void QgsAbstractRelationEditorWidget::setNmRelationId( const QVariant &nmRelationId )

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -174,6 +174,11 @@ void QgsAbstractRelationEditorWidget::updateTitle()
 {
 }
 
+bool QgsAbstractRelationEditorWidget::multiEditModeActive() const
+{
+  return mFeatureList.size() > 1;
+}
+
 QgsFeature QgsAbstractRelationEditorWidget::feature() const
 {
   if ( !mFeatureList.isEmpty() )
@@ -693,11 +698,6 @@ void QgsAbstractRelationEditorWidget::duplicateFeatures( const QgsFeatureIds &fi
     QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicatedFeatureContext;
     QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), duplicatedFeatureContext );
   }
-}
-
-bool QgsAbstractRelationEditorWidget::multiEditModeActive() const
-{
-  return mFeatureList.size() > 1;
 }
 
 void QgsAbstractRelationEditorWidget::showEvent( QShowEvent * )

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -98,6 +98,13 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     void setFeature( const QgsFeature &feature, bool update = true );
 
     /**
+     * Set multiple feature to edit simultaneously.
+     * \param fids Multiple Id of features to edit
+     * \since QGIS 3.22
+     */
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+
+    /**
      * Sets the editor \a context
      * \note if context cadDockWidget is null, it won't be possible to digitize
      * the geometry of a referencing feature from this widget
@@ -229,7 +236,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     QgsAttributeEditorContext mEditorContext;
     QgsRelation mRelation;
     QgsRelation mNmRelation;
-    QgsFeature mFeature;
+    QgsFeatureList mFeatureList;
 
     bool mLayerInSameTransactionGroup = false;
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -231,6 +231,12 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      */
     void duplicateFeatures( const QgsFeatureIds &fids );
 
+    /**
+     * Return true if editing multiple features at a time
+     * \since QGIS 3.22
+     */
+    bool multiEditModeActive() const;
+
   protected:
 
     QgsAttributeEditorContext mEditorContext;

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -198,7 +198,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Adds new features with given \a geometry
-     * Return the Id of added features \since QGIS 3.24
+     * Returns the Id of added features \since QGIS 3.24
      */
     QgsFeatureIds addFeature( const QgsGeometry &geometry = QgsGeometry() );
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -199,7 +199,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     /**
      * Adds a new feature with given \a geometry
      */
-    void addFeature( const QgsGeometry &geometry = QgsGeometry() );
+    QgsFeatureIds addFeature( const QgsGeometry &geometry = QgsGeometry() );
 
     /**
      * Delete a feature with given \a fid

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -100,7 +100,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     /**
      * Set multiple feature to edit simultaneously.
      * \param fids Multiple Id of features to edit
-     * \since QGIS 3.22
+     * \since QGIS 3.24
      */
     void setMultiEditFeatureIds( const QgsFeatureIds &fids );
 
@@ -197,7 +197,8 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     void saveEdits();
 
     /**
-     * Adds a new feature with given \a geometry
+     * Adds new features with given \a geometry
+     * Return the Id of added features \since QGIS 3.24
      */
     QgsFeatureIds addFeature( const QgsGeometry &geometry = QgsGeometry() );
 
@@ -233,7 +234,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Return true if editing multiple features at a time
-     * \since QGIS 3.22
+     * \since QGIS 3.24
      */
     bool multiEditModeActive() const;
 

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -233,7 +233,7 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
     void duplicateFeatures( const QgsFeatureIds &fids );
 
     /**
-     * Return true if editing multiple features at a time
+     * Returns true if editing multiple features at a time
      * \since QGIS 3.24
      */
     bool multiEditModeActive() const;

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -177,6 +177,12 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      */
     virtual void setConfig( const QVariantMap &config ) = 0;
 
+    /**
+     * Returns true if editing multiple features at a time
+     * \since QGIS 3.24
+     */
+    bool multiEditModeActive() const;
+
   public slots:
 
     /**
@@ -231,12 +237,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * Duplicates features
      */
     void duplicateFeatures( const QgsFeatureIds &fids );
-
-    /**
-     * Returns true if editing multiple features at a time
-     * \since QGIS 3.24
-     */
-    bool multiEditModeActive() const;
 
   protected:
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -212,7 +212,7 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
     w->setContext( newContext );
   }
 
-  bool relationWidgetsVisible = ( mMode != QgsAttributeEditorContext::MultiEditMode && mMode != QgsAttributeEditorContext::AggregateSearchMode );
+  bool relationWidgetsVisible = ( mMode != QgsAttributeEditorContext::AggregateSearchMode );
   for ( QgsAttributeFormRelationEditorWidget *w : findChildren<  QgsAttributeFormRelationEditorWidget * >() )
   {
     w->setVisible( relationWidgetsVisible );
@@ -2512,6 +2512,9 @@ void QgsAttributeForm::setMultiEditFeatureIds( const QgsFeatureIds &fids )
       }
     }
   }
+
+  setMultiEditFeatureIdsRelations( fids );
+
   mIsSettingMultiEditFeatures = false;
 }
 
@@ -2662,6 +2665,18 @@ void QgsAttributeForm::updateDefaultValueDependencies()
         }
       }
     }
+  }
+}
+
+void QgsAttributeForm::setMultiEditFeatureIdsRelations( const QgsFeatureIds &fids )
+{
+  for ( QgsAttributeFormWidget *formWidget : mFormWidgets )
+  {
+    QgsAttributeFormRelationEditorWidget *relationEditorWidget = dynamic_cast<QgsAttributeFormRelationEditorWidget *>( formWidget );
+    if ( !relationEditorWidget )
+      continue;
+
+    relationEditorWidget->setMultiEditFeatureIds( fids );
   }
 }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -379,6 +379,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void updateDefaultValueDependencies();
 
+    void setMultiEditFeatureIdsRelations( const QgsFeatureIds &fids );
+
     struct WidgetInfo
     {
       QWidget *widget = nullptr;

--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -45,3 +45,8 @@ QString QgsAttributeFormRelationEditorWidget::currentFilterExpression() const
 
   return filterExpression;
 }
+
+void QgsAttributeFormRelationEditorWidget::setMultiEditFeatureIds( const QgsFeatureIds &fids )
+{
+  mWrapper->setMultiEditFeatureIds( fids );
+}

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -47,7 +47,7 @@ class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormW
     /**
      * Set multiple feature to edit simultaneously.
      * \param fids Multiple Id of features to edit
-     * \since QGIS 3.22
+     * \since QGIS 3.24
      */
     void setMultiEditFeatureIds( const QgsFeatureIds &fids );
 

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -44,6 +44,13 @@ class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormW
     void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() ) override;
     QString currentFilterExpression() const override;
 
+    /**
+     * Set multiple feature to edit simultaneously.
+     * \param fids Multiple Id of features to edit
+     * \since QGIS 3.22
+     */
+    void setMultiEditFeatureIds( const QgsFeatureIds &fids );
+
   private:
     QgsRelationAggregateSearchWidgetWrapper *mSearchWidget = nullptr;
     QgsRelationWidgetWrapper *mWrapper = nullptr;

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -402,6 +402,8 @@ void QgsRelationEditorWidget::addFeature()
     ++treeWidgetItemIterator;
   }
   mMultiEditTreeWidget->blockSignals( false );
+
+  updateButtons();
 }
 
 void QgsRelationEditorWidget::addFeatureGeometry()

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -571,7 +571,7 @@ void QgsRelationEditorWidget::updateUi()
       parentTreeWidgetItems.append( treeWidgetItem );
 
       // Get child features
-      QgsFeatureRequest request = relation().getRelatedFeaturesRequest( feature );
+      const QgsFeatureRequest request = relation().getRelatedFeaturesRequest( feature );
       QgsFeatureIterator featureIterator = mRelation.referencingLayer()->getFeatures( request );
       QgsFeature featureChild;
       while ( featureIterator.nextFeature( featureChild ) )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -578,7 +578,7 @@ void QgsRelationEditorWidget::updateUi()
       {
         if ( mNmRelation.isValid() )
         {
-          QgsFeatureRequest requestFinalChild = mNmRelation.getReferencedFeatureRequest( featureChild );
+          const QgsFeatureRequest requestFinalChild = mNmRelation.getReferencedFeatureRequest( featureChild );
           QgsFeatureIterator featureIteratorFinalChild = mNmRelation.referencedLayer()->getFeatures( requestFinalChild );
           QgsFeature featureChildChild;
           while ( featureIteratorFinalChild.nextFeature( featureChildChild ) )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -387,6 +387,7 @@ void QgsRelationEditorWidget::addFeature()
     return;
 
   mMultiEditTreeWidget->blockSignals( true );
+  mMultiEdit1NJustAddedIds = addedFeatures;
   QTreeWidgetItemIterator treeWidgetItemIterator( mMultiEditTreeWidget );
   while ( *treeWidgetItemIterator )
   {
@@ -452,12 +453,6 @@ void QgsRelationEditorWidget::multiEditItemSelectionChanged()
 {
   const QList<QTreeWidgetItem *> selectedItems = mMultiEditTreeWidget->selectedItems();
 
-  if ( ! mNmRelation.isValid() )
-  {
-    updateButtons();
-    return;
-  }
-
   // Select all items pointing to the same feature
   // but only if we are not deselecting.
   if ( selectedItems.size() == 1
@@ -465,9 +460,10 @@ void QgsRelationEditorWidget::multiEditItemSelectionChanged()
   {
     if ( selectedItems.first()->data( 0, static_cast<int>( MultiEditTreeWidgetRole::FeatureType ) ).toInt() == static_cast<int>( MultiEditFeatureType::Child ) )
     {
-      QgsFeatureId featureId = selectedItems.first()->data( 0, static_cast<int>( MultiEditTreeWidgetRole::FeatureId ) ).toInt();
-
       mMultiEditTreeWidget->blockSignals( true );
+
+      const QgsFeatureId featureIdSelectedItem = selectedItems.first()->data( 0, static_cast<int>( MultiEditTreeWidgetRole::FeatureId ) ).toInt();
+
       QTreeWidgetItemIterator treeWidgetItemIterator( mMultiEditTreeWidget );
       while ( *treeWidgetItemIterator )
       {
@@ -477,8 +473,20 @@ void QgsRelationEditorWidget::multiEditItemSelectionChanged()
           continue;
         }
 
-        if ( featureId == ( *treeWidgetItemIterator )->data( 0, static_cast<int>( MultiEditTreeWidgetRole::FeatureId ) ).toInt() )
-          ( *treeWidgetItemIterator )->setSelected( true );
+        const QgsFeatureId featureIdCurrentItem = ( *treeWidgetItemIterator )->data( 0, static_cast<int>( MultiEditTreeWidgetRole::FeatureId ) ).toInt();
+        if ( mNmRelation.isValid() )
+        {
+          if ( featureIdSelectedItem == featureIdCurrentItem )
+            ( *treeWidgetItemIterator )->setSelected( true );
+        }
+        else
+        {
+          if ( ! mMultiEdit1NJustAddedIds.contains( featureIdSelectedItem ) )
+            break;
+
+          if ( mMultiEdit1NJustAddedIds.contains( featureIdCurrentItem ) )
+            ( *treeWidgetItemIterator )->setSelected( true );
+        }
 
         ++treeWidgetItemIterator;
       }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -589,7 +589,7 @@ void QgsRelationEditorWidget::updateUi()
             treeWidgetItemChild->setText( 0, QgsVectorLayerUtils::getFeatureDisplayString( mNmRelation.referencedLayer(), featureChildChild ) );
             treeWidgetItemChild->setIcon( 0, QgsIconUtils::iconForLayer( mNmRelation.referencedLayer() ) );
 
-            // For nm relations deleting/unlinking ist not supported now, so selection
+            // For nm relations deleting/unlinking is not supported now, so selection
             // is also not possible
             if ( nmRelation().isValid() )
               treeWidgetItem->setFlags( Qt::ItemIsEnabled );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -32,6 +32,7 @@
 #include "qgsvectorlayerselectionmanager.h"
 #include "qgis_gui.h"
 
+class QTreeWidget;
 class QgsFeature;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
@@ -227,6 +228,10 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QToolButton *mFormViewButton = nullptr;
     QToolButton *mTableViewButton = nullptr;
     QToolButton *mAddFeatureGeometryButton = nullptr;
+    QStackedWidget *mStackedWidget = nullptr;
+    QWidget *mMultiEditStackedWidgetPage = nullptr;
+    QLabel *mMultiEditInformationLabel = nullptr;
+    QTreeWidget *mMultiEditTreeWidget = nullptr;
     QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;
     QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -212,6 +212,19 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();
+    QgsFeatureIds selectedChildFeatureIds() const;
+
+    enum class MultiEditFeatureType : int
+    {
+      Parent,
+      Child
+    };
+
+    enum class MultiEditTreeWidgetRole : int
+    {
+      FeatureType = Qt::UserRole + 1,
+      FeatureId = Qt::UserRole + 2
+    };
 
     QgsDualView *mDualView = nullptr;
     QPointer<QgsMessageBarItem> mMessageBarItem;
@@ -230,7 +243,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QToolButton *mAddFeatureGeometryButton = nullptr;
     QStackedWidget *mStackedWidget = nullptr;
     QWidget *mMultiEditStackedWidgetPage = nullptr;
-    QLabel *mMultiEditInformationLabel = nullptr;
     QTreeWidget *mMultiEditTreeWidget = nullptr;
     QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -33,6 +33,7 @@
 #include "qgis_gui.h"
 
 class QTreeWidget;
+class QTreeWidgetItem;
 class QgsFeature;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
@@ -209,6 +210,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void onKeyPressed( QKeyEvent *e );
     void onDigitizingCompleted( const QgsFeature &feature );
 
+    void multiEditItemSelectionChanged();
+
   private:
     void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
     void setMapTool( QgsMapTool *mapTool );
@@ -251,6 +254,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     Buttons mButtonsVisibility = Button::AllButtons;
     bool mShowFirstFeature = true;
+
+    QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
 };
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -217,6 +217,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();
     QgsFeatureIds selectedChildFeatureIds() const;
+    void updateUiSingleEdit();
+    void updateUiMultiEdit();
 
     enum class MultiEditFeatureType : int
     {

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -201,6 +201,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void setViewMode( int mode ) {setViewMode( static_cast<QgsDualView::ViewMode>( mode ) );}
     void updateButtons();
 
+    void addFeature();
     void addFeatureGeometry();
     void toggleEditing( bool state );
     void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -245,6 +245,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QToolButton *mFormViewButton = nullptr;
     QToolButton *mTableViewButton = nullptr;
     QToolButton *mAddFeatureGeometryButton = nullptr;
+    QLabel *mMultiEditInfoLabel = nullptr;
     QStackedWidget *mStackedWidget = nullptr;
     QWidget *mMultiEditStackedWidgetPage = nullptr;
     QTreeWidget *mMultiEditTreeWidget = nullptr;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -256,6 +256,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     bool mShowFirstFeature = true;
 
     QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
+    QgsFeatureIds mMultiEdit1NJustAddedIds;
 };
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -213,12 +213,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void multiEditItemSelectionChanged();
 
   private:
-    void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
-    void setMapTool( QgsMapTool *mapTool );
-    void unsetMapTool();
-    QgsFeatureIds selectedChildFeatureIds() const;
-    void updateUiSingleEdit();
-    void updateUiMultiEdit();
 
     enum class MultiEditFeatureType : int
     {
@@ -231,6 +225,18 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
       FeatureType = Qt::UserRole + 1,
       FeatureId = Qt::UserRole + 2
     };
+
+    void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
+    void setMapTool( QgsMapTool *mapTool );
+    void unsetMapTool();
+    QgsFeatureIds selectedChildFeatureIds() const;
+    void updateUiSingleEdit();
+    void updateUiMultiEdit();
+    void initializeMultiEditTreeWidgetItem( QTreeWidgetItem *treeWidgetItem,
+                                            const QString &text,
+                                            const QIcon &icon,
+                                            MultiEditFeatureType type,
+                                            const QVariant &featureId = QVariant() );
 
     QgsDualView *mDualView = nullptr;
     QPointer<QgsMessageBarItem> mMessageBarItem;
@@ -260,6 +266,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
     QgsFeatureIds mMultiEdit1NJustAddedIds;
+
+    friend class TestQgsRelationEditorWidget;
 };
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -232,11 +232,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QgsFeatureIds selectedChildFeatureIds() const;
     void updateUiSingleEdit();
     void updateUiMultiEdit();
-    void initializeMultiEditTreeWidgetItem( QTreeWidgetItem *treeWidgetItem,
-                                            const QString &text,
-                                            const QIcon &icon,
-                                            MultiEditFeatureType type,
-                                            const QVariant &featureId = QVariant() );
+    QTreeWidgetItem *createMultiEditTreeWidgetItem( const QgsFeature &feature, QgsVectorLayer *layer, MultiEditFeatureType type );
 
     QgsDualView *mDualView = nullptr;
     QPointer<QgsMessageBarItem> mMessageBarItem;

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TESTS
   testqgslayoutview.cpp
   testqgsvaluemapwidgetwrapper.cpp
   testqgsvaluerelationwidgetwrapper.cpp
+  testqgsrelationeditorwidget.cpp
   testqgsrelationreferencewidget.cpp
   testqgsfeaturelistcombobox.cpp
   testqgstexteditwrapper.cpp

--- a/tests/src/gui/testqgsrelationeditorwidget.cpp
+++ b/tests/src/gui/testqgsrelationeditorwidget.cpp
@@ -1,0 +1,287 @@
+/***************************************************************************
+    TestQgsRelationEditorWidget.cpp
+     --------------------------------------
+    Date                 : 19 11 2021
+    Copyright            : (C) 2021 Damiano Lombardi
+    Email                : damiano at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <qgstest.h>
+
+#include <editorwidgets/core/qgseditorwidgetregistry.h>
+#include <qgsapplication.h>
+#include <qgsattributeform.h>
+#include <qgsgui.h>
+#include <qgsproject.h>
+#include <qgsrelationeditorwidget.h>
+#include <qgsrelationmanager.h>
+#include <qgsrelationreferencewidget.h>
+
+#include <QTreeWidgetItem>
+
+class TestQgsRelationEditorWidget : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsRelationEditorWidget() = default;
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testMultiEdit1N();
+    void testMultiEditNM();
+
+  private:
+    std::unique_ptr<QgsVectorLayer> mLayer1;
+    std::unique_ptr<QgsVectorLayer> mLayer2;
+    std::unique_ptr<QgsVectorLayer> mLayerJoin;
+    std::unique_ptr<QgsRelation> mRelation;
+    std::unique_ptr<QgsRelation> mRelation1N;
+    std::unique_ptr<QgsRelation> mRelationNM;
+};
+
+void TestQgsRelationEditorWidget::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
+}
+
+void TestQgsRelationEditorWidget::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsRelationEditorWidget::init()
+{
+  // create layer
+  mLayer1.reset( new QgsVectorLayer( QStringLiteral( "LineString?field=pk:int&field=fk:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) ) );
+  mLayer1->setDisplayExpression( QStringLiteral( "'Layer1-' || pk" ) );
+  QgsProject::instance()->addMapLayer( mLayer1.get(), false, false );
+
+  mLayer2.reset( new QgsVectorLayer( QStringLiteral( "LineString?field=pk:int" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) ) );
+  mLayer2->setDisplayExpression( QStringLiteral( "'Layer2-' || pk" ) );
+  QgsProject::instance()->addMapLayer( mLayer2.get(), false, false );
+
+  mLayerJoin.reset( new QgsVectorLayer( QStringLiteral( "LineString?field=pk:int&field=fk_layer1:int&field=fk_layer2:int" ), QStringLiteral( "join_layer" ), QStringLiteral( "memory" ) ) );
+  mLayerJoin->setDisplayExpression( QStringLiteral( "'LayerJoin-' || pk" ) );
+  QgsProject::instance()->addMapLayer( mLayerJoin.get(), false, false );
+
+  // create relation
+  mRelation.reset( new QgsRelation() );
+  mRelation->setId( QStringLiteral( "vl1.vl2" ) );
+  mRelation->setName( QStringLiteral( "vl1.vl2" ) );
+  mRelation->setReferencingLayer( mLayer1->id() );
+  mRelation->setReferencedLayer( mLayer2->id() );
+  mRelation->addFieldPair( QStringLiteral( "fk" ), QStringLiteral( "pk" ) );
+  QVERIFY( mRelation->isValid() );
+  QgsProject::instance()->relationManager()->addRelation( *mRelation );
+
+  // create nm relations
+  mRelation1N.reset( new QgsRelation() );
+  mRelation1N->setId( QStringLiteral( "join_layer.vl1" ) );
+  mRelation1N->setName( QStringLiteral( "join_layer.vl1" ) );
+  mRelation1N->setReferencingLayer( mLayerJoin->id() );
+  mRelation1N->setReferencedLayer( mLayer1->id() );
+  mRelation1N->addFieldPair( QStringLiteral( "fk_layer1" ), QStringLiteral( "pk" ) );
+  QVERIFY( mRelation1N->isValid() );
+  QgsProject::instance()->relationManager()->addRelation( *mRelation1N );
+
+  mRelationNM.reset( new QgsRelation() );
+  mRelationNM->setId( QStringLiteral( "join_layer.vl2" ) );
+  mRelationNM->setName( QStringLiteral( "join_layer.vl2" ) );
+  mRelationNM->setReferencingLayer( mLayerJoin->id() );
+  mRelationNM->setReferencedLayer( mLayer2->id() );
+  mRelationNM->addFieldPair( QStringLiteral( "fk_layer2" ), QStringLiteral( "pk" ) );
+  QVERIFY( mRelationNM->isValid() );
+  QgsProject::instance()->relationManager()->addRelation( *mRelationNM );
+
+  // add features
+  QgsFeature ft0( mLayer1->fields() );
+  ft0.setAttribute( QStringLiteral( "pk" ), 0 );
+  ft0.setAttribute( QStringLiteral( "fk" ), 10 );
+  mLayer1->startEditing();
+  mLayer1->addFeature( ft0 );
+  mLayer1->commitChanges();
+
+  QgsFeature ft1( mLayer1->fields() );
+  ft1.setAttribute( QStringLiteral( "pk" ), 1 );
+  ft1.setAttribute( QStringLiteral( "fk" ), 11 );
+  mLayer1->startEditing();
+  mLayer1->addFeature( ft1 );
+  mLayer1->commitChanges();
+
+  QgsFeature ft2( mLayer2->fields() );
+  ft2.setAttribute( QStringLiteral( "pk" ), 10 );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft2 );
+  mLayer2->commitChanges();
+
+  QgsFeature ft3( mLayer2->fields() );
+  ft3.setAttribute( QStringLiteral( "pk" ), 11 );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft3 );
+  mLayer2->commitChanges();
+
+  QgsFeature ft4( mLayer2->fields() );
+  ft4.setAttribute( QStringLiteral( "pk" ), 12 );
+  mLayer2->startEditing();
+  mLayer2->addFeature( ft4 );
+  mLayer2->commitChanges();
+
+  // Add join features
+  QgsFeature jft1( mLayerJoin->fields() );
+  jft1.setAttribute( QStringLiteral( "pk" ), 101 );
+  jft1.setAttribute( QStringLiteral( "fk_layer1" ), 0 );
+  jft1.setAttribute( QStringLiteral( "fk_layer2" ), 10 );
+  mLayerJoin->startEditing();
+  mLayerJoin->addFeature( jft1 );
+  mLayerJoin->commitChanges();
+
+  QgsFeature jft2( mLayerJoin->fields() );
+  jft2.setAttribute( QStringLiteral( "pk" ), 102 );
+  jft2.setAttribute( QStringLiteral( "fk_layer1" ), 1 );
+  jft2.setAttribute( QStringLiteral( "fk_layer2" ), 11 );
+  mLayerJoin->startEditing();
+  mLayerJoin->addFeature( jft2 );
+  mLayerJoin->commitChanges();
+
+  QgsFeature jft3( mLayerJoin->fields() );
+  jft3.setAttribute( QStringLiteral( "pk" ), 102 );
+  jft3.setAttribute( QStringLiteral( "fk_layer1" ), 0 );
+  jft3.setAttribute( QStringLiteral( "fk_layer2" ), 11 );
+  mLayerJoin->startEditing();
+  mLayerJoin->addFeature( jft3 );
+  mLayerJoin->commitChanges();
+}
+
+void TestQgsRelationEditorWidget::cleanup()
+{
+  QgsProject::instance()->removeMapLayer( mLayer1.get() );
+  QgsProject::instance()->removeMapLayer( mLayer2.get() );
+  QgsProject::instance()->removeMapLayer( mLayerJoin.get() );
+}
+
+void TestQgsRelationEditorWidget::testMultiEdit1N()
+{
+  // Init a relation editor widget
+  QgsRelationEditorWidget relationEditorWidget( QVariantMap(),
+      new QWidget() );
+  relationEditorWidget.setRelations( *mRelation, QgsRelation() );
+
+  QVERIFY( !relationEditorWidget.multiEditModeActive() );
+
+  QgsFeatureIds featureIds;
+  QgsFeatureIterator featureIterator = mLayer2->getFeatures();
+  QgsFeature feature;
+  while ( featureIterator.nextFeature( feature ) )
+    featureIds.insert( feature.id() );
+  relationEditorWidget.setMultiEditFeatureIds( featureIds );
+
+  // Update ui
+  relationEditorWidget.updateUiMultiEdit();
+
+  QVERIFY( relationEditorWidget.multiEditModeActive() );
+
+  QSet<QString> setParentItemsText;
+  QSet<QString> setChildrenItemsText;
+  for ( int parentIndex = 0; parentIndex < relationEditorWidget.mMultiEditTreeWidget->topLevelItemCount(); ++parentIndex )
+  {
+    QTreeWidgetItem *parentItem = relationEditorWidget.mMultiEditTreeWidget->topLevelItem( parentIndex );
+    setParentItemsText.insert( parentItem->text( 0 ) );
+    QCOMPARE( parentItem->data( 0, static_cast<int>( QgsRelationEditorWidget::MultiEditTreeWidgetRole::FeatureType ) ).toInt(),
+              static_cast<int>( QgsRelationEditorWidget::MultiEditFeatureType::Parent ) );
+    for ( int childIndex = 0; childIndex < parentItem->childCount(); ++childIndex )
+    {
+      QTreeWidgetItem *childItem = parentItem->child( childIndex );
+      setChildrenItemsText.insert( childItem->text( 0 ) );
+      QCOMPARE( childItem->data( 0, static_cast<int>( QgsRelationEditorWidget::MultiEditTreeWidgetRole::FeatureType ) ).toInt(),
+                static_cast<int>( QgsRelationEditorWidget::MultiEditFeatureType::Child ) );
+
+      if ( childItem->text( 0 ) == QStringLiteral( "Layer1-0" ) )
+        QCOMPARE( parentItem->text( 0 ), QStringLiteral( "Layer2-10" ) );
+
+      if ( childItem->text( 0 ) == QStringLiteral( "Layer1-1" ) )
+        QCOMPARE( parentItem->text( 0 ), QStringLiteral( "Layer2-11" ) );
+    }
+  }
+
+  QCOMPARE( setParentItemsText, QSet<QString>() << QStringLiteral( "Layer2-10" )
+            << QStringLiteral( "Layer2-11" )
+            << QStringLiteral( "Layer2-12" ) );
+
+  QCOMPARE( setChildrenItemsText, QSet<QString>() << QStringLiteral( "Layer1-0" )
+            << QStringLiteral( "Layer1-1" ) );
+}
+
+void TestQgsRelationEditorWidget::testMultiEditNM()
+{
+  // Init a relation editor widget
+  QgsRelationEditorWidget relationEditorWidget( QVariantMap(),
+      new QWidget() );
+  relationEditorWidget.setRelations( *mRelation1N, *mRelationNM );
+
+  QVERIFY( !relationEditorWidget.multiEditModeActive() );
+
+  QgsFeatureIds featureIds;
+  QgsFeatureIterator featureIterator = mLayer1->getFeatures();
+  QgsFeature feature;
+  while ( featureIterator.nextFeature( feature ) )
+    featureIds.insert( feature.id() );
+  relationEditorWidget.setMultiEditFeatureIds( featureIds );
+
+  // Update ui
+  relationEditorWidget.updateUiMultiEdit();
+
+  QVERIFY( relationEditorWidget.multiEditModeActive() );
+
+  QSet<QString> setParentItemsText;
+  QStringList listChildrenItemsText;
+  for ( int parentIndex = 0; parentIndex < relationEditorWidget.mMultiEditTreeWidget->topLevelItemCount(); ++parentIndex )
+  {
+    QTreeWidgetItem *parentItem = relationEditorWidget.mMultiEditTreeWidget->topLevelItem( parentIndex );
+    setParentItemsText.insert( parentItem->text( 0 ) );
+    QCOMPARE( parentItem->data( 0, static_cast<int>( QgsRelationEditorWidget::MultiEditTreeWidgetRole::FeatureType ) ).toInt(),
+              static_cast<int>( QgsRelationEditorWidget::MultiEditFeatureType::Parent ) );
+    for ( int childIndex = 0; childIndex < parentItem->childCount(); ++childIndex )
+    {
+      QTreeWidgetItem *childItem = parentItem->child( childIndex );
+      listChildrenItemsText.append( childItem->text( 0 ) );
+      QCOMPARE( childItem->data( 0, static_cast<int>( QgsRelationEditorWidget::MultiEditTreeWidgetRole::FeatureType ) ).toInt(),
+                static_cast<int>( QgsRelationEditorWidget::MultiEditFeatureType::Child ) );
+
+      if ( childItem->text( 0 ) == QStringLiteral( "Layer2-10" ) )
+        QCOMPARE( parentItem->text( 0 ), QStringLiteral( "Layer1-0" ) );
+
+      if ( childItem->text( 0 ) == QStringLiteral( "Layer2-11" ) )
+      {
+        QStringList possibleParents;
+        possibleParents << QStringLiteral( "Layer1-0" )
+                        << QStringLiteral( "Layer1-1" );
+        QVERIFY( possibleParents.contains( parentItem->text( 0 ) ) );
+      }
+    }
+  }
+
+  QCOMPARE( setParentItemsText, QSet<QString>() << QStringLiteral( "Layer1-0" )
+            << QStringLiteral( "Layer1-1" ) );
+
+  listChildrenItemsText.sort();
+  QCOMPARE( listChildrenItemsText, QStringList() << QStringLiteral( "Layer2-10" )
+            << QStringLiteral( "Layer2-11" )
+            << QStringLiteral( "Layer2-11" ) );
+
+}
+
+QGSTEST_MAIN( TestQgsRelationEditorWidget )
+#include "testqgsrelationeditorwidget.moc"


### PR DESCRIPTION
This p.r. aims to bring multiple features support for relation editor widget.
An example of use case could be selecting multiple trees and adding a maintenance item to all of them in one click.
![Relation editor multiediting 2021-10-28 09-52](https://user-images.githubusercontent.com/9881900/139212536-bc03e3da-06d1-4304-9f54-5aeb2d1d1f36.gif)

