### PR TITLE
don't restrict create grid algorithm output for use as inputs to line and point parameters (fix #45867)

### DIFF
--- a/src/analysis/processing/qgsalgorithmgrid.cpp
+++ b/src/analysis/processing/qgsalgorithmgrid.cpp
@@ -64,7 +64,7 @@ void QgsGridAlgorithm::initAlgorithm( const QVariantMap & )
 
   addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "Grid CRS" ), QStringLiteral( "ProjectCrs" ) ) );
 
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Grid" ), QgsProcessing::TypeVectorPolygon ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Grid" ), QgsProcessing::TypeVectorAnyGeometry ) );
 }
 
 QString QgsGridAlgorithm::shortHelpString() const


### PR DESCRIPTION
## Description

Don't restrict Create Grid algorithm output for use as inputs to line and point parameters. Depending on the grid type output can be point, line or polygon layer.

Fixes #45867.