### PR TITLE
allow invalid Z value with transform mesh vertex by expression

### DIFF
--- a/src/core/mesh/qgsmeshadvancedediting.cpp
+++ b/src/core/mesh/qgsmeshadvancedediting.cpp
@@ -727,19 +727,16 @@ bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
 
     if ( calcZ )
     {
+      double z = std::numeric_limits<double>::quiet_NaN();
       if ( zvar.isValid() )
       {
-        double z = zvar.toDouble( &ok );
-        if ( ok )
-        {
-          mNewZValues.append( z );
-          mOldZValues.append( vert.z() );
-        }
-        else
-          return false;
+        z = zvar.toDouble( &ok );
+        if ( !ok )
+          z = std::numeric_limits<double>::quiet_NaN();
       }
-      else
-        return false;
+
+      mNewZValues.append( z );
+      mOldZValues.append( vert.z() );
     }
   }
 
@@ -749,7 +746,7 @@ bool QgsMeshTransformVerticesByExpression::calculate( QgsMeshLayer *layer )
   };
 
   mNativeFacesIndexesGeometryChanged = qgis::setToList( concernedFaces );
-  return layer->meshEditor()->canBeTransformed( mNativeFacesIndexesGeometryChanged, transformFunction );
+  return ( !calcX && !calcY ) || layer->meshEditor()->canBeTransformed( mNativeFacesIndexesGeometryChanged, transformFunction );
 }
 
 QString QgsMeshTransformVerticesByExpression::text() const


### PR DESCRIPTION
With transform mesh vertex by expression, the result is checked before applying the transform to avoid error in topology after transformation. If there is some invalid value returned by the expression, the checked fails even for Z value. 

This PR allows invalid Z value in the transform operation for the following reasons:
- sometime Z value can be invalid (for example, draping in raster layer with no data) 
- changing Z value can't lead to topological error
- mesh layer support NaN value for Z

Note: sometime, `raster_value` function return NaN on valid pixel, I try to find why, but that does not happen when debugging...
