### PR TITLE
Restore accidentaly removed condition from crssync cmake

### DIFF
--- a/src/crssync/CMakeLists.txt
+++ b/src/crssync/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MSVC AND NOT USING_NMAKE)
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/crssync.exe
     DEPENDS crssync
   )
-elseif()
+elseif(CMAKE_CROSSCOMPILING AND NOT MXE)
   set(NATIVE_CRSSYNC_BIN CACHE PATH "Path to a natively compiled synccrsdb binary")
   if(NOT NATIVE_CRSSYNC_BIN)
     message(FATAL_ERROR "NATIVE_CRSSYNC_BIN needs to be defined when cross-compiling")


### PR DESCRIPTION
During modernisation of CMake files (https://github.com/qgis/QGIS/commit/eddf6feb4518da3ed5bb6d8f4ece532e61832754) condition in `elseif()` statement has been removed. PR just restores the original condition.

See the accidental removal here: https://github.com/qgis/QGIS/commit/eddf6feb4518da3ed5bb6d8f4ece532e61832754#diff-e398564a4cbf096ae7d2c437ac95ba5087f695a59af5e074bd52ddce9f511475L26-R26 (line 26)

Please backport to 3.22