### PR TITLE
[ui] Adopt ogr remote layer addition's loading message bar in gdal too (avoid long unexplained UI freezes)

### DIFF
--- a/src/gui/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/gui/providers/gdal/qgsgdalsourceselect.cpp
@@ -55,7 +55,6 @@ QgsGdalSourceSelect::QgsGdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
     if ( radioSrcProtocol->isChecked() )
     {
       emit enableButtons( !text.isEmpty() );
-      fillOpenOptions();
     }
   } );
   connect( mBucket, &QLineEdit::textChanged, this, [ = ]( const QString & text )


### PR DESCRIPTION
## Description

This PR implements for gdal remote raster sources  a nice UI fix @elpaso (am I correct?) added a while back when adding remote ogr layers. Screenshot first:
![image](https://user-images.githubusercontent.com/1728657/140714189-1a1be344-95d0-406f-9198-15636b625f65.png)

Instead of having the QGIS UI freezes without any visual queue of what's happening (i.e., broken UX), we throw a message bar at users to let them know a remote layer is being added.

A second small commit tweaks the gdal source select code to prevent 10sec UI freeze at every keystroke when entering a protocol remote URI.