### PR TITLE
[Backport release-3_22] Format date and datetime fields based on locale (#46419)

### DIFF
--- a/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsdatetimefieldformatter.sip.in
@@ -22,9 +22,9 @@ the field configuration.
 #include "qgsdatetimefieldformatter.h"
 %End
   public:
-    static const QString DATE_FORMAT;
+    static QString DATE_FORMAT;
     static const QString TIME_FORMAT;
-    static const QString DATETIME_FORMAT;
+    static QString DATETIME_FORMAT;
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
 
@@ -48,6 +48,7 @@ The type is expected to be one of
 - QVariant.Date
 - QVariant.Time
 %End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -443,11 +443,12 @@ Returns the QGIS locale.
 .. versionadded:: 3.0
 %End
 
-    static void setLocale( QLocale locale );
+    static void setLocale( const QLocale &locale );
 %Docstring
-Sets the QGIS locale.
+Sets the QGIS locale - used mainly by 3rd party apps and tests.
+In QGIS this is internally triggered by the application in startup.
 
-.. versionadded:: 3.22
+.. versionadded:: 3.22.2
 %End
 
     static QString userThemesFolder();
@@ -1091,6 +1092,8 @@ In order to register translatable strings, connect to this signal and register t
     void localeChanged();
 %Docstring
 Emitted when project locale has been changed.
+
+.. versionadded:: 3.22.2
 %End
 
 

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -443,6 +443,13 @@ Returns the QGIS locale.
 .. versionadded:: 3.0
 %End
 
+    static void setLocale( QLocale locale );
+%Docstring
+Sets the QGIS locale.
+
+.. versionadded:: 3.22
+%End
+
     static QString userThemesFolder();
 %Docstring
 Returns the path to user's themes folder
@@ -1079,6 +1086,13 @@ In order to register translatable strings, connect to this signal and register t
 
 .. versionadded:: 3.4
 %End
+
+
+    void localeChanged();
+%Docstring
+Emitted when project locale has been changed.
+%End
+
 
 };
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1034,6 +1034,9 @@ int main( int argc, char *argv[] )
 
   QgsApplication myApp( argc, argv, myUseGuiFlag, QString(), QStringLiteral( "desktop" ) );
 
+  // Set locale to emit QgsApplication's localeChanged signal
+  myApp.setLocale( QLocale() );
+
   //write the log messages written before creating QgsApplication
   for ( const QString &preApplicationLogMessage : std::as_const( preApplicationLogMessages ) )
     QgsMessageLog::logMessage( preApplicationLogMessage );

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -20,9 +20,9 @@
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
 
-const QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
+QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
 const QString QgsDateTimeFieldFormatter::TIME_FORMAT = QStringLiteral( "HH:mm:ss" );
-const QString QgsDateTimeFieldFormatter::DATETIME_FORMAT = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
+QString QgsDateTimeFieldFormatter::DATETIME_FORMAT = QStringLiteral( "yyyy-MM-dd HH:mm:ss" );
 // we need to use Qt::ISODate rather than a string format definition in QDate::fromString
 const QString QgsDateTimeFieldFormatter::QT_ISO_FORMAT = QStringLiteral( "Qt ISO Date" );
 // but QDateTimeEdit::setDisplayFormat only accepts string formats, so use with time zone by default
@@ -61,6 +61,10 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
     date = value.toDateTime();
     // we always show time zones for datetime values
     showTimeZone = true;
+  }
+  else if ( static_cast<QMetaType::Type>( value.type() ) == QMetaType::QTime )
+  {
+    return  value.toTime().toString( displayFormat );
   }
   else
   {
@@ -105,4 +109,11 @@ QString QgsDateTimeFieldFormatter::defaultFormat( QVariant::Type type )
     default:
       return QgsDateTimeFieldFormatter::DATE_FORMAT;
   }
+}
+
+void QgsDateTimeFieldFormatter::applyLocaleChange()
+{
+  QString dateFormat = QLocale().dateFormat( QLocale::FormatType::ShortFormat );
+  QgsDateTimeFieldFormatter::DATETIME_FORMAT = QString( "%1 %2" ).arg( dateFormat, QgsDateTimeFieldFormatter::TIME_FORMAT );
+  QgsDateTimeFieldFormatter::DATE_FORMAT = dateFormat;
 }

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.h
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.h
@@ -31,9 +31,9 @@
 class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
 {
   public:
-    static const QString DATE_FORMAT;
+    static QString DATE_FORMAT;
     static const QString TIME_FORMAT;
-    static const QString DATETIME_FORMAT;
+    static QString DATETIME_FORMAT;
     static const QString QT_ISO_FORMAT;
     static const QString DISPLAY_FOR_ISO_FORMAT;
 
@@ -55,6 +55,13 @@ class CORE_EXPORT QgsDateTimeFieldFormatter : public QgsFieldFormatter
      * - QVariant::Time
      */
     static QString defaultFormat( QVariant::Type type );
+
+    /**
+     * Adjusts the date time formats according to locale.
+     *
+     * \since QGIS 3.22.2
+     */
+    static void applyLocaleChange(); SIP_SKIP;
 };
 
 #endif // QGSDATETIMEFIELDKIT_H

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -85,6 +85,7 @@
 
 #include "layout/qgspagesizeregistry.h"
 #include "qgsrecentstylehandler.h"
+#include "qgsdatetimefieldformatter.h"
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 #include <QDesktopWidget>
@@ -230,6 +231,8 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
   mApplicationMembers = new ApplicationMembers();
 
   *sProfilePath() = profileFolder;
+
+  connect( instance(), &QgsApplication::localeChanged, &QgsDateTimeFieldFormatter::applyLocaleChange );
 }
 
 void QgsApplication::init( QString profileFolder )
@@ -1310,7 +1313,7 @@ QString QgsApplication::locale()
   }
 }
 
-void QgsApplication::setLocale( QLocale locale )
+void QgsApplication::setLocale( const QLocale &locale )
 {
   QLocale::setDefault( locale );
   emit instance()->localeChanged();

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1310,6 +1310,12 @@ QString QgsApplication::locale()
   }
 }
 
+void QgsApplication::setLocale( QLocale locale )
+{
+  QLocale::setDefault( locale );
+  emit instance()->localeChanged();
+}
+
 QString QgsApplication::userThemesFolder()
 {
   return qgisSettingsDirPath() + QStringLiteral( "/themes" );

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -468,6 +468,12 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     static QString locale();
 
+    /**
+     * Sets the QGIS locale.
+     * \since QGIS 3.22
+     */
+    static void setLocale( QLocale locale );
+
     //! Returns the path to user's themes folder
     static QString userThemesFolder();
 
@@ -1042,6 +1048,13 @@ class CORE_EXPORT QgsApplication : public QApplication
      * \since QGIS 3.4
      */
     void requestForTranslatableObjects( QgsTranslationContext *translationContext );
+
+
+    /**
+     * Emitted when project locale has been changed.
+     */
+    void localeChanged();
+
 
   private:
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -469,10 +469,12 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString locale();
 
     /**
-     * Sets the QGIS locale.
-     * \since QGIS 3.22
+     * Sets the QGIS locale - used mainly by 3rd party apps and tests.
+     * In QGIS this is internally triggered by the application in startup.
+     *
+     * \since QGIS 3.22.2
      */
-    static void setLocale( QLocale locale );
+    static void setLocale( const QLocale &locale );
 
     //! Returns the path to user's themes folder
     static QString userThemesFolder();
@@ -1052,6 +1054,8 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     /**
      * Emitted when project locale has been changed.
+     *
+     * \since QGIS 3.22.2
      */
     void localeChanged();
 


### PR DESCRIPTION
## Description

This PR allows formatting date and datetime field values based on the selected locale. 

Backport #46419
Authored by: @Joonalai


Relates to #45617

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
