### PR TITLE
Add method to QgsProperty to determine if a property is effectively a static value in a specified QgsExpressionContext

### DIFF
--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -257,6 +257,23 @@ Returns whether the property is currently active.
 .. seealso:: :py:func:`setActive`
 %End
 
+    bool isStaticValueInContext( const QgsExpressionContext &context, QVariant &staticValue /Out/ ) const;
+%Docstring
+Returns ``True`` if the property is effectively a static value
+in the specified ``context``.
+
+I.e. if the property type is QgsProperty.ExpressionBasedProperty with
+a fixed value expression ('some static value'), this method will return
+``True``.
+
+:param context: expression context
+
+:return: - ``True`` if property is a static value
+         - staticValue: will be set to evaluated static value if property is effectively a static value
+
+.. versionadded:: 3.24
+%End
+
     void setActive( bool active );
 %Docstring
 Sets whether the property is currently active.

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -302,6 +302,22 @@ class CORE_EXPORT QgsProperty
     bool isActive() const;
 
     /**
+     * Returns TRUE if the property is effectively a static value
+     * in the specified \a context.
+     *
+     * I.e. if the property type is QgsProperty::ExpressionBasedProperty with
+     * a fixed value expression ('some static value'), this method will return
+     * TRUE.
+     *
+     * \param context expression context
+     * \param staticValue will be set to evaluated static value if property is effectively a static value
+     * \returns TRUE if property is a static value
+     *
+     * \since QGIS 3.24
+     */
+    bool isStaticValueInContext( const QgsExpressionContext &context, QVariant &staticValue SIP_OUT ) const;
+
+    /**
      * Sets whether the property is currently active.
      * \see isActive()
      */


### PR DESCRIPTION
Allows us to short-cut some calculations, e.g. by pre-evaluating
the property once during a QgsSymbol startRender instead of once
for every feature rendered.
