### PR TITLE
Don't append duplicate extents to extent history

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1264,7 +1264,10 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
     mLastExtent.removeAt( i );
   }
 
-  mLastExtent.append( extent() );
+  if ( !mLastExtent.isEmpty() && mLastExtent.last() != extent() )
+  {
+    mLastExtent.append( extent() );
+  }
 
   // adjust history to no more than 100
   if ( mLastExtent.size() > 100 )


### PR DESCRIPTION
It can happen that the same extent is added twice to the extent history, i.e. through

    QgsMapCanvas::setExtent -> QgsMapCanvas::updateScale -> QgsMapCanvas::scaleChanged -> QgsScaleComboBox::setScale -> QgsScaleComboBox::scaleChanged -> QgsMapCanvas::setExtent