### PR TITLE
Revert "[polymorphic relation] set the layer of the expression widget"

### DIFF
--- a/src/app/qgsrelationaddpolymorphicdialog.cpp
+++ b/src/app/qgsrelationaddpolymorphicdialog.cpp
@@ -87,7 +87,6 @@ void QgsRelationAddPolymorphicDialog::setPolymorphicRelation( const QgsPolymorph
   mReferencingLayerComboBox->setLayer( polyRel.referencingLayer() );
   mReferencedLayerFieldComboBox->setLayer( polyRel.referencingLayer() );
   mReferencedLayerFieldComboBox->setField( polyRel.referencedLayerField() );
-  mReferencedLayerExpressionWidget->setLayer( polyRel.referencingLayer() );
   mReferencedLayerExpressionWidget->setExpression( polyRel.referencedLayerExpression() );
   mRelationStrengthComboBox->setCurrentIndex( mRelationStrengthComboBox->findData( polyRel.strength() ) );
 
@@ -281,7 +280,6 @@ void QgsRelationAddPolymorphicDialog::updateReferencingFieldsComboBoxes()
 void QgsRelationAddPolymorphicDialog::updateReferencedLayerFieldComboBox()
 {
   mReferencedLayerFieldComboBox->setLayer( mReferencingLayerComboBox->currentLayer() );
-  mReferencedLayerExpressionWidget->setLayer( mReferencingLayerComboBox->currentLayer() );
 }
 
 void QgsRelationAddPolymorphicDialog::referencedLayersChanged()


### PR DESCRIPTION
Reverts qgis/QGIS#45408

For the layer field expression, we are not using the layer field of the referencing layer.
The original PR was not correct.