### PR TITLE
Adding a new point: linear interpolation for Z coordinate

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2118,7 +2118,21 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
 
     QgsPoint pt( layerPoint );
     if ( QgsWkbTypes::hasZ( dragLayer->wkbType() ) && !pt.is3D() )
-      pt.addZValue( defaultZValue() );
+    {
+      if ( addingAtEndpoint )
+      {
+        pt.addZValue( geom.vertexAt( dragVertexId ).z() );
+      }
+      else
+      {
+        const QgsPoint pointPrev = geom.vertexAt( dragVertexId - 1 );
+        const QgsPoint pointNext = geom.vertexAt( dragVertexId );
+        const double distPrev = QgsPointXY( pointPrev ).distance( QgsPointXY( pt ) );
+        const double distNext = QgsPointXY( pointNext ).distance( QgsPointXY( pt ) );
+        const double d = distPrev + distNext;
+        pt.addZValue( ( pointPrev.z() * distNext + pointNext.z() * distPrev ) / d );
+      }
+    }
 
     if ( !geomTmp->insertVertex( vid, pt ) )
     {

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -66,7 +66,9 @@ class TestQgsVertexTool : public QObject
     void testMoveVertex();
     void testMoveEdge();
     void testAddVertex();
+    void testAddVertexZ();
     void testAddVertexAtEndpoint();
+    void testAddVertexAtEndpointZ();
     void testAddVertexDoubleClick();
     void testAddVertexDoubleClickWithShift();
     void testDeleteVertex();
@@ -392,6 +394,10 @@ void TestQgsVertexTool::testTopologicalEditingMoveVertexOnSegmentZ()
   mLayerLineZ->undoStack()->undo();
   cfg.setEnabled( false );
   mCanvas->snappingUtils()->setConfig( cfg );
+
+  mLayerLineZ->undoStack()->undo();
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 7 7 10)" ) );
 }
 
 void TestQgsVertexTool::testMoveVertex()
@@ -537,6 +543,23 @@ void TestQgsVertexTool::testAddVertex()
   QCOMPARE( mLayerPoint->undoStack()->index(), 1 );
 }
 
+void TestQgsVertexTool::testAddVertexZ()
+{
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 7 7 10)" ) );
+
+  mouseClick( 6, 7, Qt::LeftButton );
+  mouseClick( 6, 8, Qt::LeftButton );
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 6 8 7.5, 7 7 10)" ) );
+
+  mLayerLineZ->undoStack()->undo();
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 7 7 10)" ) );
+}
+
 void TestQgsVertexTool::testAddVertexAtEndpoint()
 {
   // offset of the endpoint marker - currently set as 15px away from the last vertex in direction of the line
@@ -591,6 +614,37 @@ void TestQgsVertexTool::testAddVertexAtEndpoint()
 
   QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ) );
 
+}
+
+void TestQgsVertexTool::testAddVertexAtEndpointZ()
+{
+  // offset of the endpoint marker - currently set as 15px away from the last vertex in direction of the line
+  double offsetInMapUnits = 15 * mCanvas->mapSettings().mapUnitsPerPixel();
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 7 7 10)" ) );
+
+  mouseMove( 5, 7 ); // first we need to move to the vertex
+  mouseClick( 5 - offsetInMapUnits, 7, Qt::LeftButton );
+  mouseClick( 4, 7, Qt::LeftButton );
+  mouseClick( 4, 7, Qt::RightButton ); // we need a right click to stop adding new nodes
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (4 7 5, 5 7 5, 7 7 10)" ) );
+
+  mouseMove( 7, 7 ); // first we need to move to the vertex
+  mouseClick( 7 + offsetInMapUnits, 7, Qt::LeftButton );
+  mouseClick( 8, 7, Qt::LeftButton );
+  mouseClick( 8, 7, Qt::RightButton ); // we need a right click to stop adding new nodes
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (4 7 5, 5 7 5, 7 7 10, 8 7 10)" ) );
+
+  mLayerLineZ->undoStack()->undo();
+  mLayerLineZ->undoStack()->undo();
+
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF1 ).geometry().asWkt(), QString( "LineStringZ (5 5 1, 6 6 1, 7 5 1)" ) );
+  QCOMPARE( mLayerLineZ->getFeature( mFidLineZF2 ).geometry().asWkt(), QString( "LineStringZ (5 7 5, 7 7 10)" ) );
 }
 
 void TestQgsVertexTool::testAddVertexDoubleClick()


### PR DESCRIPTION
## Description

Use linear interpolation to calculate the Z coordinate for a new point instead of using a constant default value.

I have trouble building the `master` branch on the system I'm currently on (Ubuntu 18.04), so I have tested this change on the 3.16 release.