### PR TITLE
Improve PDF export for qt 6.3+, or when using KDE's maintained 5.15 fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,7 @@ if(WITH_CORE)
   else()
     set(QT_MIN_VERSION 5.12.0)
     set(QT_VERSION_BASE "Qt5")
+    set(WITH_QT5_KDE_FORK FALSE CACHE BOOL "Using KDE's Qt 5.15 fork")
   endif()
 
   # Use Qt5SerialPort optionally for GPS

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -104,5 +104,7 @@
 
 #cmakedefine ENABLE_TESTS
 
+#cmakedefine WITH_QT5_KDE_FORK
+
 #endif
 

--- a/python/core/auto_generated/qgspaintenginehack.sip.in
+++ b/python/core/auto_generated/qgspaintenginehack.sip.in
@@ -12,6 +12,11 @@ class QgsPaintEngineHack : QPaintEngine
 {
 %Docstring(signature="appended")
 Hack to workaround Qt #5114 by disabling PatternTransform
+
+.. note::
+
+   This is not required for builds based on Qt 6.3 or later, or Qt 5.15 builds
+   using KDE's maintained fork. On these versions the class has no effect.
 %End
 
 %TypeHeaderCode

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1219,7 +1219,11 @@ void QgsLayoutExporter::preparePrintAsPdf( QgsLayout *layout, QPrinter &printer,
   // May not work on Windows or non-X11 Linux. Works fine on Mac using QPrinter::NativeFormat
   //printer.setFontEmbeddingEnabled( true );
 
+#if defined(WITH_QT5_KDE_FORK) || QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+  // paint engine hack not required, fixed upstream
+#else
   QgsPaintEngineHack::fixEngineFlags( printer.paintEngine() );
+#endif
 }
 
 void QgsLayoutExporter::preparePrint( QgsLayout *layout, QPrinter &printer, bool setFirstPageSize )

--- a/src/core/qgspaintenginehack.cpp
+++ b/src/core/qgspaintenginehack.cpp
@@ -16,10 +16,14 @@
  ***************************************************************************/
 
 #include "qgspaintenginehack.h"
+#include "qgsconfig.h"
 
 // Hack to workaround Qt #5114 by disabling PatternTransform
 void QgsPaintEngineHack::fixFlags()
 {
+#if defined(WITH_QT5_KDE_FORK) || QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+  // not required, fixed upstream
+#else
   gccaps = PaintEngineFeatures();
   gccaps |= ( QPaintEngine::PrimitiveTransform
               // | QPaintEngine::PatternTransform
@@ -41,13 +45,19 @@ void QgsPaintEngineHack::fixFlags()
               | QPaintEngine::RasterOpModes
               | QPaintEngine::PaintOutsidePaintEvent
             );
+#endif
 }
 
 void QgsPaintEngineHack::fixEngineFlags( QPaintEngine *engine )
 {
+#if defined(WITH_QT5_KDE_FORK) || QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+  // not required, fixed upstream
+  ( void )engine;
+#else
   if ( !engine )
     return;
 
   QgsPaintEngineHack *hack = static_cast<QgsPaintEngineHack *>( engine );
   hack->fixFlags();
+#endif
 }

--- a/src/core/qgspaintenginehack.h
+++ b/src/core/qgspaintenginehack.h
@@ -21,6 +21,9 @@
 /**
  * \ingroup core
  * \brief Hack to workaround Qt #5114 by disabling PatternTransform
+ *
+ * \note This is not required for builds based on Qt 6.3 or later, or Qt 5.15 builds
+ * using KDE's maintained fork. On these versions the class has no effect.
  */
 class CORE_EXPORT QgsPaintEngineHack : public QPaintEngine
 {


### PR DESCRIPTION
We no longer require paint engine hack for Qt 6.3 or KDE's fork, which now means that pattern brushes and gradients are correctly exported to PDF without forced rasterization.

Results in higher quality PDF outputs with smaller file sizes

Thanks to KDAB for the fix!