### PR TITLE
[processing] Fix "Extract by expression" algorithm short help string

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -304,7 +304,7 @@ qgis:selectbyattribute: >
 qgis:selectbyexpression: >
   This algorithm creates a selection in a vector layer. The criteria for selecting features is based on a QGIS expression.
 
-  For more information about expressions see the <a href ="{qgisdocs}/user_manual/working_with_vector/expression.html">user manual</a>
+  For help with QGIS expression functions, see the inbuilt help for specific functions which is available in the expression builder.
 
 qgis:setstyleforrasterlayer: >
   This algorithm sets the style of a raster layer. The style must be defined in a QML file.

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.cpp
@@ -61,7 +61,8 @@ QString QgsExtractByExpressionAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm creates a new vector layer that only contains matching features from an input layer. "
                       "The criteria for adding features to the resulting layer is based on a QGIS expression.\n\n"
-                      "For more information about expressions see the <a href =\"{qgisdocs}/user_manual/working_with_vector/expression.html\">user manual</a>" );
+                      "For help with QGIS expression functions, see the inbuilt help for specific functions "
+                      "which is available in the expression builder." );
 }
 
 QgsExtractByExpressionAlgorithm *QgsExtractByExpressionAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.cpp
@@ -59,7 +59,10 @@ void QgsOrderByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 
 QString QgsOrderByExpressionAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm sorts a vector layer according to an expression. Be careful, it might not work as expected with some providers, the order might not be kept every time." );
+  return QObject::tr( "This algorithm sorts a vector layer according to an expression. Be careful, it might not work as expected with some providers, "
+                      "the order might not be kept every time.\n\n"
+                      "For help with QGIS expression functions, see the inbuilt help for specific functions "
+                      "which is available in the expression builder." );
 }
 
 QgsOrderByExpressionAlgorithm *QgsOrderByExpressionAlgorithm::createInstance() const


### PR DESCRIPTION
## Description

The "Extract by expression" (native:extractbyexpression) QGIS native C++ algorithm short help string contains an invalid link to `{qgisdocs}/user_manual/working_with_vector/expression.html`: the `{qgisdocs}` placeholder is only available for QGIS Python algorithms help description.

In order to fix the issue, I replaced the string
`For more information about expressions see the <a href =\"qgisdocs}/user_manual/working_with_vector/expression.html\">user manual</a>`
with the string
`For help with QGIS expression functions, see the inbuilt help for specific functions which is available in the expression builder.`
which is also used in the "Geometry by expression" algorithm.

This PR needs to be backported.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
