### PR TITLE
Limit height of PixmapLabel to 20 pixels

### DIFF
--- a/src/gui/qgspixmaplabel.cpp
+++ b/src/gui/qgspixmaplabel.cpp
@@ -19,13 +19,17 @@
 QgsPixmapLabel::QgsPixmapLabel( QWidget *parent )
   : QLabel( parent )
 {
-  this->setMinimumSize( 1, 1 );
 }
 
 void QgsPixmapLabel::setPixmap( const QPixmap &p )
 {
   const bool sizeChanged = ( p.size() != mPixmap.size() );
   mPixmap = p;
+
+  if ( mPixmap.isNull() )
+    this->setMinimumHeight( 0 );
+  else
+    this->setMinimumHeight( PIXMAP_MINIMUM_HEIGHT );
 
   if ( sizeChanged )
   {
@@ -66,4 +70,5 @@ void QgsPixmapLabel::clear()
 {
   mPixmap = QPixmap();
   QLabel::clear();
+  this->setMinimumHeight( 0 );
 }

--- a/src/gui/qgspixmaplabel.h
+++ b/src/gui/qgspixmaplabel.h
@@ -59,6 +59,8 @@ class GUI_EXPORT QgsPixmapLabel : public QLabel
 
   private:
 
+    static const int PIXMAP_MINIMUM_HEIGHT = 20;
+
     QPixmap mPixmap;
 };
 


### PR DESCRIPTION
Becoming smaller bring the pixmap to flickering in some situations when resizing the attribute form.
Like this:
![FlickeringPeek 2021-11-15 16-13](https://user-images.githubusercontent.com/9881900/141806141-29b3f93a-d83c-4a55-abb1-79d90d49d3fa.gif)

