### PR TITLE
Allow crash handler to be disabled through cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,24 @@ if(WITH_CORE)
 
   set (WITH_DESKTOP TRUE CACHE BOOL "Determines whether QGIS desktop should be built")
 
+  if(WITH_DESKTOP)
+      if((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID AND NOT IOS))
+	set (CRASH_HANDLER_AVAILABLE TRUE)
+      else()
+	set (CRASH_HANDLER_AVAILABLE FALSE)
+      endif()
+
+      set (WITH_CRASH_HANDLER ${CRASH_HANDLER_AVAILABLE} CACHE BOOL "Determines whether the QGIS crash handler application should be built")
+      if(WITH_CRASH_HANDLER AND NOT CRASH_HANDLER_AVAILABLE)
+	message(FATAL_ERROR "Crash handler cannot be built on this environment. Set WITH_CRASH_HANDLER to false.")
+      endif()
+      if(WITH_CRASH_HANDLER)
+	set (HAVE_CRASH_HANDLER TRUE)    # used in qgsconfig.h
+      else()
+	set (HAVE_CRASH_HANDLER FALSE)    # used in qgsconfig.h
+      endif()
+  endif()
+
   set (WITH_3D FALSE CACHE BOOL "Determines whether QGIS 3D library should be built")
 
   set (WITH_QUICK FALSE CACHE BOOL "Determines whether QGIS Quick library should be built")

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -112,5 +112,7 @@
 #cmakedefine HAS_KDE_QT5_SMALL_CAPS_FIX
 #cmakedefine HAS_KDE_QT5_FONT_STRETCH_FIX
 
+#cmakedefine HAVE_CRASH_HANDLER
+
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,10 @@ if (NOT IOS)
   add_subdirectory(crssync)
 endif()
 
-if ((WIN32 AND NOT MINGW) OR (UNIX AND NOT APPLE AND NOT ANDROID AND NOT IOS))
+if (WITH_CRASH_HANDLER)
   add_subdirectory(crashhandler)
 endif()
+
 add_subdirectory(test)
 
 if (WITH_DESKTOP)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -38,6 +38,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstdarg>
+#include "qgsconfig.h"
 
 #if !defined(Q_OS_WIN)
 #include "sigwatch.h"
@@ -75,6 +76,7 @@ typedef SInt32 SRefCon;
 #include <sys/time.h>
 #endif
 
+#ifdef HAVE_CRASH_HANDLER
 #if defined(__GLIBC__) || defined(__FreeBSD__)
 #define QGIS_CRASH
 #include <unistd.h>
@@ -82,6 +84,7 @@ typedef SInt32 SRefCon;
 #include <csignal>
 #include <sys/wait.h>
 #include <cerrno>
+#endif
 #endif
 
 #include "qgscustomization.h"
@@ -104,7 +107,9 @@ typedef SInt32 SRefCon;
 #include "qgsmapthemes.h"
 #include "qgsvectorlayer.h"
 #include "qgis_app.h"
+#ifdef HAVE_CRASH_HANDLER
 #include "qgscrashhandler.h"
+#endif
 #include "qgsziputils.h"
 #include "qgsversionmigration.h"
 #include "qgsfirstrundialog.h"

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -17567,12 +17567,14 @@ void QgisApp::saveProjectToProjectStorage( const QString &uri )
   }
 }
 
+#ifdef HAVE_CRASH_HANDLER
 void QgisApp::triggerCrashHandler()
 {
 #ifdef Q_OS_WIN
   RaiseException( 0x12345678, 0, 0, nullptr );
 #endif
 }
+#endif
 
 void QgisApp::addTabifiedDockWidget( Qt::DockWidgetArea area, QDockWidget *dockWidget, const QStringList &tabifyWith, bool raiseTab )
 {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1252,11 +1252,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void setMapTipsDelay( int timerInterval );
 
+#ifdef HAVE_CRASH_HANDLER
+
     /**
      * Abort application triggering the crash handler
      * \since QGIS 3.4
      */
     void triggerCrashHandler();
+#endif
 
     //! Create a new file from a template project
     bool fileNewFromTemplate( const QString &fileName );


### PR DESCRIPTION
It can cause issues with some environments, e.g. when building through asan
