### PR TITLE
[vectortile] Fix erroneous zoom level determination

### DIFF
--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -70,7 +70,7 @@ double QgsVectorTileUtils::scaleToZoom( double mapScale )
 
 int QgsVectorTileUtils::scaleToZoomLevel( double mapScale, int sourceMinZoom, int sourceMaxZoom )
 {
-  int tileZoom = static_cast<int>( floor( scaleToZoom( mapScale ) ) );
+  int tileZoom = static_cast<int>( round( scaleToZoom( mapScale ) ) );
 
   if ( tileZoom < sourceMinZoom )
     tileZoom = sourceMinZoom;

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -192,6 +192,7 @@ set(TESTS
  testqgsvectorlayerjoinbuffer.cpp
  testqgsvectorlayerutils.cpp
  testqgsvectortilelayer.cpp
+ testqgsvectortileutils.cpp
  testqgsvectortilewriter.cpp
  testqgstiles.cpp
  testqgsweakrelation.cpp

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************
+  testqgsvectortileutils.cpp
+  --------------------------------------
+  Date                 : November 2021
+  Copyright            : (C) 2021 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+//qgis includes...
+#include "qgsapplication.h"
+#include "qgsvectortileutils.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the vector tile utils class
+ */
+class TestQgsVectorTileUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsVectorTileUtils() = default;
+
+  private:
+    QString mReport;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+
+    void test_scaleToZoomLevel();
+};
+
+
+void TestQgsVectorTileUtils::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+  mReport += QLatin1String( "<h1>Vector Tile Utils Tests</h1>\n" );
+}
+
+void TestQgsVectorTileUtils::cleanupTestCase()
+{
+  const QString myReportFile = QDir::tempPath() + "/qgistest.html";
+  QFile myFile( myReportFile );
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Append ) )
+  {
+    QTextStream myQTextStream( &myFile );
+    myQTextStream << mReport;
+    myFile.close();
+  }
+
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVectorTileUtils::test_scaleToZoomLevel()
+{
+  // test zoom level logic
+  int zoomLevel = QgsVectorTileUtils::scaleToZoomLevel( 288896, 0, 20 );
+  QCOMPARE( zoomLevel, 10 );
+}
+
+
+QGSTEST_MAIN( TestQgsVectorTileUtils )
+#include "testqgsvectortileutils.moc"

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -33,7 +33,6 @@ class TestQgsVectorTileUtils : public QObject
     TestQgsVectorTileUtils() = default;
 
   private:
-    QString mReport;
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
@@ -50,21 +49,10 @@ void TestQgsVectorTileUtils::initTestCase()
   // init QGIS's paths - true means that all path will be inited from prefix
   QgsApplication::init();
   QgsApplication::initQgis();
-  QgsApplication::showSettings();
-  mReport += QLatin1String( "<h1>Vector Tile Utils Tests</h1>\n" );
 }
 
 void TestQgsVectorTileUtils::cleanupTestCase()
 {
-  const QString myReportFile = QDir::tempPath() + "/qgistest.html";
-  QFile myFile( myReportFile );
-  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Append ) )
-  {
-    QTextStream myQTextStream( &myFile );
-    myQTextStream << mReport;
-    myFile.close();
-  }
-
   QgsApplication::exitQgis();
 }
 


### PR DESCRIPTION
## Description

This PR fixes an erroneous zoom level determination that might have slipped in this commit (https://github.com/qgis/QGIS/commit/f1c0fe259f4934b8b1aa5500afc556cbc6b7e249).

Long story short, QGIS is constantly _one zoom level below_ what it should be when tested against raster XYZ tiles.

For e.g., this compares OSM's raster tiles against vector tiles:
![Peek 2021-11-21 12-36](https://user-images.githubusercontent.com/1728657/142751163-e401c966-b36c-44b6-9d85-c2a22a04c904.gif)

You can see the rendering of details/labels/etc. don't match (even though we're dealing with same underlying data and a vector tiles style that is made to match that used for the raster tiles. When looking at the {z} value used to fetch the raster tiles at this scale, QGIS uses _11_. _However_ QGIS was erroneously coming up with a vector tile zoom level of _10_.

Now look at the same comparison with this PR applied:
![Peek 2021-11-21 12-36_good](https://user-images.githubusercontent.com/1728657/142751186-59b1a1c7-bbff-4e02-a873-42b0bdf515eb.gif)

_Beautiful_ :wink: 