### PR TITLE
[processing] Add an optional output extent to the gdal raster calculator algorithm

### DIFF
--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -27,6 +27,7 @@ from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterBand,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterEnum,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterString,
                        QgsProcessingParameterRasterDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
@@ -49,6 +50,7 @@ class gdalcalc(GdalAlgorithm):
     BAND_E = 'BAND_E'
     BAND_F = 'BAND_F'
     FORMULA = 'FORMULA'
+    EXTENT = 'PROJWIN'
     OUTPUT = 'OUTPUT'
     NO_DATA = 'NO_DATA'
     OPTIONS = 'OPTIONS'
@@ -138,6 +140,14 @@ class gdalcalc(GdalAlgorithm):
                 type=QgsProcessingParameterNumber.Double,
                 defaultValue=None,
                 optional=True))
+
+        if GdalUtils.version() >= 3030000:
+            extent_param = QgsProcessingParameterExtent(self.EXTENT,
+                                                        self.tr('Output extent'),
+                                                        optional=True)
+            extent_param.setHelp(self.tr('Custom extent of the output raster'))
+            self.addParameter(extent_param)
+
         self.addParameter(
             QgsProcessingParameterEnum(
                 self.RTYPE,
@@ -182,7 +192,13 @@ class gdalcalc(GdalAlgorithm):
     def commandName(self):
         return 'gdal_calc'
 
+    def processAlgorithm(self, parameters, context, feedback):
+        if GdalUtils.version() < 3030000 and self.EXTENT in parameters.keys():
+            raise QgsProcessingException(self.tr('The output extent option is only available on GDAL 3.3 or later'))
+        return GdalAlgorithm.processAlgorithm(self, parameters, context, feedback)
+
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
+
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
         formula = self.parameterAsString(parameters, self.FORMULA, context)
@@ -206,6 +222,15 @@ class gdalcalc(GdalAlgorithm):
         layer = self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
         if layer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_A))
+
+        bbox = self.parameterAsExtent(parameters, self.EXTENT, context, layer.crs())
+        if not bbox.isNull():
+            arguments.append('--projwin')
+            arguments.append(str(bbox.xMinimum()))
+            arguments.append(str(bbox.yMaximum()))
+            arguments.append(str(bbox.xMaximum()))
+            arguments.append(str(bbox.yMinimum()))
+
         arguments.append('-A')
         arguments.append(layer.source())
         if self.parameterAsString(parameters, self.BAND_A, context):

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -674,6 +674,17 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['gdal_calc.py',
                  '--overwrite --calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
+            if GdalUtils.version() >= 3030000:
+                extent = QgsReferencedRectangle(QgsRectangle(1, 2, 3, 4), QgsCoordinateReferenceSystem('EPSG:4326'))
+                self.assertEqual(
+                    alg.getConsoleCommands({'INPUT_A': source,
+                                            'BAND_A': 1,
+                                            'FORMULA': formula,
+                                            'PROJWIN': extent,
+                                            'OUTPUT': output}, context, feedback),
+                    ['gdal_calc.py',
+                     '--overwrite --calc "{}" --format JPEG --type Float32 --projwin 1.0 4.0 3.0 2.0 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+
             # check that formula is not escaped and formula is returned as it is
             formula = 'A * 2'  # <--- add spaces in the formula
             self.assertEqual(


### PR DESCRIPTION
## Description

Since gdal 3.3, its raster calculator has a very useful output extent parameter, this PR adds it to the processing algorithm.

![image](https://user-images.githubusercontent.com/1728657/147430987-f660a6a2-e3b9-430c-b038-a3ee8aec6f84.png)

