### PR TITLE
Append the style name to output filename instead of an iterative number

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -140,7 +140,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   if ( lyr->styleManager()->styles().count() > 1 )
   {
     mActionSaveStyle = menuStyle->addAction( tr( "Save Current Style…" ) );
-    mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save All Styles…" ) );
+    mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save Styles…" ) );
     connect( mActionSaveMultipleStyles, &QAction::triggered, this, &QgsVectorLayerProperties::saveMultipleStylesAs );
   }
   else

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1273,9 +1273,8 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
       }
     }
 
-    if ( ! stylesSelected.isEmpty() )
+    if ( !stylesSelected.isEmpty() )
     {
-      int styleIndex = 0;
       for ( const QString &styleName : std::as_const( stylesSelected ) )
       {
         bool defaultLoadedFlag = false;
@@ -1290,17 +1289,12 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
             QString message;
             const QString filePath { dlg.outputFilePath() };
             QString safePath { filePath };
-            if ( styleIndex > 0 && stylesSelected.count( ) > 1 )
+            if ( stylesSelected.count() > 1 )
             {
-              int i = 1;
-              while ( QFile::exists( safePath ) )
-              {
-                const QFileInfo fi { filePath };
-                safePath = QString( filePath ).replace( '.' + fi.completeSuffix(), QStringLiteral( "_%1.%2" )
-                                                        .arg( QString::number( i ) )
-                                                        .arg( fi.completeSuffix() ) );
-                i++;
-              }
+              const QFileInfo fi { filePath };
+              safePath = QString( filePath ).replace( '.' + fi.completeSuffix(), QStringLiteral( "_%1.%2" )
+                                                      .arg( styleName )
+                                                      .arg( fi.completeSuffix() ) );
             }
             if ( type == QML )
               message = mLayer->saveNamedStyle( safePath, defaultLoadedFlag, dlg.styleCategories() );
@@ -1360,7 +1354,6 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
             break;
           }
         }
-        styleIndex ++;
       }
       // Restore original style
       mLayer->styleManager()->setCurrentStyle( originalStyle );


### PR DESCRIPTION
when multiple styles are saved simultaneously (fixes #46597)

The logic: if you save multiple styles the output files are appended the style name but if you select only one, no style name appended to the output.
Also rename "save all styles..." button into "save styles..." because you can choose to not save them all.

Todo: Apply the same logic to DB storage?