### PR TITLE
use enum parameter for "type" metadata in the Write vector tiles (MBTiles) algorithm (fix #46685)

### DIFF
--- a/src/analysis/processing/qgsalgorithmwritevectortiles.cpp
+++ b/src/analysis/processing/qgsalgorithmwritevectortiles.cpp
@@ -157,7 +157,14 @@ void QgsWriteVectorTilesMbtilesAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterString( QStringLiteral( "META_DESCRIPTION" ), QObject::tr( "Metadata: Description" ), QVariant(), false, true ) );
   addParameter( new QgsProcessingParameterString( QStringLiteral( "META_ATTRIBUTION" ), QObject::tr( "Metadata: Attribution" ), QVariant(), false, true ) );
   addParameter( new QgsProcessingParameterString( QStringLiteral( "META_VERSION" ), QObject::tr( "Metadata: Version" ), QVariant(), false, true ) );
-  addParameter( new QgsProcessingParameterString( QStringLiteral( "META_TYPE" ), QObject::tr( "Metadata: Type" ), QVariant(), false, true ) );
+  std::unique_ptr< QgsProcessingParameterString > metaTypeParam = std::make_unique< QgsProcessingParameterString >( QStringLiteral( "META_TYPE" ), QObject::tr( "Metadata: Type" ), QVariant(), false, true );
+  metaTypeParam->setMetadata( {{
+      QStringLiteral( "widget_wrapper" ), QVariantMap(
+      {{QStringLiteral( "value_hints" ), QStringList() << QStringLiteral( "overlay" ) << QStringLiteral( "baselayer" ) }}
+      )
+    }
+  } );
+  addParameter( metaTypeParam.release() );
   addParameter( new QgsProcessingParameterString( QStringLiteral( "META_CENTER" ), QObject::tr( "Metadata: Center" ), QVariant(), false, true ) );
 }
 


### PR DESCRIPTION
## Description

According to the MBTiles [specs](https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#content) "type" metadata can only accept values "overlay" and "baselayer", so instead of string parameter better to use enum. To maintain backward compatibility new enum parameter was added and existing parameter was hidden, so existing workflows continue to work.

Fixes #46685.