### PR TITLE
[themes] Fix nested floating dock background rendering and resizing area

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -4,10 +4,14 @@ QWidget
     background: transparent;
 }
 
-QWindow, QMainWindow, QMdiSubWindow, QDialog, QAbstractScrollArea, QFocusFrame, QWizardPage, QDockWidget, QTabWidget, QGroupBox
+QWindow, QMainWindow, QMdiSubWindow, QDialog, QAbstractScrollArea, QFocusFrame, QWizardPage, QDockWidget, QDockWidgetGroupWindow, QTabWidget, QGroupBox
 {
     color: @text;
     background-color: @background;
+}
+
+QDockWidget, QDockWidgetGroupWindow {
+  padding: 0.2em;
 }
 
 QWidget:item:hover

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -4,10 +4,14 @@ QWidget
     background: transparent;
 }
 
-QWindow, QMainWindow, QMdiSubWindow, QDialog, QAbstractScrollArea, QFocusFrame, QWizardPage, QDockWidget, QTabWidget, QGroupBox
+QWindow, QMainWindow, QMdiSubWindow, QDialog, QAbstractScrollArea, QFocusFrame, QWizardPage, QDockWidget, QDockWidgetGroupWindow, QTabWidget, QGroupBox
 {
     color: @text;
     background-color: @background;
+}
+
+QDockWidget, QDockWidgetGroupWindow {
+  padding: 0.2em;
 }
 
 QWidget:item:hover


### PR DESCRIPTION
## Description

This PR fixes nested floating dock widgets missing a background color definition, leading to:
![image](https://user-images.githubusercontent.com/1728657/140865147-6f200240-2238-4b5d-b8d4-e188039522e9.png)

Not great. 

This PR also provides some padding for floating dock widgets, fixing resizing of floating dock widgets (nested or otherwise).