### PR TITLE
[AttributeForm] respect size policy of embedded widgets

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1495,6 +1495,7 @@ void QgsAttributeForm::init()
     int column = 0;
     int columnCount = 1;
     bool hasRootFields = false;
+    bool addSpacer = true;
 
     const QList<QgsAttributeEditorElement *> tabs = mLayer->editFormConfig().tabs();
 
@@ -1574,6 +1575,9 @@ void QgsAttributeForm::init()
 
         label->setBuddy( widgetInfo.widget );
 
+        if ( widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed )
+          addSpacer = false;
+
         if ( !widgetInfo.showLabel )
         {
           QVBoxLayout *c = new QVBoxLayout();
@@ -1624,7 +1628,7 @@ void QgsAttributeForm::init()
       }
     }
 
-    if ( hasRootFields )
+    if ( hasRootFields && addSpacer )
     {
       QSpacerItem *spacerItem = new QSpacerItem( 20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding );
       layout->addItem( spacerItem, row, 0 );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1575,7 +1575,10 @@ void QgsAttributeForm::init()
 
         label->setBuddy( widgetInfo.widget );
 
-        if ( widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed )
+        // If at least one expanding widget is present do not add a spacer
+        if ( widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed
+             && widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Maximum
+             && widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Preferred )
           addSpacer = false;
 
         if ( !widgetInfo.showLabel )

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -46,7 +46,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
 
   mMultiEditButton->setField( mEditorWidget->field() );
   mAggregateButton = new QgsAggregateToolButton();
-  mAggregateButton->setType( editorWidget->field().type() );
+  mAggregateButton->setType( mEditorWidget->field().type() );
   connect( mAggregateButton, &QgsAggregateToolButton::aggregateChanged, this, &QgsAttributeFormEditorWidget::onAggregateChanged );
 
   if ( mEditorWidget->widget() )

--- a/src/gui/qgsattributeformwidget.cpp
+++ b/src/gui/qgsattributeformwidget.cpp
@@ -60,6 +60,9 @@ QgsAttributeFormWidget::QgsAttributeFormWidget( QgsWidgetWrapper *widget, QgsAtt
 
   mEditPage->layout()->addWidget( mWidget->widget() );
 
+  // Respect size policy of embedded widget
+  setSizePolicy( mWidget->widget()->sizePolicy() );
+
   updateWidgets();
 }
 


### PR DESCRIPTION
This let widgets wich can make use of more vertical space grow
togheter with the form dialog

New:
![Peek 2021-11-11 08-40 - NEW](https://user-images.githubusercontent.com/9881900/141258153-002fad0e-c62f-4668-892f-68a0dc10615c.gif)

Old:
![Peek 2021-11-11 08-41 - OLD](https://user-images.githubusercontent.com/9881900/141258185-c051ffb7-16af-4bb5-bac9-526a45a26619.gif)

