### PR TITLE
Unlock static build support for a bunch of providers

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2134,6 +2134,8 @@ if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_core
     provider_wms_a
     provider_delimitedtext_a
+    provider_arcgisfeatureserver_a
+    provider_arcgismapserver_a
   )
   if (HAVE_SPATIALITE)
     target_link_libraries(qgis_core

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2133,6 +2133,7 @@ endif()
 if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_core
     provider_wms_a
+    provider_wcs_a
     provider_delimitedtext_a
     provider_arcgisfeatureserver_a
     provider_arcgismapserver_a

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2138,6 +2138,7 @@ if (FORCE_STATIC_LIBS)
   if (HAVE_SPATIALITE)
     target_link_libraries(qgis_core
       provider_spatialite_a
+      provider_wfs_a
     )
   endif()
   if (HAVE_POSTGRESQL)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2134,6 +2134,7 @@ if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_core
     provider_wms_a
     provider_postgres_a
+    provider_delimitedtext_a
   )
 
   if (WITH_AUTH)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2139,6 +2139,7 @@ if (FORCE_STATIC_LIBS)
     target_link_libraries(qgis_core
       provider_spatialite_a
       provider_wfs_a
+      provider_virtuallayer_a
     )
   endif()
   if (HAVE_POSTGRESQL)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2133,9 +2133,18 @@ endif()
 if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_core
     provider_wms_a
-    provider_postgres_a
     provider_delimitedtext_a
   )
+  if (HAVE_SPATIALITE)
+    target_link_libraries(qgis_core
+      provider_spatialite_a
+    )
+  endif()
+  if (HAVE_POSTGRESQL)
+    target_link_libraries(qgis_core
+      provider_postgres_a
+    )
+  endif()
 
   if (WITH_AUTH)
     target_link_libraries(qgis_core

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -49,6 +49,7 @@
 #include "qgsspatialiteprovider.h"
 #include "qgswfsprovider.h"
 #include "qgsoapifprovider.h"
+#include "qgsvirtuallayerprovider.h"
 #endif
 #ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovider.h"
@@ -203,6 +204,7 @@ void QgsProviderRegistry::init()
   mProviders[ QgsSpatiaLiteProvider::providerKey() ] = new QgsSpatiaLiteProviderMetadata();
   mProviders[ QgsWFSProvider::providerKey() ] = new QgsWfsProviderMetadata();
   mProviders[ QgsOapifProvider::providerKey() ] = new QgsOapifProviderMetadata();
+  mProviders[ QgsVirtualLayerProvider::providerKey() ] = new QgsVirtualLayerProviderMetadata();
 #endif
 #ifdef HAVE_POSTGRESQL
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -47,6 +47,8 @@
 #include "qgsdelimitedtextprovider.h"
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovider.h"
+#include "qgswfsprovider.h"
+#include "qgsoapifprovider.h"
 #endif
 #ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovider.h"
@@ -199,6 +201,8 @@ void QgsProviderRegistry::init()
   mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
 #ifdef HAVE_SPATIALITE
   mProviders[ QgsSpatiaLiteProvider::providerKey() ] = new QgsSpatiaLiteProviderMetadata();
+  mProviders[ QgsWFSProvider::providerKey() ] = new QgsWfsProviderMetadata();
+  mProviders[ QgsOapifProvider::providerKey() ] = new QgsOapifProviderMetadata();
 #endif
 #ifdef HAVE_POSTGRESQL
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -45,6 +45,7 @@
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovider.h"
 #include "qgspostgresprovider.h"
+#include "qgsdelimitedtextprovider.h"
 #endif
 
 #include <QString>
@@ -191,6 +192,7 @@ void QgsProviderRegistry::init()
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();
+  mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
 #endif
 
   // add dynamic providers

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -44,6 +44,7 @@
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovider.h"
+#include "qgswcsprovider.h"
 #include "qgsdelimitedtextprovider.h"
 #include "qgsafsprovider.h"
 #include "qgsamsprovider.h"
@@ -201,6 +202,7 @@ void QgsProviderRegistry::init()
 
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
+  mProviders[ QgsWcsProvider::providerKey() ] = new QgsWcsProviderMetadata();
   mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
   mProviders[ QgsAfsProvider::providerKey() ] = new QgsAfsProviderMetadata();
   mProviders[ QgsAmsProvider::providerKey() ] = new QgsAmsProviderMetadata();

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -45,6 +45,8 @@
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovider.h"
 #include "qgsdelimitedtextprovider.h"
+#include "qgsafsprovider.h"
+#include "qgsamsprovider.h"
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovider.h"
 #include "qgswfsprovider.h"
@@ -200,6 +202,8 @@ void QgsProviderRegistry::init()
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
   mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
+  mProviders[ QgsAfsProvider::providerKey() ] = new QgsAfsProviderMetadata();
+  mProviders[ QgsAmsProvider::providerKey() ] = new QgsAmsProviderMetadata();
 #ifdef HAVE_SPATIALITE
   mProviders[ QgsSpatiaLiteProvider::providerKey() ] = new QgsSpatiaLiteProviderMetadata();
   mProviders[ QgsWFSProvider::providerKey() ] = new QgsWfsProviderMetadata();

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -44,10 +44,13 @@
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovider.h"
+#include "qgsdelimitedtextprovider.h"
+#ifdef HAVE_SPATIALITE
+#include "qgsspatialiteprovider.h"
+#endif
 #ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovider.h"
 #endif
-#include "qgsdelimitedtextprovider.h"
 #endif
 
 #include <QString>
@@ -193,10 +196,13 @@ void QgsProviderRegistry::init()
 
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
+  mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
+#ifdef HAVE_SPATIALITE
+  mProviders[ QgsSpatiaLiteProvider::providerKey() ] = new QgsSpatiaLiteProviderMetadata();
+#endif
 #ifdef HAVE_POSTGRESQL
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();
 #endif
-  mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
 #endif
 
   // add dynamic providers

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -44,7 +44,9 @@
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovider.h"
+#ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovider.h"
+#endif
 #include "qgsdelimitedtextprovider.h"
 #endif
 
@@ -191,7 +193,9 @@ void QgsProviderRegistry::init()
 
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
+#ifdef HAVE_POSTGRESQL
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();
+#endif
   mProviders[ QgsDelimitedTextProvider::providerKey() ] = new QgsDelimitedTextProviderMetadata();
 #endif
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1544,6 +1544,7 @@ endif()
 if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_gui
     provider_wms_gui_a
+    provider_wcs_gui_a
     provider_delimitedtext_gui_a
     provider_arcgisfeatureserver_gui_a
   )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1549,6 +1549,7 @@ if (FORCE_STATIC_LIBS)
   if (HAVE_SPATIALITE)
     target_link_libraries(qgis_gui
       provider_spatialite_gui_a
+      provider_wfs_gui_a
     )
   endif()
   if (HAVE_POSTGRESQL)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1550,6 +1550,7 @@ if (FORCE_STATIC_LIBS)
     target_link_libraries(qgis_gui
       provider_spatialite_gui_a
       provider_wfs_gui_a
+      provider_virtuallayer_gui_a
     )
   endif()
   if (HAVE_POSTGRESQL)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1545,6 +1545,7 @@ if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_gui
     provider_wms_gui_a
     provider_postgres_gui_a
+    provider_delimitedtext_gui_a
   )
 endif()
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1544,9 +1544,18 @@ endif()
 if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_gui
     provider_wms_gui_a
-    provider_postgres_gui_a
     provider_delimitedtext_gui_a
   )
+  if (HAVE_SPATIALITE)
+    target_link_libraries(qgis_gui
+      provider_spatialite_gui_a
+    )
+  endif()
+  if (HAVE_POSTGRESQL)
+    target_link_libraries(qgis_gui
+      provider_postgres_gui_a
+    )
+  endif()
 endif()
 
 if(ENABLE_MODELTEST)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1545,6 +1545,7 @@ if (FORCE_STATIC_LIBS)
   target_link_libraries(qgis_gui
     provider_wms_gui_a
     provider_delimitedtext_gui_a
+    provider_arcgisfeatureserver_gui_a
   )
   if (HAVE_SPATIALITE)
     target_link_libraries(qgis_gui

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -35,6 +35,7 @@
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovidergui.h"
+#include "qgswcsprovidergui.h"
 #include "qgsdelimitedtextprovidergui.h"
 #include "qgsarcgisrestprovidergui.h"
 #ifdef HAVE_SPATIALITE
@@ -101,6 +102,8 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 #ifdef HAVE_STATIC_PROVIDERS
   QgsProviderGuiMetadata *wms = new QgsWmsProviderGuiMetadata();
   mProviders[ wms->key() ] = wms;
+  QgsProviderGuiMetadata *wcs = new QgsWcsProviderGuiMetadata();
+  mProviders[ wcs->key() ] = wcs;
   QgsProviderGuiMetadata *delimitedtext = new QgsDelimitedTextProviderGuiMetadata();
   mProviders[ delimitedtext->key() ] = delimitedtext;
   QgsProviderGuiMetadata *arc = new QgsArcGisRestProviderGuiMetadata();

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -36,6 +36,7 @@
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovidergui.h"
 #include "qgspostgresprovidergui.h"
+#include "qgsdelimitedtextprovidergui.h"
 #endif
 
 /**
@@ -95,6 +96,9 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 
   QgsProviderGuiMetadata *postgres = new QgsPostgresProviderGuiMetadata();
   mProviders[ postgres->key() ] = postgres;
+
+  QgsProviderGuiMetadata *delimitedtext = new QgsDelimitedTextProviderGuiMetadata();
+  mProviders[ delimitedtext->key() ] = delimitedtext;
 #endif
 }
 

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -36,6 +36,7 @@
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovidergui.h"
 #include "qgsdelimitedtextprovidergui.h"
+#include "qgsarcgisrestprovidergui.h"
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovidergui.h"
 #include "qgswfsprovidergui.h"
@@ -100,9 +101,10 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 #ifdef HAVE_STATIC_PROVIDERS
   QgsProviderGuiMetadata *wms = new QgsWmsProviderGuiMetadata();
   mProviders[ wms->key() ] = wms;
-
   QgsProviderGuiMetadata *delimitedtext = new QgsDelimitedTextProviderGuiMetadata();
   mProviders[ delimitedtext->key() ] = delimitedtext;
+  QgsProviderGuiMetadata *arc = new QgsArcGisRestProviderGuiMetadata();
+  mProviders[ arc->key() ] = arc;
 #ifdef HAVE_SPATIALITE
   QgsProviderGuiMetadata *spatialite = new QgsSpatiaLiteProviderGuiMetadata();
   mProviders[ spatialite->key() ] = spatialite;

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -39,6 +39,7 @@
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovidergui.h"
 #include "qgswfsprovidergui.h"
+#include "qgsvirtuallayerprovidergui.h"
 #endif
 #ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovidergui.h"
@@ -107,6 +108,8 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
   mProviders[ spatialite->key() ] = spatialite;
   QgsProviderGuiMetadata *wfs = new QgsWfsProviderGuiMetadata();
   mProviders[ wfs->key() ] = wfs;
+  QgsProviderGuiMetadata *virtuallayer = new QgsVirtualLayerProviderGuiMetadata();
+  mProviders[ virtuallayer->key() ] = virtuallayer;
 #endif
 #ifdef HAVE_POSTGRESQL
   QgsProviderGuiMetadata *postgres = new QgsPostgresProviderGuiMetadata();

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -35,8 +35,13 @@
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovidergui.h"
-#include "qgspostgresprovidergui.h"
 #include "qgsdelimitedtextprovidergui.h"
+#ifdef HAVE_SPATIALITE
+#include "qgsspatialiteprovidergui.h"
+#endif
+#ifdef HAVE_POSTGRESQL
+#include "qgspostgresprovidergui.h"
+#endif
 #endif
 
 /**
@@ -94,11 +99,16 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
   QgsProviderGuiMetadata *wms = new QgsWmsProviderGuiMetadata();
   mProviders[ wms->key() ] = wms;
 
-  QgsProviderGuiMetadata *postgres = new QgsPostgresProviderGuiMetadata();
-  mProviders[ postgres->key() ] = postgres;
-
   QgsProviderGuiMetadata *delimitedtext = new QgsDelimitedTextProviderGuiMetadata();
   mProviders[ delimitedtext->key() ] = delimitedtext;
+#ifdef HAVE_SPATIALITE
+  QgsProviderGuiMetadata *spatialite = new QgsSpatiaLiteProviderGuiMetadata();
+  mProviders[ spatialite->key() ] = spatialite;
+#endif
+#ifdef HAVE_POSTGRESQL
+  QgsProviderGuiMetadata *postgres = new QgsPostgresProviderGuiMetadata();
+  mProviders[ postgres->key() ] = postgres;
+#endif
 #endif
 }
 

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -38,6 +38,7 @@
 #include "qgsdelimitedtextprovidergui.h"
 #ifdef HAVE_SPATIALITE
 #include "qgsspatialiteprovidergui.h"
+#include "qgswfsprovidergui.h"
 #endif
 #ifdef HAVE_POSTGRESQL
 #include "qgspostgresprovidergui.h"
@@ -104,6 +105,8 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 #ifdef HAVE_SPATIALITE
   QgsProviderGuiMetadata *spatialite = new QgsSpatiaLiteProviderGuiMetadata();
   mProviders[ spatialite->key() ] = spatialite;
+  QgsProviderGuiMetadata *wfs = new QgsWfsProviderGuiMetadata();
+  mProviders[ wfs->key() ] = wfs;
 #endif
 #ifdef HAVE_POSTGRESQL
   QgsProviderGuiMetadata *postgres = new QgsPostgresProviderGuiMetadata();

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -4,6 +4,7 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_PLUGIN_SUBDI
 
 # providers with implemented both static and dynamic building
 add_subdirectory(wms)
+add_subdirectory(wcs)
 add_subdirectory(delimitedtext)
 add_subdirectory(arcgisrest)
 
@@ -20,7 +21,6 @@ endif()
 if (NOT FORCE_STATIC_LIBS)
   add_subdirectory(geonode)
   add_subdirectory(mssql)
-  add_subdirectory(wcs)
   add_subdirectory(gpx)
   add_subdirectory(db2)
   add_subdirectory(mdal)

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -5,6 +5,7 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_PLUGIN_SUBDI
 # providers with implemented both static and dynamic building
 add_subdirectory(wms)
 add_subdirectory(delimitedtext)
+add_subdirectory(arcgisrest)
 
 if (WITH_SPATIALITE)
   add_subdirectory(spatialite)
@@ -17,7 +18,6 @@ if (POSTGRES_FOUND)
 endif()
 
 if (NOT FORCE_STATIC_LIBS)
-  add_subdirectory(arcgisrest)
   add_subdirectory(geonode)
   add_subdirectory(mssql)
   add_subdirectory(wcs)

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(delimitedtext)
 
 if (WITH_SPATIALITE)
   add_subdirectory(spatialite)
+  add_subdirectory(wfs)
 endif()
 
 if (POSTGRES_FOUND)
@@ -28,7 +29,6 @@ if (NOT FORCE_STATIC_LIBS)
 
   if (WITH_SPATIALITE)
     add_subdirectory(virtual)
-    add_subdirectory(wfs)
   endif()
 
   if (WITH_ORACLE)

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(delimitedtext)
 if (WITH_SPATIALITE)
   add_subdirectory(spatialite)
   add_subdirectory(wfs)
+  add_subdirectory(virtual)
 endif()
 
 if (POSTGRES_FOUND)
@@ -25,10 +26,6 @@ if (NOT FORCE_STATIC_LIBS)
   add_subdirectory(mdal)
   if (WITH_ANALYSIS)
     add_subdirectory(virtualraster)
-  endif()
-
-  if (WITH_SPATIALITE)
-    add_subdirectory(virtual)
   endif()
 
   if (WITH_ORACLE)

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -5,6 +5,11 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_PLUGIN_SUBDI
 # providers with implemented both static and dynamic building
 add_subdirectory(wms)
 add_subdirectory(delimitedtext)
+
+if (WITH_SPATIALITE)
+  add_subdirectory(spatialite)
+endif()
+
 if (POSTGRES_FOUND)
   add_subdirectory(postgres)
 endif()
@@ -22,7 +27,6 @@ if (NOT FORCE_STATIC_LIBS)
   endif()
 
   if (WITH_SPATIALITE)
-    add_subdirectory(spatialite)
     add_subdirectory(virtual)
     add_subdirectory(wfs)
   endif()

--- a/src/providers/CMakeLists.txt
+++ b/src/providers/CMakeLists.txt
@@ -4,13 +4,13 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_PLUGIN_SUBDI
 
 # providers with implemented both static and dynamic building
 add_subdirectory(wms)
+add_subdirectory(delimitedtext)
 if (POSTGRES_FOUND)
   add_subdirectory(postgres)
 endif()
 
 if (NOT FORCE_STATIC_LIBS)
   add_subdirectory(arcgisrest)
-  add_subdirectory(delimitedtext)
   add_subdirectory(geonode)
   add_subdirectory(mssql)
   add_subdirectory(wcs)

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -1,14 +1,3 @@
-include_directories(
-
-  ${CMAKE_BINARY_DIR}/src/ui
-)
-
-if (WITH_GUI)
-  include_directories(SYSTEM
-    ${QSCINTILLA_INCLUDE_DIR}
-  )
-endif()
-
 ###############################################################################
 
 set (AFS_SRCS
@@ -18,26 +7,29 @@ set (AFS_SRCS
   qgsarcgisrestdataitems.cpp
 )
 if (WITH_GUI)
-  set(AFS_SRCS ${AFS_SRCS}
+  set(AFS_GUI_SRCS
     qgsarcgisrestdataitemguiprovider.cpp
     qgsarcgisrestprovidergui.cpp
     qgsarcgisrestsourceselect.cpp
     qgsarcgisrestsourcewidget.cpp
     qgsnewarcgisrestconnection.cpp
   )
+  
+  set(AFS_UIS
+    qgsarcgisrestsourcewidgetbase.ui
+    qgsarcgisservicesourceselectbase.ui
+    qgsnewarcgisrestconnectionbase.ui
+  )
 endif()
 
 add_library (provider_arcgisfeatureserver_a STATIC ${AFS_SRCS})
-add_library(provider_arcgisfeatureserver MODULE ${AFS_SRCS})
+
+target_include_directories(provider_arcgisfeatureserver_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
+)
 
 # require c++17
 target_compile_features(provider_arcgisfeatureserver_a PRIVATE cxx_std_17)
-target_compile_features(provider_arcgisfeatureserver PRIVATE cxx_std_17)
-
-target_link_libraries(provider_arcgisfeatureserver
-  qgis_core
-  ${QCA_LIBRARY}
-)
 
 target_link_libraries (provider_arcgisfeatureserver_a
   qgis_core
@@ -45,19 +37,55 @@ target_link_libraries (provider_arcgisfeatureserver_a
 )
 
 if (WITH_GUI)
-  target_link_libraries(provider_arcgisfeatureserver
+  if (WITH_QT6)
+    QT6_WRAP_UI(AFS_UIS_H ${AFS_UIS})
+  else()
+    QT5_WRAP_UI(AFS_UIS_H ${AFS_UIS})
+  endif()
+  
+  add_library(provider_arcgisfeatureserver_gui_a STATIC ${AFS_GUI_SRCS} ${AFS_UIS_H})
+  
+  target_link_libraries(provider_arcgisfeatureserver_gui_a
     qgis_gui
   )
-  target_link_libraries(provider_arcgisfeatureserver_a
-    qgis_gui
+
+  include_directories(SYSTEM
+    ${CMAKE_BINARY_DIR}/src/ui
+    ${QSCINTILLA_INCLUDE_DIR}
   )
-  add_dependencies(provider_arcgisfeatureserver ui)
-  add_dependencies(provider_arcgisfeatureserver_a ui)
+
+  add_dependencies(provider_arcgisfeatureserver_gui_a ui)
 endif()
 
-install (TARGETS provider_arcgisfeatureserver
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_arcgisfeatureserver_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_arcgisfeatureserver_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_arcgisfeatureserver MODULE ${AFS_SRCS} ${AFS_GUI_SRCS} ${AFS_UIS_H})
+  
+  target_link_libraries(provider_arcgisfeatureserver
+    qgis_core
+    ${QCA_LIBRARY}
+  )
+  
+  # require c++17
+  target_compile_features(provider_arcgisfeatureserver PRIVATE cxx_std_17)
+  
+  if (WITH_GUI)
+    target_link_libraries(provider_arcgisfeatureserver
+      qgis_gui
+    )
+    add_dependencies(provider_arcgisfeatureserver ui)
+  endif()
+  
+  install (TARGETS provider_arcgisfeatureserver
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()
 
 ###############################################################################
 
@@ -65,16 +93,36 @@ set (AMS_SRCS
   qgsamsprovider.cpp
 )
 
-add_library(provider_arcgismapserver MODULE ${AMS_SRCS})
+add_library (provider_arcgismapserver_a STATIC ${AMS_SRCS})
+
+target_include_directories(provider_arcgismapserver_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
+)
 
 # require c++17
-target_compile_features(provider_arcgismapserver PRIVATE cxx_std_17)
+target_compile_features(provider_arcgismapserver_a PRIVATE cxx_std_17)
 
-target_link_libraries(provider_arcgismapserver
+target_link_libraries (provider_arcgismapserver_a
   qgis_core
   ${QCA_LIBRARY}
 )
 
-install (TARGETS provider_arcgismapserver
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_arcgismapserver_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+else()
+  add_library(provider_arcgismapserver MODULE ${AMS_SRCS})
+  
+  # require c++17
+  target_compile_features(provider_arcgismapserver PRIVATE cxx_std_17)
+  
+  target_link_libraries(provider_arcgismapserver
+    qgis_core
+    ${QCA_LIBRARY}
+  )
+  
+  install (TARGETS provider_arcgismapserver
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -44,7 +44,13 @@ if (WITH_GUI)
   endif()
   
   add_library(provider_arcgisfeatureserver_gui_a STATIC ${AFS_GUI_SRCS} ${AFS_UIS_H})
+
+  # require c++17
+  target_compile_features(provider_arcgisfeatureserver_gui_a PRIVATE cxx_std_17)
   
+  target_link_libraries(provider_arcgisfeatureserver_a
+    qgis_gui
+  )
   target_link_libraries(provider_arcgisfeatureserver_gui_a
     qgis_gui
   )

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -353,6 +353,11 @@ QString QgsAfsProvider::name() const
   return AFS_PROVIDER_KEY;
 }
 
+QString QgsAfsProvider::providerKey()
+{
+  return AFS_PROVIDER_KEY;
+}
+
 QString QgsAfsProvider::description() const
 {
   return AFS_PROVIDER_DESCRIPTION;
@@ -469,7 +474,9 @@ QgsAfsProvider *QgsAfsProviderMetadata::createProvider( const QString &uri, cons
 }
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsAfsProviderMetadata();
 }
+#endif

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -78,6 +78,8 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
+    static QString providerKey();
+
   private:
     bool mValid = false;
     std::shared_ptr<QgsAfsSharedData> mSharedData;

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -350,6 +350,8 @@ QgsRasterDataProvider::ProviderCapabilities QgsAmsProvider::providerCapabilities
 
 QString QgsAmsProvider::name() const { return AMS_PROVIDER_KEY; }
 
+QString QgsAmsProvider::providerKey() { return AMS_PROVIDER_KEY; }
+
 QString QgsAmsProvider::description() const { return AMS_PROVIDER_DESCRIPTION; }
 
 QStringList QgsAmsProvider::subLayerStyles() const
@@ -1318,7 +1320,9 @@ QString QgsAmsProviderMetadata::encodeUri( const QVariantMap &parts ) const
   return dsUri.uri( false );
 }
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsAmsProviderMetadata();
 }
+#endif

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -88,6 +88,8 @@ class QgsAmsProvider : public QgsRasterDataProvider
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
     QgsLayerMetadata layerMetadata() const override;
 
+    static QString providerKey();
+
     /* Inherited from QgsRasterInterface */
     int bandCount() const override { return 1; }
     int capabilities() const override { return Identify | IdentifyText | IdentifyFeature | Prefetch; }

--- a/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
@@ -13,6 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsarcgisrestprovidergui.h"
+
 #include "qgsapplication.h"
 #include "qgsproviderguimetadata.h"
 #include "qgssourceselectprovider.h"
@@ -63,38 +65,37 @@ class QgsArcGisRestSourceWidgetProvider : public QgsProviderSourceWidgetProvider
     }
 };
 
-class QgsArcGisRestProviderGuiMetadata: public QgsProviderGuiMetadata
+
+QgsArcGisRestProviderGuiMetadata::QgsArcGisRestProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QgsAfsProvider::AFS_PROVIDER_KEY )
 {
-  public:
-    QgsArcGisRestProviderGuiMetadata()
-      : QgsProviderGuiMetadata( QgsAfsProvider::AFS_PROVIDER_KEY )
-    {
-    }
+}
 
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
-    {
-      QList<QgsDataItemGuiProvider *> providers;
-      providers << new QgsArcGisRestDataItemGuiProvider();
-      return providers;
-    }
+QList<QgsDataItemGuiProvider *> QgsArcGisRestProviderGuiMetadata::dataItemGuiProviders() override
+{
+  QList<QgsDataItemGuiProvider *> providers;
+  providers << new QgsArcGisRestDataItemGuiProvider();
+  return providers;
+}
 
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsArcGisRestSourceSelectProvider;
-      return providers;
-    }
+QList<QgsSourceSelectProvider *> QgsArcGisRestProviderGuiMetadata::sourceSelectProviders() override
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsArcGisRestSourceSelectProvider;
+  return providers;
+}
 
-    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override
-    {
-      QList<QgsProviderSourceWidgetProvider *> providers;
-      providers << new QgsArcGisRestSourceWidgetProvider();
-      return providers;
-    }
-};
+QList<QgsProviderSourceWidgetProvider *> QgsArcGisRestProviderGuiMetadata::sourceWidgetProviders() override
+{
+  QList<QgsProviderSourceWidgetProvider *> providers;
+  providers << new QgsArcGisRestSourceWidgetProvider();
+  return providers;
+}
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
 {
   return new QgsArcGisRestProviderGuiMetadata();
 }
+#endif

--- a/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
@@ -71,21 +71,21 @@ QgsArcGisRestProviderGuiMetadata::QgsArcGisRestProviderGuiMetadata()
 {
 }
 
-QList<QgsDataItemGuiProvider *> QgsArcGisRestProviderGuiMetadata::dataItemGuiProviders() override
+QList<QgsDataItemGuiProvider *> QgsArcGisRestProviderGuiMetadata::dataItemGuiProviders()
 {
   QList<QgsDataItemGuiProvider *> providers;
   providers << new QgsArcGisRestDataItemGuiProvider();
   return providers;
 }
 
-QList<QgsSourceSelectProvider *> QgsArcGisRestProviderGuiMetadata::sourceSelectProviders() override
+QList<QgsSourceSelectProvider *> QgsArcGisRestProviderGuiMetadata::sourceSelectProviders()
 {
   QList<QgsSourceSelectProvider *> providers;
   providers << new QgsArcGisRestSourceSelectProvider;
   return providers;
 }
 
-QList<QgsProviderSourceWidgetProvider *> QgsArcGisRestProviderGuiMetadata::sourceWidgetProviders() override
+QList<QgsProviderSourceWidgetProvider *> QgsArcGisRestProviderGuiMetadata::sourceWidgetProviders()
 {
   QList<QgsProviderSourceWidgetProvider *> providers;
   providers << new QgsArcGisRestSourceWidgetProvider();

--- a/src/providers/arcgisrest/qgsarcgisrestprovidergui.h
+++ b/src/providers/arcgisrest/qgsarcgisrestprovidergui.h
@@ -1,0 +1,28 @@
+/***************************************************************************
+  qgsafsprovidergui.h
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproviderguimetadata.h"
+#include "qgssourceselectprovider.h"
+#include "qgsafsprovider.h"
+
+class QgsArcGisRestProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsArcGisRestProviderGuiMetadata();
+
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override;
+};

--- a/src/providers/delimitedtext/CMakeLists.txt
+++ b/src/providers/delimitedtext/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-########################################################
-# Files
-
 set (DTEXT_SRCS
   qgsdelimitedtextfeatureiterator.cpp
   qgsdelimitedtextprovider.cpp
@@ -9,49 +5,93 @@ set (DTEXT_SRCS
 )
 
 if (WITH_GUI)
-  set(DTEXT_SRCS ${DTEXT_SRCS}
+  set(DTEXT_GUI_SRCS
     qgsdelimitedtextprovidergui.cpp
     qgsdelimitedtextsourceselect.cpp
   )
+
+  set(DTEXT_UIS qgsdelimitedtextsourceselectbase.ui)
 endif()
 
-########################################################
-# Build
+# static library
+add_library(provider_delimitedtext_a STATIC ${DTEXT_SRCS})
 
-include_directories(
-
-  ${CMAKE_BINARY_DIR}/src/ui
+target_include_directories(provider_delimitedtext_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/delimitedtext
 )
 
-add_library(provider_delimitedtext MODULE ${DTEXT_SRCS})
-
-# require c++17
-target_compile_features(provider_delimitedtext PRIVATE cxx_std_17)
-
-target_link_libraries(provider_delimitedtext
+target_link_libraries(provider_delimitedtext_a
   qgis_core
 )
 
+# require c++17
+target_compile_features(provider_delimitedtext_a PRIVATE cxx_std_17)
+
+target_compile_definitions(provider_delimitedtext_a PRIVATE "-DQT_NO_FOREACH")
+
 if (WITH_GUI)
-  target_link_libraries (provider_delimitedtext
+  if (WITH_QT6)
+    QT6_WRAP_UI(DTEXT_UIS_H ${DTEXT_UIS})
+  else()
+    QT5_WRAP_UI(DTEXT_UIS_H ${DTEXT_UIS})
+  endif()
+
+  add_library(provider_delimitedtext_gui_a STATIC ${DTEXT_GUI_SRCS} ${DTEXT_UIS_H})
+
+  target_include_directories(provider_delimitedtext_gui_a PUBLIC
+    ${CMAKE_BINARY_DIR}/src/providers/delimitedtext
+  )
+
+  target_link_libraries(provider_delimitedtext_gui_a
     qgis_gui
   )
-  add_dependencies(provider_delimitedtext ui)
+
+  # require c++17
+  target_compile_features(provider_delimitedtext_gui_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_delimitedtext_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+  add_dependencies(provider_delimitedtext_gui_a ui)
 endif()
 
-target_compile_definitions(provider_delimitedtext PRIVATE "-DQT_NO_FOREACH")
-
-# clang-tidy
-if(CLANG_TIDY_EXE)
-  set_target_properties(
-    provider_delimitedtext PROPERTIES
-    CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_delimitedtext_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_delimitedtext_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_delimitedtext MODULE ${DTEXT_SRCS} ${DTEXT_GUI_SRCS})
+  
+  # require c++17
+  target_compile_features(provider_delimitedtext PRIVATE cxx_std_17)
+  
+  target_link_libraries(provider_delimitedtext
+    qgis_core
   )
+
+  if (WITH_GUI)
+    target_link_libraries (provider_delimitedtext
+      qgis_gui
+    )
+    add_dependencies(provider_delimitedtext ui)
+  endif()
+
+  # clang-tidy
+  if(CLANG_TIDY_EXE)
+    set_target_properties(
+      provider_delimitedtext_a PROPERTIES
+      CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+    )
+    set_target_properties(
+      provider_delimitedtext PROPERTIES
+      CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+    )
+  endif()
+
+  install (TARGETS provider_delimitedtext
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+
+  target_compile_definitions(provider_delimitedtext PRIVATE "-DQT_NO_FOREACH")
 endif()
-
-########################################################
-# Install
-
-install (TARGETS provider_delimitedtext
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1257,6 +1257,11 @@ QString  QgsDelimitedTextProvider::name() const
   return TEXT_PROVIDER_KEY;
 }
 
+QString QgsDelimitedTextProvider::providerKey()
+{
+  return TEXT_PROVIDER_KEY;
+}
+
 QString  QgsDelimitedTextProvider::description() const
 {
   return TEXT_PROVIDER_DESCRIPTION;
@@ -1330,7 +1335,9 @@ QgsDelimitedTextProviderMetadata::QgsDelimitedTextProviderMetadata():
 {
 }
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsDelimitedTextProviderMetadata();
 }
+#endif

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -135,6 +135,8 @@ class QgsDelimitedTextProvider final: public QgsVectorDataProvider
      */
     QStringList readCsvtFieldTypes( const QString &filename, QString *message = nullptr );
 
+    static QString providerKey();
+
   private slots:
 
     void onFileUpdated();

--- a/src/providers/delimitedtext/qgsdelimitedtextprovidergui.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovidergui.cpp
@@ -13,6 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsdelimitedtextprovidergui.h"
+
 #include "qgsapplication.h"
 #include "qgsproviderguimetadata.h"
 #include "qgssourceselectprovider.h"
@@ -36,24 +38,21 @@ class QgsDelimitedTextSourceSelectProvider : public QgsSourceSelectProvider
 };
 
 
-class QgsDelimitedTextProviderGuiMetadata: public QgsProviderGuiMetadata
+QgsDelimitedTextProviderGuiMetadata::QgsDelimitedTextProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QgsDelimitedTextProvider::TEXT_PROVIDER_KEY )
 {
-  public:
-    QgsDelimitedTextProviderGuiMetadata()
-      : QgsProviderGuiMetadata( QgsDelimitedTextProvider::TEXT_PROVIDER_KEY )
-    {
-    }
+}
 
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsDelimitedTextSourceSelectProvider;
-      return providers;
-    }
-};
+QList<QgsSourceSelectProvider *> QgsDelimitedTextProviderGuiMetadata::sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsDelimitedTextSourceSelectProvider;
+  return providers;
+}
 
-
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
 {
   return new QgsDelimitedTextProviderGuiMetadata();
 }
+#endif

--- a/src/providers/delimitedtext/qgsdelimitedtextprovidergui.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovidergui.h
@@ -1,0 +1,26 @@
+/***************************************************************************
+  qgsdelimitedtextprovidergui.h
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproviderguimetadata.h"
+#include "qgssourceselectprovider.h"
+#include "qgsdelimitedtextsourceselect.h"
+
+class QgsDelimitedTextProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsDelimitedTextProviderGuiMetadata();
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+};

--- a/src/providers/postgres/qgspostgresprovidergui.cpp
+++ b/src/providers/postgres/qgspostgresprovidergui.cpp
@@ -25,6 +25,7 @@
 #include "qgspostgresdataitemguiprovider.h"
 #include "raster/qgspostgresrastertemporalsettingswidget.h"
 
+
 //! Provider for postgres source select
 class QgsPostgresSourceSelectProvider : public QgsSourceSelectProvider  //#spellok
 {

--- a/src/providers/spatialite/CMakeLists.txt
+++ b/src/providers/spatialite/CMakeLists.txt
@@ -58,6 +58,9 @@ if (WITH_GUI)
     ${CMAKE_BINARY_DIR}/src/providers/spatialite
   )
 
+  target_link_libraries(provider_spatialite_a
+    qgis_gui
+  )
   target_link_libraries(provider_spatialite_gui_a
     qgis_gui
   )
@@ -82,7 +85,7 @@ if (FORCE_STATIC_LIBS)
     install (TARGETS provider_spatialite_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
   endif()
 else()
-  add_library(provider_spatialite MODULE ${SPATIALITE_SRCS} ${SPATIALITE_GUI_SRCS})
+  add_library(provider_spatialite MODULE ${SPATIALITE_SRCS} ${SPATIALITE_GUI_SRCS} ${SPATIALITE_UIS_H})
 
   # require c++17
   target_compile_features(provider_spatialite PRIVATE cxx_std_17)
@@ -95,7 +98,7 @@ else()
   )
 
   if (WITH_GUI)
-    target_link_libraries (provider_spatialite
+    target_link_libraries(provider_spatialite
       qgis_gui
     )
     add_dependencies(provider_spatialite ui)

--- a/src/providers/spatialite/CMakeLists.txt
+++ b/src/providers/spatialite/CMakeLists.txt
@@ -17,56 +17,99 @@ set(SPATIALITE_SRCS
 )
 
 if (WITH_GUI)
-  set(SPATIALITE_SRCS ${SPATIALITE_SRCS}
+  set(SPATIALITE_GUI_SRCS
     qgsspatialiteprovidergui.cpp
     qgsspatialitedataitemguiprovider.cpp
     qgsspatialitesourceselect.cpp
   )
+
+  set(SPATIALITE_UIS qgsdbsourceselectbase.ui)
 endif()
 
 
 ########################################################
-# Build
+# Static
+add_library(provider_spatialite_a STATIC ${SPATIALITE_SRCS})
 
-if (WITH_GUI)
-  include_directories(SYSTEM
-    ${QSCINTILLA_INCLUDE_DIR}
-  )
-endif()
-
-include_directories(
-
-  ${CMAKE_BINARY_DIR}/src/ui
+target_include_directories(provider_spatialite_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/spatialite
 )
 
-add_library (provider_spatialite MODULE ${SPATIALITE_SRCS})
-
-# require c++17
-target_compile_features(provider_spatialite PRIVATE cxx_std_17)
-
-target_link_libraries(provider_spatialite
+target_link_libraries(provider_spatialite_a
   qgis_core
   ${SPATIALITE_LIBRARY}
 )
 
+# require c++17
+target_compile_features(provider_spatialite_a PRIVATE cxx_std_17)
+
+target_compile_definitions(provider_spatialite_a PRIVATE "-DQT_NO_FOREACH")
+
 if (WITH_GUI)
-  target_link_libraries (provider_spatialite
+  if (WITH_QT6)
+    QT6_WRAP_UI(SPATIALITE_UIS_H ${SPATIALITE_UIS})
+  else()
+    QT5_WRAP_UI(SPATIALITE_UIS_H ${SPATIALITE_UIS})
+  endif()
+
+  add_library(provider_spatialite_gui_a STATIC ${SPATIALITE_GUI_SRCS} ${SPATIALITE_UIS_H})
+
+  target_include_directories(provider_spatialite_gui_a PUBLIC
+    ${CMAKE_BINARY_DIR}/src/providers/spatialite
+  )
+
+  target_link_libraries(provider_spatialite_gui_a
     qgis_gui
   )
-  add_dependencies(provider_spatialite ui)
-endif()
 
-# clang-tidy
-if(CLANG_TIDY_EXE)
-  set_target_properties(
-    provider_spatialite PROPERTIES
-    CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+  # require c++17
+  target_compile_features(provider_spatialite_gui_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_spatialite_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+  add_dependencies(provider_spatialite_gui_a ui)
+
+  include_directories(SYSTEM
+    ${QSCINTILLA_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/src/ui
   )
 endif()
 
-########################################################
-# Install
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_spatialite_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_spatialite_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_spatialite MODULE ${SPATIALITE_SRCS} ${SPATIALITE_GUI_SRCS})
 
-install(TARGETS provider_spatialite
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+  # require c++17
+  target_compile_features(provider_spatialite PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_spatialite PRIVATE "-DQT_NO_FOREACH")
+  
+  target_link_libraries(provider_spatialite
+    qgis_core
+    ${SPATIALITE_LIBRARY}
+  )
+
+  if (WITH_GUI)
+    target_link_libraries (provider_spatialite
+      qgis_gui
+    )
+    add_dependencies(provider_spatialite ui)
+  endif()
+
+  # clang-tidy
+  if(CLANG_TIDY_EXE)
+    set_target_properties(
+      provider_spatialite PROPERTIES
+      CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
+    )
+  endif()
+
+  install(TARGETS provider_spatialite
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+endif()

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3788,6 +3788,10 @@ QString QgsSpatiaLiteProvider::name() const
   return SPATIALITE_KEY;
 }                               //  QgsSpatiaLiteProvider::name()
 
+QString QgsSpatiaLiteProvider::providerKey()
+{
+  return SPATIALITE_KEY;
+}
 
 QString QgsSpatiaLiteProvider::description() const
 {
@@ -6476,8 +6480,9 @@ void QgsSpatiaLiteProviderMetadata::saveConnection( const QgsAbstractProviderCon
 }
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsSpatiaLiteProviderMetadata();
 }
-
+#endif

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -146,6 +146,8 @@ class QgsSpatiaLiteProvider final: public QgsVectorDataProvider
     void invalidateConnections( const QString &connection ) override;
     QList<QgsRelation> discoverRelations( const QgsVectorLayer *self, const QList<QgsVectorLayer *> &layers ) const override;
 
+    static QString providerKey();
+
     // static functions
     static void convertToGeosWKB( const unsigned char *blob, int blob_size,
                                   unsigned char **wkb, int *geom_size );

--- a/src/providers/spatialite/qgsspatialiteprovidergui.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.cpp
@@ -13,6 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsspatialiteprovidergui.h"
+
 #include "qgsapplication.h"
 #include "qgsproviderguimetadata.h"
 #include "qgssourceselectprovider.h"
@@ -44,14 +46,14 @@ QgsSpatiaLiteProviderGuiMetadata::QgsSpatiaLiteProviderGuiMetadata()
 {
 }
 
-QList<QgsSourceSelectProvider *> QgsSpatiaLiteProviderGuiMetadata::sourceSelectProviders() override
+QList<QgsSourceSelectProvider *> QgsSpatiaLiteProviderGuiMetadata::sourceSelectProviders()
 {
   QList<QgsSourceSelectProvider *> providers;
   providers << new QgsSpatialiteSourceSelectProvider;
   return providers;
 }
 
-QList<QgsDataItemGuiProvider *> QgsSpatiaLiteProviderGuiMetadata::dataItemGuiProviders() override
+QList<QgsDataItemGuiProvider *> QgsSpatiaLiteProviderGuiMetadata::dataItemGuiProviders()
 {
   return QList<QgsDataItemGuiProvider *>()
          << new QgsSpatiaLiteDataItemGuiProvider;

--- a/src/providers/spatialite/qgsspatialiteprovidergui.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.cpp
@@ -38,30 +38,28 @@ class QgsSpatialiteSourceSelectProvider : public QgsSourceSelectProvider
 };
 
 
-class QgsSpatiaLiteProviderGuiMetadata: public QgsProviderGuiMetadata
+
+QgsSpatiaLiteProviderGuiMetadata::QgsSpatiaLiteProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QgsSpatiaLiteProvider::SPATIALITE_KEY )
 {
-  public:
-    QgsSpatiaLiteProviderGuiMetadata()
-      : QgsProviderGuiMetadata( QgsSpatiaLiteProvider::SPATIALITE_KEY )
-    {
-    }
+}
 
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsSpatialiteSourceSelectProvider;
-      return providers;
-    }
+QList<QgsSourceSelectProvider *> QgsSpatiaLiteProviderGuiMetadata::sourceSelectProviders() override
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsSpatialiteSourceSelectProvider;
+  return providers;
+}
 
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
-    {
-      return QList<QgsDataItemGuiProvider *>()
-             << new QgsSpatiaLiteDataItemGuiProvider;
-    }
-};
+QList<QgsDataItemGuiProvider *> QgsSpatiaLiteProviderGuiMetadata::dataItemGuiProviders() override
+{
+  return QList<QgsDataItemGuiProvider *>()
+         << new QgsSpatiaLiteDataItemGuiProvider;
+}
 
-
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
 {
   return new QgsSpatiaLiteProviderGuiMetadata();
 }
+#endif

--- a/src/providers/spatialite/qgsspatialiteprovidergui.h
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.h
@@ -1,0 +1,31 @@
+/***************************************************************************
+  qgsspatialiteprovidergui.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproviderguimetadata.h"
+#include "qgssourceselectprovider.h"
+
+#include "qgsspatialitesourceselect.h"
+#include "qgsspatialiteprovider.h"
+
+
+class QgsSpatiaLiteProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsSpatiaLiteProviderGuiMetadata();
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
+};
+

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -16,7 +16,9 @@
  ***************************************************************************/
 #ifndef QGSSPATIALITESOURCESELECT_H
 #define QGSSPATIALITESOURCESELECT_H
+
 #include "ui_qgsdbsourceselectbase.h"
+
 #include "qgsguiutils.h"
 #include "qgsdbfilterproxymodel.h"
 #include "qgsspatialitetablemodel.h"

--- a/src/providers/virtual/CMakeLists.txt
+++ b/src/providers/virtual/CMakeLists.txt
@@ -40,8 +40,6 @@ target_include_directories(provider_virtuallayer_a PUBLIC
 
 target_link_libraries(provider_virtuallayer_a
   qgis_core
-  ${QT_VERSION_BASE}::Core
-  ${QT_VERSION_BASE}::Widgets
   ${SQLITE3_LIBRARY}
   ${SPATIALITE_LIBRARY}
 )

--- a/src/providers/virtual/CMakeLists.txt
+++ b/src/providers/virtual/CMakeLists.txt
@@ -2,14 +2,9 @@
 ########################################################
 # Files
 
-set (QGIS_VLAYER_SQL_FUNCTIONS_RCCS  sqlfunctionslist.qrc)
+set (VLAYER_SQL_FUNCTIONS_RCCS  sqlfunctionslist.qrc)
 
-set(QGIS_VLAYER_PROVIDER_HDRS
-  qgsvirtuallayerprovider.h
-  qgsslottofunction.h
-)
-
-set(QGIS_VLAYER_PROVIDER_SRCS
+set(VLAYER_PROVIDER_SRCS
   qgsvirtuallayerprovider.cpp
   qgsvirtuallayerfeatureiterator.cpp
   qgsvirtuallayerblob.cpp
@@ -17,64 +12,107 @@ set(QGIS_VLAYER_PROVIDER_SRCS
   qgsvirtuallayersqlitehelper.cpp
   qgsvirtuallayerqueryparser.cpp
 )
+set(VLAYER_PROVIDER_HDRS
+  qgsvirtuallayerprovider.h
+  qgsslottofunction.h
+)
 
 if (WITH_GUI)
-  set(QGIS_VLAYER_PROVIDER_SRCS ${QGIS_VLAYER_PROVIDER_SRCS}
+  set(VLAYER_PROVIDER_GUI_SRCS
+    qgsvirtuallayerprovidergui.cpp
     qgsvirtuallayersourceselect.cpp
     qgsembeddedlayerselectdialog.cpp
   )
-  set(QGIS_VLAYER_PROVIDER_HDRS ${QGIS_VLAYER_PROVIDER_HDRS}
+  set(VLAYER_PROVIDER_GUI_HDRS
+    qgsvirtuallayerprovidergui.h
     qgsvirtuallayersourceselect.h
     qgsembeddedlayerselectdialog.h
   )
 endif()
 
-if (WITH_GUI)
-  if (WITH_QT6)
-    QT6_WRAP_UI(vlayer_provider_UI_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
-  else()
-    QT5_WRAP_UI(vlayer_provider_UI_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
-  endif()
-endif()
+########################################################
+# Static
+add_library(provider_virtuallayer_a STATIC ${VLAYER_PROVIDER_SRCS} ${VLAYER_PROVIDER_HDRS} ${VLAYER_SQL_FUNCTIONS_RCCS})
 
-include_directories(
-
-  ${CMAKE_BINARY_DIR}/src/ui
-
-  ${CMAKE_CURRENT_BINARY_DIR} # ui_xxx_dlg.h
+target_include_directories(provider_virtuallayer_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/virtual
 )
 
-include_directories(SYSTEM
-  ${POSTGRES_INCLUDE_DIR}
-)
-
-add_library(provider_virtuallayer MODULE
-  ${QGIS_VLAYER_PROVIDER_SRCS}
-  ${QGIS_VLAYER_PROVIDER_HDRS}
-  ${vlayer_provider_UI_H}
-  ${QGIS_VLAYER_SQL_FUNCTIONS_RCCS}
-)
-
-# require c++17
-target_compile_features(provider_virtuallayer PRIVATE cxx_std_17)
-
-target_link_libraries(provider_virtuallayer
+target_link_libraries(provider_virtuallayer_a
   qgis_core
   ${QT_VERSION_BASE}::Core
-  ${QT_VERSION_BASE}::Gui
   ${QT_VERSION_BASE}::Widgets
   ${SQLITE3_LIBRARY}
   ${SPATIALITE_LIBRARY}
 )
 
+# require c++17
+target_compile_features(provider_virtuallayer_a PRIVATE cxx_std_17)
+
+target_compile_definitions(provider_virtuallayer_a PRIVATE "-DQT_NO_FOREACH")
+
 if (WITH_GUI)
-  target_link_libraries (provider_virtuallayer
+  if (WITH_QT6)
+    QT6_WRAP_UI(VLAYER_PROVIDER_UIS_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
+  else()
+    QT5_WRAP_UI(VLAYER_PROVIDER_UIS_H qgsvirtuallayersourceselectbase.ui qgsembeddedlayerselect.ui)
+  endif()
+  add_library(provider_virtuallayer_gui_a STATIC ${VLAYER_PROVIDER_GUI_SRCS} ${VLAYER_PROVIDER_GUI_HDRS} ${VLAYER_PROVIDER_UIS_H})
+
+  target_include_directories(provider_virtuallayer_gui_a PUBLIC
+    ${CMAKE_BINARY_DIR}/src/providers/virtual
+  )
+
+  target_link_libraries(provider_virtuallayer_gui_a
     qgis_gui
   )
-  add_dependencies(provider_virtuallayer ui)
+
+  # require c++17
+  target_compile_features(provider_virtuallayer_gui_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_virtuallayer_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+  add_dependencies(provider_virtuallayer_gui_a ui)
+
+  include_directories(
+    ${CMAKE_BINARY_DIR}/src/ui
+    ${CMAKE_CURRENT_BINARY_DIR} # ui_xxx_dlg.h
+  )
 endif()
 
-install(TARGETS provider_virtuallayer
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_virtuallayer_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_virtuallayer_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_virtuallayer MODULE ${VLAYER_PROVIDER_SRCS} ${VLAYER_PROVIDER_HDRS} ${VLAYER_PROVIDER_UIS_H} ${VLAYER_SQL_FUNCTIONS_RCCS})
+
+  # require c++17
+  target_compile_features(provider_virtuallayer PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_virtuallayer PRIVATE "-DQT_NO_FOREACH")
+  
+  target_link_libraries(provider_virtuallayer
+    qgis_core
+    ${QT_VERSION_BASE}::Core
+    ${QT_VERSION_BASE}::Widgets
+    ${SQLITE3_LIBRARY}
+    ${SPATIALITE_LIBRARY}
   )
+
+  if (WITH_GUI)
+    target_link_libraries (provider_virtuallayer
+      qgis_gui
+      ${QT_VERSION_BASE}::Gui
+    )
+    add_dependencies(provider_virtuallayer ui)
+  endif()
+  
+  install(TARGETS provider_virtuallayer
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -20,8 +20,6 @@ extern "C"
 #include <spatialite.h>
 }
 
-#include <QUrl>
-
 #include <stdexcept>
 
 #include "qgsvirtuallayerprovider.h"
@@ -30,23 +28,23 @@ extern "C"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 #include "qgslogger.h"
-#include "qgsapplication.h"
 
 #include "qgsvirtuallayerprovider.h"
 #include "qgsvirtuallayersqlitemodule.h"
 #include "qgsvirtuallayerqueryparser.h"
 
-const QString VIRTUAL_LAYER_KEY = QStringLiteral( "virtual" );
-const QString VIRTUAL_LAYER_DESCRIPTION = QStringLiteral( "Virtual layer data provider" );
+#include <QUrl>
 
-const QString VIRTUAL_LAYER_QUERY_VIEW = QStringLiteral( "_query" );
+const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY = QStringLiteral( "virtual" );
+const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_DESCRIPTION = QStringLiteral( "Virtual layer data provider" );
+const QString QgsVirtualLayerProvider::VIRTUAL_LAYER_QUERY_VIEW = QStringLiteral( "_query" );
 
 static QString quotedColumn( QString name )
 {
   return "\"" + name.replace( QLatin1String( "\"" ), QLatin1String( "\"\"" ) ) + "\"";
 }
 
-#define PROVIDER_ERROR( msg ) do { mError = QgsError( msg, VIRTUAL_LAYER_KEY ); QgsDebugMsg( msg ); } while(0)
+#define PROVIDER_ERROR( msg ) do { mError = QgsError( msg, QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY ); QgsDebugMsg( msg ); } while(0)
 
 
 QgsVirtualLayerProvider::QgsVirtualLayerProvider( QString const &uri,
@@ -673,7 +671,7 @@ QgsVirtualLayerProvider *QgsVirtualLayerProviderMetadata::createProvider(
 }
 
 QgsVirtualLayerProviderMetadata::QgsVirtualLayerProviderMetadata():
-  QgsProviderMetadata( VIRTUAL_LAYER_KEY, VIRTUAL_LAYER_DESCRIPTION )
+  QgsProviderMetadata( QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY, QgsVirtualLayerProvider::VIRTUAL_LAYER_DESCRIPTION )
 {
 }
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -36,11 +36,6 @@ extern "C"
 #include "qgsvirtuallayersqlitemodule.h"
 #include "qgsvirtuallayerqueryparser.h"
 
-#ifdef HAVE_GUI
-#include "qgssourceselectprovider.h"
-#include "qgsvirtuallayersourceselect.h"
-#endif
-
 const QString VIRTUAL_LAYER_KEY = QStringLiteral( "virtual" );
 const QString VIRTUAL_LAYER_DESCRIPTION = QStringLiteral( "Virtual layer data provider" );
 
@@ -629,6 +624,11 @@ QString QgsVirtualLayerProvider::name() const
   return VIRTUAL_LAYER_KEY;
 }
 
+QString QgsVirtualLayerProvider::providerKey()
+{
+  return VIRTUAL_LAYER_KEY;
+}
+
 QString QgsVirtualLayerProvider::description() const
 {
   return VIRTUAL_LAYER_DESCRIPTION;
@@ -672,53 +672,15 @@ QgsVirtualLayerProvider *QgsVirtualLayerProviderMetadata::createProvider(
   return new QgsVirtualLayerProvider( uri, options, flags );
 }
 
-
-#ifdef HAVE_GUI
-
-//! Provider for virtual layers source select
-class QgsVirtualSourceSelectProvider : public QgsSourceSelectProvider
-{
-  public:
-
-    QString providerKey() const override { return QStringLiteral( "virtual" ); }
-    QString text() const override { return QObject::tr( "Virtual Layer" ); }
-    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 60; }
-    QString toolTip() const override { return QObject::tr( "Add Virtual Layer" ); }
-    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ); }
-    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
-    {
-      return new QgsVirtualLayerSourceSelect( parent, fl, widgetMode );
-    }
-};
-
-
-QgsVirtualLayerProviderGuiMetadata::QgsVirtualLayerProviderGuiMetadata()
-  : QgsProviderGuiMetadata( VIRTUAL_LAYER_KEY )
-{
-}
-
-QList<QgsSourceSelectProvider *> QgsVirtualLayerProviderGuiMetadata::sourceSelectProviders()
-{
-  QList<QgsSourceSelectProvider *> providers;
-  providers << new QgsVirtualSourceSelectProvider;
-  return providers;
-}
-#endif
-
 QgsVirtualLayerProviderMetadata::QgsVirtualLayerProviderMetadata():
   QgsProviderMetadata( VIRTUAL_LAYER_KEY, VIRTUAL_LAYER_DESCRIPTION )
 {
 }
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsVirtualLayerProviderMetadata();
-}
-
-#ifdef HAVE_GUI
-QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
-{
-  return new QgsVirtualLayerProviderGuiMetadata();
 }
 #endif

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-           qgsvirtuallayerprovider.cpp Virtual layer data provider
+           qgsvirtuallayerprovider.h Virtual layer data provider
 begin                : Jan, 2015
 copyright            : (C) 2015 Hugo Mercier, Oslandia
 email                : hugo dot mercier at oslandia dot com
@@ -25,9 +25,6 @@ email                : hugo dot mercier at oslandia dot com
 #include "qgsvirtuallayersqlitehelper.h"
 
 #include "qgsprovidermetadata.h"
-#ifdef HAVE_GUI
-#include "qgsproviderguimetadata.h"
-#endif
 
 class QgsVirtualLayerFeatureIterator;
 
@@ -61,6 +58,8 @@ class QgsVirtualLayerProvider final: public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override;
     QSet<QgsMapLayerDependency> dependencies() const override;
     bool cancelReload() override;
+
+    static QString providerKey();
 
   private:
 
@@ -136,15 +135,6 @@ class QgsVirtualLayerProviderMetadata final: public QgsProviderMetadata
     QgsVirtualLayerProviderMetadata();
     QgsVirtualLayerProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags = QgsDataProvider::ReadFlags() ) override;
 };
-
-#ifdef HAVE_GUI
-class QgsVirtualLayerProviderGuiMetadata final: public QgsProviderGuiMetadata
-{
-  public:
-    QgsVirtualLayerProviderGuiMetadata();
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
-};
-#endif
 
 // clazy:excludeall=qstring-allocations
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -33,6 +33,10 @@ class QgsVirtualLayerProvider final: public QgsVectorDataProvider
     Q_OBJECT
   public:
 
+    static const QString VIRTUAL_LAYER_KEY;
+    static const QString VIRTUAL_LAYER_DESCRIPTION;
+    static const QString VIRTUAL_LAYER_QUERY_VIEW;
+
     /**
      * Constructor of the vector provider
      * \param uri uniform resource locator (URI) for a dataset

--- a/src/providers/virtual/qgsvirtuallayerprovidergui.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovidergui.cpp
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgsvirtuallayerprovidergui.cpp
+  --------------------------------------
+  Date                 : Octpner 2021
+  Copyright            : (C) 2021 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvirtuallayerprovidergui.h"
+#include "qgssourceselectprovider.h"
+#include "qgsvirtuallayersourceselect.h"
+
+//! Provider for virtual layers source select
+class QgsVirtualSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    QString providerKey() const override { return QStringLiteral( "virtual" ); }
+    QString text() const override { return QObject::tr( "Virtual Layer" ); }
+    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 60; }
+    QString toolTip() const override { return QObject::tr( "Add Virtual Layer" ); }
+    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ); }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsVirtualLayerSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+QgsVirtualLayerProviderGuiMetadata::QgsVirtualLayerProviderGuiMetadata()
+  : QgsProviderGuiMetadata( VIRTUAL_LAYER_KEY )
+{
+}
+
+QList<QgsSourceSelectProvider *> QgsVirtualLayerProviderGuiMetadata::sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsVirtualSourceSelectProvider;
+  return providers;
+}
+
+
+#ifndef HAVE_STATIC_PROVIDERS
+QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
+{
+  return new QgsVirtualLayerProviderGuiMetadata();
+}
+#endif

--- a/src/providers/virtual/qgsvirtuallayerprovidergui.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovidergui.cpp
@@ -14,7 +14,10 @@
  ***************************************************************************/
 
 #include "qgsvirtuallayerprovidergui.h"
+
+#include "qgsapplication.h"
 #include "qgssourceselectprovider.h"
+#include "qgsvirtuallayerprovider.h"
 #include "qgsvirtuallayersourceselect.h"
 
 //! Provider for virtual layers source select
@@ -35,7 +38,7 @@ class QgsVirtualSourceSelectProvider : public QgsSourceSelectProvider
 
 
 QgsVirtualLayerProviderGuiMetadata::QgsVirtualLayerProviderGuiMetadata()
-  : QgsProviderGuiMetadata( VIRTUAL_LAYER_KEY )
+  : QgsProviderGuiMetadata( QgsVirtualLayerProvider::VIRTUAL_LAYER_KEY )
 {
 }
 

--- a/src/providers/virtual/qgsvirtuallayerprovidergui.h
+++ b/src/providers/virtual/qgsvirtuallayerprovidergui.h
@@ -1,0 +1,23 @@
+/***************************************************************************
+  qgsvirtuallayerprovidergui.h
+  --------------------------------------
+  Date                 : Octpner 2021
+  Copyright            : (C) 2021 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproviderguimetadata.h"
+
+class QgsVirtualLayerProviderGuiMetadata final: public QgsProviderGuiMetadata
+{
+  public:
+    QgsVirtualLayerProviderGuiMetadata();
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+};

--- a/src/providers/wcs/CMakeLists.txt
+++ b/src/providers/wcs/CMakeLists.txt
@@ -7,33 +7,80 @@ set (WCS_SRCS
 )
 
 if (WITH_GUI)
-  set(WCS_SRCS ${WCS_SRCS}
+  set(WCS_GUI_SRCS
     qgswcsprovidergui.cpp
     qgswcsdataitemguiprovider.cpp
     qgswcssourceselect.cpp
   )
 endif()
 
-include_directories(
+########################################################
+# Static
+add_library(provider_wcs_a STATIC ${WCS_SRCS})
 
-  ${CMAKE_BINARY_DIR}/src/ui
+target_include_directories(provider_wcs_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/wcs
 )
 
-add_library(provider_wcs MODULE ${WCS_SRCS})
-
-# require c++17
-target_compile_features(provider_wcs PRIVATE cxx_std_17)
-
-target_link_libraries(provider_wcs
+target_link_libraries(provider_wcs_a
   qgis_core
 )
 
+# require c++17
+target_compile_features(provider_wcs_a PRIVATE cxx_std_17)
+
+target_compile_definitions(provider_wcs_a PRIVATE "-DQT_NO_FOREACH")
+
 if (WITH_GUI)
-  target_link_libraries (provider_wcs
+  add_library(provider_wcs_gui_a STATIC ${WCS_GUI_SRCS})
+
+  target_include_directories(provider_wcs_gui_a PUBLIC
+    ${CMAKE_BINARY_DIR}/src/providers/wcs
+  )
+
+  target_link_libraries(provider_wcs_a
     qgis_gui
+  )
+  target_link_libraries(provider_wcs_gui_a
+    qgis_gui
+  )
+
+  # require c++17
+  target_compile_features(provider_wcs_gui_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_wcs_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+  add_dependencies(provider_wcs_gui_a ui)
+
+  include_directories(SYSTEM
+    ${CMAKE_BINARY_DIR}/src/ui
   )
 endif()
 
-install (TARGETS provider_wcs
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_wcs_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_wcs_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_wcs MODULE ${WCS_SRCS} ${WCS_GUI_SRCS})
+  
+  # require c++17
+  target_compile_features(provider_wcs PRIVATE cxx_std_17)
+  
+  target_link_libraries(provider_wcs
+    qgis_core
+  )
+  
+  if (WITH_GUI)
+    target_link_libraries (provider_wcs
+      qgis_gui
+    )
+  endif()
+  
+  install (TARGETS provider_wcs
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1586,7 +1586,12 @@ QString QgsWcsProvider::lastErrorFormat()
   return mErrorFormat;
 }
 
-QString  QgsWcsProvider::name() const
+QString QgsWcsProvider::name() const
+{
+  return WCS_KEY;
+}
+
+QString QgsWcsProvider::providerKey()
 {
   return WCS_KEY;
 }
@@ -1979,7 +1984,10 @@ QList< QgsDataItemProvider * > QgsWcsProviderMetadata::dataItemProviders() const
 QgsWcsProviderMetadata::QgsWcsProviderMetadata():
   QgsProviderMetadata( QgsWcsProvider::WCS_KEY, QgsWcsProvider::WCS_DESCRIPTION ) {}
 
+
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsWcsProviderMetadata();
 }
+#endif

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -190,6 +190,8 @@ class QgsWcsProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
 
+    static QString providerKey();
+
     int colorInterpretation( int bandNo ) const override;
 
     static QMap<QString, QString> supportedMimes();

--- a/src/providers/wcs/qgswcsprovidergui.cpp
+++ b/src/providers/wcs/qgswcsprovidergui.cpp
@@ -13,8 +13,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgswcsprovider.h"
+#include "qgswcsprovidergui.h"
 
+#include "qgswcsprovider.h"
 #include "qgswcssourceselect.h"
 #include "qgssourceselectprovider.h"
 #include "qgsproviderguimetadata.h"
@@ -37,30 +38,28 @@ class QgsWcsSourceSelectProvider : public QgsSourceSelectProvider
 };
 
 
-class QgsWcsProviderGuiMetadata: public QgsProviderGuiMetadata
+QgsWcsProviderGuiMetadata::QgsWcsProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QgsWcsProvider::WCS_KEY )
 {
-  public:
-    QgsWcsProviderGuiMetadata()
-      : QgsProviderGuiMetadata( QgsWcsProvider::WCS_KEY )
-    {
-    }
+}
 
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsWcsSourceSelectProvider;
-      return providers;
-    }
+QList<QgsSourceSelectProvider *> QgsWcsProviderGuiMetadata::sourceSelectProviders()
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsWcsSourceSelectProvider;
+  return providers;
+}
 
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
-    {
-      return QList<QgsDataItemGuiProvider *>()
-             << new QgsWcsDataItemGuiProvider;
-    }
-};
+QList<QgsDataItemGuiProvider *> QgsWcsProviderGuiMetadata::dataItemGuiProviders()
+{
+  return QList<QgsDataItemGuiProvider *>()
+         << new QgsWcsDataItemGuiProvider;
+}
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
 {
   return new QgsWcsProviderGuiMetadata();
 }
+#endif

--- a/src/providers/wcs/qgswcsprovidergui.h
+++ b/src/providers/wcs/qgswcsprovidergui.h
@@ -1,0 +1,27 @@
+/***************************************************************************
+  qgswcsprovidergui.h
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswcsprovider.h"
+#include "qgsproviderguimetadata.h"
+
+class QgsWcsProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsWcsProviderGuiMetadata();
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
+};
+

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -72,6 +72,9 @@ if (WITH_GUI)
     ${CMAKE_BINARY_DIR}/src/providers/wfs
   )
 
+  target_link_libraries(provider_wfs_a
+    qgis_gui
+  )
   target_link_libraries(provider_wfs_gui_a
     qgis_gui
   )

--- a/src/providers/wfs/CMakeLists.txt
+++ b/src/providers/wfs/CMakeLists.txt
@@ -29,7 +29,7 @@ set(WFS_SRCS
 )
 
 if (WITH_GUI)
-  set(WFS_SRCS ${WFS_SRCS}
+  set(WFS_GUI_SRCS
     qgswfsprovidergui.cpp
     qgswfsdataitemguiprovider.cpp
     qgswfssourceselect.cpp
@@ -37,42 +37,85 @@ if (WITH_GUI)
     qgswfsguiutils.cpp
     qgswfssubsetstringeditor.cpp
   )
+
+  set(WFS_UIS qgswfssourceselectbase.ui)
 endif()
 
 ########################################################
-# Build
+# Static
+add_library(provider_wfs_a STATIC ${WFS_SRCS})
 
-include_directories (
-
-  ${CMAKE_BINARY_DIR}/src/ui
+target_include_directories(provider_wfs_a PUBLIC
+  ${CMAKE_SOURCE_DIR}/src/providers/wfs
 )
 
-if (WITH_GUI)
-  include_directories(SYSTEM
-    ${QSCINTILLA_INCLUDE_DIR}
-  )
-endif()
-
-add_library (provider_wfs MODULE ${WFS_SRCS})
-
-# require c++17
-target_compile_features(provider_wfs PRIVATE cxx_std_17)
-
-target_link_libraries (provider_wfs
+target_link_libraries(provider_wfs_a
   ${EXPAT_LIBRARY}
   qgis_core
 )
 
+# require c++17
+target_compile_features(provider_wfs_a PRIVATE cxx_std_17)
+
+target_compile_definitions(provider_wfs_a PRIVATE "-DQT_NO_FOREACH")
+
 if (WITH_GUI)
-  target_link_libraries (provider_wfs
+  if (WITH_QT6)
+    QT6_WRAP_UI(WFS_UIS_H ${WFS_UIS})
+  else()
+    QT5_WRAP_UI(WFS_UIS_H ${WFS_UIS})
+  endif()
+
+  add_library(provider_wfs_gui_a STATIC ${WFS_GUI_SRCS} ${WFS_UIS_H})
+
+  target_include_directories(provider_wfs_gui_a PUBLIC
+    ${CMAKE_BINARY_DIR}/src/providers/wfs
+  )
+
+  target_link_libraries(provider_wfs_gui_a
     qgis_gui
   )
-  add_dependencies(provider_wfs ui)
+
+  # require c++17
+  target_compile_features(provider_wfs_gui_a PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_wfs_gui_a PRIVATE "-DQT_NO_FOREACH")
+
+  add_dependencies(provider_wfs_gui_a ui)
+
+  include_directories(SYSTEM
+    ${QSCINTILLA_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/src/ui
+  )
 endif()
 
-########################################################
-# Install
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS provider_wfs_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_wfs_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
+else()
+  add_library(provider_wfs MODULE ${WFS_SRCS} ${WFS_GUI_SRCS})
 
-install(TARGETS provider_wfs
-  RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
-  LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+  # require c++17
+  target_compile_features(provider_wfs PRIVATE cxx_std_17)
+
+  target_compile_definitions(provider_wfs PRIVATE "-DQT_NO_FOREACH")
+
+  target_link_libraries (provider_wfs
+    ${EXPAT_LIBRARY}
+    qgis_core
+  )
+
+  if (WITH_GUI)
+    target_link_libraries (provider_wfs
+      qgis_gui
+    )
+    add_dependencies(provider_wfs ui)
+  endif()
+  
+  install(TARGETS provider_wfs
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
+endif()

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -216,7 +216,7 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
 
   if ( synchronous && QThread::currentThread() == QApplication::instance()->thread() )
   {
-    std::unique_ptr<DownloaderThread> downloaderThread = std::make_unique<DownloaderThread>( downloaderFunction );
+    std::unique_ptr<_DownloaderThread> downloaderThread = std::make_unique<_DownloaderThread>( downloaderFunction );
     downloaderThread->start();
 
     while ( true )

--- a/src/providers/wfs/qgsbasenetworkrequest.h
+++ b/src/providers/wfs/qgsbasenetworkrequest.h
@@ -128,12 +128,12 @@ class QgsBaseNetworkRequest : public QObject
 };
 
 
-class DownloaderThread : public QThread
+class _DownloaderThread : public QThread
 {
     Q_OBJECT
 
   public:
-    DownloaderThread( std::function<void()> function, QObject *parent = nullptr )
+    _DownloaderThread( std::function<void()> function, QObject *parent = nullptr )
       : QThread( parent )
       , mFunction( function )
     {

--- a/src/providers/wfs/qgsoapifprovider.cpp
+++ b/src/providers/wfs/qgsoapifprovider.cpp
@@ -340,6 +340,11 @@ QString QgsOapifProvider::name() const
   return OAPIF_PROVIDER_KEY;
 }
 
+QString QgsOapifProvider::providerKey()
+{
+  return OAPIF_PROVIDER_KEY;
+}
+
 QString QgsOapifProvider::description() const
 {
   return OAPIF_PROVIDER_DESCRIPTION;

--- a/src/providers/wfs/qgsoapifprovider.h
+++ b/src/providers/wfs/qgsoapifprovider.h
@@ -68,6 +68,8 @@ class QgsOapifProvider final: public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
 
+    static QString providerKey();
+
     QgsVectorDataProvider::Capabilities capabilities() const override;
 
     QgsLayerMetadata layerMetadata() const override { return mLayerMetadata; }

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1636,6 +1636,11 @@ QString QgsWFSProvider::name() const
   return WFS_PROVIDER_KEY;
 }
 
+QString QgsWFSProvider::providerKey()
+{
+  return WFS_PROVIDER_KEY;
+}
+
 QString QgsWFSProvider::description() const
 {
   return WFS_PROVIDER_DESCRIPTION;
@@ -2034,7 +2039,10 @@ QList<QgsDataItemProvider *> QgsWfsProviderMetadata::dataItemProviders() const
 QgsWfsProviderMetadata::QgsWfsProviderMetadata():
   QgsProviderMetadata( QgsWFSProvider::WFS_PROVIDER_KEY, QgsWFSProvider::WFS_PROVIDER_DESCRIPTION ) {}
 
+
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN void *multipleProviderMetadataFactory()
 {
   return new std::vector<QgsProviderMetadata *> { new QgsWfsProviderMetadata(), new QgsOapifProviderMetadata() };
 }
+#endif

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -98,6 +98,8 @@ class QgsWFSProvider final: public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
 
+    static QString providerKey();
+
     QgsVectorDataProvider::Capabilities capabilities() const override;
 
     QString storageType() const override { return QStringLiteral( "OGC WFS (Web Feature Service)" ); }

--- a/src/providers/wfs/qgswfsprovidergui.cpp
+++ b/src/providers/wfs/qgswfsprovidergui.cpp
@@ -13,6 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgswfsprovidergui.h"
+
 #include "qgswfsprovider.h"
 #include "qgswfsdataitemguiprovider.h"
 #include "qgswfssourceselect.h"
@@ -65,20 +67,20 @@ QgsWfsProviderGuiMetadata::QgsWfsProviderGuiMetadata()
 {
 }
 
-QList<QgsSourceSelectProvider *> QgsWfsProviderGuiMetadata::sourceSelectProviders() override
+QList<QgsSourceSelectProvider *> QgsWfsProviderGuiMetadata::sourceSelectProviders()
 {
   QList<QgsSourceSelectProvider *> providers;
   providers << new QgsWfsSourceSelectProvider;
   return providers;
 }
 
-QList<QgsDataItemGuiProvider *> QgsWfsProviderGuiMetadata::dataItemGuiProviders() override
+QList<QgsDataItemGuiProvider *> QgsWfsProviderGuiMetadata::dataItemGuiProviders()
 {
   return QList<QgsDataItemGuiProvider *>()
          << new QgsWfsDataItemGuiProvider;
 }
 
-QList<QgsSubsetStringEditorProvider *> QgsWfsProviderGuiMetadata::subsetStringEditorProviders() override
+QList<QgsSubsetStringEditorProvider *> QgsWfsProviderGuiMetadata::subsetStringEditorProviders()
 {
   return QList<QgsSubsetStringEditorProvider *>()
          << new QgsWfsSubsetStringEditorProvider;

--- a/src/providers/wfs/qgswfsprovidergui.cpp
+++ b/src/providers/wfs/qgswfsprovidergui.cpp
@@ -60,37 +60,34 @@ class QgsWfsSubsetStringEditorProvider: public QgsSubsetStringEditorProvider
 };
 
 
-class QgsWfsProviderGuiMetadata: public QgsProviderGuiMetadata
+QgsWfsProviderGuiMetadata::QgsWfsProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QgsWFSProvider::WFS_PROVIDER_KEY )
 {
-  public:
-    QgsWfsProviderGuiMetadata()
-      : QgsProviderGuiMetadata( QgsWFSProvider::WFS_PROVIDER_KEY )
-    {
-    }
+}
 
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsWfsSourceSelectProvider;
-      return providers;
-    }
+QList<QgsSourceSelectProvider *> QgsWfsProviderGuiMetadata::sourceSelectProviders() override
+{
+  QList<QgsSourceSelectProvider *> providers;
+  providers << new QgsWfsSourceSelectProvider;
+  return providers;
+}
 
-    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
-    {
-      return QList<QgsDataItemGuiProvider *>()
-             << new QgsWfsDataItemGuiProvider;
-    }
+QList<QgsDataItemGuiProvider *> QgsWfsProviderGuiMetadata::dataItemGuiProviders() override
+{
+  return QList<QgsDataItemGuiProvider *>()
+         << new QgsWfsDataItemGuiProvider;
+}
 
-    QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders() override
-    {
-      return QList<QgsSubsetStringEditorProvider *>()
-             << new QgsWfsSubsetStringEditorProvider;
-    }
-
-};
+QList<QgsSubsetStringEditorProvider *> QgsWfsProviderGuiMetadata::subsetStringEditorProviders() override
+{
+  return QList<QgsSubsetStringEditorProvider *>()
+         << new QgsWfsSubsetStringEditorProvider;
+}
 
 
+#ifndef HAVE_STATIC_PROVIDERS
 QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
 {
   return new QgsWfsProviderGuiMetadata();
 }
+#endif

--- a/src/providers/wfs/qgswfsprovidergui.h
+++ b/src/providers/wfs/qgswfsprovidergui.h
@@ -1,0 +1,30 @@
+/***************************************************************************
+  qgswfsprovidergui.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswfsprovider.h"
+#include "qgswfssourceselect.h"
+#include "qgssourceselectprovider.h"
+#include "qgsproviderguimetadata.h"
+
+
+class QgsWfsProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsWfsProviderGuiMetadata();
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
+    QList<QgsSubsetStringEditorProvider *> subsetStringEditorProviders() override;
+};


### PR DESCRIPTION
Static build support for the following providers:
- delimited text
- spatialite
- virtual layer
- wfs
- wcs
- afs
- ams

This also includes fix for progresql-less static builds.

Let the iOS consumers rejoice.