### PR TITLE
Check file existance in QgsFileWidget - Fixes #46077

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -281,7 +281,7 @@ void QgsFileWidget::openFileDialog()
 
   // if we use a relative path option, we need to obtain the full path
   // first choice is the current file path, if one is entered
-  if ( !mFilePath.isEmpty() && QFile( mFilePath ).exists() )
+  if ( !mFilePath.isEmpty() && QFile::exists( mFilePath ) )
   {
     oldPath = relativePath( mFilePath, false );
   }

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -281,7 +281,7 @@ void QgsFileWidget::openFileDialog()
 
   // if we use a relative path option, we need to obtain the full path
   // first choice is the current file path, if one is entered
-  if ( !mFilePath.isEmpty() )
+  if ( !mFilePath.isEmpty() && QFile( mFilePath ).exists() )
   {
     oldPath = relativePath( mFilePath, false );
   }


### PR DESCRIPTION
## Description

This MR fixes #46077 

---

Currently the behavior of the QgsFileWidget browse button depends on the text already in the file text zone :

- If the text is an existing file, the browse window opens 
  - in the file directory, the file is selected
- If the text is empty, the browse windows opens
  - in the default root path if the default root path is specified
  - in the last browsed path if it's not the first time the browse window is opened
  - in the project directory if it's the first time the browse window is opened
- if the text is not an existing file but still something, the browser opens
  - in a system-dependent default path (decided by QFileDialog.getOpenFileName method)

This MR aims to handle the following cases:
- if the QgsFileWidget text is not empty and not an existing directory/file --> treat as if the text is empty


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
