### PR TITLE
Fix DistanceWithin algorithm with PostgreSQL provider

### DIFF
--- a/python/core/auto_additions/qgsfeatureiterator.py
+++ b/python/core/auto_additions/qgsfeatureiterator.py
@@ -1,0 +1,6 @@
+# The following has been generated automatically from src/core/qgsfeatureiterator.h
+# monkey patching scoped based enum
+QgsAbstractFeatureIterator.RequestToSourceCrsResult.Success.__doc__ = "Request was successfully updated to the source CRS, or no changes were required"
+QgsAbstractFeatureIterator.RequestToSourceCrsResult.DistanceWithinMustBeCheckedManually.__doc__ = "The distance within request cannot be losslessly updated to the source CRS, and callers will need to take appropriate steps to handle the distance within requirement manually during feature iteration"
+QgsAbstractFeatureIterator.RequestToSourceCrsResult.__doc__ = 'Possible results from the :py:func:`~QgsAbstractFeatureIterator.updateRequestToSourceCrs` method.\n\n.. versionadded:: 3.22\n\n' + '* ``Success``: ' + QgsAbstractFeatureIterator.RequestToSourceCrsResult.Success.__doc__ + '\n' + '* ``DistanceWithinMustBeCheckedManually``: ' + QgsAbstractFeatureIterator.RequestToSourceCrsResult.DistanceWithinMustBeCheckedManually.__doc__
+# --

--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
@@ -75,6 +75,12 @@ This indicates that there is something wrong with the expression compiler.
 .. versionadded:: 3.2
 %End
 
+    enum class RequestToSourceCrsResult
+    {
+      Success,
+      DistanceWithinMustBeCheckedManually,
+    };
+
   protected:
 
     virtual bool fetchFeature( QgsFeature &f ) = 0;
@@ -138,13 +144,17 @@ Will throw a :py:class:`QgsCsException` if the rect cannot be transformed from t
 .. versionadded:: 3.0
 %End
 
-    void updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const throw( QgsCsException );
+    RequestToSourceCrsResult updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const throw( QgsCsException );
 %Docstring
 Update a :py:class:`QgsFeatureRequest` so that spatial filters are
 transformed to the source's coordinate reference system.
 Iterators should call this method against the request used for filtering
 features to ensure that any :py:func:`QgsFeatureRequest.destinationCrs()` set on the request is respected.
-Will throw a :py:class:`QgsCsException` if the rect cannot be transformed from the destination CRS.
+
+:return: result of operation. See QgsAbstractFeatureIterator.RequestToSourceCrsResult for interpretation.
+
+:raises QgsCsException: if the rect cannot be transformed from the destination CRS.
+
 
 .. versionadded:: 3.22
 %End

--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
@@ -138,6 +138,17 @@ Will throw a :py:class:`QgsCsException` if the rect cannot be transformed from t
 .. versionadded:: 3.0
 %End
 
+    void updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const throw( QgsCsException );
+%Docstring
+Update a :py:class:`QgsFeatureRequest` so that spatial filters are
+transformed to the source's coordinate reference system.
+Iterators should call this method against the request used for filtering
+features to ensure that any :py:func:`QgsFeatureRequest.destinationCrs()` set on the request is respected.
+Will throw a :py:class:`QgsCsException` if the rect cannot be transformed from the destination CRS.
+
+.. versionadded:: 3.22
+%End
+
 
 
 

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -205,6 +205,10 @@ Dumps the content to an SQL equivalent
 %End
 
 
+        bool operator==( const OrderByClause &v ) const;
+
+        bool operator!=( const OrderByClause &v ) const;
+
     };
 
 

--- a/python/core/auto_generated/qgssimplifymethod.sip.in
+++ b/python/core/auto_generated/qgssimplifymethod.sip.in
@@ -74,6 +74,10 @@ Gets whether the simplification executes after fetch the geometries from provide
 Creates a geometry simplifier according to specified method
 %End
 
+    bool operator==( const QgsSimplifyMethod &v ) const;
+
+    bool operator!=( const QgsSimplifyMethod &v ) const;
+
   protected:
 };
 

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -17,6 +17,7 @@
 
 #include "qgssimplifymethod.h"
 #include "qgsexception.h"
+#include "qgslinestring.h"
 #include "qgsexpressionsorter.h"
 #include "qgsfeedback.h"
 #include "qgscoordinatetransform.h"
@@ -116,6 +117,37 @@ void QgsAbstractFeatureIterator::geometryToDestinationCrs( QgsFeature &feature, 
       }
       // remove geometry - we can't reproject so better not return a geometry in a different crs
       feature.clearGeometry();
+    }
+  }
+}
+
+void QgsAbstractFeatureIterator::updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const
+{
+  switch ( request.spatialFilterType() )
+  {
+    case Qgis::SpatialFilterType::NoFilter:
+      break;
+    case Qgis::SpatialFilterType::BoundingBox:
+    {
+      QgsRectangle newRect = transform.transformBoundingBox( request.filterRect(), Qgis::TransformDirection::Reverse );
+      request.setFilterRect( newRect );
+      break;
+    }
+    case Qgis::SpatialFilterType::DistanceWithin:
+    {
+      QgsGeometry geom = request.referenceGeometry();
+      QgsRectangle bbox = geom.boundingBox();
+      double x0 = bbox.xMaximum();
+      double y0 = bbox.yMaximum();
+      double dist = request.distanceWithin();
+      QgsPoint p0( x0, y0 );
+      QgsPoint p1( x0 + dist, y0 );
+      QgsLineString newDistLine( p0, p1 );
+      newDistLine.transform( transform, Qgis::TransformDirection::Reverse );
+      dist = newDistLine.length();
+      geom.transform( transform, Qgis::TransformDirection::Reverse );
+      request.setDistanceWithin( geom, dist );
+      break;
     }
   }
 }

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -91,6 +91,17 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      */
     bool compileFailed() const;
 
+    /**
+     * Possible results from the updateRequestToSourceCrs() method.
+     *
+     * \since QGIS 3.22
+     */
+    enum class RequestToSourceCrsResult : int
+    {
+      Success, //!< Request was successfully updated to the source CRS, or no changes were required
+      DistanceWithinMustBeCheckedManually, //!< The distance within request cannot be losslessly updated to the source CRS, and callers will need to take appropriate steps to handle the distance within requirement manually during feature iteration
+    };
+
   protected:
 
     /**
@@ -154,10 +165,14 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      * transformed to the source's coordinate reference system.
      * Iterators should call this method against the request used for filtering
      * features to ensure that any QgsFeatureRequest::destinationCrs() set on the request is respected.
-     * Will throw a QgsCsException if the rect cannot be transformed from the destination CRS.
+     *
+     * \returns result of operation. See QgsAbstractFeatureIterator::RequestToSourceCrsResult for interpretation.
+     *
+     * \throws QgsCsException if the rect cannot be transformed from the destination CRS.
+     *
      * \since QGIS 3.22
      */
-    void updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const SIP_THROW( QgsCsException );
+    RequestToSourceCrsResult updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const SIP_THROW( QgsCsException );
 
     //! A copy of the feature request.
     QgsFeatureRequest mRequest;

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -149,6 +149,16 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      */
     QgsRectangle filterRectToSourceCrs( const QgsCoordinateTransform &transform ) const SIP_THROW( QgsCsException );
 
+    /**
+     * Update a QgsFeatureRequest so that spatial filters are
+     * transformed to the source's coordinate reference system.
+     * Iterators should call this method against the request used for filtering
+     * features to ensure that any QgsFeatureRequest::destinationCrs() set on the request is respected.
+     * Will throw a QgsCsException if the rect cannot be transformed from the destination CRS.
+     * \since QGIS 3.22
+     */
+    void updateRequestToSourceCrs( QgsFeatureRequest &request, const QgsCoordinateTransform &transform ) const SIP_THROW( QgsCsException );
+
     //! A copy of the feature request.
     QgsFeatureRequest mRequest;
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -222,6 +222,18 @@ class CORE_EXPORT QgsFeatureRequest
 
         // friend inline int qHash(const OrderByClause &a) { return qHash(a.mExpression.expression()) ^ qHash(a.mAscending) ^ qHash( a.mNullsFirst); }
 
+        bool operator==( const OrderByClause &v ) const
+        {
+          return mExpression == v.mExpression &&
+                 mAscending == v.mAscending &&
+                 mNullsFirst == v.mNullsFirst;
+        }
+
+        bool operator!=( const OrderByClause &v ) const
+        {
+          return !( v == *this );
+        }
+
       private:
         QgsExpression mExpression;
         bool mAscending;

--- a/src/core/qgssimplifymethod.cpp
+++ b/src/core/qgssimplifymethod.cpp
@@ -54,3 +54,17 @@ QgsAbstractGeometrySimplifier *QgsSimplifyMethod::createGeometrySimplifier( cons
     return nullptr;
   }
 }
+
+bool QgsSimplifyMethod::operator==( const QgsSimplifyMethod &v ) const
+{
+  return
+    mMethodType == v.mMethodType &&
+    mTolerance == v.mTolerance &&
+    mThreshold == v.mThreshold &&
+    mForceLocalOptimization == v.mForceLocalOptimization;
+}
+
+bool QgsSimplifyMethod::operator!=( const QgsSimplifyMethod &v ) const
+{
+  return !( v == *this );
+}

--- a/src/core/qgssimplifymethod.h
+++ b/src/core/qgssimplifymethod.h
@@ -61,6 +61,12 @@ class CORE_EXPORT QgsSimplifyMethod
     //! Creates a geometry simplifier according to specified method
     static QgsAbstractGeometrySimplifier *createGeometrySimplifier( const QgsSimplifyMethod &simplifyMethod );
 
+    //! Equality operator
+    bool operator==( const QgsSimplifyMethod &v ) const;
+
+    //! Inequality operator
+    bool operator!=( const QgsSimplifyMethod &v ) const;
+
   protected:
     //! Simplification method
     MethodType mMethodType = QgsSimplifyMethod::NoSimplification;

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -130,6 +130,9 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   }
 
   // prepare spatial filter geometries for optimal speed
+  // since the mDistanceWithin* constraint member variables are all in the DESTINATION CRS,
+  // we set all these upfront before any transformation to the source CRS is done.
+
   switch ( mRequest.spatialFilterType() )
   {
     case Qgis::SpatialFilterType::NoFilter:
@@ -139,6 +142,10 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
     case Qgis::SpatialFilterType::DistanceWithin:
       if ( !mRequest.referenceGeometry().isEmpty() )
       {
+        // Note that regardless of whether or not we'll ultimately be able to handoff this check to the underlying provider,
+        // we still need these reference geometry constraints in the vector layer iterator as we need them to check against
+        // the features from the vector layer's edit buffer! (In other words, we cannot completely hand off responsibility for
+        // these checks to the provider and ignore them locally)
         mDistanceWithinGeom = mRequest.referenceGeometry();
         mDistanceWithinEngine = mRequest.referenceGeometryEngine();
         mDistanceWithinEngine->prepareGeometry();
@@ -147,9 +154,22 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
       break;
   }
 
+  bool canDelegateLimitToProvider = true;
   try
   {
-    updateRequestToSourceCrs( mRequest, mTransform );
+    switch ( updateRequestToSourceCrs( mRequest, mTransform ) )
+    {
+      case QgsAbstractFeatureIterator::RequestToSourceCrsResult::Success:
+        break;
+
+      case QgsAbstractFeatureIterator::RequestToSourceCrsResult::DistanceWithinMustBeCheckedManually:
+        // we have to disable any limit on the provider's request -- since that request may be returning features which are outside the
+        // distance tolerance, we'll have to fetch them all and then handle the limit check manually only after testing for the distance within constraint
+        canDelegateLimitToProvider = false;
+        break;
+    }
+
+    // mFilterRect is in the source CRS, so we set that now (after request transformation has been done)
     mFilterRect = mRequest.filterRect();
   }
   catch ( QgsCsException & )
@@ -158,7 +178,6 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
     close();
     return;
   }
-
 
   // check whether the order by clause(s) can be delegated to the provider
   mDelegatedOrderByToProvider = !mSource->mHasEditBuffer;
@@ -212,6 +231,11 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
   if ( !mDelegatedOrderByToProvider )
   {
     mProviderRequest.setOrderBy( QgsFeatureRequest::OrderBy() );
+  }
+
+  if ( !canDelegateLimitToProvider )
+  {
+    mProviderRequest.setLimit( -1 );
   }
 
   if ( mProviderRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )

--- a/src/core/vector/qgsvectorlayerfeatureiterator.h
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.h
@@ -268,9 +268,11 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsFeatureRequest mChangedFeaturesRequest;
     QgsFeatureIterator mChangedFeaturesIterator;
 
+    // filter bounding box constraint, in SOURCE CRS
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
 
+    // distance within constraint reference geometry and distance IN DESTINATION CRS
     QgsGeometry mDistanceWithinGeom;
     std::shared_ptr< QgsGeometryEngine > mDistanceWithinEngine;
     double mDistanceWithin = 0;

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TESTS
  testqgsexpression.cpp
  testqgsexpressioncontext.cpp
  testqgsfeature.cpp
+ testqgsfeaturerequest.cpp
  testqgsfield.cpp
  testqgsfields.cpp
  testqgsfilledmarker.cpp

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -164,6 +164,7 @@ set(TESTS
  testqgssettingsregistry.cpp
  testqgsshapeburst.cpp
  testqgssimplemarker.cpp
+ testqgssimplifymethod.cpp
  testqgssnappingutils.cpp
  testqgsspatialindex.cpp
  testqgsspatialindexkdbush.cpp

--- a/tests/src/core/testqgsfeaturerequest.cpp
+++ b/tests/src/core/testqgsfeaturerequest.cpp
@@ -1,0 +1,149 @@
+/***************************************************************************
+     testqgsfeaturerequest.cpp
+     -------------------------
+    Date                 : May 2021
+    Copyright            : (C) 2021 Sandro Santilli
+    Email                : strk at kbt dot io
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QSettings>
+
+#include "qgsfeature.h"
+#include "qgsfield.h"
+#include "qgsgeometry.h"
+#include "qgssymbol.h"
+#include "qgssimplifymethod.h"
+#include "qgslinesymbol.h"
+#include "qgsexpressioncontextutils.h"
+
+class TestQgsFeatureRequest: public QObject
+{
+    Q_OBJECT
+
+  private:
+    void testDefaultConstructed( const QgsFeatureRequest &f );
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void constructorTest(); //test default constructors
+    void copyConstructorTest(); //test copy constructor
+    void assignmentOperatorTest(); //test copy constructor
+
+
+  private:
+
+};
+
+void TestQgsFeatureRequest::initTestCase()
+{
+
+}
+
+void TestQgsFeatureRequest::cleanupTestCase()
+{
+
+}
+
+void TestQgsFeatureRequest::init()
+{
+
+}
+
+void TestQgsFeatureRequest::cleanup()
+{
+
+}
+
+void TestQgsFeatureRequest::testDefaultConstructed( const QgsFeatureRequest &f )
+{
+  // Test public getter members
+  QCOMPARE( f.filterType(), QgsFeatureRequest::FilterType::FilterNone );
+  QCOMPARE( f.spatialFilterType(), Qgis::SpatialFilterType::NoFilter );
+  QCOMPARE( f.filterRect(), QgsRectangle() );
+  QVERIFY( f.referenceGeometry().isEmpty() );
+  QCOMPARE( f.distanceWithin(), double() );
+  // NOTE: this is not QgsFeatureId() because QgsFeatureId is just
+  //       a typedef for an integer, so doesn't have QGIS-specific
+  //       behavior encoded in a default constructor
+  QCOMPARE( f.filterFid(), -1 ); // I think FID_NULL should be used
+  QCOMPARE( f.filterFids(), QgsFeatureIds() );
+  QCOMPARE( f.invalidGeometryCheck(), QgsFeatureRequest::InvalidGeometryCheck::GeometryNoCheck );
+  QCOMPARE( f.invalidGeometryCallback(), nullptr );
+  QCOMPARE( f.filterExpression(), nullptr );
+  // Disabled because:
+  //  1. expressionContext is non-const at time of writing this test
+  //  2. QgsExpressionContext does not have an equality operator and
+  //     this method always returns a valid pointer
+  //QCOMPARE( *const_cast< QgsFeatureRequest & > (f).expressionContext(), QgsExpressionContext() );
+  QCOMPARE( f.orderBy(), QgsFeatureRequest::OrderBy() );
+  QCOMPARE( f.limit(), -1LL ); // I think 0 could be used to mean no limit
+  QCOMPARE( f.flags(), QgsFeatureRequest::Flags() );
+  QCOMPARE( f.subsetOfAttributes(), QgsAttributeList() );
+  QCOMPARE( f.simplifyMethod(), QgsSimplifyMethod() );
+  QCOMPARE( f.destinationCrs(), QgsCoordinateReferenceSystem() );
+  QCOMPARE( f.transformContext(), QgsCoordinateTransformContext() );
+  QCOMPARE( f.transformErrorCallback(), nullptr );
+  QCOMPARE( f.timeout(), -1 ); // I think 0 could be used to mean no timeout
+  QCOMPARE( f.requestMayBeNested(), false );
+  QCOMPARE( f.feedback(), nullptr );
+}
+
+void TestQgsFeatureRequest::constructorTest()
+{
+  const QgsFeatureRequest f;
+  testDefaultConstructed( f );
+}
+
+void TestQgsFeatureRequest::copyConstructorTest()
+{
+  const QgsFeatureRequest f;
+  const QgsFeatureRequest f2( f );
+  testDefaultConstructed( f2 );
+}
+
+void TestQgsFeatureRequest::assignmentOperatorTest()
+{
+  const QgsFeatureRequest f;
+  QgsFeatureRequest f2;
+
+  // modify all members of f2
+  f2.setFilterRect( QgsRectangle( 10, 10, 20, 20 ) );
+  f2.setDistanceWithin( QgsGeometry::fromWkt( "POINT(10 15)" ), 12 );
+  f2.setFilterFid( 52 );
+  f2.setFilterFids( {3, 4} );
+  f2.setInvalidGeometryCheck( QgsFeatureRequest::InvalidGeometryCheck::GeometrySkipInvalid );
+  f2.setInvalidGeometryCallback( []( const QgsFeature & ) {} );
+  f2.setFilterExpression( "this not that" );
+  QgsExpressionContextScope *scope = QgsExpressionContextUtils::globalScope();
+  f2.setExpressionContext( QgsExpressionContext( { scope } ) );
+  f2.addOrderBy( "someField" );
+  f2.setLimit( 5 );
+  f2.setFlags( QgsFeatureRequest::NoGeometry );
+  f2.setSubsetOfAttributes( {1, 2} );
+  QgsSimplifyMethod sm;
+  sm.setMethodType( QgsSimplifyMethod::PreserveTopology );
+  f2.setSimplifyMethod( sm );
+  // TODO: modify more members of f2
+  //f2.setDestinationCrs( QgsCoordinateReferenceSystem( "EPSG:3111") );
+
+  f2 = f;
+
+  testDefaultConstructed( f2 );
+}
+
+
+QGSTEST_MAIN( TestQgsFeatureRequest )
+#include "testqgsfeaturerequest.moc"

--- a/tests/src/core/testqgssimplifymethod.cpp
+++ b/tests/src/core/testqgssimplifymethod.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+     testqgssimplifymethod.cpp
+     --------------------------
+    Date                 : Oct 2021
+    Copyright            : (C) 2021 Sandro Santilli
+    Email                : strk at kbt dot io
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QLocale>
+
+#include <memory>
+
+#include "qgssimplifymethod.h"
+
+class TestQgsSimplifyMethod: public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void testCreate();//test creating a simplify method
+    void testEqualityInequality();//test equality operator
+
+  private:
+};
+
+void TestQgsSimplifyMethod::initTestCase()
+{
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+}
+
+void TestQgsSimplifyMethod::cleanupTestCase()
+{
+
+}
+
+void TestQgsSimplifyMethod::init()
+{
+  QLocale::setDefault( QLocale::English );
+}
+
+void TestQgsSimplifyMethod::cleanup()
+{
+  QLocale::setDefault( QLocale::English );
+}
+
+void TestQgsSimplifyMethod::testCreate()
+{
+  QgsSimplifyMethod method0;
+  QCOMPARE( method0.methodType(), QgsSimplifyMethod::NoSimplification );
+}
+
+void TestQgsSimplifyMethod::testEqualityInequality()
+{
+  QgsSimplifyMethod method0;
+  QgsSimplifyMethod method1;
+  method1.setMethodType( QgsSimplifyMethod::OptimizeForRendering );
+
+  QVERIFY( method0 == method0 );
+  QVERIFY( method0 != method1 );
+}
+
+
+QGSTEST_MAIN( TestQgsSimplifyMethod )
+#include "testqgssimplifymethod.moc"

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -634,7 +634,7 @@ class FeatureSourceTestCase(object):
         request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3857'), QgsProject.instance().transformContext()).setDistanceWithin(QgsGeometry.fromWkt('LineString (-7035391 11036245, -7622045 11023301, -7763421 15092839)'), 250000)
         features = [f['pk'] for f in self.source.getFeatures(request)]
         all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
-        assert set(features) == set([2, 5]), 'Got {} instead'.format(features)
+        self.assertEqual(set(features), {2, 5})
         self.assertTrue(all_valid)
 
         # point geometry

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -682,6 +682,15 @@ class FeatureSourceTestCase(object):
         for f in self.source.getFeatures():
             self.assertEqual(request.acceptFeature(f), f['pk'] in set([1, 2, 4]))
 
+        # test with linestring whose bounding box overlaps all query
+        # points but being only within one of them, which we hope will
+        # be returned NOT as the first one.
+        # This is a test for https://github.com/qgis/QGIS/issues/45352
+        request = QgsFeatureRequest().setDistanceWithin(
+            QgsGeometry.fromWkt('LINESTRING(-100 80, -100 66, -30 66, -30 80)'), 0.5)
+        features = {f['pk'] for f in self.source.getFeatures(request)}
+        self.assertEqual(features, {1}, "Unexpected return from QgsFeatureRequest with DistanceWithin filter")
+
     def testGeomAndAllAttributes(self):
         """
         Test combination of a filter which requires geometry and all attributes

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -72,18 +72,21 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         cls.dbconn = 'service=qgis_test'
         if 'QGIS_PGTEST_DB' in os.environ:
             cls.dbconn = os.environ['QGIS_PGTEST_DB']
+
         # Create test layers
         cls.vl = QgsVectorLayer(
             cls.dbconn +
             ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=',
             'test', 'postgres')
-        assert cls.vl.isValid()
+        assert cls.vl.isValid(), "Could not create a layer from the 'qgis_test.someData' table using dbconn '" + cls.dbconn + "'"
+
         cls.source = cls.vl.dataProvider()
         cls.poly_vl = QgsVectorLayer(
             cls.dbconn +
             ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="qgis_test"."some_poly_data" (geom) sql=',
             'test', 'postgres')
-        assert cls.poly_vl.isValid()
+        assert cls.poly_vl.isValid(), "Could not create a layer from the 'qgis_test.some_poly_data' table using dbconn '" + cls.dbconn + "'"
+
         cls.poly_provider = cls.poly_vl.dataProvider()
         QgsGui.editorWidgetRegistry().initEditors()
         cls.con = psycopg2.connect(cls.dbconn)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -28,6 +28,7 @@ import time
 from datetime import datetime
 
 from qgis.core import (
+    QgsApplication,
     QgsVectorLayer,
     QgsVectorLayerExporter,
     QgsFeatureRequest,
@@ -35,7 +36,6 @@ from qgis.core import (
     QgsFeature,
     QgsFieldConstraints,
     QgsDataProvider,
-    NULL,
     QgsVectorLayerUtils,
     QgsSettings,
     QgsTransactionGroup,
@@ -44,6 +44,9 @@ from qgis.core import (
     QgsReferencedGeometry,
     QgsDefaultValue,
     QgsCoordinateReferenceSystem,
+    QgsProcessingUtils,
+    QgsProcessingContext,
+    QgsProcessingFeedback,
     QgsProject,
     QgsWkbTypes,
     QgsGeometry,
@@ -51,7 +54,9 @@ from qgis.core import (
     QgsVectorDataProvider,
     QgsDataSourceUri,
     QgsProviderConnectionException,
+    NULL,
 )
+from qgis.analysis import QgsNativeAlgorithms
 from qgis.gui import QgsGui, QgsAttributeForm
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject, QByteArray, QTemporaryDir
 from qgis.PyQt.QtWidgets import QLabel
@@ -125,6 +130,22 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 self.tester.execSQLCommand('DROP TABLE {s}.{t}_edit'.format(s=self.schema, t=self.table))
 
         return ScopedBackup(self, schema, table)
+
+    def temporarySchema(self, name):
+
+        class TemporarySchema():
+            def __init__(self, tester, name):
+                self.tester = tester
+                self.name = name
+
+            def __enter__(self):
+                self.tester.execSQLCommand('CREATE SCHEMA {}'.format(self.name))
+                return self.name
+
+            def __exit__(self, type, value, traceback):
+                self.tester.execSQLCommand('DROP SCHEMA {} CASCADE'.format(self.name))
+
+        return TemporarySchema(self, 'qgis_test_' + name)
 
     def getSource(self):
         # create temporary table for edit tests
@@ -2870,6 +2891,89 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(feat["thetext2"], NULL)
         self.assertEqual(feat["thetext3"], "blabla")
         self.assertEqual(feat["thenumber"], 4)
+
+    def testExtractWithinDistanceAlgorithm(self):
+
+        with self.temporarySchema('extract_within_distance') as schema:
+
+            # Create data tables
+            self.execSQLCommand(
+                'CREATE TABLE {}.target (id serial primary key, g geometry(linestring))'
+                .format(schema))
+            self.execSQLCommand(
+                "INSERT INTO {}.target (g) values('LINESTRING(0 0, 1000 1000)')"
+                .format(schema))
+            self.execSQLCommand(
+                'CREATE TABLE {}.reference (id serial primary key, g geometry(point))'
+                .format(schema))
+            self.execSQLCommand(
+                "INSERT INTO {}.reference (g) values('POINT(500 999)')"
+                .format(schema))
+            self.execSQLCommand(
+                "INSERT INTO {}.reference (g) values('POINT(501 999)')"
+                .format(schema))
+            self.execSQLCommand(
+                # -- this is ON the line (id=4)
+                "INSERT INTO {}.reference (g) values('POINT(500 500)')"
+                .format(schema))
+            self.execSQLCommand(
+                "INSERT INTO {}.reference (g) values('POINT(503 999)')"
+                .format(schema))
+            self.execSQLCommand(
+                "INSERT INTO {}.reference (g) values('POINT(504 999)')"
+                .format(schema))
+
+            # Create target and reference layers
+            vl_target = QgsVectorLayer(
+                '{} sslmode=disable key=id srid=0 type=LINESTRING table="{}"."target" (g) sql='
+                .format(self.dbconn, schema),
+                'target', 'postgres')
+            assert vl_target.isValid(), "Could not create a layer from the '{}.target' table using dbconn '{}'" .format(schema, self.dbconn)
+            vl_reference = QgsVectorLayer(
+                '{} sslmode=disable key=id srid=0 type=POINT table="{}"."reference" (g) sql='
+                .format(self.dbconn, schema),
+                'reference', 'postgres')
+            assert vl_target.isValid(), "Could not create a layer from the '{}.reference' table using dbconn '{}'" .format(schema, self.dbconn)
+
+            # Create the ExtractWithinDistance algorithm
+            # TODO: move registry initialization in class initialization ?
+            QgsApplication.processingRegistry().addProvider(QgsNativeAlgorithms())
+            registry = QgsApplication.instance().processingRegistry()
+            alg = registry.createAlgorithmById('native:extractwithindistance')
+            self.assertIsNotNone(alg)
+
+            # Run the ExtractWithinDistance algorithm
+            parameters = {
+                # extract features from here:
+                'INPUT': vl_target,
+                # extracted features must be within given
+                # distance from this layer:
+                'REFERENCE': vl_reference,
+                # distance
+                'DISTANCE': 10,
+                'OUTPUT': 'memory:result'
+            }
+
+            class ConsoleFeedBack(QgsProcessingFeedback):
+                _error = ''
+
+                def reportError(self, error, fatalError=False):
+                    self._error = error
+                    print(error)
+
+            feedback = ConsoleFeedBack()
+            context = QgsProcessingContext()
+            # Note: the following returns true also in case of errors ...
+
+            result = alg.run(parameters, context, feedback)
+            self.assertEqual(result[1], True)
+
+            result_layer_name = result[0]['OUTPUT']
+            vl_result = QgsProcessingUtils.mapLayerFromString(result_layer_name, context)
+            self.assertTrue(vl_result.isValid())
+
+            extracted_fids = [f['id'] for f in vl_result.getFeatures()]
+            self.assertEqual(set(extracted_fids), {1})
 
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2928,12 +2928,12 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 '{} sslmode=disable key=id srid=0 type=LINESTRING table="{}"."target" (g) sql='
                 .format(self.dbconn, schema),
                 'target', 'postgres')
-            assert vl_target.isValid(), "Could not create a layer from the '{}.target' table using dbconn '{}'" .format(schema, self.dbconn)
+            self.assertTrue(vl_target.isValid(), "Could not create a layer from the '{}.target' table using dbconn '{}'" .format(schema, self.dbconn))
             vl_reference = QgsVectorLayer(
                 '{} sslmode=disable key=id srid=0 type=POINT table="{}"."reference" (g) sql='
                 .format(self.dbconn, schema),
                 'reference', 'postgres')
-            assert vl_target.isValid(), "Could not create a layer from the '{}.reference' table using dbconn '{}'" .format(schema, self.dbconn)
+            self.assertTrue(vl_target.isValid(), "Could not create a layer from the '{}.reference' table using dbconn '{}'" .format(schema, self.dbconn))
 
             # Create the ExtractWithinDistance algorithm
             # TODO: move registry initialization in class initialization ?
@@ -2973,7 +2973,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             self.assertTrue(vl_result.isValid())
 
             extracted_fids = [f['id'] for f in vl_result.getFeatures()]
-            self.assertEqual(set(extracted_fids), {1})
+            self.assertCountEqual(extracted_fids, [1])
 
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/45384

Adds some extra safety to the solution from https://github.com/qgis/QGIS/pull/45384 by forcing all distance within checks to be done by the vector layer iterator when a coordinate transform is involved.

