### PR TITLE
Provide a show first feature setting to avoid UI freeze of attribute form containing a large number of embedded relations

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -55,7 +55,7 @@ Constructor
                QgsMapCanvas *mapCanvas,
                const QgsFeatureRequest &request = QgsFeatureRequest(),
                const QgsAttributeEditorContext &context = QgsAttributeEditorContext(),
-               bool loadFeatures = true );
+               bool loadFeatures = true, bool showFirstFeature = true );
 %Docstring
 Has to be called to initialize the dual view.
 
@@ -66,6 +66,7 @@ Has to be called to initialize the dual view.
 :param context: The context in which this view is shown
 :param loadFeatures: whether to initially load all features into the view. If set to
                      ``False``, limited features can later be loaded using :py:func:`~QgsDualView.setFilterMode`
+:param showFirstFeature: whether to initially show the first feature form upon initializing the dual view
 %End
 
     void setView( ViewMode view );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -119,7 +119,7 @@ QgsDualView::~QgsDualView()
 }
 
 void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const QgsFeatureRequest &request,
-                        const QgsAttributeEditorContext &context, bool loadFeatures )
+                        const QgsAttributeEditorContext &context, bool loadFeatures, bool showFirstFeature )
 {
   if ( !layer )
     return;
@@ -162,9 +162,8 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   // This slows down load of the attribute table heaps and uses loads of memory.
   //mTableView->resizeColumnsToContents();
 
-  if ( mFeatureListModel->rowCount( ) > 0 )
+  if ( showFirstFeature && mFeatureListModel->rowCount( ) > 0 )
     mFeatureListView->setEditSelection( QgsFeatureIds() << mFeatureListModel->data( mFeatureListModel->index( 0, 0 ), QgsFeatureListModel::Role::FeatureRole ).value<QgsFeature>().id() );
-
 }
 
 void QgsDualView::initAttributeForm( const QgsFeature &feature )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -96,12 +96,13 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      * \param context    The context in which this view is shown
      * \param loadFeatures whether to initially load all features into the view. If set to
      *                   FALSE, limited features can later be loaded using setFilterMode()
+     * \param showFirstFeature whether to initially show the first feature form upon initializing the dual view
      */
     void init( QgsVectorLayer *layer,
                QgsMapCanvas *mapCanvas,
                const QgsFeatureRequest &request = QgsFeatureRequest(),
                const QgsAttributeEditorContext &context = QgsAttributeEditorContext(),
-               bool loadFeatures = true );
+               bool loadFeatures = true, bool showFirstFeature = true );
 
     /**
      * Change the current view mode.

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -97,6 +97,7 @@ void QgsFilteredSelectionManager::onSelectionChanged( const QgsFeatureIds &selec
 QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWidget *parent )
   : QgsAbstractRelationEditorWidget( config, parent )
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
+  , mShowFirstFeature( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() )
 {
   QVBoxLayout *rootLayout = new QVBoxLayout( this );
   rootLayout->setContentsMargins( 0, 9, 0, 0 );
@@ -226,7 +227,7 @@ void QgsRelationEditorWidget::initDualView( QgsVectorLayer *layer, const QgsFeat
 {
   QgsAttributeEditorContext ctx { mEditorContext };
   ctx.setParentFormFeature( mFeature );
-  mDualView->init( layer, mEditorContext.mapCanvas(), request, ctx );
+  mDualView->init( layer, mEditorContext.mapCanvas(), request, ctx, true, mShowFirstFeature );
   mFeatureSelectionMgr = new QgsFilteredSelectionManager( layer, request, mDualView );
   mDualView->setFeatureSelectionManager( mFeatureSelectionMgr );
 
@@ -489,12 +490,14 @@ void QgsRelationEditorWidget::mapToolDeactivated()
 
 QVariantMap QgsRelationEditorWidget::config() const
 {
-  return QVariantMap( {{"buttons", qgsFlagValueToKeys( visibleButtons() )}} );
+  return QVariantMap( {{"buttons", qgsFlagValueToKeys( visibleButtons() )},
+    {"show_first_feature", mShowFirstFeature}} );
 }
 
 void QgsRelationEditorWidget::setConfig( const QVariantMap &config )
 {
   mButtonsVisibility = qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons );
+  mShowFirstFeature = config.value( QStringLiteral( "show_first_feature" ), true ).toBool();
   updateButtons();
 }
 
@@ -623,6 +626,7 @@ QVariantMap QgsRelationEditorConfigWidget::config()
   return QVariantMap(
   {
     {"buttons", qgsFlagValueToKeys( buttons )},
+    {"show_first_feature", mShowFirstFeature->isChecked()}
   } );
 }
 
@@ -637,6 +641,7 @@ void QgsRelationEditorConfigWidget::setConfig( const QVariantMap &config )
   mRelationShowZoomToFeatureCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::ZoomToChildFeature ) );
   mRelationDeleteChildFeatureCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );
   mRelationShowSaveChildEditsCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) );
+  mShowFirstFeature->setChecked( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() );
 }
 
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -237,17 +237,17 @@ void QgsRelationEditorWidget::initDualView( QgsVectorLayer *layer, const QgsFeat
   if ( layer->geometryType() == QgsWkbTypes::PointGeometry )
   {
     icon = QgsApplication::getThemeIcon( QStringLiteral( "/mActionCapturePoint.svg" ) );
-    text = tr( "Add Point child Feature" );
+    text = tr( "Add Point Child Feature" );
   }
   else if ( layer->geometryType() == QgsWkbTypes::LineGeometry )
   {
     icon = QgsApplication::getThemeIcon( QStringLiteral( "/mActionCaptureLine.svg" ) );
-    text = tr( "Add Line child Feature" );
+    text = tr( "Add Line Child Feature" );
   }
   else if ( layer->geometryType() == QgsWkbTypes::PolygonGeometry )
   {
     icon = QgsApplication::getThemeIcon( QStringLiteral( "/mActionCapturePolygon.svg" ) );
-    text = tr( "Add Polygon Feature" );
+    text = tr( "Add Polygon Child Feature" );
   }
 
   mAddFeatureGeometryButton->setIcon( icon );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -232,6 +232,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;
 
     Buttons mButtonsVisibility = Button::AllButtons;
+    bool mShowFirstFeature = true;
 };
 
 

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -15,52 +15,74 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QCheckBox" name="mRelationShowLinkCheckBox">
+    <widget class="QCheckBox" name="mShowFirstFeature">
      <property name="text">
-      <string>Show link button</string>
+      <string>Automatically show first child feature</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="mRelationShowUnlinkCheckBox">
-     <property name="text">
-      <string>Show unlink button</string>
+    <widget class="QGroupBox" name="mButtonsVisibility">
+     <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>4</verstretch>
+        </sizepolicy>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mRelationShowSaveChildEditsCheckBox">
-     <property name="text">
-      <string>Show save child layer edits button</string>
+     <property name="title">
+        <string>Toolbar settings</string>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mRelationShowAddChildCheckBox">
-     <property name="text">
-      <string>Add child feature</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mRelationShowDuplicateChildFeatureCheckBox">
-     <property name="text">
-      <string>Duplicate child feature</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mRelationDeleteChildFeatureCheckBox">
-     <property name="text">
-      <string>Delete child feature</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mRelationShowZoomToFeatureCheckBox">
-     <property name="text">
-      <string>Zoom to child feature</string>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="mRelationShowLinkCheckBox">
+        <property name="text">
+         <string>Show link button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationShowUnlinkCheckBox">
+        <property name="text">
+         <string>Show unlink button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationShowSaveChildEditsCheckBox">
+        <property name="text">
+         <string>Show save child layer edits button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationShowAddChildCheckBox">
+        <property name="text">
+         <string>Add child feature button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationShowDuplicateChildFeatureCheckBox">
+        <property name="text">
+         <string>Duplicate child feature button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationDeleteChildFeatureCheckBox">
+        <property name="text">
+         <string>Delete child feature button</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="mRelationShowZoomToFeatureCheckBox">
+        <property name="text">
+         <string>Zoom to child feature button</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -17,7 +17,10 @@
    <item>
     <widget class="QCheckBox" name="mShowFirstFeature">
      <property name="text">
-      <string>Automatically show first child feature</string>
+      <string>Automatically select first child feature and show attribute form</string>
+     </property>
+     <property name="toolTip">
+      <string>Unchecking this can lead to faster loading time of attribute forms and avoid unnecessary queries.</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

This PR adds a `[x] show first feature` configuration option to the relation editor widget to prevent _long_ UI freeze when a large number of embedded relations is present in a feature form.

When toggling the option off, the feature form avoids the cost of creating editor widgets for that first child feature. Most importantly, If a child feature previously always shown would contain a relation editor widget of its own, that cost (feature list querying + 1st feature fetching) can also be postponed. On remote connections, this can be the difference between waiting 10sec or 0.5sec :)

I took the opportunity to fix a couple of inconsistencies within relation editor UI elements. Screenshot of configuration widget with added option:
![image](https://user-images.githubusercontent.com/1728657/139519888-f48fdc5d-25bb-4551-bc10-da9714490978.png)



