### PR TITLE
[pal] Remove calculation of total solution cost which was done before solving labeling and once after solving labeling, yet was never retrieved anywhere

### DIFF
--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -580,11 +580,7 @@ void Problem::chain_search()
 
   std::fill( ok, ok + mFeatureCount, false );
 
-  //initialization();
   init_sol_falp();
-
-  //check_solution();
-  solution_cost();
 
   int iter = 0;
 
@@ -593,9 +589,6 @@ void Problem::chain_search()
 
   while ( true )
   {
-
-    //check_solution();
-
     for ( seed = ( iter + 1 ) % mFeatureCount;
           ok[seed] && seed != iter;
           seed = ( seed + 1 ) % mFeatureCount )
@@ -643,11 +636,10 @@ void Problem::chain_search()
 
         ok[fid] = false;
       }
-      mSol.totalCost += retainedChain->delta;
     }
     else
     {
-      // no chain or the one is not god enough
+      // no chain or the one is not good enough
       ok[seed] = true;
     }
 
@@ -655,7 +647,6 @@ void Problem::chain_search()
     popit++;
   }
 
-  solution_cost();
   delete[] ok;
 }
 
@@ -698,39 +689,4 @@ QList<LabelPosition *> Problem::getSolution( bool returnInactive, QList<LabelPos
   }
 
   return finalLabelPlacements;
-}
-
-void Problem::solution_cost()
-{
-  mSol.totalCost = 0.0;
-
-  LabelPosition *lp = nullptr;
-
-  double amin[2];
-  double amax[2];
-
-  for ( std::size_t i = 0; i < mFeatureCount; i++ )
-  {
-    if ( mSol.activeLabelIds[i] == -1 )
-    {
-      mSol.totalCost += mInactiveCost[i];
-    }
-    else
-    {
-      lp = mLabelPositions[ mSol.activeLabelIds[i] ].get();
-
-      lp->getBoundingBox( amin, amax );
-      mActiveCandidatesIndex.intersects( QgsRectangle( amin[0], amin[1], amax[0], amax[1] ), [&lp, this]( const LabelPosition * lp2 )->bool
-      {
-        if ( candidatesAreConflicting( lp, lp2 ) )
-        {
-          mSol.totalCost += mInactiveCost[lp2->getProblemFeatureId()] + lp2->cost();
-        }
-
-        return true;
-      } );
-
-      mSol.totalCost += lp->cost();
-    }
-  }
 }

--- a/src/core/pal/problem.h
+++ b/src/core/pal/problem.h
@@ -214,12 +214,9 @@ namespace pal
           //! Placeholder list for active labels. Will contain label id for active labels, or -1 for empty positions in list
           std::vector< int > activeLabelIds;
 
-          double totalCost = 0;
-
           void init( std::size_t featureCount )
           {
             activeLabelIds.resize( featureCount, -1 );
-            totalCost = 0;
           }
       };
 


### PR DESCRIPTION
This is a non-trival cost to calculate, involving spatial index
lookups for every label to determine if it is in conflict. Removing
the unused calculation saves a significant amount of time from the
label placement routine!
