### PR TITLE
[Clazy] Remove useless variables

### DIFF
--- a/src/analysis/interpolation/qgsdualedgetriangulation.cpp
+++ b/src/analysis/interpolation/qgsdualedgetriangulation.cpp
@@ -3262,8 +3262,6 @@ bool QgsDualEdgeTriangulation::saveTriangulation( QgsFeatureSink *sink, QgsFeedb
 
 QgsMesh QgsDualEdgeTriangulation::triangulationToMesh( QgsFeedback *feedback ) const
 {
-  const QVector<bool> alreadyVisitedEdges( mHalfEdge.count(), false );
-
   if ( feedback )
     feedback->setProgress( 0 );
 

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -142,8 +142,6 @@ bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameter
     feedback->pushWarning( QObject::tr( "Field name %1 already exists and will be replaced" ).arg( field.name() ) );
   }
 
-  const QString dest;
-
   mFieldIdx = mFields.lookupField( field.name() );
 
   // prepare expression

--- a/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
@@ -427,7 +427,6 @@ bool QgsJoinByLocationAlgorithm::processFeatureFromJoinSource( QgsFeature &joinF
   std::unique_ptr< QgsGeometryEngine > engine;
   QgsFeatureRequest req = QgsFeatureRequest().setFilterRect( featGeom.boundingBox() );
   QgsFeatureIterator it = mBaseSource->getFeatures( req );
-  QList<QgsFeature> filtered;
   QgsFeature baseFeature;
   bool ok = false;
   QgsAttributes joinAttributes;
@@ -516,7 +515,6 @@ bool QgsJoinByLocationAlgorithm::processFeatureFromInputSource( QgsFeature &base
   QgsFeatureRequest req = QgsFeatureRequest().setDestinationCrs( mBaseSource->sourceCrs(), context.transformContext() ).setFilterRect( featGeom.boundingBox() ).setSubsetOfAttributes( mJoinedFieldIndices );
 
   QgsFeatureIterator it = mJoinSource->getFeatures( req );
-  QList<QgsFeature> filtered;
   QgsFeature joinFeature;
   bool ok = false;
 

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -101,7 +101,6 @@ void QgsRasterizeAlgorithm::initAlgorithm( const QVariantMap & )
                   QObject::tr( "Map theme to render" ),
                   QVariant(), true ) );
 
-  QList<QgsMapLayer *> projectLayers { QgsProject::instance()->mapLayers().values() };
   addParameter( new QgsProcessingParameterMultipleLayers(
                   QStringLiteral( "LAYERS" ),
                   QObject::tr( "Layers to render" ),
@@ -216,7 +215,6 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
   // Start rendering
   const double extentRatio { mapUnitsPerPixel * tileSize };
   const int numTiles { xTileCount * yTileCount };
-  const QString fileExtension { QFileInfo( outputLayerFileName ).suffix() };
 
   // Custom deleter for CPL allocation
   struct CPLDelete

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1187,7 +1187,6 @@ void QgsFieldsItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *me
       {
         QAction *addColumnAction = new QAction( tr( "Add New Field…" ), menu );
         QPointer<QgsDataItem>itemPtr { item };
-        const QString itemName { item->name() };
 
         connect( addColumnAction, &QAction::triggered, fieldsItem, [ md, fieldsItem, context, itemPtr, menu ]
         {

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -2050,8 +2050,6 @@ void QgsMapToolEditMeshFrame::prepareSelection()
   }
 
   mConcernedFaceBySelection.clear();
-  QMap<int, SelectedVertexData> movingVertices;
-
 
   double xMin = std::numeric_limits<double>::max();
   double xMax = -std::numeric_limits<double>::max();

--- a/src/app/mesh/qgsmeshselectbyexpressiondialog.cpp
+++ b/src/app/mesh/qgsmeshselectbyexpressiondialog.cpp
@@ -31,7 +31,6 @@ QgsMeshSelectByExpressionDialog::QgsMeshSelectByExpressionDialog( QWidget *paren
 
   setWindowTitle( tr( "Select Mesh Elements by Expression" ) );
 
-  QString elementText = tr( "Vertices" );
   mActionSelect = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mIconExpressionSelect.svg" ) ),  tr( "Select" ), this );
   mActionAddToSelection = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mIconSelectAdd.svg" ) ), tr( "Add to current selection" ), this );
   mActionRemoveFromSelection = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mIconSelectRemove.svg" ) ), tr( "Remove from current selection" ), this );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5425,7 +5425,6 @@ void QgisApp::about()
     versionString += QLatin1String( "</tr><tr>" );
 
     // Python version
-    const QString pythonVersion{ PYTHON_VERSION };
     versionString += QStringLiteral( "<td>%1</td><td colspan=\"3\">%2</td>" ).arg( tr( "Python version" ), PYTHON_VERSION );
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -16061,7 +16060,6 @@ bool QgisApp::addRasterLayers( QStringList const &files, bool guiWarning )
     }
 
     const bool isVsiCurl { src.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) };
-    const auto scheme { QUrl( src ).scheme() };
     const bool isRemoteUrl { src.startsWith( QLatin1String( "http" ) ) || src == QLatin1String( "ftp" ) };
 
     std::unique_ptr< QgsTemporaryCursorOverride > cursorOverride;

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -75,7 +75,6 @@ void QgsHtmlAnnotationDialog::applySettingsToItem()
   if ( mItem && mItem->annotation() )
   {
     QgsHtmlAnnotation *annotation = static_cast< QgsHtmlAnnotation * >( mItem->annotation() );
-    const QString file = mFileLineEdit->text();
     if ( mFileRadioButton->isChecked() )
     {
       annotation->setSourceFile( mFileLineEdit->text() );

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -118,7 +118,6 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
              ! topologyTestPoints.isEmpty() )
         {
           //check if we need to add topological points to other layers
-          const QList<QgsVectorLayer *> editableLayers;
           const auto layers = canvas()->layers();
           for ( QgsMapLayer *layer : layers )
           {

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -422,8 +422,6 @@ bool QgsNewSpatialiteLayerDialog::apply()
   }
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  const QString uri = QStringLiteral( "dbname='%1' table='%2'%3 sql=" ).arg( dbPath, leLayerName->text(),
-                      mGeometryTypeBox->currentIndex() != 0 ? QStringLiteral( "(%1)" ).arg( leGeometryColumn->text() ) : QString() );
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "%1 table='%2'%3 sql=" )
       .arg( mDatabaseComboBox->currentConnectionUri(),
             leLayerName->text(),

--- a/src/app/qgsprovidersublayersdialog.cpp
+++ b/src/app/qgsprovidersublayersdialog.cpp
@@ -258,8 +258,6 @@ QString QgsProviderSublayersDialog::groupName() const
   if ( !mCbxAddToGroup->isChecked() )
     return QString();
 
-  const QFileInfo fi( mFilePath );
-
   QString res = QgsProviderUtils::suggestLayerNameFromFilePath( mFilePath );
 
   const QgsSettings settings;

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -210,7 +210,6 @@ void QgsVectorTileLayerProperties::loadStyle()
 {
   const QgsSettings settings;  // where we keep last used filter in persistent state
 
-  const QString errorMsg;
   QStringList ids, names, descriptions;
 
   QgsMapLayerLoadStyleDialog dlg( mLayer );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1550,7 +1550,6 @@ QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type ) c
   if ( ! QgsWkbTypes::isMultiType( type ) && newGeom.isMultipart( ) )
   {
     const QgsGeometryCollection *parts( static_cast< const QgsGeometryCollection * >( newGeom.constGet() ) );
-    QgsAttributeMap attrMap;
     res.reserve( parts->partCount() );
     for ( int i = 0; i < parts->partCount( ); i++ )
     {

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1591,7 +1591,6 @@ QgsGeometry QgsInternalGeometryEngine::orientedMinimumBoundingBox( double &area,
     return QgsGeometry();
 
   std::unique_ptr< QgsGeometryEngine >engine( QgsGeometry::createGeometryEngine( mGeometry ) );
-  QString error;
   std::unique_ptr< QgsAbstractGeometry > hull( engine->convexHull( &mLastError ) );
   if ( !hull )
     return QgsGeometry();

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -490,8 +490,6 @@ void QgsMeshLayerRenderer::renderScalarDatasetOnEdges( const QgsMeshRendererScal
   const QVector<QgsMeshEdge> edges = mTriangularMesh.edges();
   const QVector<QgsMeshVertex> vertices = mTriangularMesh.vertices();
   const QList<int> egdesInExtent = mTriangularMesh.edgeIndexesForRectangle( context.mapExtent() );
-  const QSet<int> nativeEdgesInExtent = QgsMeshUtils::nativeEdgesFromEdges( egdesInExtent,
-                                        mTriangularMesh.edgesToNativeEdges() );
 
   QgsInterpolatedLineRenderer edgePlotter;
   edgePlotter.setInterpolatedColor( QgsInterpolatedLineColor( scalarSettings.colorRampShader() ) );

--- a/src/core/processing/qgsprocessingparametermeshdataset.cpp
+++ b/src/core/processing/qgsprocessingparametermeshdataset.cpp
@@ -308,8 +308,6 @@ bool QgsProcessingParameterMeshDatasetTime::valueIsAcceptable( const QVariant &i
   if ( !input.isValid() )
     return allowEmpty;
 
-  const QDateTime timeDate = input.toDateTime();
-
   if ( input.toDateTime().isValid() )
     return true;
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7581,8 +7581,6 @@ bool QgsProcessingParameterMapTheme::fromVariantMap( const QVariantMap &map )
 
 QgsProcessingParameterMapTheme *QgsProcessingParameterMapTheme::fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition )
 {
-  const QString parent;
-
   QString def = definition;
   if ( def.startsWith( '"' ) || def.startsWith( '\'' ) )
     def = def.mid( 1 );
@@ -7902,8 +7900,6 @@ bool QgsProcessingParameterProviderConnection::fromVariantMap( const QVariantMap
 
 QgsProcessingParameterProviderConnection *QgsProcessingParameterProviderConnection::fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition )
 {
-  const QString parent;
-
   QString def = definition;
   QString provider;
   if ( def.contains( ' ' ) )

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -2125,7 +2125,6 @@ void getOperationAndEllipsoidFromProjString( const QString &proj, QString &opera
   }
   operation = projMatch.captured( 1 );
 
-  thread_local const QRegularExpression ellipseRegExp( QStringLiteral( "\\+(?:ellps|datum)=(\\S+)" ) );
   const QRegularExpressionMatch ellipseMatch = projRegExp.match( proj );
   if ( ellipseMatch.hasMatch() )
   {
@@ -2186,8 +2185,6 @@ bool QgsCoordinateReferenceSystem::loadFromAuthCode( const QString &auth, const 
   d->setPj( std::move( crs ) );
 
   const QString dbVals = sAuthIdToQgisSrsIdMap.value( QStringLiteral( "%1:%2" ).arg( auth, code ).toUpper() );
-  QString srsId;
-  QString srId;
   if ( !dbVals.isEmpty() )
   {
     const QStringList parts = dbVals.split( ',' );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3678,7 +3678,6 @@ QgsAuxiliaryStorage *QgsProject::auxiliaryStorage()
 
 QString QgsProject::createAttachedFile( const QString &nameTemplate )
 {
-  const QString fileName = nameTemplate;
   const QDir archiveDir( mArchive->dir() );
   QTemporaryFile tmpFile( archiveDir.filePath( "XXXXXX_" + nameTemplate ), this );
   tmpFile.setAutoRemove( false );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -122,7 +122,6 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
         if ( vl && vl->isValid() )
         {
-          const QString origLayerId = vl->id();
           convertToOfflineLayer( vl, database.get(), dbPath, onlySelected, containerType, layerNameSuffix );
         }
       }

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3198,7 +3198,6 @@ QgsFontMarkerSymbolLayer::~QgsFontMarkerSymbolLayer() = default;
 QgsSymbolLayer *QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
 {
   QString fontFamily = DEFAULT_FONTMARKER_FONT;
-  const QString fontStyle = DEFAULT_FONTMARKER_FONT;
   QString string = DEFAULT_FONTMARKER_CHR;
   double pointSize = DEFAULT_FONTMARKER_SIZE;
   QColor color = DEFAULT_FONTMARKER_COLOR;

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -610,7 +610,6 @@ void QgsModelGraphicsView::pasteItems( QgsModelGraphicsView::PasteMode mode )
   if ( !modelScene() )
     return;
 
-  QList< QgsModelComponentGraphicItem * > pastedItems;
   QDomDocument doc;
   QClipboard *clipboard = QApplication::clipboard();
   if ( doc.setContent( clipboard->mimeData()->data( QStringLiteral( "text/xml" ) ) ) )

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -75,8 +75,6 @@ void QgsModelViewToolSelect::modelPressEvent( QgsModelViewMouseEvent *event )
 
   QgsModelComponentGraphicItem *selectedItem = nullptr;
 
-  QList<QgsModelComponentGraphicItem *> selectedItems = scene()->selectedComponentItems();
-
   //select topmost item at position of event
   selectedItem = scene()->componentItemAt( event->modelPoint() );
 

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.cpp
@@ -179,7 +179,6 @@ void QgsProcessingVectorTileWriterLayersPanelWidget::copyLayer()
   }
 
   QStandardItem *item = mModel->itemFromIndex( selection[0] );
-  const QVariant value = item->data( Qt::UserRole );
   mModel->insertRow( selection[0].row() + 1, item->clone() );
 }
 

--- a/src/gui/vector/qgsvectorlayerlegendwidget.cpp
+++ b/src/gui/vector/qgsvectorlayerlegendwidget.cpp
@@ -287,7 +287,6 @@ void QgsVectorLayerLegendWidget::applyLabelLegend()
     QTreeWidgetItem *item = mLabelLegendTreeWidget->topLevelItem( i );
     if ( item )
     {
-      const QString id = item->data( 0, Qt::UserRole ).toString();
       const QString legendText = item->text( 1 );
 
       QgsPalLayerSettings *s = new QgsPalLayerSettings( labeling->settings( ids.at( i ) ) );

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -72,7 +72,6 @@ namespace QgsWfs
 
     QDomDocument doc;
 
-    const QgsServerRequest::Parameters parameters = request.parameters();
     const QgsWfsParameters wfsParameters( QUrlQuery( request.url() ) );
     const QgsWfsParameters::Format oFormat = wfsParameters.outputFormat();
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1781,7 +1781,6 @@ namespace QgsWms
 
     // external layers
     QStringList layers;
-    QList<QgsWmsParametersExternalLayer> eParams;
 
     for ( const auto &layer : std::as_const( allLayers ) )
     {

--- a/tests/qt_modeltest/modeltest.cpp
+++ b/tests/qt_modeltest/modeltest.cpp
@@ -125,7 +125,6 @@ void ModelTest::nonDestructiveBasicTest()
   model->setData( QModelIndex(), variant, -1 );
   model->setHeaderData( -1, Qt::Horizontal, QVariant() );
   model->setHeaderData( 999999, Qt::Horizontal, QVariant() );
-  QMap<int, QVariant> roles;
   model->sibling( 0, 0, QModelIndex() );
   model->span( QModelIndex() );
   model->supportedDropActions();

--- a/tests/src/3d/testqgs3dsymbolregistry.cpp
+++ b/tests/src/3d/testqgs3dsymbolregistry.cpp
@@ -85,7 +85,6 @@ void TestQgs3DSymbolRegistry::metadata()
   QCOMPARE( metadata.visibleName(), QString( "display name" ) );
 
   //test creating symbol from metadata
-  const QVariantMap map;
   const std::unique_ptr< QgsAbstract3DSymbol > symbol( metadata.create() );
   QVERIFY( symbol );
   Dummy3DSymbol *dummySymbol = dynamic_cast<Dummy3DSymbol *>( symbol.get() );

--- a/tests/src/3d/testqgsmaterialregistry.cpp
+++ b/tests/src/3d/testqgsmaterialregistry.cpp
@@ -88,7 +88,6 @@ void TestQgsMaterialRegistry::metadata()
   QCOMPARE( metadata.visibleName(), QString( "display name" ) );
 
   //test creating material settings from metadata
-  const QVariantMap map;
   const std::unique_ptr< QgsAbstractMaterialSettings > material( metadata.create() );
   QVERIFY( material );
   DummyMaterialSettings *dummyMaterial = dynamic_cast<DummyMaterialSettings *>( material.get() );

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -404,7 +404,6 @@ void TestQgsProcessingAlgs::packageAlg()
   if ( QFile::exists( outputGpkg ) )
     QFile::remove( outputGpkg );
 
-  const QVariantMap parameters;
   const QStringList layers = QStringList() << mPointsLayer->id() << mPolygonLayer->id();
   bool ok = false;
   const QVariantMap results = pkgAlg( layers, outputGpkg, true, false, false, &ok );

--- a/tests/src/core/testqgsannotationitemregistry.cpp
+++ b/tests/src/core/testqgsannotationitemregistry.cpp
@@ -110,7 +110,6 @@ void TestQgsAnnotationItemRegistry::metadata()
   QCOMPARE( metadata.visibleName(), QString( "display name" ) );
 
   //test creating item from metadata
-  const QVariantMap map;
   const std::unique_ptr< QgsAnnotationItem > item( metadata.createItem() );
   QVERIFY( item );
   TestItem *dummyItem = dynamic_cast<TestItem *>( item.get() );

--- a/tests/src/core/testqgslayoutmanualtable.cpp
+++ b/tests/src/core/testqgslayoutmanualtable.cpp
@@ -274,8 +274,6 @@ void TestQgsLayoutManualTable::setContents()
 
 void TestQgsLayoutManualTable::scopeForCell()
 {
-  const QVector<QStringList> expectedRows;
-
   QgsPrintLayout l( QgsProject::instance() );
   l.initializeDefaults();
   l.setName( QStringLiteral( "my layout" ) );

--- a/tests/src/core/testqgspointcloudrendererregistry.cpp
+++ b/tests/src/core/testqgspointcloudrendererregistry.cpp
@@ -83,7 +83,6 @@ void TestQgsPointCloudRendererRegistry::metadata()
   QCOMPARE( metadata.visibleName(), QString( "display name" ) );
 
   //test creating renderer from metadata
-  const QVariantMap map;
   QDomElement elem;
   const std::unique_ptr< QgsPointCloudRenderer > renderer( metadata.createRenderer( elem, QgsReadWriteContext() ) );
   QVERIFY( renderer );

--- a/tests/src/gui/testqgsscalecombobox.cpp
+++ b/tests/src/gui/testqgsscalecombobox.cpp
@@ -275,9 +275,9 @@ void TestQgsScaleComboBox::testLocale()
 
   QLocale::setDefault( QLocale::German );
   QCOMPARE( s->toString( 1e8 ), QString( "1:100.000.000" ) );
-  const QLocale customGerman( QLocale::German );
-  customFrench.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
-  QLocale::setDefault( customFrench );
+  QLocale customGerman( QLocale::German );
+  customGerman.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customGerman );
   QCOMPARE( s->toString( 1e8 ), QString( "1:100000000" ) );
 }
 

--- a/tests/src/providers/testqgspostgresprovider.cpp
+++ b/tests/src/providers/testqgspostgresprovider.cpp
@@ -304,7 +304,6 @@ void TestQgsPostgresProvider::testWhereClauseFids()
 
   QgsFields fields;
   QList<int> pkAttrs;
-  const QString clause;
 
   const std::shared_ptr< QgsPostgresSharedData > sdata( new QgsPostgresSharedData() );
 


### PR DESCRIPTION
## Description

This PR deletes all unused variables found by [unused-non-trivial-variable](https://github.com/KDE/clazy/blob/master/docs/checks/README-unused-non-trivial-variable.md) (Clazy).

But in the tests, I didn't delete all variables like :
```C++
const QImage img = cache.pathAsImage( QStringLiteral( "bbbbbbb" ), QSize( 200, 200 ), true, 1.0, inCache, false, 96,  &missingImage );
```
in the potential case where we want to check that the program doesn't crash.

There is a test in `testqgsscalecombobox.cpp` where, I think, the wrong variable is used, I fixed it.