### PR TITLE
Fix the "Save As..." project saving dialog in order to respect the default project file format setting

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7285,6 +7285,7 @@ bool QgisApp::fileSave()
 void QgisApp::fileSaveAs()
 {
   QString defaultPath;
+  QgsSettings settings;
   // First priority is to default to same path as existing file
   const QString currentPath = QgsProject::instance()->absoluteFilePath();
   if ( !currentPath.isEmpty() )
@@ -7294,18 +7295,28 @@ void QgisApp::fileSaveAs()
   else
   {
     // Retrieve last used project dir from persistent settings
-    QgsSettings settings;
     defaultPath = settings.value( QStringLiteral( "UI/lastProjectDir" ), QDir::homePath() ).toString();
     defaultPath += QString( '/' + QgsProject::instance()->title() );
   }
 
   const QString qgsExt = tr( "QGIS files" ) + " (*.qgs *.QGS)";
   const QString zipExt = tr( "QGZ files" ) + " (*.qgz)";
+
+  QString exts;
+  QgsProject::FileFormat defaultProjectFileFormat = settings.enumValue( QStringLiteral( "/qgis/defaultProjectFileFormat" ), QgsProject::FileFormat::Qgz );
+  if ( defaultProjectFileFormat == QgsProject::FileFormat::Qgs )
+  {
+    exts = qgsExt + QStringLiteral( ";;" ) + zipExt;
+  }
+  else
+  {
+    exts = zipExt + QStringLiteral( ";;" ) + qgsExt;
+  }
   QString filter;
   QString path = QFileDialog::getSaveFileName( this,
                  tr( "Save Project As" ),
                  defaultPath,
-                 zipExt + ";;" + qgsExt, &filter );
+                 exts, &filter );
   if ( path.isEmpty() )
     return;
 


### PR DESCRIPTION
## Description

Fixes an inconsistent behaviour of the "Save As..." dialog, for saving the current project, which doesn't respect the default project file format setting (introduced with https://github.com/qgis/QGIS/pull/33872 since QGIS 3.12), as the "Save" dialog do.

Fixes https://github.com/qgis/QGIS/issues/46083.

I think this PR needs to be backported.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
