### PR TITLE
QML - Do not save the Python function in the form section of the XML when it's not needed

### DIFF
--- a/src/core/editform/qgseditformconfig.cpp
+++ b/src/core/editform/qgseditformconfig.cpp
@@ -553,7 +553,7 @@ void QgsEditFormConfig::writeXml( QDomNode &node, const QgsReadWriteContext &con
   node.appendChild( efField );
 
   QDomElement efiField  = doc.createElement( QStringLiteral( "editforminit" ) );
-  if ( !initFunction().isEmpty() )
+  if ( !initFunction().isEmpty() && initCodeSource() == PythonInitCodeSource::CodeSourceDialog )
     efiField.appendChild( doc.createTextNode( initFunction() ) );
   node.appendChild( efiField );
 
@@ -562,7 +562,8 @@ void QgsEditFormConfig::writeXml( QDomNode &node, const QgsReadWriteContext &con
   node.appendChild( eficsField );
 
   QDomElement efifpField  = doc.createElement( QStringLiteral( "editforminitfilepath" ) );
-  efifpField.appendChild( doc.createTextNode( context.pathResolver().writePath( initFilePath() ) ) );
+  if ( initCodeSource() == PythonInitCodeSource::CodeSourceFile )
+    efifpField.appendChild( doc.createTextNode( context.pathResolver().writePath( initFilePath() ) ) );
   node.appendChild( efifpField );
 
   QDomElement eficField  = doc.createElement( QStringLiteral( "editforminitcode" ) );


### PR DESCRIPTION
## Description

I want to keep this block of Python code only when it's needed :  

```xml
      <editforminitcode># -*- coding: utf-8 -*-
"""
QGIS forms can have a Python function that is called when the form is
opened.

Use this function to add extra logic to your forms.

Enter the name of the function in the "Python Init function"
field.
An example follows:
"""
from qgis.PyQt.QtWidgets import QWidget

def my_form_open(dialog, layer, feature):
	geom = feature.geometry()
	control = dialog.findChild(QWidget, "MyLineEdit")
</editforminitcode>
```

I think this can be backported, ok ?
