### PR TITLE
[processing] multidirectional and combined shading options are mutually exclusive (fix #45957)

### DIFF
--- a/python/plugins/processing/algs/gdal/hillshade.py
+++ b/python/plugins/processing/algs/gdal/hillshade.py
@@ -168,11 +168,13 @@ class hillshade(GdalAlgorithm):
             arguments.append('-alg')
             arguments.append('ZevenbergenThorne')
 
-        if self.parameterAsBoolean(parameters, self.COMBINED, context):
+        combined = self.parameterAsBoolean(parameters, self.COMBINED, context)
+        if combined and not multidirectional:
             arguments.append('-combined')
-
-        if multidirectional:
+        elif multidirectional and not combined:
             arguments.append('-multidirectional')
+        elif multidirectional and combined:
+            raise QgsProcessingException(self.tr('Options -multirectional and -combined are mutually exclusive.'))
 
         options = self.parameterAsString(parameters, self.OPTIONS, context)
         if options:

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -27,6 +27,7 @@ import shutil
 import tempfile
 
 from qgis.core import (QgsProcessingContext,
+                       QgsProcessingException,
                        QgsProcessingFeedback,
                        QgsRectangle,
                        QgsRasterLayer,
@@ -1205,6 +1206,18 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  'hillshade ' +
                  source + ' ' +
                  outdir + '/check.tif -of GTiff -b 1 -z 1.0 -s 1.0 -az 315.0 -alt 45.0 -q'])
+
+            # multidirectional and combined are mutually exclusive
+            self.assertRaises(
+                QgsProcessingException,
+                lambda: alg.getConsoleCommands({'INPUT': source,
+                                                'BAND': 1,
+                                                'Z_FACTOR': 5,
+                                                'SCALE': 2,
+                                                'AZIMUTH': 90,
+                                                'COMBINED': True,
+                                                'MULTIDIRECTIONAL': True,
+                                                'OUTPUT': outdir + '/check.tif'}, context, feedback))
 
     def testAspect(self):
         context = QgsProcessingContext()


### PR DESCRIPTION
## Description
GDAL hillshade algorithm exposes options for multidirectional and combined shading which should be mutually exclusive.
In QGIS 4 we probably should replace these options with an enum parameter.

Fixes #45957.