### PR TITLE
New button to open attribute table on filtered features

### DIFF
--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -254,6 +254,14 @@ Emitted when the user chooses to flash a filtered set of features.
 .. versionadded:: 3.0
 %End
 
+    void openFilteredFeaturesAttributeTable( const QString &filter );
+%Docstring
+Emitted when the user chooses to open the attribute table dialog with a filtered set of features.
+
+.. versionadded:: 3.24
+%End
+
+
   public slots:
 
     void changeAttribute( const QString &field, const QVariant &value, const QString &hintText = QString() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10623,6 +10623,19 @@ void QgisApp::selectByForm()
   dlg->setMessageBar( messageBar() );
   dlg->setMapCanvas( mapCanvas() );
   dlg->setAttribute( Qt::WA_DeleteOnClose );
+  connect( dlg, &QgsSelectByFormDialog::showFilteredFeaturesAttributeTable, [ = ]( const QString & filter )
+  {
+    if ( !vlayer || !vlayer->dataProvider() )
+    {
+      return;
+    }
+
+    QgsAttributeTableDialog *dialog = new QgsAttributeTableDialog( vlayer, QgsAttributeTableFilterModel::FilterMode::ShowFilteredList );
+    dialog->setFilterExpression( filter );
+    dialog->setView( QgsDualView::ViewMode::AttributeEditor );
+    dialog->show();
+
+  } );
   dlg->show();
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10625,7 +10625,7 @@ void QgisApp::selectByForm()
   dlg->setAttribute( Qt::WA_DeleteOnClose );
   connect( dlg, &QgsSelectByFormDialog::showFilteredFeaturesAttributeTable, [ = ]( const QString & filter )
   {
-    if ( !vlayer || !vlayer->dataProvider() )
+    if ( !vlayer->dataProvider() )
     {
       return;
     }

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -962,6 +962,11 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
   mFeatureFilterWidget->setFilterExpression( filterString, type, alwaysShowFilter );
 }
 
+void QgsAttributeTableDialog::setView( QgsDualView::ViewMode mode )
+{
+  mMainView->setView( mode );
+}
+
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {
   QgsDebugMsg( QStringLiteral( "Delete %1" ).arg( fid ) );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -71,6 +71,12 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
                               QgsAttributeForm::FilterType type = QgsAttributeForm::ReplaceFilter,
                               bool alwaysShowFilter = false );
 
+    /**
+     * Set the view \a mode (e.g. attribute table or attribute editor).
+     * \since QGIS 3.24
+     */
+    void setView( QgsDualView::ViewMode mode );
+
   private slots:
 
     /**

--- a/src/app/qgsselectbyformdialog.cpp
+++ b/src/app/qgsselectbyformdialog.cpp
@@ -62,6 +62,7 @@ void QgsSelectByFormDialog::setMapCanvas( QgsMapCanvas *canvas )
   mMapCanvas = canvas;
   connect( mForm, &QgsAttributeForm::zoomToFeatures, this, &QgsSelectByFormDialog::zoomToFeatures );
   connect( mForm, &QgsAttributeForm::flashFeatures, this, &QgsSelectByFormDialog::flashFeatures );
+  connect( mForm, &QgsAttributeForm::openFilteredFeaturesAttributeTable, this, &QgsSelectByFormDialog::showFilteredFeaturesAttributeTable );
 }
 
 void QgsSelectByFormDialog::zoomToFeatures( const QString &filter )
@@ -92,5 +93,25 @@ void QgsSelectByFormDialog::flashFeatures( const QString &filter )
     mMessageBar->pushMessage( QString(),
                               tr( "No matching features found" ),
                               Qgis::MessageLevel::Info );
+  }
+}
+
+void QgsSelectByFormDialog::openFeaturesAttributeTable( const QString &filter )
+{
+  Q_ASSERT( mLayer );
+  QgsFeatureIterator it = mLayer->getFeatures( filter );
+  QgsFeature f;
+  if ( it.isValid() && it.nextFeature( f ) )
+  {
+    emit showFilteredFeaturesAttributeTable( filter );
+  }
+  else
+  {
+    if ( mMessageBar )
+    {
+      mMessageBar->pushMessage( QString(),
+                                tr( "No matching features found" ),
+                                Qgis::MessageLevel::Info );
+    }
   }
 }

--- a/src/app/qgsselectbyformdialog.h
+++ b/src/app/qgsselectbyformdialog.h
@@ -66,6 +66,11 @@ class APP_EXPORT QgsSelectByFormDialog : public QDialog
 
     void zoomToFeatures( const QString &filter );
     void flashFeatures( const QString &filter );
+    void openFeaturesAttributeTable( const QString &filter );
+
+  signals:
+
+    void showFilteredFeaturesAttributeTable( const QString &filter );
 
   private:
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1874,8 +1874,8 @@ void QgsAttributeForm::init()
 
     QPushButton *openAttributeTableButton = new QPushButton();
     openAttributeTableButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
-    openAttributeTableButton->setText( tr( "&Open Attribute Table" ) );
-    openAttributeTableButton->setToolTip( tr( "Open attribute table editor with filtered features" ) );
+    openAttributeTableButton->setText( tr( "Show in &Table" ) );
+    openAttributeTableButton->setToolTip( tr( "Open the attribute table editor with the filtered features" ) );
     connect( openAttributeTableButton, &QToolButton::clicked, this, [ = ]
     {
       emit openFilteredFeaturesAttributeTable( createFilterExpression() );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1872,6 +1872,16 @@ void QgsAttributeForm::init()
     connect( flashButton, &QToolButton::clicked, this, &QgsAttributeForm::searchFlash );
     boxLayout->addWidget( flashButton );
 
+    QPushButton *openAttributeTableButton = new QPushButton();
+    openAttributeTableButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
+    openAttributeTableButton->setText( tr( "&Open Attribute Table" ) );
+    openAttributeTableButton->setToolTip( tr( "Open attribute table editor with filtered features" ) );
+    connect( openAttributeTableButton, &QToolButton::clicked, this, [ = ]
+    {
+      emit openFilteredFeaturesAttributeTable( createFilterExpression() );
+    } );
+    boxLayout->addWidget( openAttributeTableButton );
+
     QPushButton *zoomButton = new QPushButton();
     zoomButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Minimum );
     zoomButton->setText( tr( "&Zoom to Features" ) );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -268,6 +268,13 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void flashFeatures( const QString &filter );
 
+    /**
+     * Emitted when the user chooses to open the attribute table dialog with a filtered set of features.
+     * \since QGIS 3.24
+     */
+    void openFilteredFeaturesAttributeTable( const QString &filter );
+
+
   public slots:
 
     /**


### PR DESCRIPTION
Adds a new button to the attribute form in search mode
to open the attribute table in attribute editor mode
from the filtered features.

![open_attr_table](https://user-images.githubusercontent.com/142164/144413145-bc61ea60-2067-4852-8605-d2ba04e78e37.gif)


Fixes #46317

Funded by: ARPA Piemonte

