### PR TITLE
Add Canadian national CSW to MetaSearch default connections

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -16,4 +16,6 @@
     <csw name="Portugal: Sistema Nacional de Informação Geográfica (SNIG)" url="https://snig.dgterritorio.gov.pt/rndg/srv/eng/csw"/>
     <csw name="Spain: Centro Nacional de Información Geográfica (CNIG)" url="http://www.ign.es/csw-inspire/srv/spa/csw"/>
     <csw name="Germany: GDI-DE Geodatenkatalog.de" url="https://gdk.gdi-de.org/gdi-de/srv/ger/csw"/>
+    <csw name="Canada: National CSW - English (Federal Geospatial Platform-FGP)" url="https://maps.canada.ca/geonetwork/srv/eng/csw"/>
+    <csw name="Canada: CSW national - Français (Plateforme géospatiale fédérale-PGF)" url="https://maps.canada.ca/geonetwork/srv/fre/csw"/>
 </qgsCSWConnections>

--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -16,6 +16,5 @@
     <csw name="Portugal: Sistema Nacional de Informação Geográfica (SNIG)" url="https://snig.dgterritorio.gov.pt/rndg/srv/eng/csw"/>
     <csw name="Spain: Centro Nacional de Información Geográfica (CNIG)" url="http://www.ign.es/csw-inspire/srv/spa/csw"/>
     <csw name="Germany: GDI-DE Geodatenkatalog.de" url="https://gdk.gdi-de.org/gdi-de/srv/ger/csw"/>
-    <csw name="Canada: National CSW - English (Federal Geospatial Platform-FGP)" url="https://maps.canada.ca/geonetwork/srv/eng/csw"/>
-    <csw name="Canada: CSW national - Français (Plateforme géospatiale fédérale-PGF)" url="https://maps.canada.ca/geonetwork/srv/fre/csw"/>
+    <csw name="Canada: Federal Geospatial Platform-Plateforme géospatiale fédérale (FGP-PGF)" url="https://maps.canada.ca/geonetwork/srv/csw"/>
 </qgsCSWConnections>


### PR DESCRIPTION
## Description

Adds the Canadian national CSW to the MetaSearch default connections. Includes both French and English CSW endpoints separately.

Changes only the configuration file of MetaSearch (connections-default.xml). 

Tested by manually adding the eng/fre url to the MetaSearch plugin and searching by keywords: 'fire'/'feu', 'ontario/ontario', and 'quebec/quebec'. Metadata titles return successfully in their respective languages.

Ccing maintainer @tomkralidis for review.