### PR TITLE
Make the Identify mode combo always visible

### DIFF
--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -93,45 +93,6 @@
          </column>
         </widget>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="lblIdentifyMode">
-           <property name="toolTip">
-            <string>Select identify mode</string>
-           </property>
-           <property name="text">
-            <string>Mode</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cmbIdentifyMode">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-           </property>
-           <property name="minimumContentsLength">
-            <number>6</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="stackedWidgetPage2">
@@ -191,6 +152,45 @@
       </layout>
      </widget>
     </widget>
+   </item>
+   <item>
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="leftMargin">
+     <number>5</number>
+     </property>
+     <property name="topMargin">
+     <number>5</number>
+     </property>
+     <property name="rightMargin">
+     <number>5</number>
+     </property>
+     <item>
+     <widget class="QLabel" name="lblIdentifyMode">
+       <property name="toolTip">
+       <string>Select identify mode</string>
+       </property>
+       <property name="text">
+       <string>Mode</string>
+       </property>
+     </widget>
+     </item>
+     <item>
+     <widget class="QComboBox" name="cmbIdentifyMode">
+       <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+       </sizepolicy>
+       </property>
+       <property name="sizeAdjustPolicy">
+       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+       </property>
+       <property name="minimumContentsLength">
+       <number>6</number>
+       </property>
+     </widget>
+     </item>
+   </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">


### PR DESCRIPTION
## Description

The identify mode is currently shown only when the view mode is set to `Tree` but always takes effect. This can be confusing when you're e.g. looking at the table view but don't find your layer in the result because the identify mode is set to `Top Down, Stop at First`, especially if you're a new user.

So make the combo box always visible by pulling it below the `QStackedWidget`.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
