### PR TITLE
Default to "external" for QgsApplication::platformName()

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -420,7 +420,7 @@ Returns a string name of the operating system QGIS is running on.
 
     static QString platform();
 %Docstring
-Returns the QGIS platform name, e.g., "desktop" or "server".
+Returns the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts).
 
 .. seealso:: :py:func:`osName`
 

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -84,7 +84,16 @@ to change due to centralization.
     static const char *QGIS_ORGANIZATION_NAME;
     static const char *QGIS_ORGANIZATION_DOMAIN;
     static const char *QGIS_APPLICATION_NAME;
+
     QgsApplication( SIP_PYLIST argv, bool GUIenabled, QString profileFolder = QString(), QString platformName = "desktop" ) / PostHook = __pyQtQAppHook__ / [( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "desktop" )];
+%Docstring
+Constructor for QgsApplication.
+
+:param argv: command line arguments
+:param GUIenabled: set to ``True`` if a GUI application is required, or ``False`` for a console only application
+:param profileFolder: optional string representing the profile to load at startup
+:param platformName: the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts)
+%End
 %MethodCode
     // The Python interface is a list of argument strings that is modified.
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1036,7 +1036,7 @@ int main( int argc, char *argv[] )
     QgsApplication::setTranslation( translationCode );
   }
 
-  QgsApplication myApp( argc, argv, myUseGuiFlag );
+  QgsApplication myApp( argc, argv, myUseGuiFlag, QString(), QStringLiteral( "desktop" ) );
 
   //write the log messages written before creating QgsApplication
   for ( const QString &preApplicationLogMessage : std::as_const( preApplicationLogMessages ) )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -173,7 +173,7 @@ Q_GLOBAL_STATIC( QString, sAuthDbDirPath )
 
 Q_GLOBAL_STATIC( QString, sUserName )
 Q_GLOBAL_STATIC( QString, sUserFullName )
-Q_GLOBAL_STATIC_WITH_ARGS( QString, sPlatformName, ( "desktop" ) )
+Q_GLOBAL_STATIC_WITH_ARGS( QString, sPlatformName, ( "external" ) )
 Q_GLOBAL_STATIC( QString, sTranslation )
 
 Q_GLOBAL_STATIC( QTemporaryDir, sIconCacheDir )

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -160,7 +160,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static const char *QGIS_ORGANIZATION_DOMAIN;
     static const char *QGIS_APPLICATION_NAME;
 #ifndef SIP_RUN
-    QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "desktop" );
+    QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "external" );
 #else
     QgsApplication( SIP_PYLIST argv, bool GUIenabled, QString profileFolder = QString(), QString platformName = "desktop" ) / PostHook = __pyQtQAppHook__ / [( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "desktop" )];
     % MethodCode
@@ -437,7 +437,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString osName();
 
     /**
-     * Returns the QGIS platform name, e.g., "desktop" or "server".
+     * Returns the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts).
      * \see osName()
      * \since QGIS 2.14
      */

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -160,8 +160,27 @@ class CORE_EXPORT QgsApplication : public QApplication
     static const char *QGIS_ORGANIZATION_DOMAIN;
     static const char *QGIS_APPLICATION_NAME;
 #ifndef SIP_RUN
+
+    /**
+     * Constructor for QgsApplication.
+     *
+     * \param argc command line argument count
+     * \param argv command line arguments
+     * \param GUIenabled set to TRUE if a GUI application is required, or FALSE for a console only application
+     * \param profileFolder optional string representing the profile to load at startup
+     * \param platformName the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts)
+     */
     QgsApplication( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "external" );
 #else
+
+    /**
+     * Constructor for QgsApplication.
+     *
+     * \param argv command line arguments
+     * \param GUIenabled set to TRUE if a GUI application is required, or FALSE for a console only application
+     * \param profileFolder optional string representing the profile to load at startup
+     * \param platformName the QGIS platform name, e.g., "desktop", "server", "qgis_process" or "external" (for external CLI scripts)
+     */
     QgsApplication( SIP_PYLIST argv, bool GUIenabled, QString profileFolder = QString(), QString platformName = "desktop" ) / PostHook = __pyQtQAppHook__ / [( int &argc, char **argv, bool GUIenabled, const QString &profileFolder = QString(), const QString &platformName = "desktop" )];
     % MethodCode
     // The Python interface is a list of argument strings that is modified.

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -86,7 +86,7 @@ int main( int argc, char *argv[] )
 #endif  // _MSC_VER
 #endif  // Q_OS_WIN
 
-  QgsApplication app( argc, argv, false );
+  QgsApplication app( argc, argv, false, QString(), QStringLiteral( "qgis_process" ) );
   QString myPrefixPath;
   if ( myPrefixPath.isEmpty() )
   {

--- a/tests/src/core/testqgsapplication.cpp
+++ b/tests/src/core/testqgsapplication.cpp
@@ -94,8 +94,8 @@ void TestQgsApplication::osName()
 
 void TestQgsApplication::platformName()
 {
-  // test will always be run under desktop platform
-  QCOMPARE( QgsApplication::platform(), QString( "desktop" ) );
+  // test will always be run under external platform
+  QCOMPARE( QgsApplication::platform(), QString( "external" ) );
 }
 
 void TestQgsApplication::themeIcon()

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -86,6 +86,12 @@ class TestPyQgsAppStartup(unittest.TestCase):
             if s > timeOut:
                 raise Exception('Timed out waiting for application start, Call: "{}", Env: {}'.format(' '.join(call), env))
 
+        with open(myTestFile, 'rt', encoding='utf-8') as res_file:
+            lines = res_file.readlines()
+
+        # platform should be "Desktop"
+        self.assertEqual(lines, ['Platform: desktop'])
+
         try:
             p.terminate()
         except OSError as e:
@@ -98,8 +104,9 @@ class TestPyQgsAppStartup(unittest.TestCase):
         testfile = 'pyqgis_startup.txt'
         testfilepath = os.path.join(self.TMP_DIR, testfile).replace('\\', '/')
         testcode = [
+            "from qgis.core import QgsApplication\n"
             "f = open('{0}', 'w')\n".format(testfilepath),
-            "f.write('This is a test')\n",
+            "f.write('Platform: ' + QgsApplication.platform())\n",
             "f.close()\n"
         ]
         testmod = os.path.join(self.TMP_DIR, 'pyqgis_startup.py').replace('\\', '/')


### PR DESCRIPTION
 and only use "desktop" when actually run from the desktop. Also add "qgis_process" platform.

The initial use case here is to fix #45935, be providing a way for processing to determine if it's running from outside of the qgis desktop application (in which case the grass and saga plugin providers should also be initialised when calling Processing.initialize())