### PR TITLE
fix percent encoding in server query parameter

### DIFF
--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -454,7 +454,7 @@ QUrlQuery QgsServerParameters::urlQuery() const
     const auto constMap( toMap().toStdMap() );
     for ( const auto &param : constMap )
     {
-      const QString value = QString( param.second ).replace( '+', QLatin1String( "%2B" ) );
+      const QString value = QUrl::toPercentEncoding( QString( param.second ) );
       query.addQueryItem( param.first, value );
     }
   }

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -83,14 +83,19 @@ void TestQgsServerWmsParameters::percent_encoding()
   // '+' in its encoded ('%2B') form is transformed in '+' sign and
   // forwarded to parameters subclasses
   QUrlQuery query;
-  query.addQueryItem( "MYPARAM", QString( "my%1value" ).arg( QLatin1String( "%2B" ) ) );
+  query.addQueryItem( "MYPARAM", QString( "a%2Cb%2Cc%2C%C3%A4%C3%B6s+%2B+%25%26%23" ) );
 
   QgsServerParameters params;
   params.load( query );
-  QCOMPARE( params.value( "MYPARAM" ), QString( "my+value" ) );
+  QCOMPARE( params.value( "MYPARAM" ), QString( "a,b,c,äös + %&#" ) );
 
   const QgsWms::QgsWmsParameters wmsParams( params );
-  QCOMPARE( wmsParams.value( "MYPARAM" ), QString( "my+value" ) );
+  QCOMPARE( wmsParams.value( "MYPARAM" ), QString( "a,b,c,äös + %&#" ) );
+
+  // back to urlQuery
+  QgsServerParameters params2;
+  params2.load( params.urlQuery() );
+  QCOMPARE( params2.value( "MYPARAM" ), QString( "a,b,c,äös + %&#" ) );
 }
 
 void TestQgsServerWmsParameters::version_negotiation()


### PR DESCRIPTION
## Description

The query parameters are handled properly in `QgsServerParameters` but when they are passed to `QgsWmsParameters`, they are parsed again with error.

For example: this parameter `FILTER=cable_optique:+"auteur"+LIKE+(+'%33'+)` is correctly decoded in`QgsServerParamters` 
```
wms_qgis-1.0.j9zkc10byld8@dvgerdk13    | 13:05:40 INFO Server[25]: FILTER:cable_optique: "auteur" LIKE '%33'
```
but misinterpreted in `QgsWmsParameters`:
```
wms_qgis-1.0.j9zkc10byld8@dvgerdk13    | 13:05:40 INFO Server[25]: WMS Request parameters:
wms_qgis-1.0.j9zkc10byld8@dvgerdk13    | 13:05:40 INFO Server[25]:  - FILTER : cable_optique: "auteur" LIKE '3'
```

need backport to 3.22, 3.16