### PR TITLE
[Fix] Minor display issues on the advanced digitizing

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
@@ -36,6 +36,8 @@ The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CA
 
     virtual void paint( QPainter *painter );
 
+    virtual void updatePosition();
+
 
 };
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -69,7 +69,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     return;
 
   const double canvasRotationRad = mMapCanvas->rotation() * M_PI / 180;
-  const double canvasMaxDimension = std::max( canvasWidth / mupp, canvasHeight / mupp );
+  const double canvasDiagonalDimension = std::sqrt( std::pow( canvasWidth, 2 ) + std::pow( canvasHeight, 2 ) ) / mupp ;
 
   QPointF curPointPix, prevPointPix, penulPointPix, snapSegmentPix1, snapSegmentPix2;
 
@@ -159,8 +159,8 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     {
       painter->setPen( mLockedPen );
       const double canvasPadding = QLineF( prevPointPix, curPointPix ).length();
-      painter->drawLine( prevPointPix + ( canvasPadding - canvasMaxDimension ) * QPointF( std::cos( a ), std::sin( a ) ),
-                         prevPointPix + ( canvasPadding + canvasMaxDimension ) * QPointF( std::cos( a ), std::sin( a ) ) );
+      painter->drawLine( prevPointPix + ( canvasPadding - canvasDiagonalDimension ) * QPointF( std::cos( a ), std::sin( a ) ),
+                         prevPointPix + ( canvasPadding + canvasDiagonalDimension ) * QPointF( std::cos( a ), std::sin( a ) ) );
     }
   }
 
@@ -195,8 +195,8 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     if ( draw )
     {
-      painter->drawLine( toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) - canvasMaxDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ),
-                         toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) + canvasMaxDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ) );
+      painter->drawLine( toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) - canvasDiagonalDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ),
+                         toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) + canvasDiagonalDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ) );
     }
   }
 
@@ -223,8 +223,8 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     if ( draw )
     {
-      painter->drawLine( toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) - canvasMaxDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ),
-                         toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) + canvasMaxDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ) );
+      painter->drawLine( toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) - canvasDiagonalDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ),
+                         toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) + canvasDiagonalDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ) );
 
     }
   }

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -61,7 +61,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     return;
 
   const double canvasRotationRad = mMapCanvas->rotation() * M_PI / 180;
-  const double canvasDiagonalDimension = std::sqrt( std::pow( canvasWidth, 2 ) + std::pow( canvasHeight, 2 ) ) / mupp ;
+  const double canvasDiagonalDimension = ( canvasWidth + canvasHeight ) / mupp ;
 
   QPointF curPointPix, prevPointPix, penulPointPix, snapSegmentPix1, snapSegmentPix2;
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -41,14 +41,6 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   QPolygonF mapPoly = mMapCanvas->mapSettings().visiblePolygon();
   const double canvasWidth = QLineF( mapPoly[0], mapPoly[1] ).length();
   const double canvasHeight = QLineF( mapPoly[0], mapPoly[3] ).length();
-  const QgsRectangle mapRect = QgsRectangle( mapPoly[0],
-                               QgsPointXY(
-                                 mapPoly[0].x() + canvasWidth,
-                                 mapPoly[0].y() - canvasHeight
-                               )
-                                           );
-  if ( rect() != mapRect )
-    setRect( mapRect );
 
   const int nPoints = mAdvancedDigitizingDockWidget->pointsCount();
   if ( !nPoints )
@@ -253,4 +245,20 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     painter->drawLine( curPointPix + QPointF( -5, +5 ),
                        curPointPix + QPointF( +5, -5 ) );
   }
+}
+
+void QgsAdvancedDigitizingCanvasItem::updatePosition()
+{
+  // Use visible polygon rather than extent to properly handle rotated maps
+  QPolygonF mapPoly = mMapCanvas->mapSettings().visiblePolygon();
+  const double canvasWidth = QLineF( mapPoly[0], mapPoly[1] ).length();
+  const double canvasHeight = QLineF( mapPoly[0], mapPoly[3] ).length();
+  const QgsRectangle mapRect = QgsRectangle( mapPoly[0],
+                               QgsPointXY(
+                                 mapPoly[0].x() + canvasWidth,
+                                 mapPoly[0].y() - canvasHeight
+                               )
+                                           );
+  if ( rect() != mapRect )
+    setRect( mapRect );
 }

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -158,8 +158,9 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() )
     {
       painter->setPen( mLockedPen );
-      painter->drawLine( prevPointPix - canvasMaxDimension * QPointF( std::cos( a ), std::sin( a ) ),
-                         prevPointPix + canvasMaxDimension * QPointF( std::cos( a ), std::sin( a ) ) );
+      const double canvasPadding = QLineF( prevPointPix, curPointPix ).length();
+      painter->drawLine( prevPointPix + ( canvasPadding - canvasMaxDimension ) * QPointF( std::cos( a ), std::sin( a ) ),
+                         prevPointPix + ( canvasPadding + canvasMaxDimension ) * QPointF( std::cos( a ), std::sin( a ) ) );
     }
   }
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -51,6 +51,7 @@ class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
     explicit QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
     void paint( QPainter *painter ) override;
+    void updatePosition() override;
 
   private:
     QPen mLockedPen;

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -836,6 +836,7 @@ void QgsAdvancedDigitizingDockWidget::updateCapacity( bool updateUIwithoutChange
 
   // update capacities
   mCapacities = newCapacities;
+  mCadPaintItem->updatePosition();
 }
 
 


### PR DESCRIPTION
## Description

This PR fixes 3 minor issues.

### Angle constraint line 1
`canvasMaxDimension` takes the largest dimension between X and Y. However, the constraint line can be diagonal, so it doesn't go to the end of the canvas.

I changed this size to the diagonal size of the canvas. I put the exact formula, but for performance reasons, a less exact but simpler formula could be added, for example the dimension x + y.

<img src="https://user-images.githubusercontent.com/37629967/143230988-de4a5860-3701-4b67-af23-59592bc8b069.png" width=49%> <img src="https://user-images.githubusercontent.com/37629967/143231065-2f157c99-1017-4e73-9e26-0760f96dda5e.png" width=49%>


### Angle constraint line 2
Another problem comes up when we move the layer while digitizing. This constraint line starts from the last digitized point, so it can be too short.

I added a padding (distance between the point being digitized and the last one digitized) to the line.

<img src="https://user-images.githubusercontent.com/37629967/143231610-2edbcb38-f548-4e92-86e3-7e0a91b69b3a.png" width=49%> <img src="https://user-images.githubusercontent.com/37629967/143231619-43e1e42b-5493-47e4-bdb5-daaea0098771.png" width=49%>

### Drawing rectangle update
The `QgsMapCanvasItem::paint` method is only called if a piece of the `mRect` rectangle is in the canvas. However, the update of the position of `mRect` is done in the `paint` method. In the case where this rectangle is no longer visible, all advanced digitizing drawings are no longer done.

I moved the update logic into `updatePosition` and the method is called in `QgsAdvancedDigitizingDockWidget::updateCapacity`

This happens when, for example, we change the CRS from EPSG:4326 to EPSG:3950.

<img src="https://user-images.githubusercontent.com/37629967/143231955-2c93b906-a534-4f77-943c-4d2cfcd4c8d1.png" width=49%> <img src="https://user-images.githubusercontent.com/37629967/143232239-91af5733-14bb-442d-8e73-1247a86136f5.png" width=49%>

Sponsored by: Métropole Européenne de Lille @Jean-Roc