### PR TITLE
Fix QgsBlockingNetworkRequest race condition issue

### DIFF
--- a/.ci/test_blocklist_qt5.txt
+++ b/.ci/test_blocklist_qt5.txt
@@ -22,7 +22,3 @@ test_core_layerdefinition
 
 # MSSQL requires the MSSQL docker
 PyQgsProviderConnectionMssql
-
-# Too fragile at the moment
-test_core_networkaccessmanager
-

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -217,6 +217,7 @@ QgsNetworkAccessManager *QgsNetworkAccessManager::instance( Qt::ConnectionType c
 
 QgsNetworkAccessManager::QgsNetworkAccessManager( QObject *parent )
   : QNetworkAccessManager( parent )
+  , mAuthRequestHandlerSemaphore( 1 )
 {
   setProxyFactory( new QgsNetworkProxyFactory() );
   setCookieJar( new QgsNetworkCookieJar( this ) );
@@ -466,23 +467,12 @@ void QgsNetworkAccessManager::afterSslErrorHandled( QNetworkReply *reply )
   }
 }
 
-void QgsNetworkAccessManager::unlockAfterAuthRequestHandled()
-{
-  Q_ASSERT( QThread::currentThread() == QApplication::instance()->thread() );
-  mAuthRequestWaitCondition.wakeOne();
-}
-
 void QgsNetworkAccessManager::afterAuthRequestHandled( QNetworkReply *reply )
 {
   if ( reply->manager() == this )
   {
     restartTimeout( reply );
     emit authRequestHandled( reply );
-  }
-  else if ( this == sMainNAM )
-  {
-    // notify other threads to allow them to handle the reply
-    qobject_cast< QgsNetworkAccessManager *>( reply->manager() )->unlockAfterAuthRequestHandled(); // safe to call directly - the other thread will be stuck waiting for us
   }
 }
 
@@ -534,6 +524,7 @@ void QgsNetworkAccessManager::onAuthRequired( QNetworkReply *reply, QAuthenticat
 
   emit requestRequiresAuth( getRequestId( reply ), auth->realm() );
 
+  mAuthRequestHandlerSemaphore.acquire();
   // in main thread this will trigger auth handler immediately and return once the request is satisfied,
   // while in worker thread the signal will be queued (and return immediately) -- hence the need to lock the thread in the next block
   emit authRequestOccurred( reply, auth );
@@ -542,9 +533,8 @@ void QgsNetworkAccessManager::onAuthRequired( QNetworkReply *reply, QAuthenticat
   {
     // lock thread and wait till error is handled. If we return from this slot now, then the reply will resume
     // without actually giving the main thread the chance to act on the ssl error and possibly ignore it.
-    mAuthRequestHandlerMutex.lock();
-    mAuthRequestWaitCondition.wait( &mAuthRequestHandlerMutex );
-    mAuthRequestHandlerMutex.unlock();
+    mAuthRequestHandlerSemaphore.acquire();
+    mAuthRequestHandlerSemaphore.release();
     afterAuthRequestHandled( reply );
   }
 }
@@ -587,6 +577,7 @@ void QgsNetworkAccessManager::handleAuthRequest( QNetworkReply *reply, QAuthenti
   emit requestAuthDetailsAdded( getRequestId( reply ), auth->realm(), auth->user(), auth->password() );
 
   afterAuthRequestHandled( reply );
+  qobject_cast<QgsNetworkAccessManager *>( reply->manager() )->mAuthRequestHandlerSemaphore.release();
 }
 
 QString QgsNetworkAccessManager::cacheLoadControlName( QNetworkRequest::CacheLoadControl control )

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -824,7 +824,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     // auth request handler, will be set for main thread ONLY
     std::unique_ptr< QgsNetworkAuthenticationHandler > mAuthHandler;
-    // Used by worker threads to wait for authentification handler run in main thread
+    // Used by worker threads to wait for authentication handler run in main thread
     QSemaphore mAuthRequestHandlerSemaphore;
 };
 

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -29,6 +29,7 @@
 #include <QNetworkRequest>
 #include <QMutex>
 #include <QWaitCondition>
+#include <QSemaphore>
 #include <memory>
 
 #include "qgis_core.h"
@@ -800,7 +801,6 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void afterSslErrorHandled( QNetworkReply *reply );
 #endif
 
-    void unlockAfterAuthRequestHandled();
     void afterAuthRequestHandled( QNetworkReply *reply );
 
     void pauseTimeout( QNetworkReply *reply );
@@ -824,10 +824,8 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     // auth request handler, will be set for main thread ONLY
     std::unique_ptr< QgsNetworkAuthenticationHandler > mAuthHandler;
-    // only in use by worker threads, unused in main thread
-    QMutex mAuthRequestHandlerMutex;
-    // only in use by worker threads, unused in main thread
-    QWaitCondition mAuthRequestWaitCondition;
+    // Used by worker threads to wait for authentification handler run in main thread
+    QSemaphore mAuthRequestHandlerSemaphore;
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H


### PR DESCRIPTION
This PR fixes QgsBlockingNetworkRequest race condition issues (supersedes  #44992)

Main issue with actual code is that when *mAuthRequestWaitCondition.wakeOne()* was called in *unlockAfterAuthRequestHandled()* from main thread, you had no garantee that you already reach *mAuthRequestWaitCondition.wait( &mAuthRequestHandlerMutex )* in *onAuthRequired()* from worker. And so, worker will wait forever. 

The fix use a semaphore to be sure it works in both situation (main thread has handled authentication before the waiting of worker or vice versa).

I've made some bench tests with random generated sleep and the PR works all the time while the actual code fails quite often. Though, I propose to not backport to 3.22 for now (and never in 3.16), I will backport in 2/3 weeks if nobody complains.

I've restored the test_core_networkmanager test to detect a potential flaw in my solution.

This fix should also fix the CI issue on *PyQgsExternalStorageWebDAV* that was randomly failing sometimes.
