### PR TITLE
New HMAC SHA256 auth method for MapTiler 

### DIFF
--- a/debian/qgis-providers.install
+++ b/debian/qgis-providers.install
@@ -6,6 +6,7 @@ usr/lib/qgis/plugins/libauthmethod_identcert.so
 usr/lib/qgis/plugins/libauthmethod_pkcs12.so
 usr/lib/qgis/plugins/libauthmethod_pkipaths.so
 usr/lib/qgis/plugins/libauthmethod_apiheader.so
+usr/lib/qgis/plugins/libauthmethod_maptilerhmacsha256.so
 usr/lib/qgis/plugins/libprovider_arcgisfeatureserver.so
 usr/lib/qgis/plugins/libprovider_arcgismapserver.so
 usr/lib/qgis/plugins/libprovider_db2.so

--- a/ms-windows/osgeo4w/package.cmd
+++ b/ms-windows/osgeo4w/package.cmd
@@ -313,6 +313,7 @@ for %%i in (%packages%) do (
   "apps/%PACKAGENAME%/plugins/provider_mdal.dll" ^
   "apps/%PACKAGENAME%/plugins/provider_hana.dll" ^
   "apps/%PACKAGENAME%/plugins/authmethod_oauth2.dll" ^
+  "apps/%PACKAGENAME%/plugins/authmethod_maptilerhmacsha256.dll" ^
 	"apps/%PACKAGENAME%/resources/qgis.db" ^
 	"apps/%PACKAGENAME%/resources/spatialite.db" ^
 	"apps/%PACKAGENAME%/resources/srs.db" ^

--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(identcert)
 add_subdirectory(pkipaths)
 add_subdirectory(pkipkcs12)
 add_subdirectory(apiheader)
+add_subdirectory(maptiler_hmacsha256)
 
 if (WITH_OAUTH2_PLUGIN)
   add_subdirectory(oauth2)

--- a/src/auth/esritoken/core/qgsauthesritokenmethod.cpp
+++ b/src/auth/esritoken/core/qgsauthesritokenmethod.cpp
@@ -64,14 +64,14 @@ bool QgsAuthEsriTokenMethod::updateNetworkRequest( QNetworkRequest &request, con
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  const QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
-  if ( !mconfig.isValid() )
+  const QgsAuthMethodConfig config = getMethodConfig( authcfg );
+  if ( !config.isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
     return false;
   }
 
-  const QString token = mconfig.config( QStringLiteral( "token" ) );
+  const QString token = config.config( QStringLiteral( "token" ) );
 
   if ( !token.isEmpty() )
   {
@@ -89,7 +89,7 @@ void QgsAuthEsriTokenMethod::updateMethodConfig( QgsAuthMethodConfig &mconfig )
 {
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
-    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Updating old style auth method config" ), 2 );
   }
 
   // NOTE: add updates as method version() increases due to config storage changes
@@ -124,7 +124,7 @@ QgsAuthMethodConfig QgsAuthEsriTokenMethod::getMethodConfig( const QString &auth
 void QgsAuthEsriTokenMethod::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
 {
   const QMutexLocker locker( &mMutex );
-  QgsDebugMsg( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ) );
+  QgsDebugMsgLevel( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ), 2 );
   sAuthConfigCache.insert( authcfg, mconfig );
 }
 
@@ -134,7 +134,7 @@ void QgsAuthEsriTokenMethod::removeMethodConfig( const QString &authcfg )
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );
-    QgsDebugMsg( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
 

--- a/src/auth/maptiler_hmacsha256/CMakeLists.txt
+++ b/src/auth/maptiler_hmacsha256/CMakeLists.txt
@@ -1,0 +1,74 @@
+set(AUTH_MAPTILER_HMACSHA256_SRCS
+  core/qgsauthmaptilerhmacsha256method.cpp
+)
+
+set(AUTH_MAPTILER_HMACSHA256_HDRS
+  core/qgsauthmaptilerhmacsha256method.h
+)
+
+set(AUTH_MAPTILER_HMACSHA256_UIS_H "")
+
+if (WITH_GUI)
+  set(AUTH_MAPTILER_HMACSHA256_SRCS ${AUTH_MAPTILER_HMACSHA256_SRCS}
+    gui/qgsauthmaptilerhmacsha256edit.cpp
+  )
+  set(AUTH_MAPTILER_HMACSHA256_HDRS ${AUTH_MAPTILER_HMACSHA256_HDRS}
+    gui/qgsauthmaptilerhmacsha256edit.h
+  )
+  set(AUTH_MAPTILER_HMACSHA256_UIS gui/qgsauthmaptilerhmacsha256edit.ui)
+  if (WITH_QT6)
+    QT6_WRAP_UI(AUTH_MAPTILER_HMACSHA256_UIS_H ${AUTH_MAPTILER_HMACSHA256_UIS})
+  else()
+    QT5_WRAP_UI(AUTH_MAPTILER_HMACSHA256_UIS_H ${AUTH_MAPTILER_HMACSHA256_UIS})
+  endif()
+endif()
+
+
+# static library
+add_library(authmethod_maptilerhmacsha256_a STATIC ${AUTH_MAPTILER_HMACSHA256_SRCS} ${AUTH_MAPTILER_HMACSHA256_HDRS} ${AUTH_MAPTILER_HMACSHA256_UIS_H})
+
+target_include_directories(authmethod_maptilerhmacsha256_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/hmacsha256/core)
+
+# require c++17
+target_compile_features(authmethod_maptilerhmacsha256_a PRIVATE cxx_std_17)
+
+target_link_libraries(authmethod_maptilerhmacsha256_a qgis_core)
+
+if (WITH_GUI)
+  target_include_directories(authmethod_maptilerhmacsha256_a PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/auth/maptiler_hmacsha256/gui
+    ${CMAKE_BINARY_DIR}/src/auth/maptiler_hmacsha256
+  )
+  target_link_libraries (authmethod_maptilerhmacsha256_a qgis_gui)
+endif()
+
+target_compile_definitions(authmethod_maptilerhmacsha256_a PRIVATE "-DQT_NO_FOREACH")
+
+if (FORCE_STATIC_LIBS)
+  # for (external) mobile apps to be able to pick up provider for linking
+  install (TARGETS authmethod_maptilerhmacsha256_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+else()
+  # dynamically loaded module
+  add_library(authmethod_maptilerhmacsha256 MODULE ${AUTH_MAPTILER_HMACSHA256_SRCS} ${AUTH_MAPTILER_HMACSHA256_HDRS} ${AUTH_MAPTILER_HMACSHA256_UIS_H})
+
+  # require c++17
+  target_compile_features(authmethod_maptilerhmacsha256 PRIVATE cxx_std_17)
+
+  target_link_libraries(authmethod_maptilerhmacsha256 qgis_core)
+
+  if (WITH_GUI)
+    target_include_directories(authmethod_maptilerhmacsha256 PRIVATE
+      ${CMAKE_SOURCE_DIR}/src/auth/maptiler_hmacsha256/gui
+      ${CMAKE_BINARY_DIR}/src/auth/maptiler_hmacsha256
+    )
+    target_link_libraries (authmethod_maptilerhmacsha256 qgis_gui)
+    add_dependencies(authmethod_maptilerhmacsha256 ui)
+  endif()
+
+  target_compile_definitions(authmethod_maptilerhmacsha256 PRIVATE "-DQT_NO_FOREACH")
+
+  install (TARGETS authmethod_maptilerhmacsha256
+    RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
+    LIBRARY DESTINATION ${QGIS_PLUGIN_DIR}
+  )
+endif()

--- a/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
+++ b/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
@@ -64,14 +64,14 @@ bool QgsAuthMapTilerHmacSha256Method::updateNetworkRequest( QNetworkRequest &req
     const QString &dataprovider )
 {
   Q_UNUSED( dataprovider )
-  const QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
-  if ( !mconfig.isValid() )
+  const QgsAuthMethodConfig config = getMethodConfig( authcfg );
+  if ( !config.isValid() )
   {
     QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
     return false;
   }
 
-  const QString token = mconfig.config( QStringLiteral( "token" ) );
+  const QString token = config.config( QStringLiteral( "token" ) );
   const QStringList splitToken = token.split( '_' );
 
   if ( splitToken.count() != 2 )
@@ -109,7 +109,7 @@ void QgsAuthMapTilerHmacSha256Method::updateMethodConfig( QgsAuthMethodConfig &m
 {
   if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
   {
-    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Updating old style auth method config" ), 2 );
   }
 
   // NOTE: add updates as method version() increases due to config storage changes
@@ -118,33 +118,33 @@ void QgsAuthMapTilerHmacSha256Method::updateMethodConfig( QgsAuthMethodConfig &m
 QgsAuthMethodConfig QgsAuthMapTilerHmacSha256Method::getMethodConfig( const QString &authcfg, bool fullconfig )
 {
   const QMutexLocker locker( &mMutex );
-  QgsAuthMethodConfig mconfig;
+  QgsAuthMethodConfig config;
 
   // check if it is cached
   if ( sAuthConfigCache.contains( authcfg ) )
   {
-    mconfig = sAuthConfigCache.value( authcfg );
-    QgsDebugMsg( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ) );
-    return mconfig;
+    config = sAuthConfigCache.value( authcfg );
+    QgsDebugMsgLevel( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ), 2 );
+    return config;
   }
 
   // else build basic bundle
-  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, config, fullconfig ) )
   {
-    QgsDebugMsg( QStringLiteral( "Retrieve config FAILED for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ), 2 );
     return QgsAuthMethodConfig();
   }
 
   // cache bundle
-  putMethodConfig( authcfg, mconfig );
+  putMethodConfig( authcfg, config );
 
-  return mconfig;
+  return config;
 }
 
 void QgsAuthMapTilerHmacSha256Method::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
 {
   const QMutexLocker locker( &mMutex );
-  QgsDebugMsg( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ) );
+  QgsDebugMsgLevel( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ), 2 );
   sAuthConfigCache.insert( authcfg, mconfig );
 }
 
@@ -154,7 +154,7 @@ void QgsAuthMapTilerHmacSha256Method::removeMethodConfig( const QString &authcfg
   if ( sAuthConfigCache.contains( authcfg ) )
   {
     sAuthConfigCache.remove( authcfg );
-    QgsDebugMsg( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ) );
+    QgsDebugMsgLevel( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ), 2 );
   }
 }
 

--- a/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
+++ b/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
@@ -1,0 +1,188 @@
+/***************************************************************************
+    qgsauthmaptilerhmacsha256method.cpp
+    --------------------------
+    begin                : January 2022
+    copyright            : (C) 2022 by Vincent Cloarec
+    author               : Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsauthmaptilerhmacsha256method.h"
+
+#include <QMessageAuthenticationCode>
+#include <QUrlQuery>
+
+#include "qgsauthmanager.h"
+#include "qgslogger.h"
+#include "qgsapplication.h"
+
+#ifdef HAVE_GUI
+#include "qgsauthmaptilerhmacsha256edit.h"
+#endif
+
+
+const QString QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_KEY = QStringLiteral( "MapTilerHmacSha256" );
+const QString QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_DESCRIPTION = QStringLiteral( "MapTiler HMAC-SHA256" );
+const QString QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_DISPLAY_DESCRIPTION = tr( "MapTiler HMAC SHA256-Signature" );
+
+QMap<QString, QgsAuthMethodConfig> QgsAuthMapTilerHmacSha256Method::sAuthConfigCache = QMap<QString, QgsAuthMethodConfig>();
+
+
+QgsAuthMapTilerHmacSha256Method::QgsAuthMapTilerHmacSha256Method()
+{
+  setVersion( 1 );
+  setExpansions( QgsAuthMethod::NetworkRequest );
+  setDataProviders( QStringList()
+                    << QStringLiteral( "wms" )
+                    << QStringLiteral( "vectortile" ) );
+
+}
+
+QString QgsAuthMapTilerHmacSha256Method::key() const
+{
+  return AUTH_METHOD_KEY;
+}
+
+QString QgsAuthMapTilerHmacSha256Method::description() const
+{
+  return AUTH_METHOD_DESCRIPTION;
+}
+
+QString QgsAuthMapTilerHmacSha256Method::displayDescription() const
+{
+  return AUTH_METHOD_DISPLAY_DESCRIPTION;
+}
+
+bool QgsAuthMapTilerHmacSha256Method::updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
+    const QString &dataprovider )
+{
+  Q_UNUSED( dataprovider )
+  const QgsAuthMethodConfig mconfig = getMethodConfig( authcfg );
+  if ( !mconfig.isValid() )
+  {
+    QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
+    return false;
+  }
+
+  const QString token = mconfig.config( QStringLiteral( "token" ) );
+  const QStringList splitToken = token.split( '_' );
+
+  if ( splitToken.count() != 2 )
+  {
+    QgsDebugMsg( QStringLiteral( "Update request config FAILED for authcfg: %1: config invalid" ).arg( authcfg ) );
+    return false;
+  }
+
+  const QString key = splitToken.at( 0 );
+  const QString secret = splitToken.at( 1 );
+
+  QUrl url = request.url();
+  QUrlQuery query( url.query() );
+  query.removeQueryItem( QStringLiteral( "key" ) );
+
+  QList<QPair<QString, QString> > queryItems = query.queryItems();
+
+  queryItems.append( {QStringLiteral( "key" ), key} );
+
+  query.setQueryItems( queryItems );
+  url.setQuery( query );
+
+  QString signature = calculateSignature( secret, url.url() );
+  request.setUrl( QString( url.url() + QStringLiteral( "&signature=" ) + signature ) );
+
+  return true;
+}
+
+void QgsAuthMapTilerHmacSha256Method::clearCachedConfig( const QString &authcfg )
+{
+  removeMethodConfig( authcfg );
+}
+
+void QgsAuthMapTilerHmacSha256Method::updateMethodConfig( QgsAuthMethodConfig &mconfig )
+{
+  if ( mconfig.hasConfig( QStringLiteral( "oldconfigstyle" ) ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Updating old style auth method config" ) );
+  }
+
+  // NOTE: add updates as method version() increases due to config storage changes
+}
+
+QgsAuthMethodConfig QgsAuthMapTilerHmacSha256Method::getMethodConfig( const QString &authcfg, bool fullconfig )
+{
+  const QMutexLocker locker( &mMutex );
+  QgsAuthMethodConfig mconfig;
+
+  // check if it is cached
+  if ( sAuthConfigCache.contains( authcfg ) )
+  {
+    mconfig = sAuthConfigCache.value( authcfg );
+    QgsDebugMsg( QStringLiteral( "Retrieved config for authcfg: %1" ).arg( authcfg ) );
+    return mconfig;
+  }
+
+  // else build basic bundle
+  if ( !QgsApplication::authManager()->loadAuthenticationConfig( authcfg, mconfig, fullconfig ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Retrieve config FAILED for authcfg: %1" ).arg( authcfg ) );
+    return QgsAuthMethodConfig();
+  }
+
+  // cache bundle
+  putMethodConfig( authcfg, mconfig );
+
+  return mconfig;
+}
+
+void QgsAuthMapTilerHmacSha256Method::putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig )
+{
+  const QMutexLocker locker( &mMutex );
+  QgsDebugMsg( QStringLiteral( "Putting token config for authcfg: %1" ).arg( authcfg ) );
+  sAuthConfigCache.insert( authcfg, mconfig );
+}
+
+void QgsAuthMapTilerHmacSha256Method::removeMethodConfig( const QString &authcfg )
+{
+  const QMutexLocker locker( &mMutex );
+  if ( sAuthConfigCache.contains( authcfg ) )
+  {
+    sAuthConfigCache.remove( authcfg );
+    QgsDebugMsg( QStringLiteral( "Removed token config for authcfg: %1" ).arg( authcfg ) );
+  }
+}
+
+QByteArray QgsAuthMapTilerHmacSha256Method::calculateSignature( const QString &token, const QString &keyedUrl )
+{
+  QByteArray decodedToken = QByteArray::fromHex( token.toStdString().c_str() );
+
+  QMessageAuthenticationCode authCode( QCryptographicHash::Sha256, decodedToken );
+  authCode.addData( keyedUrl.toUtf8() );
+
+  return authCode.result().toBase64( QByteArray::Base64UrlEncoding );
+}
+
+#ifdef HAVE_GUI
+QWidget *QgsAuthMapTilerHmacSha256Method::editWidget( QWidget *parent ) const
+{
+  return new QgsAuthMapTilerHmacSha256Edit( parent );
+}
+#endif
+
+//////////////////////////////////////////////
+// Plugin externals
+//////////////////////////////////////////////
+
+
+#ifndef HAVE_STATIC_PROVIDERS
+QGISEXTERN QgsAuthMethodMetadata *authMethodMetadataFactory()
+{
+  return new QgsAuthMapTilerHmacSha256MethodMetadata();
+}
+#endif

--- a/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.h
+++ b/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.h
@@ -1,0 +1,80 @@
+/***************************************************************************
+    qgsauthmaptilerhmacsha256method.h
+    ---------------------
+    begin                : January 2022
+    copyright            : (C) 2022 by Vincent Cloarec
+    author               : Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAUTHHMACSHA256METHOD_H
+#define QGSAUTHHMACSHA256METHOD_H
+
+#include <QObject>
+#include <QMutex>
+
+#include "qgsauthconfig.h"
+#include "qgsauthmethod.h"
+#include "qgsauthmethodmetadata.h"
+
+
+class QgsAuthMapTilerHmacSha256Method : public QgsAuthMethod
+{
+    Q_OBJECT
+
+  public:
+
+    static const QString AUTH_METHOD_KEY;
+    static const QString AUTH_METHOD_DESCRIPTION;
+    static const QString AUTH_METHOD_DISPLAY_DESCRIPTION;
+
+    explicit QgsAuthMapTilerHmacSha256Method();
+
+    // QgsAuthMethod interface
+    QString key() const override;
+
+    QString description() const override;
+
+    QString displayDescription() const override;
+
+    bool updateNetworkRequest( QNetworkRequest &request, const QString &authcfg,
+                               const QString &dataprovider = QString() ) override;
+
+    void clearCachedConfig( const QString &authcfg ) override;
+    void updateMethodConfig( QgsAuthMethodConfig &mconfig ) override;
+
+#ifdef HAVE_GUI
+    QWidget *editWidget( QWidget *parent )const override;
+#endif
+
+  private:
+    QgsAuthMethodConfig getMethodConfig( const QString &authcfg, bool fullconfig = true );
+
+    void putMethodConfig( const QString &authcfg, const QgsAuthMethodConfig &mconfig );
+
+    void removeMethodConfig( const QString &authcfg );
+
+    QByteArray calculateSignature( const QString &token, const QString &keyedUrl );
+
+    static QMap<QString, QgsAuthMethodConfig> sAuthConfigCache;
+
+};
+
+
+class QgsAuthMapTilerHmacSha256MethodMetadata : public QgsAuthMethodMetadata
+{
+  public:
+    QgsAuthMapTilerHmacSha256MethodMetadata()
+      : QgsAuthMethodMetadata( QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_KEY, QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_DESCRIPTION )
+    {}
+    QgsAuthMapTilerHmacSha256Method *createAuthMethod() const override {return new QgsAuthMapTilerHmacSha256Method;}
+};
+
+#endif // QGSAUTHHMACSHA256METHOD_H

--- a/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.cpp
+++ b/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+    qgsauthmaptilerhmacsha256edit.cpp
+    ------------------------
+    begin                : January 2022
+    copyright            : (C) 2022 by Vincent Cloarec
+    author               : Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsauthmaptilerhmacsha256edit.h"
+#include "ui_qgsauthmaptilerhmacsha256edit.h"
+
+
+QgsAuthMapTilerHmacSha256Edit::QgsAuthMapTilerHmacSha256Edit( QWidget *parent )
+  : QgsAuthMethodEdit( parent )
+{
+  setupUi( this );
+  connect( mTokenEdit, &QPlainTextEdit::textChanged, this, &QgsAuthMapTilerHmacSha256Edit::configChanged );
+}
+
+bool QgsAuthMapTilerHmacSha256Edit::validateConfig()
+{
+  const bool curvalid = !mTokenEdit->toPlainText().isEmpty();
+  if ( mValid != curvalid )
+  {
+    mValid = curvalid;
+    emit validityChanged( curvalid );
+  }
+  return curvalid;
+}
+
+QgsStringMap QgsAuthMapTilerHmacSha256Edit::configMap() const
+{
+  QgsStringMap config;
+  config.insert( QStringLiteral( "token" ), mTokenEdit->toPlainText() );
+
+  return config;
+}
+
+void QgsAuthMapTilerHmacSha256Edit::loadConfig( const QgsStringMap &configmap )
+{
+  clearConfig();
+
+  mConfigMap = configmap;
+  mTokenEdit->setPlainText( configmap.value( QStringLiteral( "token" ) ) );
+
+  validateConfig();
+}
+
+void QgsAuthMapTilerHmacSha256Edit::resetConfig()
+{
+  loadConfig( mConfigMap );
+}
+
+void QgsAuthMapTilerHmacSha256Edit::clearConfig()
+{
+  mTokenEdit->clear();
+}
+
+void QgsAuthMapTilerHmacSha256Edit::configChanged()
+{
+  validateConfig();
+}

--- a/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.h
+++ b/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsauthmaptilerhmacsha256edit.h
+    ---------------------
+    begin                : January 2022
+    copyright            : (C) 2022 by Vincent Cloarec
+    author               : Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAUTHQGSAUTHHMACSHA256EDIT_H
+#define QGSAUTHQGSAUTHHMACSHA256EDIT_H
+
+#include <QWidget>
+#include "qgsauthmethodedit.h"
+#include "ui_qgsauthmaptilerhmacsha256edit.h"
+
+#include "qgsauthconfig.h"
+
+
+class QgsAuthMapTilerHmacSha256Edit : public QgsAuthMethodEdit, private Ui::QgsAuthEsriTokenEdit
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsAuthMapTilerHmacSha256Edit( QWidget *parent = nullptr );
+
+    bool validateConfig() override;
+
+    QgsStringMap configMap() const override;
+
+  public slots:
+    void loadConfig( const QgsStringMap &configmap ) override;
+
+    void resetConfig() override;
+
+    void clearConfig() override;
+
+  private slots:
+    void configChanged();
+
+  private:
+    QgsStringMap mConfigMap;
+    bool mValid = false;
+};
+
+#endif // QGSAUTHQGSAUTHHMACSHA256EDIT_H

--- a/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.ui
+++ b/src/auth/maptiler_hmacsha256/gui/qgsauthmaptilerhmacsha256edit.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAuthEsriTokenEdit</class>
+ <widget class="QWidget" name="QgsAuthEsriTokenEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>573</width>
+    <height>427</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>173</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblToken">
+     <property name="text">
+      <string>Token</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" rowspan="2">
+    <widget class="QPlainTextEdit" name="mTokenEdit">
+     <property name="placeholderText">
+      <string>Required</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="mLinkLabel">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Secure Token from &lt;a href=&quot;https://cloud.maptiler.com/account/credentials/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;MapTiler Account Credentials&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
A new auth method specific for MapTiler with a token encrypted  with HMAC-SHA256

![image](https://user-images.githubusercontent.com/7416892/148457574-f70e3cfa-7723-4750-82e7-f955e7f1da1e.png)

Funded by [MapTiler](https://www.maptiler.com/)
