### PR TITLE
Trace error instead of crash for bad implemented locator filters

### DIFF
--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -186,7 +186,7 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
     std::unique_ptr< QgsLocatorFilter > clone( filter->clone() );
     if ( ! clone )
     {
-      QgsMessageLog::logMessage( QObject::tr( "QgsLocatorFilter '%1' could not provide a valid clone" ).arg( filter->name() ), QString(), Qgis::MessageLevel::Critical );
+      QgsMessageLog::logMessage( tr( "QgsLocatorFilter '%1' could not provide a valid clone" ).arg( filter->name() ), QString(), Qgis::MessageLevel::Critical );
       continue;
     }
     connect( clone.get(), &QgsLocatorFilter::resultFetched, clone.get(), [this, filter]( QgsLocatorResult result )

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgslocator.h"
+#include "qgsmessagelog.h"
 #include "qgssettings.h"
 #include <QtConcurrent>
 #include <functional>
@@ -183,6 +184,11 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
   {
     filter->clearPreviousResults();
     std::unique_ptr< QgsLocatorFilter > clone( filter->clone() );
+    if ( ! clone )
+    {
+      QgsMessageLog::logMessage( QObject::tr( "QgsLocatorFilter '%1' could not provide a valid clone" ).arg( filter->name() ), QString(), Qgis::MessageLevel::Critical );
+      continue;
+    }
     connect( clone.get(), &QgsLocatorFilter::resultFetched, clone.get(), [this, filter]( QgsLocatorResult result )
     {
       result.filter = filter;


### PR DESCRIPTION
Avoid crashes of QGIS if a locator filter plugin does not implement the `clone()` method correctly.