### PR TITLE
[Backport release-3_22] Update of virtual fields considering layer dependencies

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -250,8 +250,6 @@ Emit this signal, whenever the related features changed.
 This happens for example when related features are added, removed,
 linked or unlinked.
 
-:param vectorLayer: The modified layer
-
 .. versionadded:: 3.22
 %End
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -242,6 +242,19 @@ Forward the signal to the embedded form
     virtual bool valid() const;
 
 
+  signals:
+
+    void relatedFeaturesChanged();
+%Docstring
+Emit this signal, whenever the related features changed.
+This happens for example when related features are added, removed,
+linked or unlinked.
+
+:param vectorLayer: The modified layer
+
+.. versionadded:: 3.22
+%End
+
   public slots:
     virtual void setFeature( const QgsFeature &feature );
 

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -158,6 +158,26 @@ Returns the widget configuration
 Defines the widget configuration
 %End
 
+    bool multiEditModeActive() const;
+%Docstring
+Returns true if editing multiple features at a time
+
+.. versionadded:: 3.24
+%End
+
+  signals:
+
+    void relatedFeaturesChanged();
+%Docstring
+Emit this signal, whenever the related features changed.
+This happens for example when related features are added, removed,
+linked or unlinked.
+
+:param vectorLayer: The modified layer
+
+.. versionadded:: 3.22
+%End
+
   public slots:
 
     virtual void parentFormValueChanged( const QString &attribute, const QVariant &newValue ) = 0;

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -158,13 +158,6 @@ Returns the widget configuration
 Defines the widget configuration
 %End
 
-    bool multiEditModeActive() const;
-%Docstring
-Returns true if editing multiple features at a time
-
-.. versionadded:: 3.24
-%End
-
   signals:
 
     void relatedFeaturesChanged();

--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -173,8 +173,6 @@ Emit this signal, whenever the related features changed.
 This happens for example when related features are added, removed,
 linked or unlinked.
 
-:param vectorLayer: The modified layer
-
 .. versionadded:: 3.22
 %End
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -50,7 +50,7 @@ QWidget *QgsRelationWidgetWrapper::createWidget( QWidget *parent )
     relationEditorWidget = QgsGui::instance()->relationWidgetRegistry()->create( QStringLiteral( "relation_editor" ), widgetConfig(), parent );
   }
 
-  connect( relationEditorWidget, &QgsAbstractRelationEditorWidget::relatedFeaturesChanged, this, &QgsRelationWidgetWrapper::onRelatedFeaturesChanged );
+  connect( relationEditorWidget, &QgsAbstractRelationEditorWidget::relatedFeaturesChanged, this, &QgsRelationWidgetWrapper::relatedFeaturesChanged );
 
   return relationEditorWidget;
 }
@@ -65,11 +65,6 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 {
   if ( mWidget )
     mWidget->setVisible( visible );
-}
-
-void QgsRelationWidgetWrapper::onRelatedFeaturesChanged()
-{
-  emit relatedFeaturesChanged();
 }
 
 void QgsRelationWidgetWrapper::aboutToSave()

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -42,15 +42,17 @@ QWidget *QgsRelationWidgetWrapper::createWidget( QWidget *parent )
   if ( form )
     connect( form, &QgsAttributeForm::widgetValueChanged, this, &QgsRelationWidgetWrapper::widgetValueChanged );
 
-  QWidget *widget = QgsGui::instance()->relationWidgetRegistry()->create( mRelationEditorId, widgetConfig(), parent );
+  QgsAbstractRelationEditorWidget *relationEditorWidget = QgsGui::instance()->relationWidgetRegistry()->create( mRelationEditorId, widgetConfig(), parent );
 
-  if ( !widget )
+  if ( !relationEditorWidget )
   {
     QgsLogger::warning( QStringLiteral( "Failed to create relation widget \"%1\", fallback to \"basic\" relation widget" ).arg( mRelationEditorId ) );
-    widget = QgsGui::instance()->relationWidgetRegistry()->create( QStringLiteral( "relation_editor" ), widgetConfig(), parent );
+    relationEditorWidget = QgsGui::instance()->relationWidgetRegistry()->create( QStringLiteral( "relation_editor" ), widgetConfig(), parent );
   }
 
-  return widget;
+  connect( relationEditorWidget, &QgsAbstractRelationEditorWidget::relatedFeaturesChanged, this, &QgsRelationWidgetWrapper::onRelatedFeaturesChanged );
+
+  return relationEditorWidget;
 }
 
 void QgsRelationWidgetWrapper::setFeature( const QgsFeature &feature )
@@ -63,6 +65,11 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 {
   if ( mWidget )
     mWidget->setVisible( visible );
+}
+
+void QgsRelationWidgetWrapper::onRelatedFeaturesChanged()
+{
+  emit relatedFeaturesChanged();
 }
 
 void QgsRelationWidgetWrapper::aboutToSave()
@@ -102,6 +109,7 @@ void QgsRelationWidgetWrapper::widgetValueChanged( const QString &attribute, con
 {
   if ( mWidget && attributeChanged )
   {
+    // Maybe from here the other bug? jump to first feature?
     QgsFeature feature { mWidget->feature() };
     if ( feature.attribute( attribute ) != newValue )
     {

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -109,7 +109,6 @@ void QgsRelationWidgetWrapper::widgetValueChanged( const QString &attribute, con
 {
   if ( mWidget && attributeChanged )
   {
-    // Maybe from here the other bug? jump to first feature?
     QgsFeature feature { mWidget->feature() };
     if ( feature.attribute( attribute ) != newValue )
     {

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -231,10 +231,6 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      */
     void setVisible( bool visible );
 
-  private slots:
-
-    void onRelatedFeaturesChanged();
-
   private:
     void aboutToSave() override;
     QgsRelation mRelation;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -210,6 +210,18 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
+  signals:
+
+    /**
+     * Emit this signal, whenever the related features changed.
+     * This happens for example when related features are added, removed,
+     * linked or unlinked.
+     *
+     * \param vectorLayer The modified layer
+     * \since QGIS 3.22
+     */
+    void relatedFeaturesChanged();
+
   public slots:
     void setFeature( const QgsFeature &feature ) override;
 
@@ -219,6 +231,10 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      * \since QGIS 2.16
      */
     void setVisible( bool visible );
+
+  private slots:
+
+    void onRelatedFeaturesChanged();
 
   private:
     void aboutToSave() override;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -217,7 +217,6 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      * This happens for example when related features are added, removed,
      * linked or unlinked.
      *
-     * \param vectorLayer The modified layer
      * \since QGIS 3.22
      */
     void relatedFeaturesChanged();

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -250,8 +250,6 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
   updateUi();
 
   emit relatedFeaturesChanged();
-
-  return addedFeatureIds;
 }
 
 void QgsAbstractRelationEditorWidget::deleteFeature( const QgsFeatureId fid )

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -248,11 +248,17 @@ void QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &geometry )
   }
 
   updateUi();
+
+  emit relatedFeaturesChanged();
+
+  return addedFeatureIds;
 }
 
 void QgsAbstractRelationEditorWidget::deleteFeature( const QgsFeatureId fid )
 {
   deleteFeatures( QgsFeatureIds() << fid );
+
+  emit relatedFeaturesChanged();
 }
 
 void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids )
@@ -369,6 +375,8 @@ void QgsAbstractRelationEditorWidget::deleteFeatures( const QgsFeatureIds &fids 
     }
 
     updateUi();
+
+    emit relatedFeaturesChanged();
   }
 }
 
@@ -493,6 +501,8 @@ void QgsAbstractRelationEditorWidget::onLinkFeatureDlgAccepted()
   }
 
   updateUi();
+
+  emit relatedFeaturesChanged();
 }
 
 void QgsAbstractRelationEditorWidget::unlinkFeature( const QgsFeatureId fid )
@@ -580,6 +590,8 @@ void QgsAbstractRelationEditorWidget::unlinkFeatures( const QgsFeatureIds &fids 
   }
 
   updateUi();
+
+  emit relatedFeaturesChanged();
 }
 
 void QgsAbstractRelationEditorWidget::updateUi()
@@ -611,6 +623,8 @@ void QgsAbstractRelationEditorWidget::afterSetRelations()
 void QgsAbstractRelationEditorWidget::duplicateFeature( const QgsFeatureId &fid )
 {
   duplicateFeatures( QgsFeatureIds() << fid );
+
+  emit relatedFeaturesChanged();
 }
 
 void QgsAbstractRelationEditorWidget::duplicateFeatures( const QgsFeatureIds &fids )
@@ -624,6 +638,8 @@ void QgsAbstractRelationEditorWidget::duplicateFeatures( const QgsFeatureIds &fi
     QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicatedFeatureContext;
     QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), duplicatedFeatureContext );
   }
+
+  emit relatedFeaturesChanged();
 }
 
 void QgsAbstractRelationEditorWidget::showEvent( QShowEvent * )

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -170,6 +170,24 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      */
     virtual void setConfig( const QVariantMap &config ) = 0;
 
+    /**
+     * Returns true if editing multiple features at a time
+     * \since QGIS 3.24
+     */
+    bool multiEditModeActive() const;
+
+  signals:
+
+    /**
+     * Emit this signal, whenever the related features changed.
+     * This happens for example when related features are added, removed,
+     * linked or unlinked.
+     *
+     * \param vectorLayer The modified layer
+     * \since QGIS 3.22
+     */
+    void relatedFeaturesChanged();
+
   public slots:
 
     /**

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -183,7 +183,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      * This happens for example when related features are added, removed,
      * linked or unlinked.
      *
-     * \param vectorLayer The modified layer
      * \since QGIS 3.22
      */
     void relatedFeaturesChanged();

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -170,12 +170,6 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
      */
     virtual void setConfig( const QVariantMap &config ) = 0;
 
-    /**
-     * Returns true if editing multiple features at a time
-     * \since QGIS 3.24
-     */
-    bool multiEditModeActive() const;
-
   signals:
 
     /**

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -668,7 +668,7 @@ void QgsAttributeForm::updateValuesDependenciesVirtualFields( const int originId
     // Update value
     QgsExpressionContext context = createExpressionContext( updatedFeature );
     QgsExpression exp( mLayer->expressionField( eww->fieldIdx() ) );
-    QVariant value = exp.evaluate( &context );
+    const QVariant value = exp.evaluate( &context );
     updatedFeature.setAttribute( eww->fieldIdx(), value );
     eww->setValue( value );
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2514,15 +2514,15 @@ void QgsAttributeForm::afterWidgetInit()
         isFirstEww = false;
       }
 
-      connect( eww, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeForm::onAttributeChanged );
-      connect( eww, &QgsEditorWidgetWrapper::constraintStatusChanged, this, &QgsAttributeForm::onConstraintStatusChanged );
+      connect( eww, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeForm::onAttributeChanged, Qt::UniqueConnection );
+      connect( eww, &QgsEditorWidgetWrapper::constraintStatusChanged, this, &QgsAttributeForm::onConstraintStatusChanged, Qt::UniqueConnection );
     }
     else
     {
       QgsRelationWidgetWrapper *relationWidgetWrapper = qobject_cast<QgsRelationWidgetWrapper *>( ww );
       if ( relationWidgetWrapper )
       {
-        connect( relationWidgetWrapper, &QgsRelationWidgetWrapper::relatedFeaturesChanged, this, &QgsAttributeForm::onRelatedFeaturesChanged, Qt::QueuedConnection );
+        connect( relationWidgetWrapper, &QgsRelationWidgetWrapper::relatedFeaturesChanged, this, &QgsAttributeForm::onRelatedFeaturesChanged, static_cast<Qt::ConnectionType>( Qt::UniqueConnection | Qt::QueuedConnection ) );
       }
     }
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -659,7 +659,7 @@ void QgsAttributeForm::updateValuesDependenciesVirtualFields( const int originId
   {
     QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
     if ( !eww )
-      return;
+      continue;
 
     //do not update when this widget is already updating (avoid recursions)
     if ( mAlreadyUpdatedFields.contains( eww->fieldIdx() ) )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -622,6 +622,77 @@ void QgsAttributeForm::updateValuesDependenciesVirtualFields( const int originId
   }
 }
 
+void QgsAttributeForm::updateRelatedLayerFields()
+{
+  // Synchronize dependencies
+  for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
+  {
+    QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
+    if ( ! eww )
+      continue;
+
+    updateRelatedLayerFieldsDependencies( eww );
+  }
+
+  if ( mRelatedLayerFieldsDependencies.isEmpty() )
+    return;
+
+  if ( !mFeature.isValid() )
+    return;
+
+  QgsAttributes featureAttributes = mFeature.attributes();
+  for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
+  {
+    QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
+    if ( !eww )
+      continue;
+
+    QVariantList dstVars = QVariantList() << featureAttributes.at( eww->fieldIdx() );
+    QVariantList srcVars = QVariantList() << eww->value();
+    QList<int> fieldIndexes = QList<int>() << eww->fieldIdx();
+
+    // append additional fields
+    const QStringList additionalFields = eww->additionalFields();
+    for ( const QString &fieldName : additionalFields )
+    {
+      int idx = eww->layer()->fields().lookupField( fieldName );
+      fieldIndexes << idx;
+      dstVars << featureAttributes.at( idx );
+    }
+    srcVars.append( eww->additionalFieldValues() );
+
+    Q_ASSERT( dstVars.count() == srcVars.count() );
+
+    for ( int i = 0; i < dstVars.count(); i++ )
+    {
+      if ( !qgsVariantEqual( dstVars[i], srcVars[i] ) && srcVars[i].isValid() && fieldIsEditable( fieldIndexes[i] ) )
+        featureAttributes[fieldIndexes[i]] = srcVars[i];
+    }
+  }
+
+  // go through depending fields and update the fields with virtual field
+  for ( QgsWidgetWrapper *ww : std::as_const( mRelatedLayerFieldsDependencies ) )
+  {
+    QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
+    if ( !eww )
+      continue;
+
+    //do not update when this widget is already updating (avoid recursions)
+    if ( mAlreadyUpdatedFields.contains( eww->fieldIdx() ) )
+      continue;
+
+    // create updated Feature
+    QgsFeature updatedFeature = QgsFeature( mFeature );
+    updatedFeature.setAttributes( featureAttributes );
+    QgsExpressionContext context = createExpressionContext( updatedFeature );
+
+    QgsExpression exp( mLayer->expressionField( eww->fieldIdx() ) );
+    QVariant value = exp.evaluate( &context );
+
+    eww->setValue( value );
+  }
+}
+
 void QgsAttributeForm::resetMultiEdit( bool promptToSave )
 {
   if ( promptToSave )
@@ -1278,6 +1349,11 @@ void QgsAttributeForm::onAttributeDeleted( int idx )
   }
   init();
   setFeature( mFeature );
+}
+
+void QgsAttributeForm::onRelatedFeaturesChanged()
+{
+  updateRelatedLayerFields();
 }
 
 void QgsAttributeForm::onUpdatedFields()
@@ -2430,6 +2506,14 @@ void QgsAttributeForm::afterWidgetInit()
       connect( eww, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeForm::onAttributeChanged );
       connect( eww, &QgsEditorWidgetWrapper::constraintStatusChanged, this, &QgsAttributeForm::onConstraintStatusChanged );
     }
+    else
+    {
+      QgsRelationWidgetWrapper *relationWidgetWrapper = qobject_cast<QgsRelationWidgetWrapper *>( ww );
+      if ( relationWidgetWrapper )
+      {
+        connect( relationWidgetWrapper, &QgsRelationWidgetWrapper::relatedFeaturesChanged, this, &QgsAttributeForm::onRelatedFeaturesChanged );
+      }
+    }
   }
 }
 
@@ -2713,6 +2797,7 @@ void QgsAttributeForm::updateFieldDependencies()
 {
   mDefaultValueDependencies.clear();
   mVirtualFieldsDependencies.clear();
+  mRelatedLayerFieldsDependencies.clear();
 
   //create defaultValueDependencies
   for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
@@ -2724,6 +2809,8 @@ void QgsAttributeForm::updateFieldDependencies()
     updateFieldDependenciesDefaultValue( eww );
 
     updateFieldDependenciesVirtualFields( eww );
+
+    updateRelatedLayerFieldsDependencies( eww );
   }
 }
 
@@ -2771,6 +2858,33 @@ void QgsAttributeForm::updateFieldDependenciesVirtualFields( QgsEditorWidgetWrap
     {
       mVirtualFieldsDependencies.insertMulti( mLayer->fields().lookupField( referencedColumn ), eww );
     }
+  }
+}
+
+void QgsAttributeForm::updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrapper *eww )
+{
+  for ( QgsAttributeFormWidget *formWidget : mFormWidgets )
+  {
+    QgsAttributeFormRelationEditorWidget *relationEditorWidget = dynamic_cast<QgsAttributeFormRelationEditorWidget *>( formWidget );
+    if ( !relationEditorWidget )
+      continue;
+
+    QString expressionField = eww->layer()->expressionField( eww->fieldIdx() );
+    if ( expressionField.contains( QStringLiteral( "relation_aggregate" ) )
+         || expressionField.contains( QStringLiteral( "get_features" ) ) )
+      mRelatedLayerFieldsDependencies.insert( eww );
+  }
+}
+
+void QgsAttributeForm::setMultiEditFeatureIdsRelations( const QgsFeatureIds &fids )
+{
+  for ( QgsAttributeFormWidget *formWidget : mFormWidgets )
+  {
+    QgsAttributeFormRelationEditorWidget *relationEditorWidget = dynamic_cast<QgsAttributeFormRelationEditorWidget *>( formWidget );
+    if ( !relationEditorWidget )
+      continue;
+
+    relationEditorWidget->setMultiEditFeatureIds( fids );
   }
 }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -341,6 +341,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void onAttributeChanged( const QVariant &value, const QVariantList &additionalFieldValues );
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
+    void onRelatedFeaturesChanged();
     void onUpdatedFields();
     void onConstraintStatusChanged( const QString &constraint,
                                     const QString &description, const QString &err, QgsEditorWidgetWrapper::ConstraintResult result );
@@ -380,6 +381,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateFieldDependencies();
     void updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapper *eww );
     void updateFieldDependenciesVirtualFields( QgsEditorWidgetWrapper *eww );
+    void updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrapper *eww );
 
     struct WidgetInfo
     {
@@ -412,6 +414,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateValuesDependencies( const int originIdx );
     void updateValuesDependenciesDefaultValues( const int originIdx );
     void updateValuesDependenciesVirtualFields( const int originIdx );
+
+    void updateRelatedLayerFields();
 
     void clearMultiEditMessages();
     void pushSelectedFeaturesMessage();
@@ -524,6 +528,11 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * Attribute indexes will be added multiple times if more than one widget depends on them.
      */
     QMap<int, QgsWidgetWrapper *> mVirtualFieldsDependencies;
+
+    /**
+     * Dependency list for values depending on related layers.
+     */
+    QSet<QgsWidgetWrapper *> mRelatedLayerFieldsDependencies;
 
     //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -410,8 +410,9 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! Save single feature or add feature edits
     bool saveEdits( QString *error );
 
-    //! update the default values and virtual fields in the fields after a referenced field changed
     QgsFeature getUpdatedFeature() const;
+
+    //! update the default values and virtual fields in the fields after a referenced field changed
     void updateValuesDependencies( const int originIdx );
     void updateValuesDependenciesDefaultValues( const int originIdx );
     void updateValuesDependenciesVirtualFields( const int originIdx );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -381,7 +381,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateFieldDependencies();
     void updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapper *eww );
     void updateFieldDependenciesVirtualFields( QgsEditorWidgetWrapper *eww );
-    void updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrapper *eww );
+    void updateRelatedLayerFieldsDependencies( QgsEditorWidgetWrapper *eww = nullptr );
 
     struct WidgetInfo
     {
@@ -411,10 +411,10 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     bool saveEdits( QString *error );
 
     //! update the default values and virtual fields in the fields after a referenced field changed
+    QgsFeature getUpdatedFeature() const;
     void updateValuesDependencies( const int originIdx );
     void updateValuesDependenciesDefaultValues( const int originIdx );
     void updateValuesDependenciesVirtualFields( const int originIdx );
-
     void updateRelatedLayerFields();
 
     void clearMultiEditMessages();
@@ -532,7 +532,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     /**
      * Dependency list for values depending on related layers.
      */
-    QSet<QgsWidgetWrapper *> mRelatedLayerFieldsDependencies;
+    QSet<QgsEditorWidgetWrapper *> mRelatedLayerFieldsDependencies;
 
     //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;


### PR DESCRIPTION
Relation editor widget emit a new signal relatedFeaturesChanged wherever a child feature is added, removed, linked or unlinked.
The signal is used in the attribute form to update virtual field values containing relation_aggregate or get_features in the field expression.
Fix #43901
Backport of #46167