### PR TITLE
Revert "Fix locking of ogr datasource in case the datasource is shared (trans…"

### DIFF
--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -53,11 +53,6 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   , mSymbolType( QgsSymbol::symbolTypeForGeometryType( QgsWkbTypes::geometryType( source->mWkbType ) ) )
 {
 
-  if ( mSharedDS )
-  {
-    mSharedDS->mutex().lock();
-  }
-
   /* When inside a transaction for GPKG/SQLite and fetching fid(s) we might be nested inside an outer fetching loop,
    * (see GH #39178) so we need to skip all calls that might reset the reading (rewind) to avoid an endless loop in the
    * outer fetching iterator that uses the same connection.
@@ -129,6 +124,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
       }
     }
   }
+  QMutexLocker locker( mSharedDS ? &mSharedDS->mutex() : nullptr );
 
   if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mSource->mCrs )
   {
@@ -376,6 +372,8 @@ void QgsOgrFeatureIterator::setInterruptionChecker( QgsFeedback *interruptionChe
 
 bool QgsOgrFeatureIterator::fetchFeature( QgsFeature &feature )
 {
+  QMutexLocker locker( mSharedDS ? &mSharedDS->mutex() : nullptr );
+
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg, mInterruptionChecker );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrFeatureIterator" ) )
 
@@ -471,6 +469,8 @@ void QgsOgrFeatureIterator::resetReading()
 
 bool QgsOgrFeatureIterator::rewind()
 {
+  QMutexLocker locker( mSharedDS ? &mSharedDS->mutex() : nullptr );
+
   if ( mClosed || !mOgrLayer )
     return false;
 
@@ -487,10 +487,10 @@ bool QgsOgrFeatureIterator::close()
   if ( mSharedDS )
   {
     iteratorClosed();
+
     mOgrLayer = nullptr;
-    mClosed = true;
-    mSharedDS->mutex().unlock();
     mSharedDS.reset();
+    mClosed = true;
     return true;
   }
 
@@ -525,9 +525,6 @@ bool QgsOgrFeatureIterator::close()
   mOgrLayer = nullptr;
 
   mClosed = true;
-
-
-
   return true;
 }
 


### PR DESCRIPTION
During our work, we discovered deadlocks with the mutex protection introduced in #46049. I did some debugging and I think it is not possible to prevent the deadlocks completely (e.g. a piece of code could have an iterator open and call map rendering). I therefore propose to revert these changes. It is not ideal as well if working with geopackages in transaction mode, but the deadlocks are worse.