### PR TITLE
Added support for suppressing bad layers handler on startup. 

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -148,6 +148,7 @@ void usage( const QString &appName )
       << QStringLiteral( "\t[--nologo]\thide splash screen\n" )
       << QStringLiteral( "\t[--noversioncheck]\tdon't check for new version of QGIS at startup\n" )
       << QStringLiteral( "\t[--noplugins]\tdon't restore plugins on startup\n" )
+      << QStringLiteral( "\t[--skipbadlayers]\tdon't prompt for missing layers\n" )
       << QStringLiteral( "\t[--nocustomization]\tdon't apply GUI customization\n" )
       << QStringLiteral( "\t[--customizationfile path]\tuse the given ini file as GUI customization\n" )
       << QStringLiteral( "\t[--globalsettingsfile path]\tuse the given ini file as Global Settings (defaults)\n" )
@@ -575,6 +576,7 @@ int main( int argc, char *argv[] )
 
   bool myRestoreDefaultWindowState = false;
   bool myRestorePlugins = true;
+  bool mySkipBadLayers = false;
   bool myCustomization = true;
 
   QString dxfOutputFile;
@@ -662,6 +664,11 @@ int main( int argc, char *argv[] )
         else if ( arg == QLatin1String( "--noplugins" ) || arg == QLatin1String( "-P" ) )
         {
           myRestorePlugins = false;
+        }
+        else if ( arg == QLatin1String( "--skipbadlayers" ) || arg == QLatin1String( "-B" ) )
+        {
+          QgsDebugMsg( QStringLiteral( "Skipping bad layers" ) );
+          mySkipBadLayers = true;
         }
         else if ( arg == QLatin1String( "--nocustomization" ) || arg == QLatin1String( "-C" ) )
         {
@@ -1381,7 +1388,7 @@ int main( int argc, char *argv[] )
   // this should be done in QgsApplication::init() but it doesn't know the settings dir.
   QgsApplication::setMaxThreads( settings.value( QStringLiteral( "qgis/max_threads" ), -1 ).toInt() );
 
-  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, mySkipVersionCheck, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
+  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, mySkipBadLayers, mySkipVersionCheck, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( QStringLiteral( "QgisApp" ) );
 
   myApp.connect(

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -926,7 +926,7 @@ static bool cmpByText_( QAction *a, QAction *b )
 QgisApp *QgisApp::sInstance = nullptr;
 
 // constructor starts here
-QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCheck, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
+QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers, bool skipVersionCheck, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
   , mSplash( splash )
 {
@@ -938,7 +938,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
       tr( "Multiple instances of QGIS application object detected.\nPlease contact the developers.\n" ) );
     abort();
   }
-
+  this->skipBadLayers = skipBadLayers;
   sInstance = this;
   QgsRuntimeProfiler *profiler = QgsApplication::profiler();
 
@@ -1484,8 +1484,12 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsHtmlDataItemProvider() );
 
   // set handler for missing layers (will be owned by QgsProject)
-  mAppBadLayersHandler = new QgsHandleBadLayersHandler();
-  QgsProject::instance()->setBadLayerHandler( mAppBadLayersHandler );
+  if ( ! this->skipBadLayers )
+  {
+    QgsDebugMsg( QStringLiteral( "NOT creating bad layers handler" ) );
+    mAppBadLayersHandler = new QgsHandleBadLayersHandler();
+    QgsProject::instance()->setBadLayerHandler( mAppBadLayersHandler );
+  }
 
   mSplash->showMessage( tr( "Starting Python" ), Qt::AlignHCenter | Qt::AlignBottom, splashTextColor );
   qApp->processEvents();
@@ -7020,8 +7024,13 @@ bool QgisApp::addProject( const QString &projectFile )
   bool returnCode = false;
   std::unique_ptr< QgsProjectDirtyBlocker > dirtyBlocker = std::make_unique< QgsProjectDirtyBlocker >( QgsProject::instance() );
   QObject connectionScope; // manually control scope of layersChanged lambda connection - we need the connection automatically destroyed when this function finishes
+
   bool badLayersHandled = false;
-  connect( mAppBadLayersHandler, &QgsHandleBadLayersHandler::layersChanged, &connectionScope, [&badLayersHandled] { badLayersHandled = true; } );
+  if ( ! this->skipBadLayers )
+  {
+    QgsDebugMsg( QStringLiteral( "NOT Skipping bad layers" ) );
+    connect( mAppBadLayersHandler, &QgsHandleBadLayersHandler::layersChanged, &connectionScope, [&badLayersHandled] { badLayersHandled = true; } );
+  }
 
   // close the previous opened project if any
   closeProject();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -938,7 +938,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
       tr( "Multiple instances of QGIS application object detected.\nPlease contact the developers.\n" ) );
     abort();
   }
-  this->skipBadLayers = skipBadLayers;
+  mSkipBadLayers = skipBadLayers;
   sInstance = this;
   QgsRuntimeProfiler *profiler = QgsApplication::profiler();
 
@@ -1484,7 +1484,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsHtmlDataItemProvider() );
 
   // set handler for missing layers (will be owned by QgsProject)
-  if ( ! this->skipBadLayers )
+  if ( !mSkipBadLayers )
   {
     QgsDebugMsg( QStringLiteral( "NOT creating bad layers handler" ) );
     mAppBadLayersHandler = new QgsHandleBadLayersHandler();
@@ -7026,7 +7026,7 @@ bool QgisApp::addProject( const QString &projectFile )
   QObject connectionScope; // manually control scope of layersChanged lambda connection - we need the connection automatically destroyed when this function finishes
 
   bool badLayersHandled = false;
-  if ( ! this->skipBadLayers )
+  if ( !mSkipBadLayers )
   {
     QgsDebugMsg( QStringLiteral( "NOT Skipping bad layers" ) );
     connect( mAppBadLayersHandler, &QgsHandleBadLayersHandler::layersChanged, &connectionScope, [&badLayersHandled] { badLayersHandled = true; } );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2074,7 +2074,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
   private:
     //Flag to allow user to bypass badlayer checks.
-    bool skipBadLayers;
+    bool mSkipBadLayers;
     void createPreviewImage( const QString &path, const QIcon &overlayIcon = QIcon() );
     void startProfile( const QString &name );
     void endProfile();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -202,7 +202,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     Q_OBJECT
   public:
     //! Constructor
-    QgisApp( QSplashScreen *splash, bool restorePlugins = true,
+    QgisApp( QSplashScreen *splash, bool restorePlugins = true, bool skipBadLayers = false,
              bool skipVersionCheck = false, const QString &rootProfileLocation = QString(),
              const QString &activeProfile = QString(),
              QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Window );
@@ -213,6 +213,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgisApp( QgisApp const & ) = delete;
     QgisApp &operator=( QgisApp const & ) = delete;
+
 
     /**
      * Returns and adjusted uri for the layer based on current and available CRS as well as the last selected image format
@@ -2072,6 +2073,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activeLayerChanged( QgsMapLayer *layer );
 
   private:
+    //Flag to allow user to bypass badlayer checks.
+    bool skipBadLayers;
     void createPreviewImage( const QString &path, const QIcon &overlayIcon = QIcon() );
     void startProfile( const QString &name );
     void endProfile();


### PR DESCRIPTION
Shout out to Giuseppe Baiamonte on the QGIS Open Day 17 Dec 2021

## Description

Added support for a new command line flag 

```
[--skipbadlayers]       don't prompt for missing layers
```

example invocation:

```
./qgis --skipbadlayers
```
or

```
./qgis -B
```



The use case for this is that sometimes users have automation or other post-startup processes happen and do not want to have the startup process interrupted if there are bad layers present in the project. After startup, QGIS will ignore any missing layers, but they will still be marked in the layers list e.g.

![image](https://user-images.githubusercontent.com/178003/146592374-fe7492e9-3e64-4346-bd9d-fbae57aecb4d.png)


