### PR TITLE
Fix headers

### DIFF
--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -57,6 +57,12 @@ class QgsServerRequest
       X_QGIS_WCS_SERVICE_URL,
       // The QGIS WMTS service URL
       X_QGIS_WMTS_SERVICE_URL,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
+      ACCEPT,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+      USER_AGENT,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
+      AUTHORIZATION,
     };
 
     QgsServerRequest();

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -223,11 +223,7 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
     QStringLiteral( "CONTENT_TYPE" ),
     QStringLiteral( "REQUEST_METHOD" ),
     QStringLiteral( "AUTH_TYPE" ),
-    QStringLiteral( "HTTP_ACCEPT" ),
-    QStringLiteral( "HTTP_USER_AGENT" ),
-    QStringLiteral( "HTTP_PROXY" ),
     QStringLiteral( "NO_PROXY" ),
-    QStringLiteral( "HTTP_AUTHORIZATION" ),
     QStringLiteral( "QGIS_PROJECT_FILE" ),
     QStringLiteral( "QGIS_SERVER_IGNORE_BAD_LAYERS" ),
     QStringLiteral( "QGIS_SERVER_SERVICE_URL" ),
@@ -235,27 +231,47 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
     QStringLiteral( "QGIS_SERVER_WFS_SERVICE_URL" ),
     QStringLiteral( "QGIS_SERVER_WMTS_SERVICE_URL" ),
     QStringLiteral( "QGIS_SERVER_WCS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_X_QGIS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_X_QGIS_WMS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_X_QGIS_WFS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_X_QGIS_WCS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_X_QGIS_WMTS_SERVICE_URL" ),
-    QStringLiteral( "HTTP_FORWARDED" ),
-    QStringLiteral( "HTTP_X_FORWARDED_HOST" ),
-    QStringLiteral( "HTTP_X_FORWARDED_PROTO" ),
-    QStringLiteral( "HTTP_HOST" ),
     QStringLiteral( "SERVER_PROTOCOL" )
   };
+  const QStringList headers
+  {
+    QStringLiteral( "Accept" ),
+    QStringLiteral( "User-Agent" ),
+    QStringLiteral( "Proxy" ),
+    QStringLiteral( "Authorization" ),
+    QStringLiteral( "X-Qgis-Service-Url" ),
+    QStringLiteral( "X-Qgis-WMS-Service-Url" ),
+    QStringLiteral( "X-Qgis-WFS-Service-Url" ),
+    QStringLiteral( "X-Qgis-WCS-Service-Url" ),
+    QStringLiteral( "X-Qgis-WMTS-Service-Url" ),
+    QStringLiteral( "Forwarded" ),
+    QStringLiteral( "X-Forwarded-Host" ),
+    QStringLiteral( "X-Forwarded-Proto" ),
+    QStringLiteral( "Host" )
+  };
+
 
   QgsMessageLog::logMessage( QStringLiteral( "Request URL: %2" ).arg( url.url() ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+
   QgsMessageLog::logMessage( QStringLiteral( "Environment:" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
   QgsMessageLog::logMessage( QStringLiteral( "------------------------------------------------" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
-
   for ( const auto &envVar : envVars )
   {
     if ( getenv( envVar.toStdString().c_str() ) )
     {
       QgsMessageLog::logMessage( QStringLiteral( "%1: %2" ).arg( envVar ).arg( QString( getenv( envVar.toStdString().c_str() ) ) ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+    }
+  }
+
+  QgsMessageLog::logMessage( QStringLiteral( "Headers:" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+  QgsMessageLog::logMessage( QStringLiteral( "------------------------------------------------" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+  for ( const auto &headerName : headers )
+  {
+    if ( !header( headerName ).isEmpty() )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "%1: %2" ).arg( headerName, header( headerName ) ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+      // Fill the headers dictionary
+      setHeader( headerName, header( headerName ) );
     }
   }
 }

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -254,11 +254,11 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url )
     }
   }
 
-  QgsMessageLog::logMessage( QStringLiteral( "Headers:" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
-  QgsMessageLog::logMessage( QStringLiteral( "------------------------------------------------" ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+  qDebug() << "Headers:";
+  qDebug() << "------------------------------------------------";
   for ( const auto &headerName : headers().keys() )
   {
-    QgsMessageLog::logMessage( QStringLiteral( "%1: %2" ).arg( headerName ).arg( headers().value( headerName ) ), QStringLiteral( "Server" ), Qgis::MessageLevel::Info );
+    qDebug() << headerName << ": " << headers().value( headerName );
   }
 }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -355,7 +355,7 @@ QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServ
   QString proto;
   QString host;
 
-  QString  forwarded = request.header( QgsServerRequest::FORWARDED );
+  QString forwarded = request.header( QgsServerRequest::FORWARDED );
   if ( ! forwarded.isEmpty() )
   {
     forwarded = forwarded.split( QLatin1Char( ',' ) )[0];

--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -18,13 +18,9 @@
  ***************************************************************************/
 
 #include "qgsserverrequest.h"
+#include "qgsstringutils.h"
 #include <QUrlQuery>
 
-
-QgsServerRequest::QgsServerRequest( )
-{
-  init();
-}
 
 QgsServerRequest::QgsServerRequest( const QString &url, Method method, const Headers &headers )
   : QgsServerRequest( QUrl( url ), method, headers )
@@ -37,10 +33,7 @@ QgsServerRequest::QgsServerRequest( const QUrl &url, Method method, const Header
   , mBaseUrl( url )
   , mMethod( method )
   , mHeaders( headers )
-  , mRequestHeaderConv()
 {
-  init();
-
   mParams.load( QUrlQuery( url ) );
 }
 
@@ -51,22 +44,7 @@ QgsServerRequest::QgsServerRequest( const QgsServerRequest &other )
   , mMethod( other.mMethod )
   , mHeaders( other.mHeaders )
   , mParams( other.mParams )
-  , mRequestHeaderConv( other.mRequestHeaderConv )
 {
-}
-
-void QgsServerRequest::init( )
-{
-  mRequestHeaderConv.insert( HOST, QStringLiteral( "Host" ) );
-  mRequestHeaderConv.insert( FORWARDED, QStringLiteral( "Forwarded" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_FOR, QStringLiteral( "X-Forwarded-For" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_HOST, QStringLiteral( "X-Forwarded-Host" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_PROTO, QStringLiteral( "X-Forwarded-Proto" ) );
-  mRequestHeaderConv.insert( X_QGIS_SERVICE_URL, QStringLiteral( "X-Qgis-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WMS_SERVICE_URL, QStringLiteral( "X-Qgis-Wms-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WFS_SERVICE_URL, QStringLiteral( "X-Qgis-Wfs-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WCS_SERVICE_URL, QStringLiteral( "X-Qgis-Wcs-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WMTS_SERVICE_URL, QStringLiteral( "X-Qgis-Wmts-Service-Url" ) );
 }
 
 QString QgsServerRequest::methodToString( const QgsServerRequest::Method &method )
@@ -83,7 +61,11 @@ QString QgsServerRequest::header( const QString &name ) const
 
 QString QgsServerRequest::header( const QgsServerRequest::RequestHeader &headerEnum ) const
 {
-  return header( mRequestHeaderConv[ headerEnum ] );
+  const QString headerKey = QString( qgsEnumValueToKey<QgsServerRequest::RequestHeader>( headerEnum ) );
+  const QString headerName = QgsStringUtils::capitalize(
+                               QString( headerKey ).replace( QLatin1Char( '_' ), QLatin1Char( ' ' ) ), Qgis::Capitalization::TitleCase
+                             ).replace( QLatin1Char( ' ' ), QLatin1Char( '-' ) );
+  return header( headerName );
 }
 
 void QgsServerRequest::setHeader( const QString &name, const QString &value )

--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -21,6 +21,11 @@
 #include <QUrlQuery>
 
 
+QgsServerRequest::QgsServerRequest( )
+{
+  init();
+}
+
 QgsServerRequest::QgsServerRequest( const QString &url, Method method, const Headers &headers )
   : QgsServerRequest( QUrl( url ), method, headers )
 {
@@ -34,16 +39,7 @@ QgsServerRequest::QgsServerRequest( const QUrl &url, Method method, const Header
   , mHeaders( headers )
   , mRequestHeaderConv()
 {
-  mRequestHeaderConv.insert( HOST, QStringLiteral( "Host" ) );
-  mRequestHeaderConv.insert( FORWARDED, QStringLiteral( "Forwarded" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_FOR, QStringLiteral( "X-Forwarded-For" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_HOST, QStringLiteral( "X-Forwarded-Host" ) );
-  mRequestHeaderConv.insert( X_FORWARDED_PROTO, QStringLiteral( "X-Forwarded-Proto" ) );
-  mRequestHeaderConv.insert( X_QGIS_SERVICE_URL, QStringLiteral( "X-Qgis-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WMS_SERVICE_URL, QStringLiteral( "X-Qgis-Wms-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WFS_SERVICE_URL, QStringLiteral( "X-Qgis-Wfs-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WCS_SERVICE_URL, QStringLiteral( "X-Qgis-Wcs-Service-Url" ) );
-  mRequestHeaderConv.insert( X_QGIS_WMTS_SERVICE_URL, QStringLiteral( "X-Qgis-Wmts-Service-Url" ) );
+  init();
 
   mParams.load( QUrlQuery( url ) );
 }
@@ -57,6 +53,20 @@ QgsServerRequest::QgsServerRequest( const QgsServerRequest &other )
   , mParams( other.mParams )
   , mRequestHeaderConv( other.mRequestHeaderConv )
 {
+}
+
+void QgsServerRequest::init( )
+{
+  mRequestHeaderConv.insert( HOST, QStringLiteral( "Host" ) );
+  mRequestHeaderConv.insert( FORWARDED, QStringLiteral( "Forwarded" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_FOR, QStringLiteral( "X-Forwarded-For" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_HOST, QStringLiteral( "X-Forwarded-Host" ) );
+  mRequestHeaderConv.insert( X_FORWARDED_PROTO, QStringLiteral( "X-Forwarded-Proto" ) );
+  mRequestHeaderConv.insert( X_QGIS_SERVICE_URL, QStringLiteral( "X-Qgis-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WMS_SERVICE_URL, QStringLiteral( "X-Qgis-Wms-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WFS_SERVICE_URL, QStringLiteral( "X-Qgis-Wfs-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WCS_SERVICE_URL, QStringLiteral( "X-Qgis-Wcs-Service-Url" ) );
+  mRequestHeaderConv.insert( X_QGIS_WMTS_SERVICE_URL, QStringLiteral( "X-Qgis-Wmts-Service-Url" ) );
 }
 
 QString QgsServerRequest::methodToString( const QgsServerRequest::Method &method )

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -90,7 +90,7 @@ class SERVER_EXPORT QgsServerRequest
     /**
      * Constructor
      */
-    QgsServerRequest() = default;
+    QgsServerRequest();
 
     /**
      * Constructor
@@ -260,6 +260,13 @@ class SERVER_EXPORT QgsServerRequest
     void setBaseUrl( const QUrl &url );
 
   private:
+
+    /**
+     * Initialize the map used to convert the header enumeration value
+     * into header name.
+     */
+    void init();
+
     // Url as seen by QGIS server after web server rewrite
     QUrl       mUrl;
     // Unrewritten url as seen by the web server

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -84,13 +84,19 @@ class SERVER_EXPORT QgsServerRequest
       X_QGIS_WCS_SERVICE_URL,
       // The QGIS WMTS service URL
       X_QGIS_WMTS_SERVICE_URL,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
+      ACCEPT,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+      USER_AGENT,
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
+      AUTHORIZATION,
     };
     Q_ENUM( RequestHeader )
 
     /**
      * Constructor
      */
-    QgsServerRequest();
+    QgsServerRequest() = default;
 
     /**
      * Constructor
@@ -260,13 +266,6 @@ class SERVER_EXPORT QgsServerRequest
     void setBaseUrl( const QUrl &url );
 
   private:
-
-    /**
-     * Initialize the map used to convert the header enumeration value
-     * into header name.
-     */
-    void init();
-
     // Url as seen by QGIS server after web server rewrite
     QUrl       mUrl;
     // Unrewritten url as seen by the web server
@@ -277,7 +276,6 @@ class SERVER_EXPORT QgsServerRequest
     // to support lazy initialization
     mutable Headers mHeaders;
     QgsServerParameters mParams;
-    QMap<RequestHeader, QString> mRequestHeaderConv;
 };
 
 #endif

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -496,9 +496,6 @@ class TestQgsServer(QgsServerTestBase):
             item_found = False
             for item in str(r).split("\\n"):
                 if "OnlineResource" in item:
-                    print(item)
-                    print(header_name)
-                    print(header_value)
                     self.assertEqual(header_value in item, True)
                     item_found = True
             self.assertTrue(item_found)

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -217,13 +217,30 @@ class QgsServerRequestTest(QgsServerTestBase):
 
     def test_headers(self):
         """Tests that the headers are working in Fcgi mode"""
-        os.environ["HTTP_HOST"] = "example.com"
-        request = QgsFcgiServerRequest()
-        self.assertEquals(request.header("Host"), "example.com")
-        request = QgsServerRequest(request)
-        self.assertEquals(request.header("Host"), "example.com")
-        self.assertEquals(request.header(QgsServerRequest.HOST), "example.com")
-        del os.environ["HTTP_HOST"]
+        for header, env, enum, value in (
+            ("Host", "HTTP_HOST", QgsServerRequest.HOST, "example.com"),
+            ("Forwarded", "HTTP_FORWARDED", QgsServerRequest.FORWARDED, "aaa"),
+            ("X-Forwarded-For", "HTTP_X_FORWARDED_FOR", QgsServerRequest.X_FORWARDED_FOR, "bbb"),
+            ("X-Forwarded-Host", "HTTP_X_FORWARDED_HOST", QgsServerRequest.X_FORWARDED_HOST, "ccc"),
+            ("X-Forwarded-Proto", "HTTP_X_FORWARDED_PROTO", QgsServerRequest.X_FORWARDED_PROTO, "ddd"),
+            ("X-Qgis-Service-Url", "HTTP_X_QGIS_SERVICE_URL", QgsServerRequest.X_QGIS_SERVICE_URL, "eee"),
+            ("X-Qgis-Wms-Service-Url", "HTTP_X_QGIS_WMS_SERVICE_URL", QgsServerRequest.X_QGIS_WMS_SERVICE_URL, "fff"),
+            ("X-Qgis-Wfs-Service-Url", "HTTP_X_QGIS_WFS_SERVICE_URL", QgsServerRequest.X_QGIS_WFS_SERVICE_URL, "ggg"),
+            ("X-Qgis-Wcs-Service-Url", "HTTP_X_QGIS_WCS_SERVICE_URL", QgsServerRequest.X_QGIS_WCS_SERVICE_URL, "hhh"),
+            ("X-Qgis-Wmts-Service-Url", "HTTP_X_QGIS_WMTS_SERVICE_URL", QgsServerRequest.X_QGIS_WMTS_SERVICE_URL, "iii"),
+            ("Accept", "HTTP_ACCEPT", QgsServerRequest.ACCEPT, "jjj"),
+            ("User-Agent", "HTTP_USER_AGENT", QgsServerRequest.USER_AGENT, "kkk"),
+            ("Authorization", "HTTP_AUTHORIZATION", QgsServerRequest.AUTHORIZATION, "lll"),
+        ):
+            try:
+                os.environ[env] = value
+                request = QgsFcgiServerRequest()
+                self.assertEquals(request.headers(), {header: value})
+                request = QgsServerRequest(request)
+                self.assertEquals(request.headers(), {header: value})
+                self.assertEquals(request.header(enum), value)
+            finally:
+                del os.environ[env]
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -215,6 +215,16 @@ class QgsServerRequestTest(QgsServerTestBase):
         self.assertEqual(request.parameter('FOOBAR'), 'foobar')
         self.assertEqual(request.parameter('UNKNOWN'), '')
 
+    def test_headers(self):
+        """Tests that the headers are working in Fcgi mode"""
+        os.environ["HTTP_HOST"] = "example.com"
+        request = QgsFcgiServerRequest()
+        self.assertEquals(request.header("Host"), "example.com")
+        request = QgsServerRequest(request)
+        self.assertEquals(request.header("Host"), "example.com")
+        self.assertEquals(request.header(QgsServerRequest.HOST), "example.com")
+        del os.environ["HTTP_HOST"]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsserver_service_url_env.py
+++ b/tests/src/python/test_qgsserver_service_url_env.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+QGIS Unit tests for QgsServer with service URL defined in the environment variables
+"""
+__author__ = 'Stéphane Brunner'
+__date__ = '12/01/2021'
+__copyright__ = 'Copyright 2021, The QGIS Project'
+
+import os
+
+# Deterministic XML
+os.environ['QT_HASH_SEED'] = '1'
+
+import urllib.request
+import urllib.parse
+import urllib.error
+
+from qgis.server import QgsServer
+from qgis.core import QgsFontUtils
+from qgis.testing import unittest, start_app
+from utilities import unitTestDataPath
+
+
+start_app()
+
+
+class TestQgsServerServiceUrlEnv(unittest.TestCase):
+
+    def setUp(self):
+        """Create the server instance"""
+        self.fontFamily = QgsFontUtils.standardTestFontFamily()
+        QgsFontUtils.loadStandardTestFonts(['All'])
+
+        self.testdata_path = unitTestDataPath('qgis_server') + '/'
+        project = os.path.join(self.testdata_path, "test_project_without_urls.qgs")
+
+        del os.environ['QUERY_STRING']
+        os.environ['QGIS_PROJECT_FILE'] = project
+        # Disable landing page API to test standard legacy XML responses in case of errors
+        os.environ["QGIS_SERVER_DISABLED_APIS"] = "Landing Page"
+
+        self.server = QgsServer()
+
+    def tearDown(self):
+        """Cleanup env"""
+
+        super().tearDown()
+        for env in ["QGIS_SERVER_DISABLED_APIS", "QGIS_PROJECT_FILE"]:
+            if env in os.environ:
+                del os.environ[env]
+
+    """Tests container"""
+
+    def test_getcapabilities_url(self):
+
+        # Service URL in environment
+        for env_name, env_value, service in (
+            ("QGIS_SERVER_SERVICE_URL", "http://test1", "WMS"),
+            ("QGIS_SERVER_WMS_SERVICE_URL", "http://test2", "WMS")
+            ("QGIS_SERVER_SERVICE_URL", "http://test3", "WFS", "href="),
+            ("QGIS_SERVER_WFS_SERVICE_URL", "http://test4", "WFS", "href=")
+            ("QGIS_SERVER_SERVICE_URL", "http://test5", "WCS"),
+            ("QGIS_SERVER_WCS_SERVICE_URL", "http://test6", "WCS")
+            ("QGIS_SERVER_SERVICE_URL", "http://test7", "WMTS"),
+            ("QGIS_SERVER_WMTS_SERVICE_URL", "http://test8", "WMTS")
+        ):
+            try:
+                os.environ[env_name] = env_value
+                qs = "?" + "&".join(["%s=%s" % i for i in list({
+                    "SERVICE": service,
+                    "REQUEST": "GetCapabilities",
+                }.items())])
+
+                r, _ = self._result(self._execute_request(qs))
+
+                item_found = False
+                for item in str(r).split("\\n"):
+                    if "href=" in item:
+                        self.assertEqual(env_value in item, True)
+                        item_found = True
+                self.assertTrue(item_found)
+            finally:
+                del os.environ[env_name]
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This pull request fixes two issues regarding the Request headers in FCGI

First when the default constructor of `QgsServerRequest` is called, the `mRequestHeaderConv` map will not be filled.
Second, the copy constructor of `QgsServerRequest` is called with an instance of `QgsFcgiServerRequest` in argument, then the override of the `header` method will not work anymore, to fix that we fill the `mHeaders` dictionary by using `setHeader` with the known headers (which one are displayed on request reception).

Then:
* Fix the initialization of the `mRequestHeaderConv` dictionary on FCGI request
* Fill the headers on FCGI request
* Change a bit the header display on new request message

Thanks for reading,
If you don't agree that's on the 3.22 release, I will do that only on master.

Happy Christmas :-)