### PR TITLE
Option not to build crssync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,8 @@ if(WITH_CORE)
 
   set (WITH_QGIS_PROCESS TRUE CACHE BOOL "Determines whether the standalone \"qgis_process\" tool should be built")
 
+  set (NATIVE_CRSSYNC_BIN "" CACHE PATH "Path to a natively compiled synccrsdb binary. If set, crssync will not build but use provided bin instead.")
+
   # try to configure and build python bindings by default
   set (WITH_BINDINGS TRUE CACHE BOOL "Determines whether python bindings should be built")
   if (WITH_BINDINGS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,9 +15,8 @@ if (WITH_GUI)
 endif()
 
 add_subdirectory(providers)
-if (NOT IOS)
-  add_subdirectory(crssync)
-endif()
+
+add_subdirectory(crssync)
 
 if (WITH_CRASH_HANDLER)
   add_subdirectory(crashhandler)

--- a/src/crssync/CMakeLists.txt
+++ b/src/crssync/CMakeLists.txt
@@ -1,35 +1,34 @@
-add_executable(crssync main.cpp)
-target_compile_features(crssync PRIVATE cxx_std_17)
-
-target_link_libraries(crssync
-  qgis_core
-  ${PROJ_LIBRARY}
-  ${GDAL_LIBRARY}
-)
-
-if(MSVC AND NOT USING_NMAKE)
-  add_custom_target(synccrsdb
-    COMMENT "Running crssync"
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/crssync.exe
-    DEPENDS crssync
-  )
-elseif(CMAKE_CROSSCOMPILING AND NOT MXE)
-  set(NATIVE_CRSSYNC_BIN CACHE PATH "Path to a natively compiled synccrsdb binary")
-  if(NOT NATIVE_CRSSYNC_BIN)
-    message(FATAL_ERROR "NATIVE_CRSSYNC_BIN needs to be defined when cross-compiling")
-  endif()
+if (NATIVE_CRSSYNC_BIN)
   add_custom_target(synccrsdb
     COMMENT "Running native crssync"
     COMMAND ${NATIVE_CRSSYNC_BIN}
-    DEPENDS crssync
   )
-else()
-  add_custom_target(synccrsdb
-    COMMENT "Running crssync"
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crssync
-    DEPENDS crssync
-  )
-endif()
 
-install(CODE "message(\"Installing crssync ...\")")
-install(TARGETS crssync RUNTIME DESTINATION ${QGIS_LIBEXEC_DIR})
+else ()
+  add_executable(crssync main.cpp)
+  target_compile_features(crssync PRIVATE cxx_std_17)
+
+  target_link_libraries(crssync
+    qgis_core
+    ${PROJ_LIBRARY}
+    ${GDAL_LIBRARY}
+  )
+
+  if(MSVC AND NOT USING_NMAKE)
+    add_custom_target(synccrsdb
+      COMMENT "Running crssync"
+      COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/crssync.exe
+      DEPENDS crssync
+    )
+  else()
+    add_custom_target(synccrsdb
+      COMMENT "Running crssync"
+      COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crssync
+      DEPENDS crssync
+    )
+  endif()
+
+  install(CODE "message(\"Installing crssync ...\")")
+  install(TARGETS crssync RUNTIME DESTINATION ${QGIS_LIBEXEC_DIR})
+
+endif()


### PR DESCRIPTION
Even though `crssync` previously had an option not to be built (via `NATIVE_CRSSYNC_BIN` option), its cmake still executed code that should not be executed when using my own crssync (cmake still added executable). This is a problem mainly when crosscompiling - in this scenario we do not want to build additional targets.

I changed `crssync` so that when `NATIVE_CRSSYNC_BIN` is used, no additional target is built.

Moreover, `CMAKE_CROSSCOMPILING` is not a trustworthy flag mainly when targeting apple devices, see its documentation https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html . 
(see also discussion with @m-kuhn here: https://github.com/qgis/QGIS/pull/46195#discussion_r757387031 )