### PR TITLE
Bugfix: using Simple Line with "Aligh dash pattern to line length"

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -770,14 +770,14 @@ void QgsSimpleLineSymbolLayer::drawPathWithDashPatternTweaks( QPainter *painter,
   if ( pen.dashPattern().empty() || points.size() < 2 )
     return;
 
+  if ( pen.widthF() <= 1.0 )
+    pen.setWidthF( 1.0001 );
+
   QVector< qreal > sourcePattern = pen.dashPattern();
-  const double dashWidthDiv = std::max( 1.0001, pen.widthF() );
+  const double dashWidthDiv = pen.widthF();
   // back to painter units
   for ( int i = 0; i < sourcePattern.size(); ++ i )
     sourcePattern[i] *= pen.widthF();
-
-  if ( pen.widthF() <= 1.0 )
-    pen.setWidthF( 1.0001 );
 
   QVector< qreal > buffer;
   QPolygonF bufferedPoints;
@@ -953,6 +953,8 @@ void QgsSimpleLineSymbolLayer::drawPathWithDashPatternTweaks( QPainter *painter,
           patternIndex++;
           currentRemainingDashLength = 0.0;
           currentRemainingGapLength = sourcePattern.at( patternIndex );
+          if ( currentRemainingGapLength == 0.0 )
+            patternIndex++;
         }
         else
         {
@@ -985,7 +987,7 @@ void QgsSimpleLineSymbolLayer::drawPathWithDashPatternTweaks( QPainter *painter,
         }
       }
 
-      if ( patternIndex >= sourcePattern.size() )
+      if ( patternIndex + 1 >= sourcePattern.size() )
         patternIndex = 0;
 
       const double nextPatternDashLength = sourcePattern.at( patternIndex );


### PR DESCRIPTION
* bad_alloc when "Stroke width" is zero;
* out-of-bounds access error crash when gap length is set to zero in Custom Dash Pattern

Fixes #45432

## Description

* Dash pattern values were being multiplied by "Stroke width" `pen.widthF()` before setting it to =>1 value, resulting in infinite loop.
* `patternIndex` was not being updated correctly when zero length gap is present in dash pattern causing out of bounds access to `sourcePattern`

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
