### PR TITLE
Add QgsGeometryUtils::perpendicularCenterSegment

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -644,6 +644,35 @@ Create a perpendicular line segment from p to segment [s1, s2]
 %End
 
 
+    static void perpendicularCenterSegment( double centerPointx, double centerPointy,
+                                            double segmentPoint1x, double segmentPoint1y,
+                                            double segmentPoint2x, double segmentPoint2y,
+                                            double &perpendicularSegmentPoint1x /Out/, double &perpendicularSegmentPoint1y /Out/,
+                                            double &perpendicularSegmentPoint2x /Out/, double &perpendicularSegmentPoint2y /Out/,
+                                            double segmentLength = 0
+                                          ) /HoldGIL/;
+%Docstring
+Create a perpendicular line segment to a given segment [``segmentPoint1``,``segmentPoint2``] with its center at ``centerPoint``.
+
+May be used to split geometries. Unless ``segmentLength`` is specified the new centered perpendicular line segment will have double the length of the input segment.
+
+The result is a line (segment) centered in point p and perpendicular to segment [segmentPoint1, segmentPoint2].
+
+:param centerPointx: x-coordinate of the point where the center of the perpendicular should be located
+:param centerPointy: y-coordinate of the point where the center of the perpendicular should be located
+:param segmentPoint1x: : x-coordinate of segmentPoint1, the segment's start point
+:param segmentPoint1y: : y-coordinate of segmentPoint1, the segment's start point
+:param segmentPoint2x: : x-coordinate of segmentPoint2, the segment's end point
+:param y2: : y-coordinate of segmentPoint2, the segment's end point
+:param perpendicularSegmentPoint1x: : x-coordinate of the perpendicularCenterSegment's start point
+:param perpendicularSegmentPoint1y: : y-coordinate of the perpendicularCenterSegment's start point
+:param perpendicularSegmentPoint2x: : x-coordinate of the perpendicularCenterSegment's end point
+:param perpendicularSegmentPoint2y: : y-coordinate of the perpendicularCenterSegment's end point
+:param segmentLength: (optional) Trims to given length. A segmentLength value of 0 refers to the default length which is double the length of the input segment. Set to 1 for a normalized length.
+
+.. versionadded:: 3.17
+%End
+
     static double skewLinesDistance( const QgsVector3D &P1, const QgsVector3D &P12,
                                      const QgsVector3D &P2, const QgsVector3D &P22 ) /HoldGIL/;
 %Docstring

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1605,6 +1605,23 @@ QgsLineString QgsGeometryUtils::perpendicularSegment( const QgsPoint &p, const Q
   return line;
 }
 
+void QgsGeometryUtils::perpendicularCenterSegment( double pointx, double pointy, double segmentPoint1x, double segmentPoint1y, double segmentPoint2x, double segmentPoint2y, double &perpendicularSegmentPoint1x, double &perpendicularSegmentPoint1y, double &perpendicularSegmentPoint2x, double &perpendicularSegmentPoint2y, double desiredSegmentLength )
+{
+  QgsVector segmentVector =  QgsVector( segmentPoint2x - segmentPoint1x, segmentPoint2y - segmentPoint1y );
+  QgsVector perpendicularVector = segmentVector.perpVector();
+  if ( desiredSegmentLength )
+  {
+    if ( desiredSegmentLength != 0 )
+    {
+      perpendicularVector = perpendicularVector.normalized() * ( desiredSegmentLength ) / 2;
+    }
+  }
+  perpendicularSegmentPoint1x = pointx - perpendicularVector.x();
+  perpendicularSegmentPoint1y = pointy - perpendicularVector.y();
+  perpendicularSegmentPoint2x = pointx + perpendicularVector.x();
+  perpendicularSegmentPoint2y = pointy + perpendicularVector.y();
+}
+
 double QgsGeometryUtils::lineAngle( double x1, double y1, double x2, double y2 )
 {
   const double at = std::atan2( y2 - y1, x2 - x1 );

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -674,6 +674,37 @@ class CORE_EXPORT QgsGeometryUtils
      */
     static QgsLineString perpendicularSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 ) SIP_HOLDGIL;
 
+    /**
+     * \brief Create a perpendicular line segment to a given segment [\a segmentPoint1,\a segmentPoint2] with its center at \a centerPoint.
+     *
+     * May be used to split geometries. Unless \a segmentLength is specified the new centered perpendicular line segment will have double the length of the input segment.
+     *
+     * The result is a line (segment) centered in point p and perpendicular to segment [segmentPoint1, segmentPoint2].
+     *
+     * \param centerPointx x-coordinate of the point where the center of the perpendicular should be located
+     * \param centerPointy y-coordinate of the point where the center of the perpendicular should be located
+     * \param segmentPoint1x: x-coordinate of segmentPoint1, the segment's start point
+     * \param segmentPoint1y: y-coordinate of segmentPoint1, the segment's start point
+     * \param segmentPoint2x: x-coordinate of segmentPoint2, the segment's end point
+     * \param y2: y-coordinate of segmentPoint2, the segment's end point
+     * \param perpendicularSegmentPoint1x: x-coordinate of the perpendicularCenterSegment's start point
+     * \param perpendicularSegmentPoint1y: y-coordinate of the perpendicularCenterSegment's start point
+     * \param perpendicularSegmentPoint2x: x-coordinate of the perpendicularCenterSegment's end point
+     * \param perpendicularSegmentPoint2y: y-coordinate of the perpendicularCenterSegment's end point
+     * \param segmentLength (optional) Trims to given length. A segmentLength value of 0 refers to the default length which is double the length of the input segment. Set to 1 for a normalized length.
+     *
+     *
+     * \since QGIS 3.17?
+     *
+     */
+
+    static void perpendicularCenterSegment( double centerPointx, double centerPointy,
+                                            double segmentPoint1x, double segmentPoint1y,
+                                            double segmentPoint2x, double segmentPoint2y,
+                                            double &perpendicularSegmentPoint1x SIP_OUT, double &perpendicularSegmentPoint1y SIP_OUT,
+                                            double &perpendicularSegmentPoint2x SIP_OUT, double &perpendicularSegmentPoint2y SIP_OUT,
+                                            double segmentLength = 0
+                                          ) SIP_HOLDGIL;
 
     /**
      * An algorithm to calculate the shortest distance between two skew lines.

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -60,6 +60,7 @@ class TestQgsGeometryUtils: public QObject
     void testGradient();
     void testCoefficients();
     void testPerpendicularSegment();
+    void testPerpendicularCenterSegment();
     void testClosestPoint();
     void testlinesIntersection3D();
     void testSegmentIntersection();
@@ -727,6 +728,99 @@ void TestQgsGeometryUtils::testPerpendicularSegment()
   line.addVertex( QgsPoint( 3, 8 ) );
   QCOMPARE( line.pointN( 0 ), line_r.pointN( 0 ) );
   QCOMPARE( line.pointN( 1 ), line_r.pointN( 1 ) );
+}
+
+
+void TestQgsGeometryUtils::testPerpendicularCenterSegment()
+{
+  double perpendicularSegmentPoint1x = 0, perpendicularSegmentPoint1y = 0, perpendicularSegmentPoint2x = 0, perpendicularSegmentPoint2y = 0, segmentLength = 0;
+
+  // default case 1: centerPoint and perpendicular line on given segment without segmentLength
+  QgsPoint centerPoint( 2, 1.5 );
+  QgsPoint segmentPoint1( 2, 1 );
+  QgsPoint segmentPoint2( 2, 2 );
+
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y );
+  QCOMPARE( perpendicularSegmentPoint1x, 3.0 );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 1.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 1.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 1.5 ) );
+
+  // case 1 with segmentLength
+  segmentLength = 3;
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y, segmentLength );
+  QCOMPARE( perpendicularSegmentPoint1x, ( 3.5 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 1.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 0.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 1.5 ) );
+
+  // default case 1 with default segmentLength=0 (meaning no effect)
+  segmentLength = 0;
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y, segmentLength );
+  QCOMPARE( perpendicularSegmentPoint1x, 3.0 );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 1.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 1.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 1.5 ) );
+
+
+  // default case 2: centerPoint not on given segment without segmentLength
+  centerPoint = QgsPoint( 3, 13 );
+  segmentPoint1 = QgsPoint( 2, 3 );
+  segmentPoint2 = QgsPoint( 7, 11 );
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y );
+  QCOMPARE( perpendicularSegmentPoint1x, ( 11.0 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 8.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( -5.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 18.0 ) );
+
+  // case 3: centerPoint segment with segmentLength
+  centerPoint = QgsPoint( 1, 3 );
+  segmentPoint1 = QgsPoint( 4, 3 );
+  segmentPoint2 = QgsPoint( -5, -9 );
+
+  segmentLength = 5;
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y, segmentLength );
+
+  QCOMPARE( perpendicularSegmentPoint1x, ( -1.0 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 4.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 3.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 1.5 ) );
+
+  // horizontal without segmentLength
+  segmentPoint1 = QgsPoint( -3, 3 );
+  segmentPoint2 = QgsPoint( 2, 3 );
+  centerPoint = QgsPoint( 3, 13 );
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y );
+  QCOMPARE( perpendicularSegmentPoint1x, ( 3.0 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 8.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 3.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 18.0 ) );
+
+  // vertical without segmentLength
+  segmentPoint1 = QgsPoint( 3, 13 );
+  segmentPoint2 = QgsPoint( 3, 3 );
+  centerPoint = QgsPoint( -7, 8 );
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y );
+  QCOMPARE( perpendicularSegmentPoint1x, ( -17.0 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 8.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( 3. ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 8.0 ) );
+
+  // vertical with normalization of segmentLength
+  segmentLength = 1;
+  QgsGeometryUtils::perpendicularCenterSegment( centerPoint.x(), centerPoint.y(), segmentPoint1.x(), segmentPoint1.y(), segmentPoint2.x(), segmentPoint2.y(),
+      perpendicularSegmentPoint1x, perpendicularSegmentPoint1y, perpendicularSegmentPoint2x, perpendicularSegmentPoint2y, segmentLength );
+  QCOMPARE( perpendicularSegmentPoint1x, ( -7.5 ) );
+  QCOMPARE( perpendicularSegmentPoint1y, ( 8.0 ) );
+  QCOMPARE( perpendicularSegmentPoint2x, ( -6.5 ) );
+  QCOMPARE( perpendicularSegmentPoint2y, ( 8.0 ) );
 }
 
 void TestQgsGeometryUtils::testClosestPoint()


### PR DESCRIPTION
..with description in header file, qgsgeometryutils.sip.in and test cases. SegmentLength argument is optional with default as 0

### Suggestion of a different perpendicularSegment geometry method

During my python scripting I was missing a function that I had to create
for myself in python which I needed in order to split a polyline using
QgsGeometry.splitGeometry().

The function I want to contribute will creates a perpendicular segment to
a given segment with it's center at a given point (the already available
function QgsGeometryUtils.perpendicularSegment doesn't fullfill that need)

This PR is **probably** a replacement and follow-up of https://github.com/qgis/QGIS/pull/39559 where I accidentally seem to seriously have damaged the branch (geom_utils_enhancements) when trying to sync the git repos. Meanwhile I created the  follow-up PR https://github.com/qgis/QGIS/pull/46694 on branch geom_utils_enhancements. If https://github.com/qgis/QGIS/pull/46694 works I will cancel this PR.