### PR TITLE
Remove setting PyQt API versions

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -110,24 +110,6 @@ bool QgsPythonUtilsImpl::checkSystemImports()
     return false;
   }
 
-  // set PyQt api versions
-  for ( const QString &clsName :
-        {
-          QStringLiteral( "QDate" ),
-          QStringLiteral( "QDateTime" ),
-          QStringLiteral( "QString" ),
-          QStringLiteral( "QTextStream" ),
-          QStringLiteral( "QTime" ),
-          QStringLiteral( "QUrl" ),
-          QStringLiteral( "QVariant" )
-        } )
-  {
-    if ( !runString( QStringLiteral( "sip.setapi('%1', 2)" ).arg( clsName ),
-                     QObject::tr( "Couldn't set SIP API versions." ) + '\n' + QObject::tr( "Python support will be disabled." ) ) )
-    {
-      return false;
-    }
-  }
   // import Qt bindings
   if ( !runString( QStringLiteral( "from PyQt5 import QtCore, QtGui" ),
                    QObject::tr( "Couldn't load PyQt." ) + '\n' + QObject::tr( "Python support will be disabled." ) ) )


### PR DESCRIPTION
PyQt5 dropped multiple API support.

## Description

Remove code having no effect, apart from causing a deprecation warning.
