### PR TITLE
[ui] Allow blend mode combo boxes to adjust width to be shorter longest item label

### DIFF
--- a/src/gui/qgsblendmodecombobox.cpp
+++ b/src/gui/qgsblendmodecombobox.cpp
@@ -28,6 +28,7 @@
 QgsBlendModeComboBox::QgsBlendModeComboBox( QWidget *parent )
   : QComboBox( parent )
 {
+  setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
   updateModes();
 }
 

--- a/src/ui/qgsrendererpropsdialogbase.ui
+++ b/src/ui/qgsrendererpropsdialogbase.ui
@@ -209,6 +209,12 @@
             </item>
             <item row="0" column="1" colspan="2">
              <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>4</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="focusPolicy">
                <enum>Qt::StrongFocus</enum>
               </property>


### PR DESCRIPTION
## Description

A necessity now that the combo box has a few long item labels within group layers.

Before (top) vs. PR (bottom:
![image](https://user-images.githubusercontent.com/1728657/143824446-cff4062e-6b61-4ae2-b1a8-e1408702f661.png)

