### PR TITLE
Fix Delimited Text provider types recognition from csvt

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -222,6 +222,7 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   // This is a slightly generous regular expression in that it allows spaces and unquoted field types
   // not allowed in OGR CSVT files.  Also doesn't care if int and string fields have
 
+  strTypeList = strTypeList.toLower();
   const QRegularExpression reTypeList( QRegularExpression::anchoredPattern( QStringLiteral( "^(?:\\s*(\\\"?)(?:integer|real|double|long|longlong|int8|string|date|datetime|time)(?:\\(\\d+(?:\\.\\d+)?\\))?\\1\\s*(?:,|$))+" ) ) );
   const QRegularExpressionMatch match = reTypeList.match( strTypeList );
   if ( !match.hasMatch() )
@@ -236,7 +237,7 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   QgsDebugMsgLevel( QStringLiteral( "Field type string: %1" ).arg( strTypeList ), 2 );
 
   int pos = 0;
-  const QRegularExpression reType( QStringLiteral( "(integer|real|double|string|date|datetime|time)" ) );
+  const QRegularExpression reType( QStringLiteral( "(integer|real|double|string|datetime|date|time)" ) );
   QRegularExpressionMatch typeMatch = reType.match( strTypeList, pos );
   while ( typeMatch.hasMatch() )
   {

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -933,6 +933,13 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         assert vl.fields().at(6).type() == QVariant.Time
         assert vl.fields().at(9).type() == QVariant.String
 
+    def test_048_csvt_file(self):
+        # CSVT field types non lowercase
+        filename = 'testcsvt5.csv'
+        params = {'geomType': 'none', 'type': 'csv'}
+        requests = None
+        self.runTest(filename, requests, **params)
+
     def testSpatialIndex(self):
         srcpath = os.path.join(TEST_DATA_DIR, 'provider')
         basetestfile = os.path.join(srcpath, 'delimited_xyzm.csv')

--- a/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
@@ -2587,3 +2587,32 @@ def test_042_no_detect_types_csvt():
     wanted['log'] = [
     ]
     return wanted
+
+
+def test_048_csvt_file():
+    wanted = {}
+    wanted['uri'] = 'file://testcsvt5.csv?geomType=none&type=csv'
+    wanted['fieldTypes'] = ['text', 'text', 'double', 'double', 'double']
+    wanted['geometryType'] = 4
+    wanted['data'] = {
+        2: {
+            'id': '01',
+            'description': 'Test csvt 1',
+            'f1': '0.3',
+            'f2': '0.8',
+            'f3': '1.4',
+            '#fid': 2,
+            '#geometry': 'None',
+        },
+        3: {
+            'id': '12',
+            'description': 'Test csvt 2',
+            'f1': '0.2',
+            'f2': '78.0',
+            'f3': '13.4',
+            '#fid': 3,
+            '#geometry': 'None',
+        },
+    }
+    wanted['log'] = []
+    return wanted

--- a/tests/testdata/delimitedtext/testcsvt5.csv
+++ b/tests/testdata/delimitedtext/testcsvt5.csv
@@ -1,0 +1,3 @@
+id,description,f1,f2,f3
+01,Test csvt 1,0.3,0.8,1.4
+12,Test csvt 2,0.2,78,13.4

--- a/tests/testdata/delimitedtext/testcsvt5.csvt
+++ b/tests/testdata/delimitedtext/testcsvt5.csvt
@@ -1,0 +1,1 @@
+"String","String","Real","Real","Real"


### PR DESCRIPTION
## Description

Fixes a regression introduced by https://github.com/qgis/QGIS/commit/be1ba89063e525c54f49d81317af2b8f78db8e56 (https://github.com/qgis/QGIS/pull/42609) since 3.20.0, which prevents to correctly read the fields types of a csv layer file, if the csvt sidecar file contains the field types name non lowercase, when imported using Data Source Manager - Delimited Text dialog window.

This PR needs to be backported to the 3.22 branch.

Fixes https://github.com/qgis/QGIS/issues/46117.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
