### PR TITLE
Include Python stack trace in crash handler dialog

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if(WIN32 AND NOT MINGW)
+if((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID))
   add_subdirectory(crashhandler)
 endif()
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if(not WITH_QT6 and ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID)))
+if (NOT WITH_QT6 AND ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID)))
   add_subdirectory(crashhandler)
 endif()
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID))
+if(not WITH_QT6 and ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID)))
   add_subdirectory(crashhandler)
 endif()
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if (NOT WITH_QT6 AND ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID)))
+if (NOT WITH_QT6 AND ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID AND NOT IOS)))
   add_subdirectory(crashhandler)
 endif()
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if (NOT WITH_QT6 AND ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID AND NOT IOS)))
+if ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID AND NOT IOS))
   add_subdirectory(crashhandler)
 endif()
 add_subdirectory(test)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -316,6 +316,8 @@ void qgisCrash( int signal )
 {
   fprintf( stderr, "QGIS died on signal %d", signal );
 
+  QgsCrashHandler::handle( 0 );
+
   if ( access( "/usr/bin/gdb", X_OK ) == 0 )
   {
     // take full stacktrace using gdb
@@ -361,8 +363,6 @@ void qgisCrash( int signal )
       }
     }
   }
-
-  QgsCrashHandler::handle( 0 );
 
   abort();
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -362,6 +362,8 @@ void qgisCrash( int signal )
     }
   }
 
+  QgsCrashHandler::handle( 0 );
+
   abort();
 }
 #endif

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16236,7 +16236,7 @@ void QgisApp::keyPressEvent( QKeyEvent *e )
 {
   emit keyPressed( e );
 
-#if 0 && defined(_MSC_VER) && defined(QGISDEBUG)
+#if 0 && defined(QGISDEBUG)
   if ( e->key() == Qt::Key_Backslash && e->modifiers() == Qt::ControlModifier )
   {
     QgsCrashHandler::handle( 0 );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12794,7 +12794,8 @@ void QgisApp::loadPythonSupport()
   mPythonUtils = pythonlib_inst();
   if ( mPythonUtils )
   {
-    mPythonUtils->initPython( mQgisInterface, true );
+    QgsCrashHandler::sPythonCrashLogFile = QStandardPaths::standardLocations( QStandardPaths::TempLocation ).at( 0 ) + "/qgis-python-crash-info-" + QString::number( QCoreApplication::applicationPid() );
+    mPythonUtils->initPython( mQgisInterface, true, QgsCrashHandler::sPythonCrashLogFile );
   }
 
   if ( mPythonUtils && mPythonUtils->isEnabled() )

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -28,6 +28,8 @@
 #include <QStandardPaths>
 #include <QUuid>
 
+QString QgsCrashHandler::sPythonCrashLogFile;
+
 #ifdef _MSC_VER
 LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
 {
@@ -104,6 +106,7 @@ void QgsCrashHandler::handleCrash( int processID, int threadID,
     stream << QString::number( threadID ) << endl;
     stream << ptrStr << endl;
     stream << symbolPath << endl;
+    stream << sPythonCrashLogFile << endl;
     stream << arguments.join( ' ' ) << endl;
     stream << reportData.join( '\n' ) << endl;
   }

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -31,8 +31,6 @@
 #ifdef _MSC_VER
 LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
 {
-  QgsDebugMsg( QStringLiteral( "CRASH!!!" ) );
-
   DWORD processID = GetCurrentProcessId();
   DWORD threadID = GetCurrentThreadId();
 
@@ -52,6 +50,21 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   }
 
   QString ptrStr = QString( "0x%1" ).arg( ( quintptr )exception, QT_POINTER_SIZE * 2, 16, QChar( '0' ) );
+
+  handleCrash( processID, threadID, symbolPath, ptrStr );
+  return TRUE;
+}
+#endif
+
+void QgsCrashHandler::handle( int )
+{
+  handleCrash( QCoreApplication::applicationPid(), 0, QString(), QString() );
+}
+
+void QgsCrashHandler::handleCrash( int processID, int threadID,
+                                   const QString &symbolPath,
+                                   const QString &ptrStr )
+{
   QString fileName = QStandardPaths::standardLocations( QStandardPaths::TempLocation ).at( 0 ) + "/qgis-crash-info-" + QString::number( processID );
   QgsDebugMsg( fileName );
 
@@ -91,8 +104,8 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
     stream << QString::number( threadID ) << endl;
     stream << ptrStr << endl;
     stream << symbolPath << endl;
-    stream << arguments.join( " " ) << endl;
-    stream << reportData.join( "\n" ) << endl;
+    stream << arguments.join( ' ' ) << endl;
+    stream << reportData.join( '\n' ) << endl;
   }
 
   file.close();
@@ -100,10 +113,11 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   args << fileName;
 
   QString prefixPath( getenv( "QGIS_PREFIX_PATH" ) ? getenv( "QGIS_PREFIX_PATH" ) : QApplication::applicationDirPath() );
-  QString path = prefixPath + "/qgiscrashhandler.exe";
+#ifdef MSVC
+  QString path = prefixPath + QStringLiteral( "/qgiscrashhandler.exe" );
+#else
+  QString path = prefixPath + QStringLiteral( "/qgiscrashhandler" );
+#endif
   QgsDebugMsg( path );
   QProcess::execute( path, args );
-
-  return TRUE;
 }
-#endif

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -18,6 +18,8 @@
 
 #include "qgis_app.h"
 
+#include <QString>
+
 #ifdef WIN32
 #include <windows.h>
 #include <dbghelp.h>
@@ -39,7 +41,17 @@ class APP_EXPORT QgsCrashHandler
 
 #ifdef _MSC_VER
     static LONG WINAPI handle( LPEXCEPTION_POINTERS ExceptionInfo );
+#else
+    static void handle( int );
 #endif
+
+  private:
+
+    static void handleCrash( int processId,
+                             int threadId,
+                             const QString &symbolPath,
+                             const QString &ptrStr
+                           );
 };
 
 

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -45,6 +45,8 @@ class APP_EXPORT QgsCrashHandler
     static void handle( int );
 #endif
 
+    static QString sPythonCrashLogFile;
+
   private:
 
     static void handleCrash( int processId,

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -578,6 +578,8 @@ QString QgsStringUtils::htmlToMarkdown( const QString &html )
   converted.replace( QLatin1String( "<br>" ), QLatin1String( "\n" ) );
   converted.replace( QLatin1String( "<b>" ), QLatin1String( "**" ) );
   converted.replace( QLatin1String( "</b>" ), QLatin1String( "**" ) );
+  converted.replace( QLatin1String( "<pre>" ), QLatin1String( "\n```\n" ) );
+  converted.replace( QLatin1String( "</pre>" ), QLatin1String( "```\n" ) );
 
   static thread_local QRegularExpression hrefRegEx( QStringLiteral( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" ) );
 

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -525,9 +525,9 @@ QString QgsStringUtils::insertLinks( const QString &string, bool *foundLinks )
 
   // http://alanstorm.com/url_regex_explained
   // note - there's more robust implementations available
-  static thread_local QRegularExpression urlRegEx( "(\\b(([\\w-]+://?|www[.])[^\\s()<>]+(?:\\([\\w\\d]+\\)|([^!\"#$%&'()*+,\\-./:;<=>?@[\\\\\\]^_`{|}~\\s]|/))))" );
-  static thread_local QRegularExpression protoRegEx( "^(?:f|ht)tps?://|file://" );
-  static thread_local QRegularExpression emailRegEx( "([\\w._%+-]+@[\\w.-]+\\.[A-Za-z]+)" );
+  static thread_local QRegularExpression urlRegEx( QStringLiteral( "(\\b(([\\w-]+://?|www[.])[^\\s()<>]+(?:\\([\\w\\d]+\\)|([^!\"#$%&'()*+,\\-./:;<=>?@[\\\\\\]^_`{|}~\\s]|/))))" ) );
+  static thread_local QRegularExpression protoRegEx( QStringLiteral( "^(?:f|ht)tps?://|file://" ) );
+  static thread_local QRegularExpression emailRegEx( QStringLiteral( "([\\w._%+-]+@[\\w.-]+\\.[A-Za-z]+)" ) );
 
   int offset = 0;
   bool found = false;
@@ -567,7 +567,7 @@ QString QgsStringUtils::insertLinks( const QString &string, bool *foundLinks )
 
 bool QgsStringUtils::isUrl( const QString &string )
 {
-  const thread_local QRegularExpression rxUrl( "^(http|https|ftp|file)://\\S+$" );
+  const thread_local QRegularExpression rxUrl( QStringLiteral( "^(http|https|ftp|file)://\\S+$" ) );
   return rxUrl.match( string ).hasMatch();
 }
 
@@ -579,7 +579,7 @@ QString QgsStringUtils::htmlToMarkdown( const QString &html )
   converted.replace( QLatin1String( "<b>" ), QLatin1String( "**" ) );
   converted.replace( QLatin1String( "</b>" ), QLatin1String( "**" ) );
 
-  static thread_local QRegularExpression hrefRegEx( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" );
+  static thread_local QRegularExpression hrefRegEx( QStringLiteral( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" ) );
 
   int offset = 0;
   QRegularExpressionMatch match = hrefRegEx.match( converted );
@@ -762,7 +762,7 @@ QgsStringReplacement::QgsStringReplacement( const QString &match, const QString 
 {
   if ( mWholeWordOnly )
   {
-    mRx.setPattern( QString( "\\b%1\\b" ).arg( mMatch ) );
+    mRx.setPattern( QStringLiteral( "\\b%1\\b" ).arg( mMatch ) );
     mRx.setPatternOptions( mCaseSensitive ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption );
   }
 }
@@ -785,8 +785,8 @@ QgsStringMap QgsStringReplacement::properties() const
   QgsStringMap map;
   map.insert( QStringLiteral( "match" ), mMatch );
   map.insert( QStringLiteral( "replace" ), mReplacement );
-  map.insert( QStringLiteral( "caseSensitive" ), mCaseSensitive ? "1" : "0" );
-  map.insert( QStringLiteral( "wholeWord" ), mWholeWordOnly ? "1" : "0" );
+  map.insert( QStringLiteral( "caseSensitive" ), mCaseSensitive ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  map.insert( QStringLiteral( "wholeWord" ), mWholeWordOnly ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   return map;
 }
 
@@ -801,8 +801,7 @@ QgsStringReplacement QgsStringReplacement::fromProperties( const QgsStringMap &p
 QString QgsStringReplacementCollection::process( const QString &input ) const
 {
   QString result = input;
-  const auto constMReplacements = mReplacements;
-  for ( const QgsStringReplacement &r : constMReplacements )
+  for ( const QgsStringReplacement &r : mReplacements )
   {
     result = r.process( result );
   }
@@ -811,8 +810,7 @@ QString QgsStringReplacementCollection::process( const QString &input ) const
 
 void QgsStringReplacementCollection::writeXml( QDomElement &elem, QDomDocument &doc ) const
 {
-  const auto constMReplacements = mReplacements;
-  for ( const QgsStringReplacement &r : constMReplacements )
+  for ( const QgsStringReplacement &r : mReplacements )
   {
     QgsStringMap props = r.properties();
     QDomElement propEl = doc.createElement( QStringLiteral( "replacement" ) );

--- a/src/crashhandler/CMakeLists.txt
+++ b/src/crashhandler/CMakeLists.txt
@@ -12,8 +12,11 @@ endif()
 
 set(IMAGE_RCCS ../../images/images.qrc)
 
-# -wd4091 Avoid 'typedef' ignored on left of '' when no variable is declared warning in dbghelp.h
-set_source_files_properties(qgsstacktrace.cpp PROPERTIES COMPILE_FLAGS -wd4091)
+
+if(WIN32 AND NOT MINGW)
+  # -wd4091 Avoid 'typedef' ignored on left of '' when no variable is declared warning in dbghelp.h
+  set_source_files_properties(qgsstacktrace.cpp PROPERTIES COMPILE_FLAGS -wd4091)
+endif()
 
 add_executable(qgiscrashhandler WIN32
   main.cpp
@@ -32,8 +35,13 @@ target_link_libraries(qgiscrashhandler
   ${QT_VERSION_BASE}::Core
   ${QT_VERSION_BASE}::Gui
   ${QT_VERSION_BASE}::Widgets
-  dbghelp
 )
+
+if(WIN32 AND NOT MINGW)
+  target_link_libraries(qgiscrashhandler
+    dbghelp
+  )
+endif()
 
 install(CODE "message(\"Installing crashhandler ...\")")
 install(TARGETS qgiscrashhandler RUNTIME DESTINATION ${QGIS_LIBEXEC_DIR})

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -94,6 +94,7 @@ int main( int argc, char *argv[] )
 
   QgsCrashDialog dlg;
   dlg.setReloadArgs( reloadArgs );
+  dlg.setPythonFault( report.pythonFault() );
   dlg.setBugReport( report.toHtml() );
   dlg.setModal( true );
   dlg.show();

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 #include <memory>
 #include <iostream>
+#include <QFile>
 
 #define _NO_CVCONST_H
 #define _CRT_STDIO_ISO_WIDE_SPECIFIERS

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -65,6 +65,7 @@ int main( int argc, char *argv[] )
     versionInfo = info.split( "\n" );
   }
 
+#ifdef MSVC
   DWORD processId;
   DWORD threadId;
   LPEXCEPTION_POINTERS exception;
@@ -78,10 +79,13 @@ int main( int argc, char *argv[] )
   std::cout << "Symbol Path :" << symbolPaths.toUtf8().constData() << std::endl;
 
   std::unique_ptr<QgsStackTrace> stackTrace( QgsStackTrace::trace( processId, threadId, exception, symbolPaths ) );
+#endif
 
   QgsCrashReport report;
   report.setVersionInfo( versionInfo );
+#ifdef MSVC
   report.setStackTrace( stackTrace.get() );
+#endif
   report.exportToCrashFolder();
 
   QgsCrashDialog dlg;
@@ -92,12 +96,14 @@ int main( int argc, char *argv[] )
   app.exec();
 
 
+#ifdef MSVC
   for ( HANDLE threadHandle : stackTrace->threads )
   {
     ResumeThread( threadHandle );
     CloseHandle( threadHandle );
   }
   CloseHandle( stackTrace->process );
+#endif
 
   return 0;
 }

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -49,6 +49,7 @@ int main( int argc, char *argv[] )
   QString threadIdString;
   QString exceptionPointersString;
   QString symbolPaths;
+  QString pythonCrashLogFile;
   QString reloadArgs;
   QStringList versionInfo;
 
@@ -58,6 +59,7 @@ int main( int argc, char *argv[] )
     threadIdString = file.readLine();
     exceptionPointersString = file.readLine();
     symbolPaths = file.readLine();
+    pythonCrashLogFile = file.readLine().trimmed();
     reloadArgs = file.readLine();
     // The version info is the last stuff to be in the file until the end
     // bit gross but :)
@@ -86,6 +88,7 @@ int main( int argc, char *argv[] )
 #ifdef MSVC
   report.setStackTrace( stackTrace.get() );
 #endif
+  report.setPythonCrashLogFilePath( pythonCrashLogFile );
   report.exportToCrashFolder();
 
   QgsCrashDialog dlg;

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -65,6 +65,59 @@ void QgsCrashDialog::on_mUserFeedbackText_textChanged()
   mCopyReportButton->setEnabled( !mUserFeedbackText->toPlainText().isEmpty() );
 }
 
+QStringList QgsCrashDialog::splitCommand( const QString &command )
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  return QProcess::splitCommand( command );
+#else
+  // taken from Qt 5.15's implementation
+  QStringList args;
+  QString tmp;
+  int quoteCount = 0;
+  bool inQuote = false;
+
+  // handle quoting. tokens can be surrounded by double quotes
+  // "hello world". three consecutive double quotes represent
+  // the quote character itself.
+  for ( int i = 0; i < command.size(); ++i )
+  {
+    if ( command.at( i ) == QLatin1Char( '"' ) )
+    {
+      ++quoteCount;
+      if ( quoteCount == 3 )
+      {
+        // third consecutive quote
+        quoteCount = 0;
+        tmp += command.at( i );
+      }
+      continue;
+    }
+    if ( quoteCount )
+    {
+      if ( quoteCount == 1 )
+        inQuote = !inQuote;
+      quoteCount = 0;
+    }
+    if ( !inQuote && command.at( i ).isSpace() )
+    {
+      if ( !tmp.isEmpty() )
+      {
+        args += tmp;
+        tmp.clear();
+      }
+    }
+    else
+    {
+      tmp += command.at( i );
+    }
+  }
+  if ( !tmp.isEmpty() )
+    args += tmp;
+
+  return args;
+#endif
+}
+
 void QgsCrashDialog::createBugReport()
 {
   QClipboard *clipboard = QApplication::clipboard();
@@ -77,7 +130,7 @@ void QgsCrashDialog::createBugReport()
 
 void QgsCrashDialog::reloadQGIS()
 {
-  const QStringList command = QProcess::splitCommand( mReloadArgs );
+  const QStringList command = splitCommand( mReloadArgs );
   if ( command.isEmpty() )
     return;
 

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -77,8 +77,11 @@ void QgsCrashDialog::createBugReport()
 
 void QgsCrashDialog::reloadQGIS()
 {
-  bool loaded = QProcess::startDetached( mReloadArgs );
-  if ( loaded )
+  const QStringList command = QProcess::splitCommand( mReloadArgs );
+  if ( command.isEmpty() )
+    return;
+
+  if ( QProcess::startDetached( command.at( 0 ), command.mid( 1 ) ) )
   {
     accept();
   }

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -61,6 +61,7 @@ void QgsCrashDialog::setPythonFault( const QgsCrashReport::PythonFault &fault )
   switch ( fault.cause )
   {
     case QgsCrashReport::LikelyPythonFaultCause::Unknown:
+    case QgsCrashReport::LikelyPythonFaultCause::NotPython:
       break;
 
     case QgsCrashReport::LikelyPythonFaultCause::ProcessingScript:

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -56,6 +56,37 @@ void QgsCrashDialog::setReloadArgs( const QString &reloadArgs )
   mReloadArgs = reloadArgs;
 }
 
+void QgsCrashDialog::setPythonFault( const QgsCrashReport::PythonFault &fault )
+{
+  switch ( fault.cause )
+  {
+    case QgsCrashReport::LikelyPythonFaultCause::Unknown:
+      break;
+
+    case QgsCrashReport::LikelyPythonFaultCause::ProcessingScript:
+      mCrashHeaderMessage->setText( tr( "User script crashed QGIS" ).arg( fault.title ) );
+      mCrashMessage->setText( tr( "The user script <b>%1</b> caused QGIS to crash." ).arg( fault.filePath )
+                              + "<br><br>"
+                              +  tr( "This is a third party custom script, and this issue should be reported to the author of that script." ) );
+      splitter->setSizes( { 0, splitter->width() } );
+      break;
+
+    case QgsCrashReport::LikelyPythonFaultCause::Plugin:
+      mCrashHeaderMessage->setText( tr( "Plugin %1 crashed QGIS" ).arg( fault.title ) );
+      mCrashMessage->setText( tr( "The plugin <b>%1</b> caused QGIS to crash." ).arg( fault.title )
+                              + "<br><br>"
+                              +  tr( "Please report this issue to the author of that plugin." ) );
+      splitter->setSizes( { 0, splitter->width() } );
+      break;
+
+    case QgsCrashReport::LikelyPythonFaultCause::ConsoleCommand:
+      mCrashHeaderMessage->setText( tr( "Command crashed QGIS" ).arg( fault.title ) );
+      mCrashMessage->setText( tr( "A command entered in the Python console caused QGIS to crash." ) );
+      splitter->setSizes( { 0, splitter->width() } );
+      break;
+  }
+}
+
 void QgsCrashDialog::showReportWidget()
 {
 }

--- a/src/crashhandler/qgscrashdialog.h
+++ b/src/crashhandler/qgscrashdialog.h
@@ -22,6 +22,8 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 
+#include "qgscrashreport.h"
+
 #include "ui_qgscrashdialog.h"
 
 /**
@@ -39,6 +41,8 @@ class QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
 
     void setBugReport( const QString &reportData );
     void setReloadArgs( const QString &reloadArgs );
+
+    void setPythonFault( const QgsCrashReport::PythonFault &fault );
 
   private slots:
     void showReportWidget();

--- a/src/crashhandler/qgscrashdialog.h
+++ b/src/crashhandler/qgscrashdialog.h
@@ -55,6 +55,7 @@ class QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
 
     QString mReportData;
     QString mReloadArgs;
+    QgsCrashReport::PythonFault mPythonFault;
 };
 
 #endif // QGSCRASHDIALOG_H

--- a/src/crashhandler/qgscrashdialog.h
+++ b/src/crashhandler/qgscrashdialog.h
@@ -47,6 +47,8 @@ class QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
     void on_mUserFeedbackText_textChanged();
 
   private:
+    static QStringList splitCommand( const QString &command );
+
     QString mReportData;
     QString mReloadArgs;
 };

--- a/src/crashhandler/qgscrashdialog.ui
+++ b/src/crashhandler/qgscrashdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>645</width>
-    <height>565</height>
+    <width>852</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="palette">
@@ -142,6 +142,15 @@
      <colorrole role="ToolTipText">
       <brush brushstyle="SolidPattern">
        <color alpha="255">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
+     <colorrole role="PlaceholderText">
+      <brush brushstyle="NoBrush">
+       <color alpha="128">
         <red>0</red>
         <green>0</green>
         <blue>0</blue>
@@ -285,6 +294,15 @@
        </color>
       </brush>
      </colorrole>
+     <colorrole role="PlaceholderText">
+      <brush brushstyle="NoBrush">
+       <color alpha="128">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
     </inactive>
     <disabled>
      <colorrole role="WindowText">
@@ -422,6 +440,15 @@
        </color>
       </brush>
      </colorrole>
+     <colorrole role="PlaceholderText">
+      <brush brushstyle="NoBrush">
+       <color alpha="128">
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </brush>
+     </colorrole>
     </disabled>
    </palette>
   </property>
@@ -446,8 +473,20 @@
    </property>
    <item row="1" column="0" colspan="3">
     <widget class="QFrame" name="mReportFrame">
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,1,0">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <spacer name="horizontalSpacer_2">
@@ -471,42 +510,13 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="1" column="2">
-         <widget class="QTextEdit" name="mReportDetailsText">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="label_3">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Report Details</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0" rowspan="2">
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <widget class="QWidget" name="">
+         <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
           <property name="leftMargin">
            <number>0</number>
           </property>
@@ -515,12 +525,6 @@
           </property>
           <item>
            <widget class="QLabel" name="label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about when you got the crash.&lt;/p&gt;&lt;p&gt;Include as much information as you can as well as steps to reproduce the issue if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -549,10 +553,46 @@
            </widget>
           </item>
          </layout>
-        </item>
-       </layout>
+        </widget>
+        <widget class="QWidget" name="">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Report Details</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QTextEdit" name="mReportDetailsText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOn</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
       </item>
-      <item row="2" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <property name="topMargin">
          <number>0</number>
@@ -685,6 +725,7 @@
   </layout>
  </widget>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -329,6 +329,8 @@ QString QgsCrashReport::htmlToMarkdown( const QString &html )
   converted.replace( QLatin1String( "<br>" ), QLatin1String( "\n" ) );
   converted.replace( QLatin1String( "<b>" ), QLatin1String( "**" ) );
   converted.replace( QLatin1String( "</b>" ), QLatin1String( "**" ) );
+  converted.replace( QLatin1String( "<pre>" ), QLatin1String( "\n```\n" ) );
+  converted.replace( QLatin1String( "</pre>" ), QLatin1String( "```\n" ) );
 
   static thread_local QRegularExpression hrefRegEx( QStringLiteral( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" ) );
 

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -27,6 +27,7 @@
 #include <QRegularExpressionMatch>
 
 QgsCrashReport::QgsCrashReport()
+  : mPythonFault( PythonFault() )
 {
   setFlags( QgsCrashReport::All );
 }

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -330,16 +330,19 @@ QString QgsCrashReport::htmlToMarkdown( const QString &html )
   converted.replace( QLatin1String( "<b>" ), QLatin1String( "**" ) );
   converted.replace( QLatin1String( "</b>" ), QLatin1String( "**" ) );
 
-  static QRegExp hrefRegEx( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" );
+  static thread_local QRegularExpression hrefRegEx( QStringLiteral( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" ) );
+
   int offset = 0;
-  while ( hrefRegEx.indexIn( converted, offset ) != -1 )
+  QRegularExpressionMatch match = hrefRegEx.match( converted );
+  while ( match.hasMatch() )
   {
-    QString url = hrefRegEx.cap( 1 ).replace( QLatin1String( "\"" ), QString() );
+    QString url = match.captured( 1 ).replace( QLatin1String( "\"" ), QString() );
     url.replace( '\'', QString() );
-    QString name = hrefRegEx.cap( 2 );
+    QString name = match.captured( 2 );
     QString anchor = QStringLiteral( "[%1](%2)" ).arg( name, url );
-    converted.replace( hrefRegEx, anchor );
-    offset = hrefRegEx.pos( 1 ) + anchor.length();
+    converted.replace( match.capturedStart(), match.capturedLength(), anchor );
+    offset = match.capturedStart() + anchor.length();
+    match = hrefRegEx.match( converted, offset );
   }
 
   return converted;

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -44,7 +44,7 @@ const QString QgsCrashReport::toHtml() const
   {
     reportData.append( QStringLiteral( "<br>" ) );
     reportData.append( QStringLiteral( "<b>Stack Trace</b>" ) );
-    if ( mStackTrace->lines.isEmpty() )
+    if ( !mStackTrace || mStackTrace->lines.isEmpty() )
     {
       reportData.append( QStringLiteral( "Stack trace could not be generated." ) );
     }
@@ -107,6 +107,9 @@ const QString QgsCrashReport::toHtml() const
 
 const QString QgsCrashReport::crashID() const
 {
+  if ( !mStackTrace )
+    return QStringLiteral( "Not available" );
+
   if ( !mStackTrace->symbolsLoaded || mStackTrace->lines.isEmpty() )
     return QStringLiteral( "ID not generated due to missing information.<br><br> "
                            "Your version of QGIS install might not have debug information included or "
@@ -141,18 +144,23 @@ void QgsCrashReport::exportToCrashFolder()
     QDir().mkpath( folder );
   }
 
-  QString fileName = folder + "/stack.txt";
+  QString fileName;
+  QFile file;
 
-  QFile file( fileName );
-  if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( mStackTrace )
   {
-    QTextStream stream( &file );
-    stream << mStackTrace->fullStack << endl;
+    fileName = folder + "/stack.txt";
+
+    file.setFileName( fileName );
+    if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    {
+      QTextStream stream( &file );
+      stream << mStackTrace->fullStack << endl;
+    }
+    file.close();
   }
-  file.close();
 
   fileName = folder + "/report.txt";
-
   file.setFileName( fileName );
   if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
   {

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -44,28 +44,6 @@ const QString QgsCrashReport::toHtml() const
 
   if ( flags().testFlag( QgsCrashReport::Stack ) )
   {
-    reportData.append( QStringLiteral( "<br>" ) );
-    reportData.append( QStringLiteral( "<b>Stack Trace</b>" ) );
-    if ( !mStackTrace || mStackTrace->lines.isEmpty() )
-    {
-      reportData.append( QStringLiteral( "Stack trace could not be generated." ) );
-    }
-    else if ( !mStackTrace->symbolsLoaded )
-    {
-      reportData.append( QStringLiteral( "Stack trace could not be generated due to missing symbols." ) );
-    }
-    else
-    {
-      reportData.append( QStringLiteral( "<pre>" ) );
-      for ( const QgsStackTrace::StackLine &line : mStackTrace->lines )
-      {
-        QFileInfo fileInfo( line.fileName );
-        QString filename( fileInfo.fileName() );
-        reportData.append( QStringLiteral( "%2 %3:%4" ).arg( line.symbolName, filename, line.lineNumber ) );
-      }
-      reportData.append( QStringLiteral( "</pre>" ) );
-    }
-
     QStringList pythonStack;
     if ( !mPythonCrashLogFilePath.isEmpty() )
     {
@@ -120,6 +98,27 @@ const QString QgsCrashReport::toHtml() const
       }
       pythonStackString.append( QStringLiteral( "</pre>" ) );
       reportData.append( pythonStackString );
+    }
+
+    reportData.append( QStringLiteral( "<b>Stack Trace</b>" ) );
+    if ( !mStackTrace || mStackTrace->lines.isEmpty() )
+    {
+      reportData.append( QStringLiteral( "No stack trace is available." ) );
+    }
+    else if ( !mStackTrace->symbolsLoaded )
+    {
+      reportData.append( QStringLiteral( "Stack trace could not be generated due to missing symbols." ) );
+    }
+    else
+    {
+      reportData.append( QStringLiteral( "<pre>" ) );
+      for ( const QgsStackTrace::StackLine &line : mStackTrace->lines )
+      {
+        QFileInfo fileInfo( line.fileName );
+        QString filename( fileInfo.fileName() );
+        reportData.append( QStringLiteral( "%2 %3:%4" ).arg( line.symbolName, filename, line.lineNumber ) );
+      }
+      reportData.append( QStringLiteral( "</pre>" ) );
     }
   }
 

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -212,7 +212,11 @@ void QgsCrashReport::exportToCrashFolder()
     if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
     {
       QTextStream stream( &file );
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
       stream << mStackTrace->fullStack << endl;
+#else
+      stream << mStackTrace->fullStack << Qt::endl;
+#endif
     }
     file.close();
   }
@@ -222,7 +226,11 @@ void QgsCrashReport::exportToCrashFolder()
   if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
   {
     QTextStream stream( &file );
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     stream << htmlToMarkdown( toHtml() ) << endl;
+#else
+    stream << htmlToMarkdown( toHtml() ) << Qt::endl;
+#endif
   }
   file.close();
 

--- a/src/crashhandler/qgscrashreport.h
+++ b/src/crashhandler/qgscrashreport.h
@@ -89,6 +89,11 @@ class QgsCrashReport
     void setVersionInfo( const QStringList &versionInfo ) { mVersionInfo = versionInfo; }
 
     /**
+     * Sets the \a path to the associated Python crash log.
+     */
+    void setPythonCrashLogFilePath( const QString &path ) { mPythonCrashLogFilePath = path; }
+
+    /**
      * convert htmlToMarkdown (copied from QgsStringUtils::htmlToMarkdown)
      * \param html text in html
      * \return the reformatted text in markdown
@@ -99,6 +104,7 @@ class QgsCrashReport
     Flags mFlags;
     QgsStackTrace *mStackTrace = nullptr;
     QStringList mVersionInfo;
+    QString mPythonCrashLogFilePath;
 
 };
 

--- a/src/crashhandler/qgscrashreport.h
+++ b/src/crashhandler/qgscrashreport.h
@@ -48,6 +48,7 @@ class QgsCrashReport
 
     enum class LikelyPythonFaultCause
     {
+      NotPython,
       Unknown,
       ProcessingScript,
       Plugin,
@@ -103,7 +104,7 @@ class QgsCrashReport
 
     struct PythonFault
     {
-      LikelyPythonFaultCause cause = LikelyPythonFaultCause::Unknown;
+      LikelyPythonFaultCause cause = LikelyPythonFaultCause::NotPython;
       QString title;
       QString filePath;
     };

--- a/src/crashhandler/qgscrashreport.h
+++ b/src/crashhandler/qgscrashreport.h
@@ -46,6 +46,14 @@ class QgsCrashReport
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 
+    enum class LikelyPythonFaultCause
+    {
+      Unknown,
+      ProcessingScript,
+      Plugin,
+      ConsoleCommand
+    };
+
     /**
      * Sets the stack trace for the crash report.
      * \param value A string list for each line in the stack trace.
@@ -91,7 +99,16 @@ class QgsCrashReport
     /**
      * Sets the \a path to the associated Python crash log.
      */
-    void setPythonCrashLogFilePath( const QString &path ) { mPythonCrashLogFilePath = path; }
+    void setPythonCrashLogFilePath( const QString &path );
+
+    struct PythonFault
+    {
+      LikelyPythonFaultCause cause = LikelyPythonFaultCause::Unknown;
+      QString title;
+      QString filePath;
+    };
+
+    PythonFault pythonFault() const { return mPythonFault; }
 
     /**
      * convert htmlToMarkdown (copied from QgsStringUtils::htmlToMarkdown)
@@ -106,6 +123,7 @@ class QgsCrashReport
     QStringList mVersionInfo;
     QString mPythonCrashLogFilePath;
 
+    PythonFault mPythonFault;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsCrashReport::Flags )

--- a/src/crashhandler/qgscrashreport.h
+++ b/src/crashhandler/qgscrashreport.h
@@ -102,11 +102,13 @@ class QgsCrashReport
      */
     void setPythonCrashLogFilePath( const QString &path );
 
-    struct PythonFault
+    class PythonFault
     {
-      LikelyPythonFaultCause cause = LikelyPythonFaultCause::NotPython;
-      QString title;
-      QString filePath;
+      public:
+
+        LikelyPythonFaultCause cause = LikelyPythonFaultCause::NotPython;
+        QString title;
+        QString filePath;
     };
 
     PythonFault pythonFault() const { return mPythonFault; }

--- a/src/crashhandler/qgsstacktrace.cpp
+++ b/src/crashhandler/qgsstacktrace.cpp
@@ -15,8 +15,10 @@
  ***************************************************************************/
 #include <iostream>
 
+#ifdef MSVC
 #define _NO_CVCONST_H
 #define _CRT_STDIO_ISO_WIDE_SPECIFIERS
+#endif
 
 #include "qgsstacktrace.h"
 
@@ -29,10 +31,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#ifdef MSVC
 #include <tlhelp32.h>
 
 #include <Windows.h>
 #include <DbgHelp.h>
+#endif
+
 
 ///@cond PRIVATE
 

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -61,8 +61,11 @@ class PYTHON_EXPORT QgsPythonUtils
      * NULLPTR if no interface is available.
      *
      * If \a installErrorHook is true then the custom QGIS GUI error hook will be used.
+     *
+     * Since QGIS 3.24, the \a faultHandlerLogPath argument can be used to specify a file path
+     * for Python's faulthandler to dump tracebacks in if Python code causes QGIS to crash.
      */
-    virtual void initPython( QgisInterface *iface, bool installErrorHook ) = 0;
+    virtual void initPython( QgisInterface *iface, bool installErrorHook, const QString &faultHandlerLogPath = QString() ) = 0;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -209,13 +209,23 @@ void QgsPythonUtilsImpl::doCustomImports()
   }
 }
 
-void QgsPythonUtilsImpl::initPython( QgisInterface *interface, const bool installErrorHook )
+void QgsPythonUtilsImpl::initPython( QgisInterface *interface, const bool installErrorHook, const QString &faultHandlerLogPath )
 {
   init();
   if ( !checkSystemImports() )
   {
     exitPython();
     return;
+  }
+
+  if ( !faultHandlerLogPath.isEmpty() )
+  {
+    runString( QStringLiteral( "import faulthandler" ) );
+    QString escapedPath = faultHandlerLogPath;
+    escapedPath.replace( '\\', QLatin1String( "\\\\" ) );
+    escapedPath.replace( '\'', QLatin1String( "\\'" ) );
+    runString( QStringLiteral( "fault_handler_file=open('%1', 'wt')" ).arg( escapedPath ) );
+    runString( QStringLiteral( "faulthandler.enable(file=fault_handler_file)" ) );
   }
 
   if ( interface )

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -36,7 +36,7 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
 
     /* general purpose functions */
 
-    void initPython( QgisInterface *interface, bool installErrorHook ) override;
+    void initPython( QgisInterface *interface, bool installErrorHook, const QString &faultHandlerLogPath = QString() ) override;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     void initServerPython( QgsServerInterface *interface ) override;
     bool startServerPlugin( QString packageName ) override;

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -67,101 +67,101 @@ void TestQgsStringUtils::cleanup()
 void TestQgsStringUtils::levenshtein()
 {
   QCOMPARE( QgsStringUtils::levenshteinDistance( QString(), QString() ), 0 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", QString() ), 3 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( QString(), "abc" ), 3 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", "abc" ), 0 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", "aBc", true ), 1 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", "xec" ), 2 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", "abd" ), 1 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "abc", "ebg" ), 2 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "kitten", "sitting" ), 3 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "kItten", "sitting" ), 3 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "kitten", "sitTing", true ), 4 );
-  QCOMPARE( QgsStringUtils::levenshteinDistance( "kitten", "xkitte" ), 2 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ), QString() ), 3 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QString(),  QStringLiteral( "abc" ) ), 3 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ),  QStringLiteral( "abc" ) ), 0 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ),  QStringLiteral( "aBc" ), true ), 1 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ),  QStringLiteral( "xec" ) ), 2 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ),  QStringLiteral( "abd" ) ), 1 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "abc" ),  QStringLiteral( "ebg" ) ), 2 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "kitten" ),  QStringLiteral( "sitting" ) ), 3 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "kItten" ),  QStringLiteral( "sitting" ) ), 3 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "kitten" ),  QStringLiteral( "sitTing" ), true ), 4 );
+  QCOMPARE( QgsStringUtils::levenshteinDistance( QStringLiteral( "kitten" ),  QStringLiteral( "xkitte" ) ), 2 );
 }
 
 void TestQgsStringUtils::longestCommonSubstring()
 {
   QCOMPARE( QgsStringUtils::longestCommonSubstring( QString(), QString() ), QString() );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "abc", QString() ), QString() );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( QString(), "abc" ), QString() );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "abc", "def" ), QString() );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "abc", "abd" ), QString( "ab" ) );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "abc", "xbc" ), QString( "bc" ) );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "abc", "xbd" ), QString( "b" ) );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "longer test", "inger task" ), QString( "nger t" ) );
-  QCOMPARE( QgsStringUtils::longestCommonSubstring( "lonGer test", "inger task", true ), QString( "er t" ) );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "abc" ), QString() ), QString() );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QString(), QStringLiteral( "abc" ) ), QString() );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "abc" ),  QStringLiteral( "def" ) ), QString() );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "abc" ),  QStringLiteral( "abd" ) ), QStringLiteral( "ab" ) );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "abc" ),  QStringLiteral( "xbc" ) ), QStringLiteral( "bc" ) );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "abc" ),  QStringLiteral( "xbd" ) ), QStringLiteral( "b" ) );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "longer test" ),  QStringLiteral( "inger task" ) ), QStringLiteral( "nger t" ) );
+  QCOMPARE( QgsStringUtils::longestCommonSubstring( QStringLiteral( "lonGer test" ),  QStringLiteral( "inger task" ), true ), QStringLiteral( "er t" ) );
 }
 
 void TestQgsStringUtils::hammingDistance()
 {
   QCOMPARE( QgsStringUtils::hammingDistance( QString(), QString() ), 0 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", QString() ), -1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( QString(), "abc" ), -1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "abcd" ), -1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abcd", "abc" ), -1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "abc" ), 0 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "aBc", true ), 1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "xec" ), 2 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "abd" ), 1 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "abc", "ebg" ), 2 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "kitten", "sittin" ), 2 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "kItten", "sittin" ), 2 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "kitten", "sitTin", true ), 3 );
-  QCOMPARE( QgsStringUtils::hammingDistance( "kitten", "xkitte" ), 5 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QString() ), -1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QString(), QStringLiteral( "abc" ) ), -1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "abcd" ) ), -1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abcd" ), QStringLiteral( "abc" ) ), -1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "abc" ) ), 0 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "aBc" ), true ), 1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "xec" ) ), 2 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "abd" ) ), 1 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "abc" ), QStringLiteral( "ebg" ) ), 2 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "kitten" ), QStringLiteral( "sittin" ) ), 2 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "kItten" ), QStringLiteral( "sittin" ) ), 2 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "kitten" ), QStringLiteral( "sitTin" ), true ), 3 );
+  QCOMPARE( QgsStringUtils::hammingDistance( QStringLiteral( "kitten" ), QStringLiteral( "xkitte" ) ), 5 );
 }
 
 void TestQgsStringUtils::soundex()
 {
   QCOMPARE( QgsStringUtils::soundex( QString() ), QString() );
   //test data from jellyfish & fuzzycomp python libraries
-  QCOMPARE( QgsStringUtils::soundex( "Washington" ), QString( "W252" ) );
-  QCOMPARE( QgsStringUtils::soundex( "Lee" ), QString( "L000" ) );
-  QCOMPARE( QgsStringUtils::soundex( "Gutierrez" ), QString( "G362" ) );
-  QCOMPARE( QgsStringUtils::soundex( "Jackson" ), QString( "J250" ) );
-  QCOMPARE( QgsStringUtils::soundex( "a" ), QString( "A000" ) );
-  QCOMPARE( QgsStringUtils::soundex( "herman" ), QString( "H650" ) );
-  QCOMPARE( QgsStringUtils::soundex( "robert" ), QString( "R163" ) );
-  QCOMPARE( QgsStringUtils::soundex( "RuperT" ), QString( "R163" ) );
-  QCOMPARE( QgsStringUtils::soundex( "rubin" ), QString( "R150" ) );
-  QCOMPARE( QgsStringUtils::soundex( "ashcraft" ), QString( "A261" ) );
-  QCOMPARE( QgsStringUtils::soundex( "ashcroft" ), QString( "A261" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "Washington" ) ), QStringLiteral( "W252" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "Lee" ) ), QStringLiteral( "L000" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "Gutierrez" ) ), QStringLiteral( "G362" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "Jackson" ) ), QStringLiteral( "J250" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "a" ) ), QStringLiteral( "A000" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "herman" ) ), QStringLiteral( "H650" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "robert" ) ), QStringLiteral( "R163" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "RuperT" ) ), QStringLiteral( "R163" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "rubin" ) ), QStringLiteral( "R150" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "ashcraft" ) ), QStringLiteral( "A261" ) );
+  QCOMPARE( QgsStringUtils::soundex( QStringLiteral( "ashcroft" ) ), QStringLiteral( "A261" ) );
 }
 
 void TestQgsStringUtils::insertLinks()
 {
   QCOMPARE( QgsStringUtils::insertLinks( QString() ), QString() );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "not a link!" ) ), QString( "not a link!" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "not a link!" ) ), QStringLiteral( "not a link!" ) );
   bool found = true;
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "not a link!" ), &found ), QString( "not a link!" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "not a link!" ), &found ), QStringLiteral( "not a link!" ) );
   QVERIFY( !found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this www.north-road.com is a link" ), &found ), QString( "this <a href=\"http://www.north-road.com\">www.north-road.com</a> is a link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this www.north-road.com is a link" ), &found ), QStringLiteral( "this <a href=\"http://www.north-road.com\">www.north-road.com</a> is a link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this www.north-road.com.au is a link" ), &found ), QString( "this <a href=\"http://www.north-road.com.au\">www.north-road.com.au</a> is a link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this www.north-road.com.au is a link" ), &found ), QStringLiteral( "this <a href=\"http://www.north-road.com.au\">www.north-road.com.au</a> is a link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this www.north-road.sucks is not a good link" ), &found ), QString( "this <a href=\"http://www.north-road.sucks\">www.north-road.sucks</a> is not a good link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this www.north-road.sucks is not a good link" ), &found ), QStringLiteral( "this <a href=\"http://www.north-road.sucks\">www.north-road.sucks</a> is not a good link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://www.north-road.com is a link" ), &found ), QString( "this <a href=\"http://www.north-road.com\">http://www.north-road.com</a> is a link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this http://www.north-road.com is a link" ), &found ), QStringLiteral( "this <a href=\"http://www.north-road.com\">http://www.north-road.com</a> is a link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://north-road.com is a link" ), &found ), QString( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this http://north-road.com is a link" ), &found ), QStringLiteral( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this http://north-road.com is a link, so is http://qgis.org, OK?" ), &found ), QString( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link, so is <a href=\"http://qgis.org\">http://qgis.org</a>, OK?" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this http://north-road.com is a link, so is http://qgis.org, OK?" ), &found ), QStringLiteral( "this <a href=\"http://north-road.com\">http://north-road.com</a> is a link, so is <a href=\"http://qgis.org\">http://qgis.org</a>, OK?" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "this north-road.com might not be a link" ), &found ), QString( "this north-road.com might not be a link" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "this north-road.com might not be a link" ), &found ), QStringLiteral( "this north-road.com might not be a link" ) );
   QVERIFY( !found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "please ftp to ftp://droopbox.ru and submit stuff" ), &found ), QString( "please ftp to <a href=\"ftp://droopbox.ru\">ftp://droopbox.ru</a> and submit stuff" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "please ftp to ftp://droopbox.ru and submit stuff" ), &found ), QStringLiteral( "please ftp to <a href=\"ftp://droopbox.ru\">ftp://droopbox.ru</a> and submit stuff" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "please visit https://fsociety.org" ), &found ), QString( "please visit <a href=\"https://fsociety.org\">https://fsociety.org</a>" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "please visit https://fsociety.org" ), &found ), QStringLiteral( "please visit <a href=\"https://fsociety.org\">https://fsociety.org</a>" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "send your credit card number to qgis@qgis.org today!" ), &found ), QString( "send your credit card number to <a href=\"mailto:qgis@qgis.org\">qgis@qgis.org</a> today!" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "send your credit card number to qgis@qgis.org today!" ), &found ), QStringLiteral( "send your credit card number to <a href=\"mailto:qgis@qgis.org\">qgis@qgis.org</a> today!" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "send your credit card number to qgis@qgis.org.nz today!" ), &found ), QString( "send your credit card number to <a href=\"mailto:qgis@qgis.org.nz\">qgis@qgis.org.nz</a> today!" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "send your credit card number to qgis@qgis.org.nz today!" ), &found ), QStringLiteral( "send your credit card number to <a href=\"mailto:qgis@qgis.org.nz\">qgis@qgis.org.nz</a> today!" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "visit http://qgis.org or email qgis@qgis.org" ), &found ), QString( "visit <a href=\"http://qgis.org\">http://qgis.org</a> or email <a href=\"mailto:qgis@qgis.org\">qgis@qgis.org</a>" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "visit http://qgis.org or email qgis@qgis.org" ), &found ), QStringLiteral( "visit <a href=\"http://qgis.org\">http://qgis.org</a> or email <a href=\"mailto:qgis@qgis.org\">qgis@qgis.org</a>" ) );
   QVERIFY( found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "is a@a an email?" ), &found ), QString( "is a@a an email?" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "is a@a an email?" ), &found ), QStringLiteral( "is a@a an email?" ) );
   QVERIFY( !found );
-  QCOMPARE( QgsStringUtils::insertLinks( QString( "Load file:///this/is/path/to.file?query=1#anchor" ), &found ), QString( "Load <a href=\"file:///this/is/path/to.file?query=1#anchor\">file:///this/is/path/to.file?query=1#anchor</a>" ) );
+  QCOMPARE( QgsStringUtils::insertLinks( QStringLiteral( "Load file:///this/is/path/to.file?query=1#anchor" ), &found ), QStringLiteral( "Load <a href=\"file:///this/is/path/to.file?query=1#anchor\">file:///this/is/path/to.file?query=1#anchor</a>" ) );
   QVERIFY( found );
 }
 
@@ -198,16 +198,16 @@ void TestQgsStringUtils::titleCase()
 void TestQgsStringUtils::camelCase()
 {
   QCOMPARE( QgsStringUtils::capitalize( QString(), Qgis::Capitalization::UpperCamelCase ), QString() );
-  QCOMPARE( QgsStringUtils::capitalize( QString( " abc def" ), Qgis::Capitalization::UpperCamelCase ), QString( "AbcDef" ) );
-  QCOMPARE( QgsStringUtils::capitalize( QString( "ABC DEF" ), Qgis::Capitalization::UpperCamelCase ), QString( "AbcDef" ) );
-  QCOMPARE( QgsStringUtils::capitalize( QString( "àbc def" ), Qgis::Capitalization::UpperCamelCase ), QString( "ÀbcDef" ) );
-  QCOMPARE( QgsStringUtils::capitalize( QString( "àbc dÉf" ), Qgis::Capitalization::UpperCamelCase ), QString( "ÀbcDéf" ) );
+  QCOMPARE( QgsStringUtils::capitalize( QStringLiteral( " abc def" ), Qgis::Capitalization::UpperCamelCase ), QStringLiteral( "AbcDef" ) );
+  QCOMPARE( QgsStringUtils::capitalize( QStringLiteral( "ABC DEF" ), Qgis::Capitalization::UpperCamelCase ), QStringLiteral( "AbcDef" ) );
+  QCOMPARE( QgsStringUtils::capitalize( QStringLiteral( "àbc def" ), Qgis::Capitalization::UpperCamelCase ), QStringLiteral( "ÀbcDef" ) );
+  QCOMPARE( QgsStringUtils::capitalize( QStringLiteral( "àbc dÉf" ), Qgis::Capitalization::UpperCamelCase ), QStringLiteral( "ÀbcDéf" ) );
 }
 
 void TestQgsStringUtils::htmlToMarkdown()
 {
-  QCOMPARE( QgsStringUtils::htmlToMarkdown( QString( "<b>Visit</b> <a href=\"http://qgis.org\">!</a>" ) ), QString( "**Visit** [!](http://qgis.org)" ) );
-  QCOMPARE( QgsStringUtils::htmlToMarkdown( QString( "<b>Visit</b><br><a href='http://qgis.org'>QGIS</a>" ) ), QString( "**Visit**\n[QGIS](http://qgis.org)" ) );
+  QCOMPARE( QgsStringUtils::htmlToMarkdown( QStringLiteral( "<b>Visit</b> <a href=\"http://qgis.org\">!</a>" ) ), QStringLiteral( "**Visit** [!](http://qgis.org)" ) );
+  QCOMPARE( QgsStringUtils::htmlToMarkdown( QStringLiteral( "<b>Visit</b><br><a href='http://qgis.org'>QGIS</a>" ) ), QStringLiteral( "**Visit**\n[QGIS](http://qgis.org)" ) );
 }
 
 void TestQgsStringUtils::ampersandEncode_data()
@@ -268,7 +268,7 @@ void TestQgsStringUtils::testIsUrl()
   QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "ftp://example.com" ) ) );
   QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "file:///path/to/file" ) ) );
   QVERIFY( QgsStringUtils::isUrl( QStringLiteral( "file://C:\\path\\to\\file" ) ) );
-  QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "" ) ) );
+  QVERIFY( !QgsStringUtils::isUrl( QLatin1String( "" ) ) );
   QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "some:random/string" ) ) );
   QVERIFY( !QgsStringUtils::isUrl( QStringLiteral( "bla" ) ) );
 }

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -208,6 +208,9 @@ void TestQgsStringUtils::htmlToMarkdown()
 {
   QCOMPARE( QgsStringUtils::htmlToMarkdown( QStringLiteral( "<b>Visit</b> <a href=\"http://qgis.org\">!</a>" ) ), QStringLiteral( "**Visit** [!](http://qgis.org)" ) );
   QCOMPARE( QgsStringUtils::htmlToMarkdown( QStringLiteral( "<b>Visit</b><br><a href='http://qgis.org'>QGIS</a>" ) ), QStringLiteral( "**Visit**\n[QGIS](http://qgis.org)" ) );
+
+  // convert PRE
+  QCOMPARE( QgsStringUtils::htmlToMarkdown( QStringLiteral( "<b>My code</b><pre>a = 1\nb=2\nc=3</pre>" ) ), QStringLiteral( "**My code**\n```\na = 1\nb=2\nc=3```\n" ) );
 }
 
 void TestQgsStringUtils::ampersandEncode_data()


### PR DESCRIPTION
When a crash comes from python code, we can use Python's faulthandler module to get the stack trace. We now include this in the crash handler report.

Useful for debugging, and also allows us to put the blame where it lies -- when a user script or plugin caused the crash, we clearly report that and remove the options to report to the QGIS tracker:

![image](https://user-images.githubusercontent.com/1829991/144801254-e5c4fab3-a264-461a-9250-0ad5bf473a5b.png)
