### PR TITLE
Compare square distance with square tolerance in duplicated node check

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -138,7 +138,7 @@ void QgsGeometryAngleCheck::fixError( const QMap<QString, QgsFeaturePool *> &fea
     {
       changes[error->layerId()][error->featureId()].append( Change( ChangeNode, ChangeRemoved, vidx ) );
       // Avoid duplicate nodes as result of deleting spike vertex
-      if ( QgsGeometryUtils::sqrDistance2D( p1, p3 ) < mContext->tolerance &&
+      if ( QgsGeometryUtils::sqrDistance2D( p1, p3 ) < ( mContext->tolerance * mContext->tolerance ) &&
            QgsGeometryCheckerUtils::canDeleteVertex( geometry, vidx.part, vidx.ring ) &&
            geometry->deleteVertex( error->vidx() ) ) // error->vidx points to p3 after removing p2
       {

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -25,6 +25,8 @@ void QgsGeometryDuplicateNodesCheck::collectErrors( const QMap<QString, QgsFeatu
 
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
+  const double sqrTolerance = mContext->tolerance * mContext->tolerance;
+
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
@@ -39,7 +41,7 @@ void QgsGeometryDuplicateNodesCheck::collectErrors( const QMap<QString, QgsFeatu
         {
           const QgsPoint pi = geom->vertexAt( QgsVertexId( iPart, iRing, iVert ) );
           const QgsPoint pj = geom->vertexAt( QgsVertexId( iPart, iRing, jVert ) );
-          if ( QgsGeometryUtils::sqrDistance2D( pi, pj ) < mContext->tolerance )
+          if ( QgsGeometryUtils::sqrDistance2D( pi, pj ) < sqrTolerance )
           {
             errors.append( new QgsGeometryCheckError( this, layerFeature, pj, QgsVertexId( iPart, iRing, jVert ) ) );
           }

--- a/tests/src/geometry_checker/testqgsgeometrychecks.cpp
+++ b/tests/src/geometry_checker/testqgsgeometrychecks.cpp
@@ -83,6 +83,7 @@ class TestQgsGeometryChecks: public QObject
     void testDegeneratePolygonCheck();
     void testDuplicateCheck();
     void testDuplicateNodesCheck();
+    void testDuplicateNodesCheckTolerance();
     void testFollowBoundariesCheck();
     void testGapCheck();
     void testAllowedGaps();
@@ -486,6 +487,27 @@ void TestQgsGeometryChecks::testDuplicateNodesCheck()
   testContext.second[errs1[0]->layerId()]->getFeature( errs1[0]->featureId(), f );
   const int n2 = f.geometry().constGet()->vertexCount( errs1[0]->vidx().part, errs1[0]->vidx().ring );
   QCOMPARE( n1, n2 + 1 );
+
+  cleanupTestContext( testContext );
+}
+
+void TestQgsGeometryChecks::testDuplicateNodesCheckTolerance()
+{
+  QTemporaryDir dir;
+  QMap<QString, QString> layers;
+  layers.insert( "line_layer.shp", "" );
+  auto testContext = createTestContext( dir, layers, QgsCoordinateReferenceSystem( "EPSG:4326" ), 3 );
+
+  QList<QgsGeometryCheckError *> checkErrors;
+  QStringList messages;
+  QgsFeedback feedback;
+
+  const QgsGeometryDuplicateNodesCheck check( testContext.first, QVariantMap() );
+  check.collectErrors( testContext.second, checkErrors, messages, &feedback );
+  listErrors( checkErrors, messages );
+
+  int nErrors = checkErrors.size();
+  QCOMPARE( nErrors, 3 );
 
   cleanupTestContext( testContext );
 }


### PR DESCRIPTION
In the duplicated node check, the square distance between two vertices is compared to the tolerance. I think it should be compared to the square of the tolerance.
A unit test is added as well
