### PR TITLE
[expressions] Fix overlay_* functions caching when filter changes

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6547,7 +6547,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
     intDomain.grow( bboxGrow ); //optional parameter to enlarge boundary context for touches and equals methods
   }
 
-  const QString cacheBase { QStringLiteral( "%1:%2" ).arg( targetLayer->id(), subExpString ) };
+  const QString cacheBase { QStringLiteral( "%1:%2:%3" ).arg( targetLayer->id(), subExpString, filterString ) };
 
   // Cache (a local spatial index) is always enabled for nearest function (as we need QgsSpatialIndex::nearestNeighbor)
   // Otherwise, it can be toggled by the user


### PR DESCRIPTION
## Description

Adds filterString to cacheBase key for overlay_* functions to avoid using cached target layer (ovrlaylyr:) and cached spatial index (ovrlayidx:) if the filter string changes.
From `const QString cacheBase { QStringLiteral( "%1:%2" ).arg( targetLayer->id(), subExpString ) };`
To `const QString cacheBase { QStringLiteral( "%1:%2:%3" ).arg( targetLayer->id(), subExpString, filterString ) };`

Before the patch

https://user-images.githubusercontent.com/16253859/139570176-890b7971-8826-407e-97dd-50f91407f49e.mp4


After the patch

https://user-images.githubusercontent.com/16253859/139570185-0362c4dc-3536-413d-a19e-b39634149b9b.mp4


The patch allows to use a "dynamic" filter which changes for each evaluated feature of the source layer, e.g. with an expression like:
`eval( 'overlay_nearest( \'target_layer\', ID_target_layer, filter:=field_target_layer=' || "field_source_layer" || ' )' )`
that returns incorrectly cached results without this patch (thus allowing a simple workaround to https://github.com/qgis/QGIS/issues/43146).
It would be great it the overlay_* functions could also be further improved to let use an expression like:
`overlay_nearest( 'target_layer', ID_target_layer, filter:=field_target_layer=attribute(@parent,'field_source_layer') )`

Before the patch

https://user-images.githubusercontent.com/16253859/139571075-dea834f7-6817-4912-9155-d6ba814508d7.mp4


After the patch

https://user-images.githubusercontent.com/16253859/139571082-fa6ff107-37b5-4b43-8fca-e5805ff42964.mp4


This PR needs to be backported.
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
