### PR TITLE
Switch to click_x/click_y instead of clicked_* which is used in QgsMapToolFeatureAction

### DIFF
--- a/python/core/auto_generated/qgsactionscope.sip.in
+++ b/python/core/auto_generated/qgsactionscope.sip.in
@@ -20,7 +20,7 @@ Examples:
 
 <dl>
 <dt>Canvas</dt>
-<dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
+<dd>Show for canvas tools. Adds `@click_x` and `@click_y` in map coordinates.</dd>
 <dt>Feature</dt>
 <dd>Show in feature specific places like the attribute table or feature
 form.</dd>
@@ -61,7 +61,7 @@ of the corresponding properties.
 %Docstring
 An expression scope may offer additional variables for an action scope.
 This can be an `field_name` for the attribute which was clicked or
-`clicked_x` and `clicked_y` for actions which are available as map canvas clicks.
+`click_x` and `click_y` for actions which are available as map canvas clicks.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/qgsactionscope.h
+++ b/src/core/qgsactionscope.h
@@ -32,7 +32,7 @@
  *
  * <dl>
  *   <dt>Canvas</dt>
- *   <dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
+ *   <dd>Show for canvas tools. Adds `@click_x` and `@click_y` in map coordinates.</dd>
  *   <dt>Feature</dt>
  *   <dd>Show in feature specific places like the attribute table or feature
  *   form.</dd>
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsActionScope
     /**
      * An expression scope may offer additional variables for an action scope.
      * This can be an `field_name` for the attribute which was clicked or
-     * `clicked_x` and `clicked_y` for actions which are available as map canvas clicks.
+     * `click_x` and `click_y` for actions which are available as map canvas clicks.
      *
      * \since QGIS 3.0
      */

--- a/src/core/qgsactionscoperegistry.cpp
+++ b/src/core/qgsactionscoperegistry.cpp
@@ -23,8 +23,8 @@ QgsActionScopeRegistry::QgsActionScopeRegistry( QObject *parent )
   // Register some default action scopes:
 
   QgsExpressionContextScope canvasScope;
-  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "clicked_x" ), 25, true ) );
-  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "clicked_y" ), 30, true ) );
+  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "click_x" ), 25, true ) );
+  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "click_y" ), 30, true ) );
   mActionScopes.insert( QgsActionScope( QStringLiteral( "Canvas" ), tr( "Canvas" ), tr( "Available for the action map tool on the canvas." ), canvasScope ) );
 
   QgsExpressionContextScope fieldScope;

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -63,7 +63,7 @@ class TestQgsMapToolIdentifyAction : public QObject
     void identifyMesh(); // test identification for mesh layer
     void identifyVectorTile();  // test identification for vector tile layer
     void identifyInvalidPolygons(); // test selecting invalid polygons
-    void clickxy(); // test if clicked_x and clicked_y variables are propagated
+    void clickxy(); // test if click_x and click_y variables are propagated
     void closestPoint();
 
   private:


### PR DESCRIPTION
Switch to `click_x` and `click_y` instead of `clicked_x` and `clicked_y`.

These variables are inserted when writing expression in the action scope but not the evaluation.
Fix #46191 

When evaluating the expression, `click_x` and `click_y` are inserted in the expression context according to:
https://github.com/qgis/QGIS/blob/master/src/app/qgsmaptoolfeatureaction.cpp#L182..L183
https://github.com/qgis/QGIS/blob/master/src/app/qgsmaptoolidentifyaction.cpp#L262..L263

https://github.com/qgis/QGIS/search?q=click_x&type=code

