### PR TITLE
Avoid deadlock in QGIS server

### DIFF
--- a/src/server/services/wms/qgsmaprendererjobproxy.cpp
+++ b/src/server/services/wms/qgsmaprendererjobproxy.cpp
@@ -56,17 +56,20 @@ namespace QgsWms
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
       renderJob.setFeatureFilterProvider( mFeatureFilterProvider );
 #endif
-      renderJob.start();
 
       // Allows the main thread to manage blocking call coming from rendering
       // threads (see discussion in https://github.com/qgis/QGIS/issues/26819).
       QEventLoop loop;
       QObject::connect( &renderJob, &QgsMapRendererParallelJob::finished, &loop, &QEventLoop::quit );
-      loop.exec();
+      renderJob.start();
+      if ( renderJob.isActive() )
+      {
+        loop.exec();
 
-      renderJob.waitForFinished();
-      *image = renderJob.renderedImage();
-      mPainter.reset( new QPainter( image ) );
+        renderJob.waitForFinished();
+        *image = renderJob.renderedImage();
+        mPainter.reset( new QPainter( image ) );
+      }
 
       mErrors = renderJob.errors();
     }


### PR DESCRIPTION
In case of invalid map settings, `renderJob.start()` returns immediately and the `finished()` signal is emitted before the connection happens. This puts the server into an eternal loop.

https://github.com/qgis/QGIS/blob/32b19471a1bed9df095df9ae7c6eef4474136e0d/src/core/maprenderer/qgsmaprendererjob.cpp#L139-L148