### PR TITLE
fix suffix for TIN Mesh creation

### DIFF
--- a/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
+++ b/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
@@ -177,12 +177,6 @@ QVariantMap QgsTinMeshCreationAlgorithm::processAlgorithm( const QVariantMap &pa
 
   const QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "mdal" ) );
 
-//  QFileInfo fileInfo( fileName );
-//  QString suffix = fileInfo.suffix();
-
-//  if ( suffix.isEmpty() )
-//    fileName.append( QStringLiteral( ".%1" ).arg( mDriverSuffix.value( driver ) ) );
-
   fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << mDriverSuffix.value( driver ) );
 
   if ( feedback )

--- a/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
+++ b/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmtinmeshcreation.h"
+#include "qgsfileutils.h"
 #include "qgsprovidermetadata.h"
 #include "qgsproviderregistry.h"
 #include "qgsprocessingparametertininputlayers.h"
@@ -176,11 +177,13 @@ QVariantMap QgsTinMeshCreationAlgorithm::processAlgorithm( const QVariantMap &pa
 
   const QgsProviderMetadata *providerMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "mdal" ) );
 
-  QFileInfo fileInfo( fileName );
-  QString suffix = fileInfo.suffix();
+//  QFileInfo fileInfo( fileName );
+//  QString suffix = fileInfo.suffix();
 
-  if ( suffix.isEmpty() )
-    fileName.append( QStringLiteral( ".%1" ).arg( mDriverSuffix.value( driver ) ) );
+//  if ( suffix.isEmpty() )
+//    fileName.append( QStringLiteral( ".%1" ).arg( mDriverSuffix.value( driver ) ) );
+
+  fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << mDriverSuffix.value( driver ) );
 
   if ( feedback )
     feedback->setProgressText( QObject::tr( "Saving mesh to file" ) );

--- a/src/analysis/processing/qgsalgorithmtinmeshcreation.h
+++ b/src/analysis/processing/qgsalgorithmtinmeshcreation.h
@@ -46,6 +46,7 @@ class QgsTinMeshCreationAlgorithm: public QgsProcessingAlgorithm
 
   private:
     QStringList mAvailableFormat;
+    QMap<QString, QString> mDriverSuffix;
 
     struct Layer
     {


### PR DESCRIPTION
With the process tool "TIN mesh creation", if the user does not set itself the suffix of the file, the new created file does not have a suffix, that leads to the impossibility to load the file in QGIS later.
This PR fixes this issue.
