### PR TITLE
[bugfix] prevent field collision in Array of Translated Feature

### DIFF
--- a/src/analysis/processing/qgsalgorithmarraytranslatedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmarraytranslatedfeatures.cpp
@@ -211,9 +211,9 @@ QgsWkbTypes::Type QgsArrayTranslatedFeaturesAlgorithm::outputWkbType( QgsWkbType
 
 QgsFields QgsArrayTranslatedFeaturesAlgorithm::outputFields( const QgsFields &inputFields ) const
 {
-  QgsFields output = inputFields;
+  QgsFields output;
   output.append( QgsField( QStringLiteral( "instance" ), QVariant::Int ) );
-  return output;
+  return QgsProcessingUtils::combineFields( inputFields, output );
 }
 
 QgsFeatureSink::SinkFlags QgsArrayTranslatedFeaturesAlgorithm::sinkFlags() const


### PR DESCRIPTION
## Description

As the join by nearest, append was used instead of combineFields, hence why the new values were discarded a no new field was created.

Fixes #43621
