### PR TITLE
updateSaveStyleActions before showing the menu

### DIFF
--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1373,7 +1373,6 @@ void QgsVectorLayerProperties::aboutToShowStyleMenu()
   QMenu *m = qobject_cast<QMenu *>( sender() );
 
   updateSaveStyleMenuActions( m );
-  QgsDebugMsg( "D " + m->actions().at( 1 )->text() );
   QgsMapLayerStyleGuiUtils::instance()->removesExtraMenuSeparators( m );
   // re-add style manager actions!
   m->addSeparator();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -136,7 +136,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mActionLoadStyle = menuStyle->addAction( tr( "Load Style…" ) );
   connect( mActionLoadStyle, &QAction::triggered, this, &QgsVectorLayerProperties::loadStyle );
 
-  mActionSaveStyle = menuStyle->addAction( "Save Current Style…" );
+  mActionSaveStyle = menuStyle->addAction( tr( "Save Current Style…" ) );
   connect( mActionSaveStyle, &QAction::triggered, this, &QgsVectorLayerProperties::saveStyleAs );
   mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save All Styles…" ) );
   connect( mActionSaveMultipleStyles, &QAction::triggered, this, &QgsVectorLayerProperties::saveMultipleStylesAs );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -138,7 +138,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   mActionSaveStyle = menuStyle->addAction( tr( "Save Current Style…" ) );
   connect( mActionSaveStyle, &QAction::triggered, this, &QgsVectorLayerProperties::saveStyleAs );
-  mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save All Styles…" ) );
+  mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save Styles…" ) );
   connect( mActionSaveMultipleStyles, &QAction::triggered, this, &QgsVectorLayerProperties::saveMultipleStylesAs );
   // If we have multiple styles, offer an option to save them at once
   if ( lyr->styleManager()->styles().count() == 1 )

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -109,6 +109,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void saveMetadataAs();
     void saveDefaultMetadata();
     void loadDefaultMetadata();
+    void updateSaveStyleMenuActions( QMenu *m );
     void pbnUpdateExtents_clicked();
 
     void mButtonAddJoin_clicked();


### PR DESCRIPTION
## Description

FIX #46596

Solution :

By default, both saveAction and saveMultipleAction are created.

On each menu trigger, if there is more than one style, QGIS updates the saveAction text to `Save Current Style...` and adds the saveMultipleAction to the menu.
Otherwise the saveMultipleAction is removed from the menu and the saveAction text is updated to `Save Style...`