### PR TITLE
Mvt symbology expression improvements

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -270,6 +270,7 @@ tasks.
 %End
 
     virtual int type() const;
+
 %Docstring
 Returns a unique graphics item type identifier.
 

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -270,7 +270,6 @@ tasks.
 %End
 
     virtual int type() const;
-
 %Docstring
 Returns a unique graphics item type identifier.
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2429,7 +2429,7 @@ QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &
   {
     vStr = parseExpression( v.toList(), context );
     caseString += QStringLiteral( "WHEN @vector_tile_zoom > %1 "
-                                  "THEN ( %2 * %3 ) END" ).arg( z.toString() ).arg( vStr ).arg( multiplier );
+                                  "THEN ( ( %2 ) * %3 ) END" ).arg( z.toString() ).arg( vStr ).arg( multiplier );
   }
   else
   {

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2649,7 +2649,7 @@ QString QgsMapBoxGlStyleConverter::parseColorExpression( const QVariant &colorEx
   {
     return parseExpression( colorExpression.toList(), context, true );
   }
-  return parseValue( colorExpression, context );
+  return parseValue( colorExpression, context, true );
 }
 
 QColor QgsMapBoxGlStyleConverter::parseColor( const QVariant &color, QgsMapBoxGlStyleConversionContext &context )
@@ -2904,9 +2904,9 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
           caseString += QStringLiteral( "WHEN (%1) " ).arg( QgsExpression::createFieldEqualityExpression( attribute, expression.at( i ) ) );
         }
 
-        caseString += QStringLiteral( "THEN %1 " ).arg( colorExpected ? parseValueCheckColor( expression.at( i + 1 ), context ) : parseValue( expression.at( i + 1 ), context ) );
+        caseString += QStringLiteral( "THEN %1 " ).arg( parseValue( expression.at( i + 1 ), context, colorExpected ) );
       }
-      caseString += QStringLiteral( "ELSE %1 END" ).arg( colorExpected ? parseValueCheckColor( expression.last(), context ) : parseValue( expression.last(), context ) );
+      caseString += QStringLiteral( "ELSE %1 END" ).arg( parseValue( expression.last(), context, colorExpected ) );
       return caseString;
     }
   }
@@ -3137,17 +3137,25 @@ QString QgsMapBoxGlStyleConverter::retrieveSpriteAsBase64( const QVariant &value
   return spritePath;
 }
 
-QString QgsMapBoxGlStyleConverter::parseValue( const QVariant &value, QgsMapBoxGlStyleConversionContext &context )
+QString QgsMapBoxGlStyleConverter::parseValue( const QVariant &value, QgsMapBoxGlStyleConversionContext &context, bool colorExpected )
 {
   QColor c;
   switch ( value.type() )
   {
     case QVariant::List:
     case QVariant::StringList:
-      return parseExpression( value.toList(), context );
+      return parseExpression( value.toList(), context, colorExpected );
 
     case QVariant::Bool:
     case QVariant::String:
+      if ( colorExpected )
+      {
+        QColor c = parseColor( value, context );
+        if ( c.isValid() )
+        {
+          return parseValue( c, context );
+        }
+      }
       return QgsExpression::quotedValue( value );
 
     case QVariant::Int:
@@ -3163,16 +3171,6 @@ QString QgsMapBoxGlStyleConverter::parseValue( const QVariant &value, QgsMapBoxG
       break;
   }
   return QString();
-}
-
-QString QgsMapBoxGlStyleConverter::parseValueCheckColor( const QVariant &value, QgsMapBoxGlStyleConversionContext &context )
-{
-  QColor c = parseColor( value, context );
-  if ( c.isValid() )
-  {
-    return parseValue( c, context );
-  }
-  return parseValue( value, context );
 }
 
 QString QgsMapBoxGlStyleConverter::parseKey( const QVariant &value, QgsMapBoxGlStyleConversionContext &context )

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -194,6 +194,8 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
   QgsPropertyCollection ddProperties;
   QgsPropertyCollection ddRasterProperties;
 
+  std::unique_ptr< QgsSymbol > symbol( std::make_unique< QgsFillSymbol >() );
+
   // fill color
   QColor fillColor;
   if ( jsonPaint.contains( isBackgroundStyle ? QStringLiteral( "background-color" ) : QStringLiteral( "fill-color" ) ) )
@@ -281,6 +283,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
           context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
+          symbol->setDataDefinedProperty( QgsSymbol::PropertyOpacity, parseInterpolateOpacityByZoom( jsonFillOpacity.toMap(), 255, &context ) );
         }
         else
         {
@@ -295,6 +298,7 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
           context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
+          symbol->setDataDefinedProperty( QgsSymbol::PropertyOpacity, parseValueList( jsonFillOpacity.toList(), PropertyType::Numeric, context, 100, 100 ) );
         }
         else
         {
@@ -334,7 +338,6 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
     }
   }
 
-  std::unique_ptr< QgsSymbol > symbol( std::make_unique< QgsFillSymbol >() );
   QgsSimpleFillSymbolLayer *fillSymbol = dynamic_cast< QgsSimpleFillSymbolLayer * >( symbol->symbolLayer( 0 ) );
   Q_ASSERT( fillSymbol ); // should not fail since QgsFillSymbol() constructor instantiates a QgsSimpleFillSymbolLayer
 
@@ -2423,8 +2426,19 @@ QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &
 
   const QVariant z = stops.last().toList().value( 0 );
   const QVariant v = stops.last().toList().value( 1 );
-  caseString += QStringLiteral( "WHEN @vector_tile_zoom > %1 "
-                                "THEN %2 END" ).arg( z.toString() ).arg( v.toDouble() * multiplier );
+  QString vStr = v.toString();
+  if ( ( QMetaType::Type )v.type() == QMetaType::QVariantList )
+  {
+    vStr = parseExpression( v.toList(), context );
+    caseString += QStringLiteral( "WHEN @vector_tile_zoom > %1 "
+                                  "THEN ( %2 * %3 ) END" ).arg( z.toString() ).arg( vStr ).arg( multiplier );
+  }
+  else
+  {
+    caseString += QStringLiteral( "WHEN @vector_tile_zoom > %1 "
+                                  "THEN %2 END" ).arg( z.toString() ).arg( v.toDouble() * multiplier );
+  }
+
   return caseString;
 }
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -282,7 +282,6 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::Map:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
-          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
           symbol->setDataDefinedProperty( QgsSymbol::PropertyOpacity, parseInterpolateOpacityByZoom( jsonFillOpacity.toMap(), 255, &context ) );
         }
         else
@@ -297,7 +296,6 @@ bool QgsMapBoxGlStyleConverter::parseFillLayer( const QVariantMap &jsonLayer, Qg
       case QVariant::StringList:
         if ( ddProperties.isActive( QgsSymbolLayer::PropertyFillColor ) )
         {
-          context.pushWarning( QObject::tr( "%1: Could not set opacity of layer, opacity already defined in fill color" ).arg( context.layerId() ) );
           symbol->setDataDefinedProperty( QgsSymbol::PropertyOpacity, parseValueList( jsonFillOpacity.toList(), PropertyType::Numeric, context, 100, 100 ) );
         }
         else

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -550,7 +550,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      * Checks if value is a color before calling parseValue
      */
     static QString parseValueCheckColor( const QVariant &value, QgsMapBoxGlStyleConversionContext &context );
-    static QString parseKey( const QVariant &value );
+    static QString parseKey( const QVariant &value, QgsMapBoxGlStyleConversionContext &context );
 
     /**
      * Checks if interpolation bottom/top values are numeric values

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -544,12 +544,8 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
     QgsMapBoxGlStyleConverter( const QgsMapBoxGlStyleConverter &other );
 #endif
 
-    static QString parseValue( const QVariant &value, QgsMapBoxGlStyleConversionContext &context );
+    static QString parseValue( const QVariant &value, QgsMapBoxGlStyleConversionContext &context, bool colorExpected = false );
 
-    /**
-     * Checks if value is a color before calling parseValue
-     */
-    static QString parseValueCheckColor( const QVariant &value, QgsMapBoxGlStyleConversionContext &context );
     static QString parseKey( const QVariant &value, QgsMapBoxGlStyleConversionContext &context );
 
     /**

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -349,6 +349,12 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["to-string", ["get", "name"]],
                                                                    conversion_context),
                          '''to_string("name")''')
+        self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["to-number", ["get", "elevation"]],
+                                                                   conversion_context),
+                         '''to_real("elevation")''')
+        self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["%", 100, 20],
+                                                                   conversion_context),
+                         '''100 % 20''')
 
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -355,6 +355,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["%", 100, 20],
                                                                    conversion_context),
                          '''100 % 20''')
+        self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression(["match", ["get", "subclass"], "funicular", "rgba(243,243,246,0)", "rgb(243,243,246)"], conversion_context, True), '''CASE WHEN ("subclass" = 'funicular') THEN color_rgba(243,243,246,0) ELSE color_rgba(243,243,246,255) END''')
 
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -290,6 +290,24 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
                          "CASE WHEN @vector_tile_zoom > 10 AND @vector_tile_zoom <= 15 THEN scale_linear(@vector_tile_zoom,10,15,0.1,0.3) * 2 WHEN @vector_tile_zoom > 15 AND @vector_tile_zoom <= 18 THEN scale_linear(@vector_tile_zoom,15,18,0.3,0.6) * 2 WHEN @vector_tile_zoom > 18 THEN 1.2 END")
         self.assertEqual(default_val, 0.2)
 
+        prop, default_color, default_val = QgsMapBoxGlStyleConverter.parseInterpolateListByZoom([
+            "interpolate",
+            ["exponential", 1.5],
+            ["zoom"],
+            5,
+            0,
+            6,
+            ["match", ["get", "class"], ["ice", "glacier"], 0.3, 0],
+            10,
+            ["match", ["get", "class"], ["ice", "glacier"], 0.2, 0],
+            11,
+            ["match", ["get", "class"], ["ice", "glacier"], 0.2, 0.3],
+            14,
+            ["match", ["get", "class"], ["ice", "glacier"], 0, 0.3]
+        ], QgsMapBoxGlStyleConverter.Numeric, conversion_context, 2)
+        self.assertEqual(prop.expressionString(),
+                         "CASE WHEN @vector_tile_zoom > 5 AND @vector_tile_zoom <= 6 THEN scale_exp(@vector_tile_zoom,5,6,0,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.3 ELSE 0 END,1.5) * 2 WHEN @vector_tile_zoom > 6 AND @vector_tile_zoom <= 10 THEN scale_exp(@vector_tile_zoom,6,10,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.3 ELSE 0 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0 END,1.5) * 2 WHEN @vector_tile_zoom > 10 AND @vector_tile_zoom <= 11 THEN scale_exp(@vector_tile_zoom,10,11,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0.3 END,1.5) * 2 WHEN @vector_tile_zoom > 11 AND @vector_tile_zoom <= 14 THEN scale_exp(@vector_tile_zoom,11,14,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0.3 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0 ELSE 0.3 END,1.5) * 2 WHEN @vector_tile_zoom > 14 THEN ( ( CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0 ELSE 0.3 END ) * 2 ) END")
+
     def testParseExpression(self):
         conversion_context = QgsMapBoxGlStyleConversionContext()
         self.assertEqual(QgsMapBoxGlStyleConverter.parseExpression([


### PR DESCRIPTION
This PR adds the following improvements for the conversion of MVT styles to QGIS symbology:
- Support % and to-number
- keys can also be expressions
- Support conversion from string to color also if color is a subpart of an expression
- Support fill-opacity also if fill-color is present
- Add unit tests