### PR TITLE
[ui] Expand geopackage connections combobox in the save/load project to/from geopackage dialog

### DIFF
--- a/src/ui/qgsgeopackageprojectstoragedialog.ui
+++ b/src/ui/qgsgeopackageprojectstoragedialog.ui
@@ -21,7 +21,14 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QComboBox" name="mCboConnection"/>
+      <widget class="QComboBox" name="mCboConnection">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">


### PR DESCRIPTION
## Description

This PR fixes this less than ideal spacing issue:
![image](https://user-images.githubusercontent.com/1728657/140014330-f6d3547c-bf62-4cbe-bb52-8854cb29e71c.png)
