### PR TITLE
Remove CRS:84 from WMS Capabilities document

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1403,9 +1403,6 @@ namespace QgsWms
           appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, crs );
         }
       }
-
-      //Support for CRS:84 is mandatory (equals EPSG:4326 with reversed axis)
-      appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, QString( "CRS:84" ) );
     }
 
     void appendCrsElementToLayer( QDomDocument &doc, QDomElement &layerElement, const QDomElement &precedingElement,


### PR DESCRIPTION
## Description

Fix #46139

We are adding `<SRS>CRS:84</SRS>` to the GetCapabilities document for no reason. According to the WMS specification, it is recommended, but not mandatory as we have it. Is up to the user to decide if this CRS should be available or not.

This PR raises the discussion about adding or not this CRS to the GetCapabilities document.

Comments are welcome.