### PR TITLE
Brand new extent widget's calculate extent from layout map and bookmark functionality

### DIFF
--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -83,12 +83,8 @@ QgsExtentWidget::QgsExtentWidget( QWidget *parent, WidgetStyle style )
   mMenu->addAction( mDrawOnCanvasAction );
   mMenu->addAction( mUseCurrentExtentAction );
 
-  mCondensedToolButton->setToolTip( tr( "Set to current map canvas extent" ) );
-  mCondensedToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapIdentification.svg" ) ) );
-  connect( mCondensedToolButton, &QAbstractButton::clicked, this, &QgsExtentWidget::setOutputExtentFromCurrent );
-
   mCondensedToolButton->setMenu( mMenu );
-  mCondensedToolButton->setPopupMode( QToolButton::MenuButtonPopup );
+  mCondensedToolButton->setPopupMode( QToolButton::InstantPopup );
 
   mXMinLineEdit->setValidator( new QgsDoubleValidator( this ) );
   mXMaxLineEdit->setValidator( new QgsDoubleValidator( this ) );
@@ -539,6 +535,11 @@ void QgsExtentWidget::setMapCanvas( QgsMapCanvas *canvas, bool drawOnCanvasOptio
     mUseCanvasExtentAction->setVisible( true );
     if ( drawOnCanvasOption )
       mDrawOnCanvasAction->setVisible( true );
+
+    mCondensedToolButton->setToolTip( tr( "Set to current map canvas extent" ) );
+    mCondensedToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapIdentification.svg" ) ) );
+    connect( mCondensedToolButton, &QAbstractButton::clicked, this, &QgsExtentWidget::setOutputExtentFromCurrent );
+    mCondensedToolButton->setPopupMode( QToolButton::MenuButtonPopup );
   }
   else
   {
@@ -546,6 +547,11 @@ void QgsExtentWidget::setMapCanvas( QgsMapCanvas *canvas, bool drawOnCanvasOptio
     mCurrentExtentButton->setVisible( false );
     mUseCanvasExtentAction->setVisible( false );
     mUseCanvasExtentAction->setVisible( false );
+
+    mCondensedToolButton->setToolTip( QString() );
+    mCondensedToolButton->setIcon( QIcon() );
+    disconnect( mCondensedToolButton, &QAbstractButton::clicked, this, &QgsExtentWidget::setOutputExtentFromCurrent );
+    mCondensedToolButton->setPopupMode( QToolButton::InstantPopup );
   }
 }
 

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsextentwidget.h"
 
+#include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgscoordinatetransform.h"
 #include "qgsmapcanvas.h"
@@ -59,8 +60,12 @@ QgsExtentWidget::QgsExtentWidget( QWidget *parent, WidgetStyle style )
 
   mMenu->addMenu( mLayerMenu );
 
+  mCondensedToolButton->setToolTip( tr( "Set to current map canvas extent" ) );
+  mCondensedToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapIdentification.svg" ) ) );
+  connect( mCondensedToolButton, &QAbstractButton::clicked, this, &QgsExtentWidget::setOutputExtentFromCurrent );
+
   mCondensedToolButton->setMenu( mMenu );
-  mCondensedToolButton->setPopupMode( QToolButton::InstantPopup );
+  mCondensedToolButton->setPopupMode( QToolButton::MenuButtonPopup );
 
   mXMinLineEdit->setValidator( new QgsDoubleValidator( this ) );
   mXMaxLineEdit->setValidator( new QgsDoubleValidator( this ) );

--- a/src/gui/qgsextentwidget.h
+++ b/src/gui/qgsextentwidget.h
@@ -244,6 +244,7 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
   private slots:
 
     void layerMenuAboutToShow();
+    void layoutMenuAboutToShow();
 
     void extentDrawn( const QgsRectangle &extent );
     void mapToolDeactivated();
@@ -265,6 +266,7 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
 
     QMenu *mMenu = nullptr;
     QMenu *mLayerMenu = nullptr;
+    QMenu *mLayoutMenu = nullptr;
     QgsMapLayerModel *mMapLayerModel = nullptr;
     QList< QAction * > mLayerMenuActions;
     QAction *mUseCanvasExtentAction = nullptr;

--- a/src/gui/qgsextentwidget.h
+++ b/src/gui/qgsextentwidget.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <QRegularExpression>
 
+class QgsBookmarkManagerProxyModel;
 class QgsCoordinateReferenceSystem;
 class QgsMapLayerModel;
 class QgsMapLayer;
@@ -245,6 +246,7 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
 
     void layerMenuAboutToShow();
     void layoutMenuAboutToShow();
+    void bookmarkMenuAboutToShow();
 
     void extentDrawn( const QgsRectangle &extent );
     void mapToolDeactivated();
@@ -265,9 +267,14 @@ class GUI_EXPORT QgsExtentWidget : public QWidget, private Ui::QgsExtentGroupBox
     QgsCoordinateReferenceSystem mOriginalCrs;
 
     QMenu *mMenu = nullptr;
+
     QMenu *mLayerMenu = nullptr;
     QMenu *mLayoutMenu = nullptr;
+    QMenu *mBookmarkMenu = nullptr;
+
     QgsMapLayerModel *mMapLayerModel = nullptr;
+    QgsBookmarkManagerProxyModel *mBookmarkModel = nullptr;
+
     QList< QAction * > mLayerMenuActions;
     QAction *mUseCanvasExtentAction = nullptr;
     QAction *mUseCurrentExtentAction = nullptr;

--- a/src/gui/qgsscalewidget.cpp
+++ b/src/gui/qgsscalewidget.cpp
@@ -102,7 +102,7 @@ void QgsScaleWidget::menuAboutToShow()
 
   double scale = mCanvas->scale();
   QAction *canvasScaleAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapIdentification.svg" ) ),
-      tr( "Current Canvas Scale (1:%1)" ).arg( qgsDoubleToString( scale, 0 ) ), mMenu );
+      tr( "Use Current Map Canvas Scale (1:%1)" ).arg( qgsDoubleToString( scale, 0 ) ), mMenu );
   connect( canvasScaleAction, &QAction::triggered, this, [this, scale] { setScale( scale ); } );
   mMenu->addAction( canvasScaleAction );
 

--- a/src/ui/qgsextentgroupboxwidget.ui
+++ b/src/ui/qgsextentgroupboxwidget.ui
@@ -179,6 +179,23 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="mButtonCalcFromBookmark">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Bookmark</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="1" colspan="7">
+          <layout class="QHBoxLayout" name="horizontalLayout2">
+           <item>
             <widget class="QPushButton" name="mOriginalExtentButton">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">

--- a/src/ui/qgsextentgroupboxwidget.ui
+++ b/src/ui/qgsextentgroupboxwidget.ui
@@ -114,60 +114,8 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="2" column="11">
-          <widget class="QPushButton" name="mButtonDrawOnCanvas">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Draw on Canvas</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="0">
-          <widget class="QPushButton" name="mOriginalExtentButton">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Current Layer Extent</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="6">
-          <widget class="QPushButton" name="mCurrentExtentButton">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Map Canvas Extent</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
           <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="2" column="5">
-          <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -192,18 +140,84 @@
            </property>
           </spacer>
          </item>
-         <item row="2" column="3">
-          <widget class="QPushButton" name="mButtonCalcFromLayer">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Calculate from Layer</string>
-           </property>
-          </widget>
+         <item row="2" column="1" colspan="7">
+          <layout class="QHBoxLayout" name="horizontalLayout1">
+           <item>
+            <widget class="QLabel" name="calculateLabel">
+             <property name="text">
+              <string>Calculate from</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mButtonCalcFromLayer">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Layer</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mButtonCalcFromLayout">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Layout Map</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mOriginalExtentButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Current Layer Extent</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mCurrentExtentButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Map Canvas Extent</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="mButtonDrawOnCanvas">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Draw on Canvas</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
## Description

This PR adds two new functionalities to the extent widget: 
- a calculate [extent] from layout map feature; and
- a calculate [extent] from bookmark feature.

The features are available both in the compact and full mode for the widget.

Photo time:
![image](https://user-images.githubusercontent.com/1728657/148355444-80f9bef2-a619-49fb-bd30-7c067e534f9d.png)

![image](https://user-images.githubusercontent.com/1728657/148355485-7dd017bf-f7c0-406c-8020-bb1163843ad1.png)

In addition, for the compact mode, the menu tool button was updated to allow for a rapid single click on button action to set the extent widget to map canvas. This looks quite good in processing algorithm dialogs standing alongside a scale parameter widget:
![image](https://user-images.githubusercontent.com/1728657/148355664-a596048b-bd7c-4b72-b003-166ad6b3aa82.png)


