### PR TITLE
Add API to determine which environment the QGIS libraries are running in

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -27,6 +27,15 @@ QgsMapLayer.GroupLayer.is_monkey_patched = True
 QgsMapLayer.GroupLayer.__doc__ = "Composite group layer. Added in QGIS 3.24"
 QgsMapLayerType.__doc__ = 'Types of layers that can be added to a map\n\n.. versionadded:: 3.8\n\n' + '* ``VectorLayer``: ' + QgsMapLayerType.VectorLayer.__doc__ + '\n' + '* ``RasterLayer``: ' + QgsMapLayerType.RasterLayer.__doc__ + '\n' + '* ``PluginLayer``: ' + QgsMapLayerType.PluginLayer.__doc__ + '\n' + '* ``MeshLayer``: ' + QgsMapLayerType.MeshLayer.__doc__ + '\n' + '* ``VectorTileLayer``: ' + QgsMapLayerType.VectorTileLayer.__doc__ + '\n' + '* ``AnnotationLayer``: ' + QgsMapLayerType.AnnotationLayer.__doc__ + '\n' + '* ``PointCloudLayer``: ' + QgsMapLayerType.PointCloudLayer.__doc__ + '\n' + '* ``GroupLayer``: ' + QgsMapLayerType.GroupLayer.__doc__
 # --
+# monkey patching scoped based enum
+Qgis.Environment.Desktop.__doc__ = "QGIS desktop application"
+Qgis.Environment.Server.__doc__ = "QGIS server"
+Qgis.Environment.Mobile.__doc__ = "Mobile application (e.g. QField/Input)"
+Qgis.Environment.QgisProcess.__doc__ = "Qgis_process CLI application"
+Qgis.Environment.External.__doc__ = "External script, such as a PyQGIS application run outside of the QGIS desktop application"
+Qgis.Environment.__doc__ = 'Application environment.\n\n.. versionadded:: 3.22.2\n\n' + '* ``Desktop``: ' + Qgis.Environment.Desktop.__doc__ + '\n' + '* ``Server``: ' + Qgis.Environment.Server.__doc__ + '\n' + '* ``Mobile``: ' + Qgis.Environment.Mobile.__doc__ + '\n' + '* ``QgisProcess``: ' + Qgis.Environment.QgisProcess.__doc__ + '\n' + '* ``External``: ' + Qgis.Environment.External.__doc__
+# --
+Qgis.Environment.baseClass = Qgis
 Qgis.MessageLevel.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.UnknownDataType = Qgis.DataType.UnknownDataType

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -77,6 +77,15 @@ The development version
 %End
 
 
+    enum class Environment
+    {
+      Desktop,
+      Server,
+      Mobile,
+      QgisProcess,
+      External,
+    };
+
     enum MessageLevel
     {
       Info,
@@ -826,6 +835,14 @@ GEOS string version linked
 
 .. versionadded:: 3.20
 %End
+
+    static Environment environment();
+%Docstring
+Returns the application environment.
+
+.. versionadded:: 3.22.2
+%End
+
 };
 
 QFlags<Qgis::SymbolRenderHint> operator|(Qgis::SymbolRenderHint f1, QFlags<Qgis::SymbolRenderHint> f2);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -892,6 +892,8 @@ int main( int argc, char *argv[] )
   QCoreApplication::setAttribute( Qt::AA_DontShowIconsInMenus, false );
   QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton, true );
 
+  Qgis::sEnvironment = Qgis::Environment::Desktop;
+
   // Set up an OpenGL Context to be shared between threads beforehand
   // for plugins that depend on Qt WebEngine module.
   // As suggested by Qt documentation at:

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -335,6 +335,13 @@ int Qgis::geosVersionPatch()
   return version;
 }
 
+Qgis::Environment Qgis::sEnvironment = Qgis::Environment::External;
+
+Qgis::Environment Qgis::environment()
+{
+  return sEnvironment;
+}
+
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 template<>
 bool qMapLessThanKey<QVariantList>( const QVariantList &key1, const QVariantList &key2 )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -100,6 +100,21 @@ class CORE_EXPORT Qgis
     //
 
     /**
+     * Application environment.
+     *
+     * \since QGIS 3.22.2
+     */
+    enum class Environment : int
+    {
+      Desktop, //!< QGIS desktop application
+      Server, //!< QGIS server
+      Mobile, //!< Mobile application (e.g. QField/Input)
+      QgisProcess, //!< Qgis_process CLI application
+      External, //!< External script, such as a PyQGIS application run outside of the QGIS desktop application
+    };
+    Q_ENUM( Environment )
+
+    /**
      * \brief Level for messages
      * This will be used both for message log and message bar in application.
      */
@@ -1359,6 +1374,17 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     static QString geosVersion();
+
+    /**
+     * Returns the application environment.
+     *
+     * \since QGIS 3.22.2
+     */
+    static Environment environment();
+
+#ifndef SIP_RUN
+    static Environment sEnvironment;
+#endif
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolRenderHints )

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -86,6 +86,8 @@ int main( int argc, char *argv[] )
 #endif  // _MSC_VER
 #endif  // Q_OS_WIN
 
+  Qgis::sEnvironment = Qgis::Environment::QgisProcess;
+
   QgsApplication app( argc, argv, false );
   QString myPrefixPath;
   if ( myPrefixPath.isEmpty() )

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -71,6 +71,7 @@ int main( int argc, char *argv[] )
     QgsMessageLog::logMessage( "DISPLAY not set, running in offscreen mode, all printing capabilities will not be available.", "Server", Qgis::MessageLevel::Info );
   }
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
+  Qgis::sEnvironment = Qgis::Environment::Server;
   const QgsApplication app( argc, argv, withDisplay, QString(), QStringLiteral( "server" ) );
   QgsServer server;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -517,6 +517,8 @@ int main( int argc, char *argv[] )
     qputenv( "QT_QPA_PLATFORM", "offscreen" );
   }
 
+  Qgis::sEnvironment = Qgis::Environment::Server;
+
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), QStringLiteral( "QGIS Development Server" ) );
 

--- a/tests/src/python/test_qgsapplication.py
+++ b/tests/src/python/test_qgsapplication.py
@@ -11,7 +11,7 @@ __copyright__ = 'Copyright 2012, The QGIS Project'
 
 import qgis  # NOQA
 from qgis.testing import start_app, unittest
-
+from qgis.core import Qgis
 
 QGISAPP = start_app()
 
@@ -26,6 +26,9 @@ class TestPyQgsApplication(unittest.TestCase):
         myMessage = ('Expected:\n%s\nGot:\n%s\n' %
                      (myExpectedResult, myResult))
         assert myExpectedResult == myResult, myMessage
+
+    def test_environment(self):
+        self.assertEqual(Qgis.environment(), Qgis.Environment.External)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -86,6 +86,12 @@ class TestPyQgsAppStartup(unittest.TestCase):
             if s > timeOut:
                 raise Exception('Timed out waiting for application start, Call: "{}", Env: {}'.format(' '.join(call), env))
 
+        with open(myTestFile, 'rt', encoding='utf-8') as res_file:
+            lines = res_file.readlines()
+
+        # environment should be "Desktop"
+        self.assertEqual(lines, ['Environment: Environment.Desktop'])
+
         try:
             p.terminate()
         except OSError as e:
@@ -98,8 +104,9 @@ class TestPyQgsAppStartup(unittest.TestCase):
         testfile = 'pyqgis_startup.txt'
         testfilepath = os.path.join(self.TMP_DIR, testfile).replace('\\', '/')
         testcode = [
+            "from qgis.core import Qgis\n"
             "f = open('{0}', 'w')\n".format(testfilepath),
-            "f.write('This is a test')\n",
+            "f.write('Environment: ' + str(Qgis.environment()))\n",
             "f.close()\n"
         ]
         testmod = os.path.join(self.TMP_DIR, 'pyqgis_startup.py').replace('\\', '/')


### PR DESCRIPTION
The new

    Qgis.environment()

call will return an Environment enum, reflecting whether the code is running under the Desktop application, server, qgis_process, external scripts or mobile applications

This is designed to allow plugins to adapt their behavior depending on what environment they are running under.
