### PR TITLE
Mesh calculator UX fixes

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -372,6 +372,10 @@ void QgsMeshCalculatorDialog::onOutputFormatChange()
     filter.append( QStringLiteral( " (*.%1)" ).arg( suffix ) );
     mOutputDatasetFileWidget->setFilter( filter );
   }
+  else
+  {
+    mOutputDatasetFileWidget->setFilter( tr( "All Files (*)" ) );
+  }
 }
 
 QString QgsMeshCalculatorDialog::datasetGroupName( const QModelIndex &index ) const

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -371,6 +371,13 @@ void QgsMeshCalculatorDialog::onOutputFormatChange()
     QString filter = mOutputFormatComboBox->currentText();
     filter.append( QStringLiteral( " (*.%1)" ).arg( suffix ) );
     mOutputDatasetFileWidget->setFilter( filter );
+
+    // if output filename is already defined we need to replace old suffix
+    QString fileName = mOutputDatasetFileWidget->filePath();
+    if ( !fileName.isEmpty() )
+    {
+      mOutputDatasetFileWidget->setFilePath( controlSuffix( fileName ) );
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
Couple of UX fixes for mesh calculator:

- fallback to "All Files" filter when selected output format does not provide specific filter (#45257)
- update output file extension when output format is changed after selecting destination path (#41943)