### PR TITLE
improved function  searching in qgsexpressionbuilder

### DIFF
--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -69,6 +69,7 @@ Gets the type of expression item, e.g., header, field, ExpressionNode.
     static const int SEARCH_TAGS_ROLE;
     static const int ITEM_NAME_ROLE;
     static const int LAYER_ID_ROLE;
+    static const int ITEM_HELP_ROLE;
 
 };
 

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -100,7 +100,7 @@ class GUI_EXPORT QgsExpressionItem : public QStandardItem
     static const int ITEM_NAME_ROLE = Qt::UserRole + 4;
     //! Layer ID role \since QGIS 3.24
     static const int LAYER_ID_ROLE = Qt::UserRole + 5;
-    //! Item help role
+    //! Item help role \since QGIS 3.24
     static const int ITEM_HELP_ROLE = Qt::UserRole + 6;
 
   private:

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -100,6 +100,8 @@ class GUI_EXPORT QgsExpressionItem : public QStandardItem
     static const int ITEM_NAME_ROLE = Qt::UserRole + 4;
     //! Layer ID role \since QGIS 3.24
     static const int LAYER_ID_ROLE = Qt::UserRole + 5;
+    //! Item help role
+    static const int ITEM_HELP_ROLE = Qt::UserRole + 6;
 
   private:
     QString mExpressionText;


### PR DESCRIPTION
Thanks to the work by @3nids I expanded upon it in order to also part the helptext, I was also thinking about adding synonyms/aliases but that could be done py improving the helptext.

## Description

The helptext are included in the items as a new attribute/column/key.

The filter is split by space and validation is done on each element of the filter. This allows to use multiple partial strings and disregard the order, and still yield good results.

Increasing the number of possible results is a good thing instead of having to guess the proper name of a function and think of the right synonim.

Makes the following possible : 
![image](https://user-images.githubusercontent.com/12854129/147858304-eba8754b-70b5-4883-9d8d-09a905fe2c4d.png)
