### PR TITLE
Fix crash when parsing mapbox style with labeling containing mixed literal and string references (3.16)

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1083,6 +1083,12 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
         if ( part.isEmpty() )
           continue;
 
+        if ( !part.contains( '{' ) )
+        {
+          res << QgsExpression::quotedValue( part );
+          continue;
+        }
+
         // part will start at a {field} reference
         const QStringList split = part.split( '}' );
         res << QgsExpression::quotedColumnRef( split.at( 0 ).mid( 1 ) );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -548,6 +548,74 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertEqual(labeling.labelSettings().fieldName, '''lower(concat(concat("name_en",' - ',"name_fr"),"bar"))''')
         self.assertTrue(labeling.labelSettings().isExpression)
 
+    def testLabelWithLiteral(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "visibility": "visible",
+                "text-field": "Quarry {substance}",
+            },
+            "paint": {
+                "text-color": "rgba(47, 47, 47, 1)",
+            },
+            "type": "symbol"
+        }
+        rendererStyle, has_renderer, labeling_style, has_labeling = QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        self.assertTrue(has_labeling)
+        self.assertTrue(labeling_style.labelSettings().isExpression)
+        self.assertEqual(labeling_style.labelSettings().fieldName, 'concat(\'Quarry \',"substance")')
+
+    def testLabelWithLiteral2(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "visibility": "visible",
+                "text-field": "{substance} Quarry",
+            },
+            "paint": {
+                "text-color": "rgba(47, 47, 47, 1)",
+            },
+            "type": "symbol"
+        }
+        rendererStyle, has_renderer, labeling_style, has_labeling = QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        self.assertTrue(has_labeling)
+        self.assertTrue(labeling_style.labelSettings().isExpression)
+        self.assertEqual(labeling_style.labelSettings().fieldName, 'concat("substance",\' Quarry\')')
+
+    def testLabelWithLiteral3(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "visibility": "visible",
+                "text-field": "A {substance} Quarry",
+            },
+            "paint": {
+                "text-color": "rgba(47, 47, 47, 1)",
+            },
+            "type": "symbol"
+        }
+        rendererStyle, has_renderer, labeling_style, has_labeling = QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        self.assertTrue(has_labeling)
+        self.assertTrue(labeling_style.labelSettings().isExpression)
+        self.assertEqual(labeling_style.labelSettings().fieldName, 'concat(\'A \',"substance",\' Quarry\')')
+
+    def testLabelWithField(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "visibility": "visible",
+                "text-field": "{substance}",
+            },
+            "paint": {
+                "text-color": "rgba(47, 47, 47, 1)",
+            },
+            "type": "symbol"
+        }
+        rendererStyle, has_renderer, labeling_style, has_labeling = QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        self.assertTrue(has_labeling)
+        self.assertFalse(labeling_style.labelSettings().isExpression)
+        self.assertEqual(labeling_style.labelSettings().fieldName, 'substance')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/46338