### PR TITLE
Don't use geos to calculate QgsGeometry::length

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -384,6 +384,8 @@ Returns the planar, 2-dimensional area of the geometry.
 %Docstring
 Returns the planar, 2-dimensional length of geometry.
 
+If the geometry is a polygon geometry then the perimeter of the polygon will be returned.
+
 .. warning::
 
    QgsGeometry objects are inherently Cartesian/planar geometries, and the length

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1913,15 +1913,7 @@ double QgsGeometry::length() const
     return -1.0;
   }
 
-  // avoid calling geos for trivial geometry calculations
-  if ( QgsWkbTypes::geometryType( d->geometry->wkbType() ) == QgsWkbTypes::PointGeometry || QgsWkbTypes::geometryType( d->geometry->wkbType() ) == QgsWkbTypes::LineGeometry )
-  {
-    return d->geometry->length();
-  }
-
-  QgsGeos g( d->geometry.get() );
-  mLastError.clear();
-  return g.length( &mLastError );
+  return d->geometry->length();
 }
 
 double QgsGeometry::distance( const QgsGeometry &geom ) const

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1913,7 +1913,22 @@ double QgsGeometry::length() const
     return -1.0;
   }
 
-  return d->geometry->length();
+  switch ( QgsWkbTypes::geometryType( d->geometry->wkbType() ) )
+  {
+    case QgsWkbTypes::PointGeometry:
+      return 0.0;
+
+    case QgsWkbTypes::LineGeometry:
+      return d->geometry->length();
+
+    case QgsWkbTypes::PolygonGeometry:
+      return d->geometry->perimeter();
+
+    case QgsWkbTypes::UnknownGeometry:
+    case QgsWkbTypes::NullGeometry:
+      return d->geometry->length();
+  }
+  return -1;
 }
 
 double QgsGeometry::distance( const QgsGeometry &geom ) const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -419,6 +419,8 @@ class CORE_EXPORT QgsGeometry
     /**
      * Returns the planar, 2-dimensional length of geometry.
      *
+     * If the geometry is a polygon geometry then the perimeter of the polygon will be returned.
+     *
      * \warning QgsGeometry objects are inherently Cartesian/planar geometries, and the length
      * returned by this method is calculated using strictly Cartesian mathematics. In contrast,
      * the QgsDistanceArea class exposes methods for calculating the lengths of geometries using


### PR DESCRIPTION
Instead use the QgsAbstractGeometry method, so that consistent
results are obtained across the API and an exact length is used
for curved geometries (instead of the length of the segmentized
curves)

Refs https://lists.osgeo.org/pipermail/qgis-developer/2021-October/064159.html.

