### PR TITLE
Fix misleading docs that is only valid if edit buffer is used (so does not work in transaction mode)

### DIFF
--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -2891,27 +2891,27 @@ Note that at this point the geometry change is not yet saved to the provider.
 
     void committedAttributesDeleted( const QString &layerId, const QgsAttributeList &deletedAttributes );
 %Docstring
-Emitted when attributes are deleted from the provider
+Emitted when attributes are deleted from the provider if not in transaction mode.
 %End
     void committedAttributesAdded( const QString &layerId, const QList<QgsField> &addedAttributes );
 %Docstring
-Emitted when attributes are added to the provider
+Emitted when attributes are added to the provider if not in transaction mode.
 %End
     void committedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures );
 %Docstring
-Emitted when features are added to the provider
+Emitted when features are added to the provider if not in transaction mode.
 %End
     void committedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds );
 %Docstring
-Emitted when features are deleted from the provider
+Emitted when features are deleted from the provider if not in transaction mode.
 %End
     void committedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues );
 %Docstring
-Emitted when attribute value changes are saved to the provider
+Emitted when attribute value changes are saved to the provider if not in transaction mode.
 %End
     void committedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries );
 %Docstring
-Emitted when geometry changes are saved to the provider
+Emitted when geometry changes are saved to the provider if not in transaction mode.
 %End
 
     void labelingFontNotFound( QgsVectorLayer *layer, const QString &fontfamily );

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2680,17 +2680,17 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
-    //! Emitted when attributes are deleted from the provider
+    //! Emitted when attributes are deleted from the provider if not in transaction mode.
     void committedAttributesDeleted( const QString &layerId, const QgsAttributeList &deletedAttributes );
-    //! Emitted when attributes are added to the provider
+    //! Emitted when attributes are added to the provider if not in transaction mode.
     void committedAttributesAdded( const QString &layerId, const QList<QgsField> &addedAttributes );
-    //! Emitted when features are added to the provider
+    //! Emitted when features are added to the provider if not in transaction mode.
     void committedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures );
-    //! Emitted when features are deleted from the provider
+    //! Emitted when features are deleted from the provider if not in transaction mode.
     void committedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds );
-    //! Emitted when attribute value changes are saved to the provider
+    //! Emitted when attribute value changes are saved to the provider if not in transaction mode.
     void committedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues );
-    //! Emitted when geometry changes are saved to the provider
+    //! Emitted when geometry changes are saved to the provider if not in transaction mode.
     void committedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries );
 
     //! Emitted when the font family defined for labeling layer is not found on system


### PR DESCRIPTION
Long story short, the `layer.committedFeaturesAdded` signal is not fired after `layer.commitChanges()` when in transaction mode.

If the layer has the `QgsVectorLayerEditBuffer` as `layer.editBuffer()`, then the `commitedFeaturesAdded` signal is fired.
If the layer has the `QgsVectorLayerEditPasstrough` as `layer.editBuffer()`, which is the case in transaction mode, then there is no signal.

The `QgsVectorLayerEditPasstrough` class is quite empty and lacking implementation of these events, so they don't work on layers in a transaction group.
