### PR TITLE
Overlay intersects sort by intersection size

### DIFF
--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -88,7 +88,7 @@
       "returns": "an array of maps with the feature id, the expression value, the overlap value and the radius of the maximum inscribed circle"
     },
     {
-      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), sort_by_intersection_size:=true)",
+      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), sort_by_intersection_size:='des')",
       "returns": "an array of geometries (in WKT) ordered by the overlap value in descending order"
     }
   ]

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -38,6 +38,16 @@
       "arg": "min_inscribed_circle_radius",
       "description": "defines an optional exclusion filter (for polygons only): minimum radius in current feature units for the maximum inscribed circle of the intersection (if the intersection results in multiple polygons the intersection will be returned if at least one of the polygons has a radius for the maximum inscribed circle greater or equal to the value).<br>Read more on the underlying GEOS predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_MaximumInscribedCircle.html'>ST_MaximumInscribedCircle</a> function.<br>This argument requires GEOS >= 3.9.",
       "optional": true
+    },
+    {
+      "arg": "return_measure",
+      "description": "only valid when used with an expression, set this to true to return a list of maps containing the feature id, the expression result and the overlap value, the radius of the maximum inscribed circle is also returned when the target layer is a polygon.",
+      "optional": true
+    },
+    {
+      "arg": "sort_by_intersection_size",
+      "description": "only valid when used with an expression, set this to true to return the results ordered by the overlap value in descending order.",
+      "optional": true
     }
   ],
   "examples": [
@@ -72,6 +82,14 @@
     {
       "expression": "overlay_intersects(layer:='regions', min_inscribed_circle_radius:=0.54)",
       "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least one of the parts in case of multipart) is greater or equal to the 0.54"
+    },
+    {
+      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), return_measure:=true)",
+      "returns": "an array of maps with the feature id, the expression value, the overlap value and the radius of the maximum inscribed circle"
+    },
+    {
+      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), sort_by_intersection_size:=true)",
+      "returns": "an array of geometries (in WKT) ordered by the overlap value in descending order"
     }
   ]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -40,13 +40,13 @@
       "optional": true
     },
     {
-      "arg": "return_measure",
-      "description": "only valid when used with an expression, set this to true to return a list of maps containing the feature id, the expression result and the overlap value, the radius of the maximum inscribed circle is also returned when the target layer is a polygon.",
+      "arg": "return_details",
+      "description": "only valid when used with an expression, set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value, the 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon.",
       "optional": true
     },
     {
       "arg": "sort_by_intersection_size",
-      "description": "only valid when used with an expression, set this to true to return the results ordered by the overlap value in descending order.",
+      "description": "only valid when used with an expression, set this to 'des' to return the results ordered by the overlap value in descending order or set this to 'asc' for ascending order.",
       "optional": true
     }
   ],
@@ -84,7 +84,7 @@
       "returns": "true if the current feature spatially intersects a region and the intersection area maximum inscribed circle's radius (of at least one of the parts in case of multipart) is greater or equal to the 0.54"
     },
     {
-      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), return_measure:=true)",
+      "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), return_details:=true)",
       "returns": "an array of maps with the feature id, the expression value, the overlap value and the radius of the maximum inscribed circle"
     },
     {

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -41,7 +41,7 @@
     },
     {
       "arg": "return_details",
-      "description": "only valid when used with an expression, set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value, the 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon.",
+      "description": "Set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value. The 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon. Only valid when used with the expression parameter",
       "optional": true
     },
     {

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -85,7 +85,7 @@
     },
     {
       "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), return_details:=true)",
-      "returns": "an array of maps with the feature id, the expression value, the overlap value and the radius of the maximum inscribed circle"
+      "returns": "an array of maps containing 'id', 'result', 'overlap' and 'radius'"
     },
     {
       "expression": "overlay_intersects(layer:='regions', expression:= geom_to_wkt($geometry), sort_by_intersection_size:='des')",

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6649,8 +6649,8 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 
   // Sixth parameter (for intersects only) is the min overlap (area or length)
   // Seventh parameter (for intersects only) is the min inscribed circle radius
-  // Eight parameter (for intersects only) is the return_measures
-  // Nineth parameter (for intersects only) is the sort_by_measure flag
+  // Eight parameter (for intersects only) is the return_measure
+  // Nineth parameter (for intersects only) is the sort_by_intersection_size flag
   double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };
   bool returnMeasures = false;
@@ -7475,8 +7475,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           << QgsExpressionFunction::Parameter( QStringLiteral( "cache" ), true, QVariant( false ), false )
           << QgsExpressionFunction::Parameter( QStringLiteral( "min_overlap" ), true, QVariant( -1 ), false )
           << QgsExpressionFunction::Parameter( QStringLiteral( "min_inscribed_circle_radius" ), true, QVariant( -1 ), false )
-          << QgsExpressionFunction::Parameter( QStringLiteral( "return_measures" ), true, false, false )
-          << QgsExpressionFunction::Parameter( QStringLiteral( "sort_by_measure" ), true, false, false ),
+          << QgsExpressionFunction::Parameter( QStringLiteral( "return_measure" ), true, false, false )
+          << QgsExpressionFunction::Parameter( QStringLiteral( "sort_by_intersection_size" ), true, false, false ),
           i.value(), QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES, true );
 
       // The current feature is accessed for the geometry, so this should not be cached

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6649,7 +6649,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 
   // Sixth parameter (for intersects only) is the min overlap (area or length)
   // Seventh parameter (for intersects only) is the min inscribed circle radius
-  // Eight parameter (for intersects only) is the return_measure
+  // Eighth parameter (for intersects only) is the return_measure
   // Ninth parameter (for intersects only) is the sort_by_intersection_size flag
   double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6986,7 +6986,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
         } );
       }
       // Resize
-      if ( limit > 0 &&  results.size() > limit )
+      if ( limit > 0 && results.size() > limit )
       {
         results.erase( results.begin() + limit );
       }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6653,7 +6653,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   // Ninth parameter (for intersects only) is the sort_by_intersection_size flag
   double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };
-  bool returnDetails = false;
+  bool returnDetails = false;  //#spellok
   bool sortByMeasure = false;
   bool sortAscending = false;
   bool requireMeasures = false;
@@ -6680,13 +6680,13 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 #endif
     node = QgsExpressionUtils::getNode( values.at( 7 ), parent );
     // Return measures is only effective when an expression is set
-    returnDetails = !testOnly && node->eval( parent, context ).toBool();
+    returnDetails = !testOnly && node->eval( parent, context ).toBool();  //#spellok
     node = QgsExpressionUtils::getNode( values.at( 8 ), parent );
     // Sort by measures is only effective when an expression is set
     const QString sorting { node->eval( parent, context ).toString().toLower() };
     sortByMeasure = !testOnly && ( sorting.startsWith( "asc" ) || sorting.startsWith( "des" ) );
     sortAscending = sorting.startsWith( "asc" );
-    requireMeasures = sortByMeasure || returnDetails;
+    requireMeasures = sortByMeasure || returnDetails;  //#spellok
     overlapOrRadiusFilter = minInscribedCircleRadius != -1 || minOverlap != -1;
   }
 
@@ -7042,7 +7042,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
         results.erase( results.begin() + limit );
       }
 
-      if ( ! returnDetails )
+      if ( ! returnDetails )  //#spellok
       {
         QVariantList expResults;
         for ( auto it = results.constBegin(); it != results.constEnd(); ++it )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6649,8 +6649,14 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
 
   // Sixth parameter (for intersects only) is the min overlap (area or length)
   // Seventh parameter (for intersects only) is the min inscribed circle radius
+  // Eight parameter (for intersects only) is the return_measures
+  // Nineth parameter (for intersects only) is the sort_by_measure flag
   double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };
+  bool returnMeasures = false;
+  bool sortByMeasure = false;
+  bool requireMeasures = false;
+  bool overlapOrRadiusFilter = false;
   if ( isIntersectsFunc )
   {
 
@@ -6671,6 +6677,14 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
       return QVariant();
     }
 #endif
+    node = QgsExpressionUtils::getNode( values.at( 7 ), parent );
+    // Return measures is only effective when an expression is set
+    returnMeasures = !testOnly && node->eval( parent, context ).toBool();
+    node = QgsExpressionUtils::getNode( values.at( 8 ), parent );
+    // Sort by measures is only effective when an expression is set
+    sortByMeasure = !testOnly && node->eval( parent, context ).toBool();
+    requireMeasures = sortByMeasure || returnMeasures;
+    overlapOrRadiusFilter = minInscribedCircleRadius != -1 || minOverlap != -1;
   }
 
 
@@ -6788,53 +6802,77 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   QVariantList results;
 
   QListIterator<QgsFeature> i( features );
-  while ( i.hasNext() && ( limit == -1 || foundCount < limit ) )
+  while ( i.hasNext() && ( sortByMeasure || limit == -1 || foundCount < limit ) )
   {
     QgsFeature feat2 = i.next();
 
     if ( ! relationFunction || ( geometry.*relationFunction )( feat2.geometry() ) ) // Calls the method provided as template argument for the function (e.g. QgsGeometry::intersects)
     {
 
-      if ( isIntersectsFunc && ( minOverlap != -1 || minInscribedCircleRadius != -1 ) )
+      double overlapValue = -1;
+      double radiusValue = -1;
+
+      if ( isIntersectsFunc && ( requireMeasures || overlapOrRadiusFilter ) )
       {
         const QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
 
-        // overlap and inscribed circle tests must be checked both (if the valuea are != -1)
+        // overlap and inscribed circle tests must be checked both (if the values are != -1)
         switch ( intersection.type() )
         {
           case QgsWkbTypes::GeometryType::PolygonGeometry:
           {
 
             bool testResult { false };
-            for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
+            // For return measures:
+            QVector<double> overlapValues;
+            QVector<double> radiusValues;
+            for ( auto it = intersection.const_parts_begin(); ( ! testResult || requireMeasures ) && it != intersection.const_parts_end(); ++it )
             {
               const QgsCurvePolygon *geom = qgsgeometry_cast< const QgsCurvePolygon * >( *it );
               // Check min overlap for intersection (if set)
-              if ( minOverlap != -1 )
+              if ( minOverlap != -1 || requireMeasures )
               {
-                if ( geom->area() >= minOverlap )
+                overlapValue = geom->area();
+                overlapValues.append( geom->area() );
+                if ( minOverlap != - 1 )
                 {
-                  testResult = true;
-                }
-                else
-                {
-                  continue;
+                  if ( overlapValue >= minOverlap )
+                  {
+                    testResult = true;
+                  }
+                  else
+                  {
+                    continue;
+                  }
                 }
               }
 
               // Check min inscribed circle radius for intersection (if set)
-              if ( minInscribedCircleRadius != -1 )
+              if ( minInscribedCircleRadius != -1 || requireMeasures )
               {
                 const QgsRectangle bbox = geom->boundingBox();
                 const double width = bbox.width();
                 const double height = bbox.height();
                 const double size = width > height ? width : height;
                 const double tolerance = size / 100.0;
-                testResult = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length() >= minInscribedCircleRadius;
+                radiusValue = QgsGeos( geom ).maximumInscribedCircle( tolerance )->length();
+                testResult = radiusValue >= minInscribedCircleRadius;
+                radiusValues.append( radiusValues );
               }
             }
 
-            if ( ! testResult )
+            // Get the max values
+            if ( !radiusValues.isEmpty() )
+            {
+              radiusValue = *std::max_element( radiusValues.cbegin(), radiusValues.cend() );
+            }
+
+            if ( ! overlapValues.isEmpty() )
+            {
+              overlapValue = *std::max_element( overlapValues.cbegin(), overlapValues.cend() );
+            }
+
+            if ( ! testResult && overlapOrRadiusFilter )
             {
               continue;
             }
@@ -6844,27 +6882,40 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
           case QgsWkbTypes::GeometryType::LineGeometry:
           {
             bool testResult { false };
+            // For return measures:
+            QVector<double> overlapValues;
             for ( auto it = intersection.const_parts_begin(); ! testResult && it != intersection.const_parts_end(); ++it )
             {
               const QgsCurve *geom = qgsgeometry_cast< const QgsCurve * >( *it );
               // Check min overlap for intersection (if set)
-              if ( minOverlap != -1 )
+              if ( minOverlap != -1  || requireMeasures )
               {
-                if ( geom->length() >= minOverlap )
+                overlapValue = geom->length();
+                overlapValues.append( overlapValue );
+                if ( minOverlap != -1 )
                 {
-                  testResult = true;
-                }
-                else
-                {
-                  continue;
+                  if ( overlapValue >= minOverlap )
+                  {
+                    testResult = true;
+                  }
+                  else
+                  {
+                    continue;
+                  }
                 }
               }
             }
 
-            if ( ! testResult )
+            if ( ! overlapValues.isEmpty() )
+            {
+              overlapValue = *std::max_element( overlapValues.cbegin(), overlapValues.cend() );
+            }
+
+            if ( ! testResult && overlapOrRadiusFilter )
             {
               continue;
             }
+
             break;
           }
           case QgsWkbTypes::GeometryType::PointGeometry:
@@ -6887,7 +6938,26 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
       {
         // We want a list of attributes / geometries / other expression values, evaluate now
         subContext.setFeature( feat2 );
-        results.append( subExpression.evaluate( &subContext ) );
+        const QVariant expResult { subExpression.evaluate( &subContext ) };
+
+        if ( requireMeasures )
+        {
+          QVariantMap resultRecord;
+          resultRecord.insert( QStringLiteral( "id" ), feat2.id() );
+          resultRecord.insert( QStringLiteral( "result" ), expResult );
+          // Overlap is always added because return measures was set
+          resultRecord.insert( QStringLiteral( "overlap" ), overlapValue );
+          // radius is only added when is different than -1 (because for linestrings is not set)
+          if ( radiusValue != -1 )
+          {
+            resultRecord.insert( QStringLiteral( "radius" ), radiusValue );
+          }
+          results.append( resultRecord );
+        }
+        else
+        {
+          results.append( expResult );
+        }
       }
       else
       {
@@ -6905,7 +6975,35 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
   }
 
   if ( !invert )
+  {
+    if ( requireMeasures )
+    {
+      if ( sortByMeasure )
+      {
+        std::sort( results.begin(), results.end(), [ ]( const QVariant & recordA, const QVariant & recordB ) -> bool
+        {
+          return recordA.toMap().value( QStringLiteral( "overlap" ) ).toDouble() > recordB.toMap().value( QStringLiteral( "overlap" ) ).toDouble();
+        } );
+      }
+      // Resize
+      if ( limit > 0 &&  results.size() > limit )
+      {
+        results.erase( results.begin() + limit );
+      }
+
+      if ( ! returnMeasures )
+      {
+        QVariantList expResults;
+        for ( auto it = results.constBegin(); it != results.constEnd(); ++it )
+        {
+          expResults.append( it->toMap().value( QStringLiteral( "result" ) ) );
+        }
+        return expResults;
+      }
+    }
+
     return results;
+  }
 
   // for disjoint condition returns the results for cached layers not intersected feats
   QVariantList disjoint_results;
@@ -7376,7 +7474,9 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           << QgsExpressionFunction::Parameter( QStringLiteral( "limit" ), true, QVariant( -1 ), true )
           << QgsExpressionFunction::Parameter( QStringLiteral( "cache" ), true, QVariant( false ), false )
           << QgsExpressionFunction::Parameter( QStringLiteral( "min_overlap" ), true, QVariant( -1 ), false )
-          << QgsExpressionFunction::Parameter( QStringLiteral( "min_inscribed_circle_radius" ), true, QVariant( -1 ), false ),
+          << QgsExpressionFunction::Parameter( QStringLiteral( "min_inscribed_circle_radius" ), true, QVariant( -1 ), false )
+          << QgsExpressionFunction::Parameter( QStringLiteral( "return_measures" ), true, false, false )
+          << QgsExpressionFunction::Parameter( QStringLiteral( "sort_by_measure" ), true, false, false ),
           i.value(), QStringLiteral( "GeometryGroup" ), QString(), true, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES, true );
 
       // The current feature is accessed for the geometry, so this should not be cached

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6851,6 +6851,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
                 }
               }
 
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
               // Check min inscribed circle radius for intersection (if set)
               if ( minInscribedCircleRadius != -1 || requireMeasures )
               {
@@ -6863,6 +6864,7 @@ static QVariant executeGeomOverlay( const QVariantList &values, const QgsExpress
                 testResult = radiusValue >= minInscribedCircleRadius;
                 radiusValues.append( radiusValues );
               }
+#endif
             }
 
             // Get the max values

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -273,23 +273,23 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   expected1.insert( QStringLiteral( "radius" ),  0.46454276882989376 );
 #endif
-  QTest::newRow( "intersects min_overlap multi match return measure" ) << "overlay_intersects('polys', expression:=$id, min_overlap:=1.34, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 ) ;
+  QTest::newRow( "intersects min_overlap multi match return measure" ) << "overlay_intersects('polys', expression:=$id, min_overlap:=1.34, return_details:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 ) ;
 
-  QTest::newRow( "intersects multi match return measure" ) << "overlay_intersects('polys', expression:=$id, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected1 << expected3 ) ;
+  QTest::newRow( "intersects multi match return measure" ) << "overlay_intersects('polys', expression:=$id, return_details:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected1 << expected3 ) ;
 
-  QTest::newRow( "intersects multi match return sorted measure" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:=true, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 << expected1 ) ;
+  QTest::newRow( "intersects multi match return sorted measure" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:='des', return_details:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 << expected1 ) ;
 
-  QTest::newRow( "intersects multi match return sorted" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL << 1LL ) ;
+  QTest::newRow( "intersects multi match return sorted" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:='des')" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL << 1LL ) ;
 
   QTest::newRow( "intersects multi match return unsorted" ) << "overlay_intersects('polys', expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 1LL << 3LL ) ;
 
   QTest::newRow( "intersects multi match return unsorted limit " ) << "overlay_intersects('polys', limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 1LL ) ;
 
-  QTest::newRow( "intersects multi match return sorted limit " ) << "overlay_intersects('polys', sort_by_intersection_size:=true, limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL ) ;
+  QTest::newRow( "intersects multi match return sorted limit " ) << "overlay_intersects('polys', sort_by_intersection_size:='des', limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL ) ;
 
   QTest::newRow( "intersects multi match points" ) << "overlay_intersects('polys', expression:=$id)" << "MULTIPOINT((-107.37 33.75), (-102.8 36.97))" << ( QVariantList() << 1LL << 3LL ) ;
 
-  QTest::newRow( "intersects multi match points sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:=true, expression:=$id)" << "MULTIPOINT((-107.37 33.75), (-102.8 36.97))" << ( QVariantList() << 3LL << 1LL );
+  QTest::newRow( "intersects multi match points sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:='des', expression:=$id)" << "MULTIPOINT((-107.37 33.75), (-102.8 36.97))" << ( QVariantList() << 3LL << 1LL );
 
   {
     // Check returned values from point intersection
@@ -302,7 +302,7 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
     expected1.insert( QStringLiteral( "result" ), 1 );
     expected1.insert( QStringLiteral( "overlap" ), 18.569843123334977 );
 
-    QTest::newRow( "intersects multi match points return sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:=true, return_measure:=true, expression:=$id)" << "MULTIPOINT((-107.37 33.75), (-102.8 36.97))" << ( QVariantList() << expected3 << expected1 ) ;
+    QTest::newRow( "intersects multi match points return sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:='des', return_details:=true, expression:=$id)" << "MULTIPOINT((-107.37 33.75), (-102.8 36.97))" << ( QVariantList() << expected3 << expected1 ) ;
 
   }
 
@@ -319,20 +319,24 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
 
   QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 1LL << 3LL );
 
-  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
+  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
 
-  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', limit:=1, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL );
+  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', limit:=1, sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL );
 
-  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys',  sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
+  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys',  sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
+
+  QTest::newRow( "intersects linestring multi match measure sorted asc" ) << "overlay_intersects('polys',  sort_by_intersection_size:='asc', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 1LL << 3LL );
 
   // Return measure
-  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', return_measure:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine1 << expectedLine3 );
+  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', return_details:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine1 << expectedLine3 );
 
-  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', return_measure:=true, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
+  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', return_details:=true, sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
 
-  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', return_measure:=true, limit:=1, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 );
+  QTest::newRow( "intersects linestring multi match sorted asc" ) << "overlay_intersects('polys', return_details:=true, sort_by_intersection_size:='asc', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine1 << expectedLine3 );
 
-  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys', return_measure:=true, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
+  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', return_details:=true, limit:=1, sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 );
+
+  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys', return_details:=true, sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
 
 
   // Test linestring intersections
@@ -346,19 +350,19 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
     expectedLine2.insert( QStringLiteral( "result" ), 2 );
     expectedLine2.insert( QStringLiteral( "overlap" ), 0 );
 
-    QTest::newRow( "intersects linestring single match" ) << "overlay_intersects('linestrings', return_measure:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1)" << ( QVariantList() << expectedLine1 );
-    QTest::newRow( "intersects linestring single match fail overlap" ) << "overlay_intersects('linestrings', min_overlap:=0.5, return_measure:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1)" << ( QVariantList() );
-    QTest::newRow( "intersects linestring no match" ) << "overlay_intersects('linestrings', return_measure:=true, expression:=$id)" << "LINESTRING(1.5 2, 1.5 1)" << ( QVariantList() );
-    QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('linestrings', return_measure:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1, 4 -1, 4 1)" << ( QVariantList() << expectedLine1 << expectedLine2 );
+    QTest::newRow( "intersects linestring single match" ) << "overlay_intersects('linestrings', return_details:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1)" << ( QVariantList() << expectedLine1 );
+    QTest::newRow( "intersects linestring single match fail overlap" ) << "overlay_intersects('linestrings', min_overlap:=0.5, return_details:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1)" << ( QVariantList() );
+    QTest::newRow( "intersects linestring no match" ) << "overlay_intersects('linestrings', return_details:=true, expression:=$id)" << "LINESTRING(1.5 2, 1.5 1)" << ( QVariantList() );
+    QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('linestrings', return_details:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1, 4 -1, 4 1)" << ( QVariantList() << expectedLine1 << expectedLine2 );
     expectedLine2[QStringLiteral( "overlap" )] = 0.5;
-    QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('linestrings', return_measure:=true, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1, 4 -1, 4 0, 4.5 0)" << ( QVariantList() << expectedLine2 << expectedLine1 );
+    QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('linestrings', return_details:=true, sort_by_intersection_size:='des', expression:=$id)" << "LINESTRING(1.5 1, 1.5 -1, 4 -1, 4 0, 4.5 0)" << ( QVariantList() << expectedLine2 << expectedLine1 );
 
     // Full length of targets is expected
     expectedLine2[QStringLiteral( "overlap" )] = 2.0;
     expectedLine1[QStringLiteral( "overlap" )] = 1.0;
 
-    QTest::newRow( "intersects linestring multi match points" ) << "overlay_intersects('linestrings', return_measure:=true, expression:=$id)" << "MULTIPOINT((1.5 0), (3.5 0))" << ( QVariantList() << expectedLine1 << expectedLine2 );
-    QTest::newRow( "intersects linestring multi match points sorted" ) << "overlay_intersects('linestrings', sort_by_intersection_size:=true, return_measure:=true, expression:=$id)" << "MULTIPOINT((1.5 0), (3.5 0))" << ( QVariantList() << expectedLine2 << expectedLine1 );
+    QTest::newRow( "intersects linestring multi match points" ) << "overlay_intersects('linestrings', return_details:=true, expression:=$id)" << "MULTIPOINT((1.5 0), (3.5 0))" << ( QVariantList() << expectedLine1 << expectedLine2 );
+    QTest::newRow( "intersects linestring multi match points sorted" ) << "overlay_intersects('linestrings', sort_by_intersection_size:='des', return_details:=true, expression:=$id)" << "MULTIPOINT((1.5 0), (3.5 0))" << ( QVariantList() << expectedLine2 << expectedLine1 );
 
   }
 
@@ -373,8 +377,8 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
     expectedPoint2.insert( QStringLiteral( "result" ), 2 );
     expectedPoint2.insert( QStringLiteral( "overlap" ), 0 );
 
-    QTest::newRow( "intersects points single match" ) << "overlay_intersects('points', return_measure:=true, expression:=$id)" << "POLYGON((0 -1, 1.5 -1, 1.5 1, 0 1, 0 -1))" << ( QVariantList() << expectedPoint1 );
-    QTest::newRow( "intersects points multi match" ) << "overlay_intersects('points', return_measure:=true, expression:=$id)" << "POLYGON((0 -1, 3.5 -1, 3.5 1, 0 1, 0 -1))" << ( QVariantList() << expectedPoint1 << expectedPoint2 );
+    QTest::newRow( "intersects points single match" ) << "overlay_intersects('points', return_details:=true, expression:=$id)" << "POLYGON((0 -1, 1.5 -1, 1.5 1, 0 1, 0 -1))" << ( QVariantList() << expectedPoint1 );
+    QTest::newRow( "intersects points multi match" ) << "overlay_intersects('points', return_details:=true, expression:=$id)" << "POLYGON((0 -1, 3.5 -1, 3.5 1, 0 1, 0 -1))" << ( QVariantList() << expectedPoint1 << expectedPoint2 );
   }
 
 }

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -62,8 +62,6 @@ class TestQgsOverlayExpression: public QObject
     void testOverlay();
     void testOverlay_data();
 
-  private slots:
-
     void testOverlayMeasure();
     void testOverlayMeasure_data();
 
@@ -246,19 +244,19 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
   expected1.insert( QStringLiteral( "overlap" ), 1.2281139270096446 );
   expected1.insert( QStringLiteral( "radius" ),  0.46454276882989376 );
 
-  QTest::newRow( "intersects min_overlap multi match return measure" ) << "overlay_intersects('polys', expression:=$id, min_overlap:=1.34, return_measures:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 ) ;
+  QTest::newRow( "intersects min_overlap multi match return measure" ) << "overlay_intersects('polys', expression:=$id, min_overlap:=1.34, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 ) ;
 
-  QTest::newRow( "intersects multi match return measure" ) << "overlay_intersects('polys', expression:=$id, return_measures:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected1 << expected3 ) ;
+  QTest::newRow( "intersects multi match return measure" ) << "overlay_intersects('polys', expression:=$id, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected1 << expected3 ) ;
 
-  QTest::newRow( "intersects multi match return sorted measure" ) << "overlay_intersects('polys', expression:=$id, sort_by_measure:=true, return_measures:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 << expected1 ) ;
+  QTest::newRow( "intersects multi match return sorted measure" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:=true, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 << expected1 ) ;
 
-  QTest::newRow( "intersects multi match return sorted" ) << "overlay_intersects('polys', expression:=$id, sort_by_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL << 1LL ) ;
+  QTest::newRow( "intersects multi match return sorted" ) << "overlay_intersects('polys', expression:=$id, sort_by_intersection_size:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL << 1LL ) ;
 
   QTest::newRow( "intersects multi match return unsorted" ) << "overlay_intersects('polys', expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 1LL << 3LL ) ;
 
   QTest::newRow( "intersects multi match return unsorted limit " ) << "overlay_intersects('polys', limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 1LL ) ;
 
-  QTest::newRow( "intersects multi match return sorted limit " ) << "overlay_intersects('polys', sort_by_measure:=true, limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL ) ;
+  QTest::newRow( "intersects multi match return sorted limit " ) << "overlay_intersects('polys', sort_by_intersection_size:=true, limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL ) ;
 
 }
 

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -248,8 +248,6 @@ void TestQgsOverlayExpression::testOverlayMeasure()
   QVERIFY2( exp.prepare( &context ), exp.parserErrorString().toUtf8().constData() );
   const QVariant result = exp.evaluate( &context );
 
-  qDebug() << "RES:" << result;
-  qDebug() << "EXP:" << expectedResult;
   QCOMPARE( result, expectedResult );
 
 }
@@ -265,13 +263,16 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
   expected3.insert( QStringLiteral( "id" ), 3LL );
   expected3.insert( QStringLiteral( "result" ), 3LL );
   expected3.insert( QStringLiteral( "overlap" ), 1.4033836999701634 );
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   expected3 .insert( QStringLiteral( "radius" ), 0.5344336346973622 );
+#endif
   QVariantMap expected1;
   expected1.insert( QStringLiteral( "id" ), 1LL );
   expected1.insert( QStringLiteral( "result" ), 1LL );
   expected1.insert( QStringLiteral( "overlap" ), 1.2281139270096446 );
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
   expected1.insert( QStringLiteral( "radius" ),  0.46454276882989376 );
-
+#endif
   QTest::newRow( "intersects min_overlap multi match return measure" ) << "overlay_intersects('polys', expression:=$id, min_overlap:=1.34, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected3 ) ;
 
   QTest::newRow( "intersects multi match return measure" ) << "overlay_intersects('polys', expression:=$id, return_measure:=true)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << expected1 << expected3 ) ;

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -198,7 +198,7 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::newRow( "intersects linestring match" ) << "overlay_intersects('polys', min_overlap:=1.76)" << "LINESTRING(-105 33.75, -102.76 33.75)" << true;
   QTest::newRow( "intersects linestring no match" ) << "overlay_intersects('polys', min_overlap:=2.0)" << "LINESTRING(-105 33.75, -102.76 33.75)" << false;
 
-  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', min_overlap:=1.76)" << "LINESTRING(-105 33.75, -102.76 33.75)" << true;
+  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', min_overlap:=1.76)" << "LINESTRING(-102.76 33.74, -106.12 33.74)" << true;
   QTest::newRow( "intersects linestring multi no match" ) << "overlay_intersects('polys', min_overlap:=2.0)" << "LINESTRING(-102.76 33.74, -106.12 33.74)" << false;
 
 }
@@ -257,6 +257,37 @@ void TestQgsOverlayExpression::testOverlayMeasure_data()
   QTest::newRow( "intersects multi match return unsorted limit " ) << "overlay_intersects('polys', limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 1LL ) ;
 
   QTest::newRow( "intersects multi match return sorted limit " ) << "overlay_intersects('polys', sort_by_intersection_size:=true, limit:=1, expression:=$id)" << "POLYGON((-107.37 33.75, -102.76 33.75, -102.76 36.97, -107.37 36.97, -107.37 33.75))" << ( QVariantList() << 3LL ) ;
+
+
+  // Linestring tests!
+
+  // Check return measures
+  QVariantMap expectedLine3;
+  expectedLine3.insert( QStringLiteral( "id" ), 3LL );
+  expectedLine3.insert( QStringLiteral( "result" ), 3LL );
+  expectedLine3.insert( QStringLiteral( "overlap" ), 0.9114785997128507 );
+  QVariantMap expectedLine1;
+  expectedLine1.insert( QStringLiteral( "id" ), 1LL );
+  expectedLine1.insert( QStringLiteral( "result" ), 1LL );
+  expectedLine1.insert( QStringLiteral( "overlap" ), 0.4447782690201052 );
+
+  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 1LL << 3LL );
+
+  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
+
+  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', limit:=1, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL );
+
+  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys',  sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << 3LL << 1LL );
+
+  // Return measure
+  QTest::newRow( "intersects linestring multi match" ) << "overlay_intersects('polys', return_measure:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine1 << expectedLine3 );
+
+  QTest::newRow( "intersects linestring multi match sorted" ) << "overlay_intersects('polys', return_measure:=true, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
+
+  QTest::newRow( "intersects linestring multi match sorted limit" ) << "overlay_intersects('polys', return_measure:=true, limit:=1, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 );
+
+  QTest::newRow( "intersects linestring multi match measure sorted" ) << "overlay_intersects('polys', return_measure:=true, sort_by_intersection_size:=true, expression:=$id)" << "LINESTRING(-102.76 33.74, -102.76 36.44)" << ( QVariantList() << expectedLine3 << expectedLine1 );
+
 
 }
 


### PR DESCRIPTION
## overlay_intersects further enhancements

This PR adds two new optional arguments to the existing function:

+   `return_details`: only valid when used with an expression, set this to true to return a list of maps containing (key names in quotes) the feature 'id', the expression 'result' and the 'overlap' value, the 'radius' of the maximum inscribed circle is also returned when the target layer is a polygon.
+ `sort_by_intersection_size`: only valid when used with an expression, set this to true to return the results ordered by the overlap value in descending order.

This is the new documentation:
![overlay_intersects_measure](https://user-images.githubusercontent.com/142164/148393791-ee2b20d7-857b-44ce-af37-283002f864b1.png)


