### PR TITLE
[Cleanup] Static access

### DIFF
--- a/src/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/3d/materials/qgsgoochmaterialsettings.cpp
@@ -243,9 +243,9 @@ Qt3DRender::QMaterial *QgsGoochMaterialSettings::dataDefinedMaterial() const
 
   //Load shader programs
   const QUrl urlVert( QStringLiteral( "qrc:/shaders/goochDataDefined.vert" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, shaderProgram->loadSource( urlVert ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
   const QUrl urlFrag( QStringLiteral( "qrc:/shaders/goochDataDefined.frag" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, shaderProgram->loadSource( urlFrag ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, Qt3DRender::QShaderProgram::loadSource( urlFrag ) );
 
   renderPass->setShaderProgram( shaderProgram );
   technique->addRenderPass( renderPass );

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -235,9 +235,9 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::dataDefinedMaterial() const
 
   //Load shader programs
   const QUrl urlVert( QStringLiteral( "qrc:/shaders/phongDataDefined.vert" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, shaderProgram->loadSource( urlVert ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
   const QUrl urlFrag( QStringLiteral( "qrc:/shaders/phongDataDefined.frag" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, shaderProgram->loadSource( urlFrag ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, Qt3DRender::QShaderProgram::loadSource( urlFrag ) );
 
   renderPass->setShaderProgram( shaderProgram );
   technique->addRenderPass( renderPass );

--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -180,11 +180,11 @@ void QgsMesh3dMaterial::configure()
 
   //Load shader programs
   const QUrl urlVert( QStringLiteral( "qrc:/shaders/mesh/mesh.vert" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, shaderProgram->loadSource( urlVert ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
   const QUrl urlGeom( QStringLiteral( "qrc:/shaders/mesh/mesh.geom" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Geometry, shaderProgram->loadSource( urlGeom ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Geometry, Qt3DRender::QShaderProgram::loadSource( urlGeom ) );
   const QUrl urlFrag( QStringLiteral( "qrc:/shaders/mesh/mesh.frag" ) );
-  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, shaderProgram->loadSource( urlFrag ) );
+  shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Fragment, Qt3DRender::QShaderProgram::loadSource( urlFrag ) );
 
   renderPass->setShaderProgram( shaderProgram );
   mTechnique->addRenderPass( renderPass );

--- a/src/analysis/mesh/qgsmeshtriangulation.cpp
+++ b/src/analysis/mesh/qgsmeshtriangulation.cpp
@@ -398,7 +398,7 @@ QgsTopologicalMesh::Changes QgsMeshEditingDelaunayTriangulation::apply( QgsMeshE
     while ( !facesReady && !giveUp )
     {
       QgsMeshEditingError error;
-      topologicFaces = meshEditor->topologicalMesh().createNewTopologicalFaces( destinationFaces, true, error );
+      topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( destinationFaces, true, error );
 
       if ( error == QgsMeshEditingError() )
         error = meshEditor->topologicalMesh().facesCanBeAdded( topologicFaces );

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -187,7 +187,6 @@ QVariantMap QgsLayoutAtlasToImageAlgorithm::processAlgorithm( const QVariantMap 
   const int idx = parameterAsEnum( parameters, QStringLiteral( "EXTENSION" ), context );
   const QString extension = '.' + imageFormats.at( idx );
 
-  const QgsLayoutExporter exporter( layout.get() );
   QgsLayoutExporter::ImageExportSettings settings;
 
   if ( parameters.value( QStringLiteral( "DPI" ) ).isValid() )
@@ -224,7 +223,7 @@ QVariantMap QgsLayoutAtlasToImageAlgorithm::processAlgorithm( const QVariantMap 
   if ( atlas->updateFeatures() )
   {
     feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
-    switch ( exporter.exportToImage( atlas, fileName, extension, settings, error, feedback ) )
+    switch ( QgsLayoutExporter::exportToImage( atlas, fileName, extension, settings, error, feedback ) )
     {
       case QgsLayoutExporter::Success:
       {

--- a/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastopdf.cpp
@@ -220,13 +220,15 @@ QgsLayoutAtlasToPdfAlgorithm *QgsLayoutAtlasToPdfAlgorithm::createInstance() con
 QVariantMap QgsLayoutAtlasToPdfAlgorithm::exportAtlas( QgsLayoutAtlas *atlas, const QgsLayoutExporter &exporter, const QgsLayoutExporter::PdfExportSettings &settings,
     const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  Q_UNUSED( exporter )
+
   const QString dest = parameterAsFileOutput( parameters, QStringLiteral( "OUTPUT" ), context );
 
   QString error;
   if ( atlas->updateFeatures() )
   {
     feedback->pushInfo( QObject::tr( "Exporting %n atlas feature(s)", "", atlas->count() ) );
-    switch ( exporter.exportToPdf( atlas, dest, settings, error, feedback ) )
+    switch ( QgsLayoutExporter::exportToPdf( atlas, dest, settings, error, feedback ) )
     {
       case QgsLayoutExporter::Success:
       {
@@ -309,6 +311,8 @@ QgsLayoutAtlasToMultiplePdfAlgorithm *QgsLayoutAtlasToMultiplePdfAlgorithm::crea
 QVariantMap QgsLayoutAtlasToMultiplePdfAlgorithm::exportAtlas( QgsLayoutAtlas *atlas, const QgsLayoutExporter &exporter, const QgsLayoutExporter::PdfExportSettings &settings,
     const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  Q_UNUSED( exporter )
+
   QString error;
 
   const QString filename = parameterAsString( parameters, QStringLiteral( "OUTPUT_FILENAME" ), context );
@@ -334,7 +338,7 @@ QVariantMap QgsLayoutAtlasToMultiplePdfAlgorithm::exportAtlas( QgsLayoutAtlas *a
       }
     }
 
-    result = exporter.exportToPdfs( atlas, dest, settings, error, feedback );
+    result = QgsLayoutExporter::exportToPdfs( atlas, dest, settings, error, feedback );
 
     switch ( result )
     {

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -361,14 +361,14 @@ void QgsAppDirectoryItemGuiProvider::changeDirectoryColor( QgsDirectoryItem *ite
     return;
 
   // store new color for directory
-  item->setCustomColor( item->dirPath(), color );
+  QgsDirectoryItem::setCustomColor( item->dirPath(), color );
   // and update item's color immediately
   item->setIconColor( color );
 }
 
 void QgsAppDirectoryItemGuiProvider::clearDirectoryColor( QgsDirectoryItem *item )
 {
-  item->setCustomColor( item->dirPath(), QColor() );
+  QgsDirectoryItem::setCustomColor( item->dirPath(), QColor() );
   // and update item's color immediately
   item->setIconColor( QColor() );
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1049,7 +1049,7 @@ int main( int argc, char *argv[] )
   QgsApplication myApp( argc, argv, myUseGuiFlag, QString(), QStringLiteral( "desktop" ) );
 
   // Set locale to emit QgsApplication's localeChanged signal
-  myApp.setLocale( QLocale() );
+  QgsApplication::setLocale( QLocale() );
 
   //write the log messages written before creating QgsApplication
   for ( const QString &preApplicationLogMessage : std::as_const( preApplicationLogMessages ) )
@@ -1098,7 +1098,7 @@ int main( int argc, char *argv[] )
   QgsDebugMsgLevel( QStringLiteral( "\t - %1" ).arg( profileFolder ), 2 );
   QgsDebugMsgLevel( QStringLiteral( "\t - %1" ).arg( rootProfileFolder ), 2 );
 
-  myApp.init( profileFolder );
+  QgsApplication::init( profileFolder );
 
   // Redefine QgsApplication::libraryPaths as necessary.
   // IMPORTANT: Do *after* QgsApplication myApp(...), but *before* Qt uses any plugins,
@@ -1190,7 +1190,7 @@ int main( int argc, char *argv[] )
   // Set 1024x1024 icon for dock, app switcher, etc., rendering
   myApp.setWindowIcon( QIcon( QgsApplication::iconsPath() + QStringLiteral( "qgis-icon-macos.png" ) ) );
 #else
-  myApp.setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
+  QgsApplication::setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
 #endif
 
   // TODO: use QgsSettings
@@ -1396,7 +1396,7 @@ int main( int argc, char *argv[] )
   QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, mySkipBadLayers, mySkipVersionCheck, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( QStringLiteral( "QgisApp" ) );
 
-  myApp.connect(
+  QgsApplication::connect(
     &myApp, SIGNAL( preNotify( QObject *, QEvent *, bool * ) ),
     //qgis, SLOT( preNotify( QObject *, QEvent *))
     QgsCustomization::instance(), SLOT( preNotify( QObject *, QEvent *, bool * ) )
@@ -1516,11 +1516,11 @@ int main( int argc, char *argv[] )
       qApp->processEvents(), grab the pixmap, save it, hide the window and exit.
       */
     //qgis->show();
-    myApp.processEvents();
+    QgsApplication::processEvents();
     QPixmap *myQPixmap = new QPixmap( mySnapshotWidth, mySnapshotHeight );
     myQPixmap->fill();
     qgis->saveMapAsImage( mySnapshotFileName, myQPixmap );
-    myApp.processEvents();
+    QgsApplication::processEvents();
     qgis->hide();
 
     return 1;
@@ -1637,7 +1637,7 @@ int main( int argc, char *argv[] )
   // Continue on to interactive gui...
   /////////////////////////////////////////////////////////////////////
   qgis->show();
-  myApp.connect( &myApp, SIGNAL( lastWindowClosed() ), &myApp, SLOT( quit() ) );
+  QgsApplication::connect( &myApp, SIGNAL( lastWindowClosed() ), &myApp, SLOT( quit() ) );
 
   mypSplash->finish( qgis );
   delete mypSplash;
@@ -1659,7 +1659,7 @@ int main( int argc, char *argv[] )
     switch ( signal )
     {
       case SIGINT:
-        myApp.exit( 1 );
+        QgsApplication::exit( 1 );
         break;
 
       default:
@@ -1668,7 +1668,7 @@ int main( int argc, char *argv[] )
   } );
 #endif
 
-  int retval = myApp.exec();
+  int retval = QgsApplication::exec();
   delete qgis;
   return retval;
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1654,7 +1654,7 @@ int main( int argc, char *argv[] )
   UnixSignalWatcher sigwatch;
   sigwatch.watchForSignal( SIGINT );
 
-  QObject::connect( &sigwatch, &UnixSignalWatcher::unixSignal, &myApp, [&myApp ]( int signal )
+  QObject::connect( &sigwatch, &UnixSignalWatcher::unixSignal, &myApp, [ ]( int signal )
   {
     switch ( signal )
     {

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -422,7 +422,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAuthSettings->setDataprovider( QStringLiteral( "proxy" ) );
   QString authcfg = mSettings->value( QStringLiteral( "proxy/authcfg" ) ).toString();
   mAuthSettings->setConfigId( authcfg );
-  mAuthSettings->setWarningText( mAuthSettings->formattedWarning( QgsAuthSettingsWidget::UserSettings ) );
+  mAuthSettings->setWarningText( QgsAuthSettingsWidget::formattedWarning( QgsAuthSettingsWidget::UserSettings ) );
 
   //Web proxy settings
   grpProxy->setChecked( mSettings->value( QStringLiteral( "proxy/proxyEnabled" ), false ).toBool() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2118,7 +2118,7 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 
   auto showLayerLoadWarnings = [ = ]( const QString & title, const QString & shortMessage, const QString & longMessage, Qgis::MessageLevel level )
   {
-    QgsMessageBarItem *messageWidget = visibleMessageBar()->createMessage( title, shortMessage );
+    QgsMessageBarItem *messageWidget = QgsMessageBar::createMessage( title, shortMessage );
     QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
     connect( detailsButton, &QPushButton::clicked, this, [ = ]
     {

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -112,7 +112,7 @@ void QgsAppMissingGridHandler::onMissingRequiredGrid( const QgsCoordinateReferen
                                       grid.shortName );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage, downloadMessage, bar, widget, gridName]
   {
@@ -180,7 +180,7 @@ void QgsAppMissingGridHandler::onMissingPreferredGrid( const QgsCoordinateRefere
                               + gridMessage + accuracyMessage;
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage, downloadMessage, gridName, widget, bar]
   {
@@ -208,7 +208,7 @@ void QgsAppMissingGridHandler::onCoordinateOperationCreationError( const QgsCoor
   const QString longMessage = tr( "<p>No transform is available between <i>%1</i> and <i>%2</i>.</p><p style=\"color: red\">%3</p>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), error );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage]
   {
@@ -265,7 +265,7 @@ void QgsAppMissingGridHandler::onMissingGridUsedByContextHandler( const QgsCoord
                               + tr( "<p>The operation specified for use in the project is:</p><p><code>%1</code></p>" ).arg( desired.proj ) ;
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage, gridName, downloadMessage, bar, widget]
   {
@@ -293,7 +293,7 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
   const QString longMessage = tr( "<p>An alternative, ballpark-only transform was used when transforming coordinates between <i>%1</i> and <i>%2</i>. The results may not match those obtained by using the preferred operation:</p><code>%3</code><p style=\"font-weight: bold\">Possibly an incorrect choice of operation was made for transformations between these reference systems. Check the Project Properties and ensure that the selected transform operations are applicable over the whole extent of the current project." ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), desired );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage]
   {
@@ -317,7 +317,7 @@ void QgsAppMissingGridHandler::onDynamicToDynamicWarning( const QgsCoordinateRef
   const QString longMessage = tr( "<p>Transformation between %1 and %2 is not currently supported.</p><p><b>The results will be unpredictable and should not be used for high accuracy work.</b>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier() );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
-  QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *widget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, this, [longMessage]
   {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3096,8 +3096,6 @@ QgsGeometry QgsGeometry::unaryUnion( const QVector<QgsGeometry> &geometries )
 
 QgsGeometry QgsGeometry::polygonize( const QVector<QgsGeometry> &geometryList )
 {
-  QgsGeos geos( nullptr );
-
   QVector<const QgsAbstractGeometry *> geomV2List;
   for ( const QgsGeometry &g : geometryList )
   {
@@ -3108,7 +3106,7 @@ QgsGeometry QgsGeometry::polygonize( const QVector<QgsGeometry> &geometryList )
   }
 
   QString error;
-  QgsGeometry result = geos.polygonize( geomV2List, &error );
+  QgsGeometry result = QgsGeos::polygonize( geomV2List, &error );
   result.mLastError = error;
   return result;
 }

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -271,7 +271,7 @@ void QgsPalLayerSettings::initPropertyDefinitions()
 Q_NOWARN_DEPRECATED_PUSH // because of deprecated members
 QgsPalLayerSettings::QgsPalLayerSettings()
   : predefinedPositionOrder( *DEFAULT_PLACEMENT_ORDER() )
-  , mCallout( QgsApplication::calloutRegistry()->defaultCallout() )
+  , mCallout( QgsCalloutRegistry::defaultCallout() )
 {
   initPropertyDefinitions();
 
@@ -1170,12 +1170,12 @@ void QgsPalLayerSettings::readXml( const QDomElement &elem, const QgsReadWriteCo
   // TODO - replace with registry when multiple callout styles exist
   const QString calloutType = elem.attribute( QStringLiteral( "calloutType" ) );
   if ( calloutType.isEmpty() )
-    mCallout.reset( QgsApplication::calloutRegistry()->defaultCallout() );
+    mCallout.reset( QgsCalloutRegistry::defaultCallout() );
   else
   {
     mCallout.reset( QgsApplication::calloutRegistry()->createCallout( calloutType, elem.firstChildElement( QStringLiteral( "callout" ) ), context ) );
     if ( !mCallout )
-      mCallout.reset( QgsApplication::calloutRegistry()->defaultCallout() );
+      mCallout.reset( QgsCalloutRegistry::defaultCallout() );
   }
 }
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1541,7 +1541,7 @@ QJsonObject QgsVectorLabelLegendNode::exportSymbolToJson( const QgsLegendSetting
 
   double textWidth, textHeight;
   textWidthHeight( textWidth, textHeight, ctx, textFormat, textLines );
-  const QPixmap previewPixmap = mLabelSettings.labelSettingsPreviewPixmap( mLabelSettings, QSize( textWidth, textHeight ), mLabelSettings.legendString() );
+  const QPixmap previewPixmap = QgsPalLayerSettings::labelSettingsPreviewPixmap( mLabelSettings, QSize( textWidth, textHeight ), mLabelSettings.legendString() );
 
   QByteArray byteArray;
   QBuffer buffer( &byteArray );

--- a/src/core/layout/qgslayoututils.cpp
+++ b/src/core/layout/qgslayoututils.cpp
@@ -416,7 +416,8 @@ double QgsLayoutUtils::scaleFactorFromItemStyle( const QStyleOptionGraphicsItem 
 
 double QgsLayoutUtils::scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style, QPainter *painter )
 {
-  return style->levelOfDetailFromTransform( painter->worldTransform() );
+  Q_UNUSED( style );
+  return QStyleOptionGraphicsItem::levelOfDetailFromTransform( painter->worldTransform() );
 }
 
 QgsMapLayer *QgsLayoutUtils::mapLayerFromString( const QString &string, QgsProject *project )

--- a/src/core/mesh/qgsmesheditor.cpp
+++ b/src/core/mesh/qgsmesheditor.cpp
@@ -175,7 +175,7 @@ bool QgsMeshEditor::faceCanBeAdded( const QgsMeshFace &face )
     return false;
 
   // Check if there is topological error with the mesh
-  QgsTopologicalMesh::TopologicalFaces topologicalFaces = mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
+  QgsTopologicalMesh::TopologicalFaces topologicalFaces = QgsTopologicalMesh::createNewTopologicalFaces( facesToAdd, true, error );
   error = mTopologicalMesh.facesCanBeAdded( topologicalFaces );
 
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
@@ -519,7 +519,7 @@ QVector<QgsMeshFace> QgsMeshEditor::prepareFaces( const QVector<QgsMeshFace> &fa
       break;
     }
 
-    error = mTopologicalMesh.counterClockwiseFaces( face, mMesh );
+    error = QgsTopologicalMesh::counterClockwiseFaces( face, mMesh );
     if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
       break;
   }
@@ -535,7 +535,7 @@ QgsMeshEditingError QgsMeshEditor::addFaces( const QVector<QVector<int> > &faces
   if ( error.errorType != Qgis::MeshEditingErrorType::NoError )
     return error;
 
-  QgsTopologicalMesh::TopologicalFaces topologicalFaces = mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
+  QgsTopologicalMesh::TopologicalFaces topologicalFaces = QgsTopologicalMesh::createNewTopologicalFaces( facesToAdd, true, error );
 
   error = mTopologicalMesh.facesCanBeAdded( topologicalFaces );
 

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -70,7 +70,7 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
       const auto constProxyFactories = nam->proxyFactories();
       for ( QNetworkProxyFactory *f : constProxyFactories )
       {
-        QList<QNetworkProxy> systemproxies = f->systemProxyForQuery( query );
+        QList<QNetworkProxy> systemproxies = QNetworkProxyFactory::systemProxyForQuery( query );
         if ( !systemproxies.isEmpty() )
           return systemproxies;
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -202,7 +202,7 @@ bool QgsPointCloudLayer::readStyle( const QDomNode &node, QString &, QgsReadWrit
     // make sure layer has a renderer - if none exists, fallback to a default renderer
     if ( !mRenderer )
     {
-      setRenderer( QgsApplication::pointCloudRendererRegistry()->defaultRenderer( mDataProvider.get() ) );
+      setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( mDataProvider.get() ) );
     }
   }
 
@@ -382,7 +382,7 @@ void QgsPointCloudLayer::setDataSourcePrivate( const QString &dataSource, const 
     if ( !defaultLoadedFlag )
     {
       // all else failed, create default renderer
-      setRenderer( QgsApplication::pointCloudRendererRegistry()->defaultRenderer( mDataProvider.get() ) );
+      setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( mDataProvider.get() ) );
     }
   }
 }
@@ -422,7 +422,7 @@ void QgsPointCloudLayer::onPointCloudIndexGenerationStateChanged( QgsPointCloudD
     mDataProvider.get()->loadIndex();
     if ( mRenderer->type() == QLatin1String( "extent" ) )
     {
-      setRenderer( QgsApplication::pointCloudRendererRegistry()->defaultRenderer( mDataProvider.get() ) );
+      setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( mDataProvider.get() ) );
     }
     triggerRepaint();
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -2253,12 +2253,11 @@ bool QgsProject::writeProjectFile( const QString &filename )
   context.setPathResolver( pathResolver() );
   context.setTransformContext( transformContext() );
 
-  QDomImplementation DomImplementation;
-  DomImplementation.setInvalidDataPolicy( QDomImplementation::DropInvalidChars );
+  QDomImplementation::setInvalidDataPolicy( QDomImplementation::DropInvalidChars );
 
   const QDomDocumentType documentType =
-    DomImplementation.createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ),
-                                          QStringLiteral( "SYSTEM" ) );
+    QDomImplementation().createDocumentType( QStringLiteral( "qgis" ), QStringLiteral( "http://mrcc.com/qgis.dtd" ),
+        QStringLiteral( "SYSTEM" ) );
   std::unique_ptr<QDomDocument> doc( new QDomDocument( documentType ) );
 
   QDomElement qgisNode = doc->createElement( QStringLiteral( "qgis" ) );

--- a/src/core/project/qgsprojectbadlayerhandler.cpp
+++ b/src/core/project/qgsprojectbadlayerhandler.cpp
@@ -22,11 +22,11 @@
 
 void QgsProjectBadLayerHandler::handleBadLayers( const QList<QDomNode> &layers )
 {
-  QgsApplication::messageLog()->logMessage( QObject::tr( "%1 unavailable layers found:" ).arg( layers.size() ) );
+  QgsMessageLog::logMessage( QObject::tr( "%1 unavailable layers found:" ).arg( layers.size() ) );
   const auto constLayers = layers;
   for ( const QDomNode &layer : constLayers )
   {
-    QgsApplication::messageLog()->logMessage( QObject::tr( " * %1" ).arg( dataSource( layer ) ) );
+    QgsMessageLog::logMessage( QObject::tr( " * %1" ).arg( dataSource( layer ) ) );
   }
 }
 

--- a/src/core/project/qgsprojectfiletransform.cpp
+++ b/src/core/project/qgsprojectfiletransform.cpp
@@ -520,7 +520,7 @@ void transform1800to1900( QgsProjectFileTransform *pft )
     // TODO: We have to use more data from project file to read the layer it correctly,
     // OTOH, we should not read it until it was converted
     rasterLayer.readLayerXml( layerNode.toElement(), context );
-    pft->convertRasterProperties( pft->dom(), layerNode, rasterPropertiesElem, &rasterLayer );
+    QgsProjectFileTransform::convertRasterProperties( pft->dom(), layerNode, rasterPropertiesElem, &rasterLayer );
   }
 
   //composer: replace mGridAnnotationPosition with mLeftGridAnnotationPosition & co.

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -805,7 +805,7 @@ QCursor QgsApplication::getThemeCursor( Cursor cursor )
   if ( ! icon.isNull( ) )
   {
     // Apply scaling
-    float scale = Qgis::UI_SCALE_FACTOR * app->fontMetrics().height() / 32.0;
+    float scale = Qgis::UI_SCALE_FACTOR * QgsApplication::fontMetrics().height() / 32.0;
     cursorIcon = QCursor( icon.pixmap( std::ceil( scale * 32 ), std::ceil( scale * 32 ) ), std::ceil( scale * activeX ), std::ceil( scale * activeY ) );
   }
   if ( app )

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -228,7 +228,7 @@ int QgsAuxiliaryLayer::createProperty( QgsPalLayerSettings::Property property, Q
   if ( layer && layer->labeling() && layer->auxiliaryLayer() )
   {
     // property definition are identical whatever the provider id
-    const QgsPropertyDefinition def = layer->labeling()->settings().propertyDefinitions()[property];
+    const QgsPropertyDefinition def = QgsPalLayerSettings::propertyDefinitions()[property];
     const QString fieldName = nameFromProperty( def, true );
 
     layer->auxiliaryLayer()->addAuxiliaryField( def );
@@ -274,7 +274,7 @@ int QgsAuxiliaryLayer::createProperty( QgsDiagramLayerSettings::Property propert
 
   if ( layer && layer->diagramLayerSettings() && layer->auxiliaryLayer() )
   {
-    const QgsPropertyDefinition def = layer->diagramLayerSettings()->propertyDefinitions()[property];
+    const QgsPropertyDefinition def = QgsDiagramLayerSettings::propertyDefinitions()[property];
 
     if ( layer->auxiliaryLayer()->addAuxiliaryField( def ) )
     {
@@ -314,7 +314,7 @@ int QgsAuxiliaryLayer::createProperty( QgsCallout::Property property, QgsVectorL
   if ( layer && layer->labeling() && layer->labeling()->settings().callout() && layer->auxiliaryLayer() )
   {
     // property definition are identical whatever the provider id
-    const QgsPropertyDefinition def = layer->labeling()->settings().callout()->propertyDefinitions()[property];
+    const QgsPropertyDefinition def = QgsCallout::propertyDefinitions()[property];
     const QString fieldName = nameFromProperty( def, true );
 
     layer->auxiliaryLayer()->addAuxiliaryField( def );

--- a/src/core/qgsdiagramrenderer.cpp
+++ b/src/core/qgsdiagramrenderer.cpp
@@ -340,7 +340,7 @@ void QgsDiagramSettings::readXml( const QDomElement &elem, const QgsReadWriteCon
   if ( !effectElem.isNull() )
     setPaintEffect( QgsApplication::paintEffectRegistry()->createEffect( effectElem ) );
   else
-    setPaintEffect( QgsApplication::paintEffectRegistry()->defaultStack() );
+    setPaintEffect( QgsPaintEffectRegistry::defaultStack() );
 }
 
 void QgsDiagramSettings::writeXml( QDomElement &rendererElem, QDomDocument &doc, const QgsReadWriteContext &context ) const

--- a/src/core/qgsrunprocess.cpp
+++ b/src/core/qgsrunprocess.cpp
@@ -85,7 +85,7 @@ QgsRunProcess::QgsRunProcess( const QString &action, bool capture )
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     if ( ! mProcess->startDetached( action ) ) // let the program run by itself
 #else
-    if ( ! mProcess->startDetached( command, arguments ) ) // let the program run by itself
+    if ( ! QProcess::startDetached( command, arguments ) ) // let the program run by itself
 #endif
     {
       QMessageBox::critical( nullptr, tr( "Action" ),

--- a/src/core/qgstiledownloadmanager.cpp
+++ b/src/core/qgstiledownloadmanager.cpp
@@ -220,7 +220,7 @@ bool QgsTileDownloadManager::waitForPendingRequests( int msec )
       if ( mQueue.isEmpty() )
         return true;
     }
-    QThread::currentThread()->usleep( 1000 );
+    QThread::usleep( 1000 );
   }
 
   return false;
@@ -247,7 +247,7 @@ void QgsTileDownloadManager::shutdown()
         return;  // the thread has stopped
     }
 
-    QThread::currentThread()->usleep( 1000 );
+    QThread::usleep( 1000 );
   }
 }
 

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -1135,7 +1135,6 @@ void QgsSimpleLineSymbolLayer::setTweakDashPatternOnCorners( bool enabled )
 
 double QgsSimpleLineSymbolLayer::dxfOffset( const QgsDxfExport &e, QgsSymbolRenderContext &context ) const
 {
-  Q_UNUSED( e )
   double offset = mOffset;
 
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyOffset ) )

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -38,7 +38,7 @@ int main( int argc, char *argv[] )
   }
 
   QApplication app( argc, argv );
-  app.setQuitOnLastWindowClosed( true );
+  QApplication::setQuitOnLastWindowClosed( true );
   QCoreApplication::setOrganizationName( "QGIS" );
   QCoreApplication::setApplicationName( "QGIS3" );
 
@@ -98,7 +98,7 @@ int main( int argc, char *argv[] )
   dlg.setBugReport( report.toHtml() );
   dlg.setModal( true );
   dlg.show();
-  app.exec();
+  QApplication::exec();
 
 
 #ifdef MSVC

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -40,7 +40,7 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
       mSpecificEditWidget = editWidget;
       layout->addWidget( mSpecificEditWidget );
       mWidgetSpecificConfigGroupBox->setLayout( layout );
-      mWidgetSpecificConfigGroupBox->setTitle( editWidget->title() );
+      mWidgetSpecificConfigGroupBox->setTitle( QgsAttributeWidgetRelationEditWidget::title() );
 
     }
     break;

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -180,12 +180,12 @@ bool QgsEditorWidgetRegistry::registerWidget( const QString &widgetId, QgsEditor
 {
   if ( !widgetFactory )
   {
-    QgsApplication::messageLog()->logMessage( tr( "QgsEditorWidgetRegistry: Factory not valid." ) );
+    QgsMessageLog::logMessage( tr( "QgsEditorWidgetRegistry: Factory not valid." ) );
     return false;
   }
   else if ( mWidgetFactories.contains( widgetId ) )
   {
-    QgsApplication::messageLog()->logMessage( tr( "QgsEditorWidgetRegistry: Factory with id %1 already registered." ).arg( widgetId ) );
+    QgsMessageLog::logMessage( tr( "QgsEditorWidgetRegistry: Factory with id %1 already registered." ).arg( widgetId ) );
     return false;
   }
   else

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -87,9 +87,9 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
   }
   else
   {
-    QgsApplication::messageLog()->logMessage( tr( "The usual date/time widget QDateTimeEdit cannot be configured to allow NULL values. "
-        "For that the QGIS custom widget QgsDateTimeEdit needs to be used." ),
-        tr( "field widgets" ) );
+    QgsMessageLog::logMessage( tr( "The usual date/time widget QDateTimeEdit cannot be configured to allow NULL values. "
+                                   "For that the QGIS custom widget QgsDateTimeEdit needs to be used." ),
+                               tr( "field widgets" ) );
   }
 
   if ( mQgsDateTimeEdit )

--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -466,7 +466,7 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
   }
   else
   {
-    std::unique_ptr< QgsCallout > defaultCallout( QgsApplication::calloutRegistry()->defaultCallout() );
+    std::unique_ptr< QgsCallout > defaultCallout( QgsCalloutRegistry::defaultCallout() );
     whileBlocking( mCalloutStyleComboBox )->setCurrentIndex( mCalloutStyleComboBox->findData( defaultCallout->type() ) );
     whileBlocking( mCalloutsDrawCheckBox )->setChecked( false );
     updateCalloutWidget( defaultCallout.get() );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -904,7 +904,7 @@ void QgsModelDesignerDialog::validate()
   }
   else
   {
-    QgsMessageBarItem *messageWidget = mMessageBar->createMessage( QString(), tr( "Model is invalid!" ) );
+    QgsMessageBarItem *messageWidget = QgsMessageBar::createMessage( QString(), tr( "Model is invalid!" ) );
     QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
     connect( detailsButton, &QPushButton::clicked, detailsButton, [ = ]
     {

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -484,7 +484,7 @@ void QgsModelGraphicsScene::setMessageBar( QgsMessageBar *messageBar )
 
 void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level ) const
 {
-  QgsMessageBarItem *messageWidget = mMessageBar->createMessage( QString(), shortMessage );
+  QgsMessageBarItem *messageWidget = QgsMessageBar::createMessage( QString(), shortMessage );
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, detailsButton, [ = ]
   {

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -170,8 +170,7 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
   connect( mActionDecreaseIndent, &QAction::triggered, this, &QgsRichTextEditor::decreaseIndentation );
 
   // font size
-  const QFontDatabase db;
-  const QList< int > sizes = db.standardSizes();
+  const QList< int > sizes = QFontDatabase::standardSizes();
   for ( const int size : sizes )
     mFontSizeCombo->addItem( QString::number( size ), size );
 

--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -95,7 +95,7 @@ void QgsStatusBar::clearMessage()
 void QgsStatusBar::setParentStatusBar( QStatusBar *statusBar )
 {
   if ( mParentStatusBar )
-    mParentStatusBar->disconnect( mShowMessageConnection );
+    QStatusBar::disconnect( mShowMessageConnection );
 
   mParentStatusBar = statusBar;
 

--- a/src/gui/symbology/qgscptcitycolorrampdialog.cpp
+++ b/src/gui/symbology/qgscptcitycolorrampdialog.cpp
@@ -239,7 +239,7 @@ void QgsCptCityColorRampDialog::updateTreeView( QgsCptCityDataItem *item, bool r
     updateListWidget( item );
     lblSchemePath->setText( item->path() );
     lblCollectionInfo->setText( QStringLiteral( "%1 (%2)" ).arg( item->info() ).arg( item->leafCount() ) );
-    updateCopyingInfo( mArchive->copyingInfo( mArchive->copyingFileName( item->path() ) ) );
+    updateCopyingInfo( QgsCptCityArchive::copyingInfo( mArchive->copyingFileName( item->path() ) ) );
   }
   else if ( item->type() == QgsCptCityDataItem::Selection )
   {

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -609,7 +609,7 @@ void QgsSymbolSelectorWidget::addLayer()
                              ? static_cast<QgsLineSymbol *>( parentSymbol )->dataDefinedWidth()
                              : QgsProperty() );
 
-  QgsSymbolLayer *newLayer = QgsApplication::symbolLayerRegistry()->defaultSymbolLayer( parentSymbol->type() );
+  QgsSymbolLayer *newLayer = QgsSymbolLayerRegistry::defaultSymbolLayer( parentSymbol->type() );
   if ( insertIdx == -1 )
     parentSymbol->appendSymbolLayer( newLayer );
   else

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -119,5 +119,5 @@ int main( int argc, char *argv[] )
     res = exec.run( args );
     QCoreApplication::exit( res );
   } );
-  return app.exec();
+  return QgsApplication::exec();
 }

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -97,7 +97,7 @@ int main( int argc, char *argv[] )
       response.sendError( 400, "Bad request" );
     }
   }
-  app.exitQgis();
+  QgsApplication::exitQgis();
   return 0;
 }
 

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -155,7 +155,7 @@ class TcpServerWorker: public QObject
         mIsListening = true;
 
         // Incoming connection handler
-        mTcpServer.connect( &mTcpServer, &QTcpServer::newConnection, this, [ = ]
+        QTcpServer::connect( &mTcpServer, &QTcpServer::newConnection, this, [ = ]
         {
           QTcpSocket *clientConnection = mTcpServer.nextPendingConnection();
 
@@ -177,7 +177,7 @@ class TcpServerWorker: public QObject
           };
 
           // This will delete the connection
-          clientConnection->connect( clientConnection, &QAbstractSocket::disconnected, clientConnection, connectionDeleter, Qt::QueuedConnection );
+          QTcpSocket::connect( clientConnection, &QAbstractSocket::disconnected, clientConnection, connectionDeleter, Qt::QueuedConnection );
 
 #if 0     // Debugging output
           clientConnection->connect( clientConnection, &QAbstractSocket::errorOccurred, clientConnection, [ = ]( QAbstractSocket::SocketError socketError )
@@ -187,7 +187,7 @@ class TcpServerWorker: public QObject
 #endif
 
           // Incoming connection parser
-          clientConnection->connect( clientConnection, &QIODevice::readyRead, context, [ = ] {
+          QTcpSocket::connect( clientConnection, &QIODevice::readyRead, context, [ = ] {
 
             // Read all incoming data
             while ( clientConnection->bytesAvailable() > 0 )
@@ -627,7 +627,7 @@ int main( int argc, char *argv[] )
   TcpServerThread tcpServerThread{ ipAddress, serverPort.toInt() };
 
   bool isTcpError = false;
-  tcpServerThread.connect( &tcpServerThread, &TcpServerThread::serverError, qApp, [ & ]
+  TcpServerThread::connect( &tcpServerThread, &TcpServerThread::serverError, qApp, [ & ]
   {
     isTcpError = true;
     qApp->quit();
@@ -635,7 +635,7 @@ int main( int argc, char *argv[] )
 
   // Monitoring thread
   QueueMonitorThread queueMonitorThread;
-  queueMonitorThread.connect( &queueMonitorThread, &QueueMonitorThread::requestReady, qApp, [ & ]( RequestContext * requestContext )
+  QueueMonitorThread::connect( &queueMonitorThread, &QueueMonitorThread::requestReady, qApp, [ & ]( RequestContext * requestContext )
   {
     if ( requestContext->clientConnection && requestContext->clientConnection->isValid() )
     {
@@ -677,14 +677,14 @@ int main( int argc, char *argv[] )
   tcpServerThread.start();
   queueMonitorThread.start();
 
-  app.exec();
+  QgsApplication::exec();
   // Wait for threads
   tcpServerThread.exit();
   tcpServerThread.wait();
   queueMonitorThread.stop();
   REQUEST_WAIT_CONDITION.notify_all();
   queueMonitorThread.wait();
-  app.exitQgis();
+  QgsApplication::exitQgis();
 
   return isTcpError ? 1 : 0;
 }

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -322,9 +322,8 @@ namespace QgsWfs
       const QgsEditorWidgetSetup setup = field.editorWidgetSetup();
       if ( setup.type() ==  QStringLiteral( "DateTime" ) )
       {
-        const QgsDateTimeFieldFormatter fieldFormatter;
         const QVariantMap config = setup.config();
-        const QString fieldFormat = config.value( QStringLiteral( "field_format" ), fieldFormatter.defaultFormat( field.type() ) ).toString();
+        const QString fieldFormat = config.value( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field.type() ) ).toString();
         if ( fieldFormat == QLatin1String( "yyyy-MM-dd" ) )
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "date" ) );
         else if ( fieldFormat == QLatin1String( "HH:mm:ss" ) )

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1558,9 +1558,8 @@ namespace QgsWfs
 
       if ( setup.type() ==  QStringLiteral( "DateTime" ) )
       {
-        QgsDateTimeFieldFormatter fieldFormatter;
         const QVariantMap config = setup.config();
-        const QString fieldFormat = config.value( QStringLiteral( "field_format" ), fieldFormatter.defaultFormat( value.type() ) ).toString();
+        const QString fieldFormat = config.value( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( value.type() ) ).toString();
         QDateTime date = value.toDateTime();
 
         if ( date.isValid() )

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -602,13 +602,13 @@ namespace QgsWms
       exportSettings.rasterizeWholeImage = layout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
 
       // Export all pages
-      QgsLayoutExporter exporter( layout.get() );
       if ( atlas )
       {
-        exporter.exportToPdf( atlas, tempOutputFile.fileName(), exportSettings, exportError );
+        QgsLayoutExporter::exportToPdf( atlas, tempOutputFile.fileName(), exportSettings, exportError );
       }
       else
       {
+        QgsLayoutExporter exporter( layout.get() );
         exporter.exportToPdf( tempOutputFile.fileName(), exportSettings );
       }
     }

--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -120,5 +120,5 @@ int main( int argc, char *argv[] )
   canvas->resize( 800, 600 );
   canvas->show();
 
-  return app.exec();
+  return QApplication::exec();
 }

--- a/tests/src/core/testqgscalloutregistry.cpp
+++ b/tests/src/core/testqgscalloutregistry.cpp
@@ -155,8 +155,7 @@ void TestQgsCalloutRegistry::createCallout()
 
 void TestQgsCalloutRegistry::defaultCallout()
 {
-  QgsCalloutRegistry *registry = QgsApplication::calloutRegistry();
-  const std::unique_ptr< QgsCallout > callout( registry->defaultCallout() );
+  const std::unique_ptr< QgsCallout > callout( QgsCalloutRegistry::defaultCallout() );
   QVERIFY( callout.get() );
 }
 

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -280,12 +280,12 @@ void TestQgsMeshEditor::editTopologicMesh()
 
   QVector<QgsMeshFace> faces;
   faces = {{5, 7, 6}};
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) ==
            QgsMeshEditingError( Qgis::MeshEditingErrorType::UniqueSharedVertex, 5 ) );
 
   faces = {{5, 7, 6, 4}};
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
   faces =
@@ -299,7 +299,7 @@ void TestQgsMeshEditor::editTopologicMesh()
     {11, 5, 3},   // 6
   };
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
 
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
@@ -314,7 +314,7 @@ void TestQgsMeshEditor::editTopologicMesh()
     {11, 5, 3},   // 6
   };
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ).errorType ==  Qgis::MeshEditingErrorType::UniqueSharedVertex );
   QCOMPARE( topologicalMesh.freeVerticesIndexes().count(), 6 );
 
@@ -330,7 +330,7 @@ void TestQgsMeshEditor::editTopologicMesh()
     {5, 6, 4}     // face added to fixe the first one
   };
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
 
   faces =
@@ -343,13 +343,13 @@ void TestQgsMeshEditor::editTopologicMesh()
     {11, 3, 0},   // 5
   };
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( error == QgsMeshEditingError() );
   error = topologicalMesh.facesCanBeAdded( topologicFaces );
   QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 0 ) );
 
   faces = {{5, 7, 6, 4}};
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
   topologicalChanges.append( topologicalMesh.addFaces( topologicFaces ) ) ;
 
@@ -391,7 +391,7 @@ void TestQgsMeshEditor::editTopologicMesh()
     {11, 5, 3},   // 6
   };
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( faces, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( faces, true, error );
   QVERIFY( topologicalMesh.facesCanBeAdded( topologicFaces ) == QgsMeshEditingError() );
   topologicalChanges.append( topologicalMesh.addFaces( topologicFaces ) ) ;
 
@@ -539,7 +539,7 @@ void TestQgsMeshEditor::editTopologicMesh()
 
   QVERIFY( checkFacesAround( topologicalMesh, 12, {11, 12, 13, 14} ) );
 
-  topologicFaces = topologicalMesh.createNewTopologicalFaces( {{4, 8, 9}, {0, 3, 2, 1}}, true, error );
+  topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( {{4, 8, 9}, {0, 3, 2, 1}}, true, error );
   QVERIFY( error == QgsMeshEditingError() );
   topologicalChanges.append( topologicalMesh.addFaces( topologicFaces ) );
   QVERIFY( checkFacesAround( topologicalMesh, 9, {7, 6, 15} ) );
@@ -930,7 +930,7 @@ void TestQgsMeshEditor::particularCases()
 
     const QVector<QgsMeshFace> facesToAdd( {{0, 1, 2}, {0, 2, 6}, {1, 3, 2}, {2, 3, 4}} );
 
-    const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
+    const QgsTopologicalMesh::TopologicalFaces topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( facesToAdd, true, error );
     QVERIFY( error == QgsMeshEditingError() );
     error = meshEditor.mTopologicalMesh.facesCanBeAdded( topologicFaces );
     QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 2 ) );
@@ -962,7 +962,7 @@ void TestQgsMeshEditor::particularCases()
 
     const QVector<QgsMeshFace> facesToAdd( {{1, 6, 0}, {1, 2, 6}, {2, 3, 6}, {3, 4, 6 }, {1, 3, 2} } );
 
-    const QgsTopologicalMesh::TopologicalFaces topologicFaces = meshEditor.mTopologicalMesh.createNewTopologicalFaces( facesToAdd, true, error );
+    const QgsTopologicalMesh::TopologicalFaces topologicFaces = QgsTopologicalMesh::createNewTopologicalFaces( facesToAdd, true, error );
     QVERIFY( error == QgsMeshEditingError() );
     error = meshEditor.mTopologicalMesh.facesCanBeAdded( topologicFaces );
     QVERIFY( error == QgsMeshEditingError( Qgis::MeshEditingErrorType::ManifoldFace, 4 ) );
@@ -1121,7 +1121,7 @@ void TestQgsMeshEditor::particularCases()
     QCOMPARE( mesh.faceCount(), 8 );
 
     // with adding a face to make vertex 2 not an boundary anymore
-    QgsTopologicalMesh::Changes addFaceChanges = topologicMesh.addFaces( topologicMesh.createNewTopologicalFaces( {{2, 7, 8}}, false, error ) );
+    QgsTopologicalMesh::Changes addFaceChanges = topologicMesh.addFaces( QgsTopologicalMesh::createNewTopologicalFaces( {{2, 7, 8}}, false, error ) );
     Q_ASSERT( error == QgsMeshEditingError() );
 
     changes = topologicMesh.removeVertexFillHole( 5 );
@@ -1209,7 +1209,7 @@ void TestQgsMeshEditor::particularCases()
     QCOMPARE( changes.addedFaces().count(), 0 );
 
     // try adding a face, not sufficient
-    QgsTopologicalMesh::Changes addFaceChanges = topologicalMesh.addFaces( topologicalMesh.createNewTopologicalFaces( {{1, 6, 7}}, true, error ) );
+    QgsTopologicalMesh::Changes addFaceChanges = topologicalMesh.addFaces( QgsTopologicalMesh::createNewTopologicalFaces( {{1, 6, 7}}, true, error ) );
     Q_ASSERT( error == QgsMeshEditingError() );
 
     changes = topologicalMesh.removeVertexFillHole( 5 );
@@ -1228,7 +1228,7 @@ void TestQgsMeshEditor::particularCases()
 
     // try adding two faces, not sufficient
     QgsTopologicalMesh::Changes add2FacesChanges =
-    topologicalMesh.addFaces( topologicalMesh.createNewTopologicalFaces( {{1, 6, 7}, {2, 7, 8}}, true, error ) );
+    topologicalMesh.addFaces( QgsTopologicalMesh::createNewTopologicalFaces( {{1, 6, 7}, {2, 7, 8}}, true, error ) );
     Q_ASSERT( error == QgsMeshEditingError() );
 
     changes = topologicalMesh.removeVertexFillHole( 5 );
@@ -1247,7 +1247,7 @@ void TestQgsMeshEditor::particularCases()
 
     // try adding three faces, good
     QgsTopologicalMesh::Changes add3FacesChanges =
-    topologicalMesh.addFaces( topologicalMesh.createNewTopologicalFaces( {{1, 6, 7}, {2, 7, 8}, {3, 8, 9}}, true, error ) );
+    topologicalMesh.addFaces( QgsTopologicalMesh::createNewTopologicalFaces( {{1, 6, 7}, {2, 7, 8}, {3, 8, 9}}, true, error ) );
     Q_ASSERT( error == QgsMeshEditingError() );
 
     changes = topologicalMesh.removeVertexFillHole( 5 );

--- a/tests/src/core/testqgspainteffectregistry.cpp
+++ b/tests/src/core/testqgspainteffectregistry.cpp
@@ -160,7 +160,7 @@ void TestQgsPaintEffectRegistry::createEffect()
 void TestQgsPaintEffectRegistry::defaultStack()
 {
   QgsPaintEffectRegistry *registry = QgsApplication::paintEffectRegistry();
-  QgsEffectStack *effect = static_cast<QgsEffectStack *>( registry->defaultStack() );
+  QgsEffectStack *effect = static_cast<QgsEffectStack *>( QgsPaintEffectRegistry::defaultStack() );
   QVERIFY( registry->isDefaultStack( effect ) );
   effect->effect( 1 )->setEnabled( true );
   QVERIFY( !registry->isDefaultStack( effect ) );
@@ -175,7 +175,7 @@ void TestQgsPaintEffectRegistry::defaultStack()
   QVERIFY( !registry->isDefaultStack( effect2 ) );
   delete effect2;
 
-  effect = static_cast<QgsEffectStack *>( registry->defaultStack() );
+  effect = static_cast<QgsEffectStack *>( QgsPaintEffectRegistry::defaultStack() );
   static_cast< QgsDrawSourceEffect * >( effect->effect( 2 ) )->setOpacity( 0.5 );
   QVERIFY( !registry->isDefaultStack( effect ) );
   static_cast< QgsDrawSourceEffect * >( effect->effect( 2 ) )->setOpacity( 1.0 );

--- a/tests/src/core/testqgsprovidermetadata.cpp
+++ b/tests/src/core/testqgsprovidermetadata.cpp
@@ -70,11 +70,11 @@ void TestQgsProviderMetadata::cleanupTestCase()
 void TestQgsProviderMetadata::checkBoolParameterSetting()
 {
   QVariantMap uri;
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "yes" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "1" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testThree" ), 1 );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "true" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFive" ), true );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "yes" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "1" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testThree" ), 1 );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "true" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFive" ), true );
 
   QVariantMap expected = { { QStringLiteral( "testOne" ), QVariant( true ) },
     { QStringLiteral( "testTwo" ), QVariant( true ) },
@@ -85,16 +85,16 @@ void TestQgsProviderMetadata::checkBoolParameterSetting()
 
   QCOMPARE( uri, expected );
 
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "YES" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "TRUE" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "YES" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "TRUE" ) );
 
   QCOMPARE( uri, expected );
 
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "no" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "0" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testThree" ), 0 );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "false" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFive" ), false );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "no" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testTwo" ), QStringLiteral( "0" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testThree" ), 0 );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "false" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFive" ), false );
 
   expected = { { QStringLiteral( "testOne" ), QVariant( false ) },
     { QStringLiteral( "testTwo" ), QVariant( false ) },
@@ -104,8 +104,8 @@ void TestQgsProviderMetadata::checkBoolParameterSetting()
   };
   QCOMPARE( uri, expected );
 
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "NO" ) );
-  mMetadata->setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "FALSE" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testOne" ), QStringLiteral( "NO" ) );
+  QgsProviderMetadata::setBoolParameter( uri, QStringLiteral( "testFour" ), QStringLiteral( "FALSE" ) );
 
   QCOMPARE( uri, expected );
 

--- a/tests/src/gui/testqgsmessagebar.cpp
+++ b/tests/src/gui/testqgsmessagebar.cpp
@@ -149,7 +149,7 @@ void TestQgsMessageBar::autoDelete()
 {
   // ensure that items are automatically deleted when queue grows too large
   QgsMessageBar bar;
-  for ( int i = 0; i < bar.MAX_ITEMS; ++i )
+  for ( int i = 0; i < QgsMessageBar::MAX_ITEMS; ++i )
   {
     bar.pushMessage( QString::number( i ), Qgis::MessageLevel::Warning );
   }

--- a/tests/src/quickgui/app/main.cpp
+++ b/tests/src/quickgui/app/main.cpp
@@ -86,5 +86,5 @@ int main( int argc, char *argv[] )
   // Add some data for debugging if needed
   QgsDebugMsg( QStringLiteral( "data directory: %1" ).arg( dataDir ) );
 
-  return app.exec();
+  return QgsApplication::exec();
 }


### PR DESCRIPTION
## Description

After the PR #46458 and #46453, this is the last one that fixes access static method. This PR fixes almost all the warnings found. I use the tool : `readability-static-accessed-through-instance` in Clang-tidy.

With this line:
`return width * e.mapUnitScaleFactor( e.symbologyScale(), mStrokeWidthUnit, e.mapUnits(), context.renderContext().mapToPixel().mapUnitsPerPixel() );`
I did not change `e.mapUnitScaleFactor` to `QgsDxfExport::mapUnitScaleFactor` because it makes these lines a little more complex.
