### PR TITLE
Ensure zip items behave correctly as files in browser

### DIFF
--- a/python/core/auto_generated/browser/qgszipitem.sip.in
+++ b/python/core/auto_generated/browser/qgszipitem.sip.in
@@ -40,6 +40,11 @@ Constructor
 
     QStringList getZipFileList();
 
+    virtual bool hasDragEnabled() const;
+
+    virtual QgsMimeDataUtils::UriList mimeUris() const;
+
+
     static QStringList sProviderNames;
 
     static QString vsiPrefix( const QString &uri );

--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -307,7 +307,7 @@ QVector<QgsDataItem *> QgsDirectoryItem::createChildren()
     if ( fileInfo.suffix().compare( QLatin1String( "zip" ), Qt::CaseInsensitive ) == 0 ||
          fileInfo.suffix().compare( QLatin1String( "tar" ), Qt::CaseInsensitive ) == 0 )
     {
-      QgsDataItem *item = QgsZipItem::itemFromPath( this, path, name, mPath + '/' + name );
+      QgsDataItem *item = QgsZipItem::itemFromPath( this, path, name, path );
       if ( item )
       {
         children.append( item );

--- a/src/core/browser/qgszipitem.cpp
+++ b/src/core/browser/qgszipitem.cpp
@@ -57,11 +57,27 @@ void QgsZipItem::init()
   mIconName = QStringLiteral( "/mIconZip.svg" );
   mVsiPrefix = vsiPrefix( mFilePath );
 
+  setCapabilities( capabilities2() | Qgis::BrowserItemCapability::ItemRepresentsFile );
+
   static std::once_flag initialized;
   std::call_once( initialized, [ = ]
   {
     sProviderNames << QStringLiteral( "OGR" ) << QStringLiteral( "GDAL" );
   } );
+}
+
+bool QgsZipItem::hasDragEnabled() const
+{
+  return true;
+}
+
+QgsMimeDataUtils::UriList QgsZipItem::mimeUris() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.layerType = QStringLiteral( "collection" );
+  u.uri = path();
+  u.filePath = path();
+  return { u };
 }
 
 QVector<QgsDataItem *> QgsZipItem::createChildren()

--- a/src/core/browser/qgszipitem.h
+++ b/src/core/browser/qgszipitem.h
@@ -53,6 +53,9 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     QStringList getZipFileList();
 
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
+
     //! \note not available via Python bindings
     static QVector<dataItem_t *> sDataItemPtr SIP_SKIP;
     static QStringList sProviderNames;


### PR DESCRIPTION
Also fixes drag and drop support for zip to project

Refs https://github.com/qgis/QGIS/issues/45769

(Note that this isn't a regression -- < 3.22 didn't support drag of zip items either)
