### PR TITLE
Revert "[ui] Properly fix UI state restoration on QGIS launch"

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -148,8 +148,6 @@
 #include "qgsopenclutils.h"
 #endif
 
-#include "ui_defaults.h"
-
 #include <QNetworkReply>
 #include <QNetworkProxy>
 #include <QAuthenticator>
@@ -2215,45 +2213,9 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
   onActiveLayerChanged( activeLayer() );
 }
 
-void QgisApp::resizeEvent( QResizeEvent *resizeEvent )
-{
-  QMainWindow::resizeEvent( resizeEvent );
-  if ( mRestoreStateOnResize )
-  {
-    QgsSettings settings;
-    restoreState( settings.value( QStringLiteral( "UI/state" ), QByteArray::fromRawData( reinterpret_cast< const char * >( defaultUIstate ), sizeof defaultUIstate ) ).toByteArray() );
-  }
-}
-
 bool QgisApp::event( QEvent *event )
 {
   bool done = false;
-
-  if ( mRestoreStateOnResize )
-  {
-    switch ( event->type() )
-    {
-      case QEvent::Enter:
-      case QEvent::DragEnter:
-      case QEvent::DragLeave:
-      case QEvent::DragMove:
-      case QEvent::Drop:
-      case QEvent::KeyPress:
-      case QEvent::KeyRelease:
-      case QEvent::MouseButtonDblClick:
-      case QEvent::MouseButtonPress:
-      case QEvent::MouseButtonRelease:
-      case QEvent::MouseMove:
-      case QEvent::NativeGesture:
-        // The user did something, end state restores
-        mRestoreStateOnResize = false;
-        break;
-
-      default:
-        break;
-    }
-  }
-
   if ( event->type() == QEvent::FileOpen )
   {
     // handle FileOpen event (double clicking a file icon in Mac OS X Finder)
@@ -5376,14 +5338,21 @@ void QgisApp::saveWindowState()
   QgsPluginRegistry::instance()->unloadAll();
 }
 
+#include "ui_defaults.h"
+
 void QgisApp::restoreWindowState()
 {
   // restore the toolbar and dock widgets positions using Qt4 settings API
   QgsSettings settings;
+#if 0
+  // because of Qt regression: https://bugreports.qt.io/browse/QTBUG-89034
+  // we have to wait till dialog is first shown to try to restore dock geometry or it's not correctly restored
+  // so this code was moved to showEvent for now...
   if ( !restoreState( settings.value( QStringLiteral( "UI/state" ), QByteArray::fromRawData( reinterpret_cast< const char * >( defaultUIstate ), sizeof defaultUIstate ) ).toByteArray() ) )
   {
     QgsDebugMsg( QStringLiteral( "restore of UI state failed" ) );
   }
+#endif
 
   if ( settings.value( QStringLiteral( "UI/hidebrowser" ), false ).toBool() )
   {
@@ -5402,8 +5371,6 @@ void QgisApp::restoreWindowState()
     move( pos.width(), pos.height() );
   }
 
-  // restore state on resize need to work around Qt regression: https://bugreports.qt.io/browse/QTBUG-89034
-  mRestoreStateOnResize = true;
 }
 ///////////// END OF GUI SETUP ROUTINES ///////////////
 void QgisApp::sponsors()
@@ -17621,4 +17588,20 @@ QgsAttributeEditorContext QgisApp::createAttributeEditorContext()
   context.setCadDockWidget( cadDockWidget() );
   context.setMainMessageBar( messageBar() );
   return context;
+}
+
+void QgisApp::showEvent( QShowEvent *event )
+{
+  QMainWindow::showEvent( event );
+  // because of Qt regression: https://bugreports.qt.io/browse/QTBUG-89034
+  // we have to wait till dialog is first shown to try to restore dock geometry or it's not correctly restored
+  static std::once_flag firstShow;
+  std::call_once( firstShow, [this]
+  {
+    QgsSettings settings;
+    if ( !restoreState( settings.value( QStringLiteral( "UI/state" ), QByteArray::fromRawData( reinterpret_cast< const char * >( defaultUIstate ), sizeof defaultUIstate ) ).toByteArray() ) )
+    {
+      QgsDebugMsg( QStringLiteral( "restore of UI state failed" ) );
+    }
+  } );
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1070,7 +1070,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     */
     void legendLayerStretchUsingCurrentExtent();
 
-    //! Watches for QFileOpenEvent.
+    //! Watch for QFileOpenEvent.
     bool event( QEvent *event ) override;
 
     //! Sets the CRS of the current legend group
@@ -1276,9 +1276,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsAttributeEditorContext createAttributeEditorContext();
 
   protected:
-
-    //! Listens to resize event in order to properly restore UI upon re-launching QGIS
-    void resizeEvent( QResizeEvent *resizeEvent ) override;
+    void showEvent( QShowEvent *event ) override;
 
     //! Handle state changes (WindowTitleChange)
     void changeEvent( QEvent *event ) override;
@@ -2733,8 +2731,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     };
     int mFreezeCount = 0;
     friend class QgsCanvasRefreshBlocker;
-
-    bool mRestoreStateOnResize = false;
 
     friend class TestQgisAppPython;
     friend class QgisAppInterface;


### PR DESCRIPTION
This reverts commit 4758844ed1e7ee74a9467fcc7bf1c7bb65aa19ab , which has been found to have bad side effects on linux (described in details here https://github.com/qgis/QGIS/pull/45466).

Reverting the commit means QGIS won't restore docked panel's height properly, but that's likely much better than QGIS creating ghost windows that won't close.

