### PR TITLE
Option to synchronize statistics panel with layers panel

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -79,6 +79,9 @@ QgsStatisticalSummaryDockWidget::QgsStatisticalSummaryDockWidget( QWidget *paren
 
   mStatisticsMenu = new QMenu( mOptionsToolButton );
   mOptionsToolButton->setMenu( mStatisticsMenu );
+  mSyncAction = new QAction( tr( "Keep synchronized with TOC" ) );
+  mSyncAction->setCheckable( true );
+  connect( mSyncAction, &QAction::toggled, this, &QgsStatisticalSummaryDockWidget::manageSyncLayer );
 
   mFieldType = DataType::Numeric;
   mPreviousFieldType = DataType::Numeric;
@@ -104,6 +107,7 @@ void QgsStatisticalSummaryDockWidget::fieldChanged()
   if ( mFieldExpressionWidget->expression() != mExpression )
   {
     mExpression = mFieldExpressionWidget->expression();
+    mLastExpression.insert( mLayerComboBox->currentLayer()->id(), mFieldExpressionWidget->currentText() );
     refreshStatistics();
   }
 }
@@ -133,6 +137,20 @@ void QgsStatisticalSummaryDockWidget::copyStatistics()
 
     QgsClipboard clipboard;
     clipboard.setData( QStringLiteral( "text/html" ), html.toUtf8(), text );
+  }
+}
+
+void QgsStatisticalSummaryDockWidget::manageSyncLayer( bool checked )
+{
+  mLayerComboBox->setEnabled( !checked );
+  if ( checked )
+  {
+    connect( QgisApp::instance(), &QgisApp::activeLayerChanged, mLayerComboBox, &QgsMapLayerComboBox::setLayer );
+    mLayerComboBox->setLayer( QgisApp::instance()->activeLayer() );
+  }
+  else
+  {
+    disconnect( QgisApp::instance(), &QgisApp::activeLayerChanged, mLayerComboBox, &QgsMapLayerComboBox::setLayer );
   }
 }
 
@@ -376,12 +394,12 @@ void QgsStatisticalSummaryDockWidget::layerChanged( QgsMapLayer *layer )
 
   mLayer = newLayer;
 
-  // clear expression, so that we don't force an unwanted recalculation
-  mFieldExpressionWidget->setExpression( QString() );
   mFieldExpressionWidget->setLayer( mLayer );
 
   if ( mLayer )
   {
+    // Get last expression
+    mFieldExpressionWidget->setExpression( mLastExpression.value( mLayer->id(), QString() ) );
     connect( mLayer, &QgsVectorLayer::selectionChanged, this, &QgsStatisticalSummaryDockWidget::layerSelectionChanged );
   }
 
@@ -438,6 +456,10 @@ void QgsStatisticalSummaryDockWidget::layersRemoved( const QStringList &layers )
   {
     disconnect( mLayer, &QgsVectorLayer::selectionChanged, this, &QgsStatisticalSummaryDockWidget::layerSelectionChanged );
     mLayer = nullptr;
+  }
+  for ( QString layerId : layers )
+  {
+    mLastExpression.remove( layerId );
   }
 }
 
@@ -582,6 +604,9 @@ void QgsStatisticalSummaryDockWidget::refreshStatisticsMenu()
       break;
     }
   }
+
+  mStatisticsMenu->addSeparator();
+  mStatisticsMenu->addAction( mSyncAction );
 }
 
 QgsStatisticalSummaryDockWidget::DataType QgsStatisticalSummaryDockWidget::fieldType( const QString &fieldName )

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -114,6 +114,8 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     QgsVectorLayer *mLayer = nullptr;
 
     QMap< int, QAction * > mStatsActions;
+    QMap< QString, QString > mLastExpression;
+    QAction *mSyncAction;
 
     void updateNumericStatistics();
     void updateStringStatistics();
@@ -123,6 +125,7 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
     QgsExpressionContext createExpressionContext() const override;
 
     void refreshStatisticsMenu();
+    void manageSyncLayer( bool checked );
     DataType fieldType( const QString &fieldName );
 
     QMenu *mStatisticsMenu = nullptr;


### PR DESCRIPTION
## Description

This PR is about the statistics panel, to fix #46567 

### Feature 1: sync with the layer panel

Added a check box to have the possibility to have the statistics panel synced with the layers panel, so when a layer is selected in the layers panel, then this layer is selected in the statistics panel.
As a result, when this check box is checked, the layer can't be chosen with the statistics panel any more.

![image](https://user-images.githubusercontent.com/34267385/150824136-f23a2fa8-aae0-40da-a964-7227afcda712.png)

### Feature 2: remember the last expression used

When changing the layer for the statistics, the expression was always reset to en empty string.
I guess it was for saving time when switching to another layer so that the statistics are not re-computed every time the layer is changed.
But it appears that it's not an intuitive workflow to always clear the expression, because it forces the user to rewrite/reselect the expression every time he switches layer.

![image](https://user-images.githubusercontent.com/34267385/147587756-73230845-d827-4dd7-8eed-496bd168ee3c.png)

I propose to keep track of the last expression used by each layer and reuse it every time this layer is selected.
It is still possible to clear the expression so that the next time the layer is selected there will be no expression thus no computation, if needed to save time on big statistics.

## Demo video

https://user-images.githubusercontent.com/34267385/150830580-e36463db-d485-4daa-9127-d97c6b79845f.mp4



