### PR TITLE
Avoid shrinking of buttons in the Assistant property dialog

### DIFF
--- a/src/ui/qgspropertyassistantwidgetbase.ui
+++ b/src/ui/qgspropertyassistantwidgetbase.ui
@@ -28,7 +28,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>20</height>
+          <height>0</height>
          </size>
         </property>
         <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
Instead of 

https://user-images.githubusercontent.com/7983394/147124645-6c90ff94-51ca-43d6-a994-d07c09f4a31f.mp4

Let's get this

https://user-images.githubusercontent.com/7983394/147124348-11fa4985-5613-4e99-a51a-2a00d70e840f.mp4


