### PR TITLE
Add CRS:84 just to WMS 1.3.0 Server capabilities document

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1403,9 +1403,6 @@ namespace QgsWms
           appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, crs );
         }
       }
-
-      //Support for CRS:84 is mandatory (equals EPSG:4326 with reversed axis)
-      appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, QString( "CRS:84" ) );
     }
 
     void appendCrsElementToLayer( QDomDocument &doc, QDomElement &layerElement, const QDomElement &precedingElement,

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1375,6 +1375,8 @@ namespace QgsWms
         return;
       }
 
+      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+
       //insert the CRS elements after the title element to be in accordance with the WMS 1.3 specification
       QDomElement titleElement = layerElement.firstChildElement( QStringLiteral( "Title" ) );
       QDomElement abstractElement = layerElement.firstChildElement( QStringLiteral( "Abstract" ) );
@@ -1402,6 +1404,13 @@ namespace QgsWms
         {
           appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, crs );
         }
+      }
+
+      // Support for CRS:84 is mandatory (equals EPSG:4326 with reversed axis)
+      // https://github.com/opengeospatial/ets-wms13/blob/47155399c09b200cb21382874fdb21d5fae4ab6e/src/site/markdown/index.md
+      if ( version == QLatin1String( "1.3.0" ) )
+      {
+        appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, QString( "CRS:84" ) );
       }
     }
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1375,7 +1375,7 @@ namespace QgsWms
         return;
       }
 
-      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
 
       //insert the CRS elements after the title element to be in accordance with the WMS 1.3 specification
       QDomElement titleElement = layerElement.firstChildElement( QStringLiteral( "Title" ) );
@@ -1419,7 +1419,7 @@ namespace QgsWms
     {
       if ( crsText.isEmpty() )
         return;
-      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
       QDomElement crsElement = doc.createElement( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" );
       QDomText crsTextNode = doc.createTextNode( crsText );
       crsElement.appendChild( crsTextNode );
@@ -1548,7 +1548,7 @@ namespace QgsWms
         return;
       }
 
-      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
 
       QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsText );
 
@@ -1655,7 +1655,7 @@ namespace QgsWms
       }
 
 
-      QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
+      const QString version = doc.documentElement().attribute( QStringLiteral( "version" ) );
 
       //create layer crs
       QgsCoordinateReferenceSystem layerCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( boundingBoxElem.attribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" ) );

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -108,7 +108,6 @@ Content-Type: text/xml; charset=utf-8
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
-   <SRS>CRS:84</SRS>
    <SRS>EPSG:4326</SRS>
    <SRS>EPSG:3857</SRS>
    <LatLonBoundingBox maxy="44.901599" maxx="8.204165" miny="44.901236" minx="8.203154"/>
@@ -118,7 +117,6 @@ Content-Type: text/xml; charset=utf-8
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>
     <Abstract>A Layer with an abstract</Abstract>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
@@ -144,7 +142,6 @@ Content-Type: text/xml; charset=utf-8
    <Layer queryable="1">
     <Name>landsat</Name>
     <Title>landsat</Title>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="30.257289" maxx="18.045658" miny="30.151856" minx="17.924273"/>
@@ -163,7 +160,6 @@ Content-Type: text/xml; charset=utf-8
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
@@ -182,7 +178,6 @@ Content-Type: text/xml; charset=utf-8
     <Name>fields_alias</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
@@ -201,7 +196,6 @@ Content-Type: text/xml; charset=utf-8
     <Name>exclude_attribute</Name>
     <Title>A test vector layer</Title>
     <Abstract>A test vector layer with unicode òà</Abstract>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
@@ -220,7 +214,6 @@ Content-Type: text/xml; charset=utf-8
     <Name>group_name</Name>
     <Title>Group title</Title>
     <Abstract>Group abstract</Abstract>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203548" miny="44.901394" minx="8.203459"/>
@@ -229,7 +222,6 @@ Content-Type: text/xml; charset=utf-8
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
-     <SRS>CRS:84</SRS>
      <SRS>EPSG:4326</SRS>
      <SRS>EPSG:3857</SRS>
      <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
@@ -248,7 +240,6 @@ Content-Type: text/xml; charset=utf-8
    <Layer queryable="0">
     <Name>groupwithoutshortname</Name>
     <Title>groupwithoutshortname</Title>
-    <SRS>CRS:84</SRS>
     <SRS>EPSG:4326</SRS>
     <SRS>EPSG:3857</SRS>
     <LatLonBoundingBox maxy="44.901483" maxx="8.203548" miny="44.901394" minx="8.203459"/>
@@ -257,7 +248,6 @@ Content-Type: text/xml; charset=utf-8
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>
-     <SRS>CRS:84</SRS>
      <SRS>EPSG:4326</SRS>
      <SRS>EPSG:3857</SRS>
      <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>


### PR DESCRIPTION
## Description

See initial discussion in #46139 

As far as I understand, CRS:84 is recommended in the WMS 1.3.0 specification, but enforced in the WMS 1.3.0 tests.

This PR adds CRS:84 just for the 1.3.0 version.

```bash
export QUERY_STRING="SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
./output/bin/qgis_mapserv.fcgi
(...)
   <Layer queryable="1">
    <Name>agua_lentica</Name>
    <Title>agua_lentica</Title>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:3763</CRS>
    <EX_GeographicBoundingBox>
(...)
```

For versions != 1.3.0

```bash
export QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities"
./output/bin/qgis_mapserv.fcgi 
(...)
   <Layer queryable="1">
    <Name>agua_lentica</Name>
    <Title>agua_lentica</Title>
    <SRS>EPSG:3763</SRS>
    <LatLonBoundingBox maxx="-8.293961" minx="-8.50092" miny="41.995763" maxy="42.081709"/>
    <BoundingBox maxx="-13327.608" SRS="EPSG:3763" minx="-30434.687" miny="258536.337" maxy="268029.83"/>
(...)
```
