### PR TITLE
allow negative values for buffer distance in GDAL buffer algorithm (fix #46667)

### DIFF
--- a/python/plugins/processing/algs/gdal/Buffer.py
+++ b/python/plugins/processing/algs/gdal/Buffer.py
@@ -57,7 +57,6 @@ class Buffer(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterDistance(self.DISTANCE,
                                                          self.tr('Buffer distance'),
                                                          parentParameterName=self.INPUT,
-                                                         minValue=0.0,
                                                          defaultValue=10.0))
         self.addParameter(QgsProcessingParameterField(self.FIELD,
                                                       self.tr('Dissolve by attribute'),

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -180,6 +180,16 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
+                                        'DISTANCE': -5,
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['ogr2ogr',
+                 outdir + '/check.shp ' +
+                 source + ' ' +
+                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, -5.0) AS geometry,* FROM """polys2"""" ' +
+                 '-f "ESRI Shapefile"'])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
                                         'DISTANCE': 5,
                                         'DISSOLVE': True,
                                         'OUTPUT': outdir + '/check.shp'}, context, feedback),


### PR DESCRIPTION
## Description

Allow negative buffer distance in the GDAL Buffer Vectors algorithm. Fixes #46667.