### PR TITLE
Show algorithm help if available

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -304,6 +304,7 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
         "dl dd { margin - bottom: 5px; }" ) );
     textShortHelp->setHtml( algHelp );
     connect( textShortHelp, &QTextBrowser::anchorClicked, this, &QgsProcessingAlgorithmDialogBase::linkClicked );
+    textShortHelp->show();
   }
 
   if ( algorithm->helpUrl().isEmpty() && algorithm->provider()->helpId().isEmpty() )


### PR DESCRIPTION

## Description

This PR fixes #46697

If the new algorithm provides a help string, QgsProcessingAlgorithmDialogBase::setAlgorithm() will re-show a previously hidden algorithm help.

[Replace this with some text explaining the rationale and details about this pull request]
