### PR TITLE
[Feature] New soft constraints in the advanced digitizing dock

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1340,3 +1340,23 @@ Qgis.AltitudeBinding.Centroid.__doc__ = "Clamp just centroid of feature"
 Qgis.AltitudeBinding.__doc__ = 'Altitude binding.\n\n.. versionadded:: 3.26\n\n' + '* ``Vertex``: ' + Qgis.AltitudeBinding.Vertex.__doc__ + '\n' + '* ``Centroid``: ' + Qgis.AltitudeBinding.Centroid.__doc__
 # --
 Qgis.AltitudeBinding.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.NoConstraint = Qgis.BetweenLineConstraint.NoConstraint
+Qgis.NoConstraint.is_monkey_patched = True
+Qgis.BetweenLineConstraint.NoConstraint.__doc__ = "No additional constraint"
+Qgis.Perpendicular = Qgis.BetweenLineConstraint.Perpendicular
+Qgis.Perpendicular.is_monkey_patched = True
+Qgis.BetweenLineConstraint.Perpendicular.__doc__ = "Perpendicular"
+Qgis.Parallel = Qgis.BetweenLineConstraint.Parallel
+Qgis.Parallel.is_monkey_patched = True
+Qgis.BetweenLineConstraint.Parallel.__doc__ = "Parallel"
+Qgis.BetweenLineConstraint.__doc__ = 'Between line constraints which can be enabled\n\n' + '* ``NoConstraint``: ' + Qgis.BetweenLineConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + Qgis.BetweenLineConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + Qgis.BetweenLineConstraint.Parallel.__doc__
+# --
+Qgis.BetweenLineConstraint.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.LineExtensionSide.BeforeVertex.__doc__ = ""
+Qgis.LineExtensionSide.AfterVertex.__doc__ = ""
+Qgis.LineExtensionSide.NoVertex.__doc__ = ""
+Qgis.LineExtensionSide.__doc__ = 'Designates whether the line extension constraint is currently soft locked\nwith the previous or next vertex of the locked one.\n\n.. versionadded:: 3.26\n\n' + '* ``BeforeVertex``: ' + Qgis.LineExtensionSide.BeforeVertex.__doc__ + '\n' + '* ``AfterVertex``: ' + Qgis.LineExtensionSide.AfterVertex.__doc__ + '\n' + '* ``NoVertex``: ' + Qgis.LineExtensionSide.NoVertex.__doc__
+# --
+Qgis.LineExtensionSide.baseClass = Qgis

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -87,9 +87,15 @@ Returns the squared 2D distance between two points.
 Returns the squared distance between a point and a line.
 %End
 
-    static double distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon = 1e-7 );
+    static double distToInfiniteLine( const QgsPoint &point, const QgsPoint &linePoint1, const QgsPoint &linePoint2, double epsilon = 1e-7 );
 %Docstring
 Returns the distance between a point and an infinite line.
+
+:param point: Point to find the distance to the line
+:param linePoint1: First point of the line
+:param linePoint2: Second point of the line
+
+.. versionadded:: 3.24
 %End
 
     static bool lineIntersection( const QgsPoint &p1, QgsVector v1, const QgsPoint &p2, QgsVector v2, QgsPoint &intersection /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -87,6 +87,11 @@ Returns the squared 2D distance between two points.
 Returns the squared distance between a point and a line.
 %End
 
+    static double distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon = 1e-7 );
+%Docstring
+Returns the distance between a point and an infinite line.
+%End
+
     static bool lineIntersection( const QgsPoint &p1, QgsVector v1, const QgsPoint &p2, QgsVector v2, QgsPoint &intersection /Out/ ) /HoldGIL/;
 %Docstring
 Computes the intersection between two lines. Z dimension is

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -91,9 +91,10 @@ Returns the squared distance between a point and a line.
 %Docstring
 Returns the distance between a point and an infinite line.
 
-:param point: Point to find the distance to the line
-:param linePoint1: First point of the line
-:param linePoint2: Second point of the line
+:param point: The point to find the distance to the line
+:param linePoint1: The first point of the line
+:param linePoint2: The second point of the line
+:param epsilon: The tolerance to use
 
 .. versionadded:: 3.24
 %End

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -96,7 +96,7 @@ Returns the distance between a point and an infinite line.
 :param linePoint2: The second point of the line
 :param epsilon: The tolerance to use
 
-.. versionadded:: 3.24
+.. versionadded:: 3.26
 %End
 
     static bool lineIntersection( const QgsPoint &p1, QgsVector v1, const QgsPoint &p2, QgsVector v2, QgsPoint &intersection /Out/ ) /HoldGIL/;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -869,6 +869,20 @@ The development version
       Centroid,
     };
 
+    enum class BetweenLineConstraint
+    {
+      NoConstraint,
+      Perpendicular,
+      Parallel
+    };
+
+    enum class LineExtensionSide
+    {
+      BeforeVertex,
+      AfterVertex,
+      NoVertex
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -59,14 +59,6 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method
 #include "qgscadutils.h"
 %End
       public:
-
-        enum LineExtensionSide
-        {
-          BeforeVertex,
-          AfterVertex,
-          NoVertex
-        };
-
         bool valid;
 
         QgsPointXY finalMapPoint;
@@ -77,7 +69,7 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method
 
         double softLockCommonAngle;
 
-        LineExtensionSide softLockLineExtension;
+        Qgis::LineExtensionSide softLockLineExtension;
         double softLockX;
         double softLockY;
     };

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsCadUtils
 {
 %Docstring(signature="appended")
@@ -59,6 +60,13 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method
 %End
       public:
 
+        enum LineExtensionSide
+        {
+          BeforeVertex,
+          AfterVertex,
+          NoVertex
+        };
+
         bool valid;
 
         QgsPointXY finalMapPoint;
@@ -68,6 +76,10 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method
         QgsPointLocator::Match edgeMatch;
 
         double softLockCommonAngle;
+
+        LineExtensionSide softLockLineExtension;
+        double softLockX;
+        double softLockY;
     };
 
     class AlignMapPointContext
@@ -95,6 +107,9 @@ Defines constraints for the :py:func:`QgsCadUtils.alignMapPoint()` method.
         QgsCadUtils::AlignMapPointConstraint angleConstraint;
         QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
 
+        QgsCadUtils::AlignMapPointConstraint lineExtensionConstraint;
+        QgsCadUtils::AlignMapPointConstraint xyVertexConstraint;
+
 
         QList< QgsPoint > cadPoints() const;
 %Docstring
@@ -107,7 +122,7 @@ point is the most recent point.
 
 .. versionadded:: 3.22
 %End
-        void setCadPoints( const QList< QgsPoint> &points );
+        void setCadPoints( const QList< QgsPoint > &points );
 %Docstring
 Sets the list of recent CAD ``points`` (in map coordinates).
 
@@ -131,6 +146,7 @@ Returns the recent CAD point at the specified ``index`` (in map coordinates).
 
 .. versionadded:: 3.22
 %End
+
 
 %Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
         void _setCadPointList( const QList< QgsPointXY > &list );

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -147,7 +147,6 @@ Returns the recent CAD point at the specified ``index`` (in map coordinates).
 .. versionadded:: 3.22
 %End
 
-
 %Property( name = cadPointList, get = _cadPointList, set = _setCadPointList )
         void _setCadPointList( const QList< QgsPointXY > &list );
         QList< QgsPointXY > _cadPointList() const;

--- a/python/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
+++ b/python/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
@@ -2,14 +2,14 @@
 QgsAdvancedDigitizingDockWidget.CadCapacities.baseClass = QgsAdvancedDigitizingDockWidget
 CadCapacities = QgsAdvancedDigitizingDockWidget  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
-QgsAdvancedDigitizingDockWidget.NoConstraint = QgsAdvancedDigitizingDockWidget.AdditionalConstraint.NoConstraint
+QgsAdvancedDigitizingDockWidget.NoConstraint = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint
 QgsAdvancedDigitizingDockWidget.NoConstraint.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.AdditionalConstraint.NoConstraint.__doc__ = "No additional constraint"
-QgsAdvancedDigitizingDockWidget.Perpendicular = QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Perpendicular
+QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint.__doc__ = "No additional constraint"
+QgsAdvancedDigitizingDockWidget.Perpendicular = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular
 QgsAdvancedDigitizingDockWidget.Perpendicular.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Perpendicular.__doc__ = "Perpendicular"
-QgsAdvancedDigitizingDockWidget.Parallel = QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Parallel
+QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular.__doc__ = "Perpendicular"
+QgsAdvancedDigitizingDockWidget.Parallel = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel
 QgsAdvancedDigitizingDockWidget.Parallel.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Parallel.__doc__ = "Parallel"
-QgsAdvancedDigitizingDockWidget.AdditionalConstraint.__doc__ = 'Additional constraints which can be enabled\n\n' + '* ``NoConstraint``: ' + QgsAdvancedDigitizingDockWidget.AdditionalConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + QgsAdvancedDigitizingDockWidget.AdditionalConstraint.Parallel.__doc__
+QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel.__doc__ = "Parallel"
+QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.__doc__ = 'Between line constraints which can be enabled\n\n' + '* ``NoConstraint``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel.__doc__
 # --

--- a/python/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
+++ b/python/gui/auto_additions/qgsadvanceddigitizingdockwidget.py
@@ -1,15 +1,3 @@
 # The following has been generated automatically from src/gui/qgsadvanceddigitizingdockwidget.h
 QgsAdvancedDigitizingDockWidget.CadCapacities.baseClass = QgsAdvancedDigitizingDockWidget
 CadCapacities = QgsAdvancedDigitizingDockWidget  # dirty hack since SIP seems to introduce the flags in module
-# monkey patching scoped based enum
-QgsAdvancedDigitizingDockWidget.NoConstraint = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint
-QgsAdvancedDigitizingDockWidget.NoConstraint.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint.__doc__ = "No additional constraint"
-QgsAdvancedDigitizingDockWidget.Perpendicular = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular
-QgsAdvancedDigitizingDockWidget.Perpendicular.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular.__doc__ = "Perpendicular"
-QgsAdvancedDigitizingDockWidget.Parallel = QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel
-QgsAdvancedDigitizingDockWidget.Parallel.is_monkey_patched = True
-QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel.__doc__ = "Parallel"
-QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.__doc__ = 'Between line constraints which can be enabled\n\n' + '* ``NoConstraint``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + QgsAdvancedDigitizingDockWidget.BetweenLineConstraint.Parallel.__doc__
-# --

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -299,11 +299,43 @@ Returns the ``CadConstraint`` on the M coordinate
 Returns ``True`` if a constraint on a common angle is active
 %End
 
+    const CadConstraint *constraintLineExtension() const;
+%Docstring
+Returns the ``CadConstraint``
+%End
+
+    QgsCadUtils::AlignMapPointOutput::LineExtensionSide lineExtensionSide() const;
+%Docstring
+Returns on which side of the constraint line extension point, the line was created
+%End
+
+    const CadConstraint *constraintXyVertex() const;
+%Docstring
+Returns the ``CadConstraint``
+%End
+
+    double softLockX() const;
+%Docstring
+Returns the X value of the X soft lock. The value is NaN is the constraint isn't magnetized to a line
+%End
+
+    double softLockY() const;
+%Docstring
+Returns the Y value of the Y soft lock. The value is NaN is the constraint isn't magnetized to a line
+%End
+
     QgsPointLocator::Match mapPointMatch() const;
 %Docstring
 Returns the point locator match
 
 .. versionadded:: 3.4
+%End
+
+    QList< QgsPointLocator::Match > lockedSnapVertices() const;
+%Docstring
+Returns the snap matches whose vertices have been locked
+
+.. versionadded:: 3.24
 %End
 
     void clearPoints();
@@ -805,6 +837,30 @@ Could be used by widgets that must reflect the current advanced digitizing state
    unstable API (will likely change)
 
 .. versionadded:: 3.8
+%End
+
+    void softLockLineExtensionChanged( bool locked );
+%Docstring
+Emitted whenever the soft line extension parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.24
+%End
+
+    void softLockXyChanged( bool locked );
+%Docstring
+Emitted whenever the soft x/y extension parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.24
 %End
 
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -36,13 +36,6 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
     typedef QFlags<QgsAdvancedDigitizingDockWidget::CadCapacity> CadCapacities;
 
 
-    enum class BetweenLineConstraint
-    {
-      NoConstraint,
-      Perpendicular,
-      Parallel
-    };
-
     enum WidgetSetMode
     {
       ReturnPressed,
@@ -259,7 +252,7 @@ Sets whether M is enabled
 construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
 %End
 
-    BetweenLineConstraint betweenLineConstraint() const;
+    Qgis::BetweenLineConstraint betweenLineConstraint() const;
 %Docstring
 Returns the between line constraints which are used to place
 perpendicular/parallel segments to snapped segments on the canvas
@@ -304,7 +297,7 @@ Returns ``True`` if a constraint on a common angle is active
 Returns the ``CadConstraint``
 %End
 
-    QgsCadUtils::AlignMapPointOutput::LineExtensionSide lineExtensionSide() const;
+    Qgis::LineExtensionSide lineExtensionSide() const;
 %Docstring
 Returns on which side of the constraint line extension point, the line was created
 %End

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -335,16 +335,16 @@ Returns the point locator match
 %Docstring
 Returns the snap matches whose vertices have been locked
 
-.. versionadded:: 3.24
+.. versionadded:: 3.26
 %End
 
     void clearLockedSnapVertices( bool force = true );
 %Docstring
 Removes all points from the locked snap vertex list
 
-.. versionadded:: 3.26
-
 :param force: Clears the list even if the constraints that use it are still locked.
+
+.. versionadded:: 3.26
 %End
 
     void clearPoints();
@@ -857,7 +857,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.24
+.. versionadded:: 3.26
 %End
 
     void softLockXyChanged( bool locked );
@@ -869,7 +869,7 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
    unstable API (will likely change)
 
-.. versionadded:: 3.24
+.. versionadded:: 3.26
 %End
 
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -36,7 +36,7 @@ by implementing filters called from :py:class:`QgsMapToolAdvancedDigitizing`.
     typedef QFlags<QgsAdvancedDigitizingDockWidget::CadCapacity> CadCapacities;
 
 
-    enum class AdditionalConstraint
+    enum class BetweenLineConstraint
     {
       NoConstraint,
       Perpendicular,
@@ -205,8 +205,8 @@ apply the CAD constraints. The will modify the position of the map event in map 
 
     bool alignToSegment( QgsMapMouseEvent *e, QgsAdvancedDigitizingDockWidget::CadConstraint::LockMode lockMode = QgsAdvancedDigitizingDockWidget::CadConstraint::HardLock );
 %Docstring
-align to segment for additional constraint.
-If additional constraints are used, this will determine the angle to be locked depending on the snapped segment.
+align to segment for between line constraint.
+If between line constraints are used, this will determine the angle to be locked depending on the snapped segment.
 
 .. versionadded:: 3.0
 %End
@@ -259,9 +259,9 @@ Sets whether M is enabled
 construction mode is used to draw intermediate points. These points won't be given any further (i.e. to the map tools)
 %End
 
-    AdditionalConstraint additionalConstraint() const;
+    BetweenLineConstraint betweenLineConstraint() const;
 %Docstring
-Returns the additional constraints which are used to place
+Returns the between line constraints which are used to place
 perpendicular/parallel segments to snapped segments on the canvas
 %End
     const CadConstraint *constraintAngle() const;

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -338,6 +338,15 @@ Returns the snap matches whose vertices have been locked
 .. versionadded:: 3.24
 %End
 
+    void clearLockedSnapVertices( bool force = true );
+%Docstring
+Removes all points from the locked snap vertex list
+
+.. versionadded:: 3.26
+
+:param force: Clears the list even if the constraints that use it are still locked.
+%End
+
     void clearPoints();
 %Docstring
 Removes all points from the CAD point list

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -790,7 +790,7 @@ void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
   if ( e->button() == Qt::LeftButton &&
        ( !mCadDockWidget->cadEnabled() ||
-         mCadDockWidget->additionalConstraint() == QgsAdvancedDigitizingDockWidget::AdditionalConstraint::NoConstraint ) )
+         mCadDockWidget->betweenLineConstraint() == QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint ) )
     mLeftButtonPressed = true;
 
   switch ( mCurrentState )

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -790,7 +790,7 @@ void QgsMapToolEditMeshFrame::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
   if ( e->button() == Qt::LeftButton &&
        ( !mCadDockWidget->cadEnabled() ||
-         mCadDockWidget->betweenLineConstraint() == QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint ) )
+         mCadDockWidget->betweenLineConstraint() == Qgis::BetweenLineConstraint::NoConstraint ) )
     mLeftButtonPressed = true;
 
   switch ( mCurrentState )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -239,6 +239,22 @@ double QgsGeometryUtils::sqrDistToLine( double ptX, double ptY, double x1, doubl
   return dist;
 }
 
+double QgsGeometryUtils::distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon )
+{
+  const double area = std::abs(
+                        ( x1 - x2 ) * ( ptY - y2 ) -
+                        ( y1 - y2 ) * ( ptX - x2 )
+                      );
+
+  const double length = std::sqrt(
+                          std::pow( x1 - x2, 2 ) +
+                          std::pow( y1 - y2, 2 )
+                        );
+
+  const double distance = area / length;
+  return qgsDoubleNear( distance, 0.0, epsilon ) ? 0.0 : distance;
+}
+
 bool QgsGeometryUtils::lineIntersection( const QgsPoint &p1, QgsVector v1, const QgsPoint &p2, QgsVector v2, QgsPoint &intersection )
 {
   const double d = v1.y() * v2.x() - v1.x() * v2.y();

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -239,16 +239,16 @@ double QgsGeometryUtils::sqrDistToLine( double ptX, double ptY, double x1, doubl
   return dist;
 }
 
-double QgsGeometryUtils::distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon )
+double QgsGeometryUtils::distToInfiniteLine( const QgsPoint &point, const QgsPoint &linePoint1, const QgsPoint &linePoint2, double epsilon )
 {
   const double area = std::abs(
-                        ( x1 - x2 ) * ( ptY - y2 ) -
-                        ( y1 - y2 ) * ( ptX - x2 )
+                        ( linePoint1.x() - linePoint2.x() ) * ( point.y() - linePoint2.y() ) -
+                        ( linePoint1.y() - linePoint2.y() ) * ( point.x() - linePoint2.x() )
                       );
 
   const double length = std::sqrt(
-                          std::pow( x1 - x2, 2 ) +
-                          std::pow( y1 - y2, 2 )
+                          std::pow( linePoint1.x() - linePoint2.x(), 2 ) +
+                          std::pow( linePoint1.y() - linePoint2.y(), 2 )
                         );
 
   const double distance = area / length;

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -94,6 +94,11 @@ class CORE_EXPORT QgsGeometryUtils
     static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX SIP_OUT, double &minDistY SIP_OUT, double epsilon ) SIP_HOLDGIL;
 
     /**
+     * Returns the distance between a point and an infinite line.
+     */
+    static double distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon = 1e-7 );
+
+    /**
      * Computes the intersection between two lines. Z dimension is
      * supported and is retrieved from the first 3D point amongst \a p1 and
      * \a p2.

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsGeometryUtils
      * \param linePoint1 The first point of the line
      * \param linePoint2 The second point of the line
      * \param epsilon The tolerance to use
-     * \since QGIS 3.24
+     * \since QGIS 3.26
      */
     static double distToInfiniteLine( const QgsPoint &point, const QgsPoint &linePoint1, const QgsPoint &linePoint2, double epsilon = 1e-7 );
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -95,8 +95,12 @@ class CORE_EXPORT QgsGeometryUtils
 
     /**
      * Returns the distance between a point and an infinite line.
+     * \param point Point to find the distance to the line
+     * \param linePoint1 First point of the line
+     * \param linePoint2 Second point of the line
+     * \since QGIS 3.24
      */
-    static double distToInfiniteLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double epsilon = 1e-7 );
+    static double distToInfiniteLine( const QgsPoint &point, const QgsPoint &linePoint1, const QgsPoint &linePoint2, double epsilon = 1e-7 );
 
     /**
      * Computes the intersection between two lines. Z dimension is

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -95,9 +95,10 @@ class CORE_EXPORT QgsGeometryUtils
 
     /**
      * Returns the distance between a point and an infinite line.
-     * \param point Point to find the distance to the line
-     * \param linePoint1 First point of the line
-     * \param linePoint2 Second point of the line
+     * \param point The point to find the distance to the line
+     * \param linePoint1 The first point of the line
+     * \param linePoint2 The second point of the line
+     * \param epsilon The tolerance to use
      * \since QGIS 3.24
      */
     static double distToInfiniteLine( const QgsPoint &point, const QgsPoint &linePoint1, const QgsPoint &linePoint2, double epsilon = 1e-7 );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1436,6 +1436,30 @@ class CORE_EXPORT Qgis
     Q_ENUM( AltitudeBinding )
 
     /**
+     * Between line constraints which can be enabled
+     */
+    enum class BetweenLineConstraint SIP_MONKEYPATCH_SCOPEENUM : int
+    {
+      NoConstraint,  //!< No additional constraint
+      Perpendicular, //!< Perpendicular
+      Parallel       //!< Parallel
+    };
+    Q_ENUM( BetweenLineConstraint )
+
+    /**
+     * Designates whether the line extension constraint is currently soft locked
+     * with the previous or next vertex of the locked one.
+     * \since QGIS 3.26
+     */
+    enum class LineExtensionSide : int
+    {
+      BeforeVertex,
+      AfterVertex,
+      NoVertex
+    };
+    Q_ENUM( LineExtensionSide )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -414,6 +414,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
         else if ( !intersect )
         {
           res.softLockX = std::numeric_limits<double>::quiet_NaN();
+          res.softLockY = std::numeric_limits<double>::quiet_NaN(); // in the case of the 2 soft locks are activated
           res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, previousPt, point, point );
         }
       }

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -385,16 +385,17 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   // ---- Distance constraint
   if ( ctx.distanceConstraint.locked && ctx.cadPoints().count() >= 2 )
   {
-    if ( ctx.xConstraint.locked || ctx.yConstraint.locked )
+    if ( ctx.xConstraint.locked || ctx.yConstraint.locked
+         || !std::isnan( res.softLockX ) || !std::isnan( res.softLockY ) )
     {
       // perform both to detect errors in constraints
-      if ( ctx.xConstraint.locked )
+      if ( ctx.xConstraint.locked || !std::isnan( res.softLockX ) )
       {
         const QgsPointXY verticalPt0( point.x(), point.y() );
         const QgsPointXY verticalPt1( point.x(), point.y() + 1 );
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, verticalPt0, verticalPt1, point );
       }
-      if ( ctx.yConstraint.locked )
+      if ( ctx.yConstraint.locked || !std::isnan( res.softLockY ) )
       {
         const QgsPointXY horizontalPt0( point.x(), point.y() );
         const QgsPointXY horizontalPt1( point.x() + 1, point.y() );

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -42,7 +42,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   res.valid = true;
   res.softLockCommonAngle = -1;
 
-  res.softLockLineExtension = QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex;
+  res.softLockLineExtension = Qgis::LineExtensionSide::NoVertex;
   res.softLockX = std::numeric_limits<double>::quiet_NaN();
   res.softLockY = std::numeric_limits<double>::quiet_NaN();
 
@@ -382,13 +382,13 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
       bool checked = checkLineExtension( geom.vertexAt( snap.vertexIndex() - 1 ) );
       if ( checked )
       {
-        res.softLockLineExtension = QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex;
+        res.softLockLineExtension = Qgis::LineExtensionSide::BeforeVertex;
       }
 
       checked = checkLineExtension( geom.vertexAt( snap.vertexIndex() + 1 ) );
       if ( checked )
       {
-        res.softLockLineExtension = QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex;
+        res.softLockLineExtension = Qgis::LineExtensionSide::AfterVertex;
       }
     }
   }
@@ -434,7 +434,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
         }
       }
     }
-    else if ( res.softLockLineExtension != QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex )
+    else if ( res.softLockLineExtension != Qgis::LineExtensionSide::NoVertex )
     {
       const QgsPointLocator::Match snap = ctx.lockedSnapVertices().last();
       const QgsFeature feature = snap.layer()->getFeature( snap.featureId() );
@@ -444,7 +444,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
       const QgsPointXY lineExtensionPt1 = snap.point();
 
       QgsPointXY lineExtensionPt2;
-      if ( res.softLockLineExtension == QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex )
+      if ( res.softLockLineExtension == Qgis::LineExtensionSide::AfterVertex )
       {
         lineExtensionPt2 = QgsPointXY( geom.vertexAt( snap.vertexIndex() + 1 ) );
       }
@@ -456,7 +456,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
       const bool intersect = QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, lineExtensionPt1, lineExtensionPt2, point );
       if ( !intersect )
       {
-        res.softLockLineExtension = QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex;
+        res.softLockLineExtension = Qgis::LineExtensionSide::NoVertex;
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, previousPt, point, point );
       }
     }

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -332,6 +332,20 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
             );
             point = QgsPointXY( intersection );
           }
+          else if ( angleLocked )
+          {
+            const double angleValue = angleValueDeg * M_PI / 180;
+            const double cosa = std::cos( angleValue );
+            const double sina = std::sin( angleValue );
+
+            QgsPoint intersection;
+            QgsGeometryUtils::lineIntersection(
+              QgsPoint( previousPt ), QgsVector( cosa, sina ),
+              QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
+              intersection
+            );
+            point = QgsPointXY( intersection );
+          }
           else
           {
             double angleValue = std::atan2( extensionPoint.y() - vertex.y(),

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -312,15 +312,38 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
 
         if ( distance / ctx.mapUnitsPerPixel < SOFT_CONSTRAINT_TOLERANCE_PIXEL )
         {
-          double angleValue = std::atan2( extensionPoint.y() - vertex.y(),
-                                          extensionPoint.x() - vertex.x() );
+          if ( ctx.xConstraint.locked || !std::isnan( res.softLockX ) )
+          {
+            QgsPoint intersection;
+            QgsGeometryUtils::lineIntersection(
+              QgsPoint( point ), QgsVector( 0, 1 ),
+              QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
+              intersection
+            );
+            point = QgsPointXY( intersection );
+          }
+          else if ( ctx.yConstraint.locked || !std::isnan( res.softLockY ) )
+          {
+            QgsPoint intersection;
+            QgsGeometryUtils::lineIntersection(
+              QgsPoint( point ), QgsVector( 1, 0 ),
+              QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
+              intersection
+            );
+            point = QgsPointXY( intersection );
+          }
+          else
+          {
+            double angleValue = std::atan2( extensionPoint.y() - vertex.y(),
+                                            extensionPoint.x() - vertex.x() );
 
-          const double cosa = std::cos( angleValue );
-          const double sina = std::sin( angleValue );
-          const double v = ( point.x() - extensionPoint.x() ) * cosa + ( point.y() - extensionPoint.y() ) * sina;
+            const double cosa = std::cos( angleValue );
+            const double sina = std::sin( angleValue );
+            const double v = ( point.x() - extensionPoint.x() ) * cosa + ( point.y() - extensionPoint.y() ) * sina;
 
-          point.setX( extensionPoint.x() + cosa * v );
-          point.setY( extensionPoint.y() + sina * v );
+            point.setX( extensionPoint.x() + cosa * v );
+            point.setY( extensionPoint.y() + sina * v );
+          }
 
           return true;
         }

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -315,22 +315,28 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
           if ( ctx.xConstraint.locked || !std::isnan( res.softLockX ) )
           {
             QgsPoint intersection;
-            QgsGeometryUtils::lineIntersection(
-              QgsPoint( point ), QgsVector( 0, 1 ),
-              QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
-              intersection
-            );
-            point = QgsPointXY( intersection );
+            const bool intersect = QgsGeometryUtils::lineIntersection(
+                                     QgsPoint( point ), QgsVector( 0, 1 ),
+                                     QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
+                                     intersection
+                                   );
+            if ( intersect )
+            {
+              point = QgsPointXY( intersection );
+            }
           }
           else if ( ctx.yConstraint.locked || !std::isnan( res.softLockY ) )
           {
             QgsPoint intersection;
-            QgsGeometryUtils::lineIntersection(
-              QgsPoint( point ), QgsVector( 1, 0 ),
-              QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
-              intersection
-            );
-            point = QgsPointXY( intersection );
+            const bool intersect = QgsGeometryUtils::lineIntersection(
+                                     QgsPoint( point ), QgsVector( 1, 0 ),
+                                     QgsPoint( extensionPoint ), QgsPoint( extensionPoint ) - vertex,
+                                     intersection
+                                   );
+            if ( intersect )
+            {
+              point = QgsPointXY( intersection );
+            }
           }
           else if ( angleLocked )
           {

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -308,9 +308,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
         }
 
         const double distance = QgsGeometryUtils::distToInfiniteLine(
-                                  point.x(), point.y(),
-                                  extensionPoint.x(), extensionPoint.y(),
-                                  vertex.x(), vertex.y() );
+                                  QgsPoint( point ), QgsPoint( extensionPoint ), vertex );
 
         if ( distance / ctx.mapUnitsPerPixel < SOFT_CONSTRAINT_TOLERANCE_PIXEL )
         {

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -402,6 +402,27 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, horizontalPt0, horizontalPt1, point );
       }
     }
+    else if ( res.softLockLineExtension != QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex )
+    {
+      const QgsPointLocator::Match snap = ctx.lockedSnapVertices().last();
+      const QgsFeature feature = snap.layer()->getFeature( snap.featureId() );
+      const QgsGeometry geom = feature.geometry();
+
+
+      const QgsPointXY lineExtensionPt1 = snap.point();
+
+      QgsPointXY lineExtensionPt2;
+      if ( res.softLockLineExtension == QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex )
+      {
+        lineExtensionPt2 = QgsPointXY( geom.vertexAt( snap.vertexIndex() + 1 ) );
+      }
+      else
+      {
+        lineExtensionPt2 = QgsPointXY( geom.vertexAt( snap.vertexIndex() - 1 ) );
+      }
+
+      res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, lineExtensionPt1, lineExtensionPt2, point );
+    }
     else
     {
       const double dist = std::sqrt( point.sqrDist( previousPt ) );

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -225,7 +225,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
     {
       // do nothing if both X,Y are already locked
     }
-    else if ( ctx.xConstraint.locked )
+    else if ( ctx.xConstraint.locked || !std::isnan( res.softLockX ) )
     {
       if ( qgsDoubleNear( cosa, 0.0 ) )
       {
@@ -241,7 +241,7 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
         point.setY( previousPt.y() + x * sina / cosa );
       }
     }
-    else if ( ctx.yConstraint.locked )
+    else if ( ctx.yConstraint.locked || !std::isnan( res.softLockY ) )
     {
       if ( qgsDoubleNear( sina, 0.0 ) )
       {

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -17,9 +17,11 @@
 #ifndef QGSCADUTILS_H
 #define QGSCADUTILS_H
 
-#include "qgis_core.h"
+#include <QQueue>
 
+#include "qgis_core.h"
 #include "qgspointlocator.h"
+
 
 class QgsSnappingUtils;
 
@@ -68,6 +70,13 @@ class CORE_EXPORT QgsCadUtils
     {
       public:
 
+        enum LineExtensionSide
+        {
+          BeforeVertex,
+          AfterVertex,
+          NoVertex
+        };
+
         //! Whether the combination of constraints is actually valid
         bool valid;
 
@@ -88,6 +97,10 @@ class CORE_EXPORT QgsCadUtils
 
         //! Angle (in degrees) to which we have soft-locked ourselves (if not set it is -1)
         double softLockCommonAngle;
+
+        LineExtensionSide softLockLineExtension;
+        double softLockX;
+        double softLockY;
     };
 
     /**
@@ -126,6 +139,9 @@ class CORE_EXPORT QgsCadUtils
         //! Constraint for soft lock to a common angle
         QgsCadUtils::AlignMapPointConstraint commonAngleConstraint;
 
+        QgsCadUtils::AlignMapPointConstraint lineExtensionConstraint;
+        QgsCadUtils::AlignMapPointConstraint xyVertexConstraint;
+
         /**
          * Dumps the context's properties, for debugging.
          * \note Not available in Python bindings.
@@ -149,7 +165,15 @@ class CORE_EXPORT QgsCadUtils
          * \see cadPoints()
          * \since QGIS 3.22
          */
-        void setCadPoints( const QList< QgsPoint> &points ) { mCadPointList = points; };
+        void setCadPoints( const QList< QgsPoint > &points ) { mCadPointList = points; };
+
+        /**
+         * Sets the list of recent CAD \a points (in map coordinates).
+         *
+         * \see lockedSnapVertices()
+         * \since QGIS 3.24
+         */
+        void setLockedSnapVertices( const QQueue< QgsPointLocator::Match > &lockedSnapVertices ) { mLockedSnapVertices = lockedSnapVertices; } SIP_SKIP;
 
         /**
          * Sets the recent CAD point at the specified \a index to \a point (in map coordinates).
@@ -166,6 +190,7 @@ class CORE_EXPORT QgsCadUtils
          * \since QGIS 3.22
          */
         QgsPoint cadPoint( int index ) const { return mCadPointList[index]; };
+        QQueue< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; } SIP_SKIP;
 
 
 #ifdef SIP_RUN
@@ -184,6 +209,7 @@ class CORE_EXPORT QgsCadUtils
          * point (index 2) for alignment purposes.
          */
         QList<QgsPoint> mCadPointList;
+        QQueue< QgsPointLocator::Match > mLockedSnapVertices;
 
     };
 

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -69,19 +69,6 @@ class CORE_EXPORT QgsCadUtils
     class AlignMapPointOutput
     {
       public:
-
-        /**
-         * Designates whether the line extension constraint is currently soft locked
-         * with the previous or next vertex of the locked one.
-         * \since QGIS 3.26
-         */
-        enum LineExtensionSide
-        {
-          BeforeVertex,
-          AfterVertex,
-          NoVertex
-        };
-
         //! Whether the combination of constraints is actually valid
         bool valid;
 
@@ -103,7 +90,7 @@ class CORE_EXPORT QgsCadUtils
         //! Angle (in degrees) to which we have soft-locked ourselves (if not set it is -1)
         double softLockCommonAngle;
 
-        LineExtensionSide softLockLineExtension;
+        Qgis::LineExtensionSide softLockLineExtension;
         double softLockX;
         double softLockY;
     };

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -73,7 +73,7 @@ class CORE_EXPORT QgsCadUtils
         /**
          * Designates whether the line extension constraint is currently soft locked
          * with the previous or next vertex of the locked one.
-         * \since QGIS 3.24
+         * \since QGIS 3.26
          */
         enum LineExtensionSide
         {
@@ -194,7 +194,7 @@ class CORE_EXPORT QgsCadUtils
          * Point locator matches are stored instead of vertices to keep more context.
          *
          * \see lockedSnapVertices()
-         * \since QGIS 3.24
+         * \since QGIS 3.26
          */
         void setLockedSnapVertices( const QQueue< QgsPointLocator::Match > &lockedSnapVertices ) { mLockedSnapVertices = lockedSnapVertices; } SIP_SKIP;
 
@@ -202,7 +202,7 @@ class CORE_EXPORT QgsCadUtils
          * Returns the queue of point locator matches that contain the locked vertices.
          *
          * \see setLockedSnapVertices()
-         * \since QGIS 3.24
+         * \since QGIS 3.26
          */
         QQueue< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; } SIP_SKIP;
 

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsCadUtils
         /**
          * Sets the queue of locked vertices.
          *
-         * The use of QgsPointLocator::Match allows to keep more context than a QgsPoint.
+         * Point locator matches are stored instead of vertices to keep more context.
          *
          * \see lockedSnapVertices()
          * \since QGIS 3.24

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -70,6 +70,11 @@ class CORE_EXPORT QgsCadUtils
     {
       public:
 
+        /**
+         * Designates whether the line extension constraint is currently soft locked
+         * with the previous or next vertex of the locked one.
+         * \since QGIS 3.24
+         */
         enum LineExtensionSide
         {
           BeforeVertex,
@@ -168,14 +173,6 @@ class CORE_EXPORT QgsCadUtils
         void setCadPoints( const QList< QgsPoint > &points ) { mCadPointList = points; };
 
         /**
-         * Sets the list of recent CAD \a points (in map coordinates).
-         *
-         * \see lockedSnapVertices()
-         * \since QGIS 3.24
-         */
-        void setLockedSnapVertices( const QQueue< QgsPointLocator::Match > &lockedSnapVertices ) { mLockedSnapVertices = lockedSnapVertices; } SIP_SKIP;
-
-        /**
          * Sets the recent CAD point at the specified \a index to \a point (in map coordinates).
          *
          * \see cadPoint()
@@ -190,6 +187,23 @@ class CORE_EXPORT QgsCadUtils
          * \since QGIS 3.22
          */
         QgsPoint cadPoint( int index ) const { return mCadPointList[index]; };
+
+        /**
+         * Sets the queue of locked vertices.
+         *
+         * The use of QgsPointLocator::Match allows to keep more context than a QgsPoint.
+         *
+         * \see lockedSnapVertices()
+         * \since QGIS 3.24
+         */
+        void setLockedSnapVertices( const QQueue< QgsPointLocator::Match > &lockedSnapVertices ) { mLockedSnapVertices = lockedSnapVertices; } SIP_SKIP;
+
+        /**
+         * Returns the queue of point locator matches that contain the locked vertices.
+         *
+         * \see setLockedSnapVertices()
+         * \since QGIS 3.24
+         */
         QQueue< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; } SIP_SKIP;
 
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -108,7 +108,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   }
 
   // Draw segment par/per input
-  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() != QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint && hasSnappedSegment )
+  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() != Qgis::BetweenLineConstraint::NoConstraint && hasSnappedSegment )
   {
     painter->setPen( mConstruction2Pen );
     painter->drawLine( snapSegmentPix1, snapSegmentPix2 );
@@ -223,7 +223,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   }
 
   // Draw constr
-  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() == QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint )
+  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() == Qgis::BetweenLineConstraint::NoConstraint )
   {
     if ( curPointExist && previousPointExist )
     {
@@ -249,7 +249,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
 
   auto lineExtensionSide = mAdvancedDigitizingDockWidget->lineExtensionSide();
   if ( mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() &&
-       lineExtensionSide != QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex &&
+       lineExtensionSide != Qgis::LineExtensionSide::NoVertex &&
        mAdvancedDigitizingDockWidget->lockedSnapVertices().length() )
   {
     painter->setPen( mLockedPen );
@@ -261,7 +261,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     const QgsGeometry geom = feature.geometry();
 
     QgsPoint vertex;
-    if ( lineExtensionSide == QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex )
+    if ( lineExtensionSide == Qgis::LineExtensionSide::BeforeVertex )
     {
       vertex = geom.vertexAt( snap.vertexIndex() - 1 );
     }

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -18,6 +18,7 @@
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsadvanceddigitizingcanvasitem.h"
 #include "qgsmapcanvas.h"
+#include "qgscadutils.h"
 
 
 QgsAdvancedDigitizingCanvasItem::QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
@@ -244,6 +245,89 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
                        curPointPix + QPointF( +5, +5 ) );
     painter->drawLine( curPointPix + QPointF( -5, +5 ),
                        curPointPix + QPointF( +5, -5 ) );
+  }
+
+  auto lineExtensionSide = mAdvancedDigitizingDockWidget->lineExtensionSide();
+  if ( mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() &&
+       lineExtensionSide != QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex &&
+       mAdvancedDigitizingDockWidget->lockedSnapVertices().length() )
+  {
+    painter->setPen( mLockedPen );
+
+    const QgsPointLocator::Match snap = mAdvancedDigitizingDockWidget->lockedSnapVertices().last();
+    const QPointF snappedPoint = toCanvasCoordinates( snap.point() );
+
+    const QgsFeature feature = snap.layer()->getFeature( snap.featureId() );
+    const QgsGeometry geom = feature.geometry();
+
+    QgsPoint vertex;
+    if ( lineExtensionSide == QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex )
+    {
+      vertex = geom.vertexAt( snap.vertexIndex() - 1 );
+    }
+    else
+    {
+      vertex = geom.vertexAt( snap.vertexIndex() + 1 );
+    }
+
+    if ( !vertex.isEmpty() )
+    {
+      const QPointF point = toCanvasCoordinates( vertex );
+      const double angle = std::atan2( snappedPoint.y() - point.y(), snappedPoint.x() - point.x() );
+
+      const double canvasPadding = QLineF( snappedPoint, curPointPix ).length();
+      painter->drawLine( snappedPoint + ( canvasPadding - canvasDiagonalDimension ) * QPointF( std::cos( angle ), std::sin( angle ) ),
+                         snappedPoint + ( canvasPadding + canvasDiagonalDimension ) * QPointF( std::cos( angle ), std::sin( angle ) ) );
+    }
+
+  }
+
+  if ( mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() )
+  {
+    painter->setPen( mLockedPen );
+
+    double coordinateExtension = mAdvancedDigitizingDockWidget->softLockX();
+    if ( coordinateExtension != std::numeric_limits<double>::quiet_NaN() )
+    {
+      const QgsPointXY point( coordinateExtension, mapPoly[0].y() );
+      const QPointF rotation( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) );
+      painter->drawLine( toCanvasCoordinates( point ) - canvasDiagonalDimension * rotation,
+                         toCanvasCoordinates( point ) + canvasDiagonalDimension * rotation );
+    }
+
+    coordinateExtension = mAdvancedDigitizingDockWidget->softLockY();
+    if ( coordinateExtension != std::numeric_limits<double>::quiet_NaN() )
+    {
+      const QgsPointXY point( mapPoly[0].x(), coordinateExtension );
+      const QPointF rotation( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) );
+      painter->drawLine( toCanvasCoordinates( point ) - canvasDiagonalDimension * rotation,
+                         toCanvasCoordinates( point ) + canvasDiagonalDimension * rotation );
+    }
+  }
+
+  painter->setPen( mCursorPen );
+
+  const QList< QgsPointLocator::Match > lockedSnapVertices = mAdvancedDigitizingDockWidget->lockedSnapVertices();
+  for ( QgsPointLocator::Match snapMatch : lockedSnapVertices )
+  {
+    const QgsPointXY point = snapMatch.point();
+    const QPointF canvasPoint = toCanvasCoordinates( point );
+
+    painter->drawLine( canvasPoint + QPointF( 5, 5 ),
+                       canvasPoint - QPointF( 5, 5 ) );
+    painter->drawLine( canvasPoint + QPointF( -5, 5 ),
+                       canvasPoint - QPointF( -5, 5 ) );
+  }
+
+  if ( lockedSnapVertices.length() )
+  {
+    const QgsPointXY point = lockedSnapVertices.last().point();
+    const QPointF canvasPoint = toCanvasCoordinates( point );
+
+    painter->drawLine( canvasPoint + QPointF( 0, 5 ),
+                       canvasPoint - QPointF( 0, 5 ) );
+    painter->drawLine( canvasPoint + QPointF( 5, 0 ),
+                       canvasPoint - QPointF( 5, 0 ) );
   }
 }
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -107,7 +107,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   }
 
   // Draw segment par/per input
-  if ( mAdvancedDigitizingDockWidget->additionalConstraint() != QgsAdvancedDigitizingDockWidget::AdditionalConstraint::NoConstraint && hasSnappedSegment )
+  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() != QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint && hasSnappedSegment )
   {
     painter->setPen( mConstruction2Pen );
     painter->drawLine( snapSegmentPix1, snapSegmentPix2 );
@@ -222,7 +222,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   }
 
   // Draw constr
-  if ( mAdvancedDigitizingDockWidget->additionalConstraint() == QgsAdvancedDigitizingDockWidget::AdditionalConstraint::NoConstraint )
+  if ( mAdvancedDigitizingDockWidget->betweenLineConstraint() == QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint )
   {
     if ( curPointExist && previousPointExist )
     {

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -63,7 +63,7 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   mLineExtensionConstraint.reset( new CadConstraint( new QLineEdit(), new QToolButton() ) );
   mXyVertexConstraint.reset( new CadConstraint( new QLineEdit(), new QToolButton() ) );
 
-  mBetweenLineConstraint = BetweenLineConstraint::NoConstraint;
+  mBetweenLineConstraint = Qgis::BetweenLineConstraint::NoConstraint;
 
   mMapCanvas->installEventFilter( this );
   mAngleLineEdit->installEventFilter( this );
@@ -441,15 +441,15 @@ void QgsAdvancedDigitizingDockWidget::betweenLineConstraintClicked( bool activat
 {
   if ( !activated )
   {
-    lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+    lockBetweenLineConstraint( Qgis::BetweenLineConstraint::NoConstraint );
   }
   else if ( sender() == mParallelAction )
   {
-    lockBetweenLineConstraint( BetweenLineConstraint::Parallel );
+    lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Parallel );
   }
   else if ( sender() == mPerpendicularAction )
   {
-    lockBetweenLineConstraint( BetweenLineConstraint::Perpendicular );
+    lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Perpendicular );
   }
 }
 
@@ -546,7 +546,7 @@ void QgsAdvancedDigitizingDockWidget::releaseLocks( bool releaseRepeatingLocks )
 {
   // release all locks except construction mode
 
-  lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+  lockBetweenLineConstraint( Qgis::BetweenLineConstraint::NoConstraint );
 
   if ( releaseRepeatingLocks )
   {
@@ -793,7 +793,7 @@ void QgsAdvancedDigitizingDockWidget::lockConstraint( bool activate /* default t
     // deactivate perpendicular/parallel if angle has been activated
     if ( constraint == mAngleConstraint.get() )
     {
-      lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+      lockBetweenLineConstraint( Qgis::BetweenLineConstraint::NoConstraint );
     }
 
     // run a fake map mouse event to update the paint item
@@ -827,11 +827,11 @@ void QgsAdvancedDigitizingDockWidget::constraintFocusOut()
   updateConstraintValue( constraint, lineEdit->text(), true );
 }
 
-void QgsAdvancedDigitizingDockWidget::lockBetweenLineConstraint( BetweenLineConstraint constraint )
+void QgsAdvancedDigitizingDockWidget::lockBetweenLineConstraint( Qgis::BetweenLineConstraint constraint )
 {
   mBetweenLineConstraint = constraint;
-  mPerpendicularAction->setChecked( constraint == BetweenLineConstraint::Perpendicular );
-  mParallelAction->setChecked( constraint == BetweenLineConstraint::Parallel );
+  mPerpendicularAction->setChecked( constraint == Qgis::BetweenLineConstraint::Perpendicular );
+  mParallelAction->setChecked( constraint == Qgis::BetweenLineConstraint::Parallel );
 }
 
 void QgsAdvancedDigitizingDockWidget::lockParameterlessConstraint( bool activate /* default true */ )
@@ -931,7 +931,7 @@ void QgsAdvancedDigitizingDockWidget::updateCapacity( bool updateUIwithoutChange
 
   if ( !absoluteAngle )
   {
-    lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+    lockBetweenLineConstraint( Qgis::BetweenLineConstraint::NoConstraint );
   }
 
   // absolute angle = azimuth, relative = from previous line
@@ -1259,7 +1259,7 @@ QList<QgsPointXY> QgsAdvancedDigitizingDockWidget::snapSegmentToAllLayers( const
 
 bool QgsAdvancedDigitizingDockWidget::alignToSegment( QgsMapMouseEvent *e, CadConstraint::LockMode lockMode )
 {
-  if ( mBetweenLineConstraint == BetweenLineConstraint::NoConstraint )
+  if ( mBetweenLineConstraint == Qgis::BetweenLineConstraint::NoConstraint )
   {
     return false;
   }
@@ -1281,7 +1281,7 @@ bool QgsAdvancedDigitizingDockWidget::alignToSegment( QgsMapMouseEvent *e, CadCo
     angle -= std::atan2( previousPt.y() - penultimatePt.y(), previousPt.x() - penultimatePt.x() );
   }
 
-  if ( mBetweenLineConstraint == BetweenLineConstraint::Perpendicular )
+  if ( mBetweenLineConstraint == Qgis::BetweenLineConstraint::Perpendicular )
   {
     angle += M_PI_2;
   }
@@ -1292,7 +1292,7 @@ bool QgsAdvancedDigitizingDockWidget::alignToSegment( QgsMapMouseEvent *e, CadCo
   mAngleConstraint->setLockMode( lockMode );
   if ( lockMode == CadConstraint::HardLock )
   {
-    mBetweenLineConstraint = BetweenLineConstraint::NoConstraint;
+    mBetweenLineConstraint = Qgis::BetweenLineConstraint::NoConstraint;
   }
 
   return true;
@@ -1599,15 +1599,15 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
 
         if ( !parallel && !perpendicular )
         {
-          lockBetweenLineConstraint( BetweenLineConstraint::Perpendicular );
+          lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Perpendicular );
         }
         else if ( perpendicular )
         {
-          lockBetweenLineConstraint( BetweenLineConstraint::Parallel );
+          lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Parallel );
         }
         else
         {
-          lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+          lockBetweenLineConstraint( Qgis::BetweenLineConstraint::NoConstraint );
         }
         e->accept();
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -338,6 +338,12 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
   mToggleFloaterAction->setEnabled( enabled );
   mConstructionAction->setEnabled( enabled );
 
+  if ( !enabled )
+  {
+    mLineExtensionAction->setChecked( false );
+    mXyVertexAction->setChecked( false );
+  }
+
   clear();
   setConstructionMode( false );
 
@@ -537,6 +543,11 @@ void QgsAdvancedDigitizingDockWidget::releaseLocks( bool releaseRepeatingLocks )
   // release all locks except construction mode
 
   lockBetweenLineConstraint( BetweenLineConstraint::NoConstraint );
+
+  mXyVertexConstraint->setLockMode( CadConstraint::NoLock );
+  emit softLockXyChanged( false );
+  mLineExtensionConstraint->setLockMode( CadConstraint::NoLock );
+  emit softLockLineExtensionChanged( false );
 
   if ( releaseRepeatingLocks || !mAngleConstraint->isRepeatingLock() )
   {
@@ -1296,6 +1307,8 @@ bool QgsAdvancedDigitizingDockWidget::canvasKeyPressEventFilter( QKeyEvent *e )
 void QgsAdvancedDigitizingDockWidget::clear()
 {
   clearPoints();
+  mLockedSnapVertices.clear();
+
   releaseLocks();
 }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -331,8 +331,6 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
   mCadEnabled = enabled;
   mEnableAction->setChecked( enabled );
   mConstructionModeAction->setEnabled( enabled );
-  mParallelAction->setEnabled( enabled );
-  mPerpendicularAction->setEnabled( enabled );
   mSettingsAction->setEnabled( enabled );
   mInputWidgets->setEnabled( enabled );
   mToggleFloaterAction->setEnabled( enabled );
@@ -340,8 +338,12 @@ void QgsAdvancedDigitizingDockWidget::setCadEnabled( bool enabled )
 
   if ( !enabled )
   {
+    // uncheck at deactivation
     mLineExtensionAction->setChecked( false );
     mXyVertexAction->setChecked( false );
+    // will be reactivated in updateCapacities
+    mParallelAction->setEnabled( false );
+    mPerpendicularAction->setEnabled( false );
   }
 
   clear();
@@ -888,14 +890,28 @@ void QgsAdvancedDigitizingDockWidget::updateCapacity( bool updateUIwithoutChange
   const bool absoluteAngle = mCadEnabled && newCapacities.testFlag( AbsoluteAngle );
   const bool relativeCoordinates = mCadEnabled && newCapacities.testFlag( RelativeCoordinates );
 
-  mPerpendicularAction->setEnabled( distance && absoluteAngle && snappingEnabled );
-  mParallelAction->setEnabled( distance && absoluteAngle && snappingEnabled );
+  mPerpendicularAction->setEnabled( distance && snappingEnabled );
+  mParallelAction->setEnabled( distance && snappingEnabled );
+  mLineExtensionAction->setEnabled( snappingEnabled );
+  mXyVertexAction->setEnabled( snappingEnabled );
 
   //update tooltips on buttons
   if ( !snappingEnabled )
   {
-    mPerpendicularAction->setToolTip( tr( "Snapping must be enabled to utilize perpendicular mode" ) );
-    mParallelAction->setToolTip( tr( "Snapping must be enabled to utilize parallel mode" ) );
+    mPerpendicularAction->setToolTip( tr( "Snapping must be enabled to utilize perpendicular mode." ) );
+    mParallelAction->setToolTip( tr( "Snapping must be enabled to utilize parallel mode." ) );
+    mLineExtensionAction->setToolTip( tr( "Snapping must be enabled to utilize line extension mode." ) );
+    mXyVertexAction->setToolTip( tr( "Snapping must be enabled to utilize xy point mode." ) );
+  }
+  else if ( mCadPointList.count() <= 1 )
+  {
+    mPerpendicularAction->setToolTip( tr( "A first vertex should be drawn to utilize perpendicular mode." ) );
+    mParallelAction->setToolTip( tr( "A first vertex should be drawn to utilize parallel mode." ) );
+  }
+  else if ( isGeographic )
+  {
+    mPerpendicularAction->setToolTip( tr( "Perpendicular mode cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
+    mParallelAction->setToolTip( tr( "Parallel mode cannot be used on geographic coordinates. Change the coordinates system in the project properties." ) );
   }
   else
   {

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -67,9 +67,9 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     Q_FLAG( CadCapacities )
 
     /**
-     * Additional constraints which can be enabled
+     * Between line constraints which can be enabled
      */
-    enum class AdditionalConstraint SIP_MONKEYPATCH_SCOPEENUM : int
+    enum class BetweenLineConstraint SIP_MONKEYPATCH_SCOPEENUM : int
     {
       NoConstraint,  //!< No additional constraint
       Perpendicular, //!< Perpendicular
@@ -245,8 +245,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     bool applyConstraints( QgsMapMouseEvent *e );
 
     /**
-     * align to segment for additional constraint.
-     * If additional constraints are used, this will determine the angle to be locked depending on the snapped segment.
+     * align to segment for between line constraint.
+     * If between line constraints are used, this will determine the angle to be locked depending on the snapped segment.
      * \since QGIS 3.0
      */
     bool alignToSegment( QgsMapMouseEvent *e, QgsAdvancedDigitizingDockWidget::CadConstraint::LockMode lockMode = QgsAdvancedDigitizingDockWidget::CadConstraint::HardLock );
@@ -290,10 +290,10 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     bool constructionMode() const { return mConstructionMode; }
 
     /**
-     * Returns the additional constraints which are used to place
+     * Returns the between line constraints which are used to place
      * perpendicular/parallel segments to snapped segments on the canvas
      */
-    AdditionalConstraint additionalConstraint() const  { return mAdditionalConstraint; }
+    BetweenLineConstraint betweenLineConstraint() const  { return mBetweenLineConstraint; }
     //! Returns the \a CadConstraint on the angle
     const CadConstraint *constraintAngle() const  { return mAngleConstraint.get(); }
     //! Returns the \a CadConstraint on the distance
@@ -826,8 +826,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
 
   private slots:
-    //! Sets the additional constraint by clicking on the perpendicular/parallel buttons
-    void additionalConstraintClicked( bool activated );
+    //! Sets the between line constraint by clicking on the perpendicular/parallel buttons
+    void betweenLinesConstraintClicked( bool activated );
 
     //! lock/unlock a constraint and set its value
     void lockConstraint( bool activate = true );
@@ -878,8 +878,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void updateCapacity( bool updateUIwithoutChange = false );
 
-    //! defines the additional constraint to be used (no/parallel/perpendicular)
-    void lockAdditionalConstraint( AdditionalConstraint constraint );
+    //! defines the between line constraint to be used (no/parallel/perpendicular)
+    void lockBetweenLinesConstraint( BetweenLineConstraint constraint );
 
     /**
      * Returns the first snapped segment. Will try to snap a segment using all layers
@@ -948,7 +948,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr< CadConstraint > mYConstraint;
     std::unique_ptr< CadConstraint > mZConstraint;
     std::unique_ptr< CadConstraint > mMConstraint;
-    AdditionalConstraint mAdditionalConstraint;
+    BetweenLineConstraint mBetweenLineConstraint;
     double mCommonAngleConstraint; // if 0: do not snap to common angles
 
     // point list and current snap point / segment

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -342,14 +342,14 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Returns the snap matches whose vertices have been locked
-     * \since QGIS 3.24
+     * \since QGIS 3.26
      */
     QList< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; }
 
     /**
       * Removes all points from the locked snap vertex list
-      * \since QGIS 3.26
       * \param force Clears the list even if the constraints that use it are still locked.
+      * \since QGIS 3.26
       */
     void clearLockedSnapVertices( bool force = true );
 
@@ -742,7 +742,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the soft line extension parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.24
+    * \since QGIS 3.26
     */
     void softLockLineExtensionChanged( bool locked );
 
@@ -750,7 +750,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Emitted whenever the soft x/y extension parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
     * \note unstable API (will likely change)
-    * \since QGIS 3.24
+    * \since QGIS 3.26
     */
     void softLockXyChanged( bool locked );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -347,6 +347,13 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     QList< QgsPointLocator::Match > lockedSnapVertices() const { return mLockedSnapVertices; }
 
     /**
+      * Removes all points from the locked snap vertex list
+      * \since QGIS 3.26
+      * \param force Clears the list even if the constraints that use it are still locked.
+      */
+    void clearLockedSnapVertices( bool force = true );
+
+    /**
      * Removes all points from the CAD point list
      * \since QGIS 3.0
      */

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -69,16 +69,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     Q_FLAG( CadCapacities )
 
     /**
-     * Between line constraints which can be enabled
-     */
-    enum class BetweenLineConstraint SIP_MONKEYPATCH_SCOPEENUM : int
-    {
-      NoConstraint,  //!< No additional constraint
-      Perpendicular, //!< Perpendicular
-      Parallel       //!< Parallel
-    };
-
-    /**
      * Type of interaction to simulate when editing values from external widget
      * \note unstable API (will likely change)
      * \since QGIS 3.8
@@ -295,7 +285,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Returns the between line constraints which are used to place
      * perpendicular/parallel segments to snapped segments on the canvas
      */
-    BetweenLineConstraint betweenLineConstraint() const  { return mBetweenLineConstraint; }
+    Qgis::BetweenLineConstraint betweenLineConstraint() const  { return mBetweenLineConstraint; }
     //! Returns the \a CadConstraint on the angle
     const CadConstraint *constraintAngle() const  { return mAngleConstraint.get(); }
     //! Returns the \a CadConstraint on the distance
@@ -323,7 +313,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     const CadConstraint *constraintLineExtension() const { return mLineExtensionConstraint.get(); }
 
     //! Returns on which side of the constraint line extension point, the line was created
-    QgsCadUtils::AlignMapPointOutput::LineExtensionSide lineExtensionSide() const { return mSoftLockLineExtension; }
+    Qgis::LineExtensionSide lineExtensionSide() const { return mSoftLockLineExtension; }
 
     //! Returns the \a CadConstraint
     const CadConstraint *constraintXyVertex() const { return mXyVertexConstraint.get(); }
@@ -928,7 +918,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void updateCapacity( bool updateUIwithoutChange = false );
 
     //! defines the between line constraint to be used (no/parallel/perpendicular)
-    void lockBetweenLineConstraint( BetweenLineConstraint constraint );
+    void lockBetweenLineConstraint( Qgis::BetweenLineConstraint constraint );
 
     /**
      * Returns the first snapped segment. Will try to snap a segment using all layers
@@ -1007,7 +997,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr< CadConstraint > mMConstraint;
     std::unique_ptr< CadConstraint > mLineExtensionConstraint;
     std::unique_ptr< CadConstraint > mXyVertexConstraint;
-    BetweenLineConstraint mBetweenLineConstraint;
+    Qgis::BetweenLineConstraint mBetweenLineConstraint;
     double mCommonAngleConstraint; // if 0: do not snap to common angles
 
     // point list and current snap point / segment
@@ -1029,7 +1019,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     QgsPointLocator::Match mLastSnapMatch;
 
     // Extra constraint context
-    QgsCadUtils::AlignMapPointOutput::LineExtensionSide mSoftLockLineExtension;
+    Qgis::LineExtensionSide mSoftLockLineExtension;
     double mSoftLockX;
     double mSoftLockY;
     QQueue< QgsPointLocator::Match > mLockedSnapVertices;

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -56,6 +56,8 @@
       <addaction name="mSettingsAction"/>
       <addaction name="separator"/>
       <addaction name="mToggleFloaterAction"/>
+      <addaction name="separator"/>
+      <addaction name="mConstructionAction"/>
      </widget>
     </item>
     <item>
@@ -628,6 +630,18 @@
     <string>Toggle Floater</string>
    </property>
   </action>
+  <action name="mConstructionAction">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/algorithms/mAlgorithmExtractVertices.svg</normaloff>:/images/themes/default/algorithms/mAlgorithmExtractVertices.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Construction</string>
+   </property>
+   <property name="toolTip">
+    <string>Construction</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -663,6 +677,7 @@
   <tabstop>mRepeatingLockMButton</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -55,6 +55,8 @@ class TestQgsAdvancedDigitizing: public QObject
     void currentPointWhenSanpping();
     void currentPointWhenSanppingWithDiffCanvasCRS();
 
+    void releaseLockAfterDisable();
+
   private:
     TestQgsMapToolAdvancedDigitizingUtils getMapToolDigitizingUtils( QgsVectorLayer *layer );
     QString getWktFromLastAddedFeature( TestQgsMapToolAdvancedDigitizingUtils utils, QSet<QgsFeatureId> oldFeatures );
@@ -853,6 +855,103 @@ void TestQgsAdvancedDigitizing::currentPointWhenSanppingWithDiffCanvasCRS()
   // on a self point
   utils.mouseMove( 25, 0.1 );
   QGSCOMPARENEARPOINT( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 25, 0 ), 0.000001 );
+}
+
+void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
+{
+  // activate advanced digitizing
+  getMapToolDigitizingUtils( mLayer4326 );
+
+  QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
+
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintY()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintZ()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintM()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() );
+
+  // enable some constraints
+  mAdvancedDigitizingDockWidget->setAngle( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+  mAdvancedDigitizingDockWidget->setDistance( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+  mAdvancedDigitizingDockWidget->setX( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+  mAdvancedDigitizingDockWidget->setY( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+  mAdvancedDigitizingDockWidget->setZ( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+  mAdvancedDigitizingDockWidget->setM( QStringLiteral( "0" ), QgsAdvancedDigitizingDockWidget::ReturnPressed );
+
+
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintY()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintZ()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintM()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() );
+
+  // disable advanced digitizing
+  mAdvancedDigitizingDockWidget->enableAction()->trigger();
+
+  QVERIFY( !mAdvancedDigitizingDockWidget->cadEnabled() );
+
+  // all constraints should be deactivated
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintY()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintZ()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintM()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() );
+
+  // activate advanced digitizing
+  mAdvancedDigitizingDockWidget->enableAction()->trigger();
+
+  // enable another constraints
+  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+  mAdvancedDigitizingDockWidget->mXyVertexAction->trigger();
+  mAdvancedDigitizingDockWidget->mLineExtensionAction->trigger();
+
+  QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
+
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintY()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintZ()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintM()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() );
+  QVERIFY( mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() );
+
+  // disable advanced digitizing
+  mAdvancedDigitizingDockWidget->enableAction()->trigger();
+
+  QVERIFY( !mAdvancedDigitizingDockWidget->cadEnabled() );
+
+  // all constraints should be deactivated
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+           QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintY()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintZ()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintM()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintLineExtension()->isLocked() );
+  QVERIFY( !mAdvancedDigitizingDockWidget->constraintXyVertex()->isLocked() );
+
+  // to be compliant with the integration
+  mAdvancedDigitizingDockWidget->enableAction()->trigger();
 }
 
 QGSTEST_MAIN( TestQgsAdvancedDigitizing )

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -659,14 +659,14 @@ void TestQgsAdvancedDigitizing::perpendicularConstraint()
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 0, 4 ) );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+            Qgis::BetweenLineConstraint::NoConstraint );
 
   // digitizing a first vertex
   utils.mouseClick( 5, 5, Qt::LeftButton );
 
-  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Perpendicular );
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+            Qgis::BetweenLineConstraint::Perpendicular );
 
   // select the previous digitized line
   utils.mouseClick( 0.1, 4, Qt::LeftButton );
@@ -1022,7 +1022,7 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+            Qgis::BetweenLineConstraint::NoConstraint );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
@@ -1042,7 +1042,7 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
 
 
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+            Qgis::BetweenLineConstraint::NoConstraint );
   QVERIFY( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
   QVERIFY( mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
   QVERIFY( mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
@@ -1059,7 +1059,7 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
 
   // all constraints should be deactivated
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+            Qgis::BetweenLineConstraint::NoConstraint );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
@@ -1073,14 +1073,14 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
   mAdvancedDigitizingDockWidget->enableAction()->trigger();
 
   // enable another constraints
-  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( Qgis::BetweenLineConstraint::Perpendicular );
   mAdvancedDigitizingDockWidget->mXyVertexAction->trigger();
   mAdvancedDigitizingDockWidget->mLineExtensionAction->trigger();
 
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
 
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+            Qgis::BetweenLineConstraint::Perpendicular );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );
@@ -1097,7 +1097,7 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
 
   // all constraints should be deactivated
   QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
-            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
+            Qgis::BetweenLineConstraint::NoConstraint );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintDistance()->isLocked() );
   QVERIFY( !mAdvancedDigitizingDockWidget->constraintX()->isLocked() );

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -653,15 +653,15 @@ void TestQgsAdvancedDigitizing::perpendicularConstraint()
   utils.mouseMove( 0.1, 4 );
   QCOMPARE( mAdvancedDigitizingDockWidget->currentPointV2(), QgsPoint( 0, 4 ) );
 
-  QCOMPARE( mAdvancedDigitizingDockWidget->additionalConstraint(),
-            QgsAdvancedDigitizingDockWidget::AdditionalConstraint::NoConstraint );
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::NoConstraint );
 
   // digitizing a first vertex
   utils.mouseClick( 5, 5, Qt::LeftButton );
 
-  mAdvancedDigitizingDockWidget->lockAdditionalConstraint( QgsAdvancedDigitizingDockWidget::AdditionalConstraint::Perpendicular );
-  QCOMPARE( mAdvancedDigitizingDockWidget->additionalConstraint(),
-            QgsAdvancedDigitizingDockWidget::AdditionalConstraint::Perpendicular );
+  mAdvancedDigitizingDockWidget->lockBetweenLineConstraint( QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
+  QCOMPARE( mAdvancedDigitizingDockWidget->betweenLineConstraint(),
+            QgsAdvancedDigitizingDockWidget::BetweenLineConstraint::Perpendicular );
 
   // select the previous digitized line
   utils.mouseClick( 0.1, 4, Qt::LeftButton );

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -309,7 +309,7 @@ void TestQgsCadUtils::testLineExtension()
   QgsCadUtils::AlignMapPointContext context( baseContext() );
   context.mapUnitsPerPixel = 0.1;
 
-  // without no constraint
+  // without constraint
   QgsCadUtils::AlignMapPointOutput result = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 20 ), context );
   QVERIFY( result.valid );
   QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );
@@ -382,7 +382,7 @@ void TestQgsCadUtils::testLineExtension()
   context.xConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 11 );
   context.yConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 0 );
 
-  // this time, the soft lock shouldn't be actived
+  // this time, the soft lock shouldn't be activated
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 0 ), context );
   QVERIFY( result.valid );
   QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -312,7 +312,7 @@ void TestQgsCadUtils::testLineExtension()
   // without constraint
   QgsCadUtils::AlignMapPointOutput result = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 20 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::NoVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 45, 20 ) );
 
   // only line extension
@@ -329,12 +329,12 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.5, 0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::AfterVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 10, 0 ) );
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 50.5, 0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::BeforeVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 50.4, -0.2 ) );
 
   // extension + x
@@ -342,7 +342,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 0.2, 25.2 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::BeforeVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 0, 25 ) );
 
   // extension + rel x
@@ -350,7 +350,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 0, 30.2 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::BeforeVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( -10, 30 ) );
 
   // extension + y
@@ -359,7 +359,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( -0.2, 25.2 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::BeforeVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 0, 25 ) );
 
   // extension + rel y
@@ -367,7 +367,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 70.2, -100 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::BeforeVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::BeforeVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 70, -10 ) );
 
   // extension + x + y
@@ -376,7 +376,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::AfterVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 10, 0 ) );
 
   context.xConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 11 );
@@ -385,7 +385,7 @@ void TestQgsCadUtils::testLineExtension()
   // this time, the soft lock shouldn't be activated
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::NoVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 11, 0 ) );
 
   // extension + angle
@@ -396,7 +396,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 40.2 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::AfterVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 10, 40 ) );
 
   // extension + common angle
@@ -406,7 +406,7 @@ void TestQgsCadUtils::testLineExtension()
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 40.2 ), context );
   QVERIFY( result.valid );
   QCOMPARE( result.softLockCommonAngle, 135.0 );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::AfterVertex );
   QCOMPARE( result.finalMapPoint, QgsPointXY( 10, 40 ) );
 
   // extension + distance ( without intersection )
@@ -415,7 +415,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 42.0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::NoVertex );
   QGSCOMPARENEARPOINT( result.finalMapPoint, QgsPointXY( 23.273, 27.399 ), 10e-3 );
 
   // extension + distance ( with intersection )
@@ -423,7 +423,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 42.0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::AfterVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::AfterVertex );
   QGSCOMPARENEARPOINT( result.finalMapPoint, QgsPointXY( 10, 42.361 ), 10e-3 );
 
   // extension + distance + x
@@ -431,7 +431,7 @@ void TestQgsCadUtils::testLineExtension()
 
   result = QgsCadUtils::alignMapPoint( QgsPointXY( 10.2, 42.0 ), context );
   QVERIFY( result.valid );
-  QCOMPARE( result.softLockLineExtension, QgsCadUtils::AlignMapPointOutput::LineExtensionSide::NoVertex );
+  QCOMPARE( result.softLockLineExtension, Qgis::LineExtensionSide::NoVertex );
   QGSCOMPARENEARPOINT( result.finalMapPoint, QgsPointXY( 9.9, 42.271 ), 10e-3 );
 }
 


### PR DESCRIPTION
## Description

This PR adds 2 new advanced digitizing tools:
  - Line Extension, the user selects a vertex of a line and then can add a point in the continuity of the lines formed with the previous and next vertex.
  - x/y Vertex, the user selects one or more vertices and then he can add a point with the same x or y coordinates of one of these vertices.

![demo](https://user-images.githubusercontent.com/37629967/147547084-785855d6-0c01-407e-a12f-cc0f01e9acd4.gif)

I changed the name of the constraint group "Additional Constraint" to "Between Line Constraint", because the term "Additional" could be confusing.

To do:
 - [ ] Manage snapping between constraints (such as crossings)
 - [ ] Line continuity constraint with polygons and multi geometries
 - [ ] Add tests (based on the ones I'm doing in the PR #46357)
 - [ ] Be able to have several lines to extend (with line continuity constraint)
 - [ ] Create icons for the 2 actions
 - [ ] Add tool tip and modify action names
 - [ ] Snapping to the closest constraint?

This PR edits the code of the advanced digitizing panel with behavioral changes, feedback and questions are welcome.

Sponsored by: Métropole Européenne de Lille @Jean-Roc