### PR TITLE
Fix transformation errors which occur when simplification is enabled for a vector layer with a custom crs in degrees

### DIFF
--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -327,7 +327,7 @@ bool QgsVectorLayerRenderer::renderInternal( QgsFeatureRenderer *renderer )
       try
       {
         QgsPointXY center = context.extent().center();
-        double rectSize = ct.sourceCrs().isGeographic() ? 0.0008983 /* ~100/(40075014/360=111319.4833) */ : 100;
+        double rectSize = ct.sourceCrs().mapUnits() == QgsUnitTypes::DistanceDegrees ? 0.0008983 /* ~100/(40075014/360=111319.4833) */ : 100;
 
         QgsRectangle sourceRect = QgsRectangle( center.x(), center.y(), center.x() + rectSize, center.y() + rectSize );
         QgsRectangle targetRect = ct.transform( sourceRect );


### PR DESCRIPTION
Mostly just noise, but it does cause the OTF simplification during rendering to fail for these layers