### PR TITLE
Render layers as groups, pt 2

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -16,6 +16,9 @@ Layer tree group node serves as a container for layers and further groups.
 
 Group names do not need to be unique within one tree nor within one parent.
 
+While a layer tree group is typically used for hierarchical organisation of a :py:class:`QgsProject`,
+they can optionally be associated with a :py:class:`QgsGroupLayer` for map rendering purposes.
+
 .. versionadded:: 2.4
 %End
 
@@ -206,6 +209,51 @@ The initial child index determines which child should be initially checked. The 
 of -1 will determine automatically (either first one currently checked or none)
 
 .. versionadded:: 2.12
+%End
+
+    QgsGroupLayer *groupLayer();
+%Docstring
+Returns a reference to the associated group layer, if the layer tree group will be treated
+as group layer during map rendering.
+
+.. seealso:: :py:func:`setGroupLayer`
+
+.. seealso:: :py:func:`convertToGroupLayer`
+
+.. versionadded:: 3.24
+%End
+
+    void setGroupLayer( QgsGroupLayer *layer );
+%Docstring
+Sets the associated group ``layer``, if the layer tree group will be treated
+as group layer during map rendering.
+
+This method does not take ownership of the group layer, and only a weak reference
+to the layer is stored.
+
+.. seealso:: :py:func:`groupLayer`
+
+.. seealso:: :py:func:`convertToGroupLayer`
+
+.. versionadded:: 3.24
+%End
+
+    QgsGroupLayer *convertToGroupLayer( const QgsGroupLayer::LayerOptions &options ) /Factory/;
+%Docstring
+Converts the group to a :py:class:`QgsGroupLayer`.
+
+This method will convert the layer tree group to an equivalent :py:class:`QgsGroupLayer`, and
+return the result. The caller takes ownership of the returned layer, and it is the
+caller's responsibility to add the layer to the associated :py:class:`QgsProject`.
+
+If the group is already associated with a group layer (see :py:func:`~QgsLayerTreeGroup.groupLayer`), ``None``
+will be returned.
+
+.. seealso:: :py:func:`groupLayer`
+
+.. seealso:: :py:func:`setGroupLayer`
+
+.. versionadded:: 3.24
 %End
 
   protected slots:

--- a/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreegroup.sip.in
@@ -128,6 +128,8 @@ Find layer node representing the map layer specified by its ID. Searches recursi
 Find all layer nodes. Searches recursively the whole sub-tree.
 %End
 
+
+
     QStringList findLayerIds() const;
 %Docstring
 Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -234,22 +234,28 @@ Returns the magnification factor.
 .. versionadded:: 2.16
 %End
 
-    QStringList layerIds() const;
+    QStringList layerIds( bool expandGroupLayers = false ) const;
 %Docstring
 Returns the list of layer IDs which will be rendered in the map.
 
 The layers are stored in the reverse order of how they are rendered (layer with index 0 will be on top).
+
+Since QGIS 3.24, if the ``expandGroupLayers`` option is ``True`` then group layers will be converted to
+all their child layers.
 
 .. seealso:: :py:func:`layers`
 
 .. seealso:: :py:func:`setLayers`
 %End
 
-    QList<QgsMapLayer *> layers() const;
+    QList<QgsMapLayer *> layers( bool expandGroupLayers = false ) const;
 %Docstring
 Returns the list of layers which will be rendered in the map.
 
 The layers are stored in the reverse order of how they are rendered (layer with index 0 will be on top)
+
+Since QGIS 3.24, if the ``expandGroupLayers`` option is ``True`` then group layers will be converted to
+all their child layers.
 
 .. seealso:: :py:func:`setLayers`
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -460,12 +460,15 @@ layers which may be visible in the canvas, but not associated with a :py:class:`
 
     int layerCount() const;
 %Docstring
-Returns number of layers on the map
+Returns number of layers on the map.
 %End
 
-    QList<QgsMapLayer *> layers() const;
+    QList<QgsMapLayer *> layers( bool expandGroupLayers = false ) const;
 %Docstring
 Returns the list of layers shown within the map canvas.
+
+Since QGIS 3.24, if the ``expandGroupLayers`` option is ``True`` then group layers will be converted to
+all their child layers.
 
 .. seealso:: :py:func:`setLayers`
 %End

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -402,7 +402,7 @@ void Qgs3DMapCanvasDockWidget::exportScene()
 
 void Qgs3DMapCanvasDockWidget::onMainCanvasLayersChanged()
 {
-  mCanvas->map()->setLayers( mMainCanvas->layers() );
+  mCanvas->map()->setLayers( mMainCanvas->layers( true ) );
 }
 
 void Qgs3DMapCanvasDockWidget::onMainCanvasColorChanged()

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -709,7 +709,7 @@ static QList<QgsMapToolIdentify::IdentifyResult> searchFeatureOnMap( QgsMapMouse
   double x = mapPoint.x(), y = mapPoint.y();
   const double sr = QgsMapTool::searchRadiusMU( canvas );
 
-  const QList<QgsMapLayer *> layers = canvas->layers();
+  const QList<QgsMapLayer *> layers = canvas->layers( true );
   for ( QgsMapLayer *layer : layers )
   {
     if ( layer->type() == QgsMapLayerType::VectorLayer )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13783,7 +13783,7 @@ void QgisApp::new3DMapCanvas()
     map->setOrigin( QgsVector3D( fullExtent.center().x(), fullExtent.center().y(), 0 ) );
     map->setSelectionColor( mMapCanvas->selectionColor() );
     map->setBackgroundColor( mMapCanvas->canvasColor() );
-    map->setLayers( mMapCanvas->layers() );
+    map->setLayers( mMapCanvas->layers( true ) );
 //    map->setTerrainLayers( mMapCanvas->layers() );
     map->setTemporalRange( mMapCanvas->temporalRange() );
 

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -349,7 +349,7 @@ void QgsVectorLayerAndAttributeModel::applyVisibilityPreset( const QString &name
 
   if ( name.isEmpty() )
   {
-    const auto constLayers = QgisApp::instance()->mapCanvas()->layers();
+    const auto constLayers = QgisApp::instance()->mapCanvas()->layers( true );
     for ( const QgsMapLayer *ml : constLayers )
     {
       const QgsVectorLayer *vl = qobject_cast<const QgsVectorLayer *>( ml );

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -63,7 +63,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  if ( !mCanvas->layers().contains( layer ) )
+  if ( !mCanvas->layers( true ).contains( layer ) )
   {
     // do not run actions on hidden layers
     return;

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -255,7 +255,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
     double x = mapPoint.x(), y = mapPoint.y();
     const double sr = QgsMapTool::searchRadiusMU( mCanvas );
 
-    const QList<QgsMapLayer *> layers = mCanvas->layers();
+    const QList<QgsMapLayer *> layers = mCanvas->layers( true );
     for ( auto layer : layers )
     {
       if ( layer->type() == QgsMapLayerType::VectorLayer )

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -118,7 +118,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
              ! topologyTestPoints.isEmpty() )
         {
           //check if we need to add topological points to other layers
-          const auto layers = canvas()->layers();
+          const auto layers = canvas()->layers( true );
           for ( QgsMapLayer *layer : layers )
           {
             QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -844,7 +844,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   {
     if ( currentVlayer->isEditable() )
     {
-      const auto layers = canvas()->layers();
+      const auto layers = canvas()->layers( true );
       for ( QgsMapLayer *layer : layers )
       {
         QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -886,7 +886,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   // if there is no match from the current layer, try to use any editable vector layer
   if ( !m.isValid() && mMode == AllLayers )
   {
-    const auto layers = canvas()->layers();
+    const auto layers = canvas()->layers( true );
     for ( QgsMapLayer *layer : layers )
     {
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -970,7 +970,7 @@ QgsPointLocator::Match QgsVertexTool::snapToPolygonInterior( QgsMapMouseEvent *e
   // if there is no match from the current layer, try to use any editable vector layer
   if ( !m.isValid() && mMode == AllLayers )
   {
-    const auto layers = canvas()->layers();
+    const auto layers = canvas()->layers( true );
     for ( QgsMapLayer *layer : layers )
     {
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -1039,7 +1039,7 @@ QSet<QPair<QgsVectorLayer *, QgsFeatureId> > QgsVertexTool::findAllEditableFeatu
 
   if ( mMode == AllLayers )
   {
-    const auto layers = canvas()->layers();
+    const auto layers = canvas()->layers( true );
     for ( QgsMapLayer *layer : layers )
     {
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
@@ -1708,7 +1708,7 @@ void QgsVertexTool::startDragging( QgsMapMouseEvent *e )
 QList<QgsVectorLayer *> QgsVertexTool::editableVectorLayers()
 {
   QList<QgsVectorLayer *> editableLayers;
-  const auto layers = canvas()->layers();
+  const auto layers = canvas()->layers( true );
   for ( QgsMapLayer *layer : layers )
   {
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -469,7 +469,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
 
   QVariantList layersIds;
   QVariantList layers;
-  const QList<QgsMapLayer *> layersInMap = mapSettings.layers();
+  const QList<QgsMapLayer *> layersInMap = mapSettings.layers( true );
   layersIds.reserve( layersInMap.count() );
   layers.reserve( layersInMap.count() );
   for ( QgsMapLayer *layer : layersInMap )
@@ -487,7 +487,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )
 
-  scope->addFunction( QStringLiteral( "is_layer_visible" ), new GetLayerVisibility( mapSettings.layers(), mapSettings.scale() ) );
+  scope->addFunction( QStringLiteral( "is_layer_visible" ), new GetLayerVisibility( mapSettings.layers( true ), mapSettings.scale() ) );
 
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )

--- a/src/core/layertree/qgslayertree.cpp
+++ b/src/core/layertree/qgslayertree.cpp
@@ -80,18 +80,7 @@ QList<QgsMapLayer *> QgsLayerTree::layerOrder() const
   }
   else
   {
-    QList<QgsMapLayer *> layers;
-    const QList< QgsLayerTreeLayer * > foundLayers = findLayers();
-    for ( const auto &treeLayer : foundLayers )
-    {
-      QgsMapLayer *layer = treeLayer->layer();
-      if ( !layer || !layer->isSpatial() )
-      {
-        continue;
-      }
-      layers.append( layer );
-    }
-    return layers;
+    return layerOrderRespectingGroupLayers();
   }
 }
 

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -259,6 +259,34 @@ QList<QgsLayerTreeLayer *> QgsLayerTreeGroup::findLayers() const
   return list;
 }
 
+QList<QgsMapLayer *> QgsLayerTreeGroup::layerOrderRespectingGroupLayers() const
+{
+  QList<QgsMapLayer *> list;
+  for ( QgsLayerTreeNode *child : std::as_const( mChildren ) )
+  {
+    if ( QgsLayerTree::isLayer( child ) )
+    {
+      QgsMapLayer *layer = QgsLayerTree::toLayer( child )->layer();
+      if ( !layer || !layer->isSpatial() )
+        continue;
+      list << layer;
+    }
+    else if ( QgsLayerTree::isGroup( child ) )
+    {
+      QgsLayerTreeGroup *group = QgsLayerTree::toGroup( child );
+      if ( group->groupLayer() )
+      {
+        list << group->groupLayer();
+      }
+      else
+      {
+        list << group->layerOrderRespectingGroupLayers();
+      }
+    }
+  }
+  return list;
+}
+
 QgsLayerTreeGroup *QgsLayerTreeGroup::findGroup( const QString &name )
 {
   for ( QgsLayerTreeNode *child : std::as_const( mChildren ) )

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -145,6 +145,15 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
      */
     QList<QgsLayerTreeLayer *> findLayers() const;
 
+
+    /**
+     * Returns an ordered list of map layers in the group, ignoring any layers which are child layers of QgsGroupLayers. Searches recursively the whole sub-tree.
+     *
+     * \since QGIS 3.24
+     * \note Not available in Python bindings
+     */
+    QList<QgsMapLayer *> layerOrderRespectingGroupLayers() const SIP_SKIP;
+
     /**
      * Find layer IDs used in all layer nodes. Searches recursively the whole sub-tree.
      */

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -147,7 +147,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
 
     /**
-     * Returns an ordered list of map layers in the group, ignoring any layers which are child layers of QgsGroupLayers. Searches recursively the whole sub-tree.
+     * Returns an ordered list of map layers in the group, ignoring any layers which
+     * are child layers of QgsGroupLayers. Searches recursively the whole sub-tree.
      *
      * \note Not available in Python bindings
      * \since QGIS 3.24

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -19,15 +19,21 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgslayertreenode.h"
+#include "qgsmaplayerref.h"
+#include "qgsgrouplayer.h"
 
 class QgsMapLayer;
 class QgsLayerTreeLayer;
+class QgsGroupLayer;
 
 /**
  * \ingroup core
  * \brief Layer tree group node serves as a container for layers and further groups.
  *
  * Group names do not need to be unique within one tree nor within one parent.
+ *
+ * While a layer tree group is typically used for hierarchical organisation of a QgsProject,
+ * they can optionally be associated with a QgsGroupLayer for map rendering purposes.
  *
  * \since QGIS 2.4
  */
@@ -213,6 +219,45 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
      */
     void setIsMutuallyExclusive( bool enabled, int initialChildIndex = -1 );
 
+    /**
+     * Returns a reference to the associated group layer, if the layer tree group will be treated
+     * as group layer during map rendering.
+     *
+     * \see setGroupLayer()
+     * \see convertToGroupLayer()
+     * \since QGIS 3.24
+     */
+    QgsGroupLayer *groupLayer();
+
+    /**
+     * Sets the associated group \a layer, if the layer tree group will be treated
+     * as group layer during map rendering.
+     *
+     * This method does not take ownership of the group layer, and only a weak reference
+     * to the layer is stored.
+     *
+     * \see groupLayer()
+     * \see convertToGroupLayer()
+     * \since QGIS 3.24
+     */
+    void setGroupLayer( QgsGroupLayer *layer );
+
+    /**
+     * Converts the group to a QgsGroupLayer.
+     *
+     * This method will convert the layer tree group to an equivalent QgsGroupLayer, and
+     * return the result. The caller takes ownership of the returned layer, and it is the
+     * caller's responsibility to add the layer to the associated QgsProject.
+     *
+     * If the group is already associated with a group layer (see groupLayer()), NULLPTR
+     * will be returned.
+     *
+     * \see groupLayer()
+     * \see setGroupLayer()
+     * \since QGIS 3.24
+     */
+    QgsGroupLayer *convertToGroupLayer( const QgsGroupLayer::LayerOptions &options ) SIP_FACTORY;
+
   protected slots:
 
     void nodeVisibilityChanged( QgsLayerTreeNode *node );
@@ -252,7 +297,10 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
     QgsLayerTreeGroup &operator= ( const QgsLayerTreeGroup & ) = delete;
 
+    void init();
+    void updateGroupLayers();
 
+    QgsMapLayerRef mGroupLayer;
 };
 
 

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -149,8 +149,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     /**
      * Returns an ordered list of map layers in the group, ignoring any layers which are child layers of QgsGroupLayers. Searches recursively the whole sub-tree.
      *
-     * \since QGIS 3.24
      * \note Not available in Python bindings
+     * \since QGIS 3.24
      */
     QList<QgsMapLayer *> layerOrderRespectingGroupLayers() const SIP_SKIP;
 

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -57,7 +57,7 @@ void QgsMapHitTest::run()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mSettings );
   context.setPainter( &painter ); // we are not going to draw anything, but we still need a working painter
 
-  const auto constLayers = mSettings.layers();
+  const auto constLayers = mSettings.layers( true );
   for ( QgsMapLayer *layer : constLayers )
   {
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -244,20 +244,26 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      *
      * The layers are stored in the reverse order of how they are rendered (layer with index 0 will be on top).
      *
+     * Since QGIS 3.24, if the \a expandGroupLayers option is TRUE then group layers will be converted to
+     * all their child layers.
+     *
      * \see layers()
      * \see setLayers()
      */
-    QStringList layerIds() const;
+    QStringList layerIds( bool expandGroupLayers = false ) const;
 
     /**
      * Returns the list of layers which will be rendered in the map.
      *
      * The layers are stored in the reverse order of how they are rendered (layer with index 0 will be on top)
      *
+     * Since QGIS 3.24, if the \a expandGroupLayers option is TRUE then group layers will be converted to
+     * all their child layers.
+     *
      * \see setLayers()
      * \see layerIds()
      */
-    QList<QgsMapLayer *> layers() const;
+    QList<QgsMapLayer *> layers( bool expandGroupLayers = false ) const;
 
     /**
      * Sets the list of \a layers to render in the map.

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -390,7 +390,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     QgsRectangle aoi = _areaOfInterest( pointMap, tolerance );
 
     QList<LayerAndAreaOfInterest> layers;
-    const auto constLayers = mMapSettings.layers();
+    const auto constLayers = mMapSettings.layers( true );
     for ( QgsMapLayer *layer : constLayers )
       if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )
         layers << qMakePair( vl, aoi );
@@ -632,7 +632,7 @@ QString QgsSnappingUtils::dump()
   }
   else if ( mSnappingConfig.mode() == QgsSnappingConfig::AllLayers )
   {
-    const auto constLayers = mMapSettings.layers();
+    const auto constLayers = mMapSettings.layers( true );
     for ( QgsMapLayer *layer : constLayers )
     {
       if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -154,7 +154,17 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers( QgsLayerTreeNode *node, QList
 
   const QList<QgsLayerTreeNode *> children = node->children();
   for ( QgsLayerTreeNode *child : children )
+  {
+    if ( QgsLayerTreeGroup *group = QgsLayerTree::toGroup( node ) )
+    {
+      if ( QgsGroupLayer *groupLayer = group->groupLayer() )
+      {
+        canvasLayers << groupLayer;
+        continue;
+      }
+    }
     setCanvasLayers( child, canvasLayers, overviewLayers, allLayers );
+  }
 }
 
 void QgsLayerTreeMapCanvasBridge::deferredSetCanvasLayers()

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -931,7 +931,7 @@ void QgsLayoutLegendWidget::mAddToolButton_clicked()
   if ( visibleLayers.isEmpty() )
   {
     // just use current canvas layers as visible layers
-    visibleLayers = mMapCanvas->layers();
+    visibleLayers = mMapCanvas->layers( true );
   }
 
   QgsLayoutLegendLayersDialog addDialog( this );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2430,12 +2430,11 @@ QColor QgsMapCanvas::selectionColor() const
 int QgsMapCanvas::layerCount() const
 {
   return mapSettings().layers().size();
-} // layerCount
+}
 
-
-QList<QgsMapLayer *> QgsMapCanvas::layers() const
+QList<QgsMapLayer *> QgsMapCanvas::layers( bool expandGroupLayers ) const
 {
-  return mapSettings().layers();
+  return mapSettings().layers( expandGroupLayers );
 }
 
 void QgsMapCanvas::layerStateChange()

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -471,14 +471,20 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      */
     QgsMapLayer *layer( const QString &id );
 
-    //! Returns number of layers on the map
+    /**
+     * Returns number of layers on the map.
+     */
     int layerCount() const;
 
     /**
      * Returns the list of layers shown within the map canvas.
+     *
+     * Since QGIS 3.24, if the \a expandGroupLayers option is TRUE then group layers will be converted to
+     * all their child layers.
+     *
      * \see setLayers()
      */
-    QList<QgsMapLayer *> layers() const;
+    QList<QgsMapLayer *> layers( bool expandGroupLayers = false ) const;
 
     /**
      * Freeze/thaw the map canvas. This is used to prevent the canvas from

--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -141,7 +141,7 @@ void QgsMapCanvasAnnotationItem::onCanvasLayersChanged()
   }
   else
   {
-    setVisible( mMapCanvas->mapSettings().layers().contains( mAnnotation->mapLayer() ) );
+    setVisible( mMapCanvas->mapSettings().layers( true ).contains( mAnnotation->mapLayer() ) );
   }
 }
 

--- a/src/gui/qgsmapcanvastracer.cpp
+++ b/src/gui/qgsmapcanvastracer.cpp
@@ -105,7 +105,7 @@ void QgsMapCanvasTracer::configure()
   setExtent( mCanvas->extent() );
 
   QList<QgsVectorLayer *> layers;
-  const QList<QgsMapLayer *> visibleLayers = mCanvas->mapSettings().layers();
+  const QList<QgsMapLayer *> visibleLayers = mCanvas->mapSettings().layers( true );
 
   switch ( mCanvas->snappingUtils()->config().mode() )
   {

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -64,7 +64,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   // field defined as the label field in the layer configuration file/database
 
   // Do not render map tips if the layer is not visible
-  if ( !pMapCanvas->layers().contains( pLayer ) )
+  if ( !pMapCanvas->layers( true ).contains( pLayer ) )
   {
     return;
   }

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -157,23 +157,18 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsMapToolIdentify::identify( const Qg
   {
     QApplication::setOverrideCursor( Qt::WaitCursor );
 
-    int layerCount;
+    QList< QgsMapLayer * > targetLayers;
     if ( layerList.isEmpty() )
-      layerCount = mCanvas->layerCount();
+      targetLayers = mCanvas->layers( true );
     else
-      layerCount = layerList.count();
+      targetLayers = layerList;
 
-
+    const int layerCount = targetLayers.size();
     for ( int i = 0; i < layerCount; i++ )
     {
+      QgsMapLayer *layer = targetLayers.value( i );
 
-      QgsMapLayer *layer = nullptr;
-      if ( layerList.isEmpty() )
-        layer = mCanvas->layer( i );
-      else
-        layer = layerList.value( i );
-
-      emit identifyProgress( i, mCanvas->layerCount() );
+      emit identifyProgress( i, layerCount );
       emit identifyMessage( tr( "Identifying on %1…" ).arg( layer->name() ) );
 
       if ( !layer->flags().testFlag( QgsMapLayer::Identifiable ) )
@@ -186,7 +181,7 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsMapToolIdentify::identify( const Qg
       }
     }
 
-    emit identifyProgress( mCanvas->layerCount(), mCanvas->layerCount() );
+    emit identifyProgress( layerCount, layerCount );
     emit identifyMessage( tr( "Identifying done." ) );
   }
 

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -246,21 +246,21 @@ class TestQgsLayerTree(unittest.TestCase):
         self.assertEqual(group_layer.childLayers(), [layer])
 
         layer2 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer2", "memory")
+                                "layer2", "memory")
         group_node.insertLayer(0, layer2)
         self.assertEqual(group_layer.childLayers(), [layer, layer2])
 
         layer3 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer3", "memory")
+                                "layer3", "memory")
         layer4 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer4", "memory")
+                                "layer4", "memory")
         layer3_node = QgsLayerTreeLayer(layer3)
         layer4_node = QgsLayerTreeLayer(layer4)
         group_node.insertChildNodes(1, [layer3_node, layer4_node])
         self.assertEqual(group_layer.childLayers(), [layer, layer4, layer3, layer2])
 
         layer5 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer5", "memory")
+                                "layer5", "memory")
         layer5_node = QgsLayerTreeLayer(layer5)
         group_node.addChildNode(layer5_node)
         self.assertEqual(group_layer.childLayers(), [layer5, layer, layer4, layer3, layer2])
@@ -271,7 +271,7 @@ class TestQgsLayerTree(unittest.TestCase):
         group_node.removeLayer(layer)
         self.assertEqual(group_layer.childLayers(), [layer5, layer4, layer2])
 
-        group_node.removeChildren(0,2)
+        group_node.removeChildren(0, 2)
         self.assertEqual(group_layer.childLayers(), [layer5])
 
         group_node.removeAllChildren()
@@ -290,10 +290,10 @@ class TestQgsLayerTree(unittest.TestCase):
                                "layer1", "memory")
         group_node.addLayer(layer)
         layer2 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer2", "memory")
+                                "layer2", "memory")
         layer2_node = group_node.addLayer(layer2)
         layer3 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer3", "memory")
+                                "layer3", "memory")
         group_node.addLayer(layer3)
         self.assertEqual(group_layer.childLayers(), [layer3, layer2, layer])
 
@@ -317,21 +317,21 @@ class TestQgsLayerTree(unittest.TestCase):
         group_node.addLayer(layer)
         group2 = group_node.addGroup('child group 1')
         layer2 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer2", "memory")
+                                "layer2", "memory")
         group_node.addLayer(layer2)
 
         layer3 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer3", "memory")
+                                "layer3", "memory")
         layer3_node = group2.addLayer(layer3)
 
         group3 = group2.addGroup('grand child group 1')
         group4 = group2.addGroup('grand child group 2')
 
         layer4 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer4", "memory")
+                                "layer4", "memory")
         layer4_node = group3.addLayer(layer4)
         layer5 = QgsVectorLayer("Point?field=fldtxt:string",
-                               "layer5", "memory")
+                                "layer5", "memory")
         layer5_node = group4.addLayer(layer5)
 
         self.assertEqual(group_layer.childLayers(), [layer2, layer5, layer4, layer3, layer])
@@ -343,6 +343,38 @@ class TestQgsLayerTree(unittest.TestCase):
         self.assertEqual(group_layer.childLayers(), [layer2, layer])
         group2.setItemVisibilityCheckedRecursive(True)
         self.assertEqual(group_layer.childLayers(), [layer2, layer5, layer4, layer3, layer])
+
+    def test_layer_order_with_group_layer(self):
+        """
+        Test retrieving layer order with group layers present
+        """
+        p = QgsProject()
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        p.addMapLayer(layer, False)
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer2", "memory")
+        p.addMapLayer(layer2, False)
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer3", "memory")
+        p.addMapLayer(layer3, False)
+        layer4 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer4", "memory")
+        p.addMapLayer(layer4, False)
+
+        p.layerTreeRoot().addLayer(layer)
+        group_node = p.layerTreeRoot().addGroup('my group')
+        group_node.addLayer(layer2)
+        group_node.addLayer(layer3)
+        p.layerTreeRoot().addLayer(layer4)
+
+        self.assertEqual(p.layerTreeRoot().layerOrder(), [layer, layer2, layer3, layer4])
+
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        p.addMapLayer(group_layer, False)
+        self.assertEqual(p.layerTreeRoot().layerOrder(), [layer, group_layer, layer4])
+        self.assertEqual(group_layer.childLayers(), [layer3, layer2])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -18,12 +18,20 @@ from qgis.core import (
     QgsLayerTree,
     QgsProject,
     QgsVectorLayer,
-    QgsLayerTreeLayer
+    QgsLayerTreeLayer,
+    QgsLayerTreeGroup,
+    QgsGroupLayer,
+    QgsCoordinateTransformContext
 )
 from qgis.testing import start_app, unittest
 from utilities import (unitTestDataPath)
 from qgis.PyQt.QtTest import QSignalSpy
-from qgis.PyQt.QtCore import QDir
+from qgis.PyQt.QtCore import (
+    QDir,
+    QCoreApplication,
+    QEvent
+)
+from tempfile import TemporaryDirectory
 
 app = start_app()
 TEST_DATA_DIR = unitTestDataPath()
@@ -128,6 +136,213 @@ class TestQgsLayerTree(unittest.TestCase):
         # already removed, should be no extra signal
         layer1_node.removeCustomProperty('test')
         self.assertEqual(len(spy), 3)
+
+    def test_layer_tree_group_layer(self):
+        """
+        Test setting a group layer on a QgsLayerTreeGroup
+        """
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = QgsGroupLayer('group', options)
+
+        group_node = QgsLayerTreeGroup()
+        self.assertFalse(group_node.groupLayer())
+        group_node.setGroupLayer(group_layer)
+        self.assertEqual(group_node.groupLayer(), group_layer)
+
+        group_layer.deleteLater()
+        group_layer = None
+        QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+        # should be automatically cleaned
+        self.assertFalse(group_node.groupLayer())
+
+    def test_copy_layer_tree_group(self):
+        # copying layer tree group should also copy group layer setting
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = QgsGroupLayer('group', options)
+
+        group_node = QgsLayerTreeGroup()
+        group_node.setGroupLayer(group_layer)
+        self.assertEqual(group_node.groupLayer(), group_layer)
+
+        group_node2 = group_node.clone()
+        self.assertEqual(group_node2.groupLayer(), group_layer)
+
+    def test_convert_group_to_group_layer(self):
+        """
+        Test converting a QgsLayerTreeGroup to a QgsGroupLayer
+        """
+        group_node = QgsLayerTreeGroup()
+
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        self.assertFalse(group_layer.childLayers())
+        self.assertEqual(group_node.groupLayer(), group_layer)
+
+        # if a group layer is already assigned, convertToGroupLayer should do nothing
+        self.assertIsNone(group_node.convertToGroupLayer(options))
+
+        group_node.setGroupLayer(None)
+        # add some child layers to node
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        group_node.addLayer(layer)
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer2", "memory")
+        group_node.addLayer(layer2)
+
+        group_layer = group_node.convertToGroupLayer(options)
+        self.assertEqual(group_layer.childLayers(), [layer2, layer])
+        self.assertEqual(group_node.groupLayer(), group_layer)
+
+    def test_restore_group_node_group_layer(self):
+        """
+        Test that group node's QgsGroupLayers are restored with projects
+        """
+        p = QgsProject()
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        p.addMapLayer(layer, False)
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer2", "memory")
+        p.addMapLayer(layer2, False)
+
+        group_node = p.layerTreeRoot().addGroup('my group')
+        group_node.addLayer(layer)
+        group_node.addLayer(layer2)
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        p.addMapLayer(group_layer, False)
+
+        with TemporaryDirectory() as d:
+            path = os.path.join(d, 'group_layers.qgs')
+
+            p.setFileName(path)
+            p.write()
+
+            p2 = QgsProject()
+            p2.read(path)
+
+            restored_group_node = p2.layerTreeRoot().children()[0]
+            self.assertEqual(restored_group_node.name(), 'my group')
+
+            restored_group_layer = restored_group_node.groupLayer()
+            self.assertIsNotNone(restored_group_layer)
+
+            self.assertEqual(restored_group_layer.childLayers()[0].name(), 'layer2')
+            self.assertEqual(restored_group_layer.childLayers()[1].name(), 'layer1')
+
+    def test_group_layer_updates_from_node(self):
+        """
+        Test that group layer child layers are synced correctly from the group node
+        """
+        group_node = QgsLayerTreeGroup('my group')
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        self.assertFalse(group_layer.childLayers())
+
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        group_node.addLayer(layer)
+        self.assertEqual(group_layer.childLayers(), [layer])
+
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer2", "memory")
+        group_node.insertLayer(0, layer2)
+        self.assertEqual(group_layer.childLayers(), [layer, layer2])
+
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer3", "memory")
+        layer4 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer4", "memory")
+        layer3_node = QgsLayerTreeLayer(layer3)
+        layer4_node = QgsLayerTreeLayer(layer4)
+        group_node.insertChildNodes(1, [layer3_node, layer4_node])
+        self.assertEqual(group_layer.childLayers(), [layer, layer4, layer3, layer2])
+
+        layer5 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer5", "memory")
+        layer5_node = QgsLayerTreeLayer(layer5)
+        group_node.addChildNode(layer5_node)
+        self.assertEqual(group_layer.childLayers(), [layer5, layer, layer4, layer3, layer2])
+
+        group_node.removeChildNode(layer3_node)
+        self.assertEqual(group_layer.childLayers(), [layer5, layer, layer4, layer2])
+
+        group_node.removeLayer(layer)
+        self.assertEqual(group_layer.childLayers(), [layer5, layer4, layer2])
+
+        group_node.removeChildren(0,2)
+        self.assertEqual(group_layer.childLayers(), [layer5])
+
+        group_node.removeAllChildren()
+        self.assertEqual(group_layer.childLayers(), [])
+
+    def test_group_layer_updates_from_node_visibility(self):
+        """
+        Test that group layer child layers are synced correctly from the group node when layer visibility is changed
+        """
+        group_node = QgsLayerTreeGroup('my group')
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        self.assertFalse(group_layer.childLayers())
+
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        group_node.addLayer(layer)
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer2", "memory")
+        layer2_node = group_node.addLayer(layer2)
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer3", "memory")
+        group_node.addLayer(layer3)
+        self.assertEqual(group_layer.childLayers(), [layer3, layer2, layer])
+
+        layer2_node.setItemVisibilityChecked(False)
+        self.assertEqual(group_layer.childLayers(), [layer3, layer])
+
+        layer2_node.setItemVisibilityChecked(True)
+        self.assertEqual(group_layer.childLayers(), [layer3, layer2, layer])
+
+    def test_group_layer_nested(self):
+        """
+        Test group node with child nodes converted to group layer
+        """
+        group_node = QgsLayerTreeGroup('my group')
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = group_node.convertToGroupLayer(options)
+        self.assertFalse(group_layer.childLayers())
+
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        group_node.addLayer(layer)
+        group2 = group_node.addGroup('child group 1')
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer2", "memory")
+        group_node.addLayer(layer2)
+
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer3", "memory")
+        layer3_node = group2.addLayer(layer3)
+
+        group3 = group2.addGroup('grand child group 1')
+        group4 = group2.addGroup('grand child group 2')
+
+        layer4 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer4", "memory")
+        layer4_node = group3.addLayer(layer4)
+        layer5 = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer5", "memory")
+        layer5_node = group4.addLayer(layer5)
+
+        self.assertEqual(group_layer.childLayers(), [layer2, layer5, layer4, layer3, layer])
+
+        layer5_node.setItemVisibilityChecked(False)
+        self.assertEqual(group_layer.childLayers(), [layer2, layer4, layer3, layer])
+
+        group2.setItemVisibilityChecked(False)
+        self.assertEqual(group_layer.childLayers(), [layer2, layer])
+        group2.setItemVisibilityCheckedRecursive(True)
+        self.assertEqual(group_layer.childLayers(), [layer2, layer5, layer4, layer3, layer])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR continues https://github.com/qgis/QGIS/pull/46154 and adds the necessary backend API pieces to synchronize the layer tree structure with the QgsGroupLayer logic.

No visible UI changes yet!