### PR TITLE
[processing] fix order of command line arguments in gdal_polygonize (fix #46045)

### DIFF
--- a/python/plugins/processing/algs/gdal/polygonize.py
+++ b/python/plugins/processing/algs/gdal/polygonize.py
@@ -95,29 +95,31 @@ class polygonize(GdalAlgorithm):
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         arguments = []
+
+        if self.parameterAsBoolean(parameters, self.EIGHT_CONNECTEDNESS, context):
+            arguments.append('-8')
+
+        if self.EXTRA in parameters and parameters[self.EXTRA] not in (None, ''):
+            extra = self.parameterAsString(parameters, self.EXTRA, context)
+            arguments.append(extra)
+
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
         if inLayer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT))
 
         arguments.append(inLayer.source())
 
+        arguments.append('-b')
+        arguments.append(str(self.parameterAsInt(parameters, self.BAND, context)))
+
         outFile = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, outFile)
         output, outFormat = GdalUtils.ogrConnectionStringAndFormat(outFile, context)
-        arguments.append(output)
-
-        if self.parameterAsBoolean(parameters, self.EIGHT_CONNECTEDNESS, context):
-            arguments.append('-8')
-
-        arguments.append('-b')
-        arguments.append(str(self.parameterAsInt(parameters, self.BAND, context)))
 
         if outFormat:
             arguments.append('-f {}'.format(outFormat))
 
-        if self.EXTRA in parameters and parameters[self.EXTRA] not in (None, ''):
-            extra = self.parameterAsString(parameters, self.EXTRA, context)
-            arguments.append(extra)
+        arguments.append(output)
 
         layerName = GdalUtils.ogrOutputLayerName(output)
         if layerName:

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -2403,8 +2403,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outsource}, context, feedback),
                 ['gdal_polygonize.py',
                  source + ' ' +
-                 outsource + ' ' +
-                 '-b 1 -f "ESRI Shapefile" check DN'
+                 '-b 1 -f "ESRI Shapefile"' + ' ' + outsource + ' ' + 'check DN'
                  ])
 
             self.assertEqual(
@@ -2415,8 +2414,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outsource}, context, feedback),
                 ['gdal_polygonize.py',
                  source + ' ' +
-                 outsource + ' ' +
-                 '-b 1 -f "ESRI Shapefile" check VAL'
+                 '-b 1 -f "ESRI Shapefile"' + ' ' + outsource + ' ' + 'check VAL'
                  ])
 
             # 8 connectedness
@@ -2427,9 +2425,8 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'EIGHT_CONNECTEDNESS': True,
                                         'OUTPUT': outsource}, context, feedback),
                 ['gdal_polygonize.py',
-                 source + ' ' +
-                 outsource + ' ' +
-                 '-8 -b 1 -f "ESRI Shapefile" check DN'
+                 '-8' + ' ' + source + ' ' +
+                 '-b 1 -f "ESRI Shapefile"' + ' ' + outsource + ' ' + 'check DN'
                  ])
 
             # custom output format
@@ -2442,8 +2439,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outsource}, context, feedback),
                 ['gdal_polygonize.py',
                  source + ' ' +
-                 outsource + ' ' +
-                 '-b 1 -f "GPKG" check DN'
+                 '-b 1 -f "GPKG"' + ' ' + outsource + ' ' + 'check DN'
                  ])
 
             # additional parameters
@@ -2454,9 +2450,8 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'EXTRA': '-nomask -q',
                                         'OUTPUT': outsource}, context, feedback),
                 ['gdal_polygonize.py',
-                 source + ' ' +
-                 outsource + ' ' +
-                 '-b 1 -f "GPKG" -nomask -q check DN'
+                 '-nomask -q' + ' ' + source + ' ' +
+                 '-b 1 -f "GPKG"' + ' ' + outsource + ' ' + 'check DN'
                  ])
 
     def testGdalPansharpen(self):


### PR DESCRIPTION
## Description

In the latest GDAL `gdal_polygonize` tool requires output layer name and field name to be specified after the output file name.

Fixes #46045.