### PR TITLE
Use widget value when validating attrs in form

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -172,10 +172,22 @@ The optional seed value can be used as a basis for generated values.
                                    QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
 %Docstring
-Tests an attribute value to check whether it passes all constraints which are present on the corresponding field.
+Tests a feature attribute value to check whether it passes all constraints which are present on the corresponding field.
 Returns ``True`` if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
 If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
 %End
+
+    static bool validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors /Out/,
+                                        QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
+                                        QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
+%Docstring
+Tests a value to check whether it passes all constraints which are present on the corresponding field.
+Returns ``True`` if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
+If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
+
+.. versionadded:: 3.24
+%End
+
 
     static QgsFeature createFeature( const QgsVectorLayer *layer,
                                      const QgsGeometry &geometry = QgsGeometry(),

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -177,18 +177,6 @@ Returns ``True`` if the attribute value is valid for the field. Any constraint f
 If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
 %End
 
-    static bool validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors /Out/,
-                                        QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
-                                        QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
-%Docstring
-Tests a value to check whether it passes all constraints which are present on the corresponding field.
-Returns ``True`` if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
-If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
-
-.. versionadded:: 3.24
-%End
-
-
     static QgsFeature createFeature( const QgsVectorLayer *layer,
                                      const QgsGeometry &geometry = QgsGeometry(),
                                      const QgsAttributeMap &attributes = QgsAttributeMap(),

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -376,12 +376,6 @@ QVariant QgsVectorLayerUtils::createUniqueValueFromCache( const QgsVectorLayer *
 bool QgsVectorLayerUtils::validateAttribute( const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors,
     QgsFieldConstraints::ConstraintStrength strength, QgsFieldConstraints::ConstraintOrigin origin )
 {
-  const QVariant value = feature.attribute( attributeIndex );
-  return QgsVectorLayerUtils::validateAttributeValue( value, layer, feature, attributeIndex, errors, strength, origin );
-}
-
-bool QgsVectorLayerUtils::validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors, QgsFieldConstraints::ConstraintStrength strength, QgsFieldConstraints::ConstraintOrigin origin )
-{
   if ( !layer )
     return false;
 
@@ -390,6 +384,7 @@ bool QgsVectorLayerUtils::validateAttributeValue( const QVariant &value, const Q
 
   QgsFields fields = layer->fields();
   QgsField field = fields.at( attributeIndex );
+  const QVariant value = feature.attribute( attributeIndex );
   bool valid = true;
   errors.clear();
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -376,6 +376,12 @@ QVariant QgsVectorLayerUtils::createUniqueValueFromCache( const QgsVectorLayer *
 bool QgsVectorLayerUtils::validateAttribute( const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors,
     QgsFieldConstraints::ConstraintStrength strength, QgsFieldConstraints::ConstraintOrigin origin )
 {
+  const QVariant value = feature.attribute( attributeIndex );
+  return QgsVectorLayerUtils::validateAttributeValue( value, layer, feature, attributeIndex, errors, strength, origin );
+}
+
+bool QgsVectorLayerUtils::validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors, QgsFieldConstraints::ConstraintStrength strength, QgsFieldConstraints::ConstraintOrigin origin )
+{
   if ( !layer )
     return false;
 
@@ -384,7 +390,6 @@ bool QgsVectorLayerUtils::validateAttribute( const QgsVectorLayer *layer, const 
 
   QgsFields fields = layer->fields();
   QgsField field = fields.at( attributeIndex );
-  QVariant value = feature.attribute( attributeIndex );
   bool valid = true;
   errors.clear();
 

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -178,17 +178,6 @@ class CORE_EXPORT QgsVectorLayerUtils
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
 
     /**
-     * Tests a value to check whether it passes all constraints which are present on the corresponding field.
-     * Returns TRUE if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
-     * If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
-     * \since QGIS 3.24
-     */
-    static bool validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors SIP_OUT,
-                                        QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
-                                        QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
-
-
-    /**
      * Creates a new feature ready for insertion into a layer. Default values and constraints
      * (e.g., unique constraints) will automatically be handled. An optional attribute map can be
      * passed for the new feature to copy as many attribute values as possible from the map,

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -169,13 +169,24 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QVariant createUniqueValueFromCache( const QgsVectorLayer *layer, int fieldIndex, const QSet<QVariant> &existingValues, const QVariant &seed = QVariant() );
 
     /**
-     * Tests an attribute value to check whether it passes all constraints which are present on the corresponding field.
+     * Tests a feature attribute value to check whether it passes all constraints which are present on the corresponding field.
      * Returns TRUE if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
      * If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
      */
     static bool validateAttribute( const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors SIP_OUT,
                                    QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
                                    QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
+
+    /**
+     * Tests a value to check whether it passes all constraints which are present on the corresponding field.
+     * Returns TRUE if the attribute value is valid for the field. Any constraint failures will be reported in the errors argument.
+     * If the strength or origin parameter is set then only constraints with a matching strength/origin will be checked.
+     * \since QGIS 3.24
+     */
+    static bool validateAttributeValue( const QVariant &value, const QgsVectorLayer *layer, const QgsFeature &feature, int attributeIndex, QStringList &errors SIP_OUT,
+                                        QgsFieldConstraints::ConstraintStrength strength = QgsFieldConstraints::ConstraintStrengthNotSet,
+                                        QgsFieldConstraints::ConstraintOrigin origin = QgsFieldConstraints::ConstraintOriginNotSet );
+
 
     /**
      * Creates a new feature ready for insertion into a layer. Default values and constraints

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -220,9 +220,9 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int 
       toEmit = true;
     }
 
-    hardConstraintsOk = QgsVectorLayerUtils::validateAttributeValue( value(), layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
+    hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
 
-    softConstraintsOk = QgsVectorLayerUtils::validateAttributeValue( value(), layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
+    softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
     errors << softErrors;
   }
   else // invalid feature

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -220,9 +220,9 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsVectorLayer *layer, int 
       toEmit = true;
     }
 
-    hardConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
+    hardConstraintsOk = QgsVectorLayerUtils::validateAttributeValue( value(), layer, ft, index, errors, QgsFieldConstraints::ConstraintStrengthHard, constraintOrigin );
 
-    softConstraintsOk = QgsVectorLayerUtils::validateAttribute( layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
+    softConstraintsOk = QgsVectorLayerUtils::validateAttributeValue( value(), layer, ft, index, softErrors, QgsFieldConstraints::ConstraintStrengthSoft, constraintOrigin );
     errors << softErrors;
   }
   else // invalid feature

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -77,10 +77,10 @@ QVariant QgsValueRelationWidgetWrapper::value() const
       }
     }
 
-    // If there is no selection and allow NULL is not checked return invalid.
+    // If there is no selection and allow NULL is not checked return NULL.
     if ( selection.isEmpty() && ! config( QStringLiteral( "AllowNull" ) ).toBool( ) )
     {
-      return QVariant();
+      return QVariant( QVariant::Type::List );
     }
 
     QVariantList vl;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1236,7 +1236,7 @@ void QgsAttributeForm::registerContainerInformation( QgsAttributeForm::Container
 
 bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions ) const
 {
-  bool valid( true );
+  bool valid{ true };
 
   for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
   {
@@ -1260,7 +1260,7 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, 
 
 bool QgsAttributeForm::currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions ) const
 {
-  bool valid( true );
+  bool valid{ true };
 
   for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
   {

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1234,7 +1234,7 @@ void QgsAttributeForm::registerContainerInformation( QgsAttributeForm::Container
   }
 }
 
-bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions )
+bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions ) const
 {
   bool valid( true );
 
@@ -1258,7 +1258,7 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, 
   return valid;
 }
 
-bool QgsAttributeForm::currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions )
+bool QgsAttributeForm::currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions ) const
 {
   bool valid( true );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1258,6 +1258,27 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields, 
   return valid;
 }
 
+bool QgsAttributeForm::currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions )
+{
+  bool valid( true );
+
+  for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
+  {
+    QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
+    if ( eww )
+    {
+      if ( eww->isBlockingCommit() )
+      {
+        invalidFields.append( eww->field().displayName() );
+        descriptions.append( eww->constraintFailureReason() );
+        valid = false; // continue to get all invalid fields
+      }
+    }
+  }
+
+  return valid;
+}
+
 void QgsAttributeForm::onAttributeAdded( int idx )
 {
   mPreventFeatureRefresh = false;
@@ -1454,7 +1475,7 @@ void QgsAttributeForm::synchronizeState()
   if ( mMode != QgsAttributeEditorContext::SearchMode )
   {
     QStringList invalidFields, descriptions;
-    mValidConstraints = currentFormValidConstraints( invalidFields, descriptions );
+    mValidConstraints = currentFormValidHardConstraints( invalidFields, descriptions );
 
     if ( isEditable && mContext.formMode() == QgsAttributeEditorContext::Embed )
     {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -443,6 +443,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateLabels();
     bool currentFormValuesFeature( QgsFeature &feature );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
+    bool currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions );
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );
 
     Q_DECL_DEPRECATED QgsRelationWidgetWrapper *setupRelationWidgetWrapper( const QgsRelation &rel, const QgsAttributeEditorContext &context ) SIP_DEPRECATED;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -442,8 +442,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateConstraint( const QgsFeature &ft, QgsEditorWidgetWrapper *eww );
     void updateLabels();
     bool currentFormValuesFeature( QgsFeature &feature );
-    bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
-    bool currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions );
+    bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
+    bool currentFormValidHardConstraints( QStringList &invalidFields, QStringList &descriptions ) const;
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );
 
     Q_DECL_DEPRECATED QgsRelationWidgetWrapper *setupRelationWidgetWrapper( const QgsRelation &rel, const QgsAttributeEditorContext &context ) SIP_DEPRECATED;

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -1337,11 +1337,11 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
 
   // FEATURE 4
   w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
-  // Because allowNull is false we have an invalid variant here
-  QCOMPARE( w_favoriteauthors.value(), QVariant( ) );
+  // Because allowNull is false we have a NULL variant here
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariant::Type::List ) );
   cfg_favoriteauthors[ QStringLiteral( "AllowNull" ) ] = true;
   w_favoriteauthors.setConfig( cfg_favoriteauthors );
-  //check if first feature checked correctly (NULL)
+  //check if first feature checked correctly (empty list)
   QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList() ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
@@ -1355,12 +1355,12 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
 
   // FEATURE 5
   w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
-  // Because allowNull is false we have an invalid variant here
-  QCOMPARE( w_favoriteauthors.value(), QVariant( ) );
+  // Because allowNull is false we have a NULL variant here
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariant::Type::List ) );
 
   cfg_favoriteauthors[ QStringLiteral( "AllowNull" ) ] = true;
   w_favoriteauthors.setConfig( cfg_favoriteauthors );
-  //check if first feature checked correctly (blank)
+  //check if first feature checked correctly (empty list)
   QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( ) ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
@@ -1506,8 +1506,8 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   // FEATURE 4
   w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
 
-  // Because allowNull is false we have an invalid variant here
-  QCOMPARE( w_favoriteauthors.value(), QVariant( ) );
+  // Because allowNull is false we have a NULL variant here
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariant::Type::List ) );
   cfg_favoriteauthors[ QStringLiteral( "AllowNull" ) ] = true;
   w_favoriteauthors.setConfig( cfg_favoriteauthors );
 
@@ -1527,12 +1527,12 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   // FEATURE 5
   w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
 
-  // Because allowNull is false we have an invalid variant here
-  QCOMPARE( w_favoriteauthors.value(), QVariant( ) );
+  // Because allowNull is false we have a NULL variant here
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariant::Type::List ) );
   cfg_favoriteauthors[ QStringLiteral( "AllowNull" ) ] = true;
   w_favoriteauthors.setConfig( cfg_favoriteauthors );
 
-  //check if first feature checked correctly (blank)
+  //check if first feature checked correctly (empty list)
   QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList() ) );
 
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );


### PR DESCRIPTION
Also, make sure that non enforced constraints
do not block commits and do not report as violated
constraints (Fix #46364).

Followup #46439 because the constraints were
not checked against the widget value but against
the attribute value.

