### PR TITLE
Layout UI fix when click happened during left mouse button holding

### DIFF
--- a/src/gui/layout/qgslayoutruler.cpp
+++ b/src/gui/layout/qgslayoutruler.cpp
@@ -699,6 +699,10 @@ void QgsLayoutRuler::mousePressEvent( QMouseEvent *event )
         createTemporaryGuideItem();
       }
     }
+    else
+    {
+      mDraggingGuideOldPosition = mDraggingGuide->layoutPosition();
+    }
     switch ( mOrientation )
     {
       case Qt::Horizontal:
@@ -802,8 +806,18 @@ void QgsLayoutRuler::mouseReleaseEvent( QMouseEvent *event )
   }
   else if ( event->button() == Qt::RightButton )
   {
-    QMouseEvent leftReleaseEvent( event->type(), event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
-    mouseReleaseEvent( &leftReleaseEvent );
+    if ( mCreatingGuide || mDraggingGuide )
+    {
+      QApplication::restoreOverrideCursor();
+      delete mGuideItem;
+      mGuideItem = nullptr;
+      mCreatingGuide = false;
+      if ( mDraggingGuide )
+      {
+        mDraggingGuide->setLayoutPosition( mDraggingGuideOldPosition );
+      }
+      mDraggingGuide = nullptr;
+    }
     if ( mMenu )
       mMenu->popup( event->globalPos() );
   }

--- a/src/gui/layout/qgslayoutruler.cpp
+++ b/src/gui/layout/qgslayoutruler.cpp
@@ -802,8 +802,8 @@ void QgsLayoutRuler::mouseReleaseEvent( QMouseEvent *event )
   }
   else if ( event->button() == Qt::RightButton )
   {
-    QMouseEvent leftRelease( event->type(), event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
-    mouseReleaseEvent( &leftRelease );
+    QMouseEvent leftReleaseEvent( event->type(), event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
+    mouseReleaseEvent( &leftReleaseEvent );
     if ( mMenu )
       mMenu->popup( event->globalPos() );
   }

--- a/src/gui/layout/qgslayoutruler.cpp
+++ b/src/gui/layout/qgslayoutruler.cpp
@@ -802,6 +802,8 @@ void QgsLayoutRuler::mouseReleaseEvent( QMouseEvent *event )
   }
   else if ( event->button() == Qt::RightButton )
   {
+    QMouseEvent leftRelease( event->type(), event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
+    mouseReleaseEvent( &leftRelease );
     if ( mMenu )
       mMenu->popup( event->globalPos() );
   }

--- a/src/gui/layout/qgslayoutruler.h
+++ b/src/gui/layout/qgslayoutruler.h
@@ -120,6 +120,7 @@ class GUI_EXPORT QgsLayoutRuler: public QWidget
 
     int mDragGuideTolerance = 0;
     QgsLayoutGuide *mDraggingGuide = nullptr;
+    double mDraggingGuideOldPosition;
     QgsLayoutGuide *mHoverGuide = nullptr;
 
     bool mCreatingGuide = false;

--- a/src/gui/layout/qgslayoutruler.h
+++ b/src/gui/layout/qgslayoutruler.h
@@ -120,7 +120,7 @@ class GUI_EXPORT QgsLayoutRuler: public QWidget
 
     int mDragGuideTolerance = 0;
     QgsLayoutGuide *mDraggingGuide = nullptr;
-    double mDraggingGuideOldPosition;
+    double mDraggingGuideOldPosition = 0.0;
     QgsLayoutGuide *mHoverGuide = nullptr;
 
     bool mCreatingGuide = false;

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -70,9 +70,9 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
     if ( mIsSelecting )
     {
       // selection must be ended if a right button press happens, otherwise selection rubberband won't be suppress
-      QMouseEvent leftRelease( QMouseEvent::MouseButtonRelease, event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
-      QgsLayoutViewMouseEvent layoutLeftRelease( view(), &leftRelease );
-      layoutReleaseEvent( &layoutLeftRelease );
+      QMouseEvent leftReleaseEvent( QMouseEvent::MouseButtonRelease, event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
+      QgsLayoutViewMouseEvent layoutLeftReleaseEvent( view(), &leftReleaseEvent );
+      layoutReleaseEvent( &layoutLeftReleaseEvent );
     }
     event->ignore();
     return;

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -67,6 +67,13 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
 
   if ( event->button() != Qt::LeftButton )
   {
+    if ( mIsSelecting )
+    {
+      // selection must be ended if a right button press happens, otherwise selection rubberband won't be suppress
+      QMouseEvent leftRelease( QMouseEvent::MouseButtonRelease, event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
+      QgsLayoutViewMouseEvent layoutLeftRelease( view(), &leftRelease );
+      layoutReleaseEvent( &layoutLeftRelease );
+    }
     event->ignore();
     return;
   }

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -70,9 +70,8 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
     if ( mIsSelecting )
     {
       // selection must be ended if a right button press happens, otherwise selection rubberband won't be suppress
-      QMouseEvent leftReleaseEvent( QMouseEvent::MouseButtonRelease, event->localPos(), Qt::LeftButton, event->buttons(), event->modifiers() );
-      QgsLayoutViewMouseEvent layoutLeftReleaseEvent( view(), &leftReleaseEvent );
-      layoutReleaseEvent( &layoutLeftReleaseEvent );
+      mIsSelecting = false;
+      mRubberBand->finish();
     }
     event->ignore();
     return;

--- a/src/gui/layout/qgslayoutviewtoolselect.cpp
+++ b/src/gui/layout/qgslayoutviewtoolselect.cpp
@@ -69,7 +69,6 @@ void QgsLayoutViewToolSelect::layoutPressEvent( QgsLayoutViewMouseEvent *event )
   {
     if ( mIsSelecting )
     {
-      // selection must be ended if a right button press happens, otherwise selection rubberband won't be suppress
       mIsSelecting = false;
       mRubberBand->finish();
     }

--- a/src/gui/layout/qgslayoutviewtoolzoom.cpp
+++ b/src/gui/layout/qgslayoutviewtoolzoom.cpp
@@ -33,6 +33,11 @@ void QgsLayoutViewToolZoom::layoutPressEvent( QgsLayoutViewMouseEvent *event )
 {
   if ( event->button() != Qt::LeftButton )
   {
+    if ( mMarqueeZoom )
+    {
+      mMarqueeZoom = false;
+      mRubberBand->finish();
+    }
     event->ignore();
     return;
   }


### PR DESCRIPTION
FIX #46568
FIX #46569

## Description

@GisUsers reported some troubles in the layout ui when a click happened during a left mouse button holding operation (see issues above)

### Layout Ruler fix

During a rule creation, left button must be hold to place it and the cursor will change of shape . On a right button release, the QgsLayoutRuler menu pops up and the focus is set on it, so the left button release event won't be received by QgsLayoutRuler. In consequences, the cursor doesn't change of shape back.

### Layout tools fix

On a right click press, the QgsLayoutAppMenuProvider pops up and the focus is set on it instead of the layout. So the left button release event won't be received by QgsLayoutView to be transmitted to the QgsLayoutViewToolXXXX. In consequences, the rubberband created during the holding operation is not removed from QgsLayoutView and a new left press deletes the rubberband reference without remove it from QgsLayoutView. So the rubberband stays until the end of application.

-----

For both situation, before the menu pops up, I trigger a left button release event if a operation is in progress. In this way operations will finish properly. For the zoom tools, I prefered to only remove the rubberband to avoid unwanted zoom