### PR TITLE
Poly2tri library update to fix crash with self-intersecting ring & fix random marker fill 

### DIFF
--- a/external/poly2tri/common/shapes.cc
+++ b/external/poly2tri/common/shapes.cc
@@ -35,6 +35,10 @@
 
 namespace p2t {
 
+Point::Point(double x, double y) : x(x), y(y)
+{
+}
+
 std::ostream& operator<<(std::ostream& out, const Point& point) {
   return out << point.x << "," << point.y;
 }
@@ -42,7 +46,7 @@ std::ostream& operator<<(std::ostream& out, const Point& point) {
 Triangle::Triangle(Point& a, Point& b, Point& c)
 {
   points_[0] = &a; points_[1] = &b; points_[2] = &c;
-  neighbors_[0] = NULL; neighbors_[1] = NULL; neighbors_[2] = NULL;
+  neighbors_[0] = nullptr; neighbors_[1] = nullptr; neighbors_[2] = nullptr;
   constrained_edge[0] = constrained_edge[1] = constrained_edge[2] = false;
   delaunay_edge[0] = delaunay_edge[1] = delaunay_edge[2] = false;
   interior_ = false;
@@ -85,36 +89,36 @@ void Triangle::Clear()
     for( int i=0; i<3; i++ )
     {
         t = neighbors_[i];
-        if( t != NULL )
+        if( t != nullptr )
         {
             t->ClearNeighbor( this );
         }
     }
     ClearNeighbors();
-    points_[0]=points_[1]=points_[2] = NULL;
+    points_[0]=points_[1]=points_[2] = nullptr;
 }
 
 void Triangle::ClearNeighbor(const Triangle *triangle )
 {
     if( neighbors_[0] == triangle )
     {
-        neighbors_[0] = NULL;
+        neighbors_[0] = nullptr;
     }
     else if( neighbors_[1] == triangle )
     {
-        neighbors_[1] = NULL;
+        neighbors_[1] = nullptr;
     }
     else
     {
-        neighbors_[2] = NULL;
+        neighbors_[2] = nullptr;
     }
 }
 
 void Triangle::ClearNeighbors()
 {
-  neighbors_[0] = NULL;
-  neighbors_[1] = NULL;
-  neighbors_[2] = NULL;
+  neighbors_[0] = nullptr;
+  neighbors_[1] = nullptr;
+  neighbors_[2] = nullptr;
 }
 
 void Triangle::ClearDelunayEdges()
@@ -226,7 +230,7 @@ Point* Triangle::PointCW(const Point& point)
     return points_[1];
   }
   assert(0);
-  return NULL;
+  return nullptr;
 }
 
 // The point counter-clockwise to given point
@@ -240,7 +244,18 @@ Point* Triangle::PointCCW(const Point& point)
     return points_[0];
   }
   assert(0);
-  return NULL;
+  return nullptr;
+}
+
+// The neighbor across to given point
+Triangle* Triangle::NeighborAcross(const Point& point)
+{
+  if (&point == points_[0]) {
+    return neighbors_[0];
+  } else if (&point == points_[1]) {
+    return neighbors_[1];
+  }
+  return neighbors_[2];
 }
 
 // The neighbor clockwise to given point
@@ -347,17 +362,6 @@ void Triangle::SetDelunayEdgeCW(const Point& p, bool e)
   } else {
     delaunay_edge[0] = e;
   }
-}
-
-// The neighbor across to given point
-Triangle& Triangle::NeighborAcross(const Point& opoint)
-{
-  if (&opoint == points_[0]) {
-    return *neighbors_[0];
-  } else if (&opoint == points_[1]) {
-    return *neighbors_[1];
-  }
-  return *neighbors_[2];
 }
 
 void Triangle::DebugPrint()

--- a/external/poly2tri/common/shapes.h
+++ b/external/poly2tri/common/shapes.h
@@ -57,7 +57,7 @@ struct Point {
   std::vector<Edge*> edge_list;
 
   /// Construct using coordinates.
-  Point(double x, double y) : x(x), y(y) {}
+  Point(double x, double y);
 
   /// Set this point to all zeros.
   void set_zero()
@@ -176,6 +176,7 @@ void MarkConstrainedEdge(Point* p, Point* q);
 int Index(const Point* p);
 int EdgeIndex(const Point* p1, const Point* p2);
 
+Triangle* NeighborAcross(const Point& point);
 Triangle* NeighborCW(const Point& point);
 Triangle* NeighborCCW(const Point& point);
 bool GetConstrainedEdgeCCW(const Point& p);
@@ -202,8 +203,6 @@ void ClearDelunayEdges();
 
 inline bool IsInterior();
 inline void IsInterior(bool b);
-
-Triangle& NeighborAcross(const Point& opoint);
 
 void DebugPrint();
 
@@ -260,7 +259,7 @@ inline bool operator ==(const Point& a, const Point& b)
 
 inline bool operator !=(const Point& a, const Point& b)
 {
-  return !(a.x == b.x) && !(a.y == b.y);
+  return !(a.x == b.x) || !(a.y == b.y);
 }
 
 /// Peform the dot product on two vectors.

--- a/external/poly2tri/common/utils.h
+++ b/external/poly2tri/common/utils.h
@@ -33,7 +33,9 @@
 #define UTILS_H
 
 // Otherwise #defines like M_PI are undeclared under Visual Studio
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 
 #include "shapes.h"
 

--- a/external/poly2tri/common/utils.h
+++ b/external/poly2tri/common/utils.h
@@ -33,9 +33,7 @@
 #define UTILS_H
 
 // Otherwise #defines like M_PI are undeclared under Visual Studio
-#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
-#endif
 
 #include "shapes.h"
 

--- a/external/poly2tri/sweep/advancing_front.cc
+++ b/external/poly2tri/sweep/advancing_front.cc
@@ -46,21 +46,21 @@ Node* AdvancingFront::LocateNode(double x)
   Node* node = search_node_;
 
   if (x < node->value) {
-    while ((node = node->prev) != NULL) {
+    while ((node = node->prev) != nullptr) {
       if (x >= node->value) {
         search_node_ = node;
         return node;
       }
     }
   } else {
-    while ((node = node->next) != NULL) {
+    while ((node = node->next) != nullptr) {
       if (x < node->value) {
         search_node_ = node->prev;
         return node->prev;
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 Node* AdvancingFront::FindSearchNode(double x)
@@ -88,13 +88,13 @@ Node* AdvancingFront::LocatePoint(const Point* point)
       }
     }
   } else if (px < nx) {
-    while ((node = node->prev) != NULL) {
+    while ((node = node->prev) != nullptr) {
       if (point == node->point) {
         break;
       }
     }
   } else {
-    while ((node = node->next) != NULL) {
+    while ((node = node->next) != nullptr) {
       if (point == node->point)
         break;
     }

--- a/external/poly2tri/sweep/cdt.cc
+++ b/external/poly2tri/sweep/cdt.cc
@@ -1,5 +1,5 @@
 /*
- * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * Poly2Tri Copyright (c) 2009-2021, Poly2Tri Contributors
  * https://github.com/jhasse/poly2tri
  *
  * All rights reserved.
@@ -68,4 +68,4 @@ CDT::~CDT()
   delete sweep_;
 }
 
-}
+} // namespace p2t

--- a/external/poly2tri/sweep/sweep.h
+++ b/external/poly2tri/sweep/sweep.h
@@ -33,7 +33,7 @@
  * Zalik, B.(2008)'Sweep-line algorithm for constrained Delaunay triangulation',
  * International Journal of Geographical Information Science
  *
- * "FlipScan" Constrained Edge Algorithm invented by Thomas ?hl?n, thahlen@gmail.com
+ * "FlipScan" Constrained Edge Algorithm invented by Thomas Åhlén, thahlen@gmail.com
  */
 
 #ifndef SWEEP_H

--- a/external/poly2tri/sweep/sweep_context.cc
+++ b/external/poly2tri/sweep/sweep_context.cc
@@ -35,12 +35,12 @@
 namespace p2t {
 
 SweepContext::SweepContext(const std::vector<Point*>& polyline) : points_(polyline),
-  front_(0),
-  head_(0),
-  tail_(0),
-  af_head_(0),
-  af_middle_(0),
-  af_tail_(0)
+  front_(nullptr),
+  head_(nullptr),
+  tail_(nullptr),
+  af_head_(nullptr),
+  af_middle_(nullptr),
+  af_tail_(nullptr)
 {
   InitEdges(points_);
 }
@@ -87,8 +87,8 @@ void SweepContext::InitTriangulation()
 
   double dx = kAlpha * (xmax - xmin);
   double dy = kAlpha * (ymax - ymin);
-  head_ = new Point(xmax + dx, ymin - dy);
-  tail_ = new Point(xmin - dx, ymin - dy);
+  head_ = new Point(xmin - dx, ymin - dy);
+  tail_ = new Point(xmax + dx, ymin - dy);
 
   // Sort points along y-axis
   std::sort(points_.begin(), points_.end(), cmp);
@@ -114,17 +114,17 @@ void SweepContext::AddToMap(Triangle* triangle)
   map_.push_back(triangle);
 }
 
-Node& SweepContext::LocateNode(const Point& point)
+Node* SweepContext::LocateNode(const Point& point)
 {
   // TODO implement search tree
-  return *front_->LocateNode(point.x);
+  return front_->LocateNode(point.x);
 }
 
 void SweepContext::CreateAdvancingFront()
 {
 
   // Initial triangle
-  Triangle* triangle = new Triangle(*points_[0], *tail_, *head_);
+  Triangle* triangle = new Triangle(*points_[0], *head_, *tail_);
 
   map_.push_back(triangle);
 
@@ -171,7 +171,7 @@ void SweepContext::MeshClean(Triangle& triangle)
 	Triangle *t = triangles.back();
 	triangles.pop_back();
 
-    if (t != NULL && !t->IsInterior()) {
+    if (t != nullptr && !t->IsInterior()) {
       t->IsInterior(true);
       triangles_.push_back(t);
       for (int i = 0; i < 3; i++) {
@@ -207,4 +207,4 @@ SweepContext::~SweepContext()
 
 }
 
-}
+} // namespace p2t

--- a/external/poly2tri/sweep/sweep_context.h
+++ b/external/poly2tri/sweep/sweep_context.h
@@ -66,7 +66,7 @@ Point* tail() const;
 
 size_t point_count() const;
 
-Node& LocateNode(const Point& point);
+Node* LocateNode(const Point& point);
 
 void RemoveNode(Node* node);
 

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -431,64 +431,6 @@ static QgsPolygon *_transform_polygon_to_new_base( const QgsPolygon &polygon, co
   return p;
 }
 
-static bool _check_intersecting_rings( const QgsPolygon &polygon )
-{
-  std::vector< std::unique_ptr< QgsGeometryEngine > > ringEngines;
-  ringEngines.reserve( 1 + polygon.numInteriorRings() );
-  ringEngines.emplace_back( QgsGeometry::createGeometryEngine( polygon.exteriorRing() ) );
-  for ( int i = 0; i < polygon.numInteriorRings(); ++i )
-    ringEngines.emplace_back( QgsGeometry::createGeometryEngine( polygon.interiorRing( i ) ) );
-
-  // we need to make sure that the polygon has no rings with self-intersection: that may
-  // crash the tessellator. The original geometry maybe have been valid and the self-intersection
-  // was introduced when transforming to a new base (in a rare case when all points are not in the same plane)
-
-  for ( const std::unique_ptr< QgsGeometryEngine > &ring : ringEngines )
-  {
-    if ( !ring->isSimple() )
-      return false;
-  }
-
-  // At this point we assume that input polygons are valid according to the OGC definition.
-  // This means e.g. no duplicate points, polygons are simple (no butterfly shaped polygon with self-intersection),
-  // internal rings are inside exterior rings, rings do not cross each other, no dangles.
-
-  // There is however an issue with polygons where rings touch:
-  //  +---+
-  //  |   |
-  //  | +-+-+
-  //  | | | |
-  //  | +-+ |
-  //  |     |
-  //  +-----+
-  // This is a valid polygon with one exterior and one interior ring that touch at one point,
-  // but poly2tri library does not allow interior rings touch each other or exterior ring.
-  // TODO: Handle the situation better - rather than just detecting the problem, try to fix
-  // it by converting touching rings into one ring.
-
-  if ( ringEngines.size() > 1 )
-  {
-    for ( size_t i = 0; i < ringEngines.size(); ++i )
-    {
-      std::unique_ptr< QgsGeometryEngine > &first = ringEngines.at( i );
-      if ( polygon.numInteriorRings() > 1 )
-        first->prepareGeometry();
-
-      // TODO this is inefficient - QgsGeometryEngine::intersects only works with QgsAbstractGeometry
-      // objects and accordingly we have to use those, instead of the previously build geos
-      // representations available in ringEngines
-      // This needs addressing by extending the QgsGeometryEngine relation tests to allow testing against
-      // another QgsGeometryEngine object.
-      for ( int interiorRing = static_cast< int >( i ); interiorRing < polygon.numInteriorRings(); ++interiorRing )
-      {
-        if ( first->intersects( polygon.interiorRing( interiorRing ) ) )
-          return false;
-      }
-    }
-  }
-  return true;
-}
-
 
 double _minimum_distance_between_coordinates( const QgsPolygon &polygon )
 {
@@ -685,13 +627,6 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
       {
         polygonNew.reset( polygonSimplifiedData->clone() );
       }
-    }
-
-    if ( !_check_intersecting_rings( *polygonNew ) )
-    {
-      // skip the polygon - it would cause a crash inside poly2tri library
-      QgsMessageLog::logMessage( QObject::tr( "polygon rings self-intersect or intersect each other - skipping" ), QObject::tr( "3D" ) );
-      return;
     }
 
     QList< std::vector<p2t::Point *> > polylinesToDelete;


### PR DESCRIPTION
## Description

This PR updates the poly2tri to catch up a number of fixes upstream, including a fix for self-intersecting rings crashing poly2tri. As a result, we can remove that check from the QgsTessellator class, which speeds things up and avoid having to skip those polygons when building 3D scenes.

I n doing so, we also end up fixing the random marker fill symbol layer failing with valid polygons having ring(s) touching the polygon outer boundaries, as reported in #46021.

Turns out time really does heal everything :wink: 