### PR TITLE
extend geometry_n definition

### DIFF
--- a/resources/function_help/json/geometry_n
+++ b/resources/function_help/json/geometry_n
@@ -2,7 +2,7 @@
   "name": "geometry_n",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns a specific geometry from a geometry collection, or NULL if the input geometry is not a collection.",
+  "description": "Returns a specific geometry from a geometry collection, or NULL if the input geometry is not a collection. Also returns a part from a multipart geometry.",
   "arguments": [ {"arg":"geometry","description":"geometry collection"},
   {"arg":"index","description":"index of geometry to return, where 1 is the first geometry in the collection"} ],
   "examples": [ { "expression":"geom_to_wkt(geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),3))", "returns":"'Point (1 0)'"}]


### PR DESCRIPTION
## Description

The current definition of the algorithm only mentions collections, but since multipart geometries are sometimes interchangeable with collections, I assume it is a good idea to document the use of the alg for them too.