### PR TITLE
addresses #46673 (QgsProcessingMapLayerComboBox shows layers out of

### DIFF
--- a/python/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayermodel.sip.in
@@ -56,6 +56,13 @@ populate the model.
 setItemsCheckable defines if layers should be selectable in the widget
 %End
 
+    void setProject( QgsProject *project );
+%Docstring
+Sets tje :py:class:`QgsProject` from which map layers are shown
+
+.. versionadded:: 3.24
+%End
+
     void setItemsCanBeReordered( bool allow );
 %Docstring
 Sets whether items in the model can be reordered via drag and drop.

--- a/python/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayermodel.sip.in
@@ -58,7 +58,7 @@ setItemsCheckable defines if layers should be selectable in the widget
 
     void setProject( QgsProject *project );
 %Docstring
-Sets tje :py:class:`QgsProject` from which map layers are shown
+Sets the :py:class:`QgsProject` from which map layers are shown
 
 .. versionadded:: 3.24
 %End

--- a/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -73,7 +73,9 @@ Returns the filter flags which affect how layers are filtered within the model.
 
     void setProject( QgsProject *project );
 %Docstring
-Sets the :py:class:`QgsProject` from which map layers are shown
+Sets the ``project`` from which map layers are shown.
+
+If ``project`` is ``None`` then :py:func:`QgsProject.instance()` will be used.
 
 .. versionadded:: 3.24
 %End

--- a/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -71,6 +71,13 @@ Returns the filter flags which affect how layers are filtered within the model.
 .. versionadded:: 2.3
 %End
 
+    void setProject( QgsProject *project );
+%Docstring
+Sets the :py:class:`QgsProject` from which map layers are shown
+
+.. versionadded:: 3.24
+%End
+
     static bool layerMatchesFilters( const QgsMapLayer *layer, const Filters &filters );
 %Docstring
 Returns if the ``layer`` matches the given ``filters``

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -72,7 +72,7 @@ Returns the list of data providers which are excluded from the combobox.
 %Docstring
 Sets the ``project`` from which map layers are shown.
 
-If ``project`` is ``None`` then :py:func:`QgsProject.instance()` will be used.     
+If ``project`` is ``None`` then :py:func:`QgsProject.instance()` will be used.
 
 .. versionadded:: 3.24
 %End

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -70,7 +70,9 @@ Returns the list of data providers which are excluded from the combobox.
 
     void setProject( QgsProject *project );
 %Docstring
-Sets the :py:class:`QgsProject` from which map layers are shown
+Sets the ``project`` from which map layers are shown.
+
+If ``project`` is ``None`` then :py:func:`QgsProject.instance()` will be used.     
 
 .. versionadded:: 3.24
 %End

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -68,6 +68,14 @@ Returns the list of data providers which are excluded from the combobox.
 .. versionadded:: 3.0
 %End
 
+    void setProject( QgsProject *project );
+%Docstring
+Sets the :py:class:`QgsProject` from which map layers are shown
+
+.. versionadded:: 3.24
+%End
+
+
     void setAllowEmptyLayer( bool allowEmpty, const QString &text = QString(), const QIcon &icon = QIcon() );
 %Docstring
 Sets whether an optional empty layer ("not set") option is shown in the combo box.

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -40,6 +40,25 @@ QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
   addLayers( mProject->mapLayers().values() );
 }
 
+void QgsMapLayerModel::setProject( QgsProject *project )
+{
+
+  // remove layers from previous project
+  if ( mProject )
+  {
+    removeLayers( mProject->mapLayers().keys() );
+    disconnect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
+    disconnect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  }
+
+  mProject = project;
+
+  connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
+  connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  addLayers( mProject->mapLayers().values() );
+}
+
+
 void QgsMapLayerModel::setItemsCheckable( bool checkable )
 {
   mItemCheckable = checkable;

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -51,7 +51,7 @@ void QgsMapLayerModel::setProject( QgsProject *project )
     disconnect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
   }
 
-  mProject = project;
+  mProject = project ? project : QgsProject::instance();
 
   connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
   connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
     void setItemsCheckable( bool checkable );
 
     /**
-     * Sets tje QgsProject from which map layers are shown
+     * Sets the QgsProject from which map layers are shown
      *
      * \since QGIS 3.24
      */

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -77,6 +77,13 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
     void setItemsCheckable( bool checkable );
 
     /**
+     * Sets tje QgsProject from which map layers are shown
+     *
+     * \since QGIS 3.24
+     */
+    void setProject( QgsProject *project );
+
+    /**
      * Sets whether items in the model can be reordered via drag and drop.
      *
      * \see itemsCanBeReordered()

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -107,6 +107,11 @@ void QgsMapLayerProxyModel::setExceptedLayerList( const QList<QgsMapLayer *> &ex
   invalidateFilter();
 }
 
+void  QgsMapLayerProxyModel::setProject( QgsProject *project )
+{
+  mModel->setProject( project );
+}
+
 void QgsMapLayerProxyModel::setExceptedLayerIds( const QStringList &ids )
 {
   mExceptList.clear();

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -24,6 +24,7 @@
 
 class QgsMapLayerModel;
 class QgsMapLayer;
+class QgsProject;
 
 /**
  * \ingroup core
@@ -87,6 +88,13 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
      * \since QGIS 2.3
      */
     const Filters &filters() const { return mFilters; }
+
+    /**
+     * Sets the QgsProject from which map layers are shown
+     *
+     * \since QGIS 3.24
+     */
+    void setProject( QgsProject *project );
 
     /**
      * Returns if the \a layer matches the given \a filters

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -90,7 +90,9 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
     const Filters &filters() const { return mFilters; }
 
     /**
-     * Sets the QgsProject from which map layers are shown
+     * Sets the \a project from which map layers are shown.
+     *
+     * If \a project is NULLPTR then QgsProject::instance() will be used.
      *
      * \since QGIS 3.24
      */

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -373,6 +373,7 @@ QVariant QgsProcessingMapLayerComboBox::value() const
 void QgsProcessingMapLayerComboBox::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
 {
   mBrowserModel = context.browserModel();
+  mCombo->setProject( context.project() );
 }
 
 void QgsProcessingMapLayerComboBox::setEditable( bool editable )

--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -39,6 +39,12 @@ void QgsMapLayerComboBox::setExcludedProviders( const QStringList &providers )
   mProxyModel->setExcludedProviders( providers );
 }
 
+void  QgsMapLayerComboBox::setProject( QgsProject *project )
+{
+  mProxyModel->setProject( project );
+}
+
+
 QStringList QgsMapLayerComboBox::excludedProviders() const
 {
   return mProxyModel->excludedProviders();

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -74,6 +74,14 @@ class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
     QStringList excludedProviders() const;
 
     /**
+     * Sets the QgsProject from which map layers are shown
+     *
+     * \since QGIS 3.24
+     */
+    void setProject( QgsProject *project );
+
+
+    /**
      * Sets whether an optional empty layer ("not set") option is shown in the combo box.
      *
      * Since QGIS 3.20, the optional \a text and \a icon arguments allows the text and icon for the empty layer item to be set.

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -74,7 +74,9 @@ class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
     QStringList excludedProviders() const;
 
     /**
-     * Sets the QgsProject from which map layers are shown
+     * Sets the \a project from which map layers are shown.
+     *
+     * If \a project is NULLPTR then QgsProject::instance() will be used.     
      *
      * \since QGIS 3.24
      */

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
     /**
      * Sets the \a project from which map layers are shown.
      *
-     * If \a project is NULLPTR then QgsProject::instance() will be used.     
+     * If \a project is NULLPTR then QgsProject::instance() will be used.
      *
      * \since QGIS 3.24
      */

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -268,10 +268,14 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
         QgsProject.instance().clear()
         lA = create_layer('lA')
         lB = create_layer('lB')
-        QgsProject.instance().addMapLayer(lA)
+
+        projectA = QgsProject.instance()
         projectB = QgsProject()
+
+        projectA.addMapLayer(lA)
         projectB.addMapLayer(lB)
         cb = QgsMapLayerComboBox()
+
         self.assertEqual(cb.currentLayer(), lA)
 
         m.setProject(projectB)
@@ -280,6 +284,7 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
         m.setProject(projectA)
         self.assertEqual(cb.currentLayer(), lA)
 
+        QgsProject.instance().clear()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -278,10 +278,10 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
 
         self.assertEqual(cb.currentLayer(), lA)
 
-        m.setProject(projectB)
+        cb.setProject(projectB)
         self.assertEqual(cb.currentLayer(), lB)
 
-        m.setProject(projectA)
+        cb.setProject(projectA)
         self.assertEqual(cb.currentLayer(), lA)
 
         QgsProject.instance().clear()

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -286,5 +286,6 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
 
         QgsProject.instance().clear()
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsmaplayercombobox.py
+++ b/tests/src/python/test_qgsmaplayercombobox.py
@@ -264,6 +264,22 @@ class TestQgsMapLayerComboBox(unittest.TestCase):
         self.assertEqual(m.itemText(3), 'a')
         self.assertEqual(m.itemText(4), 'b')
 
+    def testProject(self):
+        QgsProject.instance().clear()
+        lA = create_layer('lA')
+        lB = create_layer('lB')
+        QgsProject.instance().addMapLayer(lA)
+        projectB = QgsProject()
+        projectB.addMapLayer(lB)
+        cb = QgsMapLayerComboBox()
+        self.assertEqual(cb.currentLayer(), lA)
+
+        m.setProject(projectB)
+        self.assertEqual(cb.currentLayer(), lB)
+
+        m.setProject(projectA)
+        self.assertEqual(cb.currentLayer(), lA)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsmaplayermodel.py
+++ b/tests/src/python/test_qgsmaplayermodel.py
@@ -258,6 +258,26 @@ class TestQgsMapLayerModel(unittest.TestCase):
 
         QgsProject.instance().removeMapLayers([l1.id(), l2.id()])
 
+    def testProject(self):
+        lA = create_layer('lA')
+        lB = create_layer('lB')
+        projectA = QgsProject.instance()
+        projectB = QgsProject()
+
+        projectA.addMapLayer(lA)
+        projectB.addMapLayer(lB)
+
+        m = QgsMapLayerModel()
+        self.assertEqual(m.data(m.index(0, 0), Qt.DisplayRole), lA.name())
+
+        m.setProject(projectB)
+        self.assertEqual(m.data(m.index(0, 0), Qt.DisplayRole), lB.name())
+
+        m.setProject(projectA)
+        self.assertEqual(m.data(m.index(0, 0), Qt.DisplayRole), lA.name())
+
+        QgsProject.instance().removeAllMapLayers()
+
     def testDisplayRole(self):
         l1 = create_layer('l1')
         l2 = create_layer('l2')


### PR DESCRIPTION
## Description

This PR fixes #46673 (QgsProcessingMapLayerComboBox shows layers out of QgsProcessingParameterWidgetContext),
which caused that QgsProcessingMapLayerComboBox disregards the QgsProject of the QgsProcessingParameterWidgetContext.

## Changes

A new `setProject(QgsProject *project)` has been implemented in `QgsMapLayerModel`, `QgsMapLayerProxyModel` and `QgsMapLayerComboBox`: 

    src/core/qgsmaplayermodel.cpp
    src/core/qgsmaplayermodel.h
    src/core/qgsmaplayerproxymodel.cpp
    src/core/qgsmaplayerproxymodel.h

Accordingly, new `testProject(self)` tests were added to:

    tests/src/python/test_qgsmaplayercombobox.py 
    tests/src/python/test_qgsmaplayermodel.py 

This way, `QgsProcessingMapLayerComboBox` now can update the QgsProject of it's map layer combo box:

````cpp
void QgsProcessingMapLayerComboBox::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
{
  mBrowserModel = context.browserModel();
  mCombo->setProject( context.project() );
}
````

SIP files were updated by scripts/sipify_all.sh:
   
    python/core/auto_generated/qgsmaplayermodel.sip.in
    python/core/auto_generated/qgsmaplayerproxymodel.sip.in
    python/gui/auto_generated/qgsmaplayercombobox.sip.in

