### PR TITLE
Overlay Intersection min area and min circle radius optional args

### DIFF
--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -36,7 +36,7 @@
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value)",
+      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.",
       "optional": true
     }
   ],

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -31,12 +31,12 @@
     },
     {
       "arg": "min_overlap",
-      "description": "for polygons an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value), for lines an optional minimum length in current feature units (if the intersection results in multiple lines the intersection will be returned if at least one of the lines has a length greater or equal to the value).",
+      "description": "defines an optional exclusion filter: for polygons a minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value), for lines a minimum length in current feature units (if the intersection results in multiple lines the intersection will be returned if at least one of the lines has a length greater or equal to the value).",
       "optional": true
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "for polygons only an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br>This argument requires GEOS >= 3.9.",
+      "description": "defines an optional exclusion filter (for polygons only): minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br>This argument requires GEOS >= 3.9.",
       "optional": true
     }
   ],

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -36,7 +36,7 @@
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.",
+      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br><b>This argument requires GEOS >= 3.9",
       "optional": true
     }
   ],

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -67,11 +67,11 @@
     },
     {
       "expression": "overlay_intersects(layer:='regions', min_area:=0.54)",
-      "returns": "true if the current feature spatially intersects a region and the intersection area (of at least on of the parts in case of multipolygons) is greater or equal to 0.54"
+      "returns": "true if the current feature spatially intersects a region and the intersection area (of at least one of the parts in case of multipolygons) is greater or equal to 0.54"
     },
     {
       "expression": "overlay_intersects(layer:='regions', min_inscribed_circle_radius:=0.54)",
-      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least on of the parts in case of multipolygons) is greater or equal to the 0.54"
+      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least one of the parts in case of multipolygons) is greater or equal to the 0.54"
     }
   ]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -28,6 +28,18 @@
       "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
       "optional": true,
       "default": "false"
+    },
+    {
+      "arg": "min_area",
+      "description": "an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value)",
+      "optional": true,
+      "default": "false"
+    },
+    {
+      "arg": "min_inscribed_circle_radius",
+      "description": "an optional minimum radius for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value)",
+      "optional": true,
+      "default": "false"
     }
   ],
   "examples": [
@@ -53,7 +65,15 @@
     },
     {
       "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), limit:=2)",
-      "returns": "an array of geometries (in WKT), for up to two regions intersected by the current feature"
+      "returns": "an array of geometries (in WKT), for up to two regions intersected by the current feature"    
+    },
+    {
+      "expression": "overlay_intersects(layer:='regions', min_area:=0.54)",
+      "returns": "true if the current feature spatially intersects a region and the intersection area (of at least on of the part in case of multipolygons) is greater or equal to the value"
+    },
+    {
+      "expression": "overlay_intersects(layer:='regions', min_inscribed_circle_radius:=0.54)",
+      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least on of the part in case of multipolygons) is greater or equal to the value"
     }
   ]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -36,7 +36,7 @@
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "for polygons only an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.",
+      "description": "for polygons only an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br>This argument requires GEOS >= 3.9.",
       "optional": true
     }
   ],

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -30,13 +30,13 @@
       "default": "false"
     },
     {
-      "arg": "min_area",
-      "description": "an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value)",
+      "arg": "min_overlap",
+      "description": "for polygons an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value), for lines an optional minimum length in current feature units (if the intersection results in multiple lines the intersection will be returned if at least one of the lines has a length greater or equal to the value).",
       "optional": true
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br><b>This argument requires GEOS >= 3.9",
+      "description": "for polygons only an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.",
       "optional": true
     }
   ],
@@ -66,12 +66,12 @@
       "returns": "an array of geometries (in WKT), for up to two regions intersected by the current feature"    
     },
     {
-      "expression": "overlay_intersects(layer:='regions', min_area:=0.54)",
+      "expression": "overlay_intersects(layer:='regions', min_overlap:=0.54)",
       "returns": "true if the current feature spatially intersects a region and the intersection area (of at least one of the parts in case of multipolygons) is greater or equal to 0.54"
     },
     {
       "expression": "overlay_intersects(layer:='regions', min_inscribed_circle_radius:=0.54)",
-      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least one of the parts in case of multipolygons) is greater or equal to the 0.54"
+      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least one of the parts in case of multipart) is greater or equal to the 0.54"
     }
   ]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -32,14 +32,12 @@
     {
       "arg": "min_area",
       "description": "an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value)",
-      "optional": true,
-      "default": "false"
+      "optional": true
     },
     {
       "arg": "min_inscribed_circle_radius",
-      "description": "an optional minimum radius for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value)",
-      "optional": true,
-      "default": "false"
+      "description": "an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value)",
+      "optional": true
     }
   ],
   "examples": [
@@ -69,11 +67,11 @@
     },
     {
       "expression": "overlay_intersects(layer:='regions', min_area:=0.54)",
-      "returns": "true if the current feature spatially intersects a region and the intersection area (of at least on of the part in case of multipolygons) is greater or equal to the value"
+      "returns": "true if the current feature spatially intersects a region and the intersection area (of at least on of the parts in case of multipolygons) is greater or equal to 0.54"
     },
     {
       "expression": "overlay_intersects(layer:='regions', min_inscribed_circle_radius:=0.54)",
-      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least on of the part in case of multipolygons) is greater or equal to the value"
+      "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least on of the parts in case of multipolygons) is greater or equal to the 0.54"
     }
   ]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6618,7 +6618,6 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   {
 
     minOverlap = QgsExpressionUtils::getDoubleValue( values.at( 5 ), parent );
-    node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
     if ( minInscribedCircleRadius != -1 )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6610,18 +6610,18 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   ENSURE_NO_EVAL_ERROR
   bool cacheEnabled = cacheValue.toBool();
 
-  // Sixth parameter (for intersects only) is the min area
+  // Sixth parameter (for intersects only) is the min overlap (area or length)
   // Seventh parameter (for intersects only) is the min inscribed circle radius
-  double minArea { -1 };
+  double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };
   if ( isIntersectsFunc )
   {
 
     node = QgsExpressionUtils::getNode( values.at( 5 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     ENSURE_NO_EVAL_ERROR
-    const QVariant minAreaValue = node->eval( parent, context );
+    const QVariant minOverlapValue = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR
-    minArea = QgsExpressionUtils::getDoubleValue( minAreaValue, parent );
+    minOverlap = QgsExpressionUtils::getDoubleValue( minOverlapValue, parent );
     node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     ENSURE_NO_EVAL_ERROR
     const QVariant minInscribedCircleRadiusValue = node->eval( parent, context );
@@ -6751,76 +6751,121 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
     if ( ! relationFunction || ( geometry.*relationFunction )( feat2.geometry() ) ) // Calls the method provided as template argument for the function (e.g. QgsGeometry::intersects)
     {
 
-      if ( isIntersectsFunc && ( minArea != -1 || minInscribedCircleRadius != -1 ) )
+      if ( isIntersectsFunc && ( minOverlap != -1 || minInscribedCircleRadius != -1 ) )
       {
         const QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
 
-        // Skip id not polygon
-        if ( intersection.type() != QgsWkbTypes::GeometryType::PolygonGeometry )
+        switch ( intersection.type() )
         {
-          continue;
-        }
-
-        // Check min area for intersection (if set)
-        if ( intersection.isMultipart() )
-        {
-          bool testResult { false };
-          for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
+          case QgsWkbTypes::GeometryType::PolygonGeometry:
           {
-            const QgsPolygon *geom = qgsgeometry_cast< const QgsPolygon * >( *it );
-            // qDebug() << "Area" << feat2.id() << geom->area();
-            if ( minArea != -1 )
+            // Check min overlap for intersection (if set)
+            if ( intersection.isMultipart() )
             {
-              if ( geom->area() >= minArea )
+              bool testResult { false };
+              for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
               {
-                testResult = true;
+                const QgsPolygon *geom = qgsgeometry_cast< const QgsPolygon * >( *it );
+                // qDebug() << "Area" << feat2.id() << geom->area();
+                if ( minOverlap != -1 )
+                {
+                  if ( geom->area() >= minOverlap )
+                  {
+                    testResult = true;
+                  }
+                  else
+                  {
+                    continue;
+                  }
+                }
+
+                // Check min inscribed circle radius for intersection (if set)
+                if ( minInscribedCircleRadius != -1 )
+                {
+                  const QgsRectangle bbox = geom->boundingBox();
+                  const double width = bbox.width();
+                  const double height = bbox.height();
+                  const double size = width > height ? width : height;
+                  const double tolerance = size / 1000.0;
+                  //qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
+                  testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
+                }
               }
-              else
+
+              if ( ! testResult )
+              {
+                continue;
+              }
+
+            }
+            else
+            {
+              if ( minOverlap != -1 && intersection.area() < minOverlap )
+              {
+                continue;
+              }
+
+              // Check min inscribed circle radius for intersection (if set)
+              if ( minInscribedCircleRadius != -1 )
+              {
+                const QgsAbstractGeometry *geom { intersection.constGet() };
+                const QgsRectangle bbox = geom->boundingBox();
+                const double width = bbox.width();
+                const double height = bbox.height();
+                const double size = width > height ? width : height;
+                const double tolerance = size / 1000.0;
+                // qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
+                if ( QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() < minInscribedCircleRadius )
+                {
+                  continue;
+                }
+              }
+            }
+            break;
+          }
+          case QgsWkbTypes::GeometryType::LineGeometry:
+          {
+            // Check min overlap for intersection (if set)
+            if ( intersection.isMultipart() )
+            {
+              bool testResult { false };
+              for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
+              {
+                const QgsLineString *geom = qgsgeometry_cast< const QgsLineString * >( *it );
+                // qDebug() << "Length" << feat2.id() << geom->length();
+                if ( minOverlap != -1 )
+                {
+                  if ( geom->length() >= minOverlap )
+                  {
+                    testResult = true;
+                  }
+                  else
+                  {
+                    continue;
+                  }
+                }
+              }
+
+              if ( ! testResult )
+              {
+                continue;
+              }
+
+            }
+            else
+            {
+              if ( minOverlap != -1 && intersection.length() < minOverlap )
               {
                 continue;
               }
             }
-
-            // Check min inscribed circle radius for intersection (if set)
-            if ( minInscribedCircleRadius != -1 )
-            {
-              const QgsRectangle bbox = geom->boundingBox();
-              const double width = bbox.width();
-              const double height = bbox.height();
-              const double size = width > height ? width : height;
-              const double tolerance = size / 1000.0;
-              //qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
-              testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
-            }
+            break;
           }
-
-          if ( ! testResult )
+          case QgsWkbTypes::GeometryType::PointGeometry:
+          case QgsWkbTypes::GeometryType::NullGeometry:
+          case QgsWkbTypes::GeometryType::UnknownGeometry:
           {
-            continue;
-          }
-
-        }
-        else
-        {
-          if ( minArea != -1 && intersection.area() < minArea )
-          {
-            continue;
-          }
-
-          // Check min inscribed circle radius for intersection (if set)
-          if ( minInscribedCircleRadius != -1 )
-          {
-            const QgsAbstractGeometry *geom { intersection.constGet() };
-            const QgsRectangle bbox = geom->boundingBox();
-            const double width = bbox.width();
-            const double height = bbox.height();
-            const double size = width > height ? width : height;
-            const double tolerance = size / 1000.0;
-            // qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
-            if ( QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() < minInscribedCircleRadius )
-            {
-              continue;
-            }
+            break;
           }
         }
       }
@@ -7324,7 +7369,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           << QgsExpressionFunction::Parameter( QStringLiteral( "filter" ), true, QVariant(), true )
           << QgsExpressionFunction::Parameter( QStringLiteral( "limit" ), true, QVariant( -1 ), true )
           << QgsExpressionFunction::Parameter( QStringLiteral( "cache" ), true, QVariant( false ), false )
-          << QgsExpressionFunction::Parameter( QStringLiteral( "min_area" ), true, QVariant( -1 ), false )
+          << QgsExpressionFunction::Parameter( QStringLiteral( "min_overlap" ), true, QVariant( -1 ), false )
           << QgsExpressionFunction::Parameter( QStringLiteral( "min_inscribed_circle_radius" ), true, QVariant( -1 ), false ),
           i.value(), QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES, true );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6621,7 +6621,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
     node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
-    if ( minInscribedCircleRadiusValue != -1 )
+    if ( minInscribedCircleRadius != -1 )
     {
       parent->setEvalErrorString( QObject::tr( "'min_inscribed_circle_radius' is only available when QGIS is built with GEOS >= 3.9." ) );
       return QVariant();
@@ -6785,7 +6785,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
                 const double width = bbox.width();
                 const double height = bbox.height();
                 const double size = width > height ? width : height;
-                const double tolerance = size / 1000.0;
+                const double tolerance = size / 100.0;
                 testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
               }
             }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6617,16 +6617,9 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   if ( isIntersectsFunc )
   {
 
-    node = QgsExpressionUtils::getNode( values.at( 5 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
-    ENSURE_NO_EVAL_ERROR
-    const QVariant minOverlapValue = node->eval( parent, context );
-    ENSURE_NO_EVAL_ERROR
-    minOverlap = QgsExpressionUtils::getDoubleValue( minOverlapValue, parent );
+    minOverlap = QgsExpressionUtils::getDoubleValue( values.at( 5 ), parent );
     node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
-    ENSURE_NO_EVAL_ERROR
-    const QVariant minInscribedCircleRadiusValue = node->eval( parent, context );
-    ENSURE_NO_EVAL_ERROR
-    minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( minInscribedCircleRadiusValue, parent );
+    minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
     if ( minInscribedCircleRadiusValue != -1 )
     {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6627,6 +6627,13 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
     const QVariant minInscribedCircleRadiusValue = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR
     minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( minInscribedCircleRadiusValue, parent );
+#if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
+    if ( minInscribedCircleRadiusValue != -1 )
+    {
+      parent->setEvalErrorString( QObject::tr( "'min_inscribed_circle_radius' is only available when QGIS is built with GEOS >= 3.9." ) );
+      return QVariant();
+    }
+#endif
   }
 
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6765,8 +6765,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
               bool testResult { false };
               for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
               {
-                const QgsPolygon *geom = qgsgeometry_cast< const QgsPolygon * >( *it );
-                // qDebug() << "Area" << feat2.id() << geom->area();
+                const QgsCurvePolygon *geom = qgsgeometry_cast< const QgsCurvePolygon * >( *it );
                 if ( minOverlap != -1 )
                 {
                   if ( geom->area() >= minOverlap )
@@ -6787,7 +6786,6 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
                   const double height = bbox.height();
                   const double size = width > height ? width : height;
                   const double tolerance = size / 1000.0;
-                  //qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
                   testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
                 }
               }
@@ -6831,8 +6829,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
               bool testResult { false };
               for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
               {
-                const QgsLineString *geom = qgsgeometry_cast< const QgsLineString * >( *it );
-                // qDebug() << "Length" << feat2.id() << geom->length();
+                const QgsCurve *geom = qgsgeometry_cast< const QgsCurve * >( *it );
                 if ( minOverlap != -1 )
                 {
                   if ( geom->length() >= minOverlap )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6617,10 +6617,18 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   if ( isIntersectsFunc )
   {
 
-    minOverlap = QgsExpressionUtils::getDoubleValue( values.at( 5 ), parent );
-    minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
+    node = QgsExpressionUtils::getNode( values.at( 5 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
+    ENSURE_NO_EVAL_ERROR
+    const QVariant minOverlapValue = node->eval( parent, context );
+    ENSURE_NO_EVAL_ERROR
+    minOverlap = QgsExpressionUtils::getDoubleValue( minOverlapValue, parent );
+    node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
+    ENSURE_NO_EVAL_ERROR
+    const QVariant minInscribedCircleRadiusValue = node->eval( parent, context );
+    ENSURE_NO_EVAL_ERROR
+    minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( minInscribedCircleRadiusValue, parent );
 #if GEOS_VERSION_MAJOR==3 && GEOS_VERSION_MINOR<9
-    if ( minInscribedCircleRadius != -1 )
+    if ( minInscribedCircleRadiusValue != -1 )
     {
       parent->setEvalErrorString( QObject::tr( "'min_inscribed_circle_radius' is only available when QGIS is built with GEOS >= 3.9." ) );
       return QVariant();

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6754,25 +6754,73 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
       if ( isIntersectsFunc && ( minArea != -1 || minInscribedCircleRadius != -1 ) )
       {
         const QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
-        // Check min area for intersection (if set)
-        // qDebug() << feat2.id() << intersection.area();
-        if ( minArea != -1 && intersection.area() <= minArea )
+
+        // Skip id not polygon
+        if ( intersection.type() != QgsWkbTypes::GeometryType::PolygonGeometry )
         {
           continue;
         }
 
-        // Check min inscribed circle radius for intersection (if set)
-        if ( minInscribedCircleRadius != -1 )
+        // Check min area for intersection (if set)
+        if ( intersection.isMultipart() )
         {
-          const QgsAbstractGeometry *geom { intersection.constGet() };
-          const QgsRectangle bbox = geom->boundingBox();
-          const double width = bbox.width();
-          const double height = bbox.height();
-          const double size = width > height ? width : height;
-          const double tolerance = size / 1000.0;
-          if ( QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() / 2 < minInscribedCircleRadius )
+          bool testResult { false };
+          for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
+          {
+            const QgsPolygon *geom = qgsgeometry_cast< const QgsPolygon * >( *it );
+            // qDebug() << "Area" << feat2.id() << geom->area();
+            if ( minArea != -1 )
+            {
+              if ( geom->area() >= minArea )
+              {
+                testResult = true;
+              }
+              else
+              {
+                continue;
+              }
+            }
+
+            // Check min inscribed circle radius for intersection (if set)
+            if ( minInscribedCircleRadius != -1 )
+            {
+              const QgsRectangle bbox = geom->boundingBox();
+              const double width = bbox.width();
+              const double height = bbox.height();
+              const double size = width > height ? width : height;
+              const double tolerance = size / 1000.0;
+              //qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
+              testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
+            }
+          }
+
+          if ( ! testResult )
           {
             continue;
+          }
+
+        }
+        else
+        {
+          if ( minArea != -1 && intersection.area() < minArea )
+          {
+            continue;
+          }
+
+          // Check min inscribed circle radius for intersection (if set)
+          if ( minInscribedCircleRadius != -1 )
+          {
+            const QgsAbstractGeometry *geom { intersection.constGet() };
+            const QgsRectangle bbox = geom->boundingBox();
+            const double width = bbox.width();
+            const double height = bbox.height();
+            const double size = width > height ? width : height;
+            const double tolerance = size / 1000.0;
+            // qDebug() << "Inscribed circle radius" << feat2.id() << QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
+            if ( QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() < minInscribedCircleRadius )
+            {
+              continue;
+            }
           }
         }
       }

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -297,7 +297,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
         QString *errorMsg = nullptr ) const;
 
     /**
-     * Returns the maximum inscribed circle.
+     * Returns the maximum inscribed circle radius.
      *
      * Constructs the Maximum Inscribed Circle for a  polygonal geometry, up to a specified tolerance.
      * The Maximum Inscribed Circle is determined by a point in the interior of the area

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -297,7 +297,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
         QString *errorMsg = nullptr ) const;
 
     /**
-     * Returns the maximum inscribed circle radius.
+     * Returns the maximum inscribed circle.
      *
      * Constructs the Maximum Inscribed Circle for a  polygonal geometry, up to a specified tolerance.
      * The Maximum Inscribed Circle is determined by a point in the interior of the area

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -158,8 +158,8 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::newRow( "disjoint no match [cached]" ) << "overlay_disjoint('rectangles',cache:=true)" << "LINESTRING(-155 15, -122 32, -84 4)" << false;
 
   // Multi part intersection
-  QTest::newRow( "intersects min_area multi no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
-  QTest::newRow( "intersects min_area multi match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+  QTest::newRow( "intersects min_overlap multi no match" ) << "overlay_intersects('polys', min_overlap:=1.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects min_overlap multi match" ) << "overlay_intersects('polys', min_overlap:=1.34)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
 
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   QTest::newRow( "intersects min_inscribed_circle_radius multi no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
@@ -167,8 +167,8 @@ void TestQgsOverlayExpression::testOverlay_data()
 #endif
 
   // Single part intersection
-  QTest::newRow( "intersects min_area no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
-  QTest::newRow( "intersects min_area match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
+  QTest::newRow( "intersects min_overlap no match" ) << "overlay_intersects('polys', min_overlap:=1.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects min_overlap match" ) << "overlay_intersects('polys', min_overlap:=1.34)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
 
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   QTest::newRow( "intersects min_inscribed_circle_radius no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
@@ -176,22 +176,28 @@ void TestQgsOverlayExpression::testOverlay_data()
 
   // Test both checks combined: they must all pass
   // Multi part intersection
-  QTest::newRow( "intersects multi combined no match 1" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
-  QTest::newRow( "intersects multi combined no match 2" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects multi combined no match 1" ) << "overlay_intersects('polys', min_overlap:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects multi combined no match 2" ) << "overlay_intersects('polys', min_overlap:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
 
-  QTest::newRow( "intersects multi combined no match 3" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
-  QTest::newRow( "intersects multi combined match" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+  QTest::newRow( "intersects multi combined no match 3" ) << "overlay_intersects('polys', min_overlap:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects multi combined match" ) << "overlay_intersects('polys', min_overlap:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
 
   // Single part intersection
-  QTest::newRow( "intersects combined no match 1" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
-  QTest::newRow( "intersects combined no match 2" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
-  QTest::newRow( "intersects combined no match 3" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects combined no match 1" ) << "overlay_intersects('polys', min_overlap:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects combined no match 2" ) << "overlay_intersects('polys', min_overlap:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects combined no match 3" ) << "overlay_intersects('polys', min_overlap:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
 
-  QTest::newRow( "intersects combined match" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
+  QTest::newRow( "intersects combined match" ) << "overlay_intersects('polys', min_overlap:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
 
-  // Check wrong args
-  QTest::newRow( "intersects wrong args" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "LINESTRING(-105 33.75, -102.76 33.75)" << false;
 #endif
+
+  // Check linestrings
+  QTest::newRow( "intersects linestring match" ) << "overlay_intersects('polys', min_overlap:=1.76)" << "LINESTRING(-105 33.75, -102.76 33.75)" << true;
+  QTest::newRow( "intersects linestring no match" ) << "overlay_intersects('polys', min_overlap:=2.0)" << "LINESTRING(-105 33.75, -102.76 33.75)" << false;
+
+  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', min_overlap:=1.76)" << "LINESTRING(-105 33.75, -102.76 33.75)" << true;
+  QTest::newRow( "intersects linestring multi no match" ) << "overlay_intersects('polys', min_overlap:=2.0)" << "LINESTRING(-102.76 33.74, -106.12 33.74)" << false;
+
 }
 
 void TestQgsOverlayExpression::testOverlayExpression()

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -36,6 +36,8 @@
 #include "qgsvectorlayerutils.h"
 #include "qgsexpressioncontextutils.h"
 
+#include "geos_c.h"
+
 class TestQgsOverlayExpression: public QObject
 {
     Q_OBJECT
@@ -159,13 +161,16 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::newRow( "intersects min_area multi no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
   QTest::newRow( "intersects min_area multi match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
 
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   QTest::newRow( "intersects min_inscribed_circle_radius multi no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
   QTest::newRow( "intersects min_inscribed_circle_radius multi match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+#endif
 
   // Single part intersection
   QTest::newRow( "intersects min_area no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
   QTest::newRow( "intersects min_area match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
 
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   QTest::newRow( "intersects min_inscribed_circle_radius no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
   QTest::newRow( "intersects min_inscribed_circle_radius match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
 
@@ -186,6 +191,7 @@ void TestQgsOverlayExpression::testOverlay_data()
 
   // Check wrong args
   QTest::newRow( "intersects wrong args" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "LINESTRING(-105 33.75, -102.76 33.75)" << false;
+#endif
 }
 
 void TestQgsOverlayExpression::testOverlayExpression()

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -116,7 +116,6 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::addColumn<QString>( "geometry" );
   QTest::addColumn<bool>( "expectedResult" );
 
-  /*
   QTest::newRow( "intersects" ) << "overlay_intersects('rectangles')" << "POLYGON((-120 30, -105 30, -105 20, -120 20, -120 30))" << true;
   QTest::newRow( "intersects [cached]" ) << "overlay_intersects('rectangles',cache:=true)" << "POLYGON((-120 30, -105 30, -105 20, -120 20, -120 30))" << true;
 
@@ -155,13 +154,38 @@ void TestQgsOverlayExpression::testOverlay_data()
 
   QTest::newRow( "disjoint no match" ) << "overlay_disjoint('rectangles')" << "LINESTRING(-155 15, -122 32, -84 4)" << false;
   QTest::newRow( "disjoint no match [cached]" ) << "overlay_disjoint('rectangles',cache:=true)" << "LINESTRING(-155 15, -122 32, -84 4)" << false;
-  */
 
-  QTest::newRow( "intersects min_area no match" ) << "overlay_intersects('polys', min_area:=1.3)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
-  QTest::newRow( "intersects min_area match" ) << "overlay_intersects('polys', min_area:=1.28)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+  // Multi part intersection
+  QTest::newRow( "intersects min_area multi no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects min_area multi match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
 
-  QTest::newRow( "intersects min_inscribed_circle_radius no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
-  QTest::newRow( "intersects min_inscribed_circle_radius match" ) << "overlay_intersects('polys', min_area:=0.457)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+  QTest::newRow( "intersects min_inscribed_circle_radius multi no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects min_inscribed_circle_radius multi match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+
+  // Single part intersection
+  QTest::newRow( "intersects min_area no match" ) << "overlay_intersects('polys', min_area:=1.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects min_area match" ) << "overlay_intersects('polys', min_area:=1.34)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
+
+  QTest::newRow( "intersects min_inscribed_circle_radius no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects min_inscribed_circle_radius match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
+
+  // Test both checks combined: they must all pass
+  // Multi part intersection
+  QTest::newRow( "intersects multi combined no match 1" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects multi combined no match 2" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+
+  QTest::newRow( "intersects multi combined no match 3" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects multi combined match" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+
+  // Single part intersection
+  QTest::newRow( "intersects combined no match 1" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects combined no match 2" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=1.0)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+  QTest::newRow( "intersects combined no match 3" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << false;
+
+  QTest::newRow( "intersects combined match" ) << "overlay_intersects('polys', min_area:=1.34, min_inscribed_circle_radius:=0.5)" << "POLYGON((-105 33.75, -102.76 33.75, -102.76 35.2, -105 35.2, -105 33.75))" << true;
+
+  // Check wrong args
+  QTest::newRow( "intersects wrong args" ) << "overlay_intersects('polys', min_area:=1.5, min_inscribed_circle_radius:=0.5)" << "LINESTRING(-105 33.75, -102.76 33.75)" << false;
 }
 
 void TestQgsOverlayExpression::testOverlayExpression()

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -43,6 +43,8 @@ class TestQgsOverlayExpression: public QObject
   public:
 
     TestQgsOverlayExpression() = default;
+    void testOverlayExpression();
+    void testOverlayExpression_data();
 
   private:
     QgsVectorLayer *mRectanglesLayer = nullptr;
@@ -57,8 +59,6 @@ class TestQgsOverlayExpression: public QObject
     void testOverlay();
     void testOverlay_data();
 
-    void testOverlayExpression();
-    void testOverlayExpression_data();
 
     void testOverlaySelf();
 };
@@ -116,6 +116,7 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::addColumn<QString>( "geometry" );
   QTest::addColumn<bool>( "expectedResult" );
 
+  /*
   QTest::newRow( "intersects" ) << "overlay_intersects('rectangles')" << "POLYGON((-120 30, -105 30, -105 20, -120 20, -120 30))" << true;
   QTest::newRow( "intersects [cached]" ) << "overlay_intersects('rectangles',cache:=true)" << "POLYGON((-120 30, -105 30, -105 20, -120 20, -120 30))" << true;
 
@@ -154,6 +155,13 @@ void TestQgsOverlayExpression::testOverlay_data()
 
   QTest::newRow( "disjoint no match" ) << "overlay_disjoint('rectangles')" << "LINESTRING(-155 15, -122 32, -84 4)" << false;
   QTest::newRow( "disjoint no match [cached]" ) << "overlay_disjoint('rectangles',cache:=true)" << "LINESTRING(-155 15, -122 32, -84 4)" << false;
+  */
+
+  QTest::newRow( "intersects min_area no match" ) << "overlay_intersects('polys', min_area:=1.3)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects min_area match" ) << "overlay_intersects('polys', min_area:=1.28)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
+
+  QTest::newRow( "intersects min_inscribed_circle_radius no match" ) << "overlay_intersects('polys', min_inscribed_circle_radius:=1.0)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << false;
+  QTest::newRow( "intersects min_inscribed_circle_radius match" ) << "overlay_intersects('polys', min_area:=0.457)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << true;
 }
 
 void TestQgsOverlayExpression::testOverlayExpression()


### PR DESCRIPTION
## overlay_intersects function enhancements

This PR adds two optional arguments to the `overlay_intersection()` expression function:

* `min_overlap`: for polygons an optional minimum area in current feature squared units for the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has an area greater or equal to the value), for lines an optional minimum length in current feature units (if the intersection results in multiple lines the intersection will be returned if at least one of the lines has a length greater or equal to the value)
* `min_inscribed_circle_radius`: for polygons only an optional minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).Read more on the underlying GEOS predicate, as described in PostGIS ST_MaximumInscribedCircle function.


![overlay_intersects](https://user-images.githubusercontent.com/142164/143412147-ec836709-2976-4ef2-9ea1-7c6670616891.png)


Funded by: Kanton Solothurn

