### PR TITLE
[vectortile] Fix mapbox gl converter fill-outline-color / background logic

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -228,39 +228,42 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
   }
 
   QColor fillOutlineColor;
-  if ( !isBackgroundStyle && !jsonPaint.contains( QStringLiteral( "fill-outline-color" ) ) )
+  if ( !isBackgroundStyle )
   {
-    // fill-outline-color
-    if ( fillColor.isValid() )
-      fillOutlineColor = fillColor;
+    if ( !jsonPaint.contains( QStringLiteral( "fill-outline-color" ) ) )
+    {
+      // fill-outline-color
+      if ( fillColor.isValid() )
+        fillOutlineColor = fillColor;
+      else
+      {
+        // use fill color data defined property
+        if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
+          ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor,  ddProperties.property( QgsSymbolLayer::PropertyFillColor ) );
+      }
+    }
     else
     {
-      // use fill color data defined property
-      if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
-        ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor,  ddProperties.property( QgsSymbolLayer::PropertyFillColor ) );
-    }
-  }
-  else
-  {
-    const QVariant jsonFillOutlineColor = jsonPaint.value( QStringLiteral( "fill-outline-color" ) );
-    switch ( jsonFillOutlineColor.type() )
-    {
-      case QVariant::Map:
-        ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor, parseInterpolateColorByZoom( jsonFillOutlineColor.toMap(), context, &fillOutlineColor ) );
-        break;
+      const QVariant jsonFillOutlineColor = jsonPaint.value( QStringLiteral( "fill-outline-color" ) );
+      switch ( jsonFillOutlineColor.type() )
+      {
+        case QVariant::Map:
+          ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor, parseInterpolateColorByZoom( jsonFillOutlineColor.toMap(), context, &fillOutlineColor ) );
+          break;
 
-      case QVariant::List:
-      case QVariant::StringList:
-        ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor, parseValueList( jsonFillOutlineColor.toList(), PropertyType::Color, context, 1, 255, &fillOutlineColor ) );
-        break;
+        case QVariant::List:
+        case QVariant::StringList:
+          ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor, parseValueList( jsonFillOutlineColor.toList(), PropertyType::Color, context, 1, 255, &fillOutlineColor ) );
+          break;
 
-      case QVariant::String:
-        fillOutlineColor = parseColor( jsonFillOutlineColor.toString(), context );
-        break;
+        case QVariant::String:
+          fillOutlineColor = parseColor( jsonFillOutlineColor.toString(), context );
+          break;
 
-      default:
-        context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-outline-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillOutlineColor.type() ) ) );
-        break;
+        default:
+          context.pushWarning( QObject::tr( "%1: Skipping unsupported fill-outline-color type (%2)" ).arg( context.layerId(), QMetaType::typeName( jsonFillOutlineColor.type() ) ) );
+          break;
+      }
     }
   }
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -232,15 +232,12 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
   {
     if ( !jsonPaint.contains( QStringLiteral( "fill-outline-color" ) ) )
     {
-      // fill-outline-color
       if ( fillColor.isValid() )
         fillOutlineColor = fillColor;
-      else
-      {
-        // use fill color data defined property
-        if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
-          ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor,  ddProperties.property( QgsSymbolLayer::PropertyFillColor ) );
-      }
+
+      // match fill color data defined property when active
+      if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
+        ddProperties.setProperty( QgsSymbolLayer::PropertyStrokeColor,  ddProperties.property( QgsSymbolLayer::PropertyFillColor ) );
     }
     else
     {


### PR DESCRIPTION
## Description

The way changes are displayed makes this looks far worse than it is. We're merely encapsulating the fill-outline-color in a if ( !isBackgroundStyle ) condition instead of using the wrong logic append of the pre-existing condition I added when working on the background support.