### PR TITLE
Add OS info to user agent

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -306,7 +306,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   QString userAgent = s.value( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), "Mozilla/5.0" ).toString();
   if ( !userAgent.isEmpty() )
     userAgent += ' ';
-  userAgent += QStringLiteral( "QGIS/%1" ).arg( Qgis::versionInt() );
+  userAgent += QStringLiteral( "QGIS/%1/%2" ).arg( Qgis::versionInt() ).arg( QSysInfo::prettyProductName() );
   pReq->setRawHeader( "User-Agent", userAgent.toLatin1() );
 
 #ifndef QT_NO_SSL


### PR DESCRIPTION
This was discussed in the last PSC meeting, the idea is to collect some statistics about the operating system in order to better understand our user base for future optimizations in packaging and release scheduling.

![user-agent](https://user-images.githubusercontent.com/142164/142219746-8b340ab0-c2c3-4d4c-ba33-a6f738b45bc9.png)

CC @andreasneumann @mbernasocchi @anitagraser @jef-n @timlinux 