### PR TITLE
Remove the unnecessary checkbox for the Label legend group box

### DIFF
--- a/src/gui/vector/qgsvectorlayerlegendwidget.cpp
+++ b/src/gui/vector/qgsvectorlayerlegendwidget.cpp
@@ -60,11 +60,9 @@ QgsVectorLayerLegendWidget::QgsVectorLayerLegendWidget( QWidget *parent )
   mTextOnSymbolGroupBox->setLayout( groupLayout );
   mTextOnSymbolGroupBox->setCollapsed( false );
 
-  mShowLabelLegendCheckBox = new QCheckBox( tr( "Show label legend" ) );
-  connect( mShowLabelLegendCheckBox, &QCheckBox::toggled, this, &QgsVectorLayerLegendWidget::enableLabelLegendGroupBox );
   mLabelLegendGroupBox = new QgsCollapsibleGroupBox;
-  mLabelLegendGroupBox->setVisible( false );
-  mLabelLegendGroupBox->setTitle( tr( "Label legend" ) );
+  mLabelLegendGroupBox->setCheckable( true );
+  mLabelLegendGroupBox->setTitle( tr( "Show Label Legend" ) );
 
   mLabelLegendTreeWidget = new QTreeWidget;
   connect( mLabelLegendTreeWidget, &QTreeWidget::itemDoubleClicked, this, &QgsVectorLayerLegendWidget::labelLegendTreeWidgetItemDoubleClicked );
@@ -85,20 +83,10 @@ QgsVectorLayerLegendWidget::QgsVectorLayerLegendWidget( QWidget *parent )
   layout->setContentsMargins( 0, 0, 0, 0 );
   layout->addWidget( mPlaceholderImageLabel );
   layout->addWidget( mImageSourceLineEdit );
-  layout->addWidget( mShowLabelLegendCheckBox );
   layout->addWidget( mLabelLegendGroupBox );
   layout->addWidget( mTextOnSymbolGroupBox );
 
   setLayout( layout );
-}
-
-void QgsVectorLayerLegendWidget::enableLabelLegendGroupBox( bool enable )
-{
-  mLabelLegendGroupBox->setVisible( enable );
-  if ( enable )
-  {
-    populateLabelLegendTreeWidget();
-  }
 }
 
 void QgsVectorLayerLegendWidget::labelLegendTreeWidgetItemDoubleClicked( QTreeWidgetItem *item, int column )
@@ -128,7 +116,8 @@ void QgsVectorLayerLegendWidget::setLayer( QgsVectorLayer *layer )
   if ( !legend )
     return;
 
-  mShowLabelLegendCheckBox->setChecked( legend->showLabelLegend() );
+  mLabelLegendGroupBox->setChecked( legend->showLabelLegend() );
+  populateLabelLegendTreeWidget();
   mTextOnSymbolGroupBox->setChecked( legend->textOnSymbolEnabled() );
   mTextOnSymbolFormatButton->setTextFormat( legend->textOnSymbolTextFormat() );
   populateLegendTreeView( legend->textOnSymbolContent() );
@@ -227,7 +216,7 @@ void QgsVectorLayerLegendWidget::applyToLayer()
   }
   legend->setTextOnSymbolContent( content );
 
-  const bool showLabelLegend = mShowLabelLegendCheckBox->isChecked();
+  const bool showLabelLegend = mLabelLegendGroupBox->isChecked();
   legend->setShowLabelLegend( showLabelLegend );
   if ( showLabelLegend )
   {

--- a/src/gui/vector/qgsvectorlayerlegendwidget.cpp
+++ b/src/gui/vector/qgsvectorlayerlegendwidget.cpp
@@ -133,7 +133,7 @@ void QgsVectorLayerLegendWidget::populateLabelLegendTreeWidget()
 {
   mLabelLegendTreeWidget->clear();
   mLabelLegendTreeWidget->setColumnCount( 2 );
-  QTreeWidgetItem *headerItem = new QTreeWidgetItem( QStringList() << tr( "Description" ) << tr( "LegendText" ) );
+  QTreeWidgetItem *headerItem = new QTreeWidgetItem( QStringList() << tr( "Description" ) << tr( "Legend Text" ) );
   mLabelLegendTreeWidget->setHeaderItem( headerItem );
 
   const QgsAbstractVectorLayerLabeling *labeling = mLayer->labeling();

--- a/src/gui/vector/qgsvectorlayerlegendwidget.cpp
+++ b/src/gui/vector/qgsvectorlayerlegendwidget.cpp
@@ -78,11 +78,13 @@ QgsVectorLayerLegendWidget::QgsVectorLayerLegendWidget( QWidget *parent )
     mImageSourceLineEdit->setSource( mLayer->legendPlaceholderImage() );
   }
 
+  QHBoxLayout *placeholderLayout = new QHBoxLayout;
+  placeholderLayout->addWidget( mPlaceholderImageLabel );
+  placeholderLayout->addWidget( mImageSourceLineEdit );
 
   QVBoxLayout *layout = new QVBoxLayout;
   layout->setContentsMargins( 0, 0, 0, 0 );
-  layout->addWidget( mPlaceholderImageLabel );
-  layout->addWidget( mImageSourceLineEdit );
+  layout->addLayout( placeholderLayout );
   layout->addWidget( mLabelLegendGroupBox );
   layout->addWidget( mTextOnSymbolGroupBox );
 

--- a/src/gui/vector/qgsvectorlayerlegendwidget.h
+++ b/src/gui/vector/qgsvectorlayerlegendwidget.h
@@ -24,7 +24,6 @@
 #include "qgstextformat.h"
 #include "qgis_gui.h"
 
-class QCheckBox;
 class QgsImageSourceLineEdit;
 class QLabel;
 class QPushButton;
@@ -60,7 +59,6 @@ class GUI_EXPORT QgsVectorLayerLegendWidget : public QWidget
 
   private slots:
     void labelsFromExpression();
-    void enableLabelLegendGroupBox( bool enable );
     void labelLegendTreeWidgetItemDoubleClicked( QTreeWidgetItem *item, int column );
 
   private:
@@ -74,7 +72,6 @@ class GUI_EXPORT QgsVectorLayerLegendWidget : public QWidget
     QPushButton *mTextOnSymbolFromExpressionButton = nullptr;
     QgsCollapsibleGroupBox *mTextOnSymbolGroupBox = nullptr;
     QLabel *mTextOnSymbolLabel = nullptr;
-    QCheckBox *mShowLabelLegendCheckBox = nullptr;
     QgsCollapsibleGroupBox *mLabelLegendGroupBox = nullptr;
     QTreeWidget *mLabelLegendTreeWidget = nullptr;
     QLabel *mPlaceholderImageLabel = nullptr;

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1418,6 +1418,18 @@ p, li { white-space: pre-wrap; }
               <string>Embedded Widgets in Legend</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_17">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
                <widget class="QgsLayerTreeEmbeddedConfigWidget" name="mLegendConfigEmbeddedWidget" native="true"/>
               </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1385,8 +1385,28 @@ p, li { white-space: pre-wrap; }
           </layout>
          </widget>
          <widget class="QWidget" name="mOptsPage_Legend">
-          <layout class="QGridLayout" name="gridLayout_15">
-           <item row="2" column="0">
+          <layout class="QVBoxLayout" name="verticalLayout_151">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="mLegendPlaceholderLabel">
+               <property name="text">
+                <string>Legend placeholder image</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsImageSourceLineEdit" name="mLegendPlaceholderWidget" native="true"/>
+             </item>
+            </layout>
+           </item>
+           <item>
             <widget class="QGroupBox" name="groupBox">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -1402,16 +1422,6 @@ p, li { white-space: pre-wrap; }
                <widget class="QgsLayerTreeEmbeddedConfigWidget" name="mLegendConfigEmbeddedWidget" native="true"/>
               </item>
              </layout>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QgsImageSourceLineEdit" name="mLegendPlaceholderWidget" native="true"/>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="mLegendPlaceholderLabel">
-             <property name="text">
-              <string>Legend placeholder image</string>
-             </property>
             </widget>
            </item>
           </layout>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -2059,6 +2059,18 @@
               <string>Embedded Widgets in Legend</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_22">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
                <widget class="QgsLayerTreeEmbeddedConfigWidget" name="mLegendConfigEmbeddedWidget" native="true"/>
               </item>


### PR DESCRIPTION
Remove the checkbox and use instead a checkable groupbox
Fixes labels, alignment and margins in the dialog

Before
![image](https://user-images.githubusercontent.com/7983394/139596141-76e4d0ec-3e86-4ba9-a952-ffec9f52a8f9.png)
After ![image](https://user-images.githubusercontent.com/7983394/139596110-2a66ecaa-d9be-415f-8e9a-2b48dd9ef0f4.png)

Should be backported to 3.22