### PR TITLE
[Fix] Advanced digitizing distance when snapping

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -538,6 +538,7 @@ Convenient method to get the M value from the line edit wiget
 .. versionadded:: 3.22
 %End
 
+    CadCapacities getCapacities() const;
   signals:
 
     void pushWarning( const QString &message );

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -542,7 +542,7 @@ Convenient method to get the M value from the line edit wiget
 %Docstring
 Returns the capacities
 
-.. versionadded:: 3.24
+.. versionadded:: 3.26
 %End
   signals:
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -538,7 +538,12 @@ Convenient method to get the M value from the line edit wiget
 .. versionadded:: 3.22
 %End
 
-    CadCapacities getCapacities() const;
+    CadCapacities capacities() const;
+%Docstring
+Returns the capacities
+
+.. versionadded:: 3.24
+%End
   signals:
 
     void pushWarning( const QString &message );

--- a/python/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/qgsmaptooledit.sip.in
@@ -23,13 +23,13 @@ Base class for map tools that edit vector geometry
 
     virtual Flags flags() const;
 
-    double defaultZValue() const;
+    static double defaultZValue();
 %Docstring
 Returns default Z value.
 Used for setting Z coordinate to new vertex.
 %End
 
-    double defaultMValue() const;
+    static double defaultMValue();
 %Docstring
 Returns default M value.
 Used for setting M coordinate to new vertex.

--- a/src/app/maptools/qgsappmaptools.cpp
+++ b/src/app/maptools/qgsappmaptools.cpp
@@ -77,7 +77,7 @@ QgsAppMapTools::QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockW
   mTools.insert( Tool::HtmlAnnotation, new QgsMapToolHtmlAnnotation( canvas ) );
   mTools.insert( Tool::SvgAnnotation, new QgsMapToolSvgAnnotation( canvas ) );
   mTools.insert( Tool::Annotation, new QgsMapToolAnnotation( canvas ) );
-  mTools.insert( Tool::AddFeature, new QgsMapToolAddFeature( canvas, QgsMapToolCapture::CaptureNone ) );
+  mTools.insert( Tool::AddFeature, new QgsMapToolAddFeature( canvas, cadDock, QgsMapToolCapture::CaptureNone ) );
   mTools.insert( Tool::MoveFeature, new QgsMapToolMoveFeature( canvas, QgsMapToolMoveFeature::Move ) );
   mTools.insert( Tool::MoveFeatureCopy, new QgsMapToolMoveFeature( canvas, QgsMapToolMoveFeature::CopyMove ) );
   mTools.insert( Tool::RotateFeature, new QgsMapToolRotateFeature( canvas ) );

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -37,8 +37,8 @@
 
 #include <QSettings>
 
-QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode )
-  : QgsMapToolDigitizeFeature( canvas, QgisApp::instance()->cadDockWidget(), mode )
+QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )
+  : QgsMapToolDigitizeFeature( canvas, cadDockWidget, mode )
   , mCheckGeometryType( true )
 {
   setLayer( canvas->currentLayer() );

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -48,6 +48,11 @@ QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, QgsAdvancedDig
   connect( QgisApp::instance(), &QgisApp::projectRead, this, &QgsMapToolAddFeature::stopCapturing );
 }
 
+QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode )
+  : QgsMapToolAddFeature( canvas, QgisApp::instance()->cadDockWidget(), mode )
+{
+}
+
 bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, const QgsFeature &f, bool showModal )
 {
   QgsFeature feat( f );

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -22,7 +22,7 @@ class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolDigitizeFeature
     Q_OBJECT
 
   public:
-    //! \since QGIS 3.24
+    //! \since QGIS 3.26
     QgsMapToolAddFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
     /**

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -20,9 +20,16 @@
 class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolDigitizeFeature
 {
     Q_OBJECT
+
   public:
-    //! \since QGIS 2.12
+    //! \since QGIS 3.24
     QgsMapToolAddFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
+
+    /**
+     * \since QGIS 2.12
+     * \deprecated Will be made in QGIS 4
+     */
+    QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode );
 
   private slots:
 

--- a/src/app/qgsmaptooladdfeature.h
+++ b/src/app/qgsmaptooladdfeature.h
@@ -22,7 +22,7 @@ class APP_EXPORT QgsMapToolAddFeature : public QgsMapToolDigitizeFeature
     Q_OBJECT
   public:
     //! \since QGIS 2.12
-    QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode );
+    QgsMapToolAddFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode );
 
   private slots:
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -914,14 +914,19 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
    * a Z value.
    * To get the value we use the snapPoint method. However, we only apply it
    * when the snapped point corresponds to the constrained point or on an edge
-   * if the topological editing is activated.
+   * if the topological editing is activated. Also, we don't apply it if
+   * the point is not linked to a layer.
    */
   e->setMapPoint( point );
   mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
-  if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( point == mSnapMatch.point() ) ) || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
+  if ( mSnapMatch.layer() )
   {
-    e->snapPoint();
-    point = mSnapMatch.interpolatedPoint( mMapCanvas->mapSettings().destinationCrs() );
+    if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( point == mSnapMatch.point() ) )
+         || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
+    {
+      e->snapPoint();
+      point = mSnapMatch.interpolatedPoint( mMapCanvas->mapSettings().destinationCrs() );
+    }
   }
 
   /*

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -921,7 +921,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   if ( ( ( mSnapMatch.hasVertex() || mSnapMatch.hasLineEndpoint() ) && ( point == mSnapMatch.point() ) ) || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
   {
     e->snapPoint();
-    point = mSnapMatch.interpolatedPoint();
+    point = mSnapMatch.interpolatedPoint( mMapCanvas->mapSettings().destinationCrs() );
   }
 
   /*

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -363,7 +363,7 @@ void QgsAdvancedDigitizingDockWidget::setEnabledZ( bool enable )
   mZLabel->setEnabled( enable );
   mZLineEdit->setEnabled( enable );
   if ( mZLineEdit->isEnabled() )
-    mZLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultZValue(), 'f', 6 ) );
+    mZLineEdit->setText( QLocale().toString( QgsMapToolEdit::defaultZValue(), 'f', 6 ) );
   else
     mZLineEdit->clear();
   mLockZButton->setEnabled( enable );
@@ -376,7 +376,7 @@ void QgsAdvancedDigitizingDockWidget::setEnabledM( bool enable )
   mMLabel->setEnabled( enable );
   mMLineEdit->setEnabled( enable );
   if ( mMLineEdit->isEnabled() )
-    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit( mMapCanvas ).defaultMValue(), 'f', 6 ) );
+    mMLineEdit->setText( QLocale().toString( QgsMapToolEdit::defaultMValue(), 'f', 6 ) );
   else
     mMLineEdit->clear();
   mLockMButton->setEnabled( enable );
@@ -905,8 +905,8 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
    * Ensure that Z and M are passed
    * It will be dropped as needed later.
    */
-  point.setZ( QgsMapToolEdit( mMapCanvas ).defaultZValue() );
-  point.setM( QgsMapToolEdit( mMapCanvas ).defaultMValue() );
+  point.setZ( QgsMapToolEdit::defaultZValue() );
+  point.setM( QgsMapToolEdit::defaultMValue() );
 
   /*
    * Constraints are applied in 2D, they are always called when using the tool

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -490,7 +490,7 @@ void QgsAdvancedDigitizingDockWidget::settingsButtonTriggered( QAction *action )
   }
 }
 
-QgsMapLayer *QgsAdvancedDigitizingDockWidget::targetLayer()
+QgsMapLayer *QgsAdvancedDigitizingDockWidget::targetLayer() const
 {
   if ( QgsMapToolAdvancedDigitizing *advancedTool = qobject_cast< QgsMapToolAdvancedDigitizing * >( mMapCanvas->mapTool() ) )
   {

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -749,15 +749,16 @@ void QgsAdvancedDigitizingDockWidget::updateCapacity( bool updateUIwithoutChange
 {
   CadCapacities newCapacities = CadCapacities();
   const bool isGeographic = mMapCanvas->mapSettings().destinationCrs().isGeographic();
-  if ( !isGeographic )
-    newCapacities |= Distance;
 
   // first point is the mouse point (it doesn't count)
   if ( mCadPointList.count() > 1 )
   {
     newCapacities |=  RelativeCoordinates;
     if ( !isGeographic )
+    {
       newCapacities |= AbsoluteAngle;
+      newCapacities |= Distance;
+    }
   }
   if ( mCadPointList.count() > 2 )
   {
@@ -1440,13 +1441,11 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
 
 void QgsAdvancedDigitizingDockWidget::enable()
 {
+  // most of theses lines can be moved to updateCapacity
   connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsAdvancedDigitizingDockWidget::enable, Qt::UniqueConnection );
   if ( mMapCanvas->mapSettings().destinationCrs().isGeographic() )
   {
-    mAngleLineEdit->setEnabled( false );
     mAngleLineEdit->setToolTip( tr( "Angle constraint cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
-
-    mDistanceLineEdit->setEnabled( false );
     mDistanceLineEdit->setToolTip( tr( "Distance constraint cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
 
     mLabelX->setText( tr( "Long" ) );
@@ -1460,7 +1459,6 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mAngleLineEdit->setToolTip( "<b>" + tr( "Angle" ) + "</b><br>(" + tr( "press a for quick access" ) + ")" );
     mAngleLineEdit->setToolTip( QString() );
 
-    mDistanceLineEdit->setEnabled( true );
     mDistanceLineEdit->setToolTip( "<b>" + tr( "Distance" ) + "</b><br>(" + tr( "press d for quick access" ) + ")" );
 
     mLabelX->setText( tr( "x" ) );
@@ -1469,6 +1467,8 @@ void QgsAdvancedDigitizingDockWidget::enable()
     mXConstraint->setPrecision( 6 );
     mYConstraint->setPrecision( 6 );
   }
+
+  updateCapacity();
 
   mEnableAction->setEnabled( true );
   mErrorLabel->hide();

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -513,6 +513,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     double getLineM( ) const;
 
+    CadCapacities getCapacities() const { return mCapacities; };
+
   signals:
 
     /**
@@ -861,7 +863,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
      * Returns the layer currently associated with the map tool using the dock widget.
      */
-    QgsMapLayer *targetLayer();
+    QgsMapLayer *targetLayer() const;
 
     //! updates the UI depending on activation of the tools and clear points / release locks.
     void setCadEnabled( bool enabled );

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -973,6 +973,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 #endif
     //! Convenient method to convert a 2D Point to a QgsPoint
     QgsPoint pointXYToPoint( const QgsPointXY &point ) const;
+
+    friend class TestQgsAdvancedDigitizing;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsAdvancedDigitizingDockWidget::CadCapacities )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -513,7 +513,11 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     double getLineM( ) const;
 
-    CadCapacities getCapacities() const { return mCapacities; };
+    /**
+     * Returns the capacities
+     * \since QGIS 3.24
+     */
+    CadCapacities capacities() const { return mCapacities; };
 
   signals:
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -515,7 +515,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Returns the capacities
-     * \since QGIS 3.24
+     * \since QGIS 3.26
      */
     CadCapacities capacities() const { return mCapacities; };
 

--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -34,14 +34,15 @@ QgsMapToolEdit::QgsMapToolEdit( QgsMapCanvas *canvas )
   }
 }
 
-double QgsMapToolEdit::defaultZValue() const
+double QgsMapToolEdit::defaultZValue()
 {
   return QgsSettingsRegistryCore::settingsDigitizingDefaultZValue.value();
 }
 
-double QgsMapToolEdit::defaultMValue() const
+double QgsMapToolEdit::defaultMValue()
 {
-  return QgsSettings().value( QStringLiteral( "/qgis/digitizing/default_m_value" ), Qgis::DEFAULT_M_COORDINATE ).toDouble();
+  return QgsSettingsRegistryCore::settingsDigitizingDefaultMValue.value();
+
 }
 
 QColor QgsMapToolEdit::digitizingStrokeColor()

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -42,7 +42,7 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
      * Returns default Z value.
      * Used for setting Z coordinate to new vertex.
      */
-    double defaultZValue() const;
+    static double defaultZValue();
 
     /**
      * Returns default M value.
@@ -50,7 +50,7 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
      *
      * \since QGIS 3.20
      */
-    double defaultMValue() const;
+    static double defaultMValue();
 
     /**
      * Creates a  geometry rubber band with the color/line width from

--- a/src/plugins/grass/qgsgrassaddfeature.cpp
+++ b/src/plugins/grass/qgsgrassaddfeature.cpp
@@ -16,8 +16,10 @@
 
 #include "qgsgrassaddfeature.h"
 
+#include "qgisapp.h"
+
 QgsGrassAddFeature::QgsGrassAddFeature( QgsMapCanvas *canvas, CaptureMode mode )
-  : QgsMapToolAddFeature( canvas, mode )
+  : QgsMapToolAddFeature( canvas, QgisApp::instance()->cadDockWidget(), mode )
 {
   setCheckGeometryType( false );
 }

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TESTS
   testqgsappbrowserproviders.cpp
   testqgisappclipboard.cpp
   testqgisappdockwidgets.cpp
+  testqgsadvanceddigitizing.cpp
   testqgsattributetable.cpp
   testqgsapplocatorfilters.cpp
   testqgsdecorationscalebar.cpp

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -217,7 +217,7 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CaptureLine );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
 
   mCanvas->setMapTool( mCaptureTool );
   mCanvas->setCurrentLayer( mLayerLine );

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
@@ -158,7 +158,7 @@ void TestQgsMapToolAddFeatureLineM::initTestCase()
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CaptureLine );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
 
   mCanvas->setMapTool( mCaptureTool );
   mCanvas->setCurrentLayer( mLayerLine );

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
@@ -149,7 +149,11 @@ void TestQgsMapToolAddFeatureLineZ::initTestCase()
 
   mLayerTopoZ->startEditing();
   QgsFeature topoFeat;
-  topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ((7.25 6 0, 7.25 7 0, 7.5 7 0, 7.5 6 0, 7.25 6 0),(6 6 0, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.25 0))" ) );
+  topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ("
+                        "(10 0 0, 10 10 0),"
+                        "(20 0 10, 20 10 10),"
+                        "(30 0 0, 30 10 10)"
+                        ")" ) );
 
   mLayerTopoZ->addFeature( topoFeat );
   QCOMPARE( mLayerTopoZ->featureCount(), ( long ) 1 );
@@ -237,17 +241,22 @@ void TestQgsMapToolAddFeatureLineZ::testTopologicalEditingZ()
   mCanvas->snappingUtils()->setConfig( cfg );
 
   oldFids = utils.existingFeatureIds();
-  utils.mouseClick( 6, 6.5, Qt::LeftButton );
-  utils.mouseClick( 6.25, 6.5, Qt::LeftButton );
-  utils.mouseClick( 6.75, 6.5, Qt::LeftButton );
-  utils.mouseClick( 7.25, 6.5, Qt::LeftButton );
-  utils.mouseClick( 7.5, 6.5, Qt::LeftButton );
-  utils.mouseClick( 8, 6.5, Qt::RightButton );
+  utils.mouseClick( 0, 5, Qt::LeftButton );
+  utils.mouseClick( 10.1, 5, Qt::LeftButton );
+  utils.mouseClick( 20.1, 5, Qt::LeftButton );
+  utils.mouseClick( 30.1, 5, Qt::LeftButton );
+  utils.mouseClick( 40, 5, Qt::LeftButton );
+  utils.mouseClick( 40, 5, Qt::RightButton );
   const QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  QString wkt = "MultiLineStringZ ((6 6.5 333, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333))";
+  QString wkt = "MultiLineStringZ ((0 5 333, 10 5 0, 20 5 10, 30 5 5, 40 5 333))";
   QCOMPARE( mLayerTopoZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
-  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 333, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
+
+  wkt = "MultiLineStringZ ("
+        "(10 0 0, 10 5 0, 10 10 0),"
+        "(20 0 10, 20 5 10, 20 10 10),"
+        "(30 0 0, 30 5 5, 30 10 10)"
+        ")";
   QCOMPARE( mLayerTopoZ->getFeature( qgis::setToList( oldFids ).constLast() ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
@@ -159,7 +159,7 @@ void TestQgsMapToolAddFeatureLineZ::initTestCase()
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CaptureLine );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
 
   mCanvas->setMapTool( mCaptureTool );
   mCanvas->setCurrentLayer( mLayerLine );

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
@@ -124,7 +124,7 @@ void TestQgsMapToolAddFeatureLineZM::initTestCase()
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CaptureLine );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
 
   mCanvas->setMapTool( mCaptureTool );
 

--- a/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepoint.cpp
@@ -100,7 +100,7 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   QCOMPARE( mLayerPoint->featureCount(), ( long )1 );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePoint );
   mCanvas->setMapTool( mCaptureTool );
 
   QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );

--- a/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointm.cpp
+++ b/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointm.cpp
@@ -97,7 +97,7 @@ void TestQgsMapToolAddFeaturePointM::initTestCase()
   QCOMPARE( mLayerPointM->featureCount(), ( long )1 );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePoint );
   mCanvas->setMapTool( mCaptureTool );
 
   QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );

--- a/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointz.cpp
+++ b/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointz.cpp
@@ -138,7 +138,7 @@ void TestQgsMapToolAddFeaturePointZ::initTestCase()
   mCanvas->snappingUtils()->locatorForLayer( mLayerLineZSnap )->init();
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePoint );
   mCanvas->setMapTool( mCaptureTool );
 
   QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );

--- a/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointzm.cpp
+++ b/tests/src/app/maptooladdfeaturepoint/testqgsmaptooladdfeaturepointzm.cpp
@@ -97,7 +97,7 @@ void TestQgsMapToolAddFeaturePointZM::initTestCase()
   QCOMPARE( mLayerPointZM->featureCount(), ( long )1 );
 
   // create the tool
-  mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
+  mCaptureTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePoint );
   mCanvas->setMapTool( mCaptureTool );
 
   QCOMPARE( mCanvas->mapSettings().outputSize(), QSize( 512, 512 ) );

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -40,15 +40,16 @@ class TestQgsAdvancedDigitizing: public QObject
     QString getWktFromLastAddedFeature( TestQgsMapToolAdvancedDigitizingUtils utils, QSet<QgsFeatureId> oldFeatures );
     void setCanvasCrs( QString crsString );
 
-    void distance();
-    void distanceDiffCrs();
-    void angle();
-    void angleWithGeographicCrs();
-    void distanceWithAngle();
-    void coordinates();
-    void coordinatesWithZM();
-    void valuesWhenSnapping();
-    void currentPoint();
+    void distanceContrainst();
+    void distanceContrainstDiffCrs();
+    void distanceContrainstWhenSnapping();
+    void angleContrainst();
+    void angleContrainstWithGeographicCrs();
+    void distanceContrainstWithAngleContrainst();
+    void coordinateContrainst();
+    void coordinateContrainstWithZM();
+    void coordinateContrainstWhenSnapping();
+    void cadPointList();
     void currentPointWhenSanpping();
     void currentPointWhenSanppingWithDiffCanvasCRS();
 
@@ -208,7 +209,7 @@ void TestQgsAdvancedDigitizing::setCanvasCrs( QString crsString )
   mCanvas->hide();
 }
 
-void TestQgsAdvancedDigitizing::distance()
+void TestQgsAdvancedDigitizing::distanceContrainst()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
@@ -256,7 +257,7 @@ void TestQgsAdvancedDigitizing::distance()
   QVERIFY( !capacities.testFlag( QgsAdvancedDigitizingDockWidget::Distance ) );
 }
 
-void TestQgsAdvancedDigitizing::distanceDiffCrs()
+void TestQgsAdvancedDigitizing::distanceContrainstDiffCrs()
 {
   auto utils = getMapToolDigitizingUtils( mLayer4326 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -344,7 +345,7 @@ void TestQgsAdvancedDigitizing::angle()
             QStringLiteral( "LineString (0 0, 1 1)" ) );
 }
 
-void TestQgsAdvancedDigitizing::angleWithGeographicCrs()
+void TestQgsAdvancedDigitizing::angleContrainstWithGeographicCrs()
 {
   setCanvasCrs( QStringLiteral( "EPSG:4326" ) );
 
@@ -381,7 +382,7 @@ void TestQgsAdvancedDigitizing::angleWithGeographicCrs()
   setCanvasCrs( QStringLiteral( "EPSG:3950" ) );
 }
 
-void TestQgsAdvancedDigitizing::distanceWithAngle()
+void TestQgsAdvancedDigitizing::distanceContrainstWithAngleContrainst()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -421,7 +422,7 @@ void TestQgsAdvancedDigitizing::distanceWithAngle()
 }
 
 
-void TestQgsAdvancedDigitizing::coordinates()
+void TestQgsAdvancedDigitizing::coordinateContrainst()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -464,7 +465,7 @@ void TestQgsAdvancedDigitizing::coordinates()
 }
 
 
-void TestQgsAdvancedDigitizing::coordinatesWithZM()
+void TestQgsAdvancedDigitizing::coordinateContrainstWithZM()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950ZM );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -503,7 +504,7 @@ void TestQgsAdvancedDigitizing::coordinatesWithZM()
             QStringLiteral( "LineStringZM (5 0 33 66, 3 5 33 66, 4 4 5 66, 6 6 33 5, 9 9 9 9)" ) );
 }
 
-void TestQgsAdvancedDigitizing::valuesWhenSnapping()
+void TestQgsAdvancedDigitizing::coordinateContrainstWhenSnapping()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
 

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -691,17 +691,11 @@ void TestQgsAdvancedDigitizing::cadPointList()
 
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2( &exist ), QgsPoint( 0, 5 ) );
   QVERIFY( exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->currentPoint( &exist ), QgsPointXY( 0, 5 ) );
-  QVERIFY( exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->previousPointV2( &exist ), QgsPoint( 0, 4 ) );
   QVERIFY( exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->previousPoint( &exist ), QgsPointXY( 0, 4 ) );
-  QVERIFY( exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->penultimatePointV2( &exist ), QgsPoint( 0, 3 ) );
-  QVERIFY( exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->penultimatePoint( &exist ), QgsPointXY( 0, 3 ) );
   QVERIFY( exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->pointsCount(), 6 );
@@ -715,17 +709,11 @@ void TestQgsAdvancedDigitizing::cadPointList()
   // with no digitized points
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2( &exist ), QgsPoint( 1, 1 ) );
   QVERIFY( exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->currentPoint( &exist ), QgsPointXY( 1, 1 ) );
-  QVERIFY( exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->previousPointV2( &exist ), QgsPoint( ) );
   QVERIFY( !exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->previousPoint( &exist ), QgsPointXY( ) );
-  QVERIFY( !exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->penultimatePointV2( &exist ), QgsPoint( ) );
-  QVERIFY( !exist );
-  QCOMPARE( mAdvancedDigitizingDockWidget->penultimatePoint( &exist ), QgsPointXY( ) );
   QVERIFY( !exist );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->pointsCount(), 1 );

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -454,7 +454,7 @@ void TestQgsAdvancedDigitizing::coordinates()
   utils.mouseClick( 0, 2, Qt::RightButton );
 
   QCOMPARE( getWktFromLastAddedFeature( utils, oldFeatures ),
-            QStringLiteral( "LineString (5 0, 0 2)" ) );
+            QStringLiteral( "LineString (0 0, 0 2)" ) );
 }
 
 

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -40,19 +40,19 @@ class TestQgsAdvancedDigitizing: public QObject
     QString getWktFromLastAddedFeature( TestQgsMapToolAdvancedDigitizingUtils utils, QSet<QgsFeatureId> oldFeatures );
     void setCanvasCrs( QString crsString );
 
-    void distanceContrainst();
-    void distanceContrainstDiffCrs();
-    void distanceContrainstWhenSnapping();
+    void distanceConstraint();
+    void distanceConstraintDiffCrs();
+    void distanceConstraintWhenSnapping();
 
-    void angleContrainst();
-    void angleContrainstWithGeographicCrs();
-    void distanceContrainstWithAngleContrainst();
+    void angleConstraint();
+    void angleConstraintWithGeographicCrs();
+    void distanceConstraintWithAngleConstraint();
 
-    void coordinateContrainst();
-    void coordinateContrainstWithZM();
-    void coordinateContrainstWhenSnapping();
+    void coordinateConstraint();
+    void coordinateConstraintWithZM();
+    void coordinateConstraintWhenSnapping();
 
-    void perpendicularConstraints();
+    void perpendicularConstraint();
 
     void cadPointList();
     void currentPointWhenSanpping();
@@ -190,7 +190,7 @@ TestQgsMapToolAdvancedDigitizingUtils TestQgsAdvancedDigitizing::getMapToolDigit
   layer->startEditing();
   mCaptureTool->setLayer( layer );
 
-  // enable the advanced digitizing widget
+  // enable the advanced digitizing dock
   mAdvancedDigitizingDockWidget->enableAction()->trigger();
 
   return TestQgsMapToolAdvancedDigitizingUtils( mCaptureTool );
@@ -224,7 +224,7 @@ void TestQgsAdvancedDigitizing::setCanvasCrs( QString crsString )
   mCanvas->hide();
 }
 
-void TestQgsAdvancedDigitizing::distanceContrainst()
+void TestQgsAdvancedDigitizing::distanceConstraint()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
@@ -238,7 +238,7 @@ void TestQgsAdvancedDigitizing::distanceContrainst()
   QVERIFY( !mAdvancedDigitizingDockWidget->mAngleLineEdit->isEnabled() );
   QVERIFY( !mAdvancedDigitizingDockWidget->mDistanceLineEdit->isEnabled() );
 
-  // activate contrainst on seconde point (one digitized vertex)
+  // activate constraint on the second point (one digitized vertex)
   utils.mouseClick( 1, 1, Qt::LeftButton );
 
   capacities = mAdvancedDigitizingDockWidget->capacities();
@@ -253,7 +253,7 @@ void TestQgsAdvancedDigitizing::distanceContrainst()
   QCOMPARE( getWktFromLastAddedFeature( utils, oldFeatures ),
             QStringLiteral( "LineString (1 1, 8.07 8.07)" ) );
 
-  // activate contrainst on third point
+  // activate constraint on the third point
   oldFeatures = utils.existingFeatureIds();
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
@@ -272,7 +272,7 @@ void TestQgsAdvancedDigitizing::distanceContrainst()
   QVERIFY( !capacities.testFlag( QgsAdvancedDigitizingDockWidget::Distance ) );
 }
 
-void TestQgsAdvancedDigitizing::distanceContrainstDiffCrs()
+void TestQgsAdvancedDigitizing::distanceConstraintDiffCrs()
 {
   auto utils = getMapToolDigitizingUtils( mLayer4326 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -290,7 +290,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstDiffCrs()
   QCOMPARE( getWktFromLastAddedFeature( utils, oldFeatures ),
             QStringLiteral( "LineString (1 1, 8.07 8.07)" ) );
 
-  // activate contrainst on third point
+  // activate constraint on third point
   oldFeatures = utils.existingFeatureIds();
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
@@ -306,7 +306,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstDiffCrs()
             QStringLiteral( "LineString (1 1, 2 2, 7 2)" ) );
 }
 
-void TestQgsAdvancedDigitizing::distanceContrainstWhenSnapping()
+void TestQgsAdvancedDigitizing::distanceConstraintWhenSnapping()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
@@ -329,7 +329,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstWhenSnapping()
   QVERIFY( !mAdvancedDigitizingDockWidget->mAngleLineEdit->isEnabled() );
   QVERIFY( !mAdvancedDigitizingDockWidget->mDistanceLineEdit->isEnabled() );
 
-  // activate contrainst on seconde point (one digitized vertex)
+  // activate constraint on the second point (one digitized vertex)
   utils.mouseClick( 1, 1, Qt::LeftButton );
 
   capacities = mAdvancedDigitizingDockWidget->capacities();
@@ -344,7 +344,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstWhenSnapping()
   QCOMPARE( getWktFromLastAddedFeature( utils, oldFeatures ),
             QStringLiteral( "LineString (1 1, 8.07 8.07)" ) );
 
-  // activate contrainst on third point
+  // activate constraint on the third point
   oldFeatures = utils.existingFeatureIds();
 
   utils.mouseClick( 1, 1, Qt::LeftButton );
@@ -363,7 +363,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstWhenSnapping()
   QVERIFY( !capacities.testFlag( QgsAdvancedDigitizingDockWidget::Distance ) );
 }
 
-void TestQgsAdvancedDigitizing::angleContrainst()
+void TestQgsAdvancedDigitizing::angleConstraint()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -417,7 +417,7 @@ void TestQgsAdvancedDigitizing::angleContrainst()
             QStringLiteral( "LineString (0 0, 1 1)" ) );
 }
 
-void TestQgsAdvancedDigitizing::angleContrainstWithGeographicCrs()
+void TestQgsAdvancedDigitizing::angleConstraintWithGeographicCrs()
 {
   setCanvasCrs( QStringLiteral( "EPSG:4326" ) );
 
@@ -454,14 +454,14 @@ void TestQgsAdvancedDigitizing::angleContrainstWithGeographicCrs()
   setCanvasCrs( QStringLiteral( "EPSG:3950" ) );
 }
 
-void TestQgsAdvancedDigitizing::distanceContrainstWithAngleContrainst()
+void TestQgsAdvancedDigitizing::distanceConstraintWithAngleConstraint()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
 
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
 
-  // with these 2 next locks, there are only 2 posssibilities
+  // with these 2 next locks, there are only 2 possibilities
   // first
   utils.mouseClick( 0, 0, Qt::LeftButton );
 
@@ -494,7 +494,7 @@ void TestQgsAdvancedDigitizing::distanceContrainstWithAngleContrainst()
 }
 
 
-void TestQgsAdvancedDigitizing::coordinateContrainst()
+void TestQgsAdvancedDigitizing::coordinateConstraint()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -537,7 +537,7 @@ void TestQgsAdvancedDigitizing::coordinateContrainst()
 }
 
 
-void TestQgsAdvancedDigitizing::coordinateContrainstWithZM()
+void TestQgsAdvancedDigitizing::coordinateConstraintWithZM()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950ZM );
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
@@ -576,7 +576,7 @@ void TestQgsAdvancedDigitizing::coordinateContrainstWithZM()
             QStringLiteral( "LineStringZM (5 0 33 66, 3 5 33 66, 4 4 5 66, 6 6 33 5, 9 9 9 9)" ) );
 }
 
-void TestQgsAdvancedDigitizing::coordinateContrainstWhenSnapping()
+void TestQgsAdvancedDigitizing::coordinateConstraintWhenSnapping()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
 
@@ -631,13 +631,13 @@ void TestQgsAdvancedDigitizing::coordinateContrainstWhenSnapping()
             QStringLiteral( "LineString (0 -2, 2.02 2)" ) );
 }
 
-void TestQgsAdvancedDigitizing::perpendicularConstraints()
+void TestQgsAdvancedDigitizing::perpendicularConstraint()
 {
   auto utils = getMapToolDigitizingUtils( mLayer3950 );
 
   QSet<QgsFeatureId> oldFeatures = utils.existingFeatureIds();
 
-  // line for the perprendicular test
+  // line for the perpendicular test
   utils.mouseClick( 0, 0, Qt::LeftButton );
   utils.mouseClick( 0, 10, Qt::LeftButton );
   utils.mouseClick( 1, 1, Qt::RightButton );
@@ -666,7 +666,7 @@ void TestQgsAdvancedDigitizing::perpendicularConstraints()
   // select the previous digitized line
   utils.mouseClick( 0.1, 4, Qt::LeftButton );
 
-  // test the perprendicular constrainst
+  // test the perpendicular constraint
   utils.mouseMove( 3, 2 );
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 3, 5 ) );
 
@@ -762,7 +762,7 @@ void TestQgsAdvancedDigitizing::currentPointWhenSanpping()
   utils.mouseMove( 0.1, 0 );
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 0, 0 ) );
 
-  // on an self point
+  // on a self point
   utils.mouseMove( 25, 0.1 );
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 25, 0 ) );
 
@@ -805,7 +805,7 @@ void TestQgsAdvancedDigitizing::currentPointWhenSanppingWithDiffCanvasCRS()
   utils.mouseMove( 0.1, 0 );
   QGSCOMPARENEARPOINT( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 0, 0 ), 0.000001 );
 
-  // on an self point
+  // on a self point
   utils.mouseMove( 25, 0.1 );
   QGSCOMPARENEARPOINT( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 25, 0 ), 0.000001 );
 }

--- a/tests/src/app/testqgsmaptoolcircle.cpp
+++ b/tests/src/app/testqgsmaptoolcircle.cpp
@@ -118,7 +118,7 @@ void TestQgsMapToolCircle::initTestCase()
   QgsProject::instance()->addMapLayers( layerList );
   mCanvas->setLayers( layerList );
 
-  mMapTool = new QgsMapToolAddFeature( mCanvas, QgsMapToolCapture::CaptureLine );
+  mMapTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
   mMapTool->setCurrentCaptureTechnique( QgsMapToolCapture::Shape );
   mCanvas->setMapTool( mMapTool );
 

--- a/tests/src/app/testqgsmaptoolcircularstring.cpp
+++ b/tests/src/app/testqgsmaptoolcircularstring.cpp
@@ -75,9 +75,9 @@ void TestQgsMapToolCircularString::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayer );
   mCanvas->setCurrentLayer( mLayer );
 
-  mMapTool = new QgsMapToolAddFeature( mCanvas, QgsMapToolCapture::CaptureLine );
+  mMapTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
   mMapTool->setCurrentCaptureTechnique( QgsMapToolCapture::Shape );
-
+//  mCanvas->setMapTool( mMapTool );
 }
 
 void TestQgsMapToolCircularString::cleanupTestCase()

--- a/tests/src/app/testqgsmaptoolellipse.cpp
+++ b/tests/src/app/testqgsmaptoolellipse.cpp
@@ -121,7 +121,7 @@ void TestQgsMapToolEllipse::initTestCase()
   QgsProject::instance()->addMapLayers( layerList );
   mCanvas->setLayers( layerList );
 
-  mMapTool = new QgsMapToolAddFeature( mCanvas, QgsMapToolCapture::CaptureLine );
+  mMapTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
   mMapTool->setCurrentCaptureTechnique( QgsMapToolCapture::Shape );
   mCanvas->setMapTool( mMapTool );
 

--- a/tests/src/app/testqgsmaptoolrectangle.cpp
+++ b/tests/src/app/testqgsmaptoolrectangle.cpp
@@ -82,7 +82,7 @@ void TestQgsMapToolRectangle::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayer );
   mCanvas->setCurrentLayer( mLayer );
 
-  mMapTool = new QgsMapToolAddFeature( mCanvas, QgsMapToolCapture::CaptureLine );
+  mMapTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
   mMapTool->setCurrentCaptureTechnique( QgsMapToolCapture::Shape );
   mCanvas->setMapTool( mMapTool );
 }

--- a/tests/src/app/testqgsmaptoolregularpolygon.cpp
+++ b/tests/src/app/testqgsmaptoolregularpolygon.cpp
@@ -80,7 +80,7 @@ void TestQgsMapToolRegularPolygon::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayer );
   mCanvas->setCurrentLayer( mLayer );
 
-  mMapTool = new QgsMapToolAddFeature( mCanvas, QgsMapToolCapture::CaptureLine );
+  mMapTool = new QgsMapToolAddFeature( mCanvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine );
   mMapTool->setCurrentCaptureTechnique( QgsMapToolCapture::Shape );
   mCanvas->setMapTool( mMapTool );
 }

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -68,7 +68,7 @@ class TestQgsMapToolAdvancedDigitizingUtils
     void mouseMove( double mapX, double mapY )
     {
       QgsMapMouseEvent e( mMapTool->canvas(), QEvent::MouseMove, mapToScreen( mapX, mapY ) );
-      mMapTool->cadCanvasMoveEvent( &e );
+      mMapTool->canvasMoveEvent( &e );
     }
 
     void mousePress( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )
@@ -78,7 +78,7 @@ class TestQgsMapToolAdvancedDigitizingUtils
       if ( snap )
         e1.snapPoint();
 
-      mMapTool->cadCanvasPressEvent( &e1 );
+      mMapTool->canvasPressEvent( &e1 );
     }
 
     void mouseRelease( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )
@@ -88,7 +88,7 @@ class TestQgsMapToolAdvancedDigitizingUtils
       if ( snap )
         e2.snapPoint();
 
-      mMapTool->cadCanvasReleaseEvent( &e2 );
+      mMapTool->canvasReleaseEvent( &e2 );
     }
 
     void mouseClick( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )


### PR DESCRIPTION
## Description

This PR fixes #46352. The destination CRS wasn't specified. So, when it is different from the layer, the `QgsGeometryUtils::closestPoint` moves the snapped point to the wrong location.

This PR also fixes #46128. The intersection snapping create a `mSnapMatch` object linked to no layer. Thus, when the `interpolatedPoint` method is called, it returns a null point and so, `point` takes the coordinates (0, 0).