### PR TITLE
make Group Selected work when only one layer is selected (fix #26211)

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -131,7 +131,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addSeparator();
 
-      if ( mView->selectedNodes( true ).count() >= 1 )
+      if ( !mView->selectedNodes( true ).empty() )
         menu->addAction( actions->actionGroupSelected( menu ) );
 
       if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -131,7 +131,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addSeparator();
 
-      if ( mView->selectedNodes( true ).count() >= 2 )
+      if ( mView->selectedNodes( true ).count() >= 1 )
         menu->addAction( actions->actionGroupSelected( menu ) );
 
       if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -240,7 +240,7 @@ void QgsLayerTreeViewDefaultActions::checkAndAllParents()
 
 void QgsLayerTreeViewDefaultActions::addGroup()
 {
-  if ( mView->selectedNodes( true ).count() >= 2 )
+  if ( mView->selectedNodes( true ).count() >= 1 )
   {
     groupSelected();
     return;
@@ -511,7 +511,7 @@ void QgsLayerTreeViewDefaultActions::moveToBottom()
 void QgsLayerTreeViewDefaultActions::groupSelected()
 {
   const QList<QgsLayerTreeNode *> nodes = mView->selectedNodes( true );
-  if ( nodes.count() < 2 || ! QgsLayerTree::isGroup( nodes[0]->parent() ) )
+  if ( nodes.count() < 1 || ! QgsLayerTree::isGroup( nodes[0]->parent() ) )
     return;
 
   QgsLayerTreeGroup *parentGroup = QgsLayerTree::toGroup( nodes[0]->parent() );

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -240,7 +240,7 @@ void QgsLayerTreeViewDefaultActions::checkAndAllParents()
 
 void QgsLayerTreeViewDefaultActions::addGroup()
 {
-  if ( mView->selectedNodes( true ).count() >= 1 )
+  if ( !mView->selectedNodes( true ).empty() )
   {
     groupSelected();
     return;
@@ -511,7 +511,7 @@ void QgsLayerTreeViewDefaultActions::moveToBottom()
 void QgsLayerTreeViewDefaultActions::groupSelected()
 {
   const QList<QgsLayerTreeNode *> nodes = mView->selectedNodes( true );
-  if ( nodes.count() < 1 || ! QgsLayerTree::isGroup( nodes[0]->parent() ) )
+  if ( nodes.empty() || ! QgsLayerTree::isGroup( nodes[0]->parent() ) )
     return;
 
   QgsLayerTreeGroup *parentGroup = QgsLayerTree::toGroup( nodes[0]->parent() );


### PR DESCRIPTION
## Description
Make it possible to group selected layers even if only single layer is selected. This is useful in case if one wants to create a group and add more layers to it later. Fixes #26211.