### PR TITLE
Update README.md with more detail on ESRI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ QGIS is a full-featured, user-friendly, free-and-open-source (FOSS) geographical
 ### 2. Beautiful cartography
 - Large variety of rendering options in 2D and 3D
 - Fine control over symbology, labeling, legends and additional graphical elements for beautifully rendered maps
-- Near-complete replication (and significant extension) of symbology options available in proprietary software by ESRI
+- Near-complete replication (and significant extension) of symbology options that are available in proprietary software by ESRI
 - Advanced styling using data-defined overrides, blending modes, and draw effects
 - 500+ built-in color ramps (cpt-city, ColorBrewer, etc.) 
 - Create and update maps with specified scale, extent, style, and decorations via saved layouts

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ QGIS is a full-featured, user-friendly, free-and-open-source (FOSS) geographical
 
 - Supports raster, vector, mesh, and point cloud data in a range of industry-standard formats
     - *Raster formats include*: GeoPackage, GeoTIFF, GRASS, ArcInfo binary and ASCII grids, ERDAS Imagine SDTS, WMS, WCS, PostgreSQL/PostGIS, and [other GDAL supported formats](https://gdal.org/drivers/raster/index.html).
-    - *Vector formats include*: GeoPackage, ESRI Shapefiles, GRASS, SpatiaLite, PostgreSQL/PostGIS, MSSQL, Oracle, WFS, Vector Tiles and [other OGR supported formats](http://www.gdal.org/ogr_formats.html). 
+    - *Vector formats include*: GeoPackage, ESRI shapefiles, GRASS, SpatiaLite, PostgreSQL/PostGIS, MSSQL, Oracle, WFS, Vector Tiles and [other OGR supported formats](http://www.gdal.org/ogr_formats.html). 
     - *Mesh formats include*: NetCDF, GRIB, 2DM, and [other MDAL supported formats](https://github.com/lutraconsulting/MDAL#supported-formats).
     - *Point-cloud format*: LAS/LAZ and EPT datasets.
 - Access and display local files, spatial databases (PostGIS, SpatiaLite, SQL Server, Oracle, SAP HANA), web services (WMS, WCS, WFS, ArcGIS REST services), tile services, etc. <!-- removed DB2 due to https://github.com/qgis/QGIS/pull/41178 -->
@@ -52,6 +52,7 @@ QGIS is a full-featured, user-friendly, free-and-open-source (FOSS) geographical
 ### 2. Beautiful cartography
 - Large variety of rendering options in 2D and 3D
 - Fine control over symbology, labeling, legends and additional graphical elements for beautifully rendered maps
+- Near-complete replication (and significant extension) of symbology options available in proprietary software by ESRI
 - Advanced styling using data-defined overrides, blending modes, and draw effects
 - 500+ built-in color ramps (cpt-city, ColorBrewer, etc.) 
 - Create and update maps with specified scale, extent, style, and decorations via saved layouts
@@ -87,7 +88,8 @@ For more maps created with QGIS, visit the [QGIS Map Showcase Flickr Group](http
 
 - Fully customizable user experience, including user interface and application settings that cater to power-users and beginners alike
 - Rich [expression engine](https://docs.qgis.org/testing/en/docs/user_manual/working_with_vector/expression.html) for maximum flexibility in visualization and processing
-- Broad and varied [plugin ecosystem](https://plugins.qgis.org/) that includes data connectors, digitizing aids, advanced analysis and charting tools, in-the-field data capture, etc.
+- Broad and varied [plugin ecosystem](https://plugins.qgis.org/) that includes data connectors, digitizing aids, advanced analysis and charting tools, 
+in-the-field data capture, conversion of ESRI style files, etc.
 - Style manager for creating, storing, and managing styles
 - [QGIS style hub](https://plugins.qgis.org/styles/) for easy sharing of styles
 - Python and C++ API for standalone (headless) applications as well as in-application comprehensive scripting (PyQGIS)


### PR DESCRIPTION
Since updating README.md some months ago, I've "market tested" the QGIS overview with various ppl. A recurring theme of questions was degree of ESRI interoperability. We already mentioned shapefiles here but added more explicit discussion of replication of ArcGis styling, which has evolved leaps and bounds thanks to North Road.

I'm proposing changes that don't go into specific detail (we can do X but not Y) or point specifically to the SLYR plugin, but aim to reassure a reader that QGIS is (reasonably) interoperable not only on data but also styling.