### PR TITLE
Improve WFS Capabilities table resizing

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -872,6 +872,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     }
   }
   twWFSLayers->setRowCount( j );
+  twWFSLayers->resizeColumnToContents( 0 );
+  twWFSLayers->resizeColumnToContents( 2 );
   twWFSLayers->verticalHeader()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
   mWCSUrlLineEdit->setText( QgsProject::instance()->readEntry( QStringLiteral( "WCSUrl" ), QStringLiteral( "/" ), QString() ) );

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2825,26 +2825,41 @@
                      </property>
                     </column>
                     <column>
+                     <property name="toolTip">
+                      <string>Layer can be published</string>
+                     </property>
                      <property name="text">
                       <string>Published</string>
                      </property>
                     </column>
                     <column>
+                     <property name="toolTip">
+                      <string>Number of decimal places to consider for geometry precision</string>
+                     </property>
                      <property name="text">
                       <string>Geometry precision</string>
                      </property>
                     </column>
                     <column>
+                     <property name="toolTip">
+                      <string>Allow features to be edited</string>
+                     </property>
                      <property name="text">
                       <string>Update</string>
                      </property>
                     </column>
                     <column>
+                     <property name="toolTip">
+                      <string>Allow addition of new features</string>
+                     </property>
                      <property name="text">
                       <string>Insert</string>
                      </property>
                     </column>
                     <column>
+                     <property name="toolTip">
+                      <string>Allow features to be deleted</string>
+                     </property>
                      <property name="text">
                       <string>Delete</string>
                      </property>
@@ -2854,14 +2869,14 @@
                   <item row="1" column="1">
                    <widget class="QPushButton" name="pbnWFSLayersDeselectAll">
                     <property name="text">
-                     <string>Deselect All</string>
+                     <string>Unpublish All</string>
                     </property>
                    </widget>
                   </item>
                   <item row="1" column="0">
                    <widget class="QPushButton" name="pbnWFSLayersSelectAll">
                     <property name="text">
-                     <string>Select All</string>
+                     <string>Publish All</string>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -2831,7 +2831,7 @@
                     </column>
                     <column>
                      <property name="text">
-                      <string>Geometry precision (decimal places)</string>
+                      <string>Geometry precision</string>
                      </property>
                     </column>
                     <column>


### PR DESCRIPTION
refs #46553 
Open the table with resizing to the "layer" and "geometry precision" columns full content. The latter column is shortened so I add a tooltip to compensate, and add tooltips to other columns also. But I have no idea what these actually mean. @gioman, mind reviewing, please?
Also rename the push buttons to what they actually do (publish, and not select).
Below, the widget when you open the dialog
![wfscapabilities](https://user-images.githubusercontent.com/7983394/147071567-1f3627e2-ea7e-4a7d-8d1e-10d4291cb301.png)
)