### PR TITLE
map_prefix_keys function

### DIFF
--- a/resources/function_help/json/map_prefix_keys
+++ b/resources/function_help/json/map_prefix_keys
@@ -1,0 +1,8 @@
+{
+  "name": "map_prefix_keys",
+  "type": "function",
+  "groups": ["Maps"],
+  "description": "Returns a map with all keys prefixed by prefix.",
+  "arguments": [ {"arg":"map","description":"a map"}, {"arg":"prefix","description":"the prefix"}],
+  "examples": [ { "expression":"map_prefix_keys(map('1','one','2','two'), 'prefix-')", "returns":"{ 'prefix-1': 'one', 'prefix-2': 'two' }"}]
+}

--- a/resources/function_help/json/map_prefix_keys
+++ b/resources/function_help/json/map_prefix_keys
@@ -2,7 +2,7 @@
   "name": "map_prefix_keys",
   "type": "function",
   "groups": ["Maps"],
-  "description": "Returns a map with all keys prefixed by prefix.",
-  "arguments": [ {"arg":"map","description":"a map"}, {"arg":"prefix","description":"the prefix"}],
+  "description": "Returns a map with all keys prefixed by a given string.",
+  "arguments": [ {"arg":"map","description":"a map"}, {"arg":"prefix","description":"a string"}],
   "examples": [ { "expression":"map_prefix_keys(map('1','one','2','two'), 'prefix-')", "returns":"{ 'prefix-1': 'one', 'prefix-2': 'two' }"}]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6325,6 +6325,20 @@ static QVariant fcnMap( const QVariantList &values, const QgsExpressionContext *
   return result;
 }
 
+static QVariant fcnMapPrefixKeys( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QVariantMap map = QgsExpressionUtils::getMapValue( values.at( 0 ), parent );
+  const QString prefix = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
+  QVariantMap resultMap;
+
+  for ( auto it = map.cbegin(); it != map.cend(); it++ )
+  {
+    resultMap.insert( QString( it.key() ).prepend( prefix ), it.value() );
+  }
+
+  return resultMap;
+}
+
 static QVariant fcnMapGet( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   return QgsExpressionUtils::getMapValue( values.at( 0 ), parent ).value( values.at( 1 ).toString() );
@@ -7890,6 +7904,10 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "map_concat" ), -1, fcnMapConcat, QStringLiteral( "Maps" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "map_akeys" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "map" ) ), fcnMapAKeys, QStringLiteral( "Maps" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "map_avals" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "map" ) ), fcnMapAVals, QStringLiteral( "Maps" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "map_prefix_keys" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "map" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "prefix" ) ),
+                                            fcnMapPrefixKeys, QStringLiteral( "Maps" ) )
+
         ;
 
     QgsExpressionContextUtils::registerContextFunctions();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3894,6 +3894,11 @@ class TestQgsExpression: public QObject
       QCOMPARE( badMap.evaluate( &context ), QVariant() );
       QVERIFY( badMap.hasEvalError() );
       QCOMPARE( badMap.evalErrorString(), QString( "Cannot convert 'not a map' to map" ) );
+
+      QCOMPARE( QgsExpression( QStringLiteral( "map_prefix_keys(map('1', 'one', '2', 'two'), 'prefix-')" ) ).evaluate( &context ), QVariantMap( {{ "prefix-1", "one" }, { "prefix-2", "two" }} ) );
+      QCOMPARE( QgsExpression( QStringLiteral( "map_prefix_keys(map(), 'prefix-')" ) ).evaluate( &context ), QVariantMap() );
+      QCOMPARE( QgsExpression( QStringLiteral( "map_prefix_keys([], 'prefix-')" ) ).evaluate( &context ), QVariant() );
+
     }
 
     void expression_from_expression_data()


### PR DESCRIPTION
## Description

This PR adds a new `map_prefix_keys` function that takes a map and a prefix, the function returns a map with all keys prefixed by the prefix.

### Example
```
map_prefix_keys(map('1','one','2','two'), 'prefix-')
```

returns:
```
{ 'prefix-1': 'one', 'prefix-2': 'two' }
```

Funded by: Kanton Solothurn

