### PR TITLE
Allow copying equivalent Python command directly from Processing algorithm dialog, without running algorithm first

### DIFF
--- a/python/gui/auto_additions/qgsprocessingwidgetwrapper.py
+++ b/python/gui/auto_additions/qgsprocessingwidgetwrapper.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/gui/processing/qgsprocessingwidgetwrapper.h
+# monkey patching scoped based enum
+QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters.__doc__ = "Parameters which are unchanged from their default values should not be included"
+QgsProcessingParametersGenerator.Flag.__doc__ = 'Flags controlling parameter generation.\n\n.. versionadded:: 3.24\n\n' + '* ``SkipDefaultValueParameters``: ' + QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters.__doc__
+# --

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsProcessingAlgorithmDialogBase : QDialog, QgsProcessingParametersGenerator
+class QgsProcessingAlgorithmDialogBase : QDialog, QgsProcessingParametersGenerator, QgsProcessingContextGenerator
 {
 %Docstring(signature="appended")
 Base class for processing algorithm dialogs.

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -34,7 +34,13 @@ Base class for processing algorithm dialogs.
       FormatHtml,
     };
 
-    QgsProcessingAlgorithmDialogBase( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::WindowFlags() );
+    enum class DialogMode
+    {
+      Single,
+      Batch,
+    };
+
+    QgsProcessingAlgorithmDialogBase( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::WindowFlags(), QgsProcessingAlgorithmDialogBase::DialogMode mode = QgsProcessingAlgorithmDialogBase::DialogMode::Single );
 %Docstring
 Constructor for QgsProcessingAlgorithmDialogBase.
 %End

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -61,7 +61,7 @@ An interface for objects which can create sets of parameter values for processin
 This method needs to be reimplemented in all classes which implement this interface
 and return a algorithm parameters.
 
-Since QGIS 3.24 the optional ``flags`` argument can be used to control the behaviour
+Since QGIS 3.24 the optional ``flags`` argument can be used to control the behavior
 of the parameter generation.
 %End
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -49,14 +49,27 @@ An interface for objects which can create sets of parameter values for processin
 %End
   public:
 
-    virtual QVariantMap createProcessingParameters() = 0;
+    enum class Flag
+    {
+      SkipDefaultValueParameters,
+    };
+    typedef QFlags<QgsProcessingParametersGenerator::Flag> Flags;
+
+
+    virtual QVariantMap createProcessingParameters( QgsProcessingParametersGenerator::Flags flags = QgsProcessingParametersGenerator::Flags() ) = 0;
 %Docstring
 This method needs to be reimplemented in all classes which implement this interface
 and return a algorithm parameters.
+
+Since QGIS 3.24 the optional ``flags`` argument can be used to control the behaviour
+of the parameter generation.
 %End
 
     virtual ~QgsProcessingParametersGenerator();
 };
+
+QFlags<QgsProcessingParametersGenerator::Flag> operator|(QgsProcessingParametersGenerator::Flag f1, QFlags<QgsProcessingParametersGenerator::Flag> f2);
+
 
 
 class QgsProcessingParameterWidgetContext

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -37,7 +37,8 @@ from qgis.core import (Qgis,
                        QgsProxyProgressTask,
                        QgsProcessingFeatureSourceDefinition)
 from qgis.gui import (QgsGui,
-                      QgsProcessingAlgorithmDialogBase)
+                      QgsProcessingAlgorithmDialogBase,
+                      QgsProcessingParametersGenerator)
 from qgis.utils import iface
 
 from processing.core.ProcessingLog import ProcessingLog
@@ -109,11 +110,11 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
     def setParameters(self, parameters):
         self.mainWidget().setParameters(parameters)
 
-    def createProcessingParameters(self, include_default=True):
+    def createProcessingParameters(self, flags=QgsProcessingParametersGenerator.Flags()):
         if self.mainWidget() is None:
             return {}
-        else:
-            return self.mainWidget().createProcessingParameters(include_default)
+
+        return self.mainWidget().createProcessingParameters(flags)
 
     def runAlgorithm(self):
         self.feedback = self.createFeedback()

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -38,7 +38,8 @@ from qgis.core import (Qgis,
                        QgsProcessingFeatureSourceDefinition)
 from qgis.gui import (QgsGui,
                       QgsProcessingAlgorithmDialogBase,
-                      QgsProcessingParametersGenerator)
+                      QgsProcessingParametersGenerator,
+                      QgsProcessingContextGenerator)
 from qgis.utils import iface
 
 from processing.core.ProcessingLog import ProcessingLog
@@ -154,6 +155,13 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         except AlgorithmDialogBase.InvalidOutputExtension as e:
             self.flag_invalid_output_extension(e.message, e.widget)
         return {}
+
+    def processingContext(self):
+        if self.context is None:
+            self.feedback = self.createFeedback()
+            self.context = dataobjects.createContext(self.feedback)
+            self.context.setLogLevel(self.logLevel())
+        return self.context
 
     def runAlgorithm(self):
         self.feedback = self.createFeedback()

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -65,7 +65,7 @@ class BatchFeedback(QgsProcessingMultiStepFeedback):
 class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
     def __init__(self, alg, parent=None):
-        super().__init__(parent)
+        super().__init__(parent, mode=QgsProcessingAlgorithmDialogBase.DialogMode.Batch)
 
         self.setAlgorithm(alg)
 

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -77,6 +77,7 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.btnRunSingle.clicked.connect(self.runAsSingle)
         self.buttonBox().addButton(self.btnRunSingle, QDialogButtonBox.ResetRole)  # reset role to ensure left alignment
 
+        self.context = None
         self.updateRunButtonVisibility()
 
     def runAsSingle(self):
@@ -92,6 +93,13 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
     def blockAdditionalControlsWhileRunning(self):
         self.btnRunSingle.setEnabled(False)
+
+    def processingContext(self):
+        if self.context is None:
+            self.feedback = self.createFeedback()
+            self.context = dataobjects.createContext(self.feedback)
+            self.context.setLogLevel(self.logLevel())
+        return self.context
 
     def runAlgorithm(self):
         alg_parameters = []

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -198,7 +198,8 @@ class ParametersPanel(QgsProcessingParametersWidget):
         for wrapper in list(self.wrappers.values()):
             wrapper.postInitialize(list(self.wrappers.values()))
 
-    def createProcessingParameters(self, include_default=True):
+    def createProcessingParameters(self, flags=QgsProcessingParametersGenerator.Flags()):
+        include_default = not (flags & QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters)
         parameters = {}
         for p, v in self.extra_parameters.items():
             parameters[p] = v

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -47,7 +47,8 @@ from qgis.gui import (QgsProcessingParameterDefinitionDialog,
                       QgsProcessingParameterWidgetContext,
                       QgsModelGraphicsScene,
                       QgsModelDesignerDialog,
-                      QgsProcessingContextGenerator)
+                      QgsProcessingContextGenerator,
+                      QgsProcessingParametersGenerator)
 from processing.gui.HelpEditionDialog import HelpEditionDialog
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from processing.modeler.ModelerParameterDefinitionDialog import ModelerParameterDefinitionDialog
@@ -159,7 +160,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         dlg.exec_()
 
         if dlg.wasExecuted():
-            self.model().setDesignerParameterValues(dlg.createProcessingParameters(include_default=False))
+            self.model().setDesignerParameterValues(dlg.createProcessingParameters(flags=QgsProcessingParametersGenerator.Flags(QgsProcessingParametersGenerator.Flag.SkipDefaultValueParameters)))
 
     def saveInProject(self):
         if not self.validateSave():

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -86,8 +86,9 @@ void QgsProcessingAlgorithmDialogFeedback::pushConsoleInfo( const QString &info 
 // QgsProcessingAlgorithmDialogBase
 //
 
-QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *parent, Qt::WindowFlags flags )
+QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *parent, Qt::WindowFlags flags, DialogMode mode )
   : QDialog( parent, flags )
+  , mMode( mode )
 {
   setupUi( this );
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -81,7 +81,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
  * \note This is not considered stable API and may change in future QGIS versions.
  * \since QGIS 3.0
  */
-class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsProcessingParametersGenerator, private Ui::QgsProcessingDialogBase
+class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsProcessingParametersGenerator, public QgsProcessingContextGenerator, private Ui::QgsProcessingDialogBase
 {
     Q_OBJECT
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -419,6 +419,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     QByteArray mSplitterState;
     QToolButton *mButtonCollapse = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
+    QPushButton *mAdvancedButton = nullptr;
+    QMenu *mAdvancedMenu = nullptr;
 
     bool mExecuted = false;
     bool mExecutedAnyResult = false;

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -98,9 +98,21 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     };
 
     /**
+     * Dialog modes.
+     *
+     * \since QGIS 3.24
+     */
+    enum class DialogMode : int
+    {
+      Single, //!< Single algorithm execution mode
+      Batch, //!< Batch processing mode
+    };
+    Q_ENUM( QgsProcessingAlgorithmDialogBase::DialogMode )
+
+    /**
      * Constructor for QgsProcessingAlgorithmDialogBase.
      */
-    QgsProcessingAlgorithmDialogBase( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
+    QgsProcessingAlgorithmDialogBase( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::WindowFlags(), QgsProcessingAlgorithmDialogBase::DialogMode mode = QgsProcessingAlgorithmDialogBase::DialogMode::Single );
     ~QgsProcessingAlgorithmDialogBase() override;
 
     /**
@@ -398,6 +410,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, public QgsPr
     void closeClicked();
 
   private:
+
+    DialogMode mMode = DialogMode::Single;
 
     QPushButton *mButtonRun = nullptr;
     QPushButton *mButtonClose = nullptr;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsProcessingParametersGenerator
      * This method needs to be reimplemented in all classes which implement this interface
      * and return a algorithm parameters.
      *
-     * Since QGIS 3.24 the optional \a flags argument can be used to control the behaviour
+     * Since QGIS 3.24 the optional \a flags argument can be used to control the behavior
      * of the parameter generation.
      */
     virtual QVariantMap createProcessingParameters( QgsProcessingParametersGenerator::Flags flags = QgsProcessingParametersGenerator::Flags() ) = 0;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -77,13 +77,29 @@ class GUI_EXPORT QgsProcessingParametersGenerator
   public:
 
     /**
+     * Flags controlling parameter generation.
+     *
+     * \since QGIS 3.24
+     */
+    enum class Flag : int
+    {
+      SkipDefaultValueParameters = 1 << 0, //!< Parameters which are unchanged from their default values should not be included
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    /**
      * This method needs to be reimplemented in all classes which implement this interface
      * and return a algorithm parameters.
+     *
+     * Since QGIS 3.24 the optional \a flags argument can be used to control the behaviour
+     * of the parameter generation.
      */
-    virtual QVariantMap createProcessingParameters() = 0;
+    virtual QVariantMap createProcessingParameters( QgsProcessingParametersGenerator::Flags flags = QgsProcessingParametersGenerator::Flags() ) = 0;
 
     virtual ~QgsProcessingParametersGenerator() = default;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingParametersGenerator::Flags )
 
 
 /**


### PR DESCRIPTION
Adds an advanced button to the toolbox algorithm dialog, which contains an option to copy the equivalent Python command as the parameters define in the dialog.

While this command is also available from the history dialog, the advanced button provides a way for users to generate these
commands WITHOUT actually having to run the algorithm in advance.

This menu will be extended with additional items (such as copy parameter as json, paste parameters, copy as qgis_process command) in follow up PRs.

Sponsored by the Research Institute for Nature and Forest, Flemish Govt