### PR TITLE
[georeferencer] Fix reprojecting projected raster

### DIFF
--- a/src/app/georeferencer/qgsgeoreftransform.cpp
+++ b/src/app/georeferencer/qgsgeoreftransform.cpp
@@ -98,7 +98,7 @@ bool QgsGeorefTransform::updateParametersFromGcps( const QVector<QgsPointXY> &so
   if ( mRasterChangeCoords.hasCrs() )
   {
     const QVector<QgsPointXY> pixelCoordsCorrect = mRasterChangeCoords.getPixelCoords( sourceCoordinates );
-    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( sourceCoordinates, pixelCoordsCorrect, invertYAxis );
+    mParametersInitialized = mGeorefTransformImplementation->updateParametersFromGcps( pixelCoordsCorrect, destinationCoordinates, invertYAxis );
   }
   else
   {


### PR DESCRIPTION
## Description

The previous code used the bad raster coordinates as the source and the raster index values as the destination.

This is what caused the faulty behaviour.

Fixes #46414 