### PR TITLE
[modeler]Make the "zoom to" action really zoom to a group box instead of pan

### DIFF
--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -534,7 +534,7 @@ bool QgsModelDesignerDialog::validateSave()
 {
   if ( mNameEdit->text().trimmed().isEmpty() )
   {
-    mMessageBar->pushWarning( QString(), tr( "Please a enter model name before saving" ) );
+    mMessageBar->pushWarning( QString(), tr( "Please enter a model name before saving" ) );
     return false;
   }
 
@@ -835,6 +835,9 @@ void QgsModelDesignerDialog::populateZoomToMenu()
       QAction *zoomAction = new QAction( box.description(), mGroupMenu );
       connect( zoomAction, &QAction::triggered, this, [ = ]
       {
+        QRectF groupRect = item->boundingRect();
+        groupRect.adjust( -10, -10, 10, 10 );
+        mView->fitInView( groupRect, Qt::KeepAspectRatio );
         mView->centerOn( item );
       } );
       mGroupMenu->addAction( zoomAction );


### PR DESCRIPTION
In the model designer, the "View --> Zoom to" button does NOT zoom to the extent of the target group box but pans the view so that the group box appears in it (not necessarily at the center as would a pan to feature do). Depending on the zoom scale of the view and/or extent, hitting that button does not help sometimes.
This PR makes it really zoom to the group extent (scale to the group extent's and pan to its center). Maybe there's a dedicated method I didn't find?