### PR TITLE
Fix build on Linux when compiled with FORCE_STATIC_LIBS

### DIFF
--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -40,7 +40,7 @@ set(PG_HDRS
 # static library
 add_library (provider_postgres_a STATIC ${PG_SRCS} ${PG_HDRS})
 
-target_include_directories(provider_postgres_a SYSTEM PRIVATE
+target_include_directories(provider_postgres_a SYSTEM PUBLIC
   ${POSTGRES_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
In #44326 the build system changes made POSTGRES_INCLUDE_DIR a PRIVATE include, so this include directory does not get propagated, but then qgis_core fails to build due to transitive include of libpq-fe.h:

```
In file included from ../src/providers/postgres/qgspostgresprovider.h:23,
                 from ../src/core/providers/qgsproviderregistry.cpp:58:
../src/providers/postgres/qgspostgresconn.h:35:10: fatal error: libpq-fe.h: No such file or directory
```

On other platforms such as Mac this does not seem to be an issue, because PostgreSQL include directory is the same as other include directories, but at least on Ubuntu the include directory is /usr/include/postgresql

If merged, this should get backported to 3.22 branch.

@3nids would you mind to have a quick look?