### PR TITLE
[spatialite] Fix broken extent filter feature request against a spatialite

### DIFF
--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -455,7 +455,7 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
       mbrFilter += QStringLiteral( "ymax >= %1" ).arg( qgsDoubleToString( mFilterRect.yMinimum() ) );
       QString idxName = QStringLiteral( "idx_%1_%2" ).arg( mSource->mIndexTable, mSource->mIndexGeometry );
       whereClause += QStringLiteral( "%1 IN (SELECT pkid FROM %2 WHERE %3)" )
-                     .arg( QStringLiteral( "ROWID" ),
+                     .arg( mSource->mViewBased ? quotedPrimaryKey() : QStringLiteral( "ROWID" ),
                            QgsSqliteUtils::quotedIdentifier( idxName ),
                            mbrFilter );
     }
@@ -464,7 +464,7 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
       // using the MbrCache spatial index
       QString idxName = QStringLiteral( "cache_%1_%2" ).arg( mSource->mIndexTable, mSource->mIndexGeometry );
       whereClause += QStringLiteral( "%1 IN (SELECT rowid FROM %2 WHERE mbr = FilterMbrIntersects(%3))" )
-                     .arg( QStringLiteral( "ROWID" ),
+                     .arg( mSource->mViewBased ? quotedPrimaryKey() : QStringLiteral( "ROWID" ),
                            QgsSqliteUtils::quotedIdentifier( idxName ),
                            mbr( mFilterRect ) );
     }

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1634,6 +1634,20 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(vl.dataProvider().defaultValueClause(0), '')
         self.assertEqual(vl.dataProvider().defaultValue(0), 1)
 
+    def testViewsExtentFilter(self):
+        """Test extent filtering of a views-based spatialite layer"""
+
+        vl = QgsVectorLayer("dbname='%s' table=\"vs_controle_ok_nok\" (geom)" %
+                            os.path.join(TEST_DATA_DIR, "views_test.sqlite"), "vs_controle_ok_nok", "spatialite")
+        self.assertTrue(vl.isValid())
+
+        feature = QgsFeature()
+        rect = QgsRectangle(822733, 6699265, 829351, 6707266)
+        it = vl.getFeatures(rect)
+        it.nextFeature(feature)
+
+        self.assertTrue(feature.isValid())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

This PR partially reverts https://github.com/qgis/QGIS/commit/c478ba9c0f128827ecf34d5f54b77cff2fd37feb , which regressed extent filtering (e.g. drawing on the map canvas :fearful:)  for e of spatialite view-based tables.

@troopa81 , ~~I think your fix (if still needed) will have to be re-written to avoid this regression.~~ FYI, this tweaks your fix to avoid views breakage.