### PR TITLE
Fix gdal command

### DIFF
--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1896,7 +1896,7 @@ QString QgsGeoreferencerMainWindow::generateGDALtranslateCommand( bool generateT
 
   for ( QgsGeorefDataPoint *pt : std::as_const( mPoints ) )
   {
-    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pt->pixelCoords().x() ).arg( -pt->pixelCoords().y() )
+    gdalCommand << QStringLiteral( "-gcp %1 %2 %3 %4" ).arg( pt->pixelCoords().x() ).arg( pt->pixelCoords().y() )
                 .arg( pt->transCoords().x() ).arg( pt->transCoords().y() );
   }
 


### PR DESCRIPTION
## Description

Minor bug/typo? encountered while digging into #46414 

@nyalldawson Would you know if this is a typo, I assume it is.

Though strangely with this error, it yielded the same results as our standard process, now the outputs are different, maybe there is another extra negative somewhere or I'm just dealing with weird cases? Still not sure why already georeferenced images are handling badly regardless of the method.