### PR TITLE
improve filtering of layers in DB dialogs

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdbtablemodel.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdbtablemodel.sip.in
@@ -33,7 +33,7 @@ Returns the list of columns in the table
 
     virtual int defaultSearchColumn() const = 0;
 %Docstring
-Returns the index of the column used by default to filter the results (probaly the table name column if it exists)
+Returns the index of the column used by default to filter the results (probably the table name column if it exists)
 %End
 
     virtual bool searchableColumn( int column ) const;

--- a/python/core/auto_generated/providers/qgsabstractdbtablemodel.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdbtablemodel.sip.in
@@ -1,0 +1,51 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/providers/qgsabstractdbtablemodel.h                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsAbstractDbTableModel : QStandardItemModel
+{
+%Docstring(signature="appended")
+The :py:class:`QgsAbstractDbTableModel` class is a pure virtual model class for results in a database source widget selector
+
+.. versionadded:: 3.24
+%End
+
+%TypeHeaderCode
+#include "qgsabstractdbtablemodel.h"
+%End
+  public:
+    explicit QgsAbstractDbTableModel( QObject *parent = 0 );
+%Docstring
+Constructor
+%End
+
+    virtual QStringList columns() const = 0;
+%Docstring
+Returns the list of columns in the table
+%End
+
+    virtual int defaultSearchColumn() const = 0;
+%Docstring
+Returns the index of the column used by default to filter the results (probaly the table name column if it exists)
+%End
+
+    virtual bool searchableColumn( int column ) const;
+%Docstring
+Returns if the column should be searchable at the given index
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/providers/qgsabstractdbtablemodel.h                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
+++ b/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
@@ -42,6 +42,7 @@ Calls QSortFilterProxyModel.setFilterRegExp and triggers update
   protected:
     virtual bool filterAcceptsRow( int row, const QModelIndex &source_parent ) const;
 
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
+++ b/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
@@ -10,23 +10,22 @@
 
 
 
-class QgsDatabaseFilterProxyModel: QSortFilterProxyModel
-{
-%Docstring(signature="appended")
+class QgsDatabaseFilterProxyModel /Deprecated/ : public QSortFilterProxyModel
+%Docstring
 A class that implements a custom filter and can be used
 as a proxy for :py:class:`QgsDbTableModel`
 
+.. deprecated:: QGIS 3.24
+
 .. versionadded:: 3.0
 %End
+{
 
-%TypeHeaderCode
-#include "qgsdbfilterproxymodel.h"
-%End
   public:
 
     QgsDatabaseFilterProxyModel( QObject *parent /TransferThis/ = 0 );
 %Docstring
-Constructor for QgsDatabaseFilterProxyModel.
+Constructor for :py:class:`QgsDatabaseFilterProxyModel`.
 %End
 
     void _setFilterWildcard( const QString &pattern );
@@ -41,7 +40,6 @@ Calls QSortFilterProxyModel.setFilterRegExp and triggers update
 
   protected:
     virtual bool filterAcceptsRow( int row, const QModelIndex &source_parent ) const;
-
 
 };
 

--- a/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
+++ b/python/core/auto_generated/qgsdbfilterproxymodel.sip.in
@@ -10,8 +10,9 @@
 
 
 
-class QgsDatabaseFilterProxyModel /Deprecated/ : public QSortFilterProxyModel
-%Docstring
+class QgsDatabaseFilterProxyModel : QSortFilterProxyModel /Deprecated/
+{
+%Docstring(signature="appended")
 A class that implements a custom filter and can be used
 as a proxy for :py:class:`QgsDbTableModel`
 
@@ -19,13 +20,15 @@ as a proxy for :py:class:`QgsDbTableModel`
 
 .. versionadded:: 3.0
 %End
-{
 
+%TypeHeaderCode
+#include "qgsdbfilterproxymodel.h"
+%End
   public:
 
     QgsDatabaseFilterProxyModel( QObject *parent /TransferThis/ = 0 );
 %Docstring
-Constructor for :py:class:`QgsDatabaseFilterProxyModel`.
+Constructor for QgsDatabaseFilterProxyModel.
 %End
 
     void _setFilterWildcard( const QString &pattern );

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -528,6 +528,7 @@
 %Include auto_generated/project/qgsprojectutils.sip
 %Include auto_generated/project/qgsprojectversion.sip
 %Include auto_generated/project/qgsprojectviewsettings.sip
+%Include auto_generated/providers/qgsabstractdbtablemodel.sip
 %Include auto_generated/providers/qgsabstractdatabaseproviderconnection.sip
 %Include auto_generated/providers/qgsabstractproviderconnection.sip
 %Include auto_generated/providers/qgsdataprovider.sip

--- a/python/gui/auto_generated/providers/qgsdbsourceselectbase.sip.in
+++ b/python/gui/auto_generated/providers/qgsdbsourceselectbase.sip.in
@@ -1,0 +1,49 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/qgsdbsourceselectbase.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsDbSourceSelectBase : QgsAbstractDataSourceWidget, protected Ui::QgsDbSourceSelectBase
+{
+%Docstring(signature="appended")
+The :py:class:`QgsDbSourceSelectBase` class is a base class for database source widget selector
+
+.. versionadded:: 3.24
+%End
+
+%TypeHeaderCode
+#include "qgsdbsourceselectbase.h"
+%End
+  public:
+    QgsDbSourceSelectBase( QWidget *parent = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
+%Docstring
+Constructor
+%End
+
+  protected:
+    void setSourceModel( QgsAbstractDbTableModel *model );
+%Docstring
+Sets the source model for the widget
+%End
+
+    QgsDatabaseFilterProxyModel *proxyModel();
+%Docstring
+Returns the proxy model used to filter the results
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/providers/qgsdbsourceselectbase.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/providers/qgsdbsourceselectbase.sip.in
+++ b/python/gui/auto_generated/providers/qgsdbsourceselectbase.sip.in
@@ -33,7 +33,7 @@ Constructor
 Sets the source model for the widget
 %End
 
-    QgsDatabaseFilterProxyModel *proxyModel();
+    QSortFilterProxyModel *proxyModel();
 %Docstring
 Returns the proxy model used to filter the results
 %End

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -378,6 +378,7 @@
 %Include auto_generated/processing/models/qgsmodelgraphicitem.sip
 %Include auto_generated/processing/models/qgsmodelgraphicsscene.sip
 %Include auto_generated/processing/models/qgsmodelgraphicsview.sip
+%Include auto_generated/providers/qgsdbsourceselectbase.sip
 %Include auto_generated/raster/qgscolorrampshaderwidget.sip
 %Include auto_generated/raster/qgshillshaderendererwidget.sip
 %Include auto_generated/raster/qgsmultibandcolorrendererwidget.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1563,6 +1563,7 @@ set(QGIS_CORE_HDRS
   project/qgsprojectversion.h
   project/qgsprojectviewsettings.h
 
+  providers/qgsabstractdbtablemodel.h
   providers/qgsabstractdatabaseproviderconnection.h
   providers/qgsabstractproviderconnection.h
   providers/qgsdataprovider.h

--- a/src/core/providers/qgsabstractdbtablemodel.h
+++ b/src/core/providers/qgsabstractdbtablemodel.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+   qgsabstractdbtablemodel.h
+    --------------------------------------
+   Date                 : 08.11.2021
+   Copyright            : (C) 2021 Denis Rouzaud
+   Email                : denis@opengis.ch
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSABSTRACTDBTABLEMODEL_H
+#define QGSABSTRACTDBTABLEMODEL_H
+
+#include "qgis_core.h"
+
+#include <QStandardItemModel>
+
+/**
+ * \ingroup gui
+ * \brief The QgsAbstractDbTableModel class is a pure virtual model class for results in a database source widget selector
+ * \since QGIS 3.24
+ */
+class CORE_EXPORT QgsAbstractDbTableModel : public QStandardItemModel
+{
+    Q_OBJECT
+  public:
+    //! Constructor
+    explicit QgsAbstractDbTableModel( QObject *parent = nullptr )
+      : QStandardItemModel( parent )
+    {}
+
+    //! Returns the list of columns in the table
+    virtual QStringList columns() const = 0;
+
+    //! Returns the index of the column used by default to filter the results (probaly the table name column if it exists)
+    virtual int defaultSearchColumn() const = 0;
+
+    //! Returns if the column should be searchable at the given index
+    virtual bool searchableColumn( int column ) const {Q_UNUSED( column ) return true;}
+};
+
+#endif // QGSABSTRACTDBTABLEMODEL_H

--- a/src/core/providers/qgsabstractdbtablemodel.h
+++ b/src/core/providers/qgsabstractdbtablemodel.h
@@ -37,7 +37,7 @@ class CORE_EXPORT QgsAbstractDbTableModel : public QStandardItemModel
     //! Returns the list of columns in the table
     virtual QStringList columns() const = 0;
 
-    //! Returns the index of the column used by default to filter the results (probaly the table name column if it exists)
+    //! Returns the index of the column used by default to filter the results (probably the table name column if it exists)
     virtual int defaultSearchColumn() const = 0;
 
     //! Returns if the column should be searchable at the given index

--- a/src/core/qgsdbfilterproxymodel.cpp
+++ b/src/core/qgsdbfilterproxymodel.cpp
@@ -17,67 +17,23 @@
 
 #include "qgsdbfilterproxymodel.h"
 
-#include <QStandardItemModel>
-
 QgsDatabaseFilterProxyModel::QgsDatabaseFilterProxyModel( QObject *parent ): QSortFilterProxyModel( parent )
 {
 
 }
 
-bool QgsDatabaseFilterProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
+bool QgsDatabaseFilterProxyModel::filterAcceptsRow( int row, const QModelIndex &source_parent ) const
 {
-  if ( filterAcceptsRowItself( source_row, source_parent ) )
-    return true;
-
-//accept if any of the parents is accepted on it's own merits
-  QModelIndex parent = source_parent;
-  while ( parent.isValid() )
-  {
-    if ( filterAcceptsRowItself( parent.row(), parent.parent() ) )
-      return true;
-    parent = parent.parent();
-  }
-
-  //accept if any of the children is accepted on it's own merits
-  if ( hasAcceptedChildren( source_row, source_parent ) )
+  //if parent is valid, we have a toplevel item that should be always shown
+  if ( !source_parent.isValid() )
   {
     return true;
   }
 
-  return false;
+  //else we have a row that describes a table and that
+  //should be tested using the given wildcard/regexp
+  return QSortFilterProxyModel::filterAcceptsRow( row, source_parent );
 }
-
-bool QgsDatabaseFilterProxyModel::filterAcceptsRowItself( int source_row, const QModelIndex &source_parent ) const
-{
-  return QSortFilterProxyModel::filterAcceptsRow( source_row, source_parent );
-}
-
-bool QgsDatabaseFilterProxyModel::hasAcceptedChildren( int source_row, const QModelIndex &source_parent ) const
-{
-  QModelIndex item = sourceModel()->index( source_row, 0, source_parent );
-  if ( !item.isValid() )
-  {
-    return false;
-  }
-
-//check if there are children
-  int childCount = item.model()->rowCount( item );
-  if ( childCount == 0 )
-    return false;
-
-  for ( int i = 0; i < childCount; ++i )
-  {
-    if ( filterAcceptsRowItself( i, item ) )
-      return true;
-    if ( hasAcceptedChildren( i, item ) )
-      return true;
-  }
-
-  return false;
-}
-
-
-
 
 void QgsDatabaseFilterProxyModel::_setFilterWildcard( const QString &pattern )
 {

--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -31,7 +31,7 @@
  * \deprecated since QGIS 3.24
  * \since QGIS 3.0 QSortFilterProxyModel with native recursive filtering can be used instead
 */
-class CORE_EXPORT Q_DECL_DEPRECATED QgsDatabaseFilterProxyModel SIP_DEPRECATED : public QSortFilterProxyModel
+class CORE_EXPORT Q_DECL_DEPRECATED QgsDatabaseFilterProxyModel : public QSortFilterProxyModel SIP_DEPRECATED
 {
     Q_OBJECT
 

--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -49,6 +49,10 @@ class CORE_EXPORT QgsDatabaseFilterProxyModel: public QSortFilterProxyModel
 
   protected:
     bool filterAcceptsRow( int row, const QModelIndex &source_parent ) const override;
+
+  private:
+    bool filterAcceptsRowItself( int source_row, const QModelIndex &source_parent ) const;
+    bool hasAcceptedChildren( int source_row, const QModelIndex &source_parent ) const;
 };
 
 #endif

--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -28,9 +28,10 @@
  * \ingroup core
  * \brief A class that implements a custom filter and can be used
  * as a proxy for QgsDbTableModel
- * \since QGIS 3.0
+ * \deprecated since QGIS 3.24
+ * \since QGIS 3.0 QSortFilterProxyModel with native recursive filtering can be used instead
 */
-class CORE_EXPORT QgsDatabaseFilterProxyModel: public QSortFilterProxyModel
+class CORE_EXPORT Q_DECL_DEPRECATED QgsDatabaseFilterProxyModel SIP_DEPRECATED : public QSortFilterProxyModel
 {
     Q_OBJECT
 
@@ -49,10 +50,6 @@ class CORE_EXPORT QgsDatabaseFilterProxyModel: public QSortFilterProxyModel
 
   protected:
     bool filterAcceptsRow( int row, const QModelIndex &source_parent ) const override;
-
-  private:
-    bool filterAcceptsRowItself( int source_row, const QModelIndex &source_parent ) const;
-    bool hasAcceptedChildren( int source_row, const QModelIndex &source_parent ) const;
 };
 
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -361,6 +361,7 @@ set(QGIS_GUI_SRCS
   processing/models/qgsmodelviewtooltemporarymousepan.cpp
   processing/models/qgsmodelviewtoolzoom.cpp
 
+  providers/qgsdbsourceselectbase.cpp
   providers/qgspointcloudproviderguimetadata.cpp
   providers/qgspointcloudsourceselect.cpp
 
@@ -1180,6 +1181,7 @@ set(QGIS_GUI_HDRS
   processing/models/qgsmodelviewtooltemporarymousepan.h
   processing/models/qgsmodelviewtoolzoom.h
 
+  providers/qgsdbsourceselectbase.h
   providers/qgspointcloudsourceselect.h
   providers/qgspointcloudproviderguimetadata.h
 

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -43,10 +43,6 @@ QgsOgrDbSourceSelect::QgsOgrDbSourceSelect( const QString &theSettingsKey, const
   connect( btnConnect, &QPushButton::clicked, this, &QgsOgrDbSourceSelect::btnConnect_clicked );
   connect( btnNew, &QPushButton::clicked, this, &QgsOgrDbSourceSelect::btnNew_clicked );
   connect( btnDelete, &QPushButton::clicked, this, &QgsOgrDbSourceSelect::btnDelete_clicked );
-  connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsOgrDbSourceSelect::mSearchGroupBox_toggled );
-  connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsOgrDbSourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsOgrDbSourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsOgrDbSourceSelect::mSearchModeComboBox_currentIndexChanged );
   connect( cbxAllowGeometrylessTables, &QCheckBox::stateChanged, this, &QgsOgrDbSourceSelect::cbxAllowGeometrylessTables_stateChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsOgrDbSourceSelect::cmbConnections_activated );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsOgrDbSourceSelect::mTablesTreeView_clicked );
@@ -75,15 +71,6 @@ QgsOgrDbSourceSelect::QgsOgrDbSourceSelect( const QString &theSettingsKey, const
 
   populateConnectionList();
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
-
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
-
   mProxyModel.setParent( this );
   mProxyModel.setFilterKeyColumn( -1 );
   mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
@@ -93,20 +80,6 @@ QgsOgrDbSourceSelect::QgsOgrDbSourceSelect( const QString &theSettingsKey, const
   mTablesTreeView->setSortingEnabled( true );
 
   connect( mTablesTreeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsOgrDbSourceSelect::treeWidgetSelectionChanged );
-
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 1 );
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 
   cbxAllowGeometrylessTables->setDisabled( true );
 }
@@ -143,56 +116,6 @@ void QgsOgrDbSourceSelect::mTablesTreeView_clicked( const QModelIndex &index )
 void QgsOgrDbSourceSelect::mTablesTreeView_doubleClicked( const QModelIndex &index )
 {
   setSql( index );
-}
-
-void QgsOgrDbSourceSelect::mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsOgrDbSourceSelect::mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsOgrDbSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 0 );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 1 );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 2 );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 3 );
-  }
-}
-
-void QgsOgrDbSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  mSearchTableEdit_textChanged( mSearchTableEdit->text() );
 }
 
 void QgsOgrDbSourceSelect::populateConnectionList()

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.h
@@ -18,13 +18,14 @@
 #ifndef QGSGOGRDBSOURCESELECT_H
 #define QGSGOGRDBSOURCESELECT_H
 
-#include "ui_qgsdbsourceselectbase.h"
 #include "qgsguiutils.h"
-#include "qgsdbfilterproxymodel.h"
 #include "qgshelp.h"
-#include "qgsabstractdatasourcewidget.h"
-#include "qgsogrdbtablemodel.h"
+#include "qgsdbsourceselectbase.h"
+#include "qgsproviderregistry.h"
 #include "qgis_sip.h"
+
+class QPushButton;
+class QgsOgrDbTableModel;
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
@@ -34,7 +35,7 @@
  * source selects.
  *
  */
-class QgsOgrDbSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsOgrDbSourceSelect: public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -100,8 +101,7 @@ class QgsOgrDbSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsD
   private:
     void setConnectionListPosition();
     //! Model that acts as datasource for mTableTreeWidget
-    QgsOgrDbTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsOgrDbTableModel *mTableModel = nullptr;
     QPushButton *mBuildQueryButton = nullptr;
     QString mPath;
     QString mOgrDriverName;

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.h
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.h
@@ -86,10 +86,6 @@ class QgsOgrDbSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsD
     void btnNew_clicked();
     //! Deletes the selected connection
     void btnDelete_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
     void cbxAllowGeometrylessTables_stateChanged( int );
     void setSql( const QModelIndex &index );
     void cmbConnections_activated( int );

--- a/src/gui/providers/ogr/qgsogrdbtablemodel.cpp
+++ b/src/gui/providers/ogr/qgsogrdbtablemodel.cpp
@@ -26,7 +26,7 @@ QgsOgrDbTableModel::QgsOgrDbTableModel( QObject *parent )
   mColumns << tr( "Table" )
            << tr( "Type" )
            << tr( "Geometry column" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( columns() );
 }
 

--- a/src/gui/providers/ogr/qgsogrdbtablemodel.cpp
+++ b/src/gui/providers/ogr/qgsogrdbtablemodel.cpp
@@ -20,14 +20,30 @@
 
 #include <QIcon>
 
-QgsOgrDbTableModel::QgsOgrDbTableModel()
+QgsOgrDbTableModel::QgsOgrDbTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "Geometry column" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Table" )
+           << tr( "Type" )
+           << tr( "Geometry column" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( columns() );
+}
+
+QStringList QgsOgrDbTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsOgrDbTableModel::defaultSearchColumn() const
+{
+  return 0;
+}
+
+bool QgsOgrDbTableModel::searchableColumn( int column ) const
+{
+  Q_UNUSED( column )
+  return true;
 }
 
 void QgsOgrDbTableModel::addTableEntry( const Qgis::BrowserLayerType &layerType, const QString &tableName, const QString &uri, const QString &geometryColName, const QString &geometryType, const QString &sql )

--- a/src/gui/providers/ogr/qgsogrdbtablemodel.h
+++ b/src/gui/providers/ogr/qgsogrdbtablemodel.h
@@ -18,22 +18,26 @@
 
 #include "qgis.h"
 
-#include <QObject>
-#include <QStandardItemModel>
 #include <type_traits>
 #include "qgslayeritem.h"
 #include "qgis_sip.h"
+#include "qgsabstractdbtablemodel.h"
+
 
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-class QgsOgrDbTableModel : public QStandardItemModel
+class QgsOgrDbTableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
 
   public:
 
-    QgsOgrDbTableModel();
+    QgsOgrDbTableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     //! Sets the geometry type for the table
     void setGeometryTypesForTable( const QString &table, const QString &attribute, const QString &type );
@@ -60,6 +64,7 @@ class QgsOgrDbTableModel : public QStandardItemModel
     //! Number of tables in the model
     int mTableCount = 0;
     QString mPath;
+    QStringList mColumns;
 
     QIcon iconForType( QgsWkbTypes::Type type ) const;
     QString displayStringForType( QgsWkbTypes::Type type ) const;

--- a/src/gui/providers/qgsdbsourceselectbase.cpp
+++ b/src/gui/providers/qgsdbsourceselectbase.cpp
@@ -49,7 +49,7 @@ void QgsDbSourceSelectBase::setSourceModel( QgsAbstractDbTableModel *model )
   mSearchSettingsMenu = new QMenu( this );
   // columns
   QActionGroup *columnActionGroup = new QActionGroup( this );
-  mSearchColumnAllAction = new QAction( tr( "All" ) );
+  mSearchColumnAllAction = new QAction( tr( "All" ), mSearchSettingsMenu );
   mSearchColumnAllAction->setCheckable( true );
   mSearchSettingsMenu->addAction( mSearchColumnAllAction );
   columnActionGroup->addAction( mSearchColumnAllAction );
@@ -59,7 +59,7 @@ void QgsDbSourceSelectBase::setSourceModel( QgsAbstractDbTableModel *model )
   {
     if ( !model->searchableColumn( i ) )
       continue;
-    QAction *action = new QAction( columns.at( i ) );
+    QAction *action = new QAction( columns.at( i ), mSearchSettingsMenu );
     action->setCheckable( true );
     if ( model->defaultSearchColumn() == i )
     {
@@ -74,13 +74,13 @@ void QgsDbSourceSelectBase::setSourceModel( QgsAbstractDbTableModel *model )
   mSearchSettingsMenu->addSeparator();
   QActionGroup *modeActionGroup = new QActionGroup( this );
   // mode: wildcard
-  QAction *wildcardAction = new QAction( tr( "Wildcard" ) );
+  QAction *wildcardAction = new QAction( tr( "Wildcard" ), mSearchSettingsMenu );
   wildcardAction->setCheckable( true );
   wildcardAction->setChecked( true );
   mSearchSettingsMenu->addAction( wildcardAction );
   modeActionGroup->addAction( wildcardAction );
   // mode: regexp
-  mSearchModeRegexAction = new QAction( tr( "Regular expression" ) );
+  mSearchModeRegexAction = new QAction( tr( "Regular expression" ), mSearchSettingsMenu );
   mSearchModeRegexAction->setCheckable( true );
   mSearchModeRegexAction->setChecked( false );
   mSearchSettingsMenu->addAction( mSearchModeRegexAction );

--- a/src/gui/providers/qgsdbsourceselectbase.cpp
+++ b/src/gui/providers/qgsdbsourceselectbase.cpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+   qgsdbsourceselectbase.h
+    --------------------------------------
+   Date                 : 08.11.2021
+   Copyright            : (C) 2021 Denis Rouzaud
+   Email                : denis@opengis.ch
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsabstractdbtablemodel.h"
+#include "qgsdbsourceselectbase.h"
+#include "qgsdbfilterproxymodel.h"
+
+#include <QMenu>
+
+
+QgsDbSourceSelectBase::QgsDbSourceSelectBase( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
+  : QgsAbstractDataSourceWidget( parent, fl, widgetMode )
+{
+  setupUi( this );
+
+  mProxyModel = new QgsDatabaseFilterProxyModel( this );
+  mProxyModel->setParent( this );
+  mProxyModel->setFilterKeyColumn( -1 );
+  mProxyModel->setFilterCaseSensitivity( Qt::CaseInsensitive );
+
+  // Do not do dynamic sorting - otherwise whenever user selects geometry type / srid / pk columns,
+  // that item suddenly jumps to the end of the list (because the item gets changed) which is very annoying.
+  // The list gets sorted in finishList() method when the listing of tables and views has finished.
+  mProxyModel->setDynamicSortFilter( false );
+
+}
+
+void QgsDbSourceSelectBase::setSourceModel( QgsAbstractDbTableModel *model )
+{
+  mProxyModel->setSourceModel( model );
+
+  // setting the search coluns in search settings menu using the model header data
+
+  if ( mSearchSettingsMenu )
+    mSearchSettingsMenu->deleteLater();
+  mSearchColumnActions.clear();
+  mSearchSettingsMenu = new QMenu( this );
+  // columns
+  QActionGroup *columnActionGroup = new QActionGroup( this );
+  mSearchColumnAllAction = new QAction( tr( "All" ) );
+  mSearchColumnAllAction->setCheckable( true );
+  mSearchSettingsMenu->addAction( mSearchColumnAllAction );
+  columnActionGroup->addAction( mSearchColumnAllAction );
+  bool hasDefaultSearchColumn = false;
+  const QStringList columns = model->columns();
+  for ( int i = 0; i < columns.count(); i++ )
+  {
+    if ( !model->searchableColumn( i ) )
+      continue;
+    QAction *action = new QAction( columns.at( i ) );
+    action->setCheckable( true );
+    if ( model->defaultSearchColumn() == i )
+    {
+      action->setChecked( true );
+      hasDefaultSearchColumn = true;
+    }
+    mSearchSettingsMenu->addAction( action );
+    columnActionGroup->addAction( action );
+    mSearchColumnActions << action;
+  }
+  mSearchColumnAllAction->setChecked( !hasDefaultSearchColumn );
+  mSearchSettingsMenu->addSeparator();
+  QActionGroup *modeActionGroup = new QActionGroup( this );
+  // mode: wildcard
+  QAction *wildcardAction = new QAction( tr( "Wildcard" ) );
+  wildcardAction->setCheckable( true );
+  wildcardAction->setChecked( true );
+  mSearchSettingsMenu->addAction( wildcardAction );
+  modeActionGroup->addAction( wildcardAction );
+  // mode: regexp
+  mSearchModeRegexAction = new QAction( tr( "Regular expression" ) );
+  mSearchModeRegexAction->setCheckable( true );
+  mSearchModeRegexAction->setChecked( false );
+  mSearchSettingsMenu->addAction( mSearchModeRegexAction );
+  modeActionGroup->addAction( mSearchModeRegexAction );
+
+  mSearchSettingsButton->setMenu( mSearchSettingsMenu );
+
+  connect( mSearchSettingsMenu, &QMenu::triggered, this, [ = ]() {filterResults();} );
+  connect( mSearchTableEdit, &QLineEdit::textChanged, this, [ = ]() {filterResults();} );
+}
+
+
+void QgsDbSourceSelectBase::filterResults()
+{
+  QString searchText = mSearchTableEdit->text();
+  bool regex = mSearchModeRegexAction->isChecked();
+
+  if ( mSearchColumnAllAction->isChecked() )
+  {
+    mProxyModel->setFilterKeyColumn( -1 );
+  }
+  else
+  {
+    for ( int i = 0; i < mSearchColumnActions.count(); i++ )
+    {
+      if ( mSearchColumnActions.at( i )->isChecked() )
+      {
+        mProxyModel->setFilterKeyColumn( i );
+      }
+    }
+  }
+
+  if ( regex )
+  {
+    mProxyModel->_setFilterRegExp( searchText );
+  }
+  else
+  {
+    mProxyModel->_setFilterWildcard( searchText );
+  }
+}
+

--- a/src/gui/providers/qgsdbsourceselectbase.cpp
+++ b/src/gui/providers/qgsdbsourceselectbase.cpp
@@ -80,7 +80,7 @@ void QgsDbSourceSelectBase::setSourceModel( QgsAbstractDbTableModel *model )
   mSearchSettingsMenu->addAction( wildcardAction );
   modeActionGroup->addAction( wildcardAction );
   // mode: regexp
-  mSearchModeRegexAction = new QAction( tr( "Regular expression" ), mSearchSettingsMenu );
+  mSearchModeRegexAction = new QAction( tr( "Regular Expression" ), mSearchSettingsMenu );
   mSearchModeRegexAction->setCheckable( true );
   mSearchModeRegexAction->setChecked( false );
   mSearchSettingsMenu->addAction( mSearchModeRegexAction );
@@ -109,6 +109,7 @@ void QgsDbSourceSelectBase::filterResults()
       if ( mSearchColumnActions.at( i )->isChecked() )
       {
         mProxyModel->setFilterKeyColumn( i );
+        break;
       }
     }
   }

--- a/src/gui/providers/qgsdbsourceselectbase.cpp
+++ b/src/gui/providers/qgsdbsourceselectbase.cpp
@@ -15,20 +15,20 @@
 
 #include "qgsabstractdbtablemodel.h"
 #include "qgsdbsourceselectbase.h"
-#include "qgsdbfilterproxymodel.h"
 
 #include <QMenu>
-
+#include <QSortFilterProxyModel>
 
 QgsDbSourceSelectBase::QgsDbSourceSelectBase( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode )
   : QgsAbstractDataSourceWidget( parent, fl, widgetMode )
 {
   setupUi( this );
 
-  mProxyModel = new QgsDatabaseFilterProxyModel( this );
+  mProxyModel = new QSortFilterProxyModel( this );
   mProxyModel->setParent( this );
   mProxyModel->setFilterKeyColumn( -1 );
   mProxyModel->setFilterCaseSensitivity( Qt::CaseInsensitive );
+  mProxyModel->setRecursiveFilteringEnabled( true );
 
   // Do not do dynamic sorting - otherwise whenever user selects geometry type / srid / pk columns,
   // that item suddenly jumps to the end of the list (because the item gets changed) which is very annoying.
@@ -115,11 +115,15 @@ void QgsDbSourceSelectBase::filterResults()
 
   if ( regex )
   {
-    mProxyModel->_setFilterRegExp( searchText );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    mProxyModel->setFilterRegExp( searchText );
+#else
+    mProxyModel->setFilterRegularExpression( searchText );
+#endif
   }
   else
   {
-    mProxyModel->_setFilterWildcard( searchText );
+    mProxyModel->setFilterWildcard( searchText );
   }
 }
 

--- a/src/gui/providers/qgsdbsourceselectbase.h
+++ b/src/gui/providers/qgsdbsourceselectbase.h
@@ -21,7 +21,7 @@
 #include "ui_qgsdbsourceselectbase.h"
 #include "qgsabstractdatasourcewidget.h"
 
-class QgsDatabaseFilterProxyModel;
+class QSortFilterProxyModel;
 class QgsAbstractDbTableModel;
 
 /**
@@ -41,12 +41,12 @@ class GUI_EXPORT QgsDbSourceSelectBase : public QgsAbstractDataSourceWidget, pro
     void setSourceModel( QgsAbstractDbTableModel *model );
 
     //! Returns the proxy model used to filter the results
-    QgsDatabaseFilterProxyModel *proxyModel() {return mProxyModel;}
+    QSortFilterProxyModel *proxyModel() {return mProxyModel;}
 
   private:
     void filterResults();
 
-    QgsDatabaseFilterProxyModel *mProxyModel = nullptr;
+    QSortFilterProxyModel *mProxyModel = nullptr;
     QMenu *mSearchSettingsMenu = nullptr;
 
     QAction *mSearchColumnAllAction = nullptr;

--- a/src/gui/providers/qgsdbsourceselectbase.h
+++ b/src/gui/providers/qgsdbsourceselectbase.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+   qgsdbsourceselectbase.h
+    --------------------------------------
+   Date                 : 08.11.2021
+   Copyright            : (C) 2021 Denis Rouzaud
+   Email                : denis@opengis.ch
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSDBSOURCESELECTBASE_H
+#define QGSDBSOURCESELECTBASE_H
+
+
+#include "qgis_gui.h"
+#include "ui_qgsdbsourceselectbase.h"
+#include "qgsabstractdatasourcewidget.h"
+
+class QgsDatabaseFilterProxyModel;
+class QgsAbstractDbTableModel;
+
+/**
+ * \ingroup gui
+ * \brief The QgsDbSourceSelectBase class is a base class for database source widget selector
+ * \since QGIS 3.24
+ */
+class GUI_EXPORT QgsDbSourceSelectBase : public QgsAbstractDataSourceWidget, protected Ui::QgsDbSourceSelectBase
+{
+    Q_OBJECT
+  public:
+    //! Constructor
+    QgsDbSourceSelectBase( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
+
+  protected:
+    //! Sets the source model for the widget
+    void setSourceModel( QgsAbstractDbTableModel *model );
+
+    //! Returns the proxy model used to filter the results
+    QgsDatabaseFilterProxyModel *proxyModel() {return mProxyModel;}
+
+  private:
+    void filterResults();
+
+    QgsDatabaseFilterProxyModel *mProxyModel = nullptr;
+    QMenu *mSearchSettingsMenu = nullptr;
+
+    QAction *mSearchColumnAllAction = nullptr;
+    QList<QAction *> mSearchColumnActions;
+    QAction *mSearchModeWildCardAction = nullptr;
+    QAction *mSearchModeRegexAction = nullptr;
+
+};
+
+#endif // QGSDBSOURCESELECTBASE_H

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -33,6 +33,7 @@
 #include "qgssettings.h"
 #include "qgsproject.h"
 #include "qgsgui.h"
+#include "qgsdbfilterproxymodel.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -122,9 +123,8 @@ void QgsDb2SourceSelectDelegate::setModelData( QWidget *editor, QAbstractItemMod
 }
 
 QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
-  : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+  : QgsDbSourceSelectBase( parent, fl, theWidgetMode )
 {
-  setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
 
   connect( btnConnect, &QPushButton::clicked, this, &QgsDb2SourceSelect::btnConnect_clicked );
@@ -134,10 +134,6 @@ QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   connect( btnDelete, &QPushButton::clicked, this, &QgsDb2SourceSelect::btnDelete_clicked );
   connect( btnSave, &QPushButton::clicked, this, &QgsDb2SourceSelect::btnSave_clicked );
   connect( btnLoad, &QPushButton::clicked, this, &QgsDb2SourceSelect::btnLoad_clicked );
-  connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsDb2SourceSelect::mSearchGroupBox_toggled );
-  connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsDb2SourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsDb2SourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsDb2SourceSelect::mSearchModeComboBox_currentIndexChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsDb2SourceSelect::cmbConnections_activated );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsDb2SourceSelect::mTablesTreeView_clicked );
   connect( mTablesTreeView, &QTreeView::doubleClicked, this, &QgsDb2SourceSelect::mTablesTreeView_doubleClicked );
@@ -163,24 +159,10 @@ QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 
   populateConnectionList();
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
+  mTableModel = new QgsDb2TableModel( this );
+  setSourceModel( mTableModel );
 
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Schema" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Primary key column" ) );
-  mSearchColumnComboBox->addItem( tr( "SRID" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
-
-  mProxyModel.setParent( this );
-  mProxyModel.setFilterKeyColumn( -1 );
-  mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
-  mProxyModel.setSourceModel( &mTableModel );
-
-  mTablesTreeView->setModel( &mProxyModel );
+  mTablesTreeView->setModel( proxyModel() );
   mTablesTreeView->setSortingEnabled( true );
   mTablesTreeView->setEditTriggers( QAbstractItemView::CurrentChanged );
   mTablesTreeView->setItemDelegate( new QgsDb2SourceSelectDelegate( this ) );
@@ -190,27 +172,12 @@ QgsDb2SourceSelect::QgsDb2SourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   const QgsSettings settings;
   mTablesTreeView->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
-
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 2 );
-
   mHoldDialogOpen->setChecked( settings.value( QStringLiteral( "Windows/Db2SourceSelect/HoldDialogOpen" ), false ).toBool() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     mTablesTreeView->setColumnWidth( i, settings.value( QStringLiteral( "Windows/Db2SourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) ).toInt() );
   }
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 
   cbxAllowGeometrylessTables->setDisabled( true );
 }
@@ -323,71 +290,9 @@ void QgsDb2SourceSelect::mTablesTreeView_doubleClicked( const QModelIndex & )
   addButtonClicked();
 }
 
-void QgsDb2SourceSelect::mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsDb2SourceSelect::mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsDb2SourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Schema" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmSchema );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmTable );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmType );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmGeomCol );
-  }
-  else if ( text == tr( "Primary key column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmPkCol );
-  }
-  else if ( text == tr( "SRID" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmSrid );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsDb2TableModel::DbtmSql );
-  }
-}
-
-void QgsDb2SourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  mSearchTableEdit_textChanged( mSearchTableEdit->text() );
-}
-
 void QgsDb2SourceSelect::setLayerType( const QgsDb2LayerProperty &layerProperty )
 {
-  mTableModel.setGeometryTypesForTable( layerProperty );
+  mTableModel->setGeometryTypesForTable( layerProperty );
 }
 
 QgsDb2SourceSelect::~QgsDb2SourceSelect()
@@ -401,7 +306,7 @@ QgsDb2SourceSelect::~QgsDb2SourceSelect()
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Windows/Db2SourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     settings.setValue( QStringLiteral( "Windows/Db2SourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) );
   }
@@ -441,7 +346,7 @@ void QgsDb2SourceSelect::addButtonClicked()
     if ( idx.column() != QgsDb2TableModel::DbtmTable )
       continue;
 
-    const QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), mConnInfo, mUseEstimatedMetadata );
+    const QString uri = mTableModel->layerURI( proxyModel()->mapToSource( idx ), mConnInfo, mUseEstimatedMetadata );
     if ( uri.isNull() )
       continue;
 
@@ -472,8 +377,8 @@ void QgsDb2SourceSelect::btnConnect_clicked()
     return;
   }
 
-  const QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
+  const QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
 
   // populate the table list
 
@@ -516,7 +421,7 @@ void QgsDb2SourceSelect::btnConnect_clicked()
     while ( db2GC.populateLayerProperty( layer ) )
     {
       QgsDebugMsg( "layer type: " + layer.type );
-      mTableModel.addTableEntry( layer );
+      mTableModel->addTableEntry( layer );
 
       if ( mColumnTypeThread )
       {
@@ -525,14 +430,14 @@ void QgsDb2SourceSelect::btnConnect_clicked()
       }
 
       //if we have only one schema item, expand it by default
-      const int numTopLevelItems = mTableModel.invisibleRootItem()->rowCount();
-      if ( numTopLevelItems < 2 || mTableModel.tableCount() < 20 )
+      const int numTopLevelItems = mTableModel->invisibleRootItem()->rowCount();
+      if ( numTopLevelItems < 2 || mTableModel->tableCount() < 20 )
       {
         //expand all the toplevel items
         for ( int i = 0; i < numTopLevelItems; ++i )
         {
-          mTablesTreeView->expand( mProxyModel.mapFromSource(
-                                     mTableModel.indexFromItem( mTableModel.invisibleRootItem()->child( i ) ) ) );
+          mTablesTreeView->expand( proxyModel()->mapFromSource(
+                                     mTableModel->indexFromItem( mTableModel->invisibleRootItem()->child( i ) ) ) );
         }
       }
     }
@@ -587,11 +492,11 @@ void QgsDb2SourceSelect::setSql( const QModelIndex &index )
     return;
   }
 
-  const QModelIndex idx = mProxyModel.mapToSource( index );
-  const QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsDb2TableModel::DbtmTable ) )->text();
+  const QModelIndex idx = proxyModel()->mapToSource( index );
+  const QString tableName = mTableModel->itemFromIndex( idx.sibling( idx.row(), QgsDb2TableModel::DbtmTable ) )->text();
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > vlayer = std::make_unique< QgsVectorLayer >( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ), options );
+  std::unique_ptr< QgsVectorLayer > vlayer = std::make_unique< QgsVectorLayer >( mTableModel->layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ), options );
 
   if ( !vlayer->isValid() )
   {
@@ -602,7 +507,7 @@ void QgsDb2SourceSelect::setSql( const QModelIndex &index )
   QgsQueryBuilder gb( vlayer.get(), this );
   if ( gb.exec() )
   {
-    mTableModel.setSql( mProxyModel.mapToSource( index ), gb.sql() );
+    mTableModel->setSql( proxyModel()->mapToSource( index ), gb.sql() );
   }
 }
 

--- a/src/providers/db2/qgsdb2sourceselect.h
+++ b/src/providers/db2/qgsdb2sourceselect.h
@@ -21,11 +21,10 @@
 
 #include "ui_qgsdbsourceselectbase.h"
 #include "qgsguiutils.h"
-#include "qgsdbfilterproxymodel.h"
 #include "qgsdb2tablemodel.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
-#include "qgsabstractdatasourcewidget.h"
+#include "qgsdbsourceselectbase.h"
 
 #include <QMap>
 #include <QPair>
@@ -89,7 +88,7 @@ class QgsDb2GeomColumnTypeThread : public QThread
  * for Db2 databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsDb2SourceSelect : public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -135,10 +134,6 @@ class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDb
     void btnSave_clicked();
     //! Loads the selected connections from file
     void btnLoad_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
     void cmbConnections_activated( int );
@@ -175,8 +170,7 @@ class QgsDb2SourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDb
     QMap<QString, QPair<QString, QIcon> > mLayerIcons;
 
     //! Model that acts as datasource for mTableTreeWidget
-    QgsDb2TableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsDb2TableModel *mTableModel = nullptr;
 
     QPushButton *mBuildQueryButton = nullptr;
 

--- a/src/providers/db2/qgsdb2tablemodel.cpp
+++ b/src/providers/db2/qgsdb2tablemodel.cpp
@@ -32,7 +32,7 @@ QgsDb2TableModel::QgsDb2TableModel( QObject *parent )
            << tr( "SRID" )
            << tr( "Primary key column" )
            << tr( "Select at id" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( mColumns );
 }
 

--- a/src/providers/db2/qgsdb2tablemodel.cpp
+++ b/src/providers/db2/qgsdb2tablemodel.cpp
@@ -22,18 +22,47 @@
 #include "qgsapplication.h"
 #include "qgsiconutils.h"
 
-QgsDb2TableModel::QgsDb2TableModel()
+QgsDb2TableModel::QgsDb2TableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Schema" );
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "Geometry column" );
-  headerLabels << tr( "SRID" );
-  headerLabels << tr( "Primary key column" );
-  headerLabels << tr( "Select at id" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Schema" )
+           << tr( "Table" )
+           << tr( "Type" )
+           << tr( "Geometry column" )
+           << tr( "SRID" )
+           << tr( "Primary key column" )
+           << tr( "Select at id" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( mColumns );
+}
+
+QStringList QgsDb2TableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsDb2TableModel::defaultSearchColumn() const
+{
+  return static_cast<int>( DbtmTable );
+}
+
+bool QgsDb2TableModel::searchableColumn( int column ) const
+{
+  Columns col = static_cast<Columns>( column );
+  switch ( col )
+  {
+    case DbtmSchema:
+    case DbtmTable:
+    case DbtmGeomCol:
+    case DbtmType:
+    case DbtmSrid:
+    case DbtmSql:
+      return true;
+
+    case DbtmPkCol:
+    case DbtmSelectAtId:
+      return false;
+  }
 }
 
 void QgsDb2TableModel::addTableEntry( const QgsDb2LayerProperty &layerProperty )
@@ -242,8 +271,8 @@ void QgsDb2TableModel::setGeometryTypesForTable( QgsDb2LayerProperty layerProper
 
     QList<QStandardItem *> row;
 
-    row.reserve( DbtmColumns );
-    for ( int j = 0; j < DbtmColumns; j++ )
+    row.reserve( columnCount() );
+    for ( int j = 0; j < columnCount(); j++ )
     {
       row << itemFromIndex( currentChildIndex.sibling( i, j ) );
     }
@@ -315,7 +344,7 @@ bool QgsDb2TableModel::setData( const QModelIndex &idx, const QVariant &value, i
     if ( ok && pkCols.size() > 0 )
       ok = pkCols.contains( idx.sibling( idx.row(), DbtmPkCol ).data().toString() );
 
-    for ( int i = 0; i < DbtmColumns; i++ )
+    for ( int i = 0; i < columnCount(); i++ )
     {
       QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
       if ( ok )

--- a/src/providers/db2/qgsdb2tablemodel.h
+++ b/src/providers/db2/qgsdb2tablemodel.h
@@ -18,10 +18,11 @@
 #ifndef QGSDB2TABLEMODEL_H
 #define QGSDB2TABLEMODEL_H
 
-#include <QStandardItemModel>
 #include <QString>
 #include <QObject>
 #include "qgswkbtypes.h"
+#include "qgsabstractdbtablemodel.h"
+
 
 //! Layer Property structure
 struct QgsDb2LayerProperty
@@ -47,11 +48,15 @@ class QIcon;
  *
  * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
 */
-class QgsDb2TableModel : public QStandardItemModel
+class QgsDb2TableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
   public:
-    QgsDb2TableModel();
+    QgsDb2TableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     //! Adds entry for one database table to the model
     void addTableEntry( const QgsDb2LayerProperty &property );
@@ -78,7 +83,6 @@ class QgsDb2TableModel : public QStandardItemModel
       DbtmPkCol,
       DbtmSelectAtId,
       DbtmSql,
-      DbtmColumns
     };
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -90,5 +94,6 @@ class QgsDb2TableModel : public QStandardItemModel
   private:
     //! Number of tables in the model
     int mTableCount = 0;
+    QStringList mColumns;
 };
 #endif

--- a/src/providers/hana/qgshanasourceselect.h
+++ b/src/providers/hana/qgshanasourceselect.h
@@ -17,15 +17,13 @@
 #ifndef QGSHANASOURCESELECT_H
 #define QGSHANASOURCESELECT_H
 
-#include "qgsabstractdatasourcewidget.h"
 #include "qgsdatasourceuri.h"
-#include "qgsdbfilterproxymodel.h"
-#include "qgshanatablemodel.h"
 #include "qgshanacolumntypethread.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
 #include "qgsguiutils.h"
-#include "ui_qgsdbsourceselectbase.h"
+#include "qgsdbsourceselectbase.h"
+
 
 #include <QMap>
 #include <QPair>
@@ -66,7 +64,7 @@ class QgsHanaSourceSelectDelegate : public QItemDelegate
  * for SAP HANA databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsHanaSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsHanaSourceSelect : public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -114,10 +112,6 @@ class QgsHanaSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsD
     void btnSave_clicked();
     //! Loads the selected connections from file
     void btnLoad_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentTextChanged( const QString &text );
-    void mSearchModeComboBox_currentTextChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
     void cmbConnections_activated( int );
@@ -151,8 +145,7 @@ class QgsHanaSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsD
     std::unique_ptr<QgsProxyProgressTask> mColumnTypeTask;
     QStringList mSelectedTables;
     //! Model that acts as datasource for mTableTreeWidget
-    QgsHanaTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsHanaTableModel *mTableModel = nullptr;
 
     QPushButton *mBuildQueryButton = nullptr;
 };

--- a/src/providers/hana/qgshanatablemodel.cpp
+++ b/src/providers/hana/qgshanatablemodel.cpp
@@ -34,7 +34,7 @@ QgsHanaTableModel::QgsHanaTableModel( QObject *parent )
            << tr( "SRID" )
            << tr( "Feature id" )
            << tr( "Select at id" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( mColumns );
 }
 

--- a/src/providers/hana/qgshanatablemodel.cpp
+++ b/src/providers/hana/qgshanatablemodel.cpp
@@ -22,19 +22,50 @@
 #include "qgshanautils.h"
 #include "qgslogger.h"
 
-QgsHanaTableModel::QgsHanaTableModel()
+QgsHanaTableModel::QgsHanaTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
+
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Schema" );
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Comment" );
-  headerLabels << tr( "Column" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "SRID" );
-  headerLabels << tr( "Feature id" );
-  headerLabels << tr( "Select at id" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Schema" )
+           << tr( "Table" )
+           << tr( "Comment" )
+           << tr( "Column" )
+           << tr( "Type" )
+           << tr( "SRID" )
+           << tr( "Feature id" )
+           << tr( "Select at id" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( mColumns );
+}
+
+QStringList QgsHanaTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsHanaTableModel::defaultSearchColumn() const
+{
+  return static_cast<int>( DbtmTable );
+}
+
+bool QgsHanaTableModel::searchableColumn( int column ) const
+{
+  Columns col = static_cast<Columns>( column );
+  switch ( col )
+  {
+    case DbtmSchema:
+    case DbtmTable:
+    case DbtmComment:
+    case DbtmGeomCol:
+    case DbtmSrid:
+    case DbtmSql:
+      return true;
+
+    case DbtmGeomType:
+    case DbtmPkCol:
+    case DbtmSelectAtId:
+      return false;
+  }
 }
 
 void QgsHanaTableModel::addTableEntry( const QString &connName, const QgsHanaLayerProperty &layerProperty )
@@ -267,7 +298,7 @@ bool QgsHanaTableModel::setData( const QModelIndex &idx, const QVariant &value, 
         tip = tr( "Select columns in the '%1' column that uniquely identify features of this layer" ).arg( tr( "Feature id" ) );
     }
 
-    for ( int i = 0; i < DbtmColumns; i++ )
+    for ( int i = 0; i < columnCount(); i++ )
     {
       QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
       if ( tip.isEmpty() )

--- a/src/providers/hana/qgshanatablemodel.h
+++ b/src/providers/hana/qgshanatablemodel.h
@@ -19,7 +19,7 @@
 
 #include "qgis.h"
 #include "qgswkbtypes.h"
-#include <QStandardItemModel>
+#include "qgsabstractdbtablemodel.h"
 
 //! Schema properties structure
 struct QgsHanaSchemaProperty
@@ -63,11 +63,15 @@ class QIcon;
  *
  * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
 */
-class QgsHanaTableModel : public QStandardItemModel
+class QgsHanaTableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
   public:
-    QgsHanaTableModel();
+    QgsHanaTableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     //! Adds entry for one database table to the model
     void addTableEntry( const QString &connName, const QgsHanaLayerProperty &property );
@@ -88,8 +92,7 @@ class QgsHanaTableModel : public QStandardItemModel
       DbtmSrid,
       DbtmPkCol,
       DbtmSelectAtId,
-      DbtmSql,
-      DbtmColumns
+      DbtmSql
     };
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -101,6 +104,8 @@ class QgsHanaTableModel : public QStandardItemModel
   private:
     //! Number of tables in the model
     int mTableCount = 0;
+    QStringList mColumns;
+
 };
 
 #endif  // QGSHANATABLEMODEL_H

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -33,6 +33,7 @@
 #include "qgsproject.h"
 #include "qgsgui.h"
 #include "qgsiconutils.h"
+#include "qgsdbfilterproxymodel.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -124,9 +125,8 @@ void QgsMssqlSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItemM
 }
 
 QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
-  : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+  : QgsDbSourceSelectBase( parent, fl, theWidgetMode )
 {
-  setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
 
   connect( btnConnect, &QPushButton::clicked, this, &QgsMssqlSourceSelect::btnConnect_clicked );
@@ -136,10 +136,6 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
   connect( btnDelete, &QPushButton::clicked, this, &QgsMssqlSourceSelect::btnDelete_clicked );
   connect( btnSave, &QPushButton::clicked, this, &QgsMssqlSourceSelect::btnSave_clicked );
   connect( btnLoad, &QPushButton::clicked, this, &QgsMssqlSourceSelect::btnLoad_clicked );
-  connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsMssqlSourceSelect::mSearchGroupBox_toggled );
-  connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsMssqlSourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsMssqlSourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsMssqlSourceSelect::mSearchModeComboBox_currentIndexChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsMssqlSourceSelect::cmbConnections_activated );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsMssqlSourceSelect::mTablesTreeView_clicked );
   connect( mTablesTreeView, &QTreeView::doubleClicked, this, &QgsMssqlSourceSelect::mTablesTreeView_doubleClicked );
@@ -168,24 +164,10 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
 
   populateConnectionList();
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
+  mTableModel = new QgsMssqlTableModel( this );
+  setSourceModel( mTableModel );
 
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Schema" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Primary key column" ) );
-  mSearchColumnComboBox->addItem( tr( "SRID" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
-
-  mProxyModel.setParent( this );
-  mProxyModel.setFilterKeyColumn( -1 );
-  mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
-  mProxyModel.setSourceModel( &mTableModel );
-
-  mTablesTreeView->setModel( &mProxyModel );
+  mTablesTreeView->setModel( proxyModel() );
   mTablesTreeView->setSortingEnabled( true );
   mTablesTreeView->setEditTriggers( QAbstractItemView::CurrentChanged );
   mTablesTreeView->setItemDelegate( new QgsMssqlSourceSelectDelegate( this ) );
@@ -195,27 +177,12 @@ QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl,
   const QgsSettings settings;
   mTablesTreeView->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
-
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 2 );
-
   mHoldDialogOpen->setChecked( settings.value( QStringLiteral( "Windows/MSSQLSourceSelect/HoldDialogOpen" ), false ).toBool() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     mTablesTreeView->setColumnWidth( i, settings.value( QStringLiteral( "Windows/MSSQLSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) ).toInt() );
   }
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 
   cbxAllowGeometrylessTables->setDisabled( true );
 }
@@ -321,71 +288,9 @@ void QgsMssqlSourceSelect::mTablesTreeView_doubleClicked( const QModelIndex & )
   addButtonClicked();
 }
 
-void QgsMssqlSourceSelect::mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsMssqlSourceSelect::mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsMssqlSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Schema" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmSchema );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmTable );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmType );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmGeomCol );
-  }
-  else if ( text == tr( "Primary key column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmPkCol );
-  }
-  else if ( text == tr( "SRID" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmSrid );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsMssqlTableModel::DbtmSql );
-  }
-}
-
-void QgsMssqlSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  mSearchTableEdit_textChanged( mSearchTableEdit->text() );
-}
-
 void QgsMssqlSourceSelect::setLayerType( const QgsMssqlLayerProperty &layerProperty )
 {
-  mTableModel.setGeometryTypesForTable( layerProperty );
+  mTableModel->setGeometryTypesForTable( layerProperty );
 }
 
 QgsMssqlSourceSelect::~QgsMssqlSourceSelect()
@@ -399,7 +304,7 @@ QgsMssqlSourceSelect::~QgsMssqlSourceSelect()
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Windows/MSSQLSourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     settings.setValue( QStringLiteral( "Windows/MSSQLSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) );
   }
@@ -441,7 +346,7 @@ void QgsMssqlSourceSelect::addButtonClicked()
     if ( idx.column() != QgsMssqlTableModel::DbtmTable )
       continue;
 
-    const QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling );
+    const QString uri = mTableModel->layerURI( proxyModel()->mapToSource( idx ), mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling );
     if ( uri.isNull() )
       continue;
 
@@ -472,10 +377,10 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
     return;
   }
 
-  const QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
+  const QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
 
-  mTableModel.setConnectionName( cmbConnections->currentText() );
+  mTableModel->setConnectionName( cmbConnections->currentText() );
   // populate the table list
   const QgsSettings settings;
   const QString key = "/MSSQL/connections/" + cmbConnections->currentText();
@@ -579,7 +484,7 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
 
       layer.type = type;
       layer.srid = srid;
-      mTableModel.addTableEntry( layer );
+      mTableModel->addTableEntry( layer );
     }
 
     if ( mColumnTypeThread )
@@ -589,14 +494,14 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
     }
 
     //if we have only one schema item, expand it by default
-    const int numTopLevelItems = mTableModel.invisibleRootItem()->rowCount();
-    if ( numTopLevelItems < 2 || mTableModel.tableCount() < 20 )
+    const int numTopLevelItems = mTableModel->invisibleRootItem()->rowCount();
+    if ( numTopLevelItems < 2 || mTableModel->tableCount() < 20 )
     {
       //expand all the toplevel items
       for ( int i = 0; i < numTopLevelItems; ++i )
       {
-        mTablesTreeView->expand( mProxyModel.mapFromSource(
-                                   mTableModel.indexFromItem( mTableModel.invisibleRootItem()->child( i ) ) ) );
+        mTablesTreeView->expand( proxyModel()->mapFromSource(
+                                   mTableModel->indexFromItem( mTableModel->invisibleRootItem()->child( i ) ) ) );
       }
     }
   }
@@ -660,11 +565,11 @@ void QgsMssqlSourceSelect::setSql( const QModelIndex &index )
     return;
   }
 
-  const QModelIndex idx = mProxyModel.mapToSource( index );
-  const QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsMssqlTableModel::DbtmTable ) )->text();
+  const QModelIndex idx = proxyModel()->mapToSource( index );
+  const QString tableName = mTableModel->itemFromIndex( idx.sibling( idx.row(), QgsMssqlTableModel::DbtmTable ) )->text();
   const bool disableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( cmbConnections->currentText() );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > vlayer = std::make_unique< QgsVectorLayer>( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ), options );
+  std::unique_ptr< QgsVectorLayer > vlayer = std::make_unique< QgsVectorLayer>( mTableModel->layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ), options );
 
   if ( !vlayer->isValid() )
   {
@@ -675,7 +580,7 @@ void QgsMssqlSourceSelect::setSql( const QModelIndex &index )
   QgsQueryBuilder gb( vlayer.get(), this );
   if ( gb.exec() )
   {
-    mTableModel.setSql( mProxyModel.mapToSource( index ), gb.sql() );
+    mTableModel->setSql( proxyModel()->mapToSource( index ), gb.sql() );
   }
 }
 

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -17,13 +17,13 @@
 #ifndef QGSMSSQLSOURCESELECT_H
 #define QGSMSSQLSOURCESELECT_H
 
-#include "ui_qgsdbsourceselectbase.h"
 #include "qgsguiutils.h"
-#include "qgsdbfilterproxymodel.h"
-#include "qgsmssqltablemodel.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
+#include "qgsdbsourceselectbase.h"
+#include "qgsmssqltablemodel.h"
+
 
 #include <QMap>
 #include <QPair>
@@ -58,7 +58,7 @@ class QgsMssqlSourceSelectDelegate : public QItemDelegate
  * for MSSQL databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsMssqlSourceSelect : public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -108,10 +108,6 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     void btnSave_clicked();
     //! Loads the selected connections from file
     void btnLoad_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
     void cmbConnections_activated( int );
@@ -149,8 +145,7 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     QMap<QString, QPair<QString, QIcon> > mLayerIcons;
 
     //! Model that acts as datasource for mTableTreeWidget
-    QgsMssqlTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsMssqlTableModel *mTableModel = nullptr;
 
     QPushButton *mBuildQueryButton = nullptr;
 

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -20,7 +20,6 @@
 #include "qgsguiutils.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
-#include "qgsabstractdatasourcewidget.h"
 #include "qgsdbsourceselectbase.h"
 #include "qgsmssqltablemodel.h"
 

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -32,7 +32,7 @@ QgsMssqlTableModel::QgsMssqlTableModel( QObject *parent )
             << tr( "SRID" )
             << tr( "Primary key column" )
             << tr( "Select at id" )
-            << tr( "Sql" )
+            << tr( "SQL" )
             << tr( "View" );
   setHorizontalHeaderLabels( mColumns );
 }

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -22,19 +22,49 @@
 #include "qgsdatasourceuri.h"
 #include "qgsiconutils.h"
 
-QgsMssqlTableModel::QgsMssqlTableModel()
+QgsMssqlTableModel::QgsMssqlTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Schema" );
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "Geometry column" );
-  headerLabels << tr( "SRID" );
-  headerLabels << tr( "Primary key column" );
-  headerLabels << tr( "Select at id" );
-  headerLabels << tr( "Sql" );
-  headerLabels << tr( "View" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns  << tr( "Schema" )
+            << tr( "Table" )
+            << tr( "Type" )
+            << tr( "Geometry column" )
+            << tr( "SRID" )
+            << tr( "Primary key column" )
+            << tr( "Select at id" )
+            << tr( "Sql" )
+            << tr( "View" );
+  setHorizontalHeaderLabels( mColumns );
+}
+
+QStringList QgsMssqlTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsMssqlTableModel::defaultSearchColumn() const
+{
+  return static_cast<int>( DbtmTable );
+}
+
+bool QgsMssqlTableModel::searchableColumn( int column ) const
+{
+  Columns col = static_cast<Columns>( column );
+  switch ( col )
+  {
+    case DbtmSchema:
+    case DbtmTable:
+    case DbtmGeomCol:
+    case DbtmType:
+    case DbtmSrid:
+    case DbtmSql:
+      return true;
+
+    case DbtmPkCol:
+    case DbtmSelectAtId:
+    case DbtmView:
+      return false;
+  }
 }
 
 void QgsMssqlTableModel::addTableEntry( const QgsMssqlLayerProperty &layerProperty )
@@ -248,9 +278,9 @@ void QgsMssqlTableModel::setGeometryTypesForTable( QgsMssqlLayerProperty layerPr
     }
 
     QList<QStandardItem *> row;
-    row.reserve( DbtmColumns );
+    row.reserve( columnCount() );
 
-    for ( int j = 0; j < DbtmColumns; j++ )
+    for ( int j = 0; j < columnCount(); j++ )
     {
       row << itemFromIndex( currentChildIndex.sibling( i, j ) );
     }
@@ -323,7 +353,7 @@ bool QgsMssqlTableModel::setData( const QModelIndex &idx, const QVariant &value,
     if ( ok && !pkCols.isEmpty() )
       ok = pkCols.contains( idx.sibling( idx.row(), DbtmPkCol ).data().toString() );
 
-    for ( int i = 0; i < DbtmColumns; i++ )
+    for ( int i = 0; i < columnCount(); i++ )
     {
       QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
       if ( ok )

--- a/src/providers/mssql/qgsmssqltablemodel.h
+++ b/src/providers/mssql/qgsmssqltablemodel.h
@@ -18,8 +18,7 @@
 #ifndef QGSMSSQLTABLEMODEL_H
 #define QGSMSSQLTABLEMODEL_H
 
-#include <QStandardItemModel>
-
+#include "qgsabstractdbtablemodel.h"
 #include "qgswkbtypes.h"
 
 //! Layer Property structure
@@ -46,11 +45,15 @@ class QIcon;
  *
  * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
 */
-class QgsMssqlTableModel : public QStandardItemModel
+class QgsMssqlTableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
   public:
-    QgsMssqlTableModel();
+    QgsMssqlTableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     //! Adds entry for one database table to the model
     void addTableEntry( const QgsMssqlLayerProperty &property );
@@ -77,8 +80,7 @@ class QgsMssqlTableModel : public QStandardItemModel
       DbtmPkCol,
       DbtmSelectAtId,
       DbtmSql,
-      DbtmView,
-      DbtmColumns
+      DbtmView
     };
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -93,6 +95,7 @@ class QgsMssqlTableModel : public QStandardItemModel
     //! Number of tables in the model
     int mTableCount = 0;
     QString mConnectionName;
+    QStringList mColumns;
 };
 
 #endif

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -32,6 +32,8 @@ email                : jef at norbit dot de
 #include "qgsproxyprogresstask.h"
 #include "qgsgui.h"
 #include "qgsiconutils.h"
+#include "qgsoracletablemodel.h"
+
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -172,7 +174,6 @@ void QgsOracleSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItem
 QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
   : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
 {
-  setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
   setupButtons( buttonBox );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOracleSourceSelect::showHelp );
@@ -196,26 +197,13 @@ QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags f
     connect( mBuildQueryButton, &QAbstractButton::clicked, this, &QgsOracleSourceSelect::buildQuery );
   }
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
-
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Owner" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Primary key column" ) );
-  mSearchColumnComboBox->addItem( tr( "SRID" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
-
-  mProxyModel.setParent( this );
-  mProxyModel.setFilterKeyColumn( -1 );
-  mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
-  mProxyModel.setSourceModel( &mTableModel );
-
   mTablesTreeDelegate = new QgsOracleSourceSelectDelegate( this );
 
-  mTablesTreeView->setModel( &mProxyModel );
+
+  mTableModel = new QgsOracleTableModel( this );
+  setSourceModel( mTableModel );
+
+  mTablesTreeView->setModel( proxyModel() );
   mTablesTreeView->setSortingEnabled( true );
   mTablesTreeView->setEditTriggers( QAbstractItemView::CurrentChanged );
   mTablesTreeView->setItemDelegate( mTablesTreeDelegate );
@@ -224,27 +212,13 @@ QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags f
 
   mTablesTreeView->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 2 );
-
   QgsSettings settings;
   mHoldDialogOpen->setChecked( settings.value( QStringLiteral( "/Windows/OracleSourceSelect/HoldDialogOpen" ), false ).toBool() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     mTablesTreeView->setColumnWidth( i, settings.value( QStringLiteral( "/Windows/OracleSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) ).toInt() );
   }
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 
   populateConnectionList();
 }
@@ -353,71 +327,9 @@ void QgsOracleSourceSelect::on_mTablesTreeView_doubleClicked( const QModelIndex 
   addButtonClicked();
 }
 
-void QgsOracleSourceSelect::on_mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  on_mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsOracleSourceSelect::on_mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsOracleSourceSelect::on_mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Owner" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmOwner );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmTable );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmType );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmGeomCol );
-  }
-  else if ( text == tr( "Primary key column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmPkCol );
-  }
-  else if ( text == tr( "SRID" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmSrid );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsOracleTableModel::DbtmSql );
-  }
-}
-
-void QgsOracleSourceSelect::on_mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  on_mSearchTableEdit_textChanged( mSearchTableEdit->text() );
-}
-
 void QgsOracleSourceSelect::setLayerType( const QgsOracleLayerProperty &layerProperty )
 {
-  mTableModel.addTableEntry( layerProperty );
+  mTableModel->addTableEntry( layerProperty );
 }
 
 QgsOracleSourceSelect::~QgsOracleSourceSelect()
@@ -431,7 +343,7 @@ QgsOracleSourceSelect::~QgsOracleSourceSelect()
   QgsSettings settings;
   settings.setValue( QStringLiteral( "/Windows/OracleSourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     settings.setValue( QStringLiteral( "Windows/OracleSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) );
   }
@@ -465,7 +377,7 @@ void QgsOracleSourceSelect::addButtonClicked()
     if ( idx.column() != QgsOracleTableModel::DbtmTable )
       continue;
 
-    QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), mConnInfo );
+    QString uri = mTableModel->layerURI( proxyModel()->mapToSource( idx ), mConnInfo );
     if ( uri.isNull() )
       continue;
 
@@ -496,8 +408,8 @@ void QgsOracleSourceSelect::on_btnConnect_clicked()
     return;
   }
 
-  QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
+  QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
 
   QApplication::setOverrideCursor( Qt::BusyCursor );
 
@@ -579,10 +491,10 @@ void QgsOracleSourceSelect::setSql( const QModelIndex &index )
     return;
   }
 
-  QModelIndex idx = mProxyModel.mapToSource( index );
-  QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsOracleTableModel::DbtmTable ) )->text();
+  QModelIndex idx = proxyModel()->mapToSource( index );
+  QString tableName = mTableModel->itemFromIndex( idx.sibling( idx.row(), QgsOracleTableModel::DbtmTable ) )->text();
 
-  QString uri = mTableModel.layerURI( idx, mConnInfo );
+  QString uri = mTableModel->layerURI( idx, mConnInfo );
   if ( uri.isNull() )
   {
     QgsDebugMsg( QStringLiteral( "no uri" ) );
@@ -600,7 +512,7 @@ void QgsOracleSourceSelect::setSql( const QModelIndex &index )
   QgsQueryBuilder *gb = new QgsQueryBuilder( vlayer, this );
   if ( gb->exec() )
   {
-    mTableModel.setSql( mProxyModel.mapToSource( index ), gb->sql() );
+    mTableModel->setSql( proxyModel()->mapToSource( index ), gb->sql() );
   }
 
   delete gb;
@@ -639,8 +551,8 @@ void QgsOracleSourceSelect::setSearchExpression( const QString &regexp )
 
 void QgsOracleSourceSelect::loadTableFromCache()
 {
-  QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
+  QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
 
   QString connName = cmbConnections->currentText();
   QgsDataSourceUri uri = QgsOracleConn::connUri( connName );
@@ -650,7 +562,7 @@ void QgsOracleSourceSelect::loadTableFromCache()
 
   const auto constLayers = layers;
   for ( const QgsOracleLayerProperty &layerProperty : constLayers )
-    mTableModel.addTableEntry( layerProperty );
+    mTableModel->addTableEntry( layerProperty );
 
   QApplication::setOverrideCursor( Qt::BusyCursor );
 

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -33,6 +33,7 @@ email                : jef at norbit dot de
 #include "qgsgui.h"
 #include "qgsiconutils.h"
 #include "qgsoracletablemodel.h"
+#include "qgsdbfilterproxymodel.h"
 
 
 #include <QFileDialog>
@@ -172,7 +173,7 @@ void QgsOracleSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItem
 }
 
 QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
-  : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+  : QgsDbSourceSelectBase( parent, fl, theWidgetMode )
 {
   QgsGui::instance()->enableAutoGeometryRestore( this );
   setupButtons( buttonBox );

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -17,10 +17,8 @@
 #ifndef QGSORACLESOURCESELECT_H
 #define QGSORACLESOURCESELECT_H
 
-#include "ui_qgsdbsourceselectbase.h"
 #include "qgsguiutils.h"
 #include "qgsdbfilterproxymodel.h"
-#include "qgsoracletablemodel.h"
 #include "qgshelp.h"
 #include "qgsoracleconnpool.h"
 #include "qgsproviderregistry.h"
@@ -32,10 +30,10 @@
 #include <QItemDelegate>
 
 class QPushButton;
-class QStringList;
 class QgsOracleColumnTypeTask;
 class QgisApp;
 class QgsOracleSourceSelect;
+class QgsOracleTableModel;
 
 class QgsOracleSourceSelectDelegate : public QItemDelegate
 {
@@ -117,10 +115,6 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     void on_btnSave_clicked();
     //! Loads the selected connections from file
     void on_btnLoad_clicked();
-    void on_mSearchGroupBox_toggled( bool );
-    void on_mSearchTableEdit_textChanged( const QString &text );
-    void on_mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void on_mSearchModeComboBox_currentIndexChanged( const QString &text );
     void on_cmbConnections_currentIndexChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
@@ -159,8 +153,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     QMap<QString, QPair<QString, QIcon> > mLayerIcons;
 
     //! Model that acts as datasource for mTableTreeWidget
-    QgsOracleTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsOracleTableModel *mTableModel = nullptr;
     QgsOracleSourceSelectDelegate *mTablesTreeDelegate = nullptr;
 
     QPushButton *mBuildQueryButton = nullptr;

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -18,11 +18,10 @@
 #define QGSORACLESOURCESELECT_H
 
 #include "qgsguiutils.h"
-#include "qgsdbfilterproxymodel.h"
 #include "qgshelp.h"
 #include "qgsoracleconnpool.h"
 #include "qgsproviderregistry.h"
-#include "qgsabstractdatasourcewidget.h"
+#include "qgsdbsourceselectbase.h"
 
 #include <QMap>
 #include <QPair>
@@ -80,7 +79,7 @@ class QgsOracleSourceSelectDelegate : public QItemDelegate
  * for Oracle databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsOracleSourceSelect : public QgsDbSourceSelectBase
 {
     Q_OBJECT
 

--- a/src/providers/oracle/qgsoracletablemodel.cpp
+++ b/src/providers/oracle/qgsoracletablemodel.cpp
@@ -20,18 +20,47 @@
 #include "qgsapplication.h"
 #include "qgsiconutils.h"
 
-QgsOracleTableModel::QgsOracleTableModel()
+QgsOracleTableModel::QgsOracleTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Owner" );
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "Geometry column" );
-  headerLabels << tr( "SRID" );
-  headerLabels << tr( "Primary key column" );
-  headerLabels << tr( "Select at id" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Owner" )
+           << tr( "Table" )
+           << tr( "Type" )
+           << tr( "Geometry column" )
+           << tr( "SRID" )
+           << tr( "Primary key column" )
+           << tr( "Select at id" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( mColumns );
+}
+
+QStringList QgsOracleTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsOracleTableModel::defaultSearchColumn() const
+{
+  return static_cast<int>( DbtmTable );
+}
+
+bool QgsOracleTableModel::searchableColumn( int column ) const
+{
+  Columns col = static_cast<Columns>( column );
+  switch ( col )
+  {
+    case DbtmOwner:
+    case DbtmTable:
+    case DbtmGeomCol:
+    case DbtmType:
+    case DbtmSrid:
+    case DbtmSql:
+      return true;
+
+    case DbtmPkCol:
+    case DbtmSelectAtId:
+      return false;
+  }
 }
 
 void QgsOracleTableModel::addTableEntry( const QgsOracleLayerProperty &layerProperty )
@@ -251,7 +280,7 @@ bool QgsOracleTableModel::setData( const QModelIndex &idx, const QVariant &value
         tip = tr( "Select a primary key" );
     }
 
-    for ( int i = 0; i < DbtmColumns; i++ )
+    for ( int i = 0; i < columnCount(); i++ )
     {
       QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
       if ( tip.isEmpty() )

--- a/src/providers/oracle/qgsoracletablemodel.cpp
+++ b/src/providers/oracle/qgsoracletablemodel.cpp
@@ -30,7 +30,7 @@ QgsOracleTableModel::QgsOracleTableModel( QObject *parent )
            << tr( "SRID" )
            << tr( "Primary key column" )
            << tr( "Select at id" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( mColumns );
 }
 

--- a/src/providers/oracle/qgsoracletablemodel.h
+++ b/src/providers/oracle/qgsoracletablemodel.h
@@ -16,10 +16,11 @@
  ***************************************************************************/
 #ifndef QGSORACLETABLEMODEL_H
 #define QGSORACLETABLEMODEL_H
-#include <QStandardItemModel>
 
 #include "qgis.h"
 #include "qgsoracleconn.h"
+#include "qgsabstractdbtablemodel.h"
+
 
 class QIcon;
 
@@ -29,11 +30,15 @@ class QIcon;
  *
  * The tables have the following columns: Type, Owner, Tablename, Geometry Column, Sql
 */
-class QgsOracleTableModel : public QStandardItemModel
+class QgsOracleTableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
   public:
-    QgsOracleTableModel();
+    QgsOracleTableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     //! Adds entry for one database table to the model
     void addTableEntry( const QgsOracleLayerProperty &property );
@@ -53,8 +58,7 @@ class QgsOracleTableModel : public QStandardItemModel
       DbtmSrid,
       DbtmPkCol,
       DbtmSelectAtId,
-      DbtmSql,
-      DbtmColumns
+      DbtmSql
     };
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -64,6 +68,8 @@ class QgsOracleTableModel : public QStandardItemModel
   private:
     //! Number of tables in the model
     int mTableCount = 0;
+    QStringList mColumns;
+
 };
 
 #endif // QGSORACLETABLEMODEL_H

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -19,6 +19,7 @@ email                : sherman at mrcc.com
 #include "qgspgsourceselect.h"
 
 #include "qgslogger.h"
+#include "qgsdbfilterproxymodel.h"
 #include "qgsapplication.h"
 #include "qgspostgresprovider.h"
 #include "qgspgnewconnection.h"
@@ -32,6 +33,7 @@ email                : sherman at mrcc.com
 #include "qgsproject.h"
 #include "qgsgui.h"
 #include "qgsiconutils.h"
+#include "qgspgtablemodel.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -213,9 +215,8 @@ void QgsPgSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItemMode
 }
 
 QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
-  : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+  : QgsDbSourceSelectBase( parent, fl, theWidgetMode )
 {
-  setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
 
   connect( btnConnect, &QPushButton::clicked, this, &QgsPgSourceSelect::btnConnect_clicked );
@@ -225,10 +226,6 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
   connect( btnDelete, &QPushButton::clicked, this, &QgsPgSourceSelect::btnDelete_clicked );
   connect( btnSave, &QPushButton::clicked, this, &QgsPgSourceSelect::btnSave_clicked );
   connect( btnLoad, &QPushButton::clicked, this, &QgsPgSourceSelect::btnLoad_clicked );
-  connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsPgSourceSelect::mSearchGroupBox_toggled );
-  connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsPgSourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsPgSourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsPgSourceSelect::mSearchModeComboBox_currentIndexChanged );
   connect( cmbConnections, &QComboBox::currentTextChanged, this, &QgsPgSourceSelect::cmbConnections_currentIndexChanged );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsPgSourceSelect::mTablesTreeView_clicked );
   connect( mTablesTreeView, &QTreeView::doubleClicked, this, &QgsPgSourceSelect::mTablesTreeView_doubleClicked );
@@ -256,30 +253,11 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
 
   populateConnectionList();
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
 
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Schema" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Comment" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Feature id" ) );
-  mSearchColumnComboBox->addItem( tr( "SRID" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
+  mTableModel = new QgsPgTableModel( this );
+  setSourceModel( mTableModel );
 
-  mProxyModel.setParent( this );
-  mProxyModel.setFilterKeyColumn( -1 );
-  mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
-  mProxyModel.setSourceModel( &mTableModel );
-
-  // Do not do dynamic sorting - otherwise whenever user selects geometry type / srid / pk columns,
-  // that item suddenly jumps to the end of the list (because the item gets changed) which is very annoying.
-  // The list gets sorted in finishList() method when the listing of tables and views has finished.
-  mProxyModel.setDynamicSortFilter( false );
-
-  mTablesTreeView->setModel( &mProxyModel );
+  mTablesTreeView->setModel( proxyModel() );
   mTablesTreeView->setSortingEnabled( true );
   mTablesTreeView->setUniformRowHeights( true );
   mTablesTreeView->setEditTriggers( QAbstractItemView::CurrentChanged );
@@ -289,28 +267,15 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
 
   mTablesTreeView->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 2 );
-
   QgsSettings settings;
   mHoldDialogOpen->setChecked( settings.value( QStringLiteral( "Windows/PgSourceSelect/HoldDialogOpen" ), false ).toBool() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     mTablesTreeView->setColumnWidth( i, settings.value( QStringLiteral( "Windows/PgSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) ).toInt() );
   }
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 }
+
 //! Autoconnected SLOTS
 // Slot for adding a new connection
 void QgsPgSourceSelect::btnNew_clicked()
@@ -404,75 +369,9 @@ void QgsPgSourceSelect::mTablesTreeView_doubleClicked( const QModelIndex & )
   addButtonClicked();
 }
 
-void QgsPgSourceSelect::mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsPgSourceSelect::mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsPgSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Schema" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmSchema );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmTable );
-  }
-  else if ( text == tr( "Comment" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmComment );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmType );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmGeomCol );
-  }
-  else if ( text == tr( "Feature id" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmPkCol );
-  }
-  else if ( text == tr( "SRID" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmSrid );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( QgsPgTableModel::DbtmSql );
-  }
-}
-
-void QgsPgSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  mSearchTableEdit_textChanged( mSearchTableEdit->text() );
-}
-
 void QgsPgSourceSelect::setLayerType( const QgsPostgresLayerProperty &layerProperty )
 {
-  mTableModel.addTableEntry( layerProperty );
+  mTableModel->addTableEntry( layerProperty );
 }
 
 QgsPgSourceSelect::~QgsPgSourceSelect()
@@ -487,7 +386,7 @@ QgsPgSourceSelect::~QgsPgSourceSelect()
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Windows/PgSourceSelect/HoldDialogOpen" ), mHoldDialogOpen->isChecked() );
 
-  for ( int i = 0; i < mTableModel.columnCount(); i++ )
+  for ( int i = 0; i < mTableModel->columnCount(); i++ )
   {
     settings.setValue( QStringLiteral( "Windows/PgSourceSelect/columnWidths/%1" ).arg( i ), mTablesTreeView->columnWidth( i ) );
   }
@@ -523,7 +422,7 @@ void QgsPgSourceSelect::addButtonClicked()
     if ( idx.column() != QgsPgTableModel::DbtmTable )
       continue;
 
-    QString uri = mTableModel.layerURI( mProxyModel.mapToSource( idx ), connectionInfo( false ), mUseEstimatedMetadata );
+    QString uri = mTableModel->layerURI( proxyModel()->mapToSource( idx ), connectionInfo( false ), mUseEstimatedMetadata );
     if ( uri.isNull() )
       continue;
 
@@ -578,9 +477,9 @@ void QgsPgSourceSelect::btnConnect_clicked()
     return;
   }
 
-  QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
-  mTableModel.setConnectionName( cmbConnections->currentText() );
+  QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
+  mTableModel->setConnectionName( cmbConnections->currentText() );
 
   // populate the table list
   QgsDataSourceUri uri = QgsPostgresConn::connUri( cmbConnections->currentText() );
@@ -664,10 +563,10 @@ void QgsPgSourceSelect::setSql( const QModelIndex &index )
     return;
   }
 
-  QModelIndex idx = mProxyModel.mapToSource( index );
-  QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsPgTableModel::DbtmTable ) )->text();
+  QModelIndex idx = proxyModel()->mapToSource( index );
+  QString tableName = mTableModel->itemFromIndex( idx.sibling( idx.row(), QgsPgTableModel::DbtmTable ) )->text();
 
-  QString uri = mTableModel.layerURI( idx, connectionInfo( false ), mUseEstimatedMetadata );
+  QString uri = mTableModel->layerURI( idx, connectionInfo( false ), mUseEstimatedMetadata );
   if ( uri.isNull() )
   {
     QgsDebugMsg( QStringLiteral( "no uri" ) );
@@ -686,7 +585,7 @@ void QgsPgSourceSelect::setSql( const QModelIndex &index )
   QgsQueryBuilder *gb = new QgsQueryBuilder( vlayer, this );
   if ( gb->exec() )
   {
-    mTableModel.setSql( mProxyModel.mapToSource( index ), gb->sql() );
+    mTableModel->setSql( proxyModel()->mapToSource( index ), gb->sql() );
   }
 
   delete gb;

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -17,14 +17,12 @@
 #ifndef QGSPGSOURCESELECT_H
 #define QGSPGSOURCESELECT_H
 
-#include "ui_qgsdbsourceselectbase.h"
 #include "qgsguiutils.h"
 #include "qgsdatasourceuri.h"
-#include "qgsdbfilterproxymodel.h"
-#include "qgspgtablemodel.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
-#include "qgsabstractdatasourcewidget.h"
+#include "qgsdbsourceselectbase.h"
+#include "qgspostgresconn.h"
 
 #include <QMap>
 #include <QPair>
@@ -36,6 +34,7 @@ class QgsGeomColumnTypeThread;
 class QgisApp;
 class QgsPgSourceSelect;
 class QgsProxyProgressTask;
+class QgsPgTableModel;
 
 class QgsPgSourceSelectDelegate : public QItemDelegate
 {
@@ -60,7 +59,7 @@ class QgsPgSourceSelectDelegate : public QItemDelegate
  * for PostGIS enabled PostgreSQL databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsPgSourceSelect : public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -105,10 +104,6 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
     void btnSave_clicked();
     //! Loads the selected connections from file
     void btnLoad_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
     void cmbConnections_currentIndexChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
@@ -149,8 +144,7 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
     QMap<QString, QPair<QString, QIcon> > mLayerIcons;
 
     //! Model that acts as datasource for mTableTreeWidget
-    QgsPgTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsPgTableModel *mTableModel = nullptr;
 
     QPushButton *mBuildQueryButton = nullptr;
 

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -24,23 +24,55 @@
 #include <QRegularExpression>
 #include <climits>
 
-QgsPgTableModel::QgsPgTableModel()
+QgsPgTableModel::QgsPgTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Schema" );
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Comment" );
-  headerLabels << tr( "Column" );
-  headerLabels << tr( "Data Type" );
-  headerLabels << tr( "Spatial Type" );
-  headerLabels << tr( "SRID" );
-  headerLabels << tr( "Feature id" );
-  headerLabels << tr( "Select at id" );
-  headerLabels << tr( "Check PK unicity" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Schema" )
+           << tr( "Table" )
+           << tr( "Comment" )
+           << tr( "Column" )
+           << tr( "Data Type" )
+           << tr( "Spatial Type" )
+           << tr( "SRID" )
+           << tr( "Feature id" )
+           << tr( "Select at id" )
+           << tr( "Check PK unicity" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( mColumns );
   setHeaderData( Columns::DbtmSelectAtId, Qt::Orientation::Horizontal, tr( "Disable 'Fast Access to Features at ID' capability to force keeping the attribute table in memory (e.g. in case of expensive views)." ), Qt::ToolTipRole );
   setHeaderData( Columns::DbtmCheckPkUnicity, Qt::Orientation::Horizontal, tr( "Enable check for primary key unicity when loading views and materialized views. This option can make loading of large datasets significantly slower." ), Qt::ToolTipRole );
+}
+
+QStringList QgsPgTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsPgTableModel::defaultSearchColumn() const
+{
+  return static_cast<int>( DbtmTable );
+}
+
+bool QgsPgTableModel::searchableColumn( int column ) const
+{
+  Columns col = static_cast<Columns>( column );
+  switch ( col )
+  {
+    case DbtmSchema:
+    case DbtmTable:
+    case DbtmComment:
+    case DbtmGeomCol:
+    case DbtmType:
+    case DbtmSrid:
+    case DbtmSql:
+      return true;
+
+    case DbtmGeomType:
+    case DbtmPkCol:
+    case DbtmSelectAtId:
+    case DbtmCheckPkUnicity:
+      return false;
+  }
 }
 
 void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProperty )
@@ -342,7 +374,7 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
         tip = tr( "Select columns in the '%1' column that uniquely identify features of this layer" ).arg( tr( "Feature id" ) );
     }
 
-    for ( int i = 0; i < DbtmColumns; i++ )
+    for ( int i = 0; i < columnCount(); i++ )
     {
       QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
       if ( tip.isEmpty() )
@@ -466,3 +498,4 @@ QString QgsPgTableModel::layerURI( const QModelIndex &index, const QString &conn
   QgsDebugMsg( QStringLiteral( "returning uri %1" ).arg( uri.uri( false ) ) );
   return uri.uri( false );
 }
+

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -37,7 +37,7 @@ QgsPgTableModel::QgsPgTableModel( QObject *parent )
            << tr( "Feature id" )
            << tr( "Select at id" )
            << tr( "Check PK unicity" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( mColumns );
   setHeaderData( Columns::DbtmSelectAtId, Qt::Orientation::Horizontal, tr( "Disable 'Fast Access to Features at ID' capability to force keeping the attribute table in memory (e.g. in case of expensive views)." ), Qt::ToolTipRole );
   setHeaderData( Columns::DbtmCheckPkUnicity, Qt::Orientation::Horizontal, tr( "Enable check for primary key unicity when loading views and materialized views. This option can make loading of large datasets significantly slower." ), Qt::ToolTipRole );

--- a/src/providers/postgres/qgspgtablemodel.h
+++ b/src/providers/postgres/qgspgtablemodel.h
@@ -16,8 +16,8 @@
  ***************************************************************************/
 #ifndef QGSPGTABLEMODEL_H
 #define QGSPGTABLEMODEL_H
-#include <QStandardItemModel>
 
+#include "qgsabstractdbtablemodel.h"
 #include "qgswkbtypes.h"
 #include "qgspostgresconn.h"
 
@@ -29,11 +29,11 @@ class QIcon;
  *
  * The tables have the following columns: Type, Schema, Tablename, Geometry Column, Sql
 */
-class QgsPgTableModel : public QStandardItemModel
+class QgsPgTableModel : public QgsAbstractDbTableModel
 {
     Q_OBJECT
   public:
-    QgsPgTableModel();
+    QgsPgTableModel( QObject *parent = nullptr );
 
     //! Adds entry for one database table to the model
     void addTableEntry( const QgsPostgresLayerProperty &property );
@@ -43,6 +43,10 @@ class QgsPgTableModel : public QStandardItemModel
 
     //! Returns the number of tables in the model
     int tableCount() const { return mTableCount; }
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
 
     enum Columns
     {
@@ -56,8 +60,7 @@ class QgsPgTableModel : public QStandardItemModel
       DbtmPkCol,
       DbtmSelectAtId,
       DbtmCheckPkUnicity,
-      DbtmSql,
-      DbtmColumns
+      DbtmSql
     };
 
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -71,6 +74,8 @@ class QgsPgTableModel : public QStandardItemModel
     int mTableCount = 0;
     //! connection name
     QString mConnName;
+    QStringList mColumns;
+
 };
 
 #endif // QGSPGTABLEMODEL_H

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -30,6 +30,8 @@ email                : a.furieri@lqt.it
 #include "qgsgui.h"
 #include "qgsprovidermetadata.h"
 #include "qgsspatialiteproviderconnection.h"
+#include "qgsspatialitetablemodel.h"
+#include "qgsdbfilterproxymodel.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -44,18 +46,13 @@ email                : a.furieri@lqt.it
 #endif
 
 QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode ):
-  QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
+  QgsDbSourceSelectBase( parent, fl, theWidgetMode )
 {
-  setupUi( this );
   QgsGui::instance()->enableAutoGeometryRestore( this );
 
   connect( btnConnect, &QPushButton::clicked, this, &QgsSpatiaLiteSourceSelect::btnConnect_clicked );
   connect( btnNew, &QPushButton::clicked, this, &QgsSpatiaLiteSourceSelect::btnNew_clicked );
   connect( btnDelete, &QPushButton::clicked, this, &QgsSpatiaLiteSourceSelect::btnDelete_clicked );
-  connect( mSearchGroupBox, &QGroupBox::toggled, this, &QgsSpatiaLiteSourceSelect::mSearchGroupBox_toggled );
-  connect( mSearchTableEdit, &QLineEdit::textChanged, this, &QgsSpatiaLiteSourceSelect::mSearchTableEdit_textChanged );
-  connect( mSearchColumnComboBox, &QComboBox::currentTextChanged, this, &QgsSpatiaLiteSourceSelect::mSearchColumnComboBox_currentIndexChanged );
-  connect( mSearchModeComboBox, &QComboBox::currentTextChanged, this, &QgsSpatiaLiteSourceSelect::mSearchModeComboBox_currentIndexChanged );
   connect( cbxAllowGeometrylessTables, &QCheckBox::stateChanged, this, &QgsSpatiaLiteSourceSelect::cbxAllowGeometrylessTables_stateChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsSpatiaLiteSourceSelect::cmbConnections_activated );
   connect( mTablesTreeView, &QTreeView::clicked, this, &QgsSpatiaLiteSourceSelect::mTablesTreeView_clicked );
@@ -90,38 +87,13 @@ QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget *parent, Qt::Windo
 
   populateConnectionList();
 
-  mSearchModeComboBox->addItem( tr( "Wildcard" ) );
-  mSearchModeComboBox->addItem( tr( "RegExp" ) );
+  mTableModel = new QgsSpatiaLiteTableModel( this );
+  setSourceModel( mTableModel );
 
-  mSearchColumnComboBox->addItem( tr( "All" ) );
-  mSearchColumnComboBox->addItem( tr( "Table" ) );
-  mSearchColumnComboBox->addItem( tr( "Type" ) );
-  mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
-  mSearchColumnComboBox->addItem( tr( "Sql" ) );
-
-  mProxyModel.setParent( this );
-  mProxyModel.setFilterKeyColumn( -1 );
-  mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
-  mProxyModel.setDynamicSortFilter( true );
-  mProxyModel.setSourceModel( &mTableModel );
-  mTablesTreeView->setModel( &mProxyModel );
+  mTablesTreeView->setModel( proxyModel() );
   mTablesTreeView->setSortingEnabled( true );
 
   connect( mTablesTreeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsSpatiaLiteSourceSelect::treeWidgetSelectionChanged );
-
-  //for Qt < 4.3.2, passing -1 to include all model columns
-  //in search does not seem to work
-  mSearchColumnComboBox->setCurrentIndex( 1 );
-
-  //hide the search options by default
-  //they will be shown when the user ticks
-  //the search options group box
-  mSearchLabel->setVisible( false );
-  mSearchColumnComboBox->setVisible( false );
-  mSearchColumnsLabel->setVisible( false );
-  mSearchModeComboBox->setVisible( false );
-  mSearchModeLabel->setVisible( false );
-  mSearchTableEdit->setVisible( false );
 
   cbxAllowGeometrylessTables->setDisabled( true );
 }
@@ -188,59 +160,9 @@ void QgsSpatiaLiteSourceSelect::mTablesTreeView_doubleClicked( const QModelIndex
   setSql( index );
 }
 
-void QgsSpatiaLiteSourceSelect::mSearchGroupBox_toggled( bool checked )
-{
-  if ( mSearchTableEdit->text().isEmpty() )
-    return;
-
-  mSearchTableEdit_textChanged( checked ? mSearchTableEdit->text() : QString() );
-}
-
-void QgsSpatiaLiteSourceSelect::mSearchTableEdit_textChanged( const QString &text )
-{
-  if ( mSearchModeComboBox->currentText() == tr( "Wildcard" ) )
-  {
-    mProxyModel._setFilterWildcard( text );
-  }
-  else if ( mSearchModeComboBox->currentText() == tr( "RegExp" ) )
-  {
-    mProxyModel._setFilterRegExp( text );
-  }
-}
-
-void QgsSpatiaLiteSourceSelect::mSearchColumnComboBox_currentIndexChanged( const QString &text )
-{
-  if ( text == tr( "All" ) )
-  {
-    mProxyModel.setFilterKeyColumn( -1 );
-  }
-  else if ( text == tr( "Table" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 0 );
-  }
-  else if ( text == tr( "Type" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 1 );
-  }
-  else if ( text == tr( "Geometry column" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 2 );
-  }
-  else if ( text == tr( "Sql" ) )
-  {
-    mProxyModel.setFilterKeyColumn( 3 );
-  }
-}
-
-void QgsSpatiaLiteSourceSelect::mSearchModeComboBox_currentIndexChanged( const QString &text )
-{
-  Q_UNUSED( text )
-  mSearchTableEdit_textChanged( mSearchTableEdit->text() );
-}
-
 void QgsSpatiaLiteSourceSelect::setLayerType( const QString &table, const QString &column, const QString &type )
 {
-  mTableModel.setGeometryTypesForTable( table, column, type );
+  mTableModel->setGeometryTypesForTable( table, column, type );
   mTablesTreeView->sortByColumn( 0, Qt::AscendingOrder );
 }
 
@@ -324,9 +246,9 @@ bool QgsSpatiaLiteSourceSelect::newConnection( QWidget *parent )
 
 QString QgsSpatiaLiteSourceSelect::layerURI( const QModelIndex &index )
 {
-  const QString tableName = mTableModel.itemFromIndex( index.sibling( index.row(), 0 ) )->text();
-  QString geomColumnName = mTableModel.itemFromIndex( index.sibling( index.row(), 2 ) )->text();
-  QString sql = mTableModel.itemFromIndex( index.sibling( index.row(), 3 ) )->text();
+  const QString tableName = mTableModel->itemFromIndex( index.sibling( index.row(), 0 ) )->text();
+  QString geomColumnName = mTableModel->itemFromIndex( index.sibling( index.row(), 2 ) )->text();
+  QString sql = mTableModel->itemFromIndex( index.sibling( index.row(), 3 ) )->text();
 
   if ( geomColumnName.contains( QLatin1String( " AS " ) ) )
   {
@@ -404,7 +326,7 @@ void QgsSpatiaLiteSourceSelect::addButtonClicked()
       //top level items only contain the schema names
       continue;
     }
-    currentItem = mTableModel.itemFromIndex( mProxyModel.mapToSource( *selected_it ) );
+    currentItem = mTableModel->itemFromIndex( proxyModel()->mapToSource( *selected_it ) );
     if ( !currentItem )
     {
       continue;
@@ -416,7 +338,7 @@ void QgsSpatiaLiteSourceSelect::addButtonClicked()
     if ( !dbInfo[currentSchemaName].contains( currentRow ) )
     {
       dbInfo[currentSchemaName][currentRow] = true;
-      m_selectedTables << layerURI( mProxyModel.mapToSource( *selected_it ) );
+      m_selectedTables << layerURI( proxyModel()->mapToSource( *selected_it ) );
     }
   }
 
@@ -483,19 +405,19 @@ void QgsSpatiaLiteSourceSelect::btnConnect_clicked()
     return;
   }
 
-  const QModelIndex rootItemIndex = mTableModel.indexFromItem( mTableModel.invisibleRootItem() );
-  mTableModel.removeRows( 0, mTableModel.rowCount( rootItemIndex ), rootItemIndex );
+  const QModelIndex rootItemIndex = mTableModel->indexFromItem( mTableModel->invisibleRootItem() );
+  mTableModel->removeRows( 0, mTableModel->rowCount( rootItemIndex ), rootItemIndex );
 
   // populate the table list
   // get the list of suitable tables and columns and populate the UI
 
-  mTableModel.setSqliteDb( subKey );
+  mTableModel->setSqliteDb( subKey );
 
   const QList<QgsSpatiaLiteConnection::TableEntry> tables = conn.tables();
   const auto constTables = tables;
   for ( const QgsSpatiaLiteConnection::TableEntry &table : constTables )
   {
-    mTableModel.addTableEntry( table.type, table.tableName, table.column, QString() );
+    mTableModel->addTableEntry( table.type, table.tableName, table.column, QString() );
   }
 
   if ( cmbConnections->count() > 0 )
@@ -506,10 +428,10 @@ void QgsSpatiaLiteSourceSelect::btnConnect_clicked()
   mTablesTreeView->sortByColumn( 0, Qt::AscendingOrder );
 
   //expand all the toplevel items
-  const int numTopLevelItems = mTableModel.invisibleRootItem()->rowCount();
+  const int numTopLevelItems = mTableModel->invisibleRootItem()->rowCount();
   for ( int i = 0; i < numTopLevelItems; ++i )
   {
-    mTablesTreeView->expand( mProxyModel.mapFromSource( mTableModel.indexFromItem( mTableModel.invisibleRootItem()->child( i ) ) ) );
+    mTablesTreeView->expand( proxyModel()->mapFromSource( mTableModel->indexFromItem( mTableModel->invisibleRootItem()->child( i ) ) ) );
   }
   mTablesTreeView->resizeColumnToContents( 0 );
   mTablesTreeView->resizeColumnToContents( 1 );
@@ -529,8 +451,8 @@ QString QgsSpatiaLiteSourceSelect::connectionInfo()
 
 void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
 {
-  const QModelIndex idx = mProxyModel.mapToSource( index );
-  const auto item { mTableModel.itemFromIndex( idx.sibling( idx.row(), 0 ) ) };
+  const QModelIndex idx = proxyModel()->mapToSource( index );
+  const auto item { mTableModel->itemFromIndex( idx.sibling( idx.row(), 0 ) ) };
   if ( !item )
   {
     return;
@@ -551,7 +473,7 @@ void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
   QgsQueryBuilder *gb = new QgsQueryBuilder( vlayer, this );
   if ( gb->exec() )
   {
-    mTableModel.setSql( mProxyModel.mapToSource( index ), gb->sql() );
+    mTableModel->setSql( proxyModel()->mapToSource( index ), gb->sql() );
   }
 
   delete gb;

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -20,9 +20,7 @@
 #include "qgsguiutils.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
-#include "qgsabstractdatasourcewidget.h"
 #include "qgsdbsourceselectbase.h"
-
 
 #include <QThread>
 #include <QMap>

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -17,14 +17,12 @@
 #ifndef QGSSPATIALITESOURCESELECT_H
 #define QGSSPATIALITESOURCESELECT_H
 
-#include "ui_qgsdbsourceselectbase.h"
-
 #include "qgsguiutils.h"
-#include "qgsdbfilterproxymodel.h"
-#include "qgsspatialitetablemodel.h"
 #include "qgshelp.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
+#include "qgsdbsourceselectbase.h"
+
 
 #include <QThread>
 #include <QMap>
@@ -33,6 +31,7 @@
 #include <QIcon>
 #include <QFileDialog>
 
+class QgsSpatiaLiteTableModel;
 class QStringList;
 class QTableWidgetItem;
 class QPushButton;
@@ -45,7 +44,7 @@ class QPushButton;
  * for SpatiaLite/SQLite databases. The user can then connect and add
  * tables from the database to the map canvas.
  */
-class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsDbSourceSelectBase
+class QgsSpatiaLiteSourceSelect:  public QgsDbSourceSelectBase
 {
     Q_OBJECT
 
@@ -84,10 +83,6 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
     void btnNew_clicked();
     //! Deletes the selected connection
     void btnDelete_clicked();
-    void mSearchGroupBox_toggled( bool );
-    void mSearchTableEdit_textChanged( const QString &text );
-    void mSearchColumnComboBox_currentIndexChanged( const QString &text );
-    void mSearchModeComboBox_currentIndexChanged( const QString &text );
     void cbxAllowGeometrylessTables_stateChanged( int );
     void setSql( const QModelIndex &index );
     void cmbConnections_activated( int );
@@ -125,8 +120,7 @@ class QgsSpatiaLiteSourceSelect: public QgsAbstractDataSourceWidget, private Ui:
     // Storage for the range of layer type icons
     QMap < QString, QPair < QString, QIcon > >mLayerIcons;
     //! Model that acts as datasource for mTableTreeWidget
-    QgsSpatiaLiteTableModel mTableModel;
-    QgsDatabaseFilterProxyModel mProxyModel;
+    QgsSpatiaLiteTableModel *mTableModel;
 
     QString layerURI( const QModelIndex &index );
     QPushButton *mBuildQueryButton = nullptr;

--- a/src/providers/spatialite/qgsspatialitetablemodel.cpp
+++ b/src/providers/spatialite/qgsspatialitetablemodel.cpp
@@ -20,6 +20,7 @@
 #include "qgsiconutils.h"
 
 QgsSpatiaLiteTableModel::QgsSpatiaLiteTableModel( QObject *parent )
+  : QgsAbstractDbTableModel( parent )
 {
   mColumns << tr( "Table" )
            << tr( "Type" )

--- a/src/providers/spatialite/qgsspatialitetablemodel.cpp
+++ b/src/providers/spatialite/qgsspatialitetablemodel.cpp
@@ -25,7 +25,7 @@ QgsSpatiaLiteTableModel::QgsSpatiaLiteTableModel( QObject *parent )
   mColumns << tr( "Table" )
            << tr( "Type" )
            << tr( "Geometry column" )
-           << tr( "Sql" );
+           << tr( "SQL" );
   setHorizontalHeaderLabels( mColumns );
 }
 

--- a/src/providers/spatialite/qgsspatialitetablemodel.cpp
+++ b/src/providers/spatialite/qgsspatialitetablemodel.cpp
@@ -19,14 +19,29 @@
 #include "qgsapplication.h"
 #include "qgsiconutils.h"
 
-QgsSpatiaLiteTableModel::QgsSpatiaLiteTableModel()
+QgsSpatiaLiteTableModel::QgsSpatiaLiteTableModel( QObject *parent )
 {
-  QStringList headerLabels;
-  headerLabels << tr( "Table" );
-  headerLabels << tr( "Type" );
-  headerLabels << tr( "Geometry column" );
-  headerLabels << tr( "Sql" );
-  setHorizontalHeaderLabels( headerLabels );
+  mColumns << tr( "Table" )
+           << tr( "Type" )
+           << tr( "Geometry column" )
+           << tr( "Sql" );
+  setHorizontalHeaderLabels( mColumns );
+}
+
+QStringList QgsSpatiaLiteTableModel::columns() const
+{
+  return mColumns;
+}
+
+int QgsSpatiaLiteTableModel::defaultSearchColumn() const
+{
+  return 0;
+}
+
+bool QgsSpatiaLiteTableModel::searchableColumn( int column ) const
+{
+  Q_UNUSED( column )
+  return true;
 }
 
 void QgsSpatiaLiteTableModel::addTableEntry( const QString &type, const QString &tableName, const QString &geometryColName, const QString &sql )

--- a/src/providers/spatialite/qgsspatialitetablemodel.h
+++ b/src/providers/spatialite/qgsspatialitetablemodel.h
@@ -18,9 +18,11 @@
 #ifndef QGSSPATIALITETABLEMODEL_H
 #define QGSSPATIALITETABLEMODEL_H
 
-#include <QStandardItemModel>
-class QIcon;
 #include "qgswkbtypes.h"
+#include "qgsabstractdbtablemodel.h"
+
+class QIcon;
+
 
 /**
  * A model that holds the tables of a database in a hierarchy where the
@@ -28,11 +30,16 @@ class QIcon;
  *
  * The tables have the following columns: Type, Tablename, Geometry Column
 */
-class QgsSpatiaLiteTableModel: public QStandardItemModel
+class QgsSpatiaLiteTableModel: public QgsAbstractDbTableModel
 {
   Q_OBJECT public:
 
-    QgsSpatiaLiteTableModel();
+    QgsSpatiaLiteTableModel( QObject *parent = nullptr );
+
+    QStringList columns() const override;
+    int defaultSearchColumn() const override;
+    bool searchableColumn( int column ) const override;
+
     //! Adds entry for one database table to the model
     void addTableEntry( const QString &type, const QString &tableName, const QString &geometryColName, const QString &sql );
     //! Sets an sql statement that belongs to a cell specified by a model index
@@ -58,6 +65,7 @@ class QgsSpatiaLiteTableModel: public QStandardItemModel
     //! Number of tables in the model
     int mTableCount = 0;
     QString mSqliteDb;
+    QStringList mColumns;
 
     QIcon iconForType( QgsWkbTypes::Type type ) const;
     QString displayStringForType( QgsWkbTypes::Type type ) const;

--- a/src/ui/qgsdbsourceselectbase.ui
+++ b/src/ui/qgsdbsourceselectbase.ui
@@ -24,6 +24,79 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="7" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QTreeView" name="mTablesTreeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mSearchSettingsButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::MenuButtonPopup</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsFilterLineEdit" name="mSearchTableEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="showSearchIcon" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="connectionsGroupBox">
      <property name="title">
@@ -110,20 +183,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QTreeView" name="mTablesTreeView">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="6" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QCheckBox" name="cbxAllowGeometrylessTables">
@@ -154,109 +214,16 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="mSearchGroupBox">
-     <property name="title">
-      <string>Search options</string>
-     </property>
-     <property name="flat">
-      <bool>true</bool>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="mSearchLabel">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Search</string>
-        </property>
-        <property name="buddy">
-         <cstring>mSearchTableEdit</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="mSearchModeLabel">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Search mode</string>
-        </property>
-        <property name="buddy">
-         <cstring>mSearchModeComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QComboBox" name="mSearchModeComboBox">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QLabel" name="mSearchColumnsLabel">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Search in columns</string>
-        </property>
-        <property name="buddy">
-         <cstring>mSearchColumnComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QComboBox" name="mSearchColumnComboBox">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="mSearchTableEdit">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbConnections</tabstop>
   <tabstop>btnConnect</tabstop>
@@ -268,13 +235,11 @@
   <tabstop>mTablesTreeView</tabstop>
   <tabstop>cbxAllowGeometrylessTables</tabstop>
   <tabstop>mHoldDialogOpen</tabstop>
-  <tabstop>mSearchGroupBox</tabstop>
-  <tabstop>mSearchTableEdit</tabstop>
-  <tabstop>mSearchColumnComboBox</tabstop>
-  <tabstop>mSearchModeComboBox</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>
@@ -289,102 +254,6 @@
     <hint type="destinationlabel">
      <x>361</x>
      <y>421</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchTableEdit</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>94</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>177</x>
-     <y>360</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchColumnComboBox</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>97</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>343</x>
-     <y>402</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchModeComboBox</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>115</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>281</x>
-     <y>410</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchLabel</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>133</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>58</x>
-     <y>360</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchColumnsLabel</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>51</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>57</x>
-     <y>402</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mSearchGroupBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mSearchModeLabel</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>82</x>
-     <y>437</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>68</x>
-     <y>411</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This PR improves a bit the UX to filter layers in DB selector widgets.
The search widget is always shown and the config is shown as a menu.

I have added some base class both for the GUI and the table model so that duplicated code can be removed.

Once accepted, there is room for further improvements.

net 200 lines of code removed and some forward declarations 🥳 

![image](https://user-images.githubusercontent.com/127259/140929612-1a588813-a275-4dba-8ff3-bdd79b1082a0.png)
