### PR TITLE
Fix triangle angles

### DIFF
--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -373,9 +373,9 @@ QVector<double> QgsTriangle::lengths() const
   if ( isEmpty() )
     return lengths;
 
-  lengths.append( vertexAt( 0 ).distance( vertexAt( 1 ) ) );
-  lengths.append( vertexAt( 1 ).distance( vertexAt( 2 ) ) );
-  lengths.append( vertexAt( 2 ).distance( vertexAt( 0 ) ) );
+  lengths.append( vertexAt( 1 ).distance( vertexAt( 2 ) ) ); // a = |BC|
+  lengths.append( vertexAt( 0 ).distance( vertexAt( 2 ) ) ); // b = |AC|
+  lengths.append( vertexAt( 0 ).distance( vertexAt( 1 ) ) ); // c = |AB|
 
   return lengths;
 }
@@ -385,22 +385,24 @@ QVector<double> QgsTriangle::angles() const
   QVector<double> angles;
   if ( isEmpty() )
     return angles;
-  double ax, ay, bx, by, cx, cy;
 
-  ax = vertexAt( 0 ).x();
-  ay = vertexAt( 0 ).y();
-  bx = vertexAt( 1 ).x();
-  by = vertexAt( 1 ).y();
-  cx = vertexAt( 2 ).x();
-  cy = vertexAt( 2 ).y();
+  QVector<double> l = lengths();
 
-  const double a1 = std::fmod( QgsGeometryUtils::angleBetweenThreePoints( cx, cy, ax, ay, bx, by ), M_PI );
-  const double a2 = std::fmod( QgsGeometryUtils::angleBetweenThreePoints( ax, ay, bx, by, cx, cy ), M_PI );
-  const double a3 = std::fmod( QgsGeometryUtils::angleBetweenThreePoints( bx, by, cx, cy, ax, ay ), M_PI );
+  const double a = l[0];
+  const double b = l[1];
+  const double c = l[2];
 
-  angles.append( ( a1 > M_PI_2 ? a1 - M_PI_2 : a1 ) );
-  angles.append( ( a2 > M_PI_2 ? a2 - M_PI_2 : a2 ) );
-  angles.append( ( a3 > M_PI_2 ? a3 - M_PI_2 : a3 ) );
+  const double a2 = a * a;
+  const double b2 = b * b;
+  const double c2 = c * c;
+
+  const double alpha = acos( ( b2 + c2 - a2 ) / ( 2 * b * c ) );
+  const double beta = acos( ( a2 + c2 - b2 ) / ( 2 * a * c ) );
+  const double gamma = M_PI - alpha - beta; // acos((a2 + b2 - c2)/(2*a*b)); but ensure that alpha+beta+gamma = 180.0
+
+  angles.append( alpha );
+  angles.append( beta );
+  angles.append( gamma );
 
   return angles;
 }
@@ -577,12 +579,12 @@ QgsPoint QgsTriangle::inscribedCenter() const
     return QgsPoint();
 
   const QVector<double> l = lengths();
-  const double x = ( l.at( 0 ) * vertexAt( 2 ).x() +
-                     l.at( 1 ) * vertexAt( 0 ).x() +
-                     l.at( 2 ) * vertexAt( 1 ).x() ) / perimeter();
-  const double y = ( l.at( 0 ) * vertexAt( 2 ).y() +
-                     l.at( 1 ) * vertexAt( 0 ).y() +
-                     l.at( 2 ) * vertexAt( 1 ).y() ) / perimeter();
+  const double x = ( l.at( 0 ) * vertexAt( 0 ).x() +
+                     l.at( 1 ) * vertexAt( 1 ).x() +
+                     l.at( 2 ) * vertexAt( 2 ).x() ) / perimeter();
+  const double y = ( l.at( 0 ) * vertexAt( 0 ).y() +
+                     l.at( 1 ) * vertexAt( 1 ).y() +
+                     l.at( 2 ) * vertexAt( 2 ).y() ) / perimeter();
 
   QgsPoint center( x, y );
 

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -373,9 +373,9 @@ QVector<double> QgsTriangle::lengths() const
   if ( isEmpty() )
     return lengths;
 
+  lengths.append( vertexAt( 0 ).distance( vertexAt( 1 ) ) ); // c = |AB|
   lengths.append( vertexAt( 1 ).distance( vertexAt( 2 ) ) ); // a = |BC|
   lengths.append( vertexAt( 0 ).distance( vertexAt( 2 ) ) ); // b = |AC|
-  lengths.append( vertexAt( 0 ).distance( vertexAt( 1 ) ) ); // c = |AB|
 
   return lengths;
 }
@@ -388,9 +388,9 @@ QVector<double> QgsTriangle::angles() const
 
   QVector<double> l = lengths();
 
-  const double a = l[0];
-  const double b = l[1];
-  const double c = l[2];
+  const double a = l[1];
+  const double b = l[2];
+  const double c = l[0];
 
   const double a2 = a * a;
   const double b2 = b * b;
@@ -579,12 +579,12 @@ QgsPoint QgsTriangle::inscribedCenter() const
     return QgsPoint();
 
   const QVector<double> l = lengths();
-  const double x = ( l.at( 0 ) * vertexAt( 0 ).x() +
-                     l.at( 1 ) * vertexAt( 1 ).x() +
-                     l.at( 2 ) * vertexAt( 2 ).x() ) / perimeter();
-  const double y = ( l.at( 0 ) * vertexAt( 0 ).y() +
-                     l.at( 1 ) * vertexAt( 1 ).y() +
-                     l.at( 2 ) * vertexAt( 2 ).y() ) / perimeter();
+  const double x = ( l.at( 0 ) * vertexAt( 2 ).x() +
+                     l.at( 1 ) * vertexAt( 0 ).x() +
+                     l.at( 2 ) * vertexAt( 1 ).x() ) / perimeter();
+  const double y = ( l.at( 0 ) * vertexAt( 2 ).y() +
+                     l.at( 1 ) * vertexAt( 0 ).y() +
+                     l.at( 2 ) * vertexAt( 1 ).y() ) / perimeter();
 
   QgsPoint center( x, y );
 

--- a/tests/src/core/geometry/testqgstriangle.cpp
+++ b/tests/src/core/geometry/testqgstriangle.cpp
@@ -818,7 +818,7 @@ void TestQgsTriangle::types()
   tr = QgsTriangle( QgsPoint( 7.2825, 4.2368 ), QgsPoint( 13.0058, 3.3218 ),
                     QgsPoint( 9.2145, 6.5242 ) );
   // angles in radians 58.8978;31.1036;89.9985
-  // length 4.96279;2.99413;5.79598
+  // length 5.79598;4.96279;2.99413
   QVERIFY( !tr.isDegenerate() );
   QVERIFY( tr.isRight() );
   QVERIFY( !tr.isIsocele() );
@@ -913,8 +913,8 @@ void TestQgsTriangle::lengths()
 
   QVector<double> l_tested, l_t7 = tr.lengths();
   l_tested.append( 5 );
-  l_tested.append( std::sqrt( 5 * 5 + 5 * 5 ) );
   l_tested.append( 5 );
+  l_tested.append( std::sqrt( 5 * 5 + 5 * 5 ) );
 
   QGSCOMPARENEAR( l_tested.at( 0 ), l_t7.at( 0 ), 0.0001 );
   QGSCOMPARENEAR( l_tested.at( 1 ), l_t7.at( 1 ), 0.0001 );

--- a/tests/src/core/geometry/testqgstriangle.cpp
+++ b/tests/src/core/geometry/testqgstriangle.cpp
@@ -818,7 +818,7 @@ void TestQgsTriangle::types()
   tr = QgsTriangle( QgsPoint( 7.2825, 4.2368 ), QgsPoint( 13.0058, 3.3218 ),
                     QgsPoint( 9.2145, 6.5242 ) );
   // angles in radians 58.8978;31.1036;89.9985
-  // length 5.79598;4.96279;2.99413
+  // length 4.96279;2.99413;5.79598
   QVERIFY( !tr.isDegenerate() );
   QVERIFY( tr.isRight() );
   QVERIFY( !tr.isIsocele() );
@@ -857,17 +857,54 @@ void TestQgsTriangle::angles()
 {
   QgsTriangle tr( QgsPoint( 0, 0 ), QgsPoint( 0, 5 ), QgsPoint( 5, 5 ) );
 
-  QVector<double> a_tested, a_t7 = tr.angles();
+  QVector<double> a_tested;
+  QVector<double> angles = tr.angles();
   a_tested.append( M_PI / 4.0 );
   a_tested.append( M_PI / 2.0 );
   a_tested.append( M_PI / 4.0 );
 
-  QGSCOMPARENEAR( a_tested.at( 0 ), a_t7.at( 0 ), 0.0001 );
-  QGSCOMPARENEAR( a_tested.at( 1 ), a_t7.at( 1 ), 0.0001 );
-  QGSCOMPARENEAR( a_tested.at( 2 ), a_t7.at( 2 ), 0.0001 );
+  QGSCOMPARENEAR( a_tested.at( 0 ), angles.at( 0 ), 0.0001 );
+  QGSCOMPARENEAR( a_tested.at( 1 ), angles.at( 1 ), 0.0001 );
+  QGSCOMPARENEAR( a_tested.at( 2 ), angles.at( 2 ), 0.0001 );
 
   QVector<double> a_empty = QgsTriangle().angles();
   QVERIFY( a_empty.isEmpty() );
+
+  // From issue #46370
+  tr = QgsTriangle( QgsPoint( 0, 0 ), QgsPoint( 1, sqrt( 3 ) ), QgsPoint( 2, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), M_PI / 3.0, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), M_PI / 3.0, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), M_PI / 3.0, 0.0001 );
+
+  tr = QgsTriangle( QgsPoint( 2, 0 ), QgsPoint( 1, sqrt( 3 ) ), QgsPoint( 0, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), M_PI / 3.0, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), M_PI / 3.0, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), M_PI / 3.0, 0.0001 );
+
+  tr = QgsTriangle( QgsPoint( 0, 0 ), QgsPoint( 0, 3 ), QgsPoint( 4, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), M_PI / 2.0, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), 0.9272952, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), 0.6435011, 0.0001 );
+  tr = QgsTriangle( QgsPoint( 4, 0 ), QgsPoint( 0, 3 ), QgsPoint( 0, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), 0.6435011, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), 0.9272952, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), M_PI / 2.0, 0.0001 );
+
+  tr = QgsTriangle( QgsPoint( 0, 0 ), QgsPoint( 1, 3 ), QgsPoint( 3, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), 1.2490457, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), 0.9097531, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), 0.9827937, 0.0001 );
+  tr = QgsTriangle( QgsPoint( 3, 0 ), QgsPoint( 1, 3 ), QgsPoint( 0, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), 0.9827937, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), 0.9097531, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), 1.2490457, 0.0001 );
+
 }
 
 void TestQgsTriangle::lengths()
@@ -876,8 +913,8 @@ void TestQgsTriangle::lengths()
 
   QVector<double> l_tested, l_t7 = tr.lengths();
   l_tested.append( 5 );
-  l_tested.append( 5 );
   l_tested.append( std::sqrt( 5 * 5 + 5 * 5 ) );
+  l_tested.append( 5 );
 
   QGSCOMPARENEAR( l_tested.at( 0 ), l_t7.at( 0 ), 0.0001 );
   QGSCOMPARENEAR( l_tested.at( 1 ), l_t7.at( 1 ), 0.0001 );

--- a/tests/src/core/geometry/testqgstriangle.cpp
+++ b/tests/src/core/geometry/testqgstriangle.cpp
@@ -905,6 +905,11 @@ void TestQgsTriangle::angles()
   QGSCOMPARENEAR( angles.at( 1 ), 0.9097531, 0.0001 );
   QGSCOMPARENEAR( angles.at( 2 ), 1.2490457, 0.0001 );
 
+  tr = QgsTriangle( QgsPoint( 78598.328125, 330538.375, 0 ), QgsPoint( 78606.3203125, 330544, 0 ), QgsPoint( 78601.46875, 330550.90625, 0 ) );
+  angles = tr.angles();
+  QGSCOMPARENEAR( angles.at( 0 ), 0.7119510, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 1 ), 1.5716821, 0.0001 );
+  QGSCOMPARENEAR( angles.at( 2 ), 0.8579596, 0.0001 );
 }
 
 void TestQgsTriangle::lengths()


### PR DESCRIPTION
## Description

There are two errors in triangle methods.

~~First, the calculation of the lengths are not in the usual order.~~
~~Second,~~ the angles are not always well computed (sometimes wrong, sometimes order differ) as mentioned in https://github.com/qgis/QGIS/issues/46370#issuecomment-986270366

This PR fix this issue.