### PR TITLE
Allow to rename 3D map views

### DIFF
--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -158,6 +158,10 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   connect( configureAction, &QAction::triggered, this, &Qgs3DMapCanvasDockWidget::configure );
   mOptionsMenu->addAction( configureAction );
 
+  QAction *mActionRename = new QAction( tr( "Rename view..." ), this );
+  connect( mActionRename, &QAction::triggered, this, &Qgs3DMapCanvasDockWidget::renameTriggered );
+  mOptionsMenu->addAction( mActionRename );
+
   mCanvas = new Qgs3DMapCanvas( contentsWidget );
   mCanvas->setMinimumSize( QSize( 200, 200 ) );
   mCanvas->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -89,7 +89,11 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     QToolButton *mBtnMapThemes = nullptr;
     QAction *mActionEnableShadows = nullptr;
     QAction *mActionEnableEyeDome = nullptr;
+    QAction *mActionRename = nullptr;
     QToolButton *mBtnOptions = nullptr;
+
+  signals:
+    void renameTriggered();
 };
 
 #endif // QGS3DMAPCANVASDOCKWIDGET_H

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -104,6 +104,7 @@ class QgsGeometryValidationDock;
 class QgsGeometryValidationModel;
 class QgsUserProfileManager;
 class QgsUserProfileManagerWidgetFactory;
+class Qgs3DMapCanvas;
 class Qgs3DMapCanvasDockWidget;
 class QgsHandleBadLayersHandler;
 class QgsNetworkAccessManager;
@@ -271,6 +272,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Returns a list of all map canvases open in the app.
      */
     QList< QgsMapCanvas * > mapCanvases();
+
+    /**
+     * Returns a list of all 3D map canvases open in the app.
+     */
+    QList< Qgs3DMapCanvas * > mapCanvases3D();
 
     /**
      * Create a new map canvas with the specified unique \a name.
@@ -1227,6 +1233,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMenu *panelMenu() { return mPanelMenu; }
 
     void renameView();
+
+    void rename3dView();
 
     void showStatusMessage( const QString &message );
 


### PR DESCRIPTION
## Description

This PR add exactly the same behavior to the 3D map views than the map views for **renaming the views**.

I based my code mainly on the existing code for the map view `QgisApp::renameView()` so it might seems like code duplication, but IMHO there is no benefit from trying to factorize it, as it is finally pretty specific at some points. I'm open to suggestions 😉 

Because it renames the `objectName` as well, we have to check that no other view (2D or 3D) already has this name.