### PR TITLE
[postgres] Preserve feature map on layer clone

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -319,6 +319,11 @@ Qgis::VectorLayerTypeFlags QgsPostgresProvider::vectorLayerTypeFlags() const
   return flags;
 }
 
+void QgsPostgresProvider::handlePostCloneOperations( QgsVectorDataProvider *source )
+{
+  mShared = qobject_cast<QgsPostgresProvider *>( source )->mShared;
+}
+
 void QgsPostgresProvider::reloadProviderData()
 {
   mShared->setFeaturesCounted( -1 );

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -247,6 +247,8 @@ class QgsPostgresProvider final: public QgsVectorDataProvider
 
     Qgis::VectorLayerTypeFlags vectorLayerTypeFlags() const override;
 
+    void handlePostCloneOperations( QgsVectorDataProvider *source ) override;
+
   private:
 
     /**

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1118,6 +1118,22 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertNotEqual(f[0]['obj_id'], NULL, f[0].attributes())
         vl.deleteFeatures([f[0].id()])
 
+    def testClonePreservesFidMap(self):
+        vl = QgsVectorLayer(
+            '{} sslmode=disable srid=4326 key="pk" table="qgis_test".{} (geom)'.format(
+                self.dbconn, 'bigint_pk'),
+            "bigint_pk", "postgres")
+
+        # Generate primary keys
+        f = next(vl.getFeatures('pk = 2'))  # 1
+        f = next(vl.getFeatures('pk = -1'))  # 2
+        fid_orig = f.id()
+
+        clone = vl.clone()
+        f = next(clone.getFeatures('pk = -1'))  # should still be 2
+        fid_copy = f.id()
+        self.assertEqual(fid_orig, fid_copy)
+
     def testNull(self):
         """
         Asserts that 0, '' and NULL are treated as different values on insert


### PR DESCRIPTION
Make sure postgres provider internals are preserved across a layer
clone.
This helps to keep feature ids stable for things like extract labels

