### PR TITLE
Introduce index example in array and map functions

### DIFF
--- a/resources/function_help/json/array
+++ b/resources/function_help/json/array
@@ -8,6 +8,7 @@
     {"arg":"value1", "syntaxOnly": true},
     {"arg":"value2", "syntaxOnly": true},
     {"arg":"value", "descOnly": true, "description":"a value"}],
-  "examples": [ { "expression":"array(2,10)", "returns":"[ 2, 10 ]"}
+  "examples": [ { "expression":"array(2,10)", "returns":"[ 2, 10 ]"},
+                { "expression":"array(2,10)[0]", "returns":"2"}
   ]
 }

--- a/resources/function_help/json/map
+++ b/resources/function_help/json/map
@@ -11,6 +11,7 @@
     {"arg":"value2", "syntaxOnly": true},
     {"arg":"key", "descOnly": true, "description":"a key (string)"},
     {"arg":"value", "descOnly": true, "description":"a value"}],
-  "examples": [ { "expression":"map('1','one','2', 'two')", "returns":"{ '1': 'one', '2': 'two' }"}
+  "examples": [ { "expression":"map('1','one','2', 'two')", "returns":"{ '1': 'one', '2': 'two' }"},
+                { "expression":"map('1','one','2', 'two')['1']", "returns":"'one'"}
   ]
 }


### PR DESCRIPTION
Well, this is a desperate pull request I'm not really happy with but...
It took me time to realize by pure chance that arrays and maps could be used with the index operator, but that operator is not listed in any of these groups. Ideally I'd list that index operator in these groups or create an index function that uses the op_index but this is a high level change for me so maybe could we just start with showing that example?