### PR TITLE
When picking a default identifier for vector layers, pick "name" instead of "xxxx_name", even if "xxxx_name" comes first

### DIFF
--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1157,8 +1157,9 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
                                       QStringLiteral( "class" ),
                                       QStringLiteral( "cat" )
                                     };
-
+  int currentBestCandidateNameScore = std::numeric_limits<int>::max();
   QString bestCandidateName;
+  int currentBestCandidateNameWithAntiCandidateScore = std::numeric_limits<int>::max();
   QString bestCandidateNameWithAntiCandidate;
 
   for ( const QString &candidate : sCandidates )
@@ -1168,6 +1169,8 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
       const QString fldName = field.name();
       if ( fldName.contains( candidate, Qt::CaseInsensitive ) )
       {
+        // lower score is better, where score = number of extra characters
+        const int score = field.name().length() - candidate.length();
         bool isAntiCandidate = false;
         for ( const QString &antiCandidate : sAntiCandidates )
         {
@@ -1182,13 +1185,20 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
         {
           if ( bestCandidateNameWithAntiCandidate.isEmpty() )
           {
-            bestCandidateNameWithAntiCandidate = fldName;
+            if ( score < currentBestCandidateNameWithAntiCandidateScore )
+            {
+              bestCandidateNameWithAntiCandidate = fldName;
+              currentBestCandidateNameWithAntiCandidateScore = score;
+            }
           }
         }
         else
         {
-          bestCandidateName = fldName;
-          break;
+          if ( score < currentBestCandidateNameScore )
+          {
+            bestCandidateName = fldName;
+            currentBestCandidateNameScore = score;
+          }
         }
       }
     }

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -836,6 +836,28 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         fields.append(QgsField('org', QVariant.String))
         self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'station')
 
+        # when multiple field names match desirable identifiers, the one which is closest should be picked
+        fields = QgsFields()
+        fields.append(QgsField('id', QVariant.Int))
+        fields.append(QgsField('carnival_name', QVariant.String))
+        fields.append(QgsField('name', QVariant.String))
+        self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'name')
+
+        fields = QgsFields()
+        fields.append(QgsField('id', QVariant.Int))
+        fields.append(QgsField('name:highway', QVariant.String))
+        fields.append(QgsField('name', QVariant.String))
+        self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'name')
+
+        fields = QgsFields()
+        fields.append(QgsField('id', QVariant.Int))
+        fields.append(QgsField('name:highway', QVariant.String))
+        fields.append(QgsField('name:road', QVariant.String))
+        fields.append(QgsField('name:carnival', QVariant.String))
+        fields.append(QgsField('name', QVariant.String))
+        fields.append(QgsField('name_2', QVariant.String))
+        self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'name')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -858,6 +858,14 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         fields.append(QgsField('name_2', QVariant.String))
         self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'name')
 
+        # two candidates with equal distance, pick first
+        fields = QgsFields()
+        fields.append(QgsField('id', QVariant.Int))
+        fields.append(QgsField('name:highway', QVariant.String))
+        fields.append(QgsField('name:road', QVariant.String))
+        fields.append(QgsField('name:town', QVariant.String))
+        self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), 'name:road')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Specifically, pick fields which are closer in overall name length to the desirable target strings

Refs https://www.youtube.com/watch?v=ikw3o3umeBM&t=2434s