### PR TITLE
Render layers as groups

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -313,7 +313,7 @@ Read common XML elements.
 Write common XML elements.
 %End
 
-    void insertChildrenPrivate( int index, QList<QgsLayerTreeNode *> nodes );
+    void insertChildrenPrivate( int index, const QList<QgsLayerTreeNode *> &nodes );
 %Docstring
 Low-level insertion of children to the node. The children must not have any parent yet!
 %End

--- a/python/core/auto_generated/project/qgsprojectutils.sip.in
+++ b/python/core/auto_generated/project/qgsprojectutils.sip.in
@@ -38,6 +38,14 @@ with sources which point to ``newPath``.
 Returns ``True`` if any layers were updated as a result.
 %End
 
+    static bool layerIsContainedInGroupLayer( QgsProject *project, QgsMapLayer *layer );
+%Docstring
+Returns ``True`` if the specified ``layer`` is a child layer from any :py:class:`QgsGroupLayer` in the given ``project``.
+
+.. versionadded:: 3.24
+%End
+
+
 };
 
 

--- a/python/core/auto_generated/qgsgrouplayer.sip.in
+++ b/python/core/auto_generated/qgsgrouplayer.sip.in
@@ -87,7 +87,7 @@ the parent :py:class:`QgsProject` wherever appropriate.
 .. seealso:: :py:func:`childLayers`
 %End
 
-    QList< QgsMapLayer * > childLayers();
+    QList< QgsMapLayer * > childLayers() const;
 %Docstring
 Returns the child layers contained by the group.
 

--- a/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidget.sip.in
@@ -68,6 +68,24 @@ Returns the message bar associated with the widget.
 .. seealso:: :py:func:`setMessageBar`
 %End
 
+    void setLayerTreeGroup( QgsLayerTreeGroup *group );
+%Docstring
+Sets the layer tree ``group`` associated with the widget.
+
+.. seealso:: :py:func:`layerTreeGroup`
+
+.. versionadded:: 3.24
+%End
+
+    QgsLayerTreeGroup *layerTreeGroup() const;
+%Docstring
+Returns the layer tree group associated with the widget.
+
+.. seealso:: :py:func:`setLayerTreeGroup`
+
+.. versionadded:: 3.24
+%End
+
 };
 
 

--- a/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
@@ -128,6 +128,15 @@ Check if the layer is supported for this widget.
 :return: ``True`` if this layer is supported for this widget
 %End
 
+    virtual bool supportsLayerTreeGroup( QgsLayerTreeGroup *group ) const;
+%Docstring
+Check if a layer tree group is supported for this widget.
+
+:return: ``True`` if the group is supported for this widget
+
+.. versionadded:: 3.24
+%End
+
     virtual ParentPage parentPage() const;
 %Docstring
 Returns the associated parent page, for factories which create sub-components of a standard page.

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -45,6 +45,7 @@ set(QGIS_APP_SRCS
   qgsfeatureaction.cpp
   qgslayercapabilitiesmodel.cpp
   qgslayernotesmanager.cpp
+  qgslayertreegrouppropertieswidget.cpp
   qgslayertreeviewindicatorprovider.cpp
   qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -23,6 +23,8 @@
 #include "qgsgui.h"
 #include "qgsannotationitemguiregistry.h"
 #include "qgspainteffect.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 #include <QStackedWidget>
 #include <QHBoxLayout>
@@ -70,6 +72,7 @@ void QgsAnnotationItemPropertiesWidget::syncToLayer( QgsMapLayer *layer )
 
   // opacity and blend modes
   mBlockLayerUpdates = true;
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mLayer ) );
   mBlendModeComboBox->setBlendMode( mLayer->blendMode() );
   mOpacityWidget->setOpacity( mLayer->opacity() );
   if ( mLayer->paintEffect() )

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -27,6 +27,8 @@
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsdatumtransformdialog.h"
 #include "qgspainteffect.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 #include <QFileDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -114,6 +116,7 @@ void QgsAnnotationLayerProperties::apply()
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
 
   // set the blend mode and opacity for the layer
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mLayer ) );
   mLayer->setBlendMode( mBlendModeComboBox->blendMode() );
   mLayer->setOpacity( mOpacityWidget->opacity() );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12180,7 +12180,7 @@ void QgisApp::removeLayer()
     return;
   }
 
-  QList<QgsLayerTreeNode *> selectedNodes = mLayerTreeView->selectedNodes( true );
+  const QList<QgsLayerTreeNode *> selectedNodes = mLayerTreeView->selectedNodes( true );
 
   //validate selection
   if ( selectedNodes.isEmpty() )
@@ -12221,7 +12221,7 @@ void QgisApp::removeLayer()
     }
   };
 
-  for ( const auto &n : std::as_const( selectedNodes ) )
+  for ( const QgsLayerTreeNode *n : selectedNodes )
   {
     harvest( n );
   }
@@ -12243,9 +12243,15 @@ void QgisApp::removeLayer()
     return;
   }
 
-  const auto constSelectedNodes = selectedNodes;
-  for ( QgsLayerTreeNode *node : constSelectedNodes )
+  for ( QgsLayerTreeNode *node : selectedNodes )
   {
+    if ( QgsLayerTreeGroup *group = qobject_cast< QgsLayerTreeGroup * >( node ) )
+    {
+      if ( QgsGroupLayer *groupLayer = group->groupLayer() )
+      {
+        QgsProject::instance()->removeMapLayer( groupLayer );
+      }
+    }
     QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( node->parent() );
     if ( parentGroup )
       parentGroup->removeChildNode( node );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -15019,6 +15019,21 @@ void QgisApp::legendLayerSelectionChanged()
 {
   const QList<QgsLayerTreeLayer *> selectedLayers = mLayerTreeView ? mLayerTreeView->selectedLayerNodes() : QList<QgsLayerTreeLayer *>();
 
+  if ( selectedLayers.empty() && mLayerTreeView )
+  {
+    // check if a group node alone is selected
+    const QList<QgsLayerTreeNode *> selectedNodes = mLayerTreeView->selectedNodes();
+    if ( selectedNodes.size() == 1 && QgsLayerTree::isGroup( selectedNodes.at( 0 ) ) )
+    {
+      QgsLayerTreeGroup *groupNode = QgsLayerTree::toGroup( selectedNodes.at( 0 ) );
+      mMapStyleWidget->setEnabled( true );
+      if ( mMapStylingDock->isVisible() )
+      {
+        mMapStyleWidget->setLayerTreeGroup( groupNode );
+      }
+    }
+  }
+
   mActionDuplicateLayer->setEnabled( !selectedLayers.isEmpty() );
   mActionSetLayerScaleVisibility->setEnabled( !selectedLayers.isEmpty() );
   mActionSetLayerCRS->setEnabled( !selectedLayers.isEmpty() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -252,6 +252,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsdiagramproperties.h"
 #include "qgslayerdefinition.h"
 #include "qgslayertree.h"
+#include "qgslayertreegrouppropertieswidget.h"
 #include "qgslayertreemapcanvasbridge.h"
 #include "qgslayertreemodel.h"
 #include "qgslayertreemodellegendnode.h"
@@ -1428,6 +1429,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 #endif
   registerMapLayerPropertiesFactory( new QgsPointCloudElevationPropertiesWidgetFactory( this ) );
   registerMapLayerPropertiesFactory( new QgsAnnotationItemPropertiesWidgetFactory( this ) );
+  registerMapLayerPropertiesFactory( new QgsLayerTreeGroupPropertiesWidgetFactory( this ) );
 
   activateDeactivateLayerRelatedActions( nullptr ); // after members were created
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -175,6 +175,7 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
   }
 
   mCurrentLayer = layer;
+  mContext.setLayerTreeGroup( nullptr );
 
   mUndoWidget->setUndoStack( layer->undoStackStyles() );
 
@@ -303,10 +304,10 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
 
 void QgsLayerStylingWidget::apply()
 {
-  if ( !mCurrentLayer )
-    return;
-
-  disconnect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
+  if ( mCurrentLayer )
+  {
+    disconnect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
+  }
 
   QString undoName = QStringLiteral( "Style Change" );
 
@@ -357,14 +358,19 @@ void QgsLayerStylingWidget::apply()
     triggerRepaint = widget->shouldTriggerLayerRepaint();
   }
 
-  pushUndoItem( undoName, triggerRepaint );
+  if ( mCurrentLayer )
+    pushUndoItem( undoName, triggerRepaint );
 
-  if ( styleWasChanged )
+  if ( mCurrentLayer && styleWasChanged )
   {
     emit styleChanged( mCurrentLayer );
     QgsProject::instance()->setDirty( true );
   }
-  connect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
+
+  if ( mCurrentLayer )
+  {
+    connect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );
+  }
 }
 
 void QgsLayerStylingWidget::autoApply()
@@ -389,12 +395,13 @@ void QgsLayerStylingWidget::redo()
 
 void QgsLayerStylingWidget::updateCurrentWidgetLayer()
 {
-  if ( !mCurrentLayer )
+  if ( !mCurrentLayer && !mContext.layerTreeGroup() )
     return;  // non-spatial are ignored in setLayer()
 
   mBlockAutoApply = true;
 
-  whileBlocking( mLayerCombo )->setLayer( mCurrentLayer );
+  if ( mCurrentLayer )
+    whileBlocking( mLayerCombo )->setLayer( mCurrentLayer );
 
   int row = mOptionsListWidget->currentIndex().row();
 
@@ -453,11 +460,11 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
   }
 
   // The last widget is always the undo stack.
-  if ( row == mOptionsListWidget->count() - 1 )
+  if ( mCurrentLayer && row == mOptionsListWidget->count() - 1 )
   {
     mWidgetStack->setMainPanel( mUndoWidget );
   }
-  else
+  else if ( mCurrentLayer )
   {
     switch ( mCurrentLayer->type() )
     {
@@ -708,6 +715,39 @@ void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const 
   mContext.setAnnotationId( itemId );
   if ( layer )
     setLayer( layer );
+
+  if ( QgsMapLayerConfigWidget *configWidget = qobject_cast< QgsMapLayerConfigWidget * >( mWidgetStack->mainPanel() ) )
+  {
+    configWidget->setMapLayerConfigWidgetContext( mContext );
+  }
+}
+
+void QgsLayerStylingWidget::setLayerTreeGroup( QgsLayerTreeGroup *group )
+{
+  mOptionsListWidget->blockSignals( true );
+  mOptionsListWidget->clear();
+  mUserPages.clear();
+
+  for ( const QgsMapLayerConfigWidgetFactory *factory : std::as_const( mPageFactories ) )
+  {
+    if ( factory->supportsStyleDock() && factory->supportsLayerTreeGroup( group ) )
+    {
+      QListWidgetItem *item = new QListWidgetItem( factory->icon(), QString() );
+      item->setToolTip( factory->title() );
+      mOptionsListWidget->addItem( item );
+      int row = mOptionsListWidget->row( item );
+      mUserPages[row] = factory;
+    }
+  }
+
+  mContext.setLayerTreeGroup( group );
+  setLayer( nullptr );
+
+  mOptionsListWidget->setCurrentRow( 0 );
+  mOptionsListWidget->blockSignals( false );
+  updateCurrentWidgetLayer();
+
+  mStackedWidget->setCurrentIndex( 1 );
 
   if ( QgsMapLayerConfigWidget *configWidget = qobject_cast< QgsMapLayerConfigWidget * >( mWidgetStack->mainPanel() ) )
   {

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -49,6 +49,7 @@ class QgsMessageBar;
 class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileBasicLabelingWidget;
 class QgsAnnotationLayer;
+class QgsLayerTreeGroup;
 
 class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWidgetFactory
 {
@@ -134,6 +135,11 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
      * Sets an annotation item to show in the widget.
      */
     void setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId );
+
+    /**
+     * Sets a layer tree group to show in the widget.
+     */
+    void setLayerTreeGroup( QgsLayerTreeGroup *group );
 
     /**
      * Focuses the default widget for the current page.

--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -33,6 +33,9 @@ QgsLayerTreeGroupPropertiesWidget::QgsLayerTreeGroupPropertiesWidget( QgsMapCanv
 {
   setupUi( this );
 
+  mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
+  mPaintEffect->setEnabled( false );
+
   connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
   connect( mBlendModeComboBox, qOverload< int >( &QgsBlendModeComboBox::currentIndexChanged ), this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
   connect( mEffectWidget, &QgsEffectStackCompactWidget::changed, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );

--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsgui.h"
 #include "qgspainteffect.h"
 #include "qgsmapcanvas.h"
+#include "qgspainteffectregistry.h"
 
 #include <QStackedWidget>
 #include <QHBoxLayout>
@@ -32,7 +33,7 @@ QgsLayerTreeGroupPropertiesWidget::QgsLayerTreeGroupPropertiesWidget( QgsMapCanv
 
   connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
   connect( mBlendModeComboBox, qOverload< int >( &QgsBlendModeComboBox::currentIndexChanged ), this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
-// connect( mEffectWidget, &QgsEffectStackCompactWidget::changed, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
+  connect( mEffectWidget, &QgsEffectStackCompactWidget::changed, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
   connect( mRenderAsGroupCheckBox, &QGroupBox::toggled, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
 
   setDockMode( true );
@@ -58,7 +59,7 @@ void QgsLayerTreeGroupPropertiesWidget::setMapLayerConfigWidgetContext( const Qg
     if ( groupLayer->paintEffect() )
     {
       mPaintEffect.reset( groupLayer->paintEffect()->clone() );
-      //mEffectWidget->setPaintEffect( mPaintEffect.get() );
+      mEffectWidget->setPaintEffect( mPaintEffect.get() );
     }
   }
   else
@@ -97,8 +98,8 @@ void QgsLayerTreeGroupPropertiesWidget::apply()
     // set the blend mode and opacity for the layer
     groupLayer->setBlendMode( mBlendModeComboBox->blendMode() );
     groupLayer->setOpacity( mOpacityWidget->opacity() );
-    if ( mPaintEffect )
-      groupLayer->setPaintEffect( mPaintEffect->clone() );
+    groupLayer->setPaintEffect( mPaintEffect->clone() );
+
     groupLayer->triggerRepaint();
   }
   else if ( mMapLayerConfigWidgetContext.mapCanvas() )

--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+    qgslayertreegrouppropertieswidget.cpp
+    ---------------------
+    begin                : Nobember 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreegrouppropertieswidget.h"
+#include "qgsstyle.h"
+#include "qgsapplication.h"
+#include "qgsmaplayer.h"
+#include "qgsgui.h"
+#include "qgspainteffect.h"
+#include "qgsmapcanvas.h"
+
+#include <QStackedWidget>
+#include <QHBoxLayout>
+#include <QLabel>
+
+QgsLayerTreeGroupPropertiesWidget::QgsLayerTreeGroupPropertiesWidget( QgsMapCanvas *canvas, QWidget *parent )
+  : QgsMapLayerConfigWidget( nullptr, canvas, parent )
+{
+  setupUi( this );
+
+  connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
+  connect( mBlendModeComboBox, qOverload< int >( &QgsBlendModeComboBox::currentIndexChanged ), this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
+// connect( mEffectWidget, &QgsEffectStackCompactWidget::changed, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
+  connect( mRenderAsGroupCheckBox, &QGroupBox::toggled, this, &QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged );
+
+  setDockMode( true );
+}
+
+QgsLayerTreeGroupPropertiesWidget::~QgsLayerTreeGroupPropertiesWidget() = default;
+
+void QgsLayerTreeGroupPropertiesWidget::syncToLayer( QgsMapLayer * )
+{
+}
+
+void QgsLayerTreeGroupPropertiesWidget::setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context )
+{
+  QgsMapLayerConfigWidget::setMapLayerConfigWidgetContext( context );
+  mLayerTreeGroup = context.layerTreeGroup();
+
+  mBlockLayerUpdates = true;
+  if ( QgsGroupLayer *groupLayer = mLayerTreeGroup->groupLayer() )
+  {
+    mRenderAsGroupCheckBox->setChecked( true );
+    mBlendModeComboBox->setBlendMode( groupLayer->blendMode() );
+    mOpacityWidget->setOpacity( groupLayer->opacity() );
+    if ( groupLayer->paintEffect() )
+    {
+      mPaintEffect.reset( groupLayer->paintEffect()->clone() );
+      //mEffectWidget->setPaintEffect( mPaintEffect.get() );
+    }
+  }
+  else
+  {
+    mRenderAsGroupCheckBox->setChecked( false );
+  }
+  mBlockLayerUpdates = false;
+}
+
+void QgsLayerTreeGroupPropertiesWidget::setDockMode( bool dockMode )
+{
+  QgsMapLayerConfigWidget::setDockMode( dockMode );
+}
+
+void QgsLayerTreeGroupPropertiesWidget::apply()
+{
+  if ( !mLayerTreeGroup )
+    return;
+
+  QgsGroupLayer *groupLayer = mLayerTreeGroup->groupLayer();
+  if ( groupLayer && !mRenderAsGroupCheckBox->isChecked() )
+  {
+    mLayerTreeGroup->setGroupLayer( nullptr );
+    QgsProject::instance()->removeMapLayer( groupLayer );
+    groupLayer = nullptr;
+  }
+  else if ( !groupLayer && mRenderAsGroupCheckBox->isChecked() )
+  {
+    QgsGroupLayer::LayerOptions options( QgsProject::instance()->transformContext() );
+    groupLayer = mLayerTreeGroup->convertToGroupLayer( options );
+    QgsProject::instance()->addMapLayer( groupLayer, false );
+  }
+
+  if ( groupLayer )
+  {
+    // set the blend mode and opacity for the layer
+    groupLayer->setBlendMode( mBlendModeComboBox->blendMode() );
+    groupLayer->setOpacity( mOpacityWidget->opacity() );
+    if ( mPaintEffect )
+      groupLayer->setPaintEffect( mPaintEffect->clone() );
+    groupLayer->triggerRepaint();
+  }
+  else if ( mMapLayerConfigWidgetContext.mapCanvas() )
+  {
+    mMapLayerConfigWidgetContext.mapCanvas()->refresh();
+  }
+}
+
+void QgsLayerTreeGroupPropertiesWidget::onLayerPropertyChanged()
+{
+  if ( mBlockLayerUpdates )
+    return;
+
+  emit widgetChanged();
+}
+
+
+//
+// QgsLayerTreeGroupPropertiesWidgetFactory
+//
+
+QgsLayerTreeGroupPropertiesWidgetFactory::QgsLayerTreeGroupPropertiesWidgetFactory( QObject *parent )
+  : QObject( parent )
+{
+  setIcon( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ) );
+  setTitle( tr( "Group" ) );
+}
+
+QgsMapLayerConfigWidget *QgsLayerTreeGroupPropertiesWidgetFactory::createWidget( QgsMapLayer *, QgsMapCanvas *canvas, bool, QWidget *parent ) const
+{
+  return new QgsLayerTreeGroupPropertiesWidget( canvas, parent );
+}
+
+bool QgsLayerTreeGroupPropertiesWidgetFactory::supportLayerPropertiesDialog() const
+{
+  return false;
+}
+
+bool QgsLayerTreeGroupPropertiesWidgetFactory::supportsStyleDock() const
+{
+  return true;
+}
+
+bool QgsLayerTreeGroupPropertiesWidgetFactory::supportsLayer( QgsMapLayer * ) const
+{
+  return false;
+}
+
+bool QgsLayerTreeGroupPropertiesWidgetFactory::supportsLayerTreeGroup( QgsLayerTreeGroup * ) const
+{
+  return true;
+}
+

--- a/src/app/qgslayertreegrouppropertieswidget.cpp
+++ b/src/app/qgslayertreegrouppropertieswidget.cpp
@@ -21,6 +21,8 @@
 #include "qgspainteffect.h"
 #include "qgsmapcanvas.h"
 #include "qgspainteffectregistry.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 #include <QStackedWidget>
 #include <QHBoxLayout>
@@ -54,6 +56,7 @@ void QgsLayerTreeGroupPropertiesWidget::setMapLayerConfigWidgetContext( const Qg
   if ( QgsGroupLayer *groupLayer = mLayerTreeGroup->groupLayer() )
   {
     mRenderAsGroupCheckBox->setChecked( true );
+    mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), groupLayer ) );
     mBlendModeComboBox->setBlendMode( groupLayer->blendMode() );
     mOpacityWidget->setOpacity( groupLayer->opacity() );
     if ( groupLayer->paintEffect() )

--- a/src/app/qgslayertreegrouppropertieswidget.h
+++ b/src/app/qgslayertreegrouppropertieswidget.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+    qgslayertreegrouppropertieswidget.h
+    ---------------------
+    begin                : November 2021
+    copyright            : (C) 2021 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEGROUPPROPERTIESWIDGET_H
+#define QGSLAYERTREEGROUPPROPERTIESWIDGET_H
+
+#include "qgsmaplayerconfigwidget.h"
+#include "qgsmaplayerconfigwidgetfactory.h"
+#include "ui_qgslayertreegrouppropertieswidgetbase.h"
+#include <QPointer>
+
+class QgsAnnotationLayer;
+class QgsAnnotationItemBaseWidget;
+class QStackedWidget;
+
+class QgsLayerTreeGroupPropertiesWidget : public QgsMapLayerConfigWidget, public Ui::QgsLayerTreeGroupPropertiesWidgetBase
+{
+    Q_OBJECT
+  public:
+
+    QgsLayerTreeGroupPropertiesWidget( QgsMapCanvas *canvas, QWidget *parent );
+    ~QgsLayerTreeGroupPropertiesWidget() override;
+
+    void syncToLayer( QgsMapLayer *layer ) override;
+    void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
+    void setDockMode( bool dockMode ) override;
+
+  public slots:
+    void apply() override;
+
+  private slots:
+
+    void onLayerPropertyChanged();
+  private:
+
+    QPointer< QgsLayerTreeGroup > mLayerTreeGroup;
+    bool mBlockLayerUpdates = false;
+
+    std::unique_ptr< QgsPaintEffect > mPaintEffect;
+
+};
+
+
+class QgsLayerTreeGroupPropertiesWidgetFactory : public QObject, public QgsMapLayerConfigWidgetFactory
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayerTreeGroupPropertiesWidgetFactory( QObject *parent = nullptr );
+
+    QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget, QWidget *parent ) const override;
+    bool supportLayerPropertiesDialog() const override;
+    bool supportsStyleDock() const override;
+    bool supportsLayer( QgsMapLayer *layer ) const override;
+    bool supportsLayerTreeGroup( QgsLayerTreeGroup *group ) const override;
+};
+
+
+
+#endif // QGSLAYERTREEGROUPPROPERTIESWIDGET_H

--- a/src/core/layertree/qgslayertree.cpp
+++ b/src/core/layertree/qgslayertree.cpp
@@ -19,14 +19,18 @@
 
 QgsLayerTree::QgsLayerTree()
 {
-  connect( this, &QgsLayerTree::addedChildren, this, &QgsLayerTree::nodeAddedChildren );
-  connect( this, &QgsLayerTree::removedChildren, this, &QgsLayerTree::nodeRemovedChildren );
+  init();
 }
 
 QgsLayerTree::QgsLayerTree( const QgsLayerTree &other )
   : QgsLayerTreeGroup( other )
   , mCustomLayerOrder( other.mCustomLayerOrder )
   , mHasCustomLayerOrder( other.mHasCustomLayerOrder )
+{
+  init();
+}
+
+void QgsLayerTree::init()
 {
   connect( this, &QgsLayerTree::addedChildren, this, &QgsLayerTree::nodeAddedChildren );
   connect( this, &QgsLayerTree::removedChildren, this, &QgsLayerTree::nodeRemovedChildren );

--- a/src/core/layertree/qgslayertree.h
+++ b/src/core/layertree/qgslayertree.h
@@ -234,6 +234,9 @@ class CORE_EXPORT QgsLayerTree : public QgsLayerTreeGroup
   private:
     //! Copy constructor \see clone()
     QgsLayerTree( const QgsLayerTree &other );
+
+    void init();
+
     void addMissingLayers();
     QgsWeakMapLayerPointerList mCustomLayerOrder;
     bool mHasCustomLayerOrder = false;

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -309,6 +309,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
 
     void init();
     void updateGroupLayers();
+    void refreshParentGroupLayerMembers();
 
     QgsMapLayerRef mGroupLayer;
 };

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -233,13 +233,12 @@ void QgsLayerTreeNode::writeCommonXml( QDomElement &element )
   mProperties.writeXml( element, doc );
 }
 
-void QgsLayerTreeNode::insertChildrenPrivate( int index, QList<QgsLayerTreeNode *> nodes )
+void QgsLayerTreeNode::insertChildrenPrivate( int index, const QList<QgsLayerTreeNode *> &nodes )
 {
   if ( nodes.isEmpty() )
     return;
 
-  const auto constNodes = nodes;
-  for ( QgsLayerTreeNode *node : constNodes )
+  for ( QgsLayerTreeNode *node : nodes )
   {
     Q_ASSERT( !node->mParent );
     node->mParent = this;

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -162,7 +162,18 @@ void fetchCheckedLayers( const QgsLayerTreeNode *node, QList<QgsMapLayer *> &lay
 
   const auto constChildren = node->children();
   for ( QgsLayerTreeNode *child : constChildren )
+  {
+    if ( QgsLayerTreeGroup *group = qobject_cast< QgsLayerTreeGroup * >( child ) )
+    {
+      if ( QgsGroupLayer *groupLayer = group->groupLayer() )
+      {
+        layers << groupLayer;
+        continue;
+      }
+    }
+
     fetchCheckedLayers( child, layers );
+  }
 }
 
 QList<QgsMapLayer *> QgsLayerTreeNode::checkedLayers() const

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -285,7 +285,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     void writeCommonXml( QDomElement &element );
 
     //! Low-level insertion of children to the node. The children must not have any parent yet!
-    void insertChildrenPrivate( int index, QList<QgsLayerTreeNode *> nodes );
+    void insertChildrenPrivate( int index, const QList<QgsLayerTreeNode *> &nodes );
     //! Low-level removal of children from the node.
     void removeChildrenPrivate( int from, int count, bool destroy = true );
 

--- a/src/core/project/qgsprojectutils.cpp
+++ b/src/core/project/qgsprojectutils.cpp
@@ -18,6 +18,7 @@
 #include "qgsprojectutils.h"
 #include "qgsmaplayerutils.h"
 #include "qgsproject.h"
+#include "qgsgrouplayer.h"
 
 QList<QgsMapLayer *> QgsProjectUtils::layersMatchingPath( const QgsProject *project, const QString &path )
 {
@@ -51,4 +52,19 @@ bool QgsProjectUtils::updateLayerPath( QgsProject *project, const QString &oldPa
     }
   }
   return res;
+}
+
+bool QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject *project, QgsMapLayer *layer )
+{
+  const QMap<QString, QgsMapLayer *> mapLayers( project->mapLayers() );
+  for ( QgsMapLayer *l : mapLayers )
+  {
+    if ( l->type() != QgsMapLayerType::GroupLayer )
+      continue;
+
+    QgsGroupLayer *groupLayer = qobject_cast< QgsGroupLayer * >( l );
+    if ( groupLayer->childLayers().contains( layer ) )
+      return true;
+  }
+  return false;
 }

--- a/src/core/project/qgsprojectutils.cpp
+++ b/src/core/project/qgsprojectutils.cpp
@@ -56,13 +56,9 @@ bool QgsProjectUtils::updateLayerPath( QgsProject *project, const QString &oldPa
 
 bool QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject *project, QgsMapLayer *layer )
 {
-  const QMap<QString, QgsMapLayer *> mapLayers( project->mapLayers() );
-  for ( QgsMapLayer *l : mapLayers )
+  const QVector< QgsGroupLayer * > groupLayers = project->layers< QgsGroupLayer * >();
+  for ( QgsGroupLayer *groupLayer : groupLayers )
   {
-    if ( l->type() != QgsMapLayerType::GroupLayer )
-      continue;
-
-    QgsGroupLayer *groupLayer = qobject_cast< QgsGroupLayer * >( l );
     if ( groupLayer->childLayers().contains( layer ) )
       return true;
   }

--- a/src/core/project/qgsprojectutils.h
+++ b/src/core/project/qgsprojectutils.h
@@ -51,6 +51,14 @@ class CORE_EXPORT QgsProjectUtils
      */
     static bool updateLayerPath( QgsProject *project, const QString &oldPath, const QString &newPath );
 
+    /**
+     * Returns TRUE if the specified \a layer is a child layer from any QgsGroupLayer in the given \a project.
+     *
+     * \since QGIS 3.24
+     */
+    static bool layerIsContainedInGroupLayer( QgsProject *project, QgsMapLayer *layer );
+
+
 };
 
 #endif // QGSPROJECTUTILS_H

--- a/src/core/qgsgrouplayer.cpp
+++ b/src/core/qgsgrouplayer.cpp
@@ -35,6 +35,9 @@ QgsGroupLayer::QgsGroupLayer( const QString &name, const LayerOptions &options )
   mShouldValidateCrs = false;
   mValid = true;
 
+  mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
+  mPaintEffect->setEnabled( false );
+
   QgsDataProvider::ProviderOptions providerOptions;
   providerOptions.transformContext = options.transformContext;
   mDataProvider = new QgsGroupLayerDataProvider( providerOptions, QgsDataProvider::ReadFlags() );
@@ -224,7 +227,8 @@ bool QgsGroupLayer::readSymbology( const QDomNode &node, QString &, QgsReadWrite
     }
     else
     {
-      mPaintEffect.reset();
+      mPaintEffect.reset( QgsPaintEffectRegistry::defaultStack() );
+      mPaintEffect->setEnabled( false );
     }
   }
 

--- a/src/core/qgsgrouplayer.h
+++ b/src/core/qgsgrouplayer.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsGroupLayer : public QgsMapLayer
      *
      * \see setChildLayers()
      */
-    QList< QgsMapLayer * > childLayers();
+    QList< QgsMapLayer * > childLayers() const;
 
     /**
      * Returns the current paint effect for the group layer.

--- a/src/core/qgsgrouplayerrenderer.cpp
+++ b/src/core/qgsgrouplayerrenderer.cpp
@@ -54,7 +54,7 @@ QgsGroupLayerRenderer::QgsGroupLayerRenderer( QgsGroupLayer *layer, QgsRenderCon
     mTransforms.emplace_back( layerToDestTransform );
   }
 
-  mPaintEffect.reset( layer->paintEffect() ? layer->paintEffect()->clone() : nullptr );
+  mPaintEffect.reset( layer->paintEffect() && layer->paintEffect()->enabled() ? layer->paintEffect()->clone() : nullptr );
 
   mForceRasterRender = layer->blendMode() != QPainter::CompositionMode_SourceOver;
 }

--- a/src/core/qgsgrouplayerrenderer.h
+++ b/src/core/qgsgrouplayerrenderer.h
@@ -55,6 +55,7 @@ class CORE_EXPORT QgsGroupLayerRenderer : public QgsMapLayerRenderer
 
   private:
     std::unique_ptr< QgsFeedback > mFeedback;
+    bool mForceRasterRender = false;
     std::vector< std::unique_ptr< QgsMapLayerRenderer > > mChildRenderers;
     std::vector< QPainter::CompositionMode > mRendererCompositionModes;
     std::vector< double > mRendererOpacity;

--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -23,6 +23,8 @@
 #include "qgsmeshdatasetgrouptreeview.h"
 #include "qgsmeshrendereractivedatasetwidget.h"
 #include "qgsmeshlayerutils.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
@@ -48,6 +50,7 @@ QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *
   syncToLayer( mMeshLayer );
 
   //blend mode
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mMeshLayer ) );
   mBlendModeComboBox->setBlendMode( mMeshLayer->blendMode() );
   connect( mBlendModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
 

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -28,6 +28,8 @@
 
 #include "qgspointcloudrgbrenderer.h"
 #include "qgslogger.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 static bool _initRenderer( const QString &name, QgsPointCloudRendererWidgetFunc f, const QString &iconName = QString() )
 {
@@ -127,6 +129,7 @@ void QgsPointCloudRendererPropertiesWidget::syncToLayer( QgsMapLayer *layer )
 
   mBlockChangedSignal = true;
   mOpacityWidget->setOpacity( mLayer->opacity() );
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mLayer ) );
   mBlendModeComboBox->setBlendMode( mLayer->blendMode() );
 
   if ( mLayer->renderer() )

--- a/src/gui/qgsmaplayerconfigwidget.cpp
+++ b/src/gui/qgsmaplayerconfigwidget.cpp
@@ -14,6 +14,25 @@
  ***************************************************************************/
 #include "qgsmaplayerconfigwidget.h"
 #include "qgspanelwidget.h"
+#include "qgslayertreegroup.h"
+
+//
+// QgsMapLayerConfigWidgetContext
+//
+
+void QgsMapLayerConfigWidgetContext::setLayerTreeGroup( QgsLayerTreeGroup *group )
+{
+  mLayerTreeGroup = group;
+}
+
+QgsLayerTreeGroup *QgsMapLayerConfigWidgetContext::layerTreeGroup() const
+{
+  return mLayerTreeGroup;
+}
+
+//
+//  QgsMapLayerConfigWidget
+//
 
 QgsMapLayerConfigWidget::QgsMapLayerConfigWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
   : QgsPanelWidget( parent )

--- a/src/gui/qgsmaplayerconfigwidget.h
+++ b/src/gui/qgsmaplayerconfigwidget.h
@@ -17,8 +17,10 @@
 
 #include <QWidget>
 #include <QIcon>
+#include <QPointer>
 
 #include "qgspanelwidget.h"
+#include "qgslayertreegroup.h"
 #include "qgis_gui.h"
 
 class QgsMapCanvas;
@@ -78,11 +80,28 @@ class GUI_EXPORT QgsMapLayerConfigWidgetContext
      */
     QgsMessageBar *messageBar() const { return mMessageBar; }
 
+    /**
+     * Sets the layer tree \a group associated with the widget.
+     *
+     * \see layerTreeGroup()
+     * \since QGIS 3.24
+     */
+    void setLayerTreeGroup( QgsLayerTreeGroup *group );
+
+    /**
+     * Returns the layer tree group associated with the widget.
+     *
+     * \see setLayerTreeGroup()
+     * \since QGIS 3.24
+     */
+    QgsLayerTreeGroup *layerTreeGroup() const;
+
   private:
 
     QString mAnnotationId;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
+    QPointer< QgsLayerTreeGroup > mLayerTreeGroup = nullptr;
 
 };
 

--- a/src/gui/qgsmaplayerconfigwidgetfactory.cpp
+++ b/src/gui/qgsmaplayerconfigwidgetfactory.cpp
@@ -32,6 +32,11 @@ bool QgsMapLayerConfigWidgetFactory::supportsLayer( QgsMapLayer *layer ) const
   return true;
 }
 
+bool QgsMapLayerConfigWidgetFactory::supportsLayerTreeGroup( QgsLayerTreeGroup * ) const
+{
+  return false;
+}
+
 QgsMapLayerConfigWidgetFactory::ParentPage QgsMapLayerConfigWidgetFactory::parentPage() const
 {
   return ParentPage::NoParent;

--- a/src/gui/qgsmaplayerconfigwidgetfactory.h
+++ b/src/gui/qgsmaplayerconfigwidgetfactory.h
@@ -23,6 +23,7 @@
 class QgsMapLayer;
 class QgsMapLayerConfigWidget;
 class QgsMapCanvas;
+class QgsLayerTreeGroup;
 
 /**
  * \ingroup gui
@@ -126,6 +127,13 @@ class GUI_EXPORT QgsMapLayerConfigWidgetFactory
      * \returns TRUE if this layer is supported for this widget
      */
     virtual bool supportsLayer( QgsMapLayer *layer ) const;
+
+    /**
+     * \brief Check if a layer tree group is supported for this widget.
+     * \returns TRUE if the group is supported for this widget
+     * \since QGIS 3.24
+     */
+    virtual bool supportsLayerTreeGroup( QgsLayerTreeGroup *group ) const;
 
     /**
      * Returns the associated parent page, for factories which create sub-components of a standard page.

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -67,6 +67,7 @@
 #include "qgsrasterlayertemporalproperties.h"
 #include "qgsdoublevalidator.h"
 #include "qgsmaplayerconfigwidgetfactory.h"
+#include "qgsprojectutils.h"
 
 #include "qgsrasterlayertemporalpropertieswidget.h"
 #include "qgsprojecttimesettings.h"
@@ -385,6 +386,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   }
 
   //blend mode
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mRasterLayer ) );
   mBlendModeComboBox->setBlendMode( mRasterLayer->blendMode() );
 
   //transparency band

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -31,7 +31,8 @@
 #include "qgssinglebandgrayrenderer.h"
 #include "qgsapplication.h"
 #include "qgscolorrampimpl.h"
-
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 #include "qgsmessagelog.h"
 
@@ -227,6 +228,7 @@ void QgsRendererRasterPropertiesWidget::syncToLayer( QgsRasterLayer *layer )
   }
 
   //blend mode
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mRasterLayer ) );
   mBlendModeComboBox->setBlendMode( mRasterLayer->blendMode() );
 
   //set combo boxes to current resampling types

--- a/src/gui/symbology/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.cpp
@@ -32,6 +32,8 @@
 #include "qgsembeddedsymbolrendererwidget.h"
 #include "qgspanelwidget.h"
 #include "qgspainteffect.h"
+#include "qgsproject.h"
+#include "qgsprojectutils.h"
 
 #include "qgsorderbydialog.h"
 #include "qgsapplication.h"
@@ -344,6 +346,9 @@ void QgsRendererPropertiesDialog::openPanel( QgsPanelWidget *panel )
 
 void QgsRendererPropertiesDialog::syncToLayer()
 {
+  mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mLayer ) );
+  mFeatureBlendComboBox->setShowClippingModes( mBlendModeComboBox->showClippingModes() );
+
   // Blend mode
   mBlendModeComboBox->setBlendMode( mLayer->blendMode() );
 

--- a/src/ui/qgslayertreegrouppropertieswidgetbase.ui
+++ b/src/ui/qgslayertreegrouppropertieswidgetbase.ui
@@ -35,6 +35,16 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="2">
+       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="lblTransparency">
         <property name="text">
@@ -49,18 +59,21 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>4</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="0" column="2">
+       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+      <item row="2" column="0" colspan="3">
+       <widget class="QgsEffectStackCompactWidget" name="mEffectWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
@@ -89,6 +102,12 @@
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsEffectStackCompactWidget</class>
+   <extends>QWidget</extends>
+   <header>qgseffectstackpropertieswidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>

--- a/src/ui/qgslayertreegrouppropertieswidgetbase.ui
+++ b/src/ui/qgslayertreegrouppropertieswidgetbase.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsLayerTreeGroupPropertiesWidgetBase</class>
+ <widget class="QWidget" name="QgsLayerTreeGroupPropertiesWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>424</width>
+    <height>702</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Annotation Item Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="mRenderAsGroupCheckBox">
+     <property name="title">
+      <string>Render Layers as a Group</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="lblBlend">
+        <property name="text">
+         <string>Blending mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/src/python/test_qgsgrouplayer.py
+++ b/tests/src/python/test_qgsgrouplayer.py
@@ -123,10 +123,10 @@ class TestQgsGroupLayer(unittest.TestCase):
 
         group_layer.setChildLayers([layer1])
         extent = group_layer.extent()
-        self.assertEqual(extent.xMinimum(), 2478778)
-        self.assertEqual(extent.xMaximum(), 2478778)
-        self.assertEqual(extent.yMinimum(), 2487236)
-        self.assertEqual(extent.yMaximum(), 2487236)
+        self.assertAlmostEqual(extent.xMinimum(), 2478778, -2)
+        self.assertAlmostEqual(extent.xMaximum(), 2478778, -2)
+        self.assertAlmostEqual(extent.yMinimum(), 2487236, -2)
+        self.assertAlmostEqual(extent.yMaximum(), 2487236, -2)
 
         layer2 = QgsVectorLayer('Point?crs=epsg:4326', 'Point', 'memory')
         f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(142.178, -35.943)))

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -405,6 +405,7 @@ class TestQgsLayerTree(unittest.TestCase):
         layer4_node = grandchild_group.addLayer(layer4)
 
         self.assertEqual(p.layerTreeRoot().layerOrder(), [layer, layer2, layer3, layer4])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [layer, layer2, layer3, layer4])
 
         spy = QSignalSpy(p.layerTreeRoot().layerOrderChanged)
 
@@ -412,12 +413,14 @@ class TestQgsLayerTree(unittest.TestCase):
         group_layer = group_node.convertToGroupLayer(options)
         p.addMapLayer(group_layer, False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [layer4, layer3, layer2, layer])
         spy_count = len(spy)
         self.assertEqual(spy_count, 1)
 
         grandchild_group_layer = grandchild_group.convertToGroupLayer(options)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [grandchild_group_layer, layer3, layer2, layer])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
         self.assertGreater(len(spy), spy_count)
@@ -425,6 +428,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer4_node.setItemVisibilityChecked(False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [grandchild_group_layer, layer3, layer2, layer])
         self.assertEqual(grandchild_group_layer.childLayers(), [])
         self.assertGreater(len(spy), spy_count)
@@ -432,6 +436,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer4_node.setItemVisibilityChecked(True)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [grandchild_group_layer, layer3, layer2, layer])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
         self.assertGreater(len(spy), spy_count)
@@ -439,12 +444,14 @@ class TestQgsLayerTree(unittest.TestCase):
 
         grandchild_group.setItemVisibilityChecked(False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [layer3, layer2, layer])
         self.assertGreater(len(spy), spy_count)
         spy_count = len(spy)
 
         grandchild_group.setItemVisibilityChecked(True)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [grandchild_group_layer, layer3, layer2, layer])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
         self.assertGreater(len(spy), spy_count)
@@ -452,6 +459,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         child_group_layer = child_group.convertToGroupLayer(options)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer, layer3])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
@@ -460,6 +468,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer4_node.setItemVisibilityChecked(False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer, layer3])
         self.assertEqual(grandchild_group_layer.childLayers(), [])
@@ -468,6 +477,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer4_node.setItemVisibilityChecked(True)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer, layer3])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
@@ -476,6 +486,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         grandchild_group.setItemVisibilityChecked(False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [layer3])
         self.assertGreater(len(spy), spy_count)
@@ -483,6 +494,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         grandchild_group.setItemVisibilityChecked(True)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer, layer3])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
@@ -491,6 +503,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer3_node.setItemVisibilityChecked(False)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
@@ -499,6 +512,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         layer3_node.setItemVisibilityChecked(True)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [grandchild_group_layer, layer3])
         self.assertEqual(grandchild_group_layer.childLayers(), [layer4])
@@ -507,6 +521,7 @@ class TestQgsLayerTree(unittest.TestCase):
 
         grandchild_group.setGroupLayer(None)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [child_group_layer, layer2, layer])
         self.assertEqual(child_group_layer.childLayers(), [layer4, layer3])
         self.assertGreater(len(spy), spy_count)
@@ -514,12 +529,14 @@ class TestQgsLayerTree(unittest.TestCase):
 
         child_group.setGroupLayer(None)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [group_layer])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [group_layer])
         self.assertEqual(group_layer.childLayers(), [layer4, layer3, layer2, layer])
         self.assertGreater(len(spy), spy_count)
         spy_count = len(spy)
 
         group_node.setGroupLayer(None)
         self.assertEqual(p.layerTreeRoot().layerOrder(), [layer, layer2, layer3, layer4])
+        self.assertEqual(p.layerTreeRoot().checkedLayers(), [layer, layer2, layer3, layer4])
         self.assertGreater(len(spy), spy_count)
 
 

--- a/tests/src/python/test_qgsprojectutils.py
+++ b/tests/src/python/test_qgsprojectutils.py
@@ -16,7 +16,7 @@ import qgis  # NOQA
 from qgis.testing import unittest
 from qgis.core import (
     QgsProjectUtils,
-    QgsCoordinateReferenceSystem,
+    QgsGroupLayer,
     QgsCoordinateTransformContext,
     QgsVectorLayer,
     QgsRasterLayer,
@@ -118,6 +118,36 @@ class TestQgsProjectUtils(unittest.TestCase):
         # should return false if we call again, no more matching paths
         self.assertFalse(QgsProjectUtils.updateLayerPath(p, unitTestDataPath() + '/mixed_layers.gpkg',
                                                          unitTestDataPath() + '/mixed_layers22.gpkg'))
+
+    def test_layer_is_contained_in_group_layer(self):
+        p = QgsProject()
+        layer = QgsVectorLayer("Point?field=fldtxt:string",
+                               "layer1", "memory")
+        p.addMapLayer(layer)
+        layer2 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer2", "memory")
+        p.addMapLayer(layer2)
+        layer3 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer3", "memory")
+        p.addMapLayer(layer3)
+        layer4 = QgsVectorLayer("Point?field=fldtxt:string",
+                                "layer4", "memory")
+        p.addMapLayer(layer4)
+
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer = QgsGroupLayer('group', options)
+        group_layer.setChildLayers([layer, layer4])
+        p.addMapLayer(group_layer)
+
+        options = QgsGroupLayer.LayerOptions(QgsCoordinateTransformContext())
+        group_layer2 = QgsGroupLayer('group2', options)
+        group_layer2.setChildLayers([group_layer, layer3])
+        p.addMapLayer(group_layer2)
+
+        self.assertTrue(QgsProjectUtils.layerIsContainedInGroupLayer(p, layer))
+        self.assertFalse(QgsProjectUtils.layerIsContainedInGroupLayer(p, layer2))
+        self.assertTrue(QgsProjectUtils.layerIsContainedInGroupLayer(p, layer3))
+        self.assertTrue(QgsProjectUtils.layerIsContainedInGroupLayer(p, layer4))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This exposes the ability to render group layers, as described by qgis/QGIS-Enhancement-Proposals#235.

When a group is selected in the layer tree the styling dock will show a new panel for controlling the appearance of the group as a whole, with options for group opacity, blend mode and layer effects.

![image](https://user-images.githubusercontent.com/1829991/143163802-03805652-ee16-4c53-b74b-1bc1492c8ea1.png)

Sponsored by Andrew Fletcher.