### PR TITLE
GoTo-locator: also add coordinate/crs combi's in result list from crs's from layers (so besides wgs84 and project crs)

### DIFF
--- a/src/app/locator/qgsgotolocatorfilter.cpp
+++ b/src/app/locator/qgsgotolocatorfilter.cpp
@@ -169,13 +169,13 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
           catch ( const QgsException &e )
           {
             Q_UNUSED( e )
-            //result.displayString = tr( "Transform exception: NOT Going to %1 %2 (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+            //result.displayString = tr( "Transform exception: NOT Going to %1 %2 (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
             continue;
           }
           if ( crs == wgs84Crs )
-            result.displayString = tr( "Go to %1° %2° (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+            result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
           else
-            result.displayString = tr( "Go to %1 %2 (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+            result.displayString = tr( "Go to %1 %2 (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
           result.score = 0.85;
           data[QStringLiteral( "point" )] = transformedPoint;
         }

--- a/src/app/locator/qgsgotolocatorfilter.cpp
+++ b/src/app/locator/qgsgotolocatorfilter.cpp
@@ -45,7 +45,6 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   bool okY = false;
   double posX = 0.0;
   double posY = 0.0;
-  bool posIsDms = false;
   const QLocale locale;
 
   // Coordinates such as 106.8468,-6.3804 or 200.000,450.000 using locale group- and decimal separators
@@ -81,7 +80,6 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
     match = separatorRx.match( string.trimmed() );
     if ( match.hasMatch() )
     {
-      posIsDms = true;
       bool isEasting = false;
       posX = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &okX, &isEasting );
       posY = QgsCoordinateUtils::dmsToDecimal( match.captured( 3 ), &okY );
@@ -90,52 +88,112 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
     }
   }
 
-  if ( okX && okY )  // Ok found a valid looking x,y coordinate pair, check against Map-crs and Wgs84crs
+  if ( okX && okY )  // Ok found a valid looking x,y coordinate pair, check against Wgs84crs, MapCanvas-crs AND layer-crs's
   {
-    QVariantMap data;
-    const QgsPointXY point( posX, posY );
-    data.insert( QStringLiteral( "point" ), point );
-
-    const bool withinWgs84 = wgs84Crs.bounds().contains( point );
-    if ( !posIsDms && currentCrs != wgs84Crs )
+    // collect all crs's from all layers (plus MapCanvas crs and wgs84)
+    QList<QString> crsList;  // TODO make this a list
+    crsList.append( wgs84Crs.authid() );
+    if ( currentCrs != wgs84Crs )
+      crsList.append( currentCrs.authid() );
+    for ( const QgsMapLayer *layer : QgsProject::instance()->mapLayers() )
     {
+      if ( !crsList.contains( layer->crs().authid() ) )
+      {
+        crsList.append( layer->crs().authid() );
+      }
+    }
+    // Now go over all crs's and check if the coordinate COULD be use in that crs
+    for ( const QString &authid : crsList )
+    {
+
+      QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem( authid );
+
+      QVariantMap data;
+      const QgsPointXY point( posX, posY );
+      data.insert( QStringLiteral( "point" ), point );
+
       QgsLocatorResult result;
       result.filter = this;
-      result.displayString = tr( "Go to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), currentCrs.userFriendlyIdentifier() );
-      result.userData = data;
-      result.score = 0.9;
-      emit resultFetched( result );
-    }
 
-    if ( withinWgs84 )
-    {
-      if ( currentCrs != wgs84Crs )
+      const bool withinWgs84 = wgs84Crs.bounds().contains( point );
+      if ( crs == wgs84Crs && crs == currentCrs && withinWgs84 )
       {
-        const QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );
-        QgsPointXY transformedPoint;
-        try
-        {
-          transformedPoint = transform.transform( point );
-        }
-        catch ( const QgsException &e )
-        {
-          Q_UNUSED( e )
-          return;
-        }
-        data[QStringLiteral( "point" )] = transformedPoint;
+        result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
+        result.score = 1.0;
+        result.userData = data;
+        emit resultFetched( result );
+        continue;
       }
 
-      QgsLocatorResult result;
-      result.filter = this;
-      result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
+      // non wgs84 project, create a transform to be able to check point against bounds
+      const QgsCoordinateTransform transform2wgs84( crs, wgs84Crs, QgsProject::instance()->transformContext() );
+      QgsPointXY wgs84Point;
+      try
+      {
+        wgs84Point = transform2wgs84.transform( point );
+      }
+      catch ( const QgsException &e )
+      {
+        Q_UNUSED( e )
+        // for testing purposes: show when a potential crs coordinate is skipped: show the resultstring
+        //result.displayString = tr( "Transform exception: NOT Going to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+        //emit resultFetched( result );
+        continue;
+      }
+
+      if ( crs == currentCrs )
+      {
+        if ( crs.bounds().contains( wgs84Point ) )
+        {
+          // data.point is already set to this crs
+          result.displayString = tr( "Go to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+          result.score = 0.9;
+        }
+        else   // (potential) currentCrs coordinate is tested outside bounds of currentCrs
+        {
+          // for testing purposes: show when a potential crs coordinate is skipped: show the resultstring
+          //result.displayString = tr( "NOT Going to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+          continue;
+        }
+      }
+      else    // crs != currentCrs ==> transform, BUT only if within crs bounds
+      {
+        if ( crs.bounds().contains( wgs84Point ) )
+        {
+          const QgsCoordinateTransform transform2mapcanvas( crs, currentCrs, QgsProject::instance()->transformContext() );
+          QgsPointXY transformedPoint;
+          try
+          {
+            transformedPoint = transform2mapcanvas.transform( point );
+          }
+          catch ( const QgsException &e )
+          {
+            Q_UNUSED( e )
+            //result.displayString = tr( "Transform exception: NOT Going to %1 %2 (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+            continue;
+          }
+          if ( crs == wgs84Crs )
+            result.displayString = tr( "Go to %1° %2° (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+          else
+            result.displayString = tr( "Go to %1 %2 (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+          result.score = 0.85;
+          data[QStringLiteral( "point" )] = transformedPoint;
+        }
+        else
+        {
+          // for testing purposes: show when a potential crs coordinate is skipped: show the resultstring
+          //result.displayString = tr( "NOT Going to %1 %2 (Layer CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), crs.userFriendlyIdentifier() );
+          continue;
+        }
+      }
       result.userData = data;
-      result.score = 1.0;
       emit resultFetched( result );
+
     }
     return;
   }
 
-  // Going to check for url patterns of (google/osm) tiling services
+  // No valid looking coordinate pair found, going to check for url patterns of (google/osm) tiling services
 
   // Scales for EPSG:3857 tiling services
   QMap<int, double> scales;

--- a/src/app/locator/qgsgotolocatorfilter.h
+++ b/src/app/locator/qgsgotolocatorfilter.h
@@ -41,6 +41,8 @@ class APP_EXPORT QgsGotoLocatorFilter : public QgsLocatorFilter
 
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
+    bool hasConfigWidget() const override {return true;}
+    void openConfigWidget( QWidget *parent ) override;
 
 };
 

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -362,19 +362,17 @@ void TestQgsAppLocatorFilters::testGoto()
 
   // simple goto
   QList< QgsLocatorResult > results = gatherResults( &filter, QStringLiteral( "4 5" ), QgsLocatorContext() );
-  QCOMPARE( results.count(), 2 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 4 5 (Map CRS, )" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
-  QCOMPARE( results.at( 1 ).displayString, QObject::tr( "Go to 4° 5° (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 1 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
-
-  // locale-specific goto
-  results = gatherResults( &filter, QStringLiteral( "1,234.56 789.012" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1,234.56 789.012 (Map CRS, )" ) );
-  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1234.56, 789.012 ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 4° 5° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
 
-  // degree/minuste/second coordinates goto
+  // locale-specific goto (RD: actually not, this tested "1,234.56 789.012" against a project without crs, which now does not have a result anymore (as not a valid WGS84 coordinate)
+  results = gatherResults( &filter, QStringLiteral( "1.23456 7.89012" ), QgsLocatorContext() );
+  QCOMPARE( results.count(), 1 );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.23456° 7.89012° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.23456, 7.89012 ) );
+
+  // degree/minutes/second coordinates goto
   // easting northing
   results = gatherResults( &filter, QStringLiteral( "40deg 1' 0\" E 11deg  55' 0\" S" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
@@ -387,7 +385,7 @@ void TestQgsAppLocatorFilters::testGoto()
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
-  // northing, esting (comma separated)
+  // northing, easting (comma separated)
   results = gatherResults( &filter, QStringLiteral( "14°49′48″N, 01°48′45″E" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );


### PR DESCRIPTION
## Description

The rationale behind this PR is that I often work with people who use a EPSG;3857 project with OSM reference map, BUT some national crs (EPSG:28992) details layers. And during (excersises for) emergency responses, they are often offered EPSG:28992 coordinates then to quickly be able to locate something.
One can off course use the perfect LatLon plugin for that (after some fiddling with the preferences to use x,y instead of default y,x... etc), but I thought: why not be able in the locator bar?

My first though: "it would be cool if one could add some crs-indication to the coordinates, so something like: 28992:150000,450000 or so: go to EPSG:28992 X:150000 Y:450000. But my users often are not very EPSG-code aware, and I do not want to make the use of the Locator more difficult.

Then I though: "OK, there is already often EPSG:28992 data, what about not only showing current Project CRS and Wgs84 coordinates, but also crs's which are available in the layer list (and probably of interest for the user...).

So when you have a EPGS:3857 map, and you would paste the valid EPSG:28992 coordinates 108542,472761 into the locator you would be shown:

![image](https://user-images.githubusercontent.com/731673/141683161-43e1bd63-b11f-4363-8a80-282d4996ef65.png)

With this pr it would be:

![Screenshot-20211114142530-778x702](https://user-images.githubusercontent.com/731673/141683202-f0ec5c71-9877-4bfe-a42b-df5bd1ee7e4d.png)

You can also configure one extra crs to test/use via a small configuration dialog (in configure dialog of locators):

![Screenshot-20211214181234-788x197](https://user-images.githubusercontent.com/731673/146047725-cbd4b38a-6a59-4e0e-800f-5822ac3da87a.png)

Note that crs for which the coordinates would not make sense are skipped: 108542,472761 can NOT be valid lat lon coordinates.
I even made this more strict then the old implementation: eg EPSG:28992 has bounds around the Netherlands, with a minimum possible x of say -10000 and a minimal possibly y of say 30000, so when pasting a coordinate like 2,3 it will NOT be shown as possible EPSG:28992 coordinate ( testing a coordinate pair against the bounds of a crs ).

Started of with adding some comments, as it was not clear to me what the scales were for, untill I found out that you can possibly also use osm or google map url's as location... :-) So I added some comments.

I did have some issues creating the logic, so if people think there is a clearer/better way, please let me know.

There are also some caveats in the use of this PR, for example: using the right-mouse click in the map and copying a WGS84 coordinate IN the netherlands, and pasting it in the goto locator, you will NOT be show a EPSG:28992 coordinate, because: the valid lat lon coordinate in NL (say 5.501,52.217) is NOT a valid coordinate in the EPSG_28992 crs... a little counter intuitive maybe?

I also hit the warning: "Used a ballpark transform from EPSG:4326 to EPSG:28992" which you off course do not want to see if you use a simple locator, that is why the logic also became a little complexer...

Let me know what you think, if you think this is troubling the code, I'm ok to thing about alternatives:
- maybe use of 28992:x,y ?
- I event thought about ALSO adding a z or scale value (so you can easily fly to a place AND set the scale) but is was indecisive about using z or scale (and do not want to spoil stuff when working with real 3D data)
- totally forget about this PR (maybe only the comments commit?)

Another thought: as I am testing (potential) xy candidates against the bounds of the crs's: why not also do this for 'Copy coordinate' from mapcanvas? Now it is possible (having a world map (EPSG:4326) loaded, with some national data (EPSG:28992) to try to copy an epsg:28992 coordinate in australia, also raising the ball park warning. While we could also maybe check against the bounds of the crs's before showing them in the context menu?

(sorry for this long text....)





