### PR TITLE
Follow up PR #46505: fix crasher

### DIFF
--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -423,8 +423,11 @@ void QgsExpressionTreeView::loadLayers()
 
 void QgsExpressionTreeView::loadLayerFields( QgsVectorLayer *layer, QgsExpressionItem *parentItem )
 {
-  const QgsFields fields { layer->fields() };
-  for ( int fieldIdx = 0; fieldIdx < layer->fields().count(); ++fieldIdx )
+  if ( !layer )
+    return;
+
+  const QgsFields fields = layer->fields();
+  for ( int fieldIdx = 0; fieldIdx < fields.count(); ++fieldIdx )
   {
     const QgsField field = fields.at( fieldIdx );
     QIcon icon = fields.iconForField( fieldIdx );


### PR DESCRIPTION
Fix crash when opening the expression builder dialog in a project containing non-vector map layers.