### PR TITLE
Expose layers field names to expression widget

### DIFF
--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -68,6 +68,7 @@ Gets the type of expression item, e.g., header, field, ExpressionNode.
     static const int ITEM_TYPE_ROLE;
     static const int SEARCH_TAGS_ROLE;
     static const int ITEM_NAME_ROLE;
+    static const int LAYER_ID_ROLE;
 
 };
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -507,16 +507,16 @@ void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QStrin
   // This is not maintained and setLayer() should be used instead.
 }
 
-void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues )
+void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, QgsVectorLayer *layer, int countLimit, bool forceUsedValues )
 {
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  if ( !mLayer )
+  if ( !layer )
     return;
 
   // TODO We should thread this so that we don't hold the user up if the layer is massive.
 
-  const QgsFields fields = mLayer->fields();
+  const QgsFields fields = layer->fields();
   int fieldIndex = fields.lookupField( fieldName );
 
   if ( fieldIndex < 0 )
@@ -534,7 +534,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   }
   else
   {
-    values = qgis::setToList( mLayer->uniqueValues( fieldIndex, countLimit ) );
+    values = qgis::setToList( layer->uniqueValues( fieldIndex, countLimit ) );
   }
   std::sort( values.begin(), values.end() );
 
@@ -564,7 +564,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
     else
       strValue = '\'' + value.toString().replace( '\'', QLatin1String( "''" ) ) + '\'';
 
-    QString representedValue = formatter->representValue( mLayer, fieldIndex, setup.config(), QVariant(), value );
+    QString representedValue = formatter->representValue( layer, fieldIndex, setup.config(), QVariant(), value );
     if ( forceRepresentedValue || representedValue != value.toString() )
       representedValue = representedValue + QStringLiteral( " [" ) + strValue + ']';
 
@@ -852,11 +852,20 @@ void QgsExpressionBuilderWidget::loadSampleValues()
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  if ( !mLayer || !item )
+  QgsVectorLayer *layer = nullptr;
+  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  {
+    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
+  }
+  else
+  {
+    layer = mLayer;
+  }
+  if ( !layer || !item )
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), 10 );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, 10 );
 }
 
 void QgsExpressionBuilderWidget::loadAllValues()
@@ -864,11 +873,20 @@ void QgsExpressionBuilderWidget::loadAllValues()
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  if ( !mLayer || !item )
+  QgsVectorLayer *layer = nullptr;
+  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  {
+    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
+  }
+  else
+  {
+    layer = mLayer;
+  }
+  if ( !layer || !item )
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), -1 );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, -1 );
 }
 
 void QgsExpressionBuilderWidget::loadSampleUsedValues()
@@ -876,11 +894,20 @@ void QgsExpressionBuilderWidget::loadSampleUsedValues()
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  if ( !mLayer || !item )
+  QgsVectorLayer *layer = nullptr;
+  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  {
+    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
+  }
+  else
+  {
+    layer = mLayer;
+  }
+  if ( !layer || !item )
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), 10, true );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, 10, true );
 }
 
 void QgsExpressionBuilderWidget::loadAllUsedValues()
@@ -888,11 +915,20 @@ void QgsExpressionBuilderWidget::loadAllUsedValues()
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  if ( !mLayer || !item )
+  QgsVectorLayer *layer = nullptr;
+  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  {
+    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
+  }
+  else
+  {
+    layer = mLayer;
+  }
+  if ( !layer || !item )
     return;
 
   mValueGroupBox->show();
-  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), -1, true );
+  fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, -1, true );
 }
 
 void QgsExpressionBuilderWidget::txtPython_textChanged()

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -352,6 +352,21 @@ void QgsExpressionBuilderWidget::runPythonCode( const QString &code )
   mExpressionTreeView->refresh();
 }
 
+QgsVectorLayer *QgsExpressionBuilderWidget::contextLayer( const QgsExpressionItem *item ) const
+{
+  QgsVectorLayer *layer = nullptr;
+  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  {
+    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
+  }
+  else
+  {
+    layer = mLayer;
+  }
+  return layer;
+}
+
+
 void QgsExpressionBuilderWidget::saveFunctionFile( QString fileName )
 {
   QDir myDir( mFunctionsPath );
@@ -850,19 +865,18 @@ void QgsExpressionBuilderWidget::operatorButtonClicked()
 void QgsExpressionBuilderWidget::loadSampleValues()
 {
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
+  if ( ! item )
+  {
+    return;
+  }
+
+  QgsVectorLayer *layer { contextLayer( item ) };
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  QgsVectorLayer *layer = nullptr;
-  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  if ( !layer )
   {
-    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
-  }
-  else
-  {
-    layer = mLayer;
-  }
-  if ( !layer || !item )
     return;
+  }
 
   mValueGroupBox->show();
   fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, 10 );
@@ -871,19 +885,18 @@ void QgsExpressionBuilderWidget::loadSampleValues()
 void QgsExpressionBuilderWidget::loadAllValues()
 {
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
+  if ( ! item )
+  {
+    return;
+  }
+
+  QgsVectorLayer *layer { contextLayer( item ) };
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  QgsVectorLayer *layer = nullptr;
-  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  if ( !layer )
   {
-    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
-  }
-  else
-  {
-    layer = mLayer;
-  }
-  if ( !layer || !item )
     return;
+  }
 
   mValueGroupBox->show();
   fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, -1 );
@@ -892,19 +905,18 @@ void QgsExpressionBuilderWidget::loadAllValues()
 void QgsExpressionBuilderWidget::loadSampleUsedValues()
 {
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
+  if ( ! item )
+  {
+    return;
+  }
+
+  QgsVectorLayer *layer { contextLayer( item ) };
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  QgsVectorLayer *layer = nullptr;
-  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  if ( !layer )
   {
-    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
-  }
-  else
-  {
-    layer = mLayer;
-  }
-  if ( !layer || !item )
     return;
+  }
 
   mValueGroupBox->show();
   fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, 10, true );
@@ -913,19 +925,18 @@ void QgsExpressionBuilderWidget::loadSampleUsedValues()
 void QgsExpressionBuilderWidget::loadAllUsedValues()
 {
   QgsExpressionItem *item = mExpressionTreeView->currentItem();
+  if ( ! item )
+  {
+    return;
+  }
+
+  QgsVectorLayer *layer { contextLayer( item ) };
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
-  QgsVectorLayer *layer = nullptr;
-  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  if ( !layer )
   {
-    layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
-  }
-  else
-  {
-    layer = mLayer;
-  }
-  if ( !layer || !item )
     return;
+  }
 
   mValueGroupBox->show();
   fillFieldValues( item->data( QgsExpressionItem::ITEM_NAME_ROLE ).toString(), layer, -1, true );

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -419,6 +419,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void clearFunctionMarkers();
     void clearErrors();
     void runPythonCode( const QString &code );
+    QgsVectorLayer *contextLayer( const QgsExpressionItem *item ) const;
     void fillFieldValues( const QString &fieldName, QgsVectorLayer *layer, int countLimit, bool forceUsedValues = false );
     QString getFunctionHelp( QgsExpressionFunction *function );
     QString loadFunctionHelp( QgsExpressionItem *functionName );

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -419,7 +419,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void clearFunctionMarkers();
     void clearErrors();
     void runPythonCode( const QString &code );
-    void fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues = false );
+    void fillFieldValues( const QString &fieldName, QgsVectorLayer *layer, int countLimit, bool forceUsedValues = false );
     QString getFunctionHelp( QgsExpressionFunction *function );
     QString loadFunctionHelp( QgsExpressionItem *functionName );
     QString helpStylesheet() const;

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -98,6 +98,8 @@ class GUI_EXPORT QgsExpressionItem : public QStandardItem
     static const int SEARCH_TAGS_ROLE = Qt::UserRole + 3;
     //! Item name role
     static const int ITEM_NAME_ROLE = Qt::UserRole + 4;
+    //! Layer ID role \since QGIS 3.24
+    static const int LAYER_ID_ROLE = Qt::UserRole + 5;
 
   private:
     QString mExpressionText;
@@ -318,13 +320,13 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
      * \param tags tags to find function
      * \param name name of the item
      */
-    void registerItem( const QString &group, const QString &label, const QString &expressionText,
-                       const QString &helpText = QString(),
-                       QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                       bool highlightedItem = false, int sortOrder = 1,
-                       const QIcon &icon = QIcon(),
-                       const QStringList &tags = QStringList(),
-                       const QString &name = QString() );
+    QgsExpressionItem *registerItem( const QString &group, const QString &label, const QString &expressionText,
+                                     const QString &helpText = QString(),
+                                     QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
+                                     bool highlightedItem = false, int sortOrder = 1,
+                                     const QIcon &icon = QIcon(),
+                                     const QStringList &tags = QStringList(),
+                                     const QString &name = QString() );
 
     /**
      * Registers a node item for the expression builder, adding multiple items when the function exists in multiple groups
@@ -345,6 +347,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     void loadExpressionContext();
     void loadRelations();
     void loadLayers();
+    void loadLayerFields( QgsVectorLayer *layer, QgsExpressionItem *parentItem );
     void loadFieldNames();
 
     /**


### PR DESCRIPTION
Fixes #37544

Note that the field names are pasted as strings `'field_name'` and not as field references `"field_name"` because they do not belong to the current layer.

IMO there is no need for async loading: the fields are already available in the layer instances and they are fast to retrieve.

![expression_layer_fields](https://user-images.githubusercontent.com/142164/146177919-8a235423-a131-4e9a-a999-06cb449666f7.png)


Funded by: ARPA Piemonte