### PR TITLE
Exclude crssync folder on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,14 @@ if(WITH_CORE)
 
   set (WITH_QGIS_PROCESS TRUE CACHE BOOL "Determines whether the standalone \"qgis_process\" tool should be built")
 
+  if (IOS OR ANDROID)
+      set (WITH_CRSSYNC_DEFAULT FALSE)
+  else()
+      set (WITH_CRSSYNC_DEFAULT TRUE)
+  endif()
+
+  set (WITH_CRSSYNC WITH_CRSSYNC_DEFAULT CACHE BOOL "Determines whether the standalone \"crssync\" tool should be built")
+
   # try to configure and build python bindings by default
   set (WITH_BINDINGS TRUE CACHE BOOL "Determines whether python bindings should be built")
   if (WITH_BINDINGS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ if (WITH_GUI)
 endif()
 
 add_subdirectory(providers)
-if (NOT IOS)
+if (NOT IOS AND NOT ANDROID)
   add_subdirectory(crssync)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ if (WITH_GUI)
 endif()
 
 add_subdirectory(providers)
-if (NOT IOS AND NOT ANDROID)
+if (WITH_CRSSYNC)
   add_subdirectory(crssync)
 endif()
 


### PR DESCRIPTION
This PR excludes `crssync` folder from build for Android. It has already been excluded for IOS, since it is not available on mobile platforms.

Backport to 3.22