### PR TITLE
[symbology] Add a thumbnail size slider to style manager dialog

### DIFF
--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -278,17 +278,12 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   connect( exportAction, &QAction::triggered, this, &QgsStyleManagerDialog::exportItems );
   btnShare->setMenu( shareMenu );
 
-  double iconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 10;
-  listItems->setIconSize( QSize( static_cast< int >( iconSize ), static_cast< int >( iconSize * 0.9 ) ) );  // ~100, 90 on low dpi
-  // set a grid size which allows sufficient vertical spacing to fit reasonably sized entity names
-  listItems->setGridSize( QSize( static_cast< int >( listItems->iconSize().width() * 1.4 ), static_cast< int >( listItems->iconSize().height() * 1.7 ) ) );
   listItems->setTextElideMode( Qt::TextElideMode::ElideRight );
   double treeIconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 2;
   mSymbolTreeView->setIconSize( QSize( static_cast< int >( treeIconSize ), static_cast< int >( treeIconSize ) ) );
 
   mModel = mStyle == QgsStyle::defaultStyle() ? new QgsCheckableStyleModel( QgsApplication::defaultStyleModel(), this, mReadOnly )
            : new QgsCheckableStyleModel( mStyle, this, mReadOnly );
-  mModel->addDesiredIconSize( listItems->iconSize() );
   mModel->addDesiredIconSize( mSymbolTreeView->iconSize() );
   listItems->setModel( mModel );
   mSymbolTreeView->setModel( mModel );
@@ -515,6 +510,11 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
     QgsSettings().setValue( QStringLiteral( "Windows/StyleV2Manager/treeState" ), mSymbolTreeView->header()->saveState(), QgsSettings::Gui );
   } );
 
+  const int thumbnailSize = settings.value( QStringLiteral( "Windows/StyleV2Manager/thumbnailSize" ), 0, QgsSettings::Gui ).toInt();
+  mSliderIconSize->setValue( thumbnailSize );
+  connect( mSliderIconSize, &QSlider::valueChanged, this, &QgsStyleManagerDialog::setThumbnailSize );
+  setThumbnailSize( thumbnailSize );
+
   // set initial disabled state for actions requiring a selection
   selectedSymbolsChanged( QItemSelection(), QItemSelection() );
 }
@@ -732,6 +732,21 @@ void QgsStyleManagerDialog::pasteItem()
     mStyle->saveTextFormat( saveDlg.name(), format, saveDlg.isFavorite(), symbolTags );
     return;
   }
+}
+
+void QgsStyleManagerDialog::setThumbnailSize( int value )
+{
+  // value ranges from 0-10
+  const double iconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * ( value * 2.5 + 10 );
+  // set a grid size which allows sufficient vertical spacing to fit reasonably sized entity names
+  const double spacing = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * ( value * 2.2 + 14 );
+  const double verticalSpacing = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 7
+                                 + iconSize * 0.8;
+  listItems->setIconSize( QSize( static_cast< int >( iconSize ), static_cast< int >( iconSize * 0.9 ) ) );
+  listItems->setGridSize( QSize( static_cast< int >( spacing ), static_cast< int >( verticalSpacing ) ) );
+  mModel->addDesiredIconSize( listItems->iconSize() );
+
+  QgsSettings().setValue( QStringLiteral( "Windows/StyleV2Manager/thumbnailSize" ), value, QgsSettings::Gui );
 }
 
 int QgsStyleManagerDialog::selectedItemType()

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -347,6 +347,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     void pasteItem();
 
+    void setThumbnailSize( int );
+
   private:
     int selectedItemType();
 

--- a/src/ui/qgsstyleitemslistwidgetbase.ui
+++ b/src/ui/qgsstyleitemslistwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>386</width>
-    <height>619</height>
+    <width>563</width>
+    <height>633</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -266,7 +266,6 @@
   <tabstop>btnAdvanced</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>867</width>
-    <height>410</height>
+    <width>950</width>
+    <height>419</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -211,6 +211,31 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QSlider" name="mSliderIconSize">
+           <property name="toolTip">
+            <string>Thumbnail size</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>10</number>
+           </property>
+           <property name="pageStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+           <property name="tracking">
+            <bool>true</bool>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
          </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_7">
@@ -672,6 +697,7 @@
   <tabstop>btnRemoveItem</tabstop>
   <tabstop>btnEditItem</tabstop>
   <tabstop>mCopyToDefaultButton</tabstop>
+  <tabstop>mSliderIconSize</tabstop>
   <tabstop>mButtonIconView</tabstop>
   <tabstop>mButtonListView</tabstop>
   <tabstop>searchBox</tabstop>


### PR DESCRIPTION
Because sometimes the thumbnail sizes are just too small to get a good representation of a symbol!

Sponsored by North Road

![image](https://user-images.githubusercontent.com/1829991/139841074-0db9d0d3-f644-4c13-8ef7-571c2da31210.png)
