### PR TITLE
Add missing qgslabelsink.h header

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1333,6 +1333,7 @@ set(QGIS_CORE_HDRS
   labeling/qgslabelobstaclesettings.h
   labeling/qgslabelposition.h
   labeling/qgslabelsearchtree.h
+  labeling/qgslabelsink.h
   labeling/qgslabelthinningsettings.h
   labeling/qgspallabeling.h
   labeling/qgsrulebasedlabeling.h


### PR DESCRIPTION
## Description

Required to fix 3rd party build against QGIS (e.g. QField). Master only.