### PR TITLE
Add tooltip to form layout buttons in drag-and-drop designer

### DIFF
--- a/src/ui/qgsattributesformproperties.ui
+++ b/src/ui/qgsattributesformproperties.ui
@@ -174,6 +174,9 @@ Use this function to add extra logic to your forms.</string>
          <property name="text">
           <string>…</string>
          </property>
+         <property name="toolTip">
+          <string>Remove selected item(s) from the form layout</string>
+         </property>
          <property name="icon">
           <iconset resource="../../images/images.qrc">
            <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
@@ -184,6 +187,9 @@ Use this function to add extra logic to your forms.</string>
         <widget class="QToolButton" name="mAddTabOrGroupButton">
          <property name="text">
           <string>…</string>
+         </property>
+         <property name="toolTip">
+          <string>Add a new tab or group to the form layout</string>
          </property>
          <property name="icon">
           <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
This concerns the buttons in 
![image](https://user-images.githubusercontent.com/7983394/142209656-27f6638a-0c49-465e-a109-408e32f6ead0.png)
