### PR TITLE
[themes] Fix glitched rendering of tab bars with a single tab

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -562,14 +562,14 @@ QTabBar::tab:disabled {
     color: @itemalternativebackground
 }
 
-QTabBar::tab:last
+QTabBar::tab:last, QTabBar::tab::only-one
 {
-    margin-right: 0; /* the last selected tab has nothing to overlap with on the right */
+    margin-right: 0;
 }
 
 QTabBar::tab:first:!selected
 {
-    margin-left: 0px; /* the last selected tab has nothing to overlap with on the right */
+    margin-left: 0px;
 }
 
 QTabBar::tab:bottom {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -564,14 +564,14 @@ QTabBar::tab:disabled {
     color: @itemdarkbackground;
 }
 
-QTabBar::tab:last
+QTabBar::tab:last, QTabBar::tab::only-one
 {
-    margin-right: 0; /* the last selected tab has nothing to overlap with on the right */
+    margin-right: 0;
 }
 
 QTabBar::tab:first:!selected
 {
-  margin-left: 0px; /* the last selected tab has nothing to overlap with on the right */
+    margin-left: 0px;
 }
 
 QTabBar::tab:bottom {


### PR DESCRIPTION
## Description

This PR fixes a glitched rendering on tab bars when those contain a single tab. The single tab would have its right border missing. 

Before (up) vs. PR (bottom):
![image](https://user-images.githubusercontent.com/1728657/146635970-79ca78de-86f9-4367-a59c-aa9f3b800c89.png)
