### PR TITLE
[Test] Split polygon tests

### DIFF
--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -31,22 +31,52 @@ class TestQgsPolygon: public QObject
     Q_OBJECT
   private slots:
     void constructor();
-    void setBadExteriorRing();
-    void setExteriorRing();
-    void setExteriorRingZM();
-    void setCurvedExteriorRing();
-    void addInteriorRing();
-    void addInteriorRingZM();
-    void polygon25D();
     void altConstructor();
-    void setInteriorRings();
-    void setExteriorRingChangesInteriorRings();
-    void removeInteriorRing();
+    void polygon25D();
     void clear();
     void equality();
     void clone();
     void copy();
     void assignment();
+    void setBadExteriorRing();
+    void setExteriorRing();
+    void setExteriorRingZM();
+    void setCurvedExteriorRing();
+    void setExteriorRingChangesInteriorRings();
+    void deleteExteriorRing();
+    void addInteriorRing();
+    void addInteriorRingZM();
+    void setInteriorRings();
+    void removeInteriorRing();
+    void removeInteriorRings();
+    void removeInvalidRings();
+    void insertVertex();
+    void moveVertex();
+    void deleteVertex();
+    void deleteVertexRemoveRing();
+    void nextVertex();
+    void vertexNumberFromVertexId();
+    void vertexAngle();
+    void adjacentVertices();
+    void removeDuplicateNodes();
+    void dropZValue();
+    void dropMValue();
+    void swapXy();
+    void boundary();
+    void pointDistanceToBoundary();
+    void closestSegment();
+    void segmentLength();
+    void forceRHR();
+    void boundingBoxIntersects();
+    void filterVertices();
+    void transformVertices();
+    void transformWithClass();
+    void transform2D();
+    void transform3D();
+    void transformReverse();
+    void transformOldVersion();
+    void Qtransform();
+    void cast();
     void toPolygon();
     void toCurveType();
     void toFromWkb();
@@ -54,36 +84,6 @@ class TestQgsPolygon: public QObject
     void toFromWkb25D();
     void toFromWKT();
     void exportImport();
-    void deleteVertexRemoveRing();
-    void boundary();
-    void pointDistanceToBoundary();
-    void removeInteriorRings();
-    void cast();
-    void transform2D();
-    void transform3D();
-    void transformReverse();
-    void transformOldVersion();
-    void Qtransform();
-    void closestSegment();
-    void nextVertex();
-    void dropZValue();
-    void dropMValue();
-    void vertexAngle();
-    void insertVertex();
-    void moveVertex();
-    void deleteVertex();
-    void deleteExteriorRing();
-    void adjacentVertices();
-    void vertexNumberFromVertexId();
-    void segmentLength();
-    void removeDuplicateNodes();
-    void filterVertices();
-    void swapXy();
-    void transformVertices();
-    void transformWithClass();
-    void removeInvalidRings();
-    void forceRHR();
-    void boundingBoxIntersects();
 };
 
 void TestQgsPolygon::constructor()
@@ -108,321 +108,21 @@ void TestQgsPolygon::constructor()
   QVERIFY( !pl.interiorRing( 0 ) );
 }
 
-void TestQgsPolygon::setBadExteriorRing()
+void TestQgsPolygon::altConstructor()
 {
-  QgsPolygon pl;
+  QgsLineString *ext = new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0 )
+                                          << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                                          << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  QgsLineString *ring1 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 1, 1 )
+      << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 )
+      << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) );
+  QgsLineString *ring2 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 3, 1 )
+      << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 )
+      << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) );
 
-  //try with no ring
-  QgsLineString *ext = nullptr;
-  pl.setExteriorRing( ext );
+  QgsPolygon pl( ext, QList< QgsLineString *>() << ring1 << ring2 );
 
-  QVERIFY( pl.isEmpty() );
-  QCOMPARE( pl.numInteriorRings(), 0 );
-  QCOMPARE( pl.nCoordinates(), 0 );
-  QCOMPARE( pl.ringCount(), 0 );
-  QCOMPARE( pl.partCount(), 0 );
-  QVERIFY( !pl.exteriorRing() );
-  QVERIFY( !pl.interiorRing( 0 ) );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  // empty exterior ring
-  ext = new QgsLineString();
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.isEmpty() );
-  QCOMPARE( pl.numInteriorRings(), 0 );
-  QCOMPARE( pl.nCoordinates(), 0 );
-  QCOMPARE( pl.ringCount(), 1 );
-  QCOMPARE( pl.partCount(), 1 );
-  QVERIFY( pl.exteriorRing() );
-  QVERIFY( !pl.interiorRing( 0 ) );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  //test that a non closed exterior ring will be automatically closed
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 )
-                  << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) );
-
-  QVERIFY( !ext->isClosed() );
-  pl.setExteriorRing( ext );
-  QVERIFY( !pl.isEmpty() );
-  QVERIFY( pl.exteriorRing()->isClosed() );
-  QCOMPARE( pl.nCoordinates(), 5 );
-}
-
-void TestQgsPolygon::setExteriorRing()
-{
-  QgsPolygon pl;
-
-  //valid exterior ring
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( !pl.isEmpty() );
-  QCOMPARE( pl.numInteriorRings(), 0 );
-  QCOMPARE( pl.nCoordinates(), 5 );
-  QCOMPARE( pl.ringCount(), 1 );
-  QCOMPARE( pl.partCount(), 1 );
-  QVERIFY( !pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( pl.wktTypeStr(), QString( "Polygon" ) );
-  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
-  QCOMPARE( pl.dimension(), 2 );
-  QVERIFY( !pl.hasCurvedSegments() );
-  QCOMPARE( pl.area(), 100.0 );
-  QCOMPARE( pl.perimeter(), 40.0 );
-  QVERIFY( pl.exteriorRing() );
-  QVERIFY( !pl.interiorRing( 0 ) );
-
-  //retrieve exterior ring and check
-  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
-}
-
-void TestQgsPolygon::setExteriorRingZM()
-{
-  QgsPolygon pl;
-
-  //initial setting of exterior ring should set z/m type
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
-  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
-  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
-
-  pl.clear();
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 10, 0, 2 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 0, 0, 4 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( !pl.is3D() );
-  QVERIFY( pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
-  QCOMPARE( pl.wktTypeStr(), QString( "PolygonM" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
-
-  pl.clear();
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 3, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 5, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 0, 4 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
-  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZM" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
-
-  pl.clear();
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon25D );
-  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
-}
-
-void TestQgsPolygon::setCurvedExteriorRing()
-{
-  QgsPolygon pl;
-
-  //setting curved exterior ring should be segmentized
-  QgsCircularString *cs = new QgsCircularString();
-  cs->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                 << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                 << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-
-  QVERIFY( cs->hasCurvedSegments() );
-
-  pl.setExteriorRing( cs );
-
-  QVERIFY( !pl.exteriorRing()->hasCurvedSegments() );
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-}
-
-void TestQgsPolygon::addInteriorRing()
-{
-  QgsPolygon pl;
-
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext );
-
-  //empty ring
-  QCOMPARE( pl.numInteriorRings(), 0 );
-  QVERIFY( !pl.interiorRing( -1 ) );
-  QVERIFY( !pl.interiorRing( 0 ) );
-
-  pl.addInteriorRing( nullptr );
-
-  QCOMPARE( pl.numInteriorRings(), 0 );
-
-  QgsLineString *ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
-                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
-                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
-  pl.addInteriorRing( ring );
-
-  QCOMPARE( pl.numInteriorRings(), 1 );
-  QCOMPARE( pl.interiorRing( 0 ), ring );
-  QVERIFY( !pl.interiorRing( 1 ) );
-
-  QgsCoordinateSequence seq = pl.coordinateSequence();
-  QgsRingSequence expected;
-  expected << ( QgsPointSequence() << QgsPoint( 0, 0 )
-                << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  expected << ( QgsPointSequence() << QgsPoint( 1, 1 )
-                << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
-                << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
-
-  QCOMPARE( seq, QgsCoordinateSequence() << expected );
-  QCOMPARE( pl.nCoordinates(), 10 );
-
-  //add non-closed interior ring, should be closed automatically
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
-                   << QgsPoint( 0.1, 0.9 ) << QgsPoint( 0.9, 0.9 )
-                   << QgsPoint( 0.9, 0.1 ) );
-
-  QVERIFY( !ring->isClosed() );
-
-  pl.addInteriorRing( ring );
-
-  QCOMPARE( pl.numInteriorRings(), 2 );
-  QVERIFY( pl.interiorRing( 1 )->isClosed() );
-}
-
-void TestQgsPolygon::addInteriorRingZM()
-{
-  QgsPolygon pl;
-
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext );
-
-  QgsLineString *ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
-                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
-                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
-  pl.addInteriorRing( ring );
-
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.9 )
-                   << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.1 ) );
-  pl.addInteriorRing( ring );
-
-  //try adding an interior ring with z to a 2d polygon, z should be dropped
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
-  pl.addInteriorRing( ring );
-
-  QCOMPARE( pl.numInteriorRings(), 3 );
-  QVERIFY( !pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-  QVERIFY( pl.interiorRing( 2 ) );
-  QVERIFY( !pl.interiorRing( 2 )->is3D() );
-  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
-
-  //try adding an interior ring with m to a 2d polygon, m should be dropped
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
-  pl.addInteriorRing( ring );
-
-  QCOMPARE( pl.numInteriorRings(), 4 );
-  QVERIFY( !pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-  QVERIFY( pl.interiorRing( 3 ) );
-  QVERIFY( !pl.interiorRing( 3 )->is3D() );
-  QVERIFY( !pl.interiorRing( 3 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 3 )->wkbType(), QgsWkbTypes::LineString );
-
-  //addInteriorRing without z/m to PolygonZM
-  pl.clear();
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( pl.isMeasure() );
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
-
-  //ring has no z
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 2 )
-                   << QgsPoint( QgsWkbTypes::PointM, 1, 9 )
-                   << QgsPoint( QgsWkbTypes::PointM, 9, 9 )
-                   << QgsPoint( QgsWkbTypes::PointM, 9, 1 )
-                   << QgsPoint( QgsWkbTypes::PointM, 1, 1 ) );
-  pl.addInteriorRing( ring );
-
-  QVERIFY( pl.interiorRing( 0 ) );
-  QVERIFY( pl.interiorRing( 0 )->is3D() );
-  QVERIFY( pl.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZM );
-  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 0, 2 ) );
-
-  //ring has no m
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
-  pl.addInteriorRing( ring );
-
-  QVERIFY( pl.interiorRing( 1 ) );
-  QVERIFY( pl.interiorRing( 1 )->is3D() );
-  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineStringZM );
-  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 0.1, 0.1, 1, 0 ) );
+  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1))" ) );
 }
 
 void TestQgsPolygon::polygon25D()
@@ -494,246 +194,6 @@ void TestQgsPolygon::polygon25D()
   QVERIFY( pl.interiorRing( 2 )->is3D() );
   QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
   QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString25D );
-}
-
-void TestQgsPolygon::altConstructor()
-{
-  QgsLineString *ext = new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0 )
-                                          << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                                          << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  QgsLineString *ring1 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 1, 1 )
-      << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 )
-      << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) );
-  QgsLineString *ring2 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 3, 1 )
-      << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 )
-      << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) );
-
-  QgsPolygon pl( ext, QList< QgsLineString *>() << ring1 << ring2 );
-
-  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1))" ) );
-}
-
-void TestQgsPolygon::setInteriorRings()
-{
-  QgsPolygon pl;
-
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext );
-
-  //add a list of rings with mixed types
-  QVector< QgsCurve * > rings;
-
-  QgsPointSequence pts;
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 ) << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 )
-      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 )
-      << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
-
-  //throw an empty ring in too
-  rings << 0;
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-      << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 );
-  rings << new QgsCircularString();
-  static_cast< QgsCircularString *>( rings[3] )->setPoints( QgsPointSequence() );
-
-  pl.setInteriorRings( rings );
-
-  QCOMPARE( pl.numInteriorRings(), 3 );
-
-  QVERIFY( pl.interiorRing( 0 ) );
-  QVERIFY( !pl.interiorRing( 0 )->is3D() );
-  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::Point, 0.1, 0.1 ) );
-
-  QVERIFY( pl.interiorRing( 1 ) );
-  QVERIFY( !pl.interiorRing( 1 )->is3D() );
-  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::Point, 0.3, 0.3 ) );
-
-  QVERIFY( pl.interiorRing( 2 ) );
-  QVERIFY( !pl.interiorRing( 2 )->is3D() );
-  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
-
-  //set rings with existing
-  rings.clear();
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 ) << QgsPoint( 0.9, 0.9 )
-      << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.8, 0.8 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
-
-  pl.setInteriorRings( rings );
-
-  QCOMPARE( pl.numInteriorRings(), 1 );
-  QVERIFY( pl.interiorRing( 0 ) );
-  QVERIFY( !pl.interiorRing( 0 )->is3D() );
-  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::Point, 0.8, 0.8 ) );
-
-  rings.clear();
-  pl.setInteriorRings( rings );
-
-  QCOMPARE( pl.numInteriorRings(), 0 );
-}
-
-void TestQgsPolygon::setExteriorRingChangesInteriorRings()
-{
-  QgsPolygon pl;
-
-  //change dimensionality of interior rings using setExteriorRing
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  pl.setExteriorRing( ext );
-
-  QVector< QgsCurve * > rings;
-
-  QgsPointSequence pts;
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3,  1 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
-
-  pl.setInteriorRings( rings );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QVERIFY( pl.interiorRing( 0 )->is3D() );
-  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
-  QVERIFY( pl.interiorRing( 1 )->is3D() );
-  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
-
-  //reset exterior ring to 2d
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-
-  pl.setExteriorRing( ext );
-
-  QVERIFY( !pl.is3D() );
-  QVERIFY( !pl.interiorRing( 0 )->is3D() ); //rings should also be made 2D
-  QVERIFY( !pl.interiorRing( 1 )->is3D() );
-
-  //reset exterior ring to LineStringM
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 10 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 10 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 0 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 0 ) );
-
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.isMeasure() );
-  QVERIFY( pl.interiorRing( 0 )->isMeasure() ); //rings should also gain measure
-  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
-
-  //25D exterior ring
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0 ) );
-
-  pl.setExteriorRing( ext );
-
-  QVERIFY( pl.is3D() );
-  QVERIFY( !pl.isMeasure() );
-  QVERIFY( pl.interiorRing( 0 )->is3D() ); //rings should also be made 25D
-  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
-  QVERIFY( pl.interiorRing( 1 )->is3D() );
-  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
-  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
-}
-
-void TestQgsPolygon::removeInteriorRing()
-{
-  QgsPolygon pl;
-
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext );
-
-  QVERIFY( !pl.removeInteriorRing( -1 ) );
-  QVERIFY( !pl.removeInteriorRing( 0 ) );
-
-  QVector< QgsCurve * > rings;
-
-  QgsPointSequence pts;
-  pts << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.2 )
-      << QgsPoint( 0.2, 0.2 ) << QgsPoint( 0.2, 0.1 )
-      << QgsPoint( 0.1, 0.1 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( 0.3, 0.3 ) << QgsPoint( 0.3, 0.4 )
-      << QgsPoint( 0.4, 0.4 ) << QgsPoint( 0.4, 0.3 )
-      << QgsPoint( 0.3, 0.3 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
-
-  pts = QgsPointSequence();
-  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 )
-      << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.8 )
-      << QgsPoint( 0.8, 0.8 );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[2] )->setPoints( pts );
-
-  pl.setInteriorRings( rings );
-
-  QCOMPARE( pl.numInteriorRings(), 3 );
-
-  QVERIFY( pl.removeInteriorRing( 0 ) );
-  QCOMPARE( pl.numInteriorRings(), 2 );
-  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
-  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.8, 0.8 ) );
-
-  QVERIFY( pl.removeInteriorRing( 1 ) );
-  QCOMPARE( pl.numInteriorRings(), 1 );
-  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
-
-  QVERIFY( pl.removeInteriorRing( 0 ) );
-  QCOMPARE( pl.numInteriorRings(), 0 );
-
-  QVERIFY( !pl.removeInteriorRing( 0 ) );
 }
 
 void TestQgsPolygon::clear()
@@ -929,6 +389,2161 @@ void TestQgsPolygon::assignment()
 
   pl1 = pl3;
   QCOMPARE( pl3, pl1 );
+}
+
+void TestQgsPolygon::setBadExteriorRing()
+{
+  QgsPolygon pl;
+
+  //try with no ring
+  QgsLineString *ext = nullptr;
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 0 );
+  QCOMPARE( pl.partCount(), 0 );
+  QVERIFY( !pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  // empty exterior ring
+  ext = new QgsLineString();
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 1 );
+  QCOMPARE( pl.partCount(), 1 );
+  QVERIFY( pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  //test that a non closed exterior ring will be automatically closed
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 )
+                  << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) );
+
+  QVERIFY( !ext->isClosed() );
+  pl.setExteriorRing( ext );
+  QVERIFY( !pl.isEmpty() );
+  QVERIFY( pl.exteriorRing()->isClosed() );
+  QCOMPARE( pl.nCoordinates(), 5 );
+}
+
+void TestQgsPolygon::setExteriorRing()
+{
+  QgsPolygon pl;
+
+  //valid exterior ring
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 5 );
+  QCOMPARE( pl.ringCount(), 1 );
+  QCOMPARE( pl.partCount(), 1 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QCOMPARE( pl.wktTypeStr(), QString( "Polygon" ) );
+  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
+  QCOMPARE( pl.dimension(), 2 );
+  QVERIFY( !pl.hasCurvedSegments() );
+  QCOMPARE( pl.area(), 100.0 );
+  QCOMPARE( pl.perimeter(), 40.0 );
+  QVERIFY( pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+
+  //retrieve exterior ring and check
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+}
+
+void TestQgsPolygon::setExteriorRingZM()
+{
+  QgsPolygon pl;
+
+  //initial setting of exterior ring should set z/m type
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
+  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 10, 0, 2 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 0, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonM" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 3, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 5, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZM" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon25D );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+}
+
+void TestQgsPolygon::setCurvedExteriorRing()
+{
+  QgsPolygon pl;
+
+  //setting curved exterior ring should be segmentized
+  QgsCircularString *cs = new QgsCircularString();
+  cs->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                 << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                 << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+
+  QVERIFY( cs->hasCurvedSegments() );
+
+  pl.setExteriorRing( cs );
+
+  QVERIFY( !pl.exteriorRing()->hasCurvedSegments() );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+}
+
+void TestQgsPolygon::setExteriorRingChangesInteriorRings()
+{
+  QgsPolygon pl;
+
+  //change dimensionality of interior rings using setExteriorRing
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3,  1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+
+  //reset exterior ring to 2d
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() ); //rings should also be made 2D
+  QVERIFY( !pl.interiorRing( 1 )->is3D() );
+
+  //reset exterior ring to LineStringM
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->isMeasure() ); //rings should also gain measure
+  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
+
+  //25D exterior ring
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->is3D() ); //rings should also be made 25D
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
+}
+
+void TestQgsPolygon::deleteExteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString l38;
+  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( l38.clone() );
+  pl.addInteriorRing( l38.clone() );
+
+  // test that interior ring is "promoted" when exterior is removed
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QVERIFY( pl.exteriorRing() );
+}
+
+void TestQgsPolygon::addInteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  //empty ring
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QVERIFY( !pl.interiorRing( -1 ) );
+  QVERIFY( !pl.interiorRing( 0 ) );
+
+  pl.addInteriorRing( nullptr );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QCOMPARE( pl.interiorRing( 0 ), ring );
+  QVERIFY( !pl.interiorRing( 1 ) );
+
+  QgsCoordinateSequence seq = pl.coordinateSequence();
+  QgsRingSequence expected;
+  expected << ( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  expected << ( QgsPointSequence() << QgsPoint( 1, 1 )
+                << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+
+  QCOMPARE( seq, QgsCoordinateSequence() << expected );
+  QCOMPARE( pl.nCoordinates(), 10 );
+
+  //add non-closed interior ring, should be closed automatically
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                   << QgsPoint( 0.1, 0.9 ) << QgsPoint( 0.9, 0.9 )
+                   << QgsPoint( 0.9, 0.1 ) );
+
+  QVERIFY( !ring->isClosed() );
+
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 2 );
+  QVERIFY( pl.interiorRing( 1 )->isClosed() );
+}
+
+void TestQgsPolygon::addInteriorRingZM()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.9 )
+                   << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.1 ) );
+  pl.addInteriorRing( ring );
+
+  //try adding an interior ring with z to a 2d polygon, z should be dropped
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QVERIFY( pl.interiorRing( 2 ) );
+  QVERIFY( !pl.interiorRing( 2 )->is3D() );
+  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
+
+  //try adding an interior ring with m to a 2d polygon, m should be dropped
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 4 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QVERIFY( pl.interiorRing( 3 ) );
+  QVERIFY( !pl.interiorRing( 3 )->is3D() );
+  QVERIFY( !pl.interiorRing( 3 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 3 )->wkbType(), QgsWkbTypes::LineString );
+
+  //addInteriorRing without z/m to PolygonZM
+  pl.clear();
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+
+  //ring has no z
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 2 )
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 9 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 9 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 1 )
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( pl.interiorRing( 0 )->is3D() );
+  QVERIFY( pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZM );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 0, 2 ) );
+
+  //ring has no m
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QVERIFY( pl.interiorRing( 1 ) );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineStringZM );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 0.1, 0.1, 1, 0 ) );
+}
+
+void TestQgsPolygon::setInteriorRings()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  //add a list of rings with mixed types
+  QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 ) << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
+  //throw an empty ring in too
+  rings << 0;
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+      << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 );
+  rings << new QgsCircularString();
+  static_cast< QgsCircularString *>( rings[3] )->setPoints( QgsPointSequence() );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.1, 0.1 ) );
+
+  QVERIFY( pl.interiorRing( 1 ) );
+  QVERIFY( !pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.3, 0.3 ) );
+
+  QVERIFY( pl.interiorRing( 2 ) );
+  QVERIFY( !pl.interiorRing( 2 )->is3D() );
+  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
+
+  //set rings with existing
+  rings.clear();
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 ) << QgsPoint( 0.9, 0.9 )
+      << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.8, 0.8 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.8, 0.8 ) );
+
+  rings.clear();
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+}
+
+void TestQgsPolygon::removeInteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.removeInteriorRing( -1 ) );
+  QVERIFY( !pl.removeInteriorRing( 0 ) );
+
+  QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.2 )
+      << QgsPoint( 0.2, 0.2 ) << QgsPoint( 0.2, 0.1 )
+      << QgsPoint( 0.1, 0.1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.3, 0.3 ) << QgsPoint( 0.3, 0.4 )
+      << QgsPoint( 0.4, 0.4 ) << QgsPoint( 0.4, 0.3 )
+      << QgsPoint( 0.3, 0.3 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 )
+      << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.8 )
+      << QgsPoint( 0.8, 0.8 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[2] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+
+  QVERIFY( pl.removeInteriorRing( 0 ) );
+  QCOMPARE( pl.numInteriorRings(), 2 );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.8, 0.8 ) );
+
+  QVERIFY( pl.removeInteriorRing( 1 ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
+
+  QVERIFY( pl.removeInteriorRing( 0 ) );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QVERIFY( !pl.removeInteriorRing( 0 ) );
+}
+
+void TestQgsPolygon::removeInteriorRings()
+{
+  QgsPolygon pl;
+  pl.removeInteriorRings();
+
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
+
+  pl.setExteriorRing( ext.clone() );
+  pl.removeInteriorRings();
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  // add interior rings
+  QgsLineString ring1;
+  ring1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                   << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
+                   << QgsPoint( 0.1, 0.1 ) );
+  QgsLineString ring2;
+  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.6, 0.8 )
+                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
+                   << QgsPoint( 0.6, 0.8 ) );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring1.clone() << ring2.clone() );
+
+  // remove ring with size filter
+  pl.removeInteriorRings( 0.0075 );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  // remove ring with no size filter
+  pl.removeInteriorRings();
+  QCOMPARE( pl.numInteriorRings(), 0 );
+}
+
+void TestQgsPolygon::removeInvalidRings()
+{
+  QgsPolygon pl;
+  pl.removeInvalidRings(); // no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.removeInvalidRings();
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.removeInvalidRings();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4),(1 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 1 2 5 6))" ) );
+}
+
+void TestQgsPolygon::insertVertex()
+{
+  //insert vertex in empty polygon
+  QgsPolygon pl;
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 1, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.isEmpty() );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
+                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 0.3, 0 ) ) );
+  QCOMPARE( pl.nCoordinates(), 8 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 100 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+
+  // first vertex
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 0, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 9 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+
+  // last vertex
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 9 ), QgsPoint( 0.1, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 10 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+
+  // with interior ring
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.nCoordinates(), 17 );
+
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 0.3, 0 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 18 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 100 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+
+  // first vertex in interior ring
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 0, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 19 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+
+  // last vertex in interior ring
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 9 ), QgsPoint( 0.1, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 20 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+}
+
+void TestQgsPolygon::moveVertex()
+{
+  //empty polygon
+  QgsPolygon pl;
+
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.isEmpty() );
+
+  //valid polygon
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 16.0, 17.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( 26.0, 27.0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+
+  //out of range
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 10 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 3.0, 4.0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+
+  // with interior ring
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 16.0, 17.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 2 ), QgsPoint( 26.0, 27.0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 10 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 3.0, 4.0 ) ) );
+}
+
+void TestQgsPolygon::deleteVertex()
+{
+  //empty polygon
+  QgsPolygon pl;
+
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
+  QVERIFY( pl.isEmpty() );
+
+  //valid polygon
+  QgsLineString l38;
+  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( l38.clone() );
+
+  //out of range vertices
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, -1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 100 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+
+  //valid vertices
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+
+  // delete first vertex
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+
+  // delete last vertex
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 4 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+
+  // delete another vertex - should remove ring
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
+  QVERIFY( !pl.exteriorRing() );
+
+  // with interior ring
+  pl.setExteriorRing( l38.clone() );
+  pl.addInteriorRing( l38.clone() );
+
+  //out of range vertices
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, -1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 100 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 2, 1 ) ) );
+
+  //valid vertices
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+
+  // delete first vertex
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+
+  // delete last vertex
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 4 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+
+  // delete another vertex - should remove ring
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QVERIFY( pl.exteriorRing() );
+}
+
+void TestQgsPolygon::deleteVertexRemoveRing()
+{
+  //removing the fourth to last vertex removes the whole ring
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
+                  << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+  QVERIFY( pl.exteriorRing() );
+
+  pl.deleteVertex( QgsVertexId( 0, 0, 2 ) );
+  QVERIFY( !pl.exteriorRing() );
+}
+
+void TestQgsPolygon::nextVertex()
+{
+  QgsPolygon pl;
+
+  QgsPoint pt;
+  QgsVertexId v;
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 0, -2 );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 0, 10 );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  v = QgsVertexId( 0, 0, 4 ); //out of range
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 0, -5 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 0, -1 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
+  QCOMPARE( pt, QgsPoint( 1, 2 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( pt, QgsPoint( 1, 12 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( pt, QgsPoint( 1, 2 ) );
+
+  v = QgsVertexId( 0, 1, 0 );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 1, 0, 0 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 1, 0, 1 ) ); //test that part number is maintained
+  QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
+  // add interior ring
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 )
+                << QgsPoint( 11, 22 ) << QgsPoint( 11, 12 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  v = QgsVertexId( 0, 1, 4 ); //out of range
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 1, -5 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 0, 1, -1 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 1, 0 ) );
+  QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
+  QCOMPARE( pt, QgsPoint( 21, 22 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
+  QCOMPARE( pt, QgsPoint( 11, 22 ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 0, 1, 3 ) );
+  QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
+  v = QgsVertexId( 0, 2, 0 );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  v = QgsVertexId( 1, 1, 0 );
+  QVERIFY( pl.nextVertex( v, pt ) );
+  QCOMPARE( v, QgsVertexId( 1, 1, 1 ) ); //test that part number is maintained
+  QCOMPARE( pt, QgsPoint( 21, 22 ) );
+}
+
+void TestQgsPolygon::vertexNumberFromVertexId()
+{
+  QgsLineString ls;
+  QCOMPARE( ls.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+
+  QgsPolygon pl;
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), -1 );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
+
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), 5 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 1 ) ), 6 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 2 ) ), 7 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 3 ) ), 8 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 4 ) ), 9 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 5 ) ), -1 );
+}
+
+void TestQgsPolygon::vertexAngle()
+{
+  QgsPolygon pl;
+
+  ( void )pl.vertexAngle( QgsVertexId() ); //just want no crash
+  ( void )pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash
+  ( void )pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ); //just want no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
+                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 2.35619, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 1.5708, 0.0001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 2 ) ), 1.17809, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 3 ) ), 0.0, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 4 ) ), 5.10509, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 5 ) ), 3.92699, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 6 ) ), 2.35619, 0.00001 );
+
+  pl.addInteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ), 2.35619, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 1 ) ), 1.5708, 0.0001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 2 ) ), 1.17809, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 3 ) ), 0.0, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 4 ) ), 5.10509, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 5 ) ), 3.92699, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 6 ) ), 2.35619, 0.00001 );
+}
+
+void TestQgsPolygon::adjacentVertices()
+{
+  // test adjacent vertices - should wrap around!
+  QgsPolygon pl;
+  QgsVertexId previous( 1, 2, 3 );
+  QgsVertexId next( 4, 5, 6 );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
+  QgsLineString *closedRing1 = new QgsLineString();
+  closedRing1->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                          << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
+                          << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
+  pl.setExteriorRing( closedRing1 );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 2 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 2 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 3 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 3 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 4 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 4 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
+  // part number should be retained
+  pl.adjacentVertices( QgsVertexId( 1, 0, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 1, 0, 3 ) );
+  QCOMPARE( next, QgsVertexId( 1, 0, 1 ) );
+
+  // interior ring
+  pl.addInteriorRing( closedRing1->clone() );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 1 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 1, 0 ) );
+  QCOMPARE( next, QgsVertexId( 0, 1, 2 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 2 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 1, 1 ) );
+  QCOMPARE( next, QgsVertexId( 0, 1, 3 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 3 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 1, 2 ) );
+  QCOMPARE( next, QgsVertexId( 0, 1, 4 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 4 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 2, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+}
+
+void TestQgsPolygon::removeDuplicateNodes()
+{
+  QgsPolygon pl;
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 11, 22 ) << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
+                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
+                << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
+  QVERIFY( !pl.removeDuplicateNodes( 0.02 ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
+                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
+                << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11.01 1.99, 11.02 2.01, 11 12, 11 22, 11.01 21.99, 10.99 1.99, 11 2))" ) );
+
+  // don't create degenerate rings
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 2.01 )
+                << QgsPoint( 11, 2.01 ) << QgsPoint( 11, 2 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2),(11 2, 11.01 2.01, 11 2.01, 11 2))" ) );
+}
+
+void TestQgsPolygon::dropZValue()
+{
+  QgsPolygon pl;
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  pl.dropZValue(); // not z
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
+  // with z
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3 ) << QgsPoint( 11, 12, 13 )
+                << QgsPoint( 1, 12, 23 ) << QgsPoint( 1, 2, 3 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
+  // with zm
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 )
+                << QgsPoint( 11, 12, 13, 14 )
+                << QgsPoint( 1, 12, 23, 24 )
+                << QgsPoint( 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringM );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
+
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringM );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
+}
+
+void TestQgsPolygon::dropMValue()
+{
+  QgsPolygon pl;
+
+  pl.dropMValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  pl.dropMValue(); // not zm
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
+  // with m
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 )
+                << QgsPoint( QgsWkbTypes::PointM, 11, 12, 0, 13 )
+                << QgsPoint( QgsWkbTypes::PointM, 1, 12, 0, 23 )
+                << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+  pl.dropMValue();
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
+  // with zm
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 ) << QgsPoint( 11, 12, 13, 14 )
+                << QgsPoint( 1, 12, 23, 24 ) << QgsPoint( 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+  pl.dropMValue();
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringZ );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
+
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZ );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
+}
+
+void TestQgsPolygon::swapXy()
+{
+  QgsPolygon pl;
+  pl.swapXy(); //no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.swapXy();
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((2 11 3 4, 12 11 13 14, 22 11 23 24, 2 11 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.swapXy();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(2 1 5 6, 2.01 11.01 15 16, 2.01 11 25 26, 2 11 5 6, 2 1 5 6))" ) );
+}
+
+void TestQgsPolygon::boundary()
+{
+  QgsPolygon pl;
+  QVERIFY( !pl.boundary() );
+
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
+                 << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  QgsAbstractGeometry *boundary = pl.boundary();
+  QgsLineString *lineBoundary = dynamic_cast< QgsLineString * >( boundary );
+
+  QVERIFY( lineBoundary );
+  QCOMPARE( lineBoundary->numPoints(), 4 );
+  QCOMPARE( lineBoundary->xAt( 0 ), 0.0 );
+  QCOMPARE( lineBoundary->xAt( 1 ), 1.0 );
+  QCOMPARE( lineBoundary->xAt( 2 ), 1.0 );
+  QCOMPARE( lineBoundary->xAt( 3 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 0 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 1 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 2 ), 1.0 );
+  QCOMPARE( lineBoundary->yAt( 3 ), 0.0 );
+
+  delete boundary;
+
+  // add interior rings
+  QgsLineString ring;
+  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
+                  << QgsPoint( 0.1, 0.1 ) );
+  QgsLineString ring2;
+  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 )
+                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
+                   << QgsPoint( 0.8, 0.8 ) );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() << ring2.clone() );
+
+  boundary = pl.boundary();
+  QgsMultiLineString *multiLineBoundary = dynamic_cast< QgsMultiLineString * >( boundary );
+
+  QVERIFY( multiLineBoundary );
+  QCOMPARE( multiLineBoundary->numGeometries(), 3 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->numPoints(), 4 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 0 ), 0.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 1 ), 1.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 2 ), 1.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 3 ), 0.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 0 ), 0.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 1 ), 0.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 2 ), 1.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 3 ), 0.0 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->numPoints(), 4 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 0 ), 0.1 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 1 ), 0.2 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 2 ), 0.2 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 3 ), 0.1 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 0 ), 0.1 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 1 ), 0.1 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 2 ), 0.2 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 3 ), 0.1 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->numPoints(), 4 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 0 ), 0.8 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 1 ), 0.9 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 2 ), 0.9 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 3 ), 0.8 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 0 ), 0.8 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 1 ), 0.8 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 2 ), 0.9 );
+  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 3 ), 0.8 );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() );
+  delete boundary;
+
+  //test boundary with z
+  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  boundary = pl.boundary();
+  lineBoundary = qgis::down_cast< QgsLineString * >( boundary );
+
+  QVERIFY( lineBoundary );
+  QCOMPARE( lineBoundary->numPoints(), 4 );
+  QCOMPARE( lineBoundary->wkbType(), QgsWkbTypes::LineStringZ );
+  QCOMPARE( lineBoundary->zAt( 0 ), 10.0 );
+  QCOMPARE( lineBoundary->zAt( 1 ), 15.0 );
+  QCOMPARE( lineBoundary->zAt( 2 ), 20.0 );
+  QCOMPARE( lineBoundary->zAt( 3 ), 10.0 );
+
+  delete boundary;
+}
+
+void TestQgsPolygon::pointDistanceToBoundary()
+{
+  QgsPolygon pl;
+  // no meaning, but let's not crash
+  ( void )pl.pointDistanceToBoundary( 0, 0 );
+
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                 << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 )
+                 << QgsPoint( 0, 1 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.1, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+
+  // with a ring
+  QgsLineString ring;
+  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.6 )
+                  << QgsPoint( 0.1, 0.6 ) << QgsPoint( 0.1, 0.1 ) );
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() );
+
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.01, 0.5 ), 0.01, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.08, 0.5 ), 0.02, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.12, 0.5 ), -0.02, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+}
+
+void TestQgsPolygon::closestSegment()
+{
+  QgsPoint pt;
+  QgsVertexId v;
+  int leftOf = 0;
+
+  QgsPolygon pl;
+  ( void )pl.closestSegment( QgsPoint( 1, 2 ), pt, v ); // empty polygon, just want no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 5, 10 )
+                << QgsPoint( 7, 12 ) << QgsPoint( 5, 15 )
+                << QgsPoint( 5, 10 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 11, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 7, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 12, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.5 ), pt, v, &leftOf ), 0.125000, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 6.25, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 11.25, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( leftOf, -1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( leftOf, -1 );
+
+  // point directly on segment
+  QCOMPARE( pl.closestSegment( QgsPoint( 5, 15 ), pt, v, &leftOf ), 0.0 );
+  QCOMPARE( pt, QgsPoint( 5, 15 ) );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+
+  // with interior ring
+  ls.setPoints( QgsPointSequence() << QgsPoint( 6, 11.5 ) << QgsPoint( 6.5, 12 )
+                << QgsPoint( 6, 13 ) << QgsPoint( 6, 11.5 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 11, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 7, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 12, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.4 ), pt, v, &leftOf ), 0.01, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 6.0, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 11.5, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( leftOf, 1 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
+  QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
+  QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
+  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( leftOf, -1 );
+
+  // point directly on segment
+  QCOMPARE( pl.closestSegment( QgsPoint( 6, 13 ), pt, v, &leftOf ), 0.0 );
+  QCOMPARE( pt, QgsPoint( 6, 13 ) );
+  QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
+  QCOMPARE( leftOf, 0 );
+}
+
+void TestQgsPolygon::segmentLength()
+{
+  QgsPolygon pl;
+
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
+                << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
+
+  // add interior ring
+  ls.setPoints( QgsPointSequence() << QgsPoint( 30, 6 )
+                << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
+                << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 4.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 2.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 2 ) ), 4.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 3 ) ), 2.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
+}
+
+void TestQgsPolygon::forceRHR()
+{
+  QgsPolygon pl;
+  pl.forceRHR(); // no crash
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
+
+  // force cw (same as force RHR)
+  pl = QgsPolygon();
+  pl.forceClockwise(); // no crash
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
+
+  // force ccw
+  pl = QgsPolygon();
+  pl.forceCounterClockwise(); // no crash
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+}
+
+void TestQgsPolygon::boundingBoxIntersects()
+{
+  QgsPolygon pl;
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 2 ) << QgsPoint( 4, 2 )
+                << QgsPoint( 4, 4 ) << QgsPoint( 0, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+
+  // double test because of cache
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 0, 2, 4, 4 ) );
+
+  // clear cache
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2 ) << QgsPoint( 14, 2 )
+                << QgsPoint( 15, 4 ) << QgsPoint( 10, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
+
+  // technically invalid -- the interior ring is outside the exterior, but we want boundingBoxIntersects to be tolerant to
+  // cases like this!
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 4, 2 )
+                << QgsPoint( 5, 4 ) << QgsPoint( 1, 2 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 21, 3, 26, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
+}
+
+void TestQgsPolygon::filterVertices()
+{
+  auto filter = []( const QgsPoint & point )-> bool
+  {
+    return point.x() > 5;
+  };
+
+  QgsPolygon pl;
+  pl.filterVertices( filter ); // no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.filterVertices( filter );
+
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.filterVertices( filter );
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(10 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 11 2 5 6, 10 2 5 6),(11.01 2.01 15 16, 11 2.01 25 26))" ) );
+}
+
+void TestQgsPolygon::transformVertices()
+{
+  auto transform = []( const QgsPoint & point )-> QgsPoint
+  {
+    return QgsPoint( point.x() + 2, point.y() + 3, point.z() + 4, point.m() + 5 );
+  };
+
+  QgsPolygon pl;
+  pl.transformVertices( transform ); // no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.transformVertices( transform );
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((13 5 7 9, 6 15 17 19, 13 15 17 19, 13 25 27 29, 13 5 7 9))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transformVertices( transform );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((15 8 11 14, 8 18 21 24, 15 18 21 24, 15 28 31 34, 15 8 11 14),(12 5 9 11, 6 15 17 19, 13.01 5.01 19 21, 13 5.01 29 31, 13 5 9 11, 12 5 9 11),(3 5 9 11, 13.01 5.01 19 21, 13 5.01 29 31, 3 5 9 11))" ) );
+}
+
+void TestQgsPolygon::transformWithClass()
+{
+  QgsPolygon pl;
+  TestTransformer transformer;
+
+  // no crash
+  QVERIFY( pl.transform( &transformer ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.transform( &transformer ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((33 16 8 3, 12 26 18 13, 33 26 18 13, 33 36 28 23, 33 16 8 3))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.transform( &transformer ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((99 30 13 2, 36 40 23 12, 99 40 23 12, 99 50 33 22, 99 30 13 2),(30 16 10 5, 12 26 18 13, 33.03 16.01 20 15, 33 16.01 30 25, 33 16 10 5, 30 16 10 5),(3 16 10 5, 33.03 16.01 20 15, 33 16.01 30 25, 3 16 10 5))" ) );
+
+  TestFailTransformer failTransformer;
+  QVERIFY( !pl.transform( &failTransformer ) );
+}
+
+void TestQgsPolygon::transform2D()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
+                << QgsPoint( 6274985, -3526584 )
+                << QgsPoint( 6474985, -3526584 )
+                << QgsPoint( 6374985, -3626584 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
+
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+}
+
+void TestQgsPolygon::transform3D()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+}
+
+void TestQgsPolygon::transformReverse()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+  pl.transform( tr, Qgis::TransformDirection::Reverse );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 6374984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 6274984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  6474984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  6374984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -3526584, 100 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 6374984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 6274984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  6474984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  6374984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), -3526584, 100 );
+}
+
+void TestQgsPolygon::transformOldVersion()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+#if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
+  //z value transform
+  pl.transform( tr, Qgis::TransformDirection::Forward, true );
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), -19.249066, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), -19.148357, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), -19.092128, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), -19.249066, 0.001 );
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), -19.249066, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), -19.148357, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), -19.092128, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), -19.249066, 0.001 );
+  pl.transform( tr, Qgis::TransformDirection::Reverse, true );
+  ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1, 0.001 );
+  ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1, 0.001 );
+#endif
+}
+
+void TestQgsPolygon::Qtransform()
+{
+  QTransform qtr = QTransform::fromScale( 2, 3 );
+
+  QgsPolygon pl;
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 11, 12, 13, 14 )
+                << QgsPoint( QgsWkbTypes::PointZM, 1, 12, 23, 24 )
+                << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( qtr, 2, 3, 4, 5 );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 24.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 22, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 41.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 74.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 71.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 124.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 24.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), 36, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 24.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 22, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 41.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 74.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 71.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 124.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 24.0, 0.001 );
+
+  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), 36, 0.001 );
+}
+
+void TestQgsPolygon::cast()
+{
+  QVERIFY( !QgsPolygon().cast( nullptr ) );
+
+  QgsPolygon pl;
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZ((0 0 0, 0 1 1, 1 0 2, 0 0 0))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonM((0 0 1, 0 1 2, 1 0 3, 0 0 1))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM((0 0 0 1, 0 1 1 2, 1 0 2 3, 0 0 0 1))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
 }
 
 void TestQgsPolygon::toPolygon()
@@ -1287,1621 +2902,6 @@ void TestQgsPolygon::exportImport()
 
   QString expectedKmlPrec3( QStringLiteral( "<Polygon><outerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>1.111,1.111,0 1.111,11.111,0 11.111,11.111,0 11.111,1.111,0 1.111,1.111,0</coordinates></LinearRing></outerBoundaryIs><innerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>0.667,0.667,0 0.667,1.333,0 1.333,1.333,0 1.333,0.667,0 0.667,0.667,0</coordinates></LinearRing></innerBoundaryIs></Polygon>" ) );
   QCOMPARE( exportPolygonFloat.asKml( 3 ), expectedKmlPrec3 );
-}
-
-void TestQgsPolygon::deleteVertexRemoveRing()
-{
-  //removing the fourth to last vertex removes the whole ring
-  QgsPolygon pl;
-
-  QgsLineString *ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
-                  << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
-
-  pl.setExteriorRing( ext );
-  QVERIFY( pl.exteriorRing() );
-
-  pl.deleteVertex( QgsVertexId( 0, 0, 2 ) );
-  QVERIFY( !pl.exteriorRing() );
-}
-
-void TestQgsPolygon::boundary()
-{
-  QgsPolygon pl;
-  QVERIFY( !pl.boundary() );
-
-  QgsLineString ext;
-  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
-                 << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext.clone() );
-
-  QgsAbstractGeometry *boundary = pl.boundary();
-  QgsLineString *lineBoundary = dynamic_cast< QgsLineString * >( boundary );
-
-  QVERIFY( lineBoundary );
-  QCOMPARE( lineBoundary->numPoints(), 4 );
-  QCOMPARE( lineBoundary->xAt( 0 ), 0.0 );
-  QCOMPARE( lineBoundary->xAt( 1 ), 1.0 );
-  QCOMPARE( lineBoundary->xAt( 2 ), 1.0 );
-  QCOMPARE( lineBoundary->xAt( 3 ), 0.0 );
-  QCOMPARE( lineBoundary->yAt( 0 ), 0.0 );
-  QCOMPARE( lineBoundary->yAt( 1 ), 0.0 );
-  QCOMPARE( lineBoundary->yAt( 2 ), 1.0 );
-  QCOMPARE( lineBoundary->yAt( 3 ), 0.0 );
-
-  delete boundary;
-
-  // add interior rings
-  QgsLineString ring;
-  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
-                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
-                  << QgsPoint( 0.1, 0.1 ) );
-  QgsLineString ring2;
-  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 )
-                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
-                   << QgsPoint( 0.8, 0.8 ) );
-
-  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() << ring2.clone() );
-
-  boundary = pl.boundary();
-  QgsMultiLineString *multiLineBoundary = dynamic_cast< QgsMultiLineString * >( boundary );
-
-  QVERIFY( multiLineBoundary );
-  QCOMPARE( multiLineBoundary->numGeometries(), 3 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 0 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 1 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 2 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 3 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 0 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 1 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 2 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 3 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 0 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 1 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 2 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 3 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 0 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 1 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 2 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 3 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 0 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 1 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 2 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 3 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 0 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 1 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 2 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 3 ), 0.8 );
-
-  pl.setInteriorRings( QVector< QgsCurve * >() );
-  delete boundary;
-
-  //test boundary with z
-  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
-  pl.setExteriorRing( ext.clone() );
-
-  boundary = pl.boundary();
-  lineBoundary = qgis::down_cast< QgsLineString * >( boundary );
-
-  QVERIFY( lineBoundary );
-  QCOMPARE( lineBoundary->numPoints(), 4 );
-  QCOMPARE( lineBoundary->wkbType(), QgsWkbTypes::LineStringZ );
-  QCOMPARE( lineBoundary->zAt( 0 ), 10.0 );
-  QCOMPARE( lineBoundary->zAt( 1 ), 15.0 );
-  QCOMPARE( lineBoundary->zAt( 2 ), 20.0 );
-  QCOMPARE( lineBoundary->zAt( 3 ), 10.0 );
-
-  delete boundary;
-}
-
-void TestQgsPolygon::pointDistanceToBoundary()
-{
-  QgsPolygon pl;
-  // no meaning, but let's not crash
-  ( void )pl.pointDistanceToBoundary( 0, 0 );
-
-  QgsLineString ext;
-  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                 << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 )
-                 << QgsPoint( 0, 1 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ext.clone() );
-
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.1, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
-
-  // with a ring
-  QgsLineString ring;
-  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
-                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.6 )
-                  << QgsPoint( 0.1, 0.6 ) << QgsPoint( 0.1, 0.1 ) );
-  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() );
-
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.01, 0.5 ), 0.01, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.08, 0.5 ), 0.02, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.12, 0.5 ), -0.02, 0.0000000001 );
-  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
-}
-
-void TestQgsPolygon::removeInteriorRings()
-{
-  QgsPolygon pl;
-  pl.removeInteriorRings();
-
-  QgsLineString ext;
-  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
-                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
-
-  pl.setExteriorRing( ext.clone() );
-  pl.removeInteriorRings();
-
-  QCOMPARE( pl.numInteriorRings(), 0 );
-
-  // add interior rings
-  QgsLineString ring1;
-  ring1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
-                   << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
-                   << QgsPoint( 0.1, 0.1 ) );
-  QgsLineString ring2;
-  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.6, 0.8 )
-                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
-                   << QgsPoint( 0.6, 0.8 ) );
-
-  pl.setInteriorRings( QVector< QgsCurve * >() << ring1.clone() << ring2.clone() );
-
-  // remove ring with size filter
-  pl.removeInteriorRings( 0.0075 );
-  QCOMPARE( pl.numInteriorRings(), 1 );
-
-  // remove ring with no size filter
-  pl.removeInteriorRings();
-  QCOMPARE( pl.numInteriorRings(), 0 );
-}
-
-void TestQgsPolygon::cast()
-{
-  QVERIFY( !QgsPolygon().cast( nullptr ) );
-
-  QgsPolygon pl;
-  QVERIFY( QgsPolygon().cast( &pl ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZ((0 0 0, 0 1 1, 1 0 2, 0 0 0))" ) );
-  QVERIFY( QgsPolygon().cast( &pl ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonM((0 0 1, 0 1 2, 1 0 3, 0 0 1))" ) );
-  QVERIFY( QgsPolygon().cast( &pl ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM((0 0 0 1, 0 1 1 2, 1 0 2 3, 0 0 0 1))" ) );
-  QVERIFY( QgsPolygon().cast( &pl ) );
-}
-
-void TestQgsPolygon::transform2D()
-{
-  //CRS transform
-  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
-  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
-  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
-
-  QgsPolygon pl;
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
-                << QgsPoint( 6274985, -3526584 )
-                << QgsPoint( 6474985, -3526584 )
-                << QgsPoint( 6374985, -3626584 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.transform( tr, Qgis::TransformDirection::Forward );
-  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-
-  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
-
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
-
-  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-
-  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
-
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
-}
-
-void TestQgsPolygon::transform3D()
-{
-  //CRS transform
-  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
-  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
-  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
-
-  QgsPolygon pl;
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.transform( tr, Qgis::TransformDirection::Forward );
-
-  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-
-  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
-
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
-
-  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-
-  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
-
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
-
-}
-
-void TestQgsPolygon::transformReverse()
-{
-  //CRS transform
-  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
-  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
-  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
-
-  QgsPolygon pl;
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.transform( tr, Qgis::TransformDirection::Forward );
-  pl.transform( tr, Qgis::TransformDirection::Reverse );
-
-  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-
-  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 6374984, 100 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 6274984, 100 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  6474984, 100 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  6374984, 100 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 6274984, 100 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -3626584, 100 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 6474984, 100 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -3526584, 100 );
-
-  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-
-  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 6374984, 100 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 6274984, 100 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  6474984, 100 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  6374984, 100 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 6274984, 100 );
-  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), -3626584, 100 );
-  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 6474984, 100 );
-  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), -3526584, 100 );
-}
-
-void TestQgsPolygon::transformOldVersion()
-{
-  //CRS transform
-  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
-  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
-  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
-
-  QgsPolygon pl;
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
-                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-#if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
-  //z value transform
-  pl.transform( tr, Qgis::TransformDirection::Forward, true );
-  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-  QGSCOMPARENEAR( ext->pointN( 0 ).z(), -19.249066, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).z(), -19.148357, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).z(), -19.092128, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).z(), -19.249066, 0.001 );
-  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-  QGSCOMPARENEAR( ring->pointN( 0 ).z(), -19.249066, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).z(), -19.148357, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).z(), -19.092128, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).z(), -19.249066, 0.001 );
-  pl.transform( tr, Qgis::TransformDirection::Reverse, true );
-  ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1, 0.001 );
-  ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1, 0.001 );
-#endif
-}
-
-void TestQgsPolygon::Qtransform()
-{
-  QTransform qtr = QTransform::fromScale( 2, 3 );
-
-  QgsPolygon pl;
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 )
-                << QgsPoint( QgsWkbTypes::PointZM, 11, 12, 13, 14 )
-                << QgsPoint( QgsWkbTypes::PointZM, 1, 12, 23, 24 )
-                << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.transform( qtr, 2, 3, 4, 5 );
-
-  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
-
-  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 2, 100 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).y(), 6, 100 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 22, 100 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).y(), 36, 100 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 41.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 74.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  2, 100 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).y(), 36, 100 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 71.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 124.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).x(), 2, 100 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).y(), 6, 100 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 24.0, 0.001 );
-
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 2, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), 6, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 22, 0.001 );
-  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), 36, 0.001 );
-
-  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
-
-  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 2, 100 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).y(), 6, 100 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 22, 100 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).y(), 36, 100 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 41.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 74.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  2, 100 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).y(), 36, 100 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 71.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 124.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).x(), 2, 100 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).y(), 6, 100 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 24.0, 0.001 );
-
-  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 2, 0.001 );
-  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), 6, 0.001 );
-  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 22, 0.001 );
-  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), 36, 0.001 );
-}
-
-void TestQgsPolygon::closestSegment()
-{
-  QgsPoint pt;
-  QgsVertexId v;
-  int leftOf = 0;
-
-  QgsPolygon pl;
-  ( void )pl.closestSegment( QgsPoint( 1, 2 ), pt, v ); // empty polygon, just want no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 5, 10 )
-                << QgsPoint( 7, 12 ) << QgsPoint( 5, 15 )
-                << QgsPoint( 5, 10 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 11, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 7, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 12, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.5 ), pt, v, &leftOf ), 0.125000, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 6.25, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 11.25, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( leftOf, -1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( leftOf, -1 );
-
-  // point directly on segment
-  QCOMPARE( pl.closestSegment( QgsPoint( 5, 15 ), pt, v, &leftOf ), 0.0 );
-  QCOMPARE( pt, QgsPoint( 5, 15 ) );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-
-  // with interior ring
-  ls.setPoints( QgsPointSequence() << QgsPoint( 6, 11.5 ) << QgsPoint( 6.5, 12 )
-                << QgsPoint( 6, 13 ) << QgsPoint( 6, 11.5 ) );
-  pl.addInteriorRing( ls.clone() );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 11, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 7, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 12, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.4 ), pt, v, &leftOf ), 0.01, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 6.0, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 11.5, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( leftOf, 1 );
-
-  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
-  QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
-  QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( leftOf, -1 );
-
-  // point directly on segment
-  QCOMPARE( pl.closestSegment( QgsPoint( 6, 13 ), pt, v, &leftOf ), 0.0 );
-  QCOMPARE( pt, QgsPoint( 6, 13 ) );
-  QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
-  QCOMPARE( leftOf, 0 );
-}
-
-void TestQgsPolygon::nextVertex()
-{
-  QgsPolygon pl;
-
-  QgsPoint pt;
-  QgsVertexId v;
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 0, -2 );
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 0, 10 );
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
-                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  v = QgsVertexId( 0, 0, 4 ); //out of range
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 0, -5 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 0, -1 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
-  QCOMPARE( pt, QgsPoint( 1, 2 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( pt, QgsPoint( 11, 12 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( pt, QgsPoint( 1, 12 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( pt, QgsPoint( 1, 2 ) );
-
-  v = QgsVertexId( 0, 1, 0 );
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 1, 0, 0 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 1, 0, 1 ) ); //test that part number is maintained
-  QCOMPARE( pt, QgsPoint( 11, 12 ) );
-
-  // add interior ring
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 )
-                << QgsPoint( 11, 22 ) << QgsPoint( 11, 12 ) );
-  pl.addInteriorRing( ls.clone() );
-
-  v = QgsVertexId( 0, 1, 4 ); //out of range
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 1, -5 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 0, 1, -1 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 1, 0 ) );
-  QCOMPARE( pt, QgsPoint( 11, 12 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
-  QCOMPARE( pt, QgsPoint( 21, 22 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
-  QCOMPARE( pt, QgsPoint( 11, 22 ) );
-
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 0, 1, 3 ) );
-  QCOMPARE( pt, QgsPoint( 11, 12 ) );
-
-  v = QgsVertexId( 0, 2, 0 );
-  QVERIFY( !pl.nextVertex( v, pt ) );
-
-  v = QgsVertexId( 1, 1, 0 );
-  QVERIFY( pl.nextVertex( v, pt ) );
-  QCOMPARE( v, QgsVertexId( 1, 1, 1 ) ); //test that part number is maintained
-  QCOMPARE( pt, QgsPoint( 21, 22 ) );
-}
-
-void TestQgsPolygon::dropZValue()
-{
-  QgsPolygon pl;
-
-  pl.dropZValue();
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
-                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  pl.dropZValue(); // not z
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
-
-  // with z
-  pl.clear();
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3 ) << QgsPoint( 11, 12, 13 )
-                << QgsPoint( 1, 12, 23 ) << QgsPoint( 1, 2, 3 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
-
-  pl.dropZValue();
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
-
-  // with zm
-  pl.clear();
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 )
-                << QgsPoint( 11, 12, 13, 14 )
-                << QgsPoint( 1, 12, 23, 24 )
-                << QgsPoint( 1, 2, 3, 4 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
-
-  pl.dropZValue();
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
-
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringM );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
-            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
-
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringM );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
-            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
-}
-
-void TestQgsPolygon::dropMValue()
-{
-  QgsPolygon pl;
-
-  pl.dropMValue();
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
-                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  pl.dropMValue(); // not zm
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
-
-  // with m
-  pl.clear();
-  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 )
-                << QgsPoint( QgsWkbTypes::PointM, 11, 12, 0, 13 )
-                << QgsPoint( QgsWkbTypes::PointM, 1, 12, 0, 23 )
-                << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
-  pl.dropMValue();
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
-
-  // with zm
-  pl.clear();
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 ) << QgsPoint( 11, 12, 13, 14 )
-                << QgsPoint( 1, 12, 23, 24 ) << QgsPoint( 1, 2, 3, 4 ) );
-  pl.setExteriorRing( ls.clone() );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
-  pl.dropMValue();
-
-  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
-  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringZ );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
-            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
-
-  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZ );
-  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
-            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
-}
-
-void TestQgsPolygon::vertexAngle()
-{
-  QgsPolygon pl;
-
-  ( void )pl.vertexAngle( QgsVertexId() ); //just want no crash
-  ( void )pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash
-  ( void )pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ); //just want no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
-                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
-                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 2.35619, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 1.5708, 0.0001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 2 ) ), 1.17809, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 3 ) ), 0.0, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 4 ) ), 5.10509, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 5 ) ), 3.92699, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 6 ) ), 2.35619, 0.00001 );
-
-  pl.addInteriorRing( ls.clone() );
-
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ), 2.35619, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 1 ) ), 1.5708, 0.0001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 2 ) ), 1.17809, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 3 ) ), 0.0, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 4 ) ), 5.10509, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 5 ) ), 3.92699, 0.00001 );
-  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 6 ) ), 2.35619, 0.00001 );
-}
-
-void TestQgsPolygon::insertVertex()
-{
-  //insert vertex in empty polygon
-  QgsPolygon pl;
-
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 1, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( pl.isEmpty() );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
-                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
-                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
-                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 0.3, 0 ) ) );
-  QCOMPARE( pl.nCoordinates(), 8 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
-
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 100 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-
-  // first vertex
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 0, 0.1 ) ) );
-
-  QCOMPARE( pl.nCoordinates(), 9 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-
-  // last vertex
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 9 ), QgsPoint( 0.1, 0.1 ) ) );
-
-  QCOMPARE( pl.nCoordinates(), 10 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
-
-  // with interior ring
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.nCoordinates(), 17 );
-
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 0.3, 0 ) ) );
-
-  QCOMPARE( pl.nCoordinates(), 18 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
-
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 100 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-
-  // first vertex in interior ring
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 0, 0.1 ) ) );
-
-  QCOMPARE( pl.nCoordinates(), 19 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-
-  // last vertex in interior ring
-  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 9 ), QgsPoint( 0.1, 0.1 ) ) );
-
-  QCOMPARE( pl.nCoordinates(), 20 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
-}
-
-void TestQgsPolygon::moveVertex()
-{
-  //empty polygon
-  QgsPolygon pl;
-
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( pl.isEmpty() );
-
-  //valid polygon
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
-                << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 16.0, 17.0 ) ) );
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( 26.0, 27.0 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
-
-  //out of range
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 10 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 3.0, 4.0 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
-
-  // with interior ring
-  pl.addInteriorRing( ls.clone() );
-
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 16.0, 17.0 ) ) );
-  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 2 ), QgsPoint( 26.0, 27.0 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
-
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 10 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 3.0, 4.0 ) ) );
-}
-
-void TestQgsPolygon::deleteVertex()
-{
-  //empty polygon
-  QgsPolygon pl;
-
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
-  QVERIFY( pl.isEmpty() );
-
-  //valid polygon
-  QgsLineString l38;
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
-                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
-                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
-                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( l38.clone() );
-
-  //out of range vertices
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, -1 ) ) );
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 100 ) ) );
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
-
-  //valid vertices
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
-
-  // delete first vertex
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
-
-  // delete last vertex
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 4 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-
-  // delete another vertex - should remove ring
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
-  QVERIFY( !pl.exteriorRing() );
-
-  // with interior ring
-  pl.setExteriorRing( l38.clone() );
-  pl.addInteriorRing( l38.clone() );
-
-  //out of range vertices
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, -1 ) ) );
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 100 ) ) );
-  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 2, 1 ) ) );
-
-  //valid vertices
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
-
-  // delete first vertex
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
-
-  // delete last vertex
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 4 ) ) );
-
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-
-  // delete another vertex - should remove ring
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
-
-  QCOMPARE( pl.numInteriorRings(), 0 );
-  QVERIFY( pl.exteriorRing() );
-}
-
-void TestQgsPolygon::deleteExteriorRing()
-{
-  QgsPolygon pl;
-
-  QgsLineString l38;
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
-                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
-                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
-                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( l38.clone() );
-  pl.addInteriorRing( l38.clone() );
-
-  // test that interior ring is "promoted" when exterior is removed
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( pl.numInteriorRings(), 1 );
-
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( pl.numInteriorRings(), 1 );
-
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( pl.numInteriorRings(), 1 );
-
-  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( pl.numInteriorRings(), 0 );
-
-  QVERIFY( pl.exteriorRing() );
-}
-
-void TestQgsPolygon::adjacentVertices()
-{
-  // test adjacent vertices - should wrap around!
-  QgsPolygon pl;
-  QgsVertexId previous( 1, 2, 3 );
-  QgsVertexId next( 4, 5, 6 );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-
-  QgsLineString *closedRing1 = new QgsLineString();
-  closedRing1->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
-                          << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
-                          << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
-  pl.setExteriorRing( closedRing1 );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 2 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 2 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 3 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 3 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 4 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 0, 4 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-
-  // part number should be retained
-  pl.adjacentVertices( QgsVertexId( 1, 0, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 1, 0, 3 ) );
-  QCOMPARE( next, QgsVertexId( 1, 0, 1 ) );
-
-  // interior ring
-  pl.addInteriorRing( closedRing1->clone() );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 1 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 1, 0 ) );
-  QCOMPARE( next, QgsVertexId( 0, 1, 2 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 2 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 1, 1 ) );
-  QCOMPARE( next, QgsVertexId( 0, 1, 3 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 3 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 1, 2 ) );
-  QCOMPARE( next, QgsVertexId( 0, 1, 4 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 1, 4 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
-
-  pl.adjacentVertices( QgsVertexId( 0, 2, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-}
-
-void TestQgsPolygon::vertexNumberFromVertexId()
-{
-  QgsLineString ls;
-  QCOMPARE( ls.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
-
-  QgsPolygon pl;
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), -1 );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
-                << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
-                << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
-
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), 5 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 1 ) ), 6 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 2 ) ), 7 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 3 ) ), 8 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 4 ) ), 9 );
-  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 5 ) ), -1 );
-}
-
-void TestQgsPolygon::segmentLength()
-{
-  QgsPolygon pl;
-
-  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
-                << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
-                << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
-
-  // add interior ring
-  ls.setPoints( QgsPointSequence() << QgsPoint( 30, 6 )
-                << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
-                << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
-  pl.addInteriorRing( ls.clone() );
-
-  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, -1 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 4.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 2.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 2 ) ), 4.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 3 ) ), 2.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 4 ) ), 0.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
-  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
-}
-
-void TestQgsPolygon::removeDuplicateNodes()
-{
-  QgsPolygon pl;
-
-  QVERIFY( !pl.removeDuplicateNodes() );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 )
-                << QgsPoint( 11, 22 ) << QgsPoint( 11, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( !pl.removeDuplicateNodes() );
-  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
-                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
-                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
-                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
-                << QgsPoint( 11, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
-  QVERIFY( !pl.removeDuplicateNodes( 0.02 ) );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
-                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
-                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
-                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
-                << QgsPoint( 11, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( !pl.removeDuplicateNodes() );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11.01 1.99, 11.02 2.01, 11 12, 11 22, 11.01 21.99, 10.99 1.99, 11 2))" ) );
-
-  // don't create degenerate rings
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 2.01 )
-                << QgsPoint( 11, 2.01 ) << QgsPoint( 11, 2 ) );
-  pl.addInteriorRing( ls.clone() );
-
-  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2),(11 2, 11.01 2.01, 11 2.01, 11 2))" ) );
-}
-
-void TestQgsPolygon::swapXy()
-{
-  QgsPolygon pl;
-  pl.swapXy(); //no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  pl.setExteriorRing( ls.clone() );
-
-  pl.swapXy();
-  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((2 11 3 4, 12 11 13 14, 22 11 23 24, 2 11 3 4))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.swapXy();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(2 1 5 6, 2.01 11.01 15 16, 2.01 11 25 26, 2 11 5 6, 2 1 5 6))" ) );
-}
-
-void TestQgsPolygon::filterVertices()
-{
-  auto filter = []( const QgsPoint & point )-> bool
-  {
-    return point.x() > 5;
-  };
-
-  QgsPolygon pl;
-  pl.filterVertices( filter ); // no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  pl.setExteriorRing( ls.clone() );
-
-  pl.filterVertices( filter );
-
-  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.filterVertices( filter );
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(10 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 11 2 5 6, 10 2 5 6),(11.01 2.01 15 16, 11 2.01 25 26))" ) );
-}
-
-void TestQgsPolygon::transformVertices()
-{
-  auto transform = []( const QgsPoint & point )-> QgsPoint
-  {
-    return QgsPoint( point.x() + 2, point.y() + 3, point.z() + 4, point.m() + 5 );
-  };
-
-  QgsPolygon pl;
-  pl.transformVertices( transform ); // no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  pl.setExteriorRing( ls.clone() );
-
-  pl.transformVertices( transform );
-  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((13 5 7 9, 6 15 17 19, 13 15 17 19, 13 25 27 29, 13 5 7 9))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.transformVertices( transform );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((15 8 11 14, 8 18 21 24, 15 18 21 24, 15 28 31 34, 15 8 11 14),(12 5 9 11, 6 15 17 19, 13.01 5.01 19 21, 13 5.01 29 31, 13 5 9 11, 12 5 9 11),(3 5 9 11, 13.01 5.01 19 21, 13 5.01 29 31, 3 5 9 11))" ) );
-}
-
-void TestQgsPolygon::transformWithClass()
-{
-  QgsPolygon pl;
-  TestTransformer transformer;
-
-  // no crash
-  QVERIFY( pl.transform( &transformer ) );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( pl.transform( &transformer ) );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((33 16 8 3, 12 26 18 13, 33 26 18 13, 33 36 28 23, 33 16 8 3))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  QVERIFY( pl.transform( &transformer ) );
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((99 30 13 2, 36 40 23 12, 99 40 23 12, 99 50 33 22, 99 30 13 2),(30 16 10 5, 12 26 18 13, 33.03 16.01 20 15, 33 16.01 30 25, 33 16 10 5, 30 16 10 5),(3 16 10 5, 33.03 16.01 20 15, 33 16.01 30 25, 3 16 10 5))" ) );
-
-  TestFailTransformer failTransformer;
-  QVERIFY( !pl.transform( &failTransformer ) );
-}
-
-void TestQgsPolygon::removeInvalidRings()
-{
-  QgsPolygon pl;
-  pl.removeInvalidRings(); // no crash
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
-                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  pl.setExteriorRing( ls.clone() );
-
-  pl.removeInvalidRings();
-  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
-                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
-                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
-                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  pl.addInteriorRing( ls.clone() );
-
-  pl.removeInvalidRings();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4),(1 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 1 2 5 6))" ) );
-}
-
-void TestQgsPolygon::forceRHR()
-{
-  QgsPolygon pl;
-  pl.forceRHR(); // no crash
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  pl.forceRHR();
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  pl.forceRHR();
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceRHR();
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceRHR();
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  pl.forceRHR();
-
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
-
-  // force cw (same as force RHR)
-  pl = QgsPolygon();
-  pl.forceClockwise(); // no crash
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  pl.forceClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  pl.forceClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  pl.forceClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
-
-  // force ccw
-  pl = QgsPolygon();
-  pl.forceCounterClockwise(); // no crash
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  pl.forceCounterClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  pl.forceCounterClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceCounterClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  pl.forceCounterClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
-
-  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  pl.forceCounterClockwise();
-  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-}
-
-void TestQgsPolygon::boundingBoxIntersects()
-{
-  QgsPolygon pl;
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-
-  QgsLineString ls;
-  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 2 ) << QgsPoint( 4, 2 )
-                << QgsPoint( 4, 4 ) << QgsPoint( 0, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-
-  // double test because of cache
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
-  QCOMPARE( pl.boundingBox(), QgsRectangle( 0, 2, 4, 4 ) );
-
-  // clear cache
-  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2 ) << QgsPoint( 14, 2 )
-                << QgsPoint( 15, 4 ) << QgsPoint( 10, 2 ) );
-  pl.setExteriorRing( ls.clone() );
-
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
-
-  // technically invalid -- the interior ring is outside the exterior, but we want boundingBoxIntersects to be tolerant to
-  // cases like this!
-  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 4, 2 )
-                << QgsPoint( 5, 4 ) << QgsPoint( 1, 2 ) );
-  pl.addInteriorRing( ls.clone() );
-
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
-  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 21, 3, 26, 9 ) ) );
-  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
 }
 
 QGSTEST_MAIN( TestQgsPolygon )

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -30,718 +30,1185 @@ class TestQgsPolygon: public QObject
 {
     Q_OBJECT
   private slots:
-    void polygon();
+    void constructor();
+    void setBadExteriorRing();
+    void setExteriorRing();
+    void setExteriorRingZM();
+    void setCurvedExteriorRing();
+    void addInteriorRing();
+    void addInteriorRingZM();
+    void polygon25D();
+    void altConstructor();
+    void setInteriorRings();
+    void setExteriorRingChangesInteriorRings();
+    void removeInteriorRing();
+    void clear();
+    void equality();
+    void clone();
+    void copy();
+    void assignment();
+    void toPolygon();
+    void toCurveType();
+    void toFromWkb();
+    void toFromWkbZM();
+    void toFromWkb25D();
+    void toFromWKT();
+    void exportImport();
+    void deleteVertexRemoveRing();
+    void boundary();
+    void pointDistanceToBoundary();
+    void removeInteriorRings();
+    void cast();
+    void transform2D();
+    void transform3D();
+    void transformReverse();
+    void transformOldVersion();
+    void Qtransform();
+    void closestSegment();
+    void nextVertex();
+    void dropZValue();
+    void dropMValue();
+    void vertexAngle();
+    void insertVertex();
+    void moveVertex();
+    void deleteVertex();
+    void deleteExteriorRing();
+    void adjacentVertices();
+    void vertexNumberFromVertexId();
+    void segmentLength();
+    void removeDuplicateNodes();
+    void filterVertices();
+    void swapXy();
+    void transformVertices();
+    void transformWithClass();
+    void removeInvalidRings();
+    void forceRHR();
+    void boundingBoxIntersects();
 };
 
-void TestQgsPolygon::polygon()
+void TestQgsPolygon::constructor()
 {
-  //test constructor
-  QgsPolygon p1;
-  QVERIFY( p1.isEmpty() );
-  QCOMPARE( p1.numInteriorRings(), 0 );
-  QCOMPARE( p1.nCoordinates(), 0 );
-  QCOMPARE( p1.ringCount(), 0 );
-  QCOMPARE( p1.partCount(), 0 );
-  QVERIFY( !p1.is3D() );
-  QVERIFY( !p1.isMeasure() );
-  QCOMPARE( p1.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p1.wktTypeStr(), QString( "Polygon" ) );
-  QCOMPARE( p1.geometryType(), QString( "Polygon" ) );
-  QCOMPARE( p1.dimension(), 2 );
-  QVERIFY( !p1.hasCurvedSegments() );
-  QCOMPARE( p1.area(), 0.0 );
-  QCOMPARE( p1.perimeter(), 0.0 );
-  QVERIFY( !p1.exteriorRing() );
-  QVERIFY( !p1.interiorRing( 0 ) );
+  QgsPolygon pl;
 
-  //set exterior ring
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 0 );
+  QCOMPARE( pl.partCount(), 0 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QCOMPARE( pl.wktTypeStr(), QString( "Polygon" ) );
+  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
+  QCOMPARE( pl.dimension(), 2 );
+  QVERIFY( !pl.hasCurvedSegments() );
+  QCOMPARE( pl.area(), 0.0 );
+  QCOMPARE( pl.perimeter(), 0.0 );
+  QVERIFY( !pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+}
+
+void TestQgsPolygon::setBadExteriorRing()
+{
+  QgsPolygon pl;
 
   //try with no ring
   QgsLineString *ext = nullptr;
-  p1.setExteriorRing( ext );
-  QVERIFY( p1.isEmpty() );
-  QCOMPARE( p1.numInteriorRings(), 0 );
-  QCOMPARE( p1.nCoordinates(), 0 );
-  QCOMPARE( p1.ringCount(), 0 );
-  QCOMPARE( p1.partCount(), 0 );
-  QVERIFY( !p1.exteriorRing() );
-  QVERIFY( !p1.interiorRing( 0 ) );
-  QCOMPARE( p1.wkbType(), QgsWkbTypes::Polygon );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 0 );
+  QCOMPARE( pl.partCount(), 0 );
+  QVERIFY( !pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
 
   // empty exterior ring
   ext = new QgsLineString();
-  p1.setExteriorRing( ext );
-  QVERIFY( p1.isEmpty() );
-  QCOMPARE( p1.numInteriorRings(), 0 );
-  QCOMPARE( p1.nCoordinates(), 0 );
-  QCOMPARE( p1.ringCount(), 1 );
-  QCOMPARE( p1.partCount(), 1 );
-  QVERIFY( p1.exteriorRing() );
-  QVERIFY( !p1.interiorRing( 0 ) );
-  QCOMPARE( p1.wkbType(), QgsWkbTypes::Polygon );
+  pl.setExteriorRing( ext );
 
-  //valid exterior ring
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p1.setExteriorRing( ext );
-  QVERIFY( !p1.isEmpty() );
-  QCOMPARE( p1.numInteriorRings(), 0 );
-  QCOMPARE( p1.nCoordinates(), 5 );
-  QCOMPARE( p1.ringCount(), 1 );
-  QCOMPARE( p1.partCount(), 1 );
-  QVERIFY( !p1.is3D() );
-  QVERIFY( !p1.isMeasure() );
-  QCOMPARE( p1.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p1.wktTypeStr(), QString( "Polygon" ) );
-  QCOMPARE( p1.geometryType(), QString( "Polygon" ) );
-  QCOMPARE( p1.dimension(), 2 );
-  QVERIFY( !p1.hasCurvedSegments() );
-  QCOMPARE( p1.area(), 100.0 );
-  QCOMPARE( p1.perimeter(), 40.0 );
-  QVERIFY( p1.exteriorRing() );
-  QVERIFY( !p1.interiorRing( 0 ) );
-
-  //retrieve exterior ring and check
-  QCOMPARE( *( static_cast< const QgsLineString * >( p1.exteriorRing() ) ), *ext );
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 1 );
+  QCOMPARE( pl.partCount(), 1 );
+  QVERIFY( pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
 
   //test that a non closed exterior ring will be automatically closed
   ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) );
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 )
+                  << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) );
+
   QVERIFY( !ext->isClosed() );
-  p1.setExteriorRing( ext );
-  QVERIFY( !p1.isEmpty() );
-  QVERIFY( p1.exteriorRing()->isClosed() );
-  QCOMPARE( p1.nCoordinates(), 5 );
+  pl.setExteriorRing( ext );
+  QVERIFY( !pl.isEmpty() );
+  QVERIFY( pl.exteriorRing()->isClosed() );
+  QCOMPARE( pl.nCoordinates(), 5 );
+}
+
+void TestQgsPolygon::setExteriorRing()
+{
+  QgsPolygon pl;
+
+  //valid exterior ring
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 5 );
+  QCOMPARE( pl.ringCount(), 1 );
+  QCOMPARE( pl.partCount(), 1 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QCOMPARE( pl.wktTypeStr(), QString( "Polygon" ) );
+  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
+  QCOMPARE( pl.dimension(), 2 );
+  QVERIFY( !pl.hasCurvedSegments() );
+  QCOMPARE( pl.area(), 100.0 );
+  QCOMPARE( pl.perimeter(), 40.0 );
+  QVERIFY( pl.exteriorRing() );
+  QVERIFY( !pl.interiorRing( 0 ) );
+
+  //retrieve exterior ring and check
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+}
+
+void TestQgsPolygon::setExteriorRingZM()
+{
+  QgsPolygon pl;
 
   //initial setting of exterior ring should set z/m type
-  QgsPolygon p2;
-  ext = new QgsLineString();
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  p2.setExteriorRing( ext );
-  QVERIFY( p2.is3D() );
-  QVERIFY( !p2.isMeasure() );
-  QCOMPARE( p2.wkbType(), QgsWkbTypes::PolygonZ );
-  QCOMPARE( p2.wktTypeStr(), QString( "PolygonZ" ) );
-  QCOMPARE( p2.geometryType(), QString( "Polygon" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( p2.exteriorRing() ) ), *ext );
-  QgsPolygon p3;
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
+  QCOMPARE( pl.geometryType(), QString( "Polygon" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 10, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 0, 0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
-  p3.setExteriorRing( ext );
-  QVERIFY( !p3.is3D() );
-  QVERIFY( p3.isMeasure() );
-  QCOMPARE( p3.wkbType(), QgsWkbTypes::PolygonM );
-  QCOMPARE( p3.wktTypeStr(), QString( "PolygonM" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( p3.exteriorRing() ) ), *ext );
-  QgsPolygon p4;
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 10, 0, 2 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 0, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonM" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 3, 2 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 5, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 ) );
-  p4.setExteriorRing( ext );
-  QVERIFY( p4.is3D() );
-  QVERIFY( p4.isMeasure() );
-  QCOMPARE( p4.wkbType(), QgsWkbTypes::PolygonZM );
-  QCOMPARE( p4.wktTypeStr(), QString( "PolygonZM" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( p4.exteriorRing() ) ), *ext );
-  QgsPolygon p5;
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 3, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 5, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 2, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZM" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+
+  pl.clear();
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
-  p5.setExteriorRing( ext );
-  QVERIFY( p5.is3D() );
-  QVERIFY( !p5.isMeasure() );
-  QCOMPARE( p5.wkbType(), QgsWkbTypes::Polygon25D );
-  QCOMPARE( p5.wktTypeStr(), QString( "PolygonZ" ) );
-  QCOMPARE( *( static_cast< const QgsLineString * >( p5.exteriorRing() ) ), *ext );
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon25D );
+  QCOMPARE( pl.wktTypeStr(), QString( "PolygonZ" ) );
+  QCOMPARE( *( static_cast< const QgsLineString * >( pl.exteriorRing() ) ), *ext );
+}
+
+void TestQgsPolygon::setCurvedExteriorRing()
+{
+  QgsPolygon pl;
 
   //setting curved exterior ring should be segmentized
-  QgsCircularString *circularRing = new QgsCircularString();
-  circularRing->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                           << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  QVERIFY( circularRing->hasCurvedSegments() );
-  p5.setExteriorRing( circularRing );
-  QVERIFY( !p5.exteriorRing()->hasCurvedSegments() );
-  QCOMPARE( p5.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QgsCircularString *cs = new QgsCircularString();
+  cs->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                 << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                 << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
 
-  //addInteriorRing
-  QgsPolygon p6;
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+  QVERIFY( cs->hasCurvedSegments() );
+
+  pl.setExteriorRing( cs );
+
+  QVERIFY( !pl.exteriorRing()->hasCurvedSegments() );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+}
+
+void TestQgsPolygon::addInteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
                   << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p6.setExteriorRing( ext );
-  //empty ring
-  QCOMPARE( p6.numInteriorRings(), 0 );
-  QVERIFY( !p6.interiorRing( -1 ) );
-  QVERIFY( !p6.interiorRing( 0 ) );
-  p6.addInteriorRing( nullptr );
-  QCOMPARE( p6.numInteriorRings(), 0 );
-  QgsLineString *ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 ) << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
-                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
-  p6.addInteriorRing( ring );
-  QCOMPARE( p6.numInteriorRings(), 1 );
-  QCOMPARE( p6.interiorRing( 0 ), ring );
-  QVERIFY( !p6.interiorRing( 1 ) );
+  pl.setExteriorRing( ext );
 
-  QgsCoordinateSequence seq = p6.coordinateSequence();
-  QCOMPARE( seq, QgsCoordinateSequence() << ( QgsRingSequence() << ( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-            << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) )
-            << ( QgsPointSequence() << QgsPoint( 1, 1 ) << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
-                 << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) ) ) );
-  QCOMPARE( p6.nCoordinates(), 10 );
+  //empty ring
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QVERIFY( !pl.interiorRing( -1 ) );
+  QVERIFY( !pl.interiorRing( 0 ) );
+
+  pl.addInteriorRing( nullptr );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QCOMPARE( pl.interiorRing( 0 ), ring );
+  QVERIFY( !pl.interiorRing( 1 ) );
+
+  QgsCoordinateSequence seq = pl.coordinateSequence();
+  QgsRingSequence expected;
+  expected << ( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  expected << ( QgsPointSequence() << QgsPoint( 1, 1 )
+                << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+
+  QCOMPARE( seq, QgsCoordinateSequence() << expected );
+  QCOMPARE( pl.nCoordinates(), 10 );
 
   //add non-closed interior ring, should be closed automatically
   ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.9 ) << QgsPoint( 0.9, 0.9 )
+  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                   << QgsPoint( 0.1, 0.9 ) << QgsPoint( 0.9, 0.9 )
                    << QgsPoint( 0.9, 0.1 ) );
+
   QVERIFY( !ring->isClosed() );
-  p6.addInteriorRing( ring );
-  QCOMPARE( p6.numInteriorRings(), 2 );
-  QVERIFY( p6.interiorRing( 1 )->isClosed() );
+
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 2 );
+  QVERIFY( pl.interiorRing( 1 )->isClosed() );
+}
+
+void TestQgsPolygon::addInteriorRingZM()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                   << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
+                   << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.9 )
+                   << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.1 ) );
+  pl.addInteriorRing( ring );
 
   //try adding an interior ring with z to a 2d polygon, z should be dropped
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
-  p6.addInteriorRing( ring );
-  QCOMPARE( p6.numInteriorRings(), 3 );
-  QVERIFY( !p6.is3D() );
-  QVERIFY( !p6.isMeasure() );
-  QCOMPARE( p6.wkbType(), QgsWkbTypes::Polygon );
-  QVERIFY( p6.interiorRing( 2 ) );
-  QVERIFY( !p6.interiorRing( 2 )->is3D() );
-  QVERIFY( !p6.interiorRing( 2 )->isMeasure() );
-  QCOMPARE( p6.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QVERIFY( pl.interiorRing( 2 ) );
+  QVERIFY( !pl.interiorRing( 2 )->is3D() );
+  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
 
   //try adding an interior ring with m to a 2d polygon, m should be dropped
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
-  p6.addInteriorRing( ring );
-  QCOMPARE( p6.numInteriorRings(), 4 );
-  QVERIFY( !p6.is3D() );
-  QVERIFY( !p6.isMeasure() );
-  QCOMPARE( p6.wkbType(), QgsWkbTypes::Polygon );
-  QVERIFY( p6.interiorRing( 3 ) );
-  QVERIFY( !p6.interiorRing( 3 )->is3D() );
-  QVERIFY( !p6.interiorRing( 3 )->isMeasure() );
-  QCOMPARE( p6.interiorRing( 3 )->wkbType(), QgsWkbTypes::LineString );
+                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 )
+                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 4 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QVERIFY( pl.interiorRing( 3 ) );
+  QVERIFY( !pl.interiorRing( 3 )->is3D() );
+  QVERIFY( !pl.interiorRing( 3 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 3 )->wkbType(), QgsWkbTypes::LineString );
 
   //addInteriorRing without z/m to PolygonZM
-  QgsPolygon p6b;
+  pl.clear();
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 ) );
-  p6b.setExteriorRing( ext );
-  QVERIFY( p6b.is3D() );
-  QVERIFY( p6b.isMeasure() );
-  QCOMPARE( p6b.wkbType(), QgsWkbTypes::PolygonZM );
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+
   //ring has no z
   ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 1, 9 ) << QgsPoint( QgsWkbTypes::PointM, 9, 9 )
-                   << QgsPoint( QgsWkbTypes::PointM, 9, 1 ) << QgsPoint( QgsWkbTypes::PointM, 1, 1 ) );
-  p6b.addInteriorRing( ring );
-  QVERIFY( p6b.interiorRing( 0 ) );
-  QVERIFY( p6b.interiorRing( 0 )->is3D() );
-  QVERIFY( p6b.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( p6b.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZM );
-  QCOMPARE( p6b.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 1, 0, 2 ) );
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 2 )
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 9 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 9 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 1 )
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( pl.interiorRing( 0 )->is3D() );
+  QVERIFY( pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZM );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 0, 2 ) );
+
   //ring has no m
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
-  p6b.addInteriorRing( ring );
-  QVERIFY( p6b.interiorRing( 1 ) );
-  QVERIFY( p6b.interiorRing( 1 )->is3D() );
-  QVERIFY( p6b.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( p6b.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineStringZM );
-  QCOMPARE( p6b.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 0.1, 0.1, 1, 0 ) );
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QVERIFY( pl.interiorRing( 1 ) );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineStringZM );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 0.1, 0.1, 1, 0 ) );
+}
+
+void TestQgsPolygon::polygon25D()
+{
   //test handling of 25D rings/polygons
-  QgsPolygon p6c;
-  ext = new QgsLineString();
+  QgsPolygon pl;
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
-  p6c.setExteriorRing( ext );
-  QVERIFY( p6c.is3D() );
-  QVERIFY( !p6c.isMeasure() );
-  QCOMPARE( p6c.wkbType(), QgsWkbTypes::Polygon25D );
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon25D );
+
   //adding a LineStringZ, should become LineString25D
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
-  QCOMPARE( ring->wkbType(), QgsWkbTypes::LineStringZ );
-  p6c.addInteriorRing( ring );
-  QVERIFY( p6c.interiorRing( 0 ) );
-  QVERIFY( p6c.interiorRing( 0 )->is3D() );
-  QVERIFY( !p6c.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( p6c.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
-  QCOMPARE( p6c.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::Point25D, 0.1, 0.1, 1 ) );
+  QgsLineString *ring1 = new QgsLineString();
+  ring1->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
+                    << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+                    << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+                    << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+                    << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+
+  QCOMPARE( ring1->wkbType(), QgsWkbTypes::LineStringZ );
+
+  pl.addInteriorRing( ring1 );
+
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point25D, 0.1, 0.1, 1 ) );
+
   //add a LineStringM, should become LineString25D
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
-                   << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
-  QCOMPARE( ring->wkbType(), QgsWkbTypes::LineStringM );
-  p6c.addInteriorRing( ring );
-  QVERIFY( p6c.interiorRing( 1 ) );
-  QVERIFY( p6c.interiorRing( 1 )->is3D() );
-  QVERIFY( !p6c.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( p6c.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
-  QCOMPARE( p6c.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::Point25D, 0.1, 0.1 ) );
+  ring1 = new QgsLineString();
+  ring1->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 )
+                    << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.2, 0, 2 )
+                    << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.2, 0, 3 )
+                    << QgsPoint( QgsWkbTypes::PointM, 0.2, 0.1, 0, 4 )
+                    << QgsPoint( QgsWkbTypes::PointM, 0.1, 0.1, 0, 1 ) );
+
+  QCOMPARE( ring1->wkbType(), QgsWkbTypes::LineStringM );
+
+  pl.addInteriorRing( ring1 );
+
+  QVERIFY( pl.interiorRing( 1 ) );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point25D, 0.1, 0.1 ) );
 
   //add curved ring to polygon
-  circularRing = new QgsCircularString();
-  circularRing->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                           << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  QVERIFY( circularRing->hasCurvedSegments() );
-  p6c.addInteriorRing( circularRing );
-  QVERIFY( p6c.interiorRing( 2 ) );
-  QVERIFY( !p6c.interiorRing( 2 )->hasCurvedSegments() );
-  QVERIFY( p6c.interiorRing( 2 )->is3D() );
-  QVERIFY( !p6c.interiorRing( 2 )->isMeasure() );
-  QCOMPARE( p6c.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString25D );
+  QgsCircularString *ring2 = new QgsCircularString();
+  ring2->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                    << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                    << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
 
-  // alternate constructor
-  QgsPolygon pc6( new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) ),
-                  QList< QgsLineString *>() << new QgsLineString( QVector< QgsPoint >() << QgsPoint( 1, 1 ) << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 ) << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) )
-                  << new QgsLineString( QVector< QgsPoint >() << QgsPoint( 3, 1 ) << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 ) << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) ) );
-  QCOMPARE( pc6.asWkt(), QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1))" ) );
+  QVERIFY( ring2->hasCurvedSegments() );
 
-  //set interior rings
-  QgsPolygon p7;
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+  pl.addInteriorRing( ring2 );
+
+  QVERIFY( pl.interiorRing( 2 ) );
+  QVERIFY( !pl.interiorRing( 2 )->hasCurvedSegments() );
+  QVERIFY( pl.interiorRing( 2 )->is3D() );
+  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString25D );
+}
+
+void TestQgsPolygon::altConstructor()
+{
+  QgsLineString *ext = new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0 )
+                                          << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                                          << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  QgsLineString *ring1 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 1, 1 )
+      << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 )
+      << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) );
+  QgsLineString *ring2 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 3, 1 )
+      << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 )
+      << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) );
+
+  QgsPolygon pl( ext, QList< QgsLineString *>() << ring1 << ring2 );
+
+  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1))" ) );
+}
+
+void TestQgsPolygon::setInteriorRings()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
                   << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p7.setExteriorRing( ext );
+  pl.setExteriorRing( ext );
+
   //add a list of rings with mixed types
   QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
   rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 ) << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 );
   rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 )
-      << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 )
-      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 ) );
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
   //throw an empty ring in too
   rings << 0;
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+      << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 );
   rings << new QgsCircularString();
-  static_cast< QgsCircularString *>( rings[3] )->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-      << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p7.setInteriorRings( rings );
-  QCOMPARE( p7.numInteriorRings(), 3 );
-  QVERIFY( p7.interiorRing( 0 ) );
-  QVERIFY( !p7.interiorRing( 0 )->is3D() );
-  QVERIFY( !p7.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( p7.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( p7.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::Point, 0.1, 0.1 ) );
-  QVERIFY( p7.interiorRing( 1 ) );
-  QVERIFY( !p7.interiorRing( 1 )->is3D() );
-  QVERIFY( !p7.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( p7.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( p7.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::Point, 0.3, 0.3 ) );
-  QVERIFY( p7.interiorRing( 2 ) );
-  QVERIFY( !p7.interiorRing( 2 )->is3D() );
-  QVERIFY( !p7.interiorRing( 2 )->isMeasure() );
-  QCOMPARE( p7.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
+  static_cast< QgsCircularString *>( rings[3] )->setPoints( QgsPointSequence() );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.1, 0.1 ) );
+
+  QVERIFY( pl.interiorRing( 1 ) );
+  QVERIFY( !pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.3, 0.3 ) );
+
+  QVERIFY( pl.interiorRing( 2 ) );
+  QVERIFY( !pl.interiorRing( 2 )->is3D() );
+  QVERIFY( !pl.interiorRing( 2 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 2 )->wkbType(), QgsWkbTypes::LineString );
 
   //set rings with existing
   rings.clear();
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 ) << QgsPoint( 0.9, 0.9 )
+      << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.8, 0.8 );
   rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 )
-      << QgsPoint( 0.8, 0.9 ) << QgsPoint( 0.9, 0.9 )
-      << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.8, 0.8 ) );
-  p7.setInteriorRings( rings );
-  QCOMPARE( p7.numInteriorRings(), 1 );
-  QVERIFY( p7.interiorRing( 0 ) );
-  QVERIFY( !p7.interiorRing( 0 )->is3D() );
-  QVERIFY( !p7.interiorRing( 0 )->isMeasure() );
-  QCOMPARE( p7.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( p7.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::Point, 0.8, 0.8 ) );
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QVERIFY( pl.interiorRing( 0 ) );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::Point, 0.8, 0.8 ) );
+
   rings.clear();
-  p7.setInteriorRings( rings );
-  QCOMPARE( p7.numInteriorRings(), 0 );
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+}
+
+void TestQgsPolygon::setExteriorRingChangesInteriorRings()
+{
+  QgsPolygon pl;
 
   //change dimensionality of interior rings using setExteriorRing
-  QgsPolygon p7a;
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  p7a.setExteriorRing( ext );
-  rings.clear();
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
   rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) );
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3,  1 );
   rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3,  1 ) );
-  p7a.setInteriorRings( rings );
-  QVERIFY( p7a.is3D() );
-  QVERIFY( !p7a.isMeasure() );
-  QVERIFY( p7a.interiorRing( 0 )->is3D() );
-  QVERIFY( !p7a.interiorRing( 0 )->isMeasure() );
-  QVERIFY( p7a.interiorRing( 1 )->is3D() );
-  QVERIFY( !p7a.interiorRing( 1 )->isMeasure() );
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+
   //reset exterior ring to 2d
   ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 )
-                  << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p7a.setExteriorRing( ext );
-  QVERIFY( !p7a.is3D() );
-  QVERIFY( !p7a.interiorRing( 0 )->is3D() ); //rings should also be made 2D
-  QVERIFY( !p7a.interiorRing( 1 )->is3D() );
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.interiorRing( 0 )->is3D() ); //rings should also be made 2D
+  QVERIFY( !pl.interiorRing( 1 )->is3D() );
+
   //reset exterior ring to LineStringM
   ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0 ) << QgsPoint( QgsWkbTypes::PointM, 0, 10 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 10 ) << QgsPoint( QgsWkbTypes::PointM, 10, 0 ) << QgsPoint( QgsWkbTypes::PointM, 0, 0 ) );
-  p7a.setExteriorRing( ext );
-  QVERIFY( p7a.isMeasure() );
-  QVERIFY( p7a.interiorRing( 0 )->isMeasure() ); //rings should also gain measure
-  QVERIFY( p7a.interiorRing( 1 )->isMeasure() );
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 0 ) );
+
+  pl.setExteriorRing( ext );
+
+  QVERIFY( pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->isMeasure() ); //rings should also gain measure
+  QVERIFY( pl.interiorRing( 1 )->isMeasure() );
+
   //25D exterior ring
   ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0 ) << QgsPoint( QgsWkbTypes::Point25D, 0, 10 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10 ) << QgsPoint( QgsWkbTypes::Point25D, 10, 0 ) << QgsPoint( QgsWkbTypes::Point25D, 0, 0 ) );
-  p7a.setExteriorRing( ext );
-  QVERIFY( p7a.is3D() );
-  QVERIFY( !p7a.isMeasure() );
-  QVERIFY( p7a.interiorRing( 0 )->is3D() ); //rings should also be made 25D
-  QVERIFY( !p7a.interiorRing( 0 )->isMeasure() );
-  QVERIFY( p7a.interiorRing( 1 )->is3D() );
-  QVERIFY( !p7a.interiorRing( 1 )->isMeasure() );
-  QCOMPARE( p7a.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
-  QCOMPARE( p7a.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0 ) );
 
+  pl.setExteriorRing( ext );
 
-  //removeInteriorRing
-  QgsPolygon p8;
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+  QVERIFY( pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QVERIFY( pl.interiorRing( 0 )->is3D() ); //rings should also be made 25D
+  QVERIFY( !pl.interiorRing( 0 )->isMeasure() );
+  QVERIFY( pl.interiorRing( 1 )->is3D() );
+  QVERIFY( !pl.interiorRing( 1 )->isMeasure() );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString25D );
+  QCOMPARE( pl.interiorRing( 1 )->wkbType(), QgsWkbTypes::LineString25D );
+}
+
+void TestQgsPolygon::removeInteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
                   << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p8.setExteriorRing( ext );
-  QVERIFY( !p8.removeInteriorRing( -1 ) );
-  QVERIFY( !p8.removeInteriorRing( 0 ) );
-  rings.clear();
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[0] )->setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
-      << QgsPoint( 0.1, 0.2 ) << QgsPoint( 0.2, 0.2 )
-      << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.1, 0.1 ) );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[1] )->setPoints( QgsPointSequence() << QgsPoint( 0.3, 0.3 )
-      << QgsPoint( 0.3, 0.4 ) << QgsPoint( 0.4, 0.4 )
-      << QgsPoint( 0.4, 0.3 ) << QgsPoint( 0.3, 0.3 ) );
-  rings << new QgsLineString();
-  static_cast< QgsLineString *>( rings[2] )->setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 )
-      << QgsPoint( 0.8, 0.9 ) << QgsPoint( 0.9, 0.9 )
-      << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.8, 0.8 ) );
-  p8.setInteriorRings( rings );
-  QCOMPARE( p8.numInteriorRings(), 3 );
-  QVERIFY( p8.removeInteriorRing( 0 ) );
-  QCOMPARE( p8.numInteriorRings(), 2 );
-  QCOMPARE( p8.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
-  QCOMPARE( p8.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.8, 0.8 ) );
-  QVERIFY( p8.removeInteriorRing( 1 ) );
-  QCOMPARE( p8.numInteriorRings(), 1 );
-  QCOMPARE( p8.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
-  QVERIFY( p8.removeInteriorRing( 0 ) );
-  QCOMPARE( p8.numInteriorRings(), 0 );
-  QVERIFY( !p8.removeInteriorRing( 0 ) );
+  pl.setExteriorRing( ext );
 
-  //clear
-  QgsPolygon p9;
+  QVERIFY( !pl.removeInteriorRing( -1 ) );
+  QVERIFY( !pl.removeInteriorRing( 0 ) );
+
+  QVector< QgsCurve * > rings;
+
+  QgsPointSequence pts;
+  pts << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.1, 0.2 )
+      << QgsPoint( 0.2, 0.2 ) << QgsPoint( 0.2, 0.1 )
+      << QgsPoint( 0.1, 0.1 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.3, 0.3 ) << QgsPoint( 0.3, 0.4 )
+      << QgsPoint( 0.4, 0.4 ) << QgsPoint( 0.4, 0.3 )
+      << QgsPoint( 0.3, 0.3 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
+
+  pts = QgsPointSequence();
+  pts << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.8, 0.9 )
+      << QgsPoint( 0.9, 0.9 ) << QgsPoint( 0.9, 0.8 )
+      << QgsPoint( 0.8, 0.8 );
+  rings << new QgsLineString();
+  static_cast< QgsLineString *>( rings[2] )->setPoints( pts );
+
+  pl.setInteriorRings( rings );
+
+  QCOMPARE( pl.numInteriorRings(), 3 );
+
+  QVERIFY( pl.removeInteriorRing( 0 ) );
+  QCOMPARE( pl.numInteriorRings(), 2 );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
+  QCOMPARE( pl.interiorRing( 1 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.8, 0.8 ) );
+
+  QVERIFY( pl.removeInteriorRing( 1 ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+  QCOMPARE( pl.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( 0.3, 0.3 ) );
+
+  QVERIFY( pl.removeInteriorRing( 0 ) );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QVERIFY( !pl.removeInteriorRing( 0 ) );
+}
+
+void TestQgsPolygon::clear()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 1, 9, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 9, 9, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 9, 1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 ) );
+  pl.addInteriorRing( ring );
+
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  pl.clear();
+
+  QVERIFY( pl.isEmpty() );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QCOMPARE( pl.nCoordinates(), 0 );
+  QCOMPARE( pl.ringCount(), 0 );
+  QCOMPARE( pl.partCount(), 0 );
+  QVERIFY( !pl.is3D() );
+  QVERIFY( !pl.isMeasure() );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+}
+
+void TestQgsPolygon::equality()
+{
+  QgsPolygon pl1;
+  QgsPolygon pl2;
+
+  QVERIFY( pl1 == pl2 );
+  QVERIFY( !( pl1 != pl2 ) );
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl1.setExteriorRing( ext );
+
+  QVERIFY( !( pl1 == pl2 ) );
+  QVERIFY( pl1 != pl2 );
+
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  pl2.setExteriorRing( ext );
+
+  QVERIFY( pl1 == pl2 );
+  QVERIFY( !( pl1 != pl2 ) );
+
+  ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                  << QgsPoint( 0, 9 ) << QgsPoint( 9, 9 )
+                  << QgsPoint( 9, 0 ) << QgsPoint( 0, 0 ) );
+  pl2.setExteriorRing( ext );
+
+  QVERIFY( !( pl1 == pl2 ) );
+  QVERIFY( pl1 != pl2 );
+
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  p9.setExteriorRing( ext );
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 1, 9, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 9, 9, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 9, 1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 ) );
-  p9.addInteriorRing( ring );
-  QCOMPARE( p9.numInteriorRings(), 1 );
-  p9.clear();
-  QVERIFY( p9.isEmpty() );
-  QCOMPARE( p9.numInteriorRings(), 0 );
-  QCOMPARE( p9.nCoordinates(), 0 );
-  QCOMPARE( p9.ringCount(), 0 );
-  QCOMPARE( p9.partCount(), 0 );
-  QVERIFY( !p9.is3D() );
-  QVERIFY( !p9.isMeasure() );
-  QCOMPARE( p9.wkbType(), QgsWkbTypes::Polygon );
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl2.setExteriorRing( ext );
 
-  //equality operator
-  QgsPolygon p10;
-  QgsPolygon p10b;
-  QVERIFY( p10 == p10b );
-  QVERIFY( !( p10 != p10b ) );
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p10.setExteriorRing( ext );
-  QVERIFY( !( p10 == p10b ) );
-  QVERIFY( p10 != p10b );
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                  << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  p10b.setExteriorRing( ext );
-  QVERIFY( p10 == p10b );
-  QVERIFY( !( p10 != p10b ) );
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0, 9 ) << QgsPoint( 9, 9 )
-                  << QgsPoint( 9, 0 ) << QgsPoint( 0, 0 ) );
-  p10b.setExteriorRing( ext );
-  QVERIFY( !( p10 == p10b ) );
-  QVERIFY( p10 != p10b );
-  ext = new QgsLineString();
-  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  p10b.setExteriorRing( ext );
-  QVERIFY( !( p10 == p10b ) );
-  QVERIFY( p10 != p10b );
-  p10b.setExteriorRing( p10.exteriorRing()->clone() );
-  QVERIFY( p10 == p10b );
-  QVERIFY( !( p10 != p10b ) );
-  ring = new QgsLineString();
+  QVERIFY( !( pl1 == pl2 ) );
+  QVERIFY( pl1 != pl2 );
+
+  pl2.setExteriorRing( pl1.exteriorRing()->clone() );
+
+  QVERIFY( pl1 == pl2 );
+  QVERIFY( !( pl1 != pl2 ) );
+
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
                    << QgsPoint( 1, 9 ) << QgsPoint( 9, 9 )
                    << QgsPoint( 9, 1 ) << QgsPoint( 1, 1 ) );
-  p10.addInteriorRing( ring );
-  QVERIFY( !( p10 == p10b ) );
-  QVERIFY( p10 != p10b );
+  pl1.addInteriorRing( ring );
+
+  QVERIFY( !( pl1 == pl2 ) );
+  QVERIFY( pl1 != pl2 );
 
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( 2, 1 )
                    << QgsPoint( 2, 9 ) << QgsPoint( 9, 9 )
                    << QgsPoint( 9, 1 ) << QgsPoint( 2, 1 ) );
-  p10b.addInteriorRing( ring );
-  QVERIFY( !( p10 == p10b ) );
-  QVERIFY( p10 != p10b );
-  p10b.removeInteriorRing( 0 );
-  p10b.addInteriorRing( p10.interiorRing( 0 )->clone() );
-  QVERIFY( p10 == p10b );
-  QVERIFY( !( p10 != p10b ) );
+  pl2.addInteriorRing( ring );
 
-  QgsLineString nonPolygon;
-  QVERIFY( p10 != nonPolygon );
-  QVERIFY( !( p10 == nonPolygon ) );
+  QVERIFY( !( pl1 == pl2 ) );
+  QVERIFY( pl1 != pl2 );
 
-  //clone
+  pl2.removeInteriorRing( 0 );
+  pl2.addInteriorRing( pl1.interiorRing( 0 )->clone() );
 
-  QgsPolygon p11;
-  std::unique_ptr< QgsPolygon >cloned( p11.clone() );
-  QCOMPARE( p11, *cloned );
-  ext = new QgsLineString();
+  QVERIFY( pl1 == pl2 );
+  QVERIFY( !( pl1 != pl2 ) );
+
+  QgsLineString ls;
+  QVERIFY( pl1 != ls );
+  QVERIFY( !( pl1 == ls ) );
+}
+
+void TestQgsPolygon::clone()
+{
+  QgsPolygon pl;
+
+  std::unique_ptr< QgsPolygon > cloned( pl.clone() );
+  QCOMPARE( pl, *cloned );
+
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
-  p11.setExteriorRing( ext );
-  ring = new QgsLineString();
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl.addInteriorRing( ring );
+
+  cloned.reset( pl.clone() );
+  QCOMPARE( pl, *cloned );
+}
+
+void TestQgsPolygon::copy()
+{
+  QgsPolygon pl1;
+  QgsPolygon pl2( pl1 );
+
+  QCOMPARE( pl1, pl2 );
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl1.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
                    << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
-  p11.addInteriorRing( ring );
-  cloned.reset( p11.clone() );
-  QCOMPARE( p11, *cloned );
+  pl1.addInteriorRing( ring );
 
-  //copy constructor
-  QgsPolygon p12;
-  QgsPolygon p13( p12 );
-  QCOMPARE( p12, p13 );
-  ext = new QgsLineString();
+  pl2 = QgsPolygon( pl1 );
+  QCOMPARE( pl1, pl2 );
+}
+
+void TestQgsPolygon::assignment()
+{
+  QgsPolygon pl1;
+  QgsPolygon pl2;
+
+  pl1 = pl2;
+  QCOMPARE( pl2, pl1 );
+
+  QgsPolygon pl3;
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
-  p12.setExteriorRing( ext );
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
-  p12.addInteriorRing( ring );
-  QgsPolygon p14( p12 );
-  QCOMPARE( p12, p14 );
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl3.setExteriorRing( ext );
 
-  //assignment operator
-  QgsPolygon p15;
-  p15 = p13;
-  QCOMPARE( p13, p15 );
-  p15 = p12;
-  QCOMPARE( p12, p15 );
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl3.addInteriorRing( ring );
+
+  pl1 = pl3;
+  QCOMPARE( pl3, pl1 );
+}
+
+void TestQgsPolygon::toPolygon()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl.addInteriorRing( ring );
 
   //surfaceToPolygon - should be identical given polygon has no curves
-  std::unique_ptr< QgsPolygon > surface( p12.surfaceToPolygon() );
-  QCOMPARE( *surface, p12 );
-  //toPolygon - should be identical given polygon has no curves
-  std::unique_ptr< QgsPolygon > toP( p12.toPolygon() );
-  QCOMPARE( *toP, p12 );
+  std::unique_ptr< QgsPolygon > surface( pl.surfaceToPolygon() );
+  QCOMPARE( *surface, pl );
 
-  //toCurveType
-  std::unique_ptr< QgsCurvePolygon > curveType( p12.toCurveType() );
+  //toPolygon - should be identical given polygon has no curves
+  std::unique_ptr< QgsPolygon > toP( pl.toPolygon() );
+  QCOMPARE( *toP, pl );
+}
+
+void TestQgsPolygon::toCurveType()
+{
+  QgsPolygon pl;
+
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl.addInteriorRing( ring );
+
+  std::unique_ptr< QgsCurvePolygon > curveType( pl.toCurveType() );
+
   QCOMPARE( curveType->wkbType(), QgsWkbTypes::CurvePolygonZM );
+
   QCOMPARE( curveType->exteriorRing()->numPoints(), 5 );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 3 ) ), QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 4 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 ) );
+  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 1 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) );
+  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 2 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 ) );
+  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 3 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) );
+  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 4 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+
   QCOMPARE( curveType->numInteriorRings(), 1 );
   QCOMPARE( curveType->interiorRing( 0 )->numPoints(), 5 );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 3 ) ), QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 4 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 ) );
+  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 1 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) );
+  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 2 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 ) );
+  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 3 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) );
+  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 4 ) ),
+            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+}
 
-  //to/fromWKB
-  QgsPolygon p16;
-  ext = new QgsLineString();
+void TestQgsPolygon::toFromWkb()
+{
+  QgsPolygon pl1;
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 0, 0 )
-                  << QgsPoint( QgsWkbTypes::Point, 0, 10 ) << QgsPoint( QgsWkbTypes::Point, 10, 10 )
-                  << QgsPoint( QgsWkbTypes::Point, 10, 0 ) << QgsPoint( QgsWkbTypes::Point, 0, 0 ) );
-  p16.setExteriorRing( ext );
-  ring = new QgsLineString();
+                  << QgsPoint( QgsWkbTypes::Point, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::Point, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::Point, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::Point, 0, 0 ) );
+  pl1.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 1, 1 )
-                   << QgsPoint( QgsWkbTypes::Point, 1, 9 ) << QgsPoint( QgsWkbTypes::Point, 9, 9 )
-                   << QgsPoint( QgsWkbTypes::Point, 9, 1 ) << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
-  p16.addInteriorRing( ring );
-  QByteArray wkb16 = p16.asWkb();
-  QCOMPARE( wkb16.size(), p16.wkbSize() );
-  QgsPolygon p17;
-  QgsConstWkbPtr wkb16ptr( wkb16 );
-  p17.fromWkb( wkb16ptr );
-  QCOMPARE( p16, p17 );
+                   << QgsPoint( QgsWkbTypes::Point, 1, 9 )
+                   << QgsPoint( QgsWkbTypes::Point, 9, 9 )
+                   << QgsPoint( QgsWkbTypes::Point, 9, 1 )
+                   << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
+  pl1.addInteriorRing( ring );
+
+  QByteArray wkb = pl1.asWkb();
+  QCOMPARE( wkb.size(), pl1.wkbSize() );
+
+  QgsPolygon pl2;
+  QgsConstWkbPtr wkbPtr( wkb );
+  pl2.fromWkb( wkbPtr );
+
+  QCOMPARE( pl1, pl2 );
+}
+
+void TestQgsPolygon::toFromWkbZM()
+{
   //PolygonZ
-  p16.clear();
-  p17.clear();
-  ext = new QgsLineString();
+  QgsPolygon pl1;
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
-  p16.setExteriorRing( ext );
-  ring = new QgsLineString();
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
+  pl1.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 1, 9, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 9, 9, 3 )
-                   << QgsPoint( QgsWkbTypes::PointZ, 9, 1, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 ) );
-  p16.addInteriorRing( ring );
-  wkb16 = p16.asWkb();
-  QCOMPARE( wkb16.size(), p16.wkbSize() );
-  QgsConstWkbPtr wkb16ptr2( wkb16 );
-  p17.fromWkb( wkb16ptr2 );
-  QCOMPARE( p16, p17 );
+                   << QgsPoint( QgsWkbTypes::PointZ, 1, 9, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 9, 9, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 9, 1, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 ) );
+  pl1.addInteriorRing( ring );
+
+  QByteArray wkb = pl1.asWkb();
+  QCOMPARE( wkb.size(), pl1.wkbSize() );
+
+  QgsPolygon pl2;
+  QgsConstWkbPtr wkbPtr1( wkb );
+  pl2.fromWkb( wkbPtr1 );
+  QCOMPARE( pl1, pl2 );
+
   //PolygonM
-  p16.clear();
-  p17.clear();
+  pl1.clear();
+  pl2.clear();
+
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::PointM, 0, 10,  0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
-                  << QgsPoint( QgsWkbTypes::PointM, 10, 0,  0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
-  p16.setExteriorRing( ext );
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 10,  0, 2 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 10, 0, 3 )
+                  << QgsPoint( QgsWkbTypes::PointM, 10, 0,  0, 4 )
+                  << QgsPoint( QgsWkbTypes::PointM, 0, 0, 0, 1 ) );
+  pl1.setExteriorRing( ext );
+
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 1 )
-                   << QgsPoint( QgsWkbTypes::PointM, 1, 9, 0, 2 ) << QgsPoint( QgsWkbTypes::PointM, 9, 9, 0, 3 )
-                   << QgsPoint( QgsWkbTypes::PointM, 9, 1, 0, 4 ) << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 1 ) );
-  p16.addInteriorRing( ring );
-  wkb16 = p16.asWkb();
-  QgsConstWkbPtr wkb16ptr3( wkb16 );
-  p17.fromWkb( wkb16ptr3 );
-  QCOMPARE( p16, p17 );
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 9, 0, 2 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 9, 0, 3 )
+                   << QgsPoint( QgsWkbTypes::PointM, 9, 1, 0, 4 )
+                   << QgsPoint( QgsWkbTypes::PointM, 1, 1, 0, 1 ) );
+  pl1.addInteriorRing( ring );
+
+  wkb = pl1.asWkb();
+  QgsConstWkbPtr wkbPtr2( wkb );
+  pl2.fromWkb( wkbPtr2 );
+
+  QCOMPARE( pl1, pl2 );
+
   //PolygonZM
-  p16.clear();
-  p17.clear();
+  pl1.clear();
+  pl2.clear();
+
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
-  p16.setExteriorRing( ext );
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl1.setExteriorRing( ext );
+
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
-  p16.addInteriorRing( ring );
-  wkb16 = p16.asWkb();
-  QgsConstWkbPtr wkb16ptr4( wkb16 );
-  p17.fromWkb( wkb16ptr4 );
-  QCOMPARE( p16, p17 );
-  //Polygon25D
-  p16.clear();
-  p17.clear();
-  ext = new QgsLineString();
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl1.addInteriorRing( ring );
+
+  wkb = pl1.asWkb();
+  QgsConstWkbPtr wkbPtr3( wkb );
+  pl2.fromWkb( wkbPtr3 );
+
+  QCOMPARE( pl1, pl2 );
+}
+
+void TestQgsPolygon::toFromWkb25D()
+{
+  QgsPolygon pl1;
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
-                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
-  p16.setExteriorRing( ext );
-  ring = new QgsLineString();
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 10, 2 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 10, 3 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 10, 0, 4 )
+                  << QgsPoint( QgsWkbTypes::Point25D, 0, 0, 1 ) );
+  pl1.setExteriorRing( ext );
+
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point25D, 1, 1, 1 )
-                   << QgsPoint( QgsWkbTypes::Point25D, 1, 9, 2 ) << QgsPoint( QgsWkbTypes::Point25D, 9, 9, 3 )
-                   << QgsPoint( QgsWkbTypes::Point25D, 9, 1, 4 ) << QgsPoint( QgsWkbTypes::Point25D, 1, 1, 1 ) );
-  p16.addInteriorRing( ring );
-  wkb16 = p16.asWkb();
-  p17.clear();
-  QgsConstWkbPtr wkb16ptr5( wkb16 );
-  p17.fromWkb( wkb16ptr5 );
-  QCOMPARE( p16, p17 );
+                   << QgsPoint( QgsWkbTypes::Point25D, 1, 9, 2 )
+                   << QgsPoint( QgsWkbTypes::Point25D, 9, 9, 3 )
+                   << QgsPoint( QgsWkbTypes::Point25D, 9, 1, 4 )
+                   << QgsPoint( QgsWkbTypes::Point25D, 1, 1, 1 ) );
+  pl1.addInteriorRing( ring );
+
+  QgsPolygon pl2;
+  QByteArray wkb = pl1.asWkb();
+  QgsConstWkbPtr wkbPtr( wkb );
+  pl2.fromWkb( wkbPtr );
+
+  QCOMPARE( pl1, pl2 );
 
   //bad WKB - check for no crash
-  p17.clear();
+  pl2.clear();
+
   QgsConstWkbPtr nullPtr( nullptr, 0 );
-  QVERIFY( !p17.fromWkb( nullPtr ) );
-  QCOMPARE( p17.wkbType(), QgsWkbTypes::Polygon );
+
+  QVERIFY( !pl2.fromWkb( nullPtr ) );
+  QCOMPARE( pl2.wkbType(), QgsWkbTypes::Polygon );
+
   QgsPoint point( 1, 2 );
   QByteArray wkbPoint = point.asWkb();
   QgsConstWkbPtr wkbPointPtr( wkbPoint );
-  QVERIFY( !p17.fromWkb( wkbPointPtr ) );
-  QCOMPARE( p17.wkbType(), QgsWkbTypes::Polygon );
 
-  //to/from WKT
-  QgsPolygon p18;
-  ext = new QgsLineString();
+  QVERIFY( !pl2.fromWkb( wkbPointPtr ) );
+  QCOMPARE( pl2.wkbType(), QgsWkbTypes::Polygon );
+}
+
+void TestQgsPolygon::toFromWKT()
+{
+  QgsPolygon pl1;
+
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
-                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
-  p18.setExteriorRing( ext );
-  ring = new QgsLineString();
-  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
-  p18.addInteriorRing( ring );
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 )
+                  << QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  pl1.setExteriorRing( ext );
 
-  QString wkt = p18.asWkt();
+  QgsLineString *ring = new QgsLineString();
+  ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+  pl1.addInteriorRing( ring );
+
+  QString wkt = pl1.asWkt();
   QVERIFY( !wkt.isEmpty() );
-  QgsPolygon p19;
-  QVERIFY( p19.fromWkt( wkt ) );
-  QCOMPARE( p18, p19 );
+
+  QgsPolygon pl2;
+  QVERIFY( pl2.fromWkt( wkt ) );
+  QCOMPARE( pl1, pl2 );
 
   //bad WKT
-  QVERIFY( !p19.fromWkt( "Point()" ) );
-  QVERIFY( p19.isEmpty() );
-  QVERIFY( !p19.exteriorRing() );
-  QCOMPARE( p19.numInteriorRings(), 0 );
-  QVERIFY( !p19.is3D() );
-  QVERIFY( !p19.isMeasure() );
-  QCOMPARE( p19.wkbType(), QgsWkbTypes::Polygon );
+  QVERIFY( !pl2.fromWkt( "Point()" ) );
+  QVERIFY( pl2.isEmpty() );
+  QVERIFY( !pl2.exteriorRing() );
+  QCOMPARE( pl2.numInteriorRings(), 0 );
+  QVERIFY( !pl2.is3D() );
+  QVERIFY( !pl2.isMeasure() );
+  QCOMPARE( pl2.wkbType(), QgsWkbTypes::Polygon );
+}
 
+void TestQgsPolygon::exportImport()
+{
   //as JSON
   QgsPolygon exportPolygon;
-  ext = new QgsLineString();
+  QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 0, 0 )
-                  << QgsPoint( QgsWkbTypes::Point, 0, 10 ) << QgsPoint( QgsWkbTypes::Point, 10, 10 )
-                  << QgsPoint( QgsWkbTypes::Point, 10, 0 ) << QgsPoint( QgsWkbTypes::Point, 0, 0 ) );
+                  << QgsPoint( QgsWkbTypes::Point, 0, 10 )
+                  << QgsPoint( QgsWkbTypes::Point, 10, 10 )
+                  << QgsPoint( QgsWkbTypes::Point, 10, 0 )
+                  << QgsPoint( QgsWkbTypes::Point, 0, 0 ) );
   exportPolygon.setExteriorRing( ext );
 
   // GML document for compare
@@ -750,12 +1217,14 @@ void TestQgsPolygon::polygon()
   // as GML2
   QString expectedSimpleGML2( QStringLiteral( "<Polygon xmlns=\"gml\"><outerBoundaryIs xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">0,0 0,10 10,10 10,0 0,0</coordinates></LinearRing></outerBoundaryIs></Polygon>" ) );
   QGSCOMPAREGML( elemToString( exportPolygon.asGml2( doc ) ), expectedSimpleGML2 );
+
   QString expectedGML2empty( QStringLiteral( "<Polygon xmlns=\"gml\"/>" ) );
   QGSCOMPAREGML( elemToString( QgsPolygon().asGml2( doc ) ), expectedGML2empty );
 
   //as GML3
   QString expectedSimpleGML3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0 0 0 10 10 10 10 0 0 0</posList></LinearRing></exterior></Polygon>" ) );
   QCOMPARE( elemToString( exportPolygon.asGml3( doc ) ), expectedSimpleGML3 );
+
   QString expectedGML3empty( QStringLiteral( "<Polygon xmlns=\"gml\"/>" ) );
   QGSCOMPAREGML( elemToString( QgsPolygon().asGml3( doc ) ), expectedGML3empty );
 
@@ -763,10 +1232,12 @@ void TestQgsPolygon::polygon()
   QString expectedSimpleJson( QStringLiteral( "{\"coordinates\":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]]],\"type\":\"Polygon\"}" ) );
   QCOMPARE( exportPolygon.asJson(), expectedSimpleJson );
 
-  ring = new QgsLineString();
+  QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 1, 1 )
-                   << QgsPoint( QgsWkbTypes::Point, 1, 9 ) << QgsPoint( QgsWkbTypes::Point, 9, 9 )
-                   << QgsPoint( QgsWkbTypes::Point, 9, 1 ) << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
+                   << QgsPoint( QgsWkbTypes::Point, 1, 9 )
+                   << QgsPoint( QgsWkbTypes::Point, 9, 9 )
+                   << QgsPoint( QgsWkbTypes::Point, 9, 1 )
+                   << QgsPoint( QgsWkbTypes::Point, 1, 1 ) );
   exportPolygon.addInteriorRing( ring );
 
   QString expectedJson( QStringLiteral( "{\"coordinates\":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]],[[1.0,1.0],[1.0,9.0],[9.0,9.0],[9.0,1.0],[1.0,1.0]]],\"type\":\"Polygon\"}" ) );
@@ -775,13 +1246,18 @@ void TestQgsPolygon::polygon()
   QgsPolygon exportPolygonFloat;
   ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 10 / 9.0, 10 / 9.0 )
-                  << QgsPoint( QgsWkbTypes::Point, 10 / 9.0, 100 / 9.0 ) << QgsPoint( QgsWkbTypes::Point, 100 / 9.0, 100 / 9.0 )
-                  << QgsPoint( QgsWkbTypes::Point, 100 / 9.0, 10 / 9.0 ) << QgsPoint( QgsWkbTypes::Point, 10 / 9.0, 10 / 9.0 ) );
+                  << QgsPoint( QgsWkbTypes::Point, 10 / 9.0, 100 / 9.0 )
+                  << QgsPoint( QgsWkbTypes::Point, 100 / 9.0, 100 / 9.0 )
+                  << QgsPoint( QgsWkbTypes::Point, 100 / 9.0, 10 / 9.0 )
+                  << QgsPoint( QgsWkbTypes::Point, 10 / 9.0, 10 / 9.0 ) );
   exportPolygonFloat.setExteriorRing( ext );
+
   ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 2 / 3.0 )
-                   << QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 4 / 3.0 ) << QgsPoint( QgsWkbTypes::Point, 4 / 3.0, 4 / 3.0 )
-                   << QgsPoint( QgsWkbTypes::Point, 4 / 3.0, 2 / 3.0 ) << QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 2 / 3.0 ) );
+                   << QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 4 / 3.0 )
+                   << QgsPoint( QgsWkbTypes::Point, 4 / 3.0, 4 / 3.0 )
+                   << QgsPoint( QgsWkbTypes::Point, 4 / 3.0, 2 / 3.0 )
+                   << QgsPoint( QgsWkbTypes::Point, 2 / 3.0, 2 / 3.0 ) );
   exportPolygonFloat.addInteriorRing( ring );
 
   QString expectedJsonPrec3( QStringLiteral( "{\"coordinates\":[[[1.111,1.111],[1.111,11.111],[11.111,11.111],[11.111,1.111],[1.111,1.111]],[[0.667,0.667],[0.667,1.333],[1.333,1.333],[1.333,0.667],[0.667,0.667]]],\"type\":\"Polygon\"}" ) );
@@ -791,6 +1267,7 @@ void TestQgsPolygon::polygon()
   QString expectedGML2( QStringLiteral( "<Polygon xmlns=\"gml\"><outerBoundaryIs xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">0,0 0,10 10,10 10,0 0,0</coordinates></LinearRing></outerBoundaryIs>" ) );
   expectedGML2 += QLatin1String( "<innerBoundaryIs xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">1,1 1,9 9,9 9,1 1,1</coordinates></LinearRing></innerBoundaryIs></Polygon>" );
   QGSCOMPAREGML( elemToString( exportPolygon.asGml2( doc ) ), expectedGML2 );
+
   QString expectedGML2prec3( QStringLiteral( "<Polygon xmlns=\"gml\"><outerBoundaryIs xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">1.111,1.111 1.111,11.111 11.111,11.111 11.111,1.111 1.111,1.111</coordinates></LinearRing></outerBoundaryIs>" ) );
   expectedGML2prec3 += QLatin1String( "<innerBoundaryIs xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">0.667,0.667 0.667,1.333 1.333,1.333 1.333,0.667 0.667,0.667</coordinates></LinearRing></innerBoundaryIs></Polygon>" );
   QGSCOMPAREGML( elemToString( exportPolygonFloat.asGml2( doc, 3 ) ), expectedGML2prec3 );
@@ -798,8 +1275,8 @@ void TestQgsPolygon::polygon()
   //as GML3
   QString expectedGML3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0 0 0 10 10 10 10 0 0 0</posList></LinearRing></exterior>" ) );
   expectedGML3 += QLatin1String( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">1 1 1 9 9 9 9 1 1 1</posList></LinearRing></interior></Polygon>" );
-
   QCOMPARE( elemToString( exportPolygon.asGml3( doc ) ), expectedGML3 );
+
   QString expectedGML3prec3( QStringLiteral( "<Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">1.111 1.111 1.111 11.111 11.111 11.111 11.111 1.111 1.111 1.111</posList></LinearRing></exterior>" ) );
   expectedGML3prec3 += QLatin1String( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">0.667 0.667 0.667 1.333 1.333 1.333 1.333 0.667 0.667 0.667</posList></LinearRing></interior></Polygon>" );
   QCOMPARE( elemToString( exportPolygonFloat.asGml3( doc, 3 ) ), expectedGML3prec3 );
@@ -807,27 +1284,40 @@ void TestQgsPolygon::polygon()
   //asKML
   QString expectedKml( QStringLiteral( "<Polygon><outerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>0,0,0 0,10,0 10,10,0 10,0,0 0,0,0</coordinates></LinearRing></outerBoundaryIs><innerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>1,1,0 1,9,0 9,9,0 9,1,0 1,1,0</coordinates></LinearRing></innerBoundaryIs></Polygon>" ) );
   QCOMPARE( exportPolygon.asKml(), expectedKml );
+
   QString expectedKmlPrec3( QStringLiteral( "<Polygon><outerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>1.111,1.111,0 1.111,11.111,0 11.111,11.111,0 11.111,1.111,0 1.111,1.111,0</coordinates></LinearRing></outerBoundaryIs><innerBoundaryIs><LinearRing><altitudeMode>clampToGround</altitudeMode><coordinates>0.667,0.667,0 0.667,1.333,0 1.333,1.333,0 1.333,0.667,0 0.667,0.667,0</coordinates></LinearRing></innerBoundaryIs></Polygon>" ) );
   QCOMPARE( exportPolygonFloat.asKml( 3 ), expectedKmlPrec3 );
+}
 
+void TestQgsPolygon::deleteVertexRemoveRing()
+{
   //removing the fourth to last vertex removes the whole ring
-  QgsPolygon p20;
-  QgsLineString *p20ExteriorRing = new QgsLineString();
-  p20ExteriorRing->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
-  p20.setExteriorRing( p20ExteriorRing );
-  QVERIFY( p20.exteriorRing() );
-  p20.deleteVertex( QgsVertexId( 0, 0, 2 ) );
-  QVERIFY( !p20.exteriorRing() );
+  QgsPolygon pl;
 
-  //boundary
-  QgsLineString boundary1;
-  boundary1.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 )  << QgsPoint( 0, 0 ) );
-  QgsPolygon boundaryPolygon;
-  QVERIFY( !boundaryPolygon.boundary() );
+  QgsLineString *ext = new QgsLineString();
+  ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
+                  << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
 
-  boundaryPolygon.setExteriorRing( boundary1.clone() );
-  QgsAbstractGeometry *boundary = boundaryPolygon.boundary();
+  pl.setExteriorRing( ext );
+  QVERIFY( pl.exteriorRing() );
+
+  pl.deleteVertex( QgsVertexId( 0, 0, 2 ) );
+  QVERIFY( !pl.exteriorRing() );
+}
+
+void TestQgsPolygon::boundary()
+{
+  QgsPolygon pl;
+  QVERIFY( !pl.boundary() );
+
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 )
+                 << QgsPoint( 1, 1 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  QgsAbstractGeometry *boundary = pl.boundary();
   QgsLineString *lineBoundary = dynamic_cast< QgsLineString * >( boundary );
+
   QVERIFY( lineBoundary );
   QCOMPARE( lineBoundary->numPoints(), 4 );
   QCOMPARE( lineBoundary->xAt( 0 ), 0.0 );
@@ -838,16 +1328,24 @@ void TestQgsPolygon::polygon()
   QCOMPARE( lineBoundary->yAt( 1 ), 0.0 );
   QCOMPARE( lineBoundary->yAt( 2 ), 1.0 );
   QCOMPARE( lineBoundary->yAt( 3 ), 0.0 );
+
   delete boundary;
 
   // add interior rings
-  QgsLineString boundaryRing1;
-  boundaryRing1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )  << QgsPoint( 0.1, 0.1 ) );
-  QgsLineString boundaryRing2;
-  boundaryRing2.setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 ) << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )  << QgsPoint( 0.8, 0.8 ) );
-  boundaryPolygon.setInteriorRings( QVector< QgsCurve * >() << boundaryRing1.clone() << boundaryRing2.clone() );
-  boundary = boundaryPolygon.boundary();
+  QgsLineString ring;
+  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
+                  << QgsPoint( 0.1, 0.1 ) );
+  QgsLineString ring2;
+  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.8, 0.8 )
+                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
+                   << QgsPoint( 0.8, 0.8 ) );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() << ring2.clone() );
+
+  boundary = pl.boundary();
   QgsMultiLineString *multiLineBoundary = dynamic_cast< QgsMultiLineString * >( boundary );
+
   QVERIFY( multiLineBoundary );
   QCOMPARE( multiLineBoundary->numGeometries(), 3 );
   QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->numPoints(), 4 );
@@ -877,15 +1375,20 @@ void TestQgsPolygon::polygon()
   QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 1 ), 0.8 );
   QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 2 ), 0.9 );
   QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 3 ), 0.8 );
-  boundaryPolygon.setInteriorRings( QVector< QgsCurve * >() );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() );
   delete boundary;
 
   //test boundary with z
-  boundary1.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
-                       << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )  << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
-  boundaryPolygon.setExteriorRing( boundary1.clone() );
-  boundary = boundaryPolygon.boundary();
+  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  boundary = pl.boundary();
   lineBoundary = qgis::down_cast< QgsLineString * >( boundary );
+
   QVERIFY( lineBoundary );
   QCOMPARE( lineBoundary->numPoints(), 4 );
   QCOMPARE( lineBoundary->wkbType(), QgsWkbTypes::LineStringZ );
@@ -893,1077 +1396,1512 @@ void TestQgsPolygon::polygon()
   QCOMPARE( lineBoundary->zAt( 1 ), 15.0 );
   QCOMPARE( lineBoundary->zAt( 2 ), 20.0 );
   QCOMPARE( lineBoundary->zAt( 3 ), 10.0 );
+
   delete boundary;
+}
 
-  // point distance to boundary
-
-  QgsLineString pd1;
-  pd1.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 ) << QgsPoint( 0, 1 ) << QgsPoint( 0, 0 ) );
-  QgsPolygon pd;
+void TestQgsPolygon::pointDistanceToBoundary()
+{
+  QgsPolygon pl;
   // no meaning, but let's not crash
-  ( void )pd.pointDistanceToBoundary( 0, 0 );
+  ( void )pl.pointDistanceToBoundary( 0, 0 );
 
-  pd.setExteriorRing( pd1.clone() );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.1, 0.5 ), 0.1, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                 << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 )
+                 << QgsPoint( 0, 1 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ext.clone() );
+
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.1, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+
   // with a ring
-  QgsLineString pdRing1;
-  pdRing1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.6 )  << QgsPoint( 0.1, 0.6 ) << QgsPoint( 0.1, 0.1 ) );
-  pd.setInteriorRings( QVector< QgsCurve * >() << pdRing1.clone() );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.1, 0.5 ), 0.0, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.01, 0.5 ), 0.01, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.08, 0.5 ), 0.02, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( 0.12, 0.5 ), -0.02, 0.0000000001 );
-  QGSCOMPARENEAR( pd.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+  QgsLineString ring;
+  ring.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                  << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.6 )
+                  << QgsPoint( 0.1, 0.6 ) << QgsPoint( 0.1, 0.1 ) );
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring.clone() );
 
-  // remove interior rings
-  QgsLineString removeRingsExt;
-  removeRingsExt.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 )  << QgsPoint( 0, 0 ) );
-  QgsPolygon removeRings1;
-  removeRings1.removeInteriorRings();
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.1, 0.5 ), 0.0, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.01, 0.5 ), 0.01, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.08, 0.5 ), 0.02, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( 0.12, 0.5 ), -0.02, 0.0000000001 );
+  QGSCOMPARENEAR( pl.pointDistanceToBoundary( -0.1, 0.5 ), -0.1, 0.0000000001 );
+}
 
-  removeRings1.setExteriorRing( boundary1.clone() );
-  removeRings1.removeInteriorRings();
-  QCOMPARE( removeRings1.numInteriorRings(), 0 );
+void TestQgsPolygon::removeInteriorRings()
+{
+  QgsPolygon pl;
+  pl.removeInteriorRings();
+
+  QgsLineString ext;
+  ext.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 0, 15 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 20 )
+                 << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 10 ) );
+
+  pl.setExteriorRing( ext.clone() );
+  pl.removeInteriorRings();
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
 
   // add interior rings
-  QgsLineString removeRingsRing1;
-  removeRingsRing1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 ) << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )  << QgsPoint( 0.1, 0.1 ) );
-  QgsLineString removeRingsRing2;
-  removeRingsRing2.setPoints( QgsPointSequence() << QgsPoint( 0.6, 0.8 ) << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )  << QgsPoint( 0.6, 0.8 ) );
-  removeRings1.setInteriorRings( QVector< QgsCurve * >() << removeRingsRing1.clone() << removeRingsRing2.clone() );
+  QgsLineString ring1;
+  ring1.setPoints( QgsPointSequence() << QgsPoint( 0.1, 0.1 )
+                   << QgsPoint( 0.2, 0.1 ) << QgsPoint( 0.2, 0.2 )
+                   << QgsPoint( 0.1, 0.1 ) );
+  QgsLineString ring2;
+  ring2.setPoints( QgsPointSequence() << QgsPoint( 0.6, 0.8 )
+                   << QgsPoint( 0.9, 0.8 ) << QgsPoint( 0.9, 0.9 )
+                   << QgsPoint( 0.6, 0.8 ) );
+
+  pl.setInteriorRings( QVector< QgsCurve * >() << ring1.clone() << ring2.clone() );
 
   // remove ring with size filter
-  removeRings1.removeInteriorRings( 0.0075 );
-  QCOMPARE( removeRings1.numInteriorRings(), 1 );
+  pl.removeInteriorRings( 0.0075 );
+  QCOMPARE( pl.numInteriorRings(), 1 );
 
   // remove ring with no size filter
-  removeRings1.removeInteriorRings();
-  QCOMPARE( removeRings1.numInteriorRings(), 0 );
+  pl.removeInteriorRings();
+  QCOMPARE( pl.numInteriorRings(), 0 );
+}
 
-  // cast
+void TestQgsPolygon::cast()
+{
   QVERIFY( !QgsPolygon().cast( nullptr ) );
-  QgsPolygon pCast;
-  QVERIFY( QgsPolygon().cast( &pCast ) );
-  QgsPolygon pCast2;
-  pCast2.fromWkt( QStringLiteral( "PolygonZ((0 0 0, 0 1 1, 1 0 2, 0 0 0))" ) );
-  QVERIFY( QgsPolygon().cast( &pCast2 ) );
-  pCast2.fromWkt( QStringLiteral( "PolygonM((0 0 1, 0 1 2, 1 0 3, 0 0 1))" ) );
-  QVERIFY( QgsPolygon().cast( &pCast2 ) );
-  pCast2.fromWkt( QStringLiteral( "PolygonZM((0 0 0 1, 0 1 1 2, 1 0 2 3, 0 0 0 1))" ) );
-  QVERIFY( QgsPolygon().cast( &pCast2 ) );
 
-  //transform
+  QgsPolygon pl;
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZ((0 0 0, 0 1 1, 1 0 2, 0 0 0))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonM((0 0 1, 0 1 2, 1 0 3, 0 0 1))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM((0 0 0 1, 0 1 1 2, 1 0 2 3, 0 0 0 1))" ) );
+  QVERIFY( QgsPolygon().cast( &pl ) );
+}
+
+void TestQgsPolygon::transform2D()
+{
   //CRS transform
   QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
   QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
   QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
 
-  // 2d CRS transform
-  QgsPolygon pTransform;
-  QgsLineString l21;
-  l21.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
-                 << QgsPoint( 6274985, -3526584 )
-                 << QgsPoint( 6474985, -3526584 )
-                 << QgsPoint( 6374985, -3626584 ) );
-  pTransform.setExteriorRing( l21.clone() );
-  pTransform.addInteriorRing( l21.clone() );
-  pTransform.transform( tr, Qgis::TransformDirection::Forward );
-  const QgsLineString *extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
-  const QgsLineString *intR = static_cast< const QgsLineString * >( pTransform.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QgsPolygon pl;
 
-  //3d CRS transform
-  QgsLineString l22;
-  l22.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
-  pTransform.clear();
-  pTransform.setExteriorRing( l22.clone() );
-  pTransform.addInteriorRing( l22.clone() );
-  pTransform.transform( tr, Qgis::TransformDirection::Forward );
-  extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
-  intR = static_cast< const QgsLineString * >( pTransform.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).x(), 175.771, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).x(),  174.581448, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).x(),  176.958633, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).y(), -38.7999, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).x(),  175.771, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).y(), -39.724, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
-  QGSCOMPARENEAR( pTransform.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 6374985, -3626584 )
+                << QgsPoint( 6274985, -3526584 )
+                << QgsPoint( 6474985, -3526584 )
+                << QgsPoint( 6374985, -3626584 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
-  //reverse transform
-  pTransform.transform( tr, Qgis::TransformDirection::Reverse );
-  extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).x(), 6374984, 100 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).x(), 6274984, 100 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).x(),  6474984, 100 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).x(),  6374984, 100 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMinimum(), 6274984, 100 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMinimum(), -3626584, 100 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().xMaximum(), 6474984, 100 );
-  QGSCOMPARENEAR( pTransform.exteriorRing()->boundingBox().yMaximum(), -3526584, 100 );
-  intR = static_cast< const QgsLineString * >( pTransform.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).x(), 6374984, 100 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).x(), 6274984, 100 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).z(), 3.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).m(), 4.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).x(),  6474984, 100 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).y(), -3526584, 100 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).z(), 5.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).m(), 6.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).x(),  6374984, 100 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).y(), -3626584, 100 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).z(), 1.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).m(), 2.0, 0.001 );
-  QGSCOMPARENEAR( intR->boundingBox().xMinimum(), 6274984, 100 );
-  QGSCOMPARENEAR( intR->boundingBox().yMinimum(), -3626584, 100 );
-  QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 6474984, 100 );
-  QGSCOMPARENEAR( intR->boundingBox().yMaximum(), -3526584, 100 );
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
+
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+}
+
+void TestQgsPolygon::transform3D()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(),  174.581448, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  176.958633, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -38.7999, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  175.771, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -39.724, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMinimum(), 174.581448, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMinimum(), -39.724, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().xMaximum(), 176.959, 0.001 );
+  QGSCOMPARENEAR( pl.interiorRing( 0 )->boundingBox().yMaximum(), -38.7999, 0.001 );
+
+}
+
+void TestQgsPolygon::transformReverse()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transform( tr, Qgis::TransformDirection::Forward );
+  pl.transform( tr, Qgis::TransformDirection::Reverse );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 6374984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 6274984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  6474984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(),  6374984, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), -3526584, 100 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 6374984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 6274984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 4.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  6474984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), -3526584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 6.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(),  6374984, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 2.0, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 6274984, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), -3626584, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 6474984, 100 );
+  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), -3526584, 100 );
+}
+
+void TestQgsPolygon::transformOldVersion()
+{
+  //CRS transform
+  QgsCoordinateReferenceSystem sourceSrs( QStringLiteral( "EPSG:3994" ) );
+  QgsCoordinateReferenceSystem destSrs( QStringLiteral( "EPSG:4202" ) ); // want a transform with ellipsoid change
+  QgsCoordinateTransform tr( sourceSrs, destSrs, QgsProject::instance() );
+
+  QgsPolygon pl;
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6274985, -3526584, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6474985, -3526584, 5, 6 )
+                << QgsPoint( QgsWkbTypes::PointZM, 6374985, -3626584, 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
 #if PROJ_VERSION_MAJOR<6 // note - z value transform doesn't currently work with proj 6+, because we don't yet support compound CRS definitions
   //z value transform
-  pTransform.transform( tr, Qgis::TransformDirection::Forward, true );
-  extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).z(), -19.249066, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).z(), -19.148357, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).z(), -19.092128, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).z(), -19.249066, 0.001 );
-  intR = static_cast< const QgsLineString * >( pTransform.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).z(), -19.249066, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).z(), -19.148357, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).z(), -19.092128, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).z(), -19.249066, 0.001 );
-  pTransform.transform( tr, Qgis::TransformDirection::Reverse, true );
-  extR = static_cast< const QgsLineString * >( pTransform.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).z(), 1, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).z(), 3, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).z(), 5, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).z(), 1, 0.001 );
-  intR = static_cast< const QgsLineString * >( pTransform.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).z(), 1, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).z(), 3, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).z(), 5, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).z(), 1, 0.001 );
+  pl.transform( tr, Qgis::TransformDirection::Forward, true );
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), -19.249066, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), -19.148357, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), -19.092128, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), -19.249066, 0.001 );
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), -19.249066, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), -19.148357, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), -19.092128, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), -19.249066, 0.001 );
+  pl.transform( tr, Qgis::TransformDirection::Reverse, true );
+  ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 1, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 3, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 5, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 1, 0.001 );
+  ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 1, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 3, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 5, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 1, 0.001 );
 #endif
+}
 
-  //QTransform transform
+void TestQgsPolygon::Qtransform()
+{
   QTransform qtr = QTransform::fromScale( 2, 3 );
-  QgsLineString l23;
-  l23.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 11, 12, 13, 14 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 1, 12, 23, 24 )
-                 << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 ) );
-  QgsPolygon pTransform2;
-  pTransform2.setExteriorRing( l23.clone() );
-  pTransform2.addInteriorRing( l23.clone() );
-  pTransform2.transform( qtr, 2, 3, 4, 5 );
 
-  extR = static_cast< const QgsLineString * >( pTransform2.exteriorRing() );
-  QGSCOMPARENEAR( extR->pointN( 0 ).x(), 2, 100 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).y(), 6, 100 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 0 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).x(), 22, 100 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).y(), 36, 100 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).z(), 41.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 1 ).m(), 74.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).x(),  2, 100 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).y(), 36, 100 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).z(), 71.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 2 ).m(), 124.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).x(), 2, 100 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).y(), 6, 100 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( extR->pointN( 3 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( pTransform2.exteriorRing()->boundingBox().xMinimum(), 2, 0.001 );
-  QGSCOMPARENEAR( pTransform2.exteriorRing()->boundingBox().yMinimum(), 6, 0.001 );
-  QGSCOMPARENEAR( pTransform2.exteriorRing()->boundingBox().xMaximum(), 22, 0.001 );
-  QGSCOMPARENEAR( pTransform2.exteriorRing()->boundingBox().yMaximum(), 36, 0.001 );
-  intR = static_cast< const QgsLineString * >( pTransform2.interiorRing( 0 ) );
-  QGSCOMPARENEAR( intR->pointN( 0 ).x(), 2, 100 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).y(), 6, 100 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 0 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).x(), 22, 100 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).y(), 36, 100 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).z(), 41.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 1 ).m(), 74.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).x(),  2, 100 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).y(), 36, 100 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).z(), 71.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 2 ).m(), 124.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).x(), 2, 100 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).y(), 6, 100 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).z(), 11.0, 0.001 );
-  QGSCOMPARENEAR( intR->pointN( 3 ).m(), 24.0, 0.001 );
-  QGSCOMPARENEAR( intR->boundingBox().xMinimum(), 2, 0.001 );
-  QGSCOMPARENEAR( intR->boundingBox().yMinimum(), 6, 0.001 );
-  QGSCOMPARENEAR( intR->boundingBox().xMaximum(), 22, 0.001 );
-  QGSCOMPARENEAR( intR->boundingBox().yMaximum(), 36, 0.001 );
+  QgsPolygon pl;
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 )
+                << QgsPoint( QgsWkbTypes::PointZM, 11, 12, 13, 14 )
+                << QgsPoint( QgsWkbTypes::PointZM, 1, 12, 23, 24 )
+                << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
-  // closestSegment
+  pl.transform( qtr, 2, 3, 4, 5 );
+
+  const QgsLineString *ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
+  QGSCOMPARENEAR( ext->pointN( 0 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 0 ).m(), 24.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).x(), 22, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).z(), 41.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 1 ).m(), 74.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).x(),  2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).z(), 71.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 2 ).m(), 124.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ext->pointN( 3 ).m(), 24.0, 0.001 );
+
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( pl.exteriorRing()->boundingBox().yMaximum(), 36, 0.001 );
+
+  const QgsLineString *ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
+
+  QGSCOMPARENEAR( ring->pointN( 0 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 0 ).m(), 24.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).x(), 22, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).z(), 41.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 1 ).m(), 74.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).x(),  2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).y(), 36, 100 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).z(), 71.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 2 ).m(), 124.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).x(), 2, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).y(), 6, 100 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).z(), 11.0, 0.001 );
+  QGSCOMPARENEAR( ring->pointN( 3 ).m(), 24.0, 0.001 );
+
+  QGSCOMPARENEAR( ring->boundingBox().xMinimum(), 2, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().yMinimum(), 6, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().xMaximum(), 22, 0.001 );
+  QGSCOMPARENEAR( ring->boundingBox().yMaximum(), 36, 0.001 );
+}
+
+void TestQgsPolygon::closestSegment()
+{
   QgsPoint pt;
   QgsVertexId v;
   int leftOf = 0;
-  QgsPolygon empty;
-  ( void )empty.closestSegment( QgsPoint( 1, 2 ), pt, v ); // empty polygon, just want no crash
 
-  QgsPolygon p21;
-  QgsLineString p21ls;
-  p21ls.setPoints( QgsPointSequence() << QgsPoint( 5, 10 ) << QgsPoint( 7, 12 ) << QgsPoint( 5, 15 ) << QgsPoint( 5, 10 ) );
-  p21.setExteriorRing( p21ls.clone() );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
+  QgsPolygon pl;
+  ( void )pl.closestSegment( QgsPoint( 1, 2 ), pt, v ); // empty polygon, just want no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 5, 10 )
+                << QgsPoint( 7, 12 ) << QgsPoint( 5, 15 )
+                << QgsPoint( 5, 10 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5, 0.01 );
   QGSCOMPARENEAR( pt.y(), 11, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 7, 0.01 );
   QGSCOMPARENEAR( pt.y(), 12, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 6, 11.5 ), pt, v, &leftOf ), 0.125000, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.5 ), pt, v, &leftOf ), 0.125000, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 6.25, 0.01 );
   QGSCOMPARENEAR( pt.y(), 11.25, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( leftOf, -1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
   QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
   QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
   QCOMPARE( leftOf, -1 );
+
   // point directly on segment
-  QCOMPARE( p21.closestSegment( QgsPoint( 5, 15 ), pt, v, &leftOf ), 0.0 );
+  QCOMPARE( pl.closestSegment( QgsPoint( 5, 15 ), pt, v, &leftOf ), 0.0 );
   QCOMPARE( pt, QgsPoint( 5, 15 ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
+
   // with interior ring
-  p21ls.setPoints( QgsPointSequence() << QgsPoint( 6, 11.5 ) << QgsPoint( 6.5, 12 ) << QgsPoint( 6, 13 ) << QgsPoint( 6, 11.5 ) );
-  p21.addInteriorRing( p21ls.clone() );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 6, 11.5 ) << QgsPoint( 6.5, 12 )
+                << QgsPoint( 6, 13 ) << QgsPoint( 6, 11.5 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 4, 11 ), pt, v, &leftOf ), 1.0, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5, 0.01 );
   QGSCOMPARENEAR( pt.y(), 11, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 8, 11 ), pt, v, &leftOf ),  2.0, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 7, 0.01 );
   QGSCOMPARENEAR( pt.y(), 12, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 6, 11.4 ), pt, v, &leftOf ), 0.01, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 6, 11.4 ), pt, v, &leftOf ), 0.01, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 6.0, 0.01 );
   QGSCOMPARENEAR( pt.y(), 11.5, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 7, 16 ), pt, v, &leftOf ), 4.923077, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5.153846, 0.01 );
   QGSCOMPARENEAR( pt.y(), 14.769231, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
   QCOMPARE( leftOf, 1 );
-  QGSCOMPARENEAR( p21.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
+
+  QGSCOMPARENEAR( pl.closestSegment( QgsPoint( 5.5, 13.5 ), pt, v, &leftOf ), 0.173077, 0.0001 );
   QGSCOMPARENEAR( pt.x(), 5.846154, 0.01 );
   QGSCOMPARENEAR( pt.y(), 13.730769, 0.01 );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
   QCOMPARE( leftOf, -1 );
+
   // point directly on segment
-  QCOMPARE( p21.closestSegment( QgsPoint( 6, 13 ), pt, v, &leftOf ), 0.0 );
+  QCOMPARE( pl.closestSegment( QgsPoint( 6, 13 ), pt, v, &leftOf ), 0.0 );
   QCOMPARE( pt, QgsPoint( 6, 13 ) );
   QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
   QCOMPARE( leftOf, 0 );
+}
 
-  //nextVertex
-  QgsPolygon p22;
-  QVERIFY( !p22.nextVertex( v, pt ) );
+void TestQgsPolygon::nextVertex()
+{
+  QgsPolygon pl;
+
+  QgsPoint pt;
+  QgsVertexId v;
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 0, -2 );
-  QVERIFY( !p22.nextVertex( v, pt ) );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 0, 10 );
-  QVERIFY( !p22.nextVertex( v, pt ) );
-  QgsLineString lp22;
-  lp22.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  p22.setExteriorRing( lp22.clone() );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
   v = QgsVertexId( 0, 0, 4 ); //out of range
-  QVERIFY( !p22.nextVertex( v, pt ) );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 0, -5 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 0, -1 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
   QCOMPARE( pt, QgsPoint( 1, 2 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( pt, QgsPoint( 11, 12 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 2 ) );
   QCOMPARE( pt, QgsPoint( 1, 12 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 3 ) );
   QCOMPARE( pt, QgsPoint( 1, 2 ) );
+
   v = QgsVertexId( 0, 1, 0 );
-  QVERIFY( !p22.nextVertex( v, pt ) );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 1, 0, 0 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 1, 0, 1 ) ); //test that part number is maintained
   QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
   // add interior ring
-  lp22.setPoints( QgsPointSequence() << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 ) << QgsPoint( 11, 22 ) << QgsPoint( 11, 12 ) );
-  p22.addInteriorRing( lp22.clone() );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 )
+                << QgsPoint( 11, 22 ) << QgsPoint( 11, 12 ) );
+  pl.addInteriorRing( ls.clone() );
+
   v = QgsVertexId( 0, 1, 4 ); //out of range
-  QVERIFY( !p22.nextVertex( v, pt ) );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 1, -5 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 0, 1, -1 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 1, 0 ) );
   QCOMPARE( pt, QgsPoint( 11, 12 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 1, 1 ) );
   QCOMPARE( pt, QgsPoint( 21, 22 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 1, 2 ) );
   QCOMPARE( pt, QgsPoint( 11, 22 ) );
-  QVERIFY( p22.nextVertex( v, pt ) );
+
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 0, 1, 3 ) );
   QCOMPARE( pt, QgsPoint( 11, 12 ) );
+
   v = QgsVertexId( 0, 2, 0 );
-  QVERIFY( !p22.nextVertex( v, pt ) );
+  QVERIFY( !pl.nextVertex( v, pt ) );
+
   v = QgsVertexId( 1, 1, 0 );
-  QVERIFY( p22.nextVertex( v, pt ) );
+  QVERIFY( pl.nextVertex( v, pt ) );
   QCOMPARE( v, QgsVertexId( 1, 1, 1 ) ); //test that part number is maintained
   QCOMPARE( pt, QgsPoint( 21, 22 ) );
+}
 
-  // dropZValue
-  QgsPolygon p23;
-  p23.dropZValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  QgsLineString lp23;
-  lp23.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  p23.dropZValue(); // not z
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+void TestQgsPolygon::dropZValue()
+{
+  QgsPolygon pl;
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  pl.dropZValue(); // not z
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
   // with z
-  lp23.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3 ) << QgsPoint( 11, 12, 13 ) << QgsPoint( 1, 12, 23 ) << QgsPoint( 1, 2, 3 ) );
-  p23.clear();
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonZ );
-  p23.dropZValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  // with zm
-  lp23.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 ) << QgsPoint( 11, 12, 13, 14 ) << QgsPoint( 1, 12, 23, 24 ) << QgsPoint( 1, 2, 3, 4 ) );
-  p23.clear();
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonZM );
-  p23.dropZValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonM );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineStringM );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringM );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3 ) << QgsPoint( 11, 12, 13 )
+                << QgsPoint( 1, 12, 23 ) << QgsPoint( 1, 2, 3 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
-  // dropMValue
-  p23.clear();
-  p23.dropMValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  lp23.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  p23.dropMValue(); // not zm
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
+  // with zm
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 )
+                << QgsPoint( 11, 12, 13, 14 )
+                << QgsPoint( 1, 12, 23, 24 )
+                << QgsPoint( 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+
+  pl.dropZValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringM );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
+
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringM );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 4 ) );
+}
+
+void TestQgsPolygon::dropMValue()
+{
+  QgsPolygon pl;
+
+  pl.dropMValue();
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 1, 12 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  pl.dropMValue(); // not zm
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
   // with m
-  lp23.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 11, 12, 0, 13 ) << QgsPoint( QgsWkbTypes::PointM, 1, 12, 0, 23 ) << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 ) );
-  p23.clear();
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonM );
-  p23.dropMValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::Polygon );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 )
+                << QgsPoint( QgsWkbTypes::PointM, 11, 12, 0, 13 )
+                << QgsPoint( QgsWkbTypes::PointM, 1, 12, 0, 23 )
+                << QgsPoint( QgsWkbTypes::PointM,  1, 2, 0, 3 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonM );
+  pl.dropMValue();
+
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::Polygon );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1, 2 ) );
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineString );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1, 2 ) );
+
   // with zm
-  lp23.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 ) << QgsPoint( 11, 12, 13, 14 ) << QgsPoint( 1, 12, 23, 24 ) << QgsPoint( 1, 2, 3, 4 ) );
-  p23.clear();
-  p23.setExteriorRing( lp23.clone() );
-  p23.addInteriorRing( lp23.clone() );
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonZM );
-  p23.dropMValue();
-  QCOMPARE( p23.wkbType(), QgsWkbTypes::PolygonZ );
-  QCOMPARE( p23.exteriorRing()->wkbType(), QgsWkbTypes::LineStringZ );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.exteriorRing() )->pointN( 0 ), QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
-  QCOMPARE( p23.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZ );
-  QCOMPARE( static_cast< const QgsLineString *>( p23.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
+  pl.clear();
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 3, 4 ) << QgsPoint( 11, 12, 13, 14 )
+                << QgsPoint( 1, 12, 23, 24 ) << QgsPoint( 1, 2, 3, 4 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
-  //vertexAngle
-  QgsPolygon p24;
-  ( void )p24.vertexAngle( QgsVertexId() ); //just want no crash
-  ( void )p24.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash
-  ( void )p24.vertexAngle( QgsVertexId( 0, 1, 0 ) ); //just want no crash
-  QgsLineString l38;
-  l38.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
-                 << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 ) << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
-  p24.setExteriorRing( l38.clone() );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 2.35619, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 1.5708, 0.0001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 2 ) ), 1.17809, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 3 ) ), 0.0, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 4 ) ), 5.10509, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 5 ) ), 3.92699, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 0, 6 ) ), 2.35619, 0.00001 );
-  p24.addInteriorRing( l38.clone() );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 0 ) ), 2.35619, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 1 ) ), 1.5708, 0.0001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 2 ) ), 1.17809, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 3 ) ), 0.0, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 4 ) ), 5.10509, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 5 ) ), 3.92699, 0.00001 );
-  QGSCOMPARENEAR( p24.vertexAngle( QgsVertexId( 0, 1, 6 ) ), 2.35619, 0.00001 );
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZM );
+  pl.dropMValue();
 
-  //insert vertex
+  QCOMPARE( pl.wkbType(), QgsWkbTypes::PolygonZ );
+  QCOMPARE( pl.exteriorRing()->wkbType(), QgsWkbTypes::LineStringZ );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.exteriorRing() )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
 
+  QCOMPARE( pl.interiorRing( 0 )->wkbType(), QgsWkbTypes::LineStringZ );
+  QCOMPARE( static_cast< const QgsLineString *>( pl.interiorRing( 0 ) )->pointN( 0 ),
+            QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) );
+}
+
+void TestQgsPolygon::vertexAngle()
+{
+  QgsPolygon pl;
+
+  ( void )pl.vertexAngle( QgsVertexId() ); //just want no crash
+  ( void )pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash
+  ( void )pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ); //just want no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
+                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 2.35619, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 1.5708, 0.0001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 2 ) ), 1.17809, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 3 ) ), 0.0, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 4 ) ), 5.10509, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 5 ) ), 3.92699, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 0, 6 ) ), 2.35619, 0.00001 );
+
+  pl.addInteriorRing( ls.clone() );
+
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 0 ) ), 2.35619, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 1 ) ), 1.5708, 0.0001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 2 ) ), 1.17809, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 3 ) ), 0.0, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 4 ) ), 5.10509, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 5 ) ), 3.92699, 0.00001 );
+  QGSCOMPARENEAR( pl.vertexAngle( QgsVertexId( 0, 1, 6 ) ), 2.35619, 0.00001 );
+}
+
+void TestQgsPolygon::insertVertex()
+{
   //insert vertex in empty polygon
-  QgsPolygon p25;
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 1, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( p25.isEmpty() );
-  l38.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
-                 << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 ) << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
-  p25.setExteriorRing( l38.clone() );
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 0.3, 0 ) ) );
-  QCOMPARE( p25.nCoordinates(), 8 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 0, 100 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QgsPolygon pl;
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 1, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.isEmpty() );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
+                << QgsPoint( 0.5, 0 ) << QgsPoint( 1, 0 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 2 )
+                << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 0.3, 0 ) ) );
+  QCOMPARE( pl.nCoordinates(), 8 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 100 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+
   // first vertex
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 0, 0.1 ) ) );
-  QCOMPARE( p25.nCoordinates(), 9 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 0, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 9 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+
   // last vertex
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 0, 9 ), QgsPoint( 0.1, 0.1 ) ) );
-  QCOMPARE( p25.nCoordinates(), 10 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.exteriorRing() )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 9 ), QgsPoint( 0.1, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 10 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+
   // with interior ring
-  p25.addInteriorRing( l38.clone() );
-  QCOMPARE( p25.nCoordinates(), 17 );
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 0.3, 0 ) ) );
-  QCOMPARE( p25.nCoordinates(), 18 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 1, 100 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( !p25.insertVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.nCoordinates(), 17 );
+
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 0.3, 0 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 18 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 100 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( !pl.insertVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+
   // first vertex in interior ring
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 0, 0.1 ) ) );
-  QCOMPARE( p25.nCoordinates(), 19 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 0, 0.1 ) ) );
+
+  QCOMPARE( pl.nCoordinates(), 19 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+
   // last vertex in interior ring
-  QVERIFY( p25.insertVertex( QgsVertexId( 0, 1, 9 ), QgsPoint( 0.1, 0.1 ) ) );
-  QCOMPARE( p25.nCoordinates(), 20 );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p25.interiorRing( 0 ) )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+  QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 9 ), QgsPoint( 0.1, 0.1 ) ) );
 
-  //move vertex
+  QCOMPARE( pl.nCoordinates(), 20 );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+}
 
+void TestQgsPolygon::moveVertex()
+{
   //empty polygon
-  QgsPolygon p26;
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( p26.isEmpty() );
+  QgsPolygon pl;
+
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.isEmpty() );
 
   //valid polygon
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
-                 << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  p26.setExteriorRing( l38.clone() );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 16.0, 17.0 ) ) );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( 26.0, 27.0 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 16.0, 17.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( 26.0, 27.0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
 
   //out of range
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 0, 10 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 3.0, 4.0 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 10 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 3.0, 4.0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
 
   // with interior ring
-  p26.addInteriorRing( l38.clone() );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 16.0, 17.0 ) ) );
-  QVERIFY( p26.moveVertex( QgsVertexId( 0, 1, 2 ), QgsPoint( 26.0, 27.0 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p26.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 1, 10 ), QgsPoint( 3.0, 4.0 ) ) );
-  QVERIFY( !p26.moveVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 3.0, 4.0 ) ) );
+  pl.addInteriorRing( ls.clone() );
 
-  //delete vertex
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 16.0, 17.0 ) ) );
+  QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 2 ), QgsPoint( 26.0, 27.0 ) ) );
 
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 10 ), QgsPoint( 3.0, 4.0 ) ) );
+  QVERIFY( !pl.moveVertex( QgsVertexId( 0, 2, 0 ), QgsPoint( 3.0, 4.0 ) ) );
+}
+
+void TestQgsPolygon::deleteVertex()
+{
   //empty polygon
-  QgsPolygon p27;
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
-  QVERIFY( p27.isEmpty() );
+  QgsPolygon pl;
+
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
+  QVERIFY( pl.isEmpty() );
 
   //valid polygon
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 ) << QgsPoint( 7, 2 )
-                 << QgsPoint( 11, 12 ) << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  QgsLineString l38;
+  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( l38.clone() );
 
-  p27.setExteriorRing( l38.clone() );
   //out of range vertices
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 0, -1 ) ) );
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 0, 100 ) ) );
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, -1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, 100 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
 
   //valid vertices
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
 
   // delete first vertex
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
 
   // delete last vertex
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 4 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 4 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
 
   // delete another vertex - should remove ring
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
-  QVERIFY( !p27.exteriorRing() );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
+  QVERIFY( !pl.exteriorRing() );
 
   // with interior ring
-  p27.setExteriorRing( l38.clone() );
-  p27.addInteriorRing( l38.clone() );
+  pl.setExteriorRing( l38.clone() );
+  pl.addInteriorRing( l38.clone() );
 
   //out of range vertices
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 1, -1 ) ) );
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 1, 100 ) ) );
-  QVERIFY( !p27.deleteVertex( QgsVertexId( 0, 2, 1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, -1 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, 100 ) ) );
+  QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 2, 1 ) ) );
 
   //valid vertices
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
 
   // delete first vertex
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
 
   // delete last vertex
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 1, 4 ) ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( p27.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 4 ) ) );
+
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
 
   // delete another vertex - should remove ring
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
-  QCOMPARE( p27.numInteriorRings(), 0 );
-  QVERIFY( p27.exteriorRing() );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
+
+  QCOMPARE( pl.numInteriorRings(), 0 );
+  QVERIFY( pl.exteriorRing() );
+}
+
+void TestQgsPolygon::deleteExteriorRing()
+{
+  QgsPolygon pl;
+
+  QgsLineString l38;
+  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( l38.clone() );
+  pl.addInteriorRing( l38.clone() );
 
   // test that interior ring is "promoted" when exterior is removed
-  p27.addInteriorRing( l38.clone() );
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( p27.numInteriorRings(), 1 );
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( p27.numInteriorRings(), 1 );
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( p27.numInteriorRings(), 1 );
-  QVERIFY( p27.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( p27.numInteriorRings(), 0 );
-  QVERIFY( p27.exteriorRing() );
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
 
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 1 );
+
+  QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QCOMPARE( pl.numInteriorRings(), 0 );
+
+  QVERIFY( pl.exteriorRing() );
+}
+
+void TestQgsPolygon::adjacentVertices()
+{
   // test adjacent vertices - should wrap around!
-  QgsLineString *closedRing1 = new QgsLineString();
-  closedRing1->setPoints( QgsPointSequence() << QgsPoint( 1, 1 ) << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 ) << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
-  QgsPolygon p28;
+  QgsPolygon pl;
   QgsVertexId previous( 1, 2, 3 );
   QgsVertexId next( 4, 5, 6 );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( ) );
-  QCOMPARE( next, QgsVertexId( ) );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
   QCOMPARE( previous, QgsVertexId( ) );
   QCOMPARE( next, QgsVertexId( ) );
 
-  p28.setExteriorRing( closedRing1 );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 2 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 2 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 1 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 3 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 3 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 2 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 4 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 0, 4 ), previous, next );
-  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
-  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
   QCOMPARE( previous, QgsVertexId( ) );
   QCOMPARE( next, QgsVertexId( ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
+  QgsLineString *closedRing1 = new QgsLineString();
+  closedRing1->setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                          << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
+                          << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
+  pl.setExteriorRing( closedRing1 );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 1 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 0 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 2 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 2 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 1 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 3 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 3 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 2 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 4 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 0, 4 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( 0, 0, 3 ) );
+  QCOMPARE( next, QgsVertexId( 0, 0, 1 ) );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  QCOMPARE( previous, QgsVertexId( ) );
+  QCOMPARE( next, QgsVertexId( ) );
+
   // part number should be retained
-  p28.adjacentVertices( QgsVertexId( 1, 0, 0 ), previous, next );
+  pl.adjacentVertices( QgsVertexId( 1, 0, 0 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 1, 0, 3 ) );
   QCOMPARE( next, QgsVertexId( 1, 0, 1 ) );
 
   // interior ring
-  p28.addInteriorRing( closedRing1->clone() );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
+  pl.addInteriorRing( closedRing1->clone() );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 0 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
   QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 1 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 1 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 0, 1, 0 ) );
   QCOMPARE( next, QgsVertexId( 0, 1, 2 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 2 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 2 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 0, 1, 1 ) );
   QCOMPARE( next, QgsVertexId( 0, 1, 3 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 3 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 3 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 0, 1, 2 ) );
   QCOMPARE( next, QgsVertexId( 0, 1, 4 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 1, 4 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 1, 4 ), previous, next );
   QCOMPARE( previous, QgsVertexId( 0, 1, 3 ) );
   QCOMPARE( next, QgsVertexId( 0, 1, 1 ) );
-  p28.adjacentVertices( QgsVertexId( 0, 2, 0 ), previous, next );
+
+  pl.adjacentVertices( QgsVertexId( 0, 2, 0 ), previous, next );
   QCOMPARE( previous, QgsVertexId( ) );
   QCOMPARE( next, QgsVertexId( ) );
+}
 
-  // vertex number
-  QgsLineString vertexLine2;
-  QCOMPARE( vertexLine2.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+void TestQgsPolygon::vertexNumberFromVertexId()
+{
+  QgsLineString ls;
+  QCOMPARE( ls.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
 
-  QgsLineString *closedRing2 = new QgsLineString();
-  closedRing2->setPoints( QgsPointSequence() << QgsPoint( 1, 1 ) << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 ) << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
-  QgsPolygon p29;
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), -1 );
-  p29.setExteriorRing( closedRing2 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
-  p29.addInteriorRing( closedRing2->clone() );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), 5 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 1 ) ), 6 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 2 ) ), 7 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 3 ) ), 8 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 4 ) ), 9 );
-  QCOMPARE( p29.vertexNumberFromVertexId( QgsVertexId( 0, 1, 5 ) ), -1 );
+  QgsPolygon pl;
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), -1 );
 
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 1 )
+                << QgsPoint( 1, 2 ) << QgsPoint( 2, 2 )
+                << QgsPoint( 2, 1 ) << QgsPoint( 1, 1 ) );
+  pl.setExteriorRing( ls.clone() );
 
-  //segmentLength
-  QgsPolygon p30;
-  QgsLineString vertexLine3;
-  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
-  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
-                         << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
-  p30.setExteriorRing( vertexLine3.clone() );
-  QCOMPARE( p30.segmentLength( QgsVertexId() ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 1, 0, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, -1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, -1 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
+
+  pl.addInteriorRing( ls.clone() );
+
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 0 ) ), 0 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 1 ) ), 1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 2 ) ), 2 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 3 ) ), 3 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 4 ) ), 4 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 0, 5 ) ), -1 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 0 ) ), 5 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 1 ) ), 6 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 2 ) ), 7 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 3 ) ), 8 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 4 ) ), 9 );
+  QCOMPARE( pl.vertexNumberFromVertexId( QgsVertexId( 0, 1, 5 ) ), -1 );
+}
+
+void TestQgsPolygon::segmentLength()
+{
+  QgsPolygon pl;
+
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 111, 12 )
+                << QgsPoint( 111, 2 ) << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 0.0 );
 
   // add interior ring
-  vertexLine3.setPoints( QgsPointSequence() << QgsPoint( 30, 6 ) << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
-                         << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
-  p30.addInteriorRing( vertexLine3.clone() );
-  QCOMPARE( p30.segmentLength( QgsVertexId() ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, -1 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 0 ) ), 4.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 1 ) ), 2.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 2 ) ), 4.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 3 ) ), 2.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 0, 1, 4 ) ), 0.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
-  QCOMPARE( p30.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 30, 6 )
+                << QgsPoint( 34, 6 ) << QgsPoint( 34, 8 )
+                << QgsPoint( 30, 8 ) << QgsPoint( 30, 6 ) );
+  pl.addInteriorRing( ls.clone() );
 
-  //removeDuplicateNodes
-  QgsPolygon nodePolygon;
-  QgsLineString nodeLine;
-  QVERIFY( !nodePolygon.removeDuplicateNodes() );
-  nodeLine.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 ) << QgsPoint( 11, 2 ) );
-  nodePolygon.setExteriorRing( nodeLine.clone() );
-  QVERIFY( !nodePolygon.removeDuplicateNodes() );
-  QCOMPARE( nodePolygon.asWkt(), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
-  nodeLine.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
-                      << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 ) << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 ) << QgsPoint( 11, 2 ) );
-  nodePolygon.setExteriorRing( nodeLine.clone() );
-  QVERIFY( nodePolygon.removeDuplicateNodes( 0.02 ) );
-  QVERIFY( !nodePolygon.removeDuplicateNodes( 0.02 ) );
-  QCOMPARE( nodePolygon.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
-  nodeLine.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
-                      << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 ) << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 ) << QgsPoint( 11, 2 ) );
-  nodePolygon.setExteriorRing( nodeLine.clone() );
-  QVERIFY( !nodePolygon.removeDuplicateNodes() );
-  QCOMPARE( nodePolygon.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11.01 1.99, 11.02 2.01, 11 12, 11 22, 11.01 21.99, 10.99 1.99, 11 2))" ) );
+  QCOMPARE( pl.segmentLength( QgsVertexId() ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 2 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 3 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 0, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( -1, 0, 0 ) ), 10.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, -1, 0 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, -1 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 0 ) ), 4.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 1 ) ), 2.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 2 ) ), 4.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 3 ) ), 2.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 0, 1, 4 ) ), 0.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 0, 1 ) ), 100.0 );
+  QCOMPARE( pl.segmentLength( QgsVertexId( 1, 1, 1 ) ), 2.0 );
+}
+
+void TestQgsPolygon::removeDuplicateNodes()
+{
+  QgsPolygon pl;
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 11, 22 ) << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+  QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
+                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
+                << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
+  QVERIFY( !pl.removeDuplicateNodes( 0.02 ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 )
+                << QgsPoint( 11.01, 1.99 ) << QgsPoint( 11.02, 2.01 )
+                << QgsPoint( 11, 12 ) << QgsPoint( 11, 22 )
+                << QgsPoint( 11.01, 21.99 ) << QgsPoint( 10.99, 1.99 )
+                << QgsPoint( 11, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.removeDuplicateNodes() );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11.01 1.99, 11.02 2.01, 11 12, 11 22, 11.01 21.99, 10.99 1.99, 11 2))" ) );
+
   // don't create degenerate rings
-  nodeLine.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 2.01 ) << QgsPoint( 11, 2.01 ) << QgsPoint( 11, 2 ) );
-  nodePolygon.addInteriorRing( nodeLine.clone() );
-  QVERIFY( nodePolygon.removeDuplicateNodes( 0.02 ) );
-  QCOMPARE( nodePolygon.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2),(11 2, 11.01 2.01, 11 2.01, 11 2))" ) );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2 ) << QgsPoint( 11.01, 2.01 )
+                << QgsPoint( 11, 2.01 ) << QgsPoint( 11, 2 ) );
+  pl.addInteriorRing( ls.clone() );
 
-  // swap XY
-  QgsPolygon swapPolygon;
-  swapPolygon.swapXy(); //no crash
-  QgsLineString swapLine;
-  swapLine.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  swapPolygon.setExteriorRing( swapLine.clone() );
-  swapPolygon.swapXy();
-  QCOMPARE( swapPolygon.asWkt(), QStringLiteral( "PolygonZM ((2 11 3 4, 12 11 13 14, 22 11 23 24, 2 11 3 4))" ) );
-  swapLine.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  swapPolygon.addInteriorRing( swapLine.clone() );
-  swapPolygon.swapXy();
-  QCOMPARE( swapPolygon.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(2 1 5 6, 2.01 11.01 15 16, 2.01 11 25 26, 2 11 5 6, 2 1 5 6))" ) );
+  QVERIFY( pl.removeDuplicateNodes( 0.02 ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "Polygon ((11 2, 11 12, 11 22, 11 2),(11 2, 11.01 2.01, 11 2.01, 11 2))" ) );
+}
 
-  // filter vertex
-  QgsPolygon filterPolygon;
+void TestQgsPolygon::swapXy()
+{
+  QgsPolygon pl;
+  pl.swapXy(); //no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.swapXy();
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((2 11 3 4, 12 11 13 14, 22 11 23 24, 2 11 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.swapXy();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(2 1 5 6, 2.01 11.01 15 16, 2.01 11 25 26, 2 11 5 6, 2 1 5 6))" ) );
+}
+
+void TestQgsPolygon::filterVertices()
+{
   auto filter = []( const QgsPoint & point )-> bool
   {
     return point.x() > 5;
   };
-  filterPolygon.filterVertices( filter ); // no crash
-  QgsLineString filterPolygonRing;
-  filterPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  filterPolygon.setExteriorRing( filterPolygonRing.clone() );
-  filterPolygon.filterVertices( filter );
-  QCOMPARE( filterPolygon.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
-  filterPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  filterPolygon.addInteriorRing( filterPolygonRing.clone() );
-  filterPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  filterPolygon.addInteriorRing( filterPolygonRing.clone() );
-  filterPolygon.filterVertices( filter );
-  QCOMPARE( filterPolygon.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(10 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 11 2 5 6, 10 2 5 6),(11.01 2.01 15 16, 11 2.01 25 26))" ) );
 
-  // transform vertex
-  QgsPolygon transformPolygon;
+  QgsPolygon pl;
+  pl.filterVertices( filter ); // no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.filterVertices( filter );
+
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.filterVertices( filter );
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 11 12 13 14, 11 22 23 24, 11 2 3 4),(10 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 11 2 5 6, 10 2 5 6),(11.01 2.01 15 16, 11 2.01 25 26))" ) );
+}
+
+void TestQgsPolygon::transformVertices()
+{
   auto transform = []( const QgsPoint & point )-> QgsPoint
   {
     return QgsPoint( point.x() + 2, point.y() + 3, point.z() + 4, point.m() + 5 );
   };
-  transformPolygon.transformVertices( transform ); // no crash
-  QgsLineString transformPolygonRing;
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  transformPolygon.setExteriorRing( transformPolygonRing.clone() );
-  transformPolygon.transformVertices( transform );
-  QCOMPARE( transformPolygon.asWkt(), QStringLiteral( "PolygonZM ((13 5 7 9, 6 15 17 19, 13 15 17 19, 13 25 27 29, 13 5 7 9))" ) );
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  transformPolygon.addInteriorRing( transformPolygonRing.clone() );
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  transformPolygon.addInteriorRing( transformPolygonRing.clone() );
-  transformPolygon.transformVertices( transform );
-  QCOMPARE( transformPolygon.asWkt( 2 ), QStringLiteral( "PolygonZM ((15 8 11 14, 8 18 21 24, 15 18 21 24, 15 28 31 34, 15 8 11 14),(12 5 9 11, 6 15 17 19, 13.01 5.01 19 21, 13 5.01 29 31, 13 5 9 11, 12 5 9 11),(3 5 9 11, 13.01 5.01 19 21, 13 5.01 29 31, 3 5 9 11))" ) );
 
-  // transform using class
-  QgsPolygon transformPolygon2;
+  QgsPolygon pl;
+  pl.transformVertices( transform ); // no crash
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.transformVertices( transform );
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((13 5 7 9, 6 15 17 19, 13 15 17 19, 13 25 27 29, 13 5 7 9))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.transformVertices( transform );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((15 8 11 14, 8 18 21 24, 15 18 21 24, 15 28 31 34, 15 8 11 14),(12 5 9 11, 6 15 17 19, 13.01 5.01 19 21, 13 5.01 29 31, 13 5 9 11, 12 5 9 11),(3 5 9 11, 13.01 5.01 19 21, 13 5.01 29 31, 3 5 9 11))" ) );
+}
+
+void TestQgsPolygon::transformWithClass()
+{
+  QgsPolygon pl;
   TestTransformer transformer;
+
   // no crash
-  QVERIFY( transformPolygon2.transform( &transformer ) );
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  transformPolygon2.setExteriorRing( transformPolygonRing.clone() );
-  QVERIFY( transformPolygon2.transform( &transformer ) );
-  QCOMPARE( transformPolygon2.asWkt( 2 ), QStringLiteral( "PolygonZM ((33 16 8 3, 12 26 18 13, 33 26 18 13, 33 36 28 23, 33 16 8 3))" ) );
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  transformPolygon2.addInteriorRing( transformPolygonRing.clone() );
-  transformPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  transformPolygon2.addInteriorRing( transformPolygonRing.clone() );
-  QVERIFY( transformPolygon2.transform( &transformer ) );
-  QCOMPARE( transformPolygon2.asWkt( 2 ), QStringLiteral( "PolygonZM ((99 30 13 2, 36 40 23 12, 99 40 23 12, 99 50 33 22, 99 30 13 2),(30 16 10 5, 12 26 18 13, 33.03 16.01 20 15, 33 16.01 30 25, 33 16 10 5, 30 16 10 5),(3 16 10 5, 33.03 16.01 20 15, 33 16.01 30 25, 3 16 10 5))" ) );
+  QVERIFY( pl.transform( &transformer ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.transform( &transformer ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((33 16 8 3, 12 26 18 13, 33 26 18 13, 33 36 28 23, 33 16 8 3))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.transform( &transformer ) );
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((99 30 13 2, 36 40 23 12, 99 40 23 12, 99 50 33 22, 99 30 13 2),(30 16 10 5, 12 26 18 13, 33.03 16.01 20 15, 33 16.01 30 25, 33 16 10 5, 30 16 10 5),(3 16 10 5, 33.03 16.01 20 15, 33 16.01 30 25, 3 16 10 5))" ) );
 
   TestFailTransformer failTransformer;
-  QVERIFY( !transformPolygon2.transform( &failTransformer ) );
+  QVERIFY( !pl.transform( &failTransformer ) );
+}
 
-  // remove invalid rings
-  QgsPolygon invalidRingPolygon;
-  invalidRingPolygon.removeInvalidRings(); // no crash
-  QgsLineString removeInvalidPolygonRing;
-  removeInvalidPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM ) << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
-  invalidRingPolygon.setExteriorRing( removeInvalidPolygonRing.clone() );
-  invalidRingPolygon.removeInvalidRings();
-  QCOMPARE( invalidRingPolygon.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
-  removeInvalidPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )  << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  invalidRingPolygon.addInteriorRing( removeInvalidPolygonRing.clone() );
-  removeInvalidPolygonRing.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM ) << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM ) << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
-  invalidRingPolygon.addInteriorRing( removeInvalidPolygonRing.clone() );
-  invalidRingPolygon.removeInvalidRings();
-  QCOMPARE( invalidRingPolygon.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4),(1 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 1 2 5 6))" ) );
+void TestQgsPolygon::removeInvalidRings()
+{
+  QgsPolygon pl;
+  pl.removeInvalidRings(); // no crash
 
-  // force RHR
-  QgsPolygon rhr;
-  rhr.forceRHR(); // no crash
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  rhr.forceRHR();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  rhr.forceRHR();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.forceRHR();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.forceRHR();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  rhr.forceRHR();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM )
+                << QgsPoint( 4, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 12, 13, 14, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 22, 23, 24, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 3, 4, QgsWkbTypes::PointZM ) );
+  pl.setExteriorRing( ls.clone() );
+
+  pl.removeInvalidRings();
+  QCOMPARE( pl.asWkt(), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4))" ) );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 10, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM )
+                << QgsPoint( 11.01, 2.01, 15, 16, QgsWkbTypes::PointZM )
+                << QgsPoint( 11, 2.01, 25, 26, QgsWkbTypes::PointZM )
+                << QgsPoint( 1, 2, 5, 6, QgsWkbTypes::PointZM ) );
+  pl.addInteriorRing( ls.clone() );
+
+  pl.removeInvalidRings();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((11 2 3 4, 4 12 13 14, 11 12 13 14, 11 22 23 24, 11 2 3 4),(1 2 5 6, 11.01 2.01 15 16, 11 2.01 25 26, 1 2 5 6))" ) );
+}
+
+void TestQgsPolygon::forceRHR()
+{
+  QgsPolygon pl;
+  pl.forceRHR(); // no crash
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceRHR();
+
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
 
   // force cw (same as force RHR)
-  rhr = QgsPolygon();
-  rhr.forceClockwise(); // no crash
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  rhr.forceClockwise();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  rhr.forceClockwise();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.forceClockwise();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.forceClockwise();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
-  rhr.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  rhr.forceClockwise();
-  QCOMPARE( rhr.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
+  pl = QgsPolygon();
+  pl.forceClockwise(); // no crash
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
 
   // force ccw
-  QgsPolygon ccw;
-  ccw.forceCounterClockwise(); // no crash
-  ccw.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
-  ccw.forceCounterClockwise();
-  QCOMPARE( ccw.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4))" ) );
-  ccw.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  ccw.forceCounterClockwise();
-  QCOMPARE( ccw.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
-  ccw.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  ccw.forceCounterClockwise();
-  QCOMPARE( ccw.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
-  ccw.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
-  ccw.forceCounterClockwise();
-  QCOMPARE( ccw.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
-  ccw.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
-  ccw.forceCounterClockwise();
-  QCOMPARE( ccw.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl = QgsPolygon();
+  pl.forceCounterClockwise(); // no crash
 
-  // test bounding box intersects
-  QgsPolygon bb;
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QgsLineString bbR;
-  bbR.setPoints( QgsPointSequence() << QgsPoint( 0, 2 ) << QgsPoint( 4, 2 ) << QgsPoint( 4, 4 ) << QgsPoint( 0, 2 ) );
-  bb.setExteriorRing( bbR.clone() );
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 10 20 6 8, 20 10 3 4, 10 10 1 2))" ) );
+
+  pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+  pl.forceCounterClockwise();
+  QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 23 24, 100 100 13 14, 0 100 13 14, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
+}
+
+void TestQgsPolygon::boundingBoxIntersects()
+{
+  QgsPolygon pl;
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 0, 2 ) << QgsPoint( 4, 2 )
+                << QgsPoint( 4, 4 ) << QgsPoint( 0, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+
   // double test because of cache
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
-  QCOMPARE( bb.boundingBox(), QgsRectangle( 0, 2, 4, 4 ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 11, 3, 6, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 0, 2, 4, 4 ) );
+
   // clear cache
-  bbR.setPoints( QgsPointSequence() << QgsPoint( 10, 2 ) << QgsPoint( 14, 2 ) << QgsPoint( 15, 4 ) << QgsPoint( 10, 2 ) );
-  bb.setExteriorRing( bbR.clone() );
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QCOMPARE( bb.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 10, 2 ) << QgsPoint( 14, 2 )
+                << QgsPoint( 15, 4 ) << QgsPoint( 10, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
+
   // technically invalid -- the interior ring is outside the exterior, but we want boundingBoxIntersects to be tolerant to
   // cases like this!
-  bbR.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 4, 2 ) << QgsPoint( 5, 4 ) << QgsPoint( 1, 2 ) );
-  bb.addInteriorRing( bbR.clone() );
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
-  QVERIFY( bb.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
-  QVERIFY( !bb.boundingBoxIntersects( QgsRectangle( 21, 3, 26, 9 ) ) );
-  QCOMPARE( bb.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 4, 2 )
+                << QgsPoint( 5, 4 ) << QgsPoint( 1, 2 ) );
+  pl.addInteriorRing( ls.clone() );
+
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
+  QVERIFY( pl.boundingBoxIntersects( QgsRectangle( 11, 3, 16, 9 ) ) );
+  QVERIFY( !pl.boundingBoxIntersects( QgsRectangle( 21, 3, 26, 9 ) ) );
+  QCOMPARE( pl.boundingBox(), QgsRectangle( 10, 2, 15, 4 ) );
 }
 
 QGSTEST_MAIN( TestQgsPolygon )

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -110,17 +110,17 @@ void TestQgsPolygon::constructor()
 
 void TestQgsPolygon::altConstructor()
 {
-  QgsLineString *ext = new QgsLineString( QVector<QgsPoint>() << QgsPoint( 0, 0 )
-                                          << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
-                                          << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
-  QgsLineString *ring1 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 1, 1 )
-      << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 )
-      << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) );
-  QgsLineString *ring2 = new QgsLineString( QVector< QgsPoint >() << QgsPoint( 3, 1 )
-      << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 )
-      << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) );
+  QgsLineString ext( QVector<QgsPoint>() << QgsPoint( 0, 0 )
+                     << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
+                     << QgsPoint( 10, 0 ) << QgsPoint( 0, 0 ) );
+  QgsLineString ring1( QVector< QgsPoint >() << QgsPoint( 1, 1 )
+                       << QgsPoint( 2, 1 ) << QgsPoint( 2, 2 )
+                       << QgsPoint( 1, 2 ) << QgsPoint( 1, 1 ) );
+  QgsLineString ring2( QVector< QgsPoint >() << QgsPoint( 3, 1 )
+                       << QgsPoint( 4, 1 ) << QgsPoint( 4, 2 )
+                       << QgsPoint( 3, 2 ) << QgsPoint( 3, 1 ) );
 
-  QgsPolygon pl( ext, QList< QgsLineString *>() << ring1 << ring2 );
+  QgsPolygon pl( ext.clone(), QList< QgsLineString *>() << ring1.clone() << ring2.clone() );
 
   QCOMPARE( pl.asWkt(), QStringLiteral( "Polygon ((0 0, 0 10, 10 10, 10 0, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1))" ) );
 }
@@ -354,8 +354,10 @@ void TestQgsPolygon::copy()
 
   QgsLineString *ring = new QgsLineString();
   ring->setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
-                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 )
+                   << QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
   pl1.addInteriorRing( ring );
 
   pl2 = QgsPolygon( pl1 );
@@ -427,7 +429,9 @@ void TestQgsPolygon::setBadExteriorRing()
                   << QgsPoint( 10, 10 ) << QgsPoint( 10, 0 ) );
 
   QVERIFY( !ext->isClosed() );
+
   pl.setExteriorRing( ext );
+
   QVERIFY( !pl.isEmpty() );
   QVERIFY( pl.exteriorRing()->isClosed() );
   QCOMPARE( pl.nCoordinates(), 5 );
@@ -437,7 +441,6 @@ void TestQgsPolygon::setExteriorRing()
 {
   QgsPolygon pl;
 
-  //valid exterior ring
   QgsLineString *ext = new QgsLineString();
   ext->setPoints( QgsPointSequence() << QgsPoint( 0, 0 )
                   << QgsPoint( 0, 10 ) << QgsPoint( 10, 10 )
@@ -565,15 +568,19 @@ void TestQgsPolygon::setExteriorRingChangesInteriorRings()
   QVector< QgsCurve * > rings;
 
   QgsPointSequence pts;
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
       << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
   rings << new QgsLineString();
   static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
 
   pts = QgsPointSequence();
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 )
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3, 1 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.4, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.4, 3 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.4, 0.3, 4 )
       << QgsPoint( QgsWkbTypes::PointZ, 0.3, 0.3,  1 );
   rings << new QgsLineString();
   static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
@@ -637,13 +644,13 @@ void TestQgsPolygon::deleteExteriorRing()
 {
   QgsPolygon pl;
 
-  QgsLineString l38;
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
-                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
-                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
-                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( l38.clone() );
-  pl.addInteriorRing( l38.clone() );
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
 
   // test that interior ring is "promoted" when exterior is removed
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
@@ -834,15 +841,19 @@ void TestQgsPolygon::setInteriorRings()
   QVector< QgsCurve * > rings;
 
   QgsPointSequence pts;
-  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 ) << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
-      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
+  pts << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.2, 2 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.2, 3 )
+      << QgsPoint( QgsWkbTypes::PointZ, 0.2, 0.1, 4 )
       << QgsPoint( QgsWkbTypes::PointZ, 0.1, 0.1, 1 );
   rings << new QgsLineString();
   static_cast< QgsLineString *>( rings[0] )->setPoints( pts );
 
   pts = QgsPointSequence();
-  pts << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 ) << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 )
-      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 )
+  pts << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.4, 0, 2 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.4, 0, 3 )
+      << QgsPoint( QgsWkbTypes::PointM, 0.4, 0.3, 0, 4 )
       << QgsPoint( QgsWkbTypes::PointM, 0.3, 0.3, 0, 1 );
   rings << new QgsLineString();
   static_cast< QgsLineString *>( rings[1] )->setPoints( pts );
@@ -1045,11 +1056,13 @@ void TestQgsPolygon::insertVertex()
                 << QgsPoint( 0, 2 ) << QgsPoint( 0, 0 ) );
   pl.setExteriorRing( ls.clone() );
 
+  auto ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 0.3, 0 ) ) );
   QCOMPARE( pl.nCoordinates(), 8 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 0.5, 0 ) );
 
   QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 6.0, 7.0 ) ) );
   QVERIFY( !pl.insertVertex( QgsVertexId( 0, 0, 100 ), QgsPoint( 6.0, 7.0 ) ) );
@@ -1059,35 +1072,37 @@ void TestQgsPolygon::insertVertex()
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 0, 0.1 ) ) );
 
   QCOMPARE( pl.nCoordinates(), 9 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ext->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( ext->pointN( 8 ), QgsPoint( 0, 0.1 ) );
 
   // last vertex
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 0, 9 ), QgsPoint( 0.1, 0.1 ) ) );
 
   QCOMPARE( pl.nCoordinates(), 10 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ext->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ext->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
 
   // with interior ring
   pl.addInteriorRing( ls.clone() );
+
+  auto ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
 
   QCOMPARE( pl.nCoordinates(), 17 );
 
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 0.3, 0 ) ) );
 
   QCOMPARE( pl.nCoordinates(), 18 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 0.5, 0 ) );
 
   QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 6.0, 7.0 ) ) );
   QVERIFY( !pl.insertVertex( QgsVertexId( 0, 1, 100 ), QgsPoint( 6.0, 7.0 ) ) );
@@ -1097,23 +1112,23 @@ void TestQgsPolygon::insertVertex()
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 0, 0.1 ) ) );
 
   QCOMPARE( pl.nCoordinates(), 19 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 7 ), QgsPoint( 0, 2 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ring->pointN( 7 ), QgsPoint( 0, 2 ) );
+  QCOMPARE( ring->pointN( 8 ), QgsPoint( 0, 0.1 ) );
 
   // last vertex in interior ring
   QVERIFY( pl.insertVertex( QgsVertexId( 0, 1, 9 ), QgsPoint( 0.1, 0.1 ) ) );
 
   QCOMPARE( pl.nCoordinates(), 20 );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 0, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 0.3, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 0.5, 0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 8 ), QgsPoint( 0, 0.1 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 0.1, 0.1 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 0.3, 0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 0.5, 0 ) );
+  QCOMPARE( ring->pointN( 8 ), QgsPoint( 0, 0.1 ) );
+  QCOMPARE( ring->pointN( 9 ), QgsPoint( 0.1, 0.1 ) );
 }
 
 void TestQgsPolygon::moveVertex()
@@ -1130,36 +1145,40 @@ void TestQgsPolygon::moveVertex()
                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
   pl.setExteriorRing( ls.clone() );
 
+  auto ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
+
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPoint( 6.0, 7.0 ) ) );
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPoint( 16.0, 17.0 ) ) );
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( 26.0, 27.0 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
 
   //out of range
   QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, -1 ), QgsPoint( 3.0, 4.0 ) ) );
   QVERIFY( !pl.moveVertex( QgsVertexId( 0, 0, 10 ), QgsPoint( 3.0, 4.0 ) ) );
   QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 3.0, 4.0 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
 
   // with interior ring
   pl.addInteriorRing( ls.clone() );
+
+  auto ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
 
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 0 ), QgsPoint( 6.0, 7.0 ) ) );
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 1 ), QgsPoint( 16.0, 17.0 ) ) );
   QVERIFY( pl.moveVertex( QgsVertexId( 0, 1, 2 ), QgsPoint( 26.0, 27.0 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 6.0, 7.0 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 16.0, 17.0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 26.0, 27.0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 6.0, 7.0 ) );
 
   QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, -1 ), QgsPoint( 3.0, 4.0 ) ) );
   QVERIFY( !pl.moveVertex( QgsVertexId( 0, 1, 10 ), QgsPoint( 3.0, 4.0 ) ) );
@@ -1176,12 +1195,14 @@ void TestQgsPolygon::deleteVertex()
   QVERIFY( pl.isEmpty() );
 
   //valid polygon
-  QgsLineString l38;
-  l38.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
-                 << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
-                 << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
-                 << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
-  pl.setExteriorRing( l38.clone() );
+  QgsLineString ls;
+  ls.setPoints( QgsPointSequence() << QgsPoint( 1, 2 )
+                << QgsPoint( 5, 2 ) << QgsPoint( 6, 2 )
+                << QgsPoint( 7, 2 ) << QgsPoint( 11, 12 )
+                << QgsPoint( 21, 22 ) << QgsPoint( 1, 2 ) );
+  pl.setExteriorRing( ls.clone() );
+
+  auto ext = static_cast< const QgsLineString * >( pl.exteriorRing() );
 
   //out of range vertices
   QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 0, -1 ) ) );
@@ -1191,36 +1212,38 @@ void TestQgsPolygon::deleteVertex()
   //valid vertices
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ext->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
 
   // delete first vertex
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ext->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
 
   // delete last vertex
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 4 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.exteriorRing() )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ext->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ext->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ext->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ext->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
 
   // delete another vertex - should remove ring
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 0, 1 ) ) );
   QVERIFY( !pl.exteriorRing() );
 
   // with interior ring
-  pl.setExteriorRing( l38.clone() );
-  pl.addInteriorRing( l38.clone() );
+  pl.setExteriorRing( ls.clone() );
+  pl.addInteriorRing( ls.clone() );
+
+  auto ring = static_cast< const QgsLineString * >( pl.interiorRing( 0 ) );
 
   //out of range vertices
   QVERIFY( !pl.deleteVertex( QgsVertexId( 0, 1, -1 ) ) );
@@ -1230,28 +1253,28 @@ void TestQgsPolygon::deleteVertex()
   //valid vertices
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ring->pointN( 5 ), QgsPoint( 1.0, 2.0 ) );
 
   // delete first vertex
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 0 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 6.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ring->pointN( 4 ), QgsPoint( 6.0, 2.0 ) );
 
   // delete last vertex
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 4 ) ) );
 
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
-  QCOMPARE( static_cast< const QgsLineString * >( pl.interiorRing( 0 ) )->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ring->pointN( 0 ), QgsPoint( 21.0, 22.0 ) );
+  QCOMPARE( ring->pointN( 1 ), QgsPoint( 7.0, 2.0 ) );
+  QCOMPARE( ring->pointN( 2 ), QgsPoint( 11.0, 12.0 ) );
+  QCOMPARE( ring->pointN( 3 ), QgsPoint( 21.0, 22.0 ) );
 
   // delete another vertex - should remove ring
   QVERIFY( pl.deleteVertex( QgsVertexId( 0, 1, 1 ) ) );
@@ -1366,6 +1389,7 @@ void TestQgsPolygon::nextVertex()
 void TestQgsPolygon::vertexNumberFromVertexId()
 {
   QgsLineString ls;
+
   QCOMPARE( ls.vertexNumberFromVertexId( QgsVertexId( -1, 0, 0 ) ), -1 );
 
   QgsPolygon pl;
@@ -1762,33 +1786,39 @@ void TestQgsPolygon::boundary()
 
   QVERIFY( multiLineBoundary );
   QCOMPARE( multiLineBoundary->numGeometries(), 3 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 0 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 1 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 2 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->xAt( 3 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 0 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 1 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 2 ), 1.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) )->yAt( 3 ), 0.0 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 0 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 1 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 2 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->xAt( 3 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 0 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 1 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 2 ), 0.2 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) )->yAt( 3 ), 0.1 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->numPoints(), 4 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 0 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 1 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 2 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->xAt( 3 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 0 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 1 ), 0.8 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 2 ), 0.9 );
-  QCOMPARE( qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) )->yAt( 3 ), 0.8 );
+
+  lineBoundary = qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 0 ) );
+  QCOMPARE( lineBoundary->numPoints(), 4 );
+  QCOMPARE( lineBoundary->xAt( 0 ), 0.0 );
+  QCOMPARE( lineBoundary->xAt( 1 ), 1.0 );
+  QCOMPARE( lineBoundary->xAt( 2 ), 1.0 );
+  QCOMPARE( lineBoundary->xAt( 3 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 0 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 1 ), 0.0 );
+  QCOMPARE( lineBoundary->yAt( 2 ), 1.0 );
+  QCOMPARE( lineBoundary->yAt( 3 ), 0.0 );
+
+  lineBoundary = qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 1 ) );
+  QCOMPARE( lineBoundary->numPoints(), 4 );
+  QCOMPARE( lineBoundary->xAt( 0 ), 0.1 );
+  QCOMPARE( lineBoundary->xAt( 1 ), 0.2 );
+  QCOMPARE( lineBoundary->xAt( 2 ), 0.2 );
+  QCOMPARE( lineBoundary->xAt( 3 ), 0.1 );
+  QCOMPARE( lineBoundary->yAt( 0 ), 0.1 );
+  QCOMPARE( lineBoundary->yAt( 1 ), 0.1 );
+  QCOMPARE( lineBoundary->yAt( 2 ), 0.2 );
+  QCOMPARE( lineBoundary->yAt( 3 ), 0.1 );
+
+  lineBoundary = qgis::down_cast< QgsLineString * >( multiLineBoundary->geometryN( 2 ) );
+  QCOMPARE( lineBoundary->numPoints(), 4 );
+  QCOMPARE( lineBoundary->xAt( 0 ), 0.8 );
+  QCOMPARE( lineBoundary->xAt( 1 ), 0.9 );
+  QCOMPARE( lineBoundary->xAt( 2 ), 0.9 );
+  QCOMPARE( lineBoundary->xAt( 3 ), 0.8 );
+  QCOMPARE( lineBoundary->yAt( 0 ), 0.8 );
+  QCOMPARE( lineBoundary->yAt( 1 ), 0.8 );
+  QCOMPARE( lineBoundary->yAt( 2 ), 0.9 );
+  QCOMPARE( lineBoundary->yAt( 3 ), 0.8 );
 
   pl.setInteriorRings( QVector< QgsCurve * >() );
   delete boundary;
@@ -2001,27 +2031,22 @@ void TestQgsPolygon::forceRHR()
 
   pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
   pl.forceRHR();
-
   QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4))" ) );
 
   pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 23 24, 0 100 23 24, 0 0 3 4))" ) );
   pl.forceRHR();
-
   QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 23 24, 100 0 13 14, 0 0 3 4))" ) );
 
   pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
   pl.forceRHR();
-
   QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
 
   pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 100 0 13 14, 100 100 13 14, 0 100 23 24, 0 0 3 4),(10 10 1 2, 20 10 3 4, 20 20 4, 5, 10 20 6 8, 10 10 1 2))" ) );
   pl.forceRHR();
-
   QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 23 24, 100 100 13 14, 100 0 13 14, 0 0 3 4),(10 10 1 2, 20 10 3 4, 10 20 6 8, 10 10 1 2))" ) );
 
   pl.fromWkt( QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 10 20 3 4, 20 10 6 8, 10 10 1 2))" ) );
   pl.forceRHR();
-
   QCOMPARE( pl.asWkt( 2 ), QStringLiteral( "PolygonZM ((0 0 3 4, 0 100 13 14, 100 100 13 14, 100 0 23 24, 0 0 3 4),(10 10 1 2, 20 10 6 8, 10 20 3 4, 10 10 1 2))" ) );
 
   // force cw (same as force RHR)
@@ -2599,30 +2624,23 @@ void TestQgsPolygon::toCurveType()
 
   QCOMPARE( curveType->wkbType(), QgsWkbTypes::CurvePolygonZM );
 
-  QCOMPARE( curveType->exteriorRing()->numPoints(), 5 );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 1 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 2 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 3 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) );
-  QCOMPARE( curveType->exteriorRing()->vertexAt( QgsVertexId( 0, 0, 4 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
+  const QgsLineString *exteriorRing = static_cast< const QgsLineString * >( curveType->exteriorRing() );
+  QCOMPARE( exteriorRing->numPoints(), 5 );
+  QCOMPARE( exteriorRing->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 5 ) );
+  QCOMPARE( exteriorRing->vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 10, 2, 6 ) );
+  QCOMPARE( exteriorRing->vertexAt( QgsVertexId( 0, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 10, 10, 3, 7 ) );
+  QCOMPARE( exteriorRing->vertexAt( QgsVertexId( 0, 0, 3 ) ), QgsPoint( QgsWkbTypes::PointZM, 10, 0, 4, 8 ) );
+  QCOMPARE( exteriorRing->vertexAt( QgsVertexId( 0, 0, 4 ) ), QgsPoint( QgsWkbTypes::PointZM, 0, 0, 1, 9 ) );
 
   QCOMPARE( curveType->numInteriorRings(), 1 );
-  QCOMPARE( curveType->interiorRing( 0 )->numPoints(), 5 );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 1 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 2 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 3 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) );
-  QCOMPARE( curveType->interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 4 ) ),
-            QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
+
+  const QgsLineString *interiorRing = static_cast< const QgsLineString * >( curveType->interiorRing( 0 ) );
+  QCOMPARE( interiorRing->numPoints(), 5 );
+  QCOMPARE( interiorRing->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 2 ) );
+  QCOMPARE( interiorRing->vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 9, 2, 3 ) );
+  QCOMPARE( interiorRing->vertexAt( QgsVertexId( 0, 0, 2 ) ), QgsPoint( QgsWkbTypes::PointZM, 9, 9, 3, 6 ) );
+  QCOMPARE( interiorRing->vertexAt( QgsVertexId( 0, 0, 3 ) ), QgsPoint( QgsWkbTypes::PointZM, 9, 1, 4, 4 ) );
+  QCOMPARE( interiorRing->vertexAt( QgsVertexId( 0, 0, 4 ) ), QgsPoint( QgsWkbTypes::PointZM, 1, 1, 1, 7 ) );
 }
 
 void TestQgsPolygon::toFromWkb()


### PR DESCRIPTION
## Description

Like previous PRs, I refactored the file `testqgspolygon.cpp`.

The class has a single method. This PR splits this method for better readability then adds tests. There are also tests added in `testqgstriangle.cpp` to test the wkb export of triangles as polygons. `QgsTriangle` doesn't overwrite `asWkb` method defined in `QgsPolygon`.

I used the [same methodology](https://github.com/qgis/QGIS/pull/44958#issuecomment-918872782) as the previous PRs.