### PR TITLE
Fix font rendering regression following font stretch addition

### DIFF
--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -562,7 +562,9 @@ void QgsTextFormat::readXml( const QDomElement &elem, const QgsReadWriteContext 
   {
     d->opacity = ( textStyleElem.attribute( QStringLiteral( "textOpacity" ) ).toDouble() );
   }
+#ifdef HAS_KDE_QT5_FONT_STRETCH_FIX
   d->textFont.setStretch( textStyleElem.attribute( QStringLiteral( "stretchFactor" ), QStringLiteral( "100" ) ).toInt() );
+#endif
   d->orientation = QgsTextRendererUtils::decodeTextOrientation( textStyleElem.attribute( QStringLiteral( "textOrientation" ) ) );
   d->previewBackgroundColor = QgsSymbolLayerUtils::decodeColor( textStyleElem.attribute( QStringLiteral( "previewBkgrdColor" ), QgsSymbolLayerUtils::encodeColor( Qt::white ) ) );
 
@@ -667,7 +669,9 @@ QDomElement QgsTextFormat::writeXml( QDomDocument &doc, const QgsReadWriteContex
   textStyleElem.setAttribute( QStringLiteral( "fontWordSpacing" ), d->textFont.wordSpacing() );
   textStyleElem.setAttribute( QStringLiteral( "fontKerning" ), d->textFont.kerning() );
   textStyleElem.setAttribute( QStringLiteral( "textOpacity" ), d->opacity );
+#ifdef HAS_KDE_QT5_FONT_STRETCH_FIX
   textStyleElem.setAttribute( QStringLiteral( "stretchFactor" ), d->textFont.stretch() );
+#endif
   textStyleElem.setAttribute( QStringLiteral( "textOrientation" ), QgsTextRendererUtils::encodeTextOrientation( d->orientation ) );
   textStyleElem.setAttribute( QStringLiteral( "blendMode" ), QgsPainting::getBlendModeEnum( d->blendMode ) );
   textStyleElem.setAttribute( QStringLiteral( "multilineHeight" ), d->multilineHeight );
@@ -977,6 +981,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
     }
   }
 
+#ifdef HAS_KDE_QT5_FONT_STRETCH_FIX
   if ( d->mDataDefinedProperties.isActive( QgsPalLayerSettings::FontStretchFactor ) )
   {
     context.expressionContext().setOriginalValueVariable( d->textFont.stretch() );
@@ -986,6 +991,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
       d->textFont.setStretch( val.toInt() );
     }
   }
+#endif
 
   if ( d->mDataDefinedProperties.isActive( QgsPalLayerSettings::TextOrientation ) )
   {


### PR DESCRIPTION
## Description

The font stretch support addition led to a bad regression on system built against a non-patched Qt version:
![image](https://user-images.githubusercontent.com/1728657/141723274-b646adb2-57db-47c2-ab6d-ecd838029670.png)

This commit fixes the regression by disabling font stretching entirely when the patch flag is turned off. Beauty is back:
![image](https://user-images.githubusercontent.com/1728657/141723331-18da147f-b7c6-4a84-bd62-7c8c77686029.png)
