### PR TITLE
[Fix] Edit imported but invalid model

### DIFF
--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -40,13 +40,9 @@ class EditModelAction(ContextAction):
 
     def execute(self):
         alg = self.itemData
-        ok, msg = alg.canExecute()
-        if not ok:
-            iface.messageBar().pushMessage(QCoreApplication.translate('EditModelAction', 'Cannot edit model: {}').format(msg), level=Qgis.Warning)
-        else:
-            dlg = ModelerDialog.create(alg)
-            dlg.update_model.connect(self.updateModel)
-            dlg.show()
+        dlg = ModelerDialog.create(alg)
+        dlg.update_model.connect(self.updateModel)
+        dlg.show()
 
     def updateModel(self):
         QgsApplication.processingRegistry().providerById('model').refreshAlgorithms()


### PR DESCRIPTION
## Description

Fixes #44672. Editing a model is prevented as soon as an algorithm does not exist in QGIS.

`QgsProcessingModelAlgorithm::canExecute()` only checks if all algorithms exist. To enter in the editor, there is no need to run the model and errors are handled in it (with `QgsProcessingModelAlgorithm::validate()` eg.). I don't think that `alg.canExecute()` should necessarily be true.

This PR proposes to remove this condition.