### PR TITLE
[bugfix] remember and revert crs change on cancel

### DIFF
--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -80,6 +80,8 @@ QgsAnnotationLayerProperties::QgsAnnotationLayerProperties( QgsAnnotationLayer *
 
   buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
 
+  mBackupCrs = mLayer->crs();
+
   if ( !mLayer->styleManager()->isDefault( mLayer->styleManager()->currentStyle() ) )
     title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
   restoreOptionsBaseUi( title );
@@ -115,6 +117,8 @@ void QgsAnnotationLayerProperties::apply()
   mLayer->setMaximumScale( mScaleRangeWidget->maximumScale() );
   mLayer->setMinimumScale( mScaleRangeWidget->minimumScale() );
 
+  mBackupCrs = mLayer->crs();
+
   // set the blend mode and opacity for the layer
   mBlendModeComboBox->setShowClippingModes( QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject::instance(), mLayer ) );
   mLayer->setBlendMode( mBlendModeComboBox->blendMode() );
@@ -131,6 +135,9 @@ void QgsAnnotationLayerProperties::apply()
 
 void QgsAnnotationLayerProperties::onCancel()
 {
+  if ( mBackupCrs != mLayer->crs() )
+    mLayer->setCrs( mBackupCrs );
+
   if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
   {
     // need to reset style to previous - style applied directly to the layer (not in apply())

--- a/src/app/annotations/qgsannotationlayerproperties.h
+++ b/src/app/annotations/qgsannotationlayerproperties.h
@@ -78,6 +78,8 @@ class QgsAnnotationLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 
+    QgsCoordinateReferenceSystem mBackupCrs;
+
 };
 
 #endif // QGSANNOTATIONLAYERPROPERTIES_H

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -105,6 +105,8 @@ QgsPointCloudLayerProperties::QgsPointCloudLayerProperties( QgsPointCloudLayer *
   mStatisticsTableView->setModel( new QgsPointCloudAttributeStatisticsModel( mLayer, mStatisticsTableView ) );
   mStatisticsTableView->verticalHeader()->hide();
 
+  mBackupCrs = mLayer->crs();
+
   if ( mLayer->dataProvider() && !mLayer->dataProvider()->metadataClasses( QStringLiteral( "Classification" ) ).isEmpty() )
   {
     mClassificationStatisticsTableView->setModel( new QgsPointCloudClassificationStatisticsModel( mLayer, QStringLiteral( "Classification" ), mStatisticsTableView ) );
@@ -146,6 +148,7 @@ void QgsPointCloudLayerProperties::apply()
   mMetadataWidget->acceptMetadata();
 
   mLayer->setName( mLayerOrigNameLineEdit->text() );
+  mBackupCrs = mLayer->crs();
 
   for ( QgsMapLayerConfigWidget *w : mConfigWidgets )
     w->apply();
@@ -155,6 +158,9 @@ void QgsPointCloudLayerProperties::apply()
 
 void QgsPointCloudLayerProperties::onCancel()
 {
+  if ( mBackupCrs != mLayer->crs() )
+    mLayer->setCrs( mBackupCrs );
+
   if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
   {
     // need to reset style to previous - style applied directly to the layer (not in apply())

--- a/src/app/pointcloud/qgspointcloudlayerproperties.h
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.h
@@ -139,6 +139,8 @@ class QgsPointCloudLayerProperties : public QgsOptionsDialogBase, private Ui::Qg
 
     QList<QgsMapLayerConfigWidget *> mConfigWidgets;
 
+    QgsCoordinateReferenceSystem mBackupCrs;
+
 };
 
 #endif // QGSPOINTCLOUDLAYERPROPERTIES_H

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -80,6 +80,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   connect( lyr->styleManager(), &QgsMapLayerStyleManager::currentStyleChanged, this, &QgsMeshLayerProperties::syncAndRepaint );
 
   connect( this, &QDialog::accepted, this, &QgsMeshLayerProperties::apply );
+  connect( this, &QDialog::rejected, this, &QgsMeshLayerProperties::onCancel );
   connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsMeshLayerProperties::apply );
 
   connect( mMeshLayer, &QgsMeshLayer::dataChanged, this, &QgsMeshLayerProperties::syncAndRepaint );
@@ -104,6 +105,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   layout->addWidget( mMetadataWidget );
   metadataFrame->setLayout( layout );
   mOptsPage_Metadata->setContentsMargins( 0, 0, 0, 0 );
+  mBackupCrs = mMeshLayer->crs();
 
   mTemporalDateTimeStart->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
   mTemporalDateTimeEnd->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
@@ -394,6 +396,8 @@ void QgsMeshLayerProperties::apply()
 
   mMetadataWidget->acceptMetadata();
 
+  mBackupCrs = mMeshLayer->crs();
+
   if ( needMeshUpdating )
     mMeshLayer->reload();
 
@@ -546,4 +550,10 @@ void QgsMeshLayerProperties::saveMetadataAs()
     myQSettings.setValue( QStringLiteral( "style/lastStyleDir" ), QFileInfo( myOutputFileName ).absolutePath() );
   else
     QMessageBox::information( this, tr( "Save Metadata" ), message );
+}
+
+void QgsMeshLayerProperties::onCancel()
+{
+  if ( mBackupCrs != mMeshLayer->crs() )
+    mMeshLayer->setCrs( mBackupCrs );
 }

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -90,7 +90,7 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void aboutToShowStyleMenu();
     //! Reloads temporal properties from the provider
     void reloadTemporalProperties();
-	//! \brief Called when cancel button is pressed
+    //! \brief Called when cancel button is pressed
     void onCancel();
 
     void onTimeReferenceChange();
@@ -131,7 +131,7 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     void showHelp();
 
-	QgsCoordinateReferenceSystem mBackupCrs;
+    QgsCoordinateReferenceSystem mBackupCrs;
 };
 
 

--- a/src/gui/mesh/qgsmeshlayerproperties.h
+++ b/src/gui/mesh/qgsmeshlayerproperties.h
@@ -90,6 +90,8 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     void aboutToShowStyleMenu();
     //! Reloads temporal properties from the provider
     void reloadTemporalProperties();
+	//! \brief Called when cancel button is pressed
+    void onCancel();
 
     void onTimeReferenceChange();
 
@@ -128,6 +130,8 @@ class GUI_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
     friend class TestQgsMeshLayerPropertiesDialog;
 
     void showHelp();
+
+	QgsCoordinateReferenceSystem mBackupCrs;
 };
 
 

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -234,6 +234,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     return;
   }
 
+  mBackupCrs = mRasterLayer->crs();
+
   // Handles window modality raising canvas
   if ( mMapCanvas && mRasterTransparencyWidget->pixelSelectorTool() )
   {
@@ -883,6 +885,7 @@ void QgsRasterLayerProperties::apply()
     mRasterLayer->setRenderer( rendererWidget->renderer() );
   }
 
+  mBackupCrs = mRasterLayer->crs();
   mMetadataWidget->acceptMetadata();
   mMetadataFilled = false;
 
@@ -1798,6 +1801,8 @@ void QgsRasterLayerProperties::onCancel()
     mRasterLayer->importNamedStyle( doc, myMessage );
     syncToLayer();
   }
+  if ( mBackupCrs != mRasterLayer->crs() )
+    mRasterLayer->setCrs( mBackupCrs );
 }
 
 void QgsRasterLayerProperties::showHelp()

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -295,6 +295,6 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
     friend class QgsAppScreenShots;
 
-	QgsCoordinateReferenceSystem mBackupCrs;
+    QgsCoordinateReferenceSystem mBackupCrs;
 };
 #endif

--- a/src/gui/raster/qgsrasterlayerproperties.h
+++ b/src/gui/raster/qgsrasterlayerproperties.h
@@ -294,5 +294,7 @@ class GUI_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QgsExpressionContext mContext;
 
     friend class QgsAppScreenShots;
+
+	QgsCoordinateReferenceSystem mBackupCrs;
 };
 #endif

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -300,6 +300,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     }
   }
 
+  
   mCrsSelector->setCrs( mLayer->crs() );
 
   //insert existing join info
@@ -557,7 +558,7 @@ void QgsVectorLayerProperties::syncToLayer()
 
   // populate the general information
   mLayerOrigNameLineEdit->setText( mLayer->name() );
-
+  mBackupCrs = mLayer->crs();
   //see if we are dealing with a pg layer here
   mSubsetGroupBox->setEnabled( true );
   txtSubsetSQL->setText( mLayer->subsetString() );
@@ -691,7 +692,7 @@ void QgsVectorLayerProperties::apply()
   {
     labelingDialog->writeSettingsToLayer();
   }
-
+  mBackupCrs = mLayer->crs();
   // apply legend settings
   mLegendWidget->applyToLayer();
   mLegendConfigEmbeddedWidget->applyToLayer();
@@ -917,6 +918,9 @@ void QgsVectorLayerProperties::onCancel()
     doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
     mLayer->importNamedStyle( doc, myMessage );
   }
+
+  if ( mBackupCrs != mLayer->crs() )
+    mLayer->setCrs( mBackupCrs );
 }
 
 void QgsVectorLayerProperties::urlClicked( const QUrl &url )
@@ -979,6 +983,7 @@ QString QgsVectorLayerProperties::htmlMetadata()
 
 void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
+
   QgsDatumTransformDialog::run( crs, QgsProject::instance()->crs(), this, mCanvas, tr( "Select Transformation for the vector layer" ) );
   mLayer->setCrs( crs );
   mMetadataFilled = false;

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -300,7 +300,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     }
   }
 
-  
   mCrsSelector->setCrs( mLayer->crs() );
 
   //insert existing join info

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -254,7 +254,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsVectorLayerTemporalPropertiesWidget *mTemporalWidget = nullptr;
 
     QgsProviderSourceWidget *mSourceWidget = nullptr;
-    
+
     QgsCoordinateReferenceSystem mBackupCrs;
 
   private slots:

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -254,6 +254,8 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsVectorLayerTemporalPropertiesWidget *mTemporalWidget = nullptr;
 
     QgsProviderSourceWidget *mSourceWidget = nullptr;
+    
+    QgsCoordinateReferenceSystem mBackupCrs;
 
   private slots:
     void openPanel( QgsPanelWidget *panel );


### PR DESCRIPTION
## Description

Proposal , Fixes ##39556

The layer crs is copied in the dialog at initiation time. 

On apply the backup is refreshed on the current crs.

On cancel if the backup conflicts with the current crs, the backup will be applied to the layer.