### PR TITLE
Increase max zoom level for landing page

### DIFF
--- a/resources/server/src/landingpage/src/views/WebGis.vue
+++ b/resources/server/src/landingpage/src/views/WebGis.vue
@@ -317,6 +317,7 @@ export default {
         tileSize: 512,
         transparent: true,
         format: "image/png",
+        maxZoom: 25, 
         dpi: window.devicePixelRatio * 96,
         onGetFeatureInfo: this.onGetFeatureInfo,
         onGetFeatureInfoStarted: this.onGetFeatureInfoStarted,

--- a/resources/server/src/landingpage/src/views/WebGis.vue
+++ b/resources/server/src/landingpage/src/views/WebGis.vue
@@ -317,7 +317,7 @@ export default {
         tileSize: 512,
         transparent: true,
         format: "image/png",
-        maxZoom: 25, 
+        maxZoom: 21, 
         dpi: window.devicePixelRatio * 96,
         onGetFeatureInfo: this.onGetFeatureInfo,
         onGetFeatureInfoStarted: this.onGetFeatureInfoStarted,


### PR DESCRIPTION
## Description

Override the max leaflet zoom of 18, fixes #45768



