### PR TITLE
Expose QgsFieldCalculator to public API

### DIFF
--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -14,6 +14,16 @@ class QgsFieldCalculator: QDialog
 %Docstring(signature="appended")
 
 A dialog class that provides calculation of new fields using existing fields, values and a set of operators
+
+Sample usage of the :py:class:`QgsFieldCalculator` class:
+
+.. code-block:: python
+
+         uri = "point?crs=epsg:4326&field=id:integer"
+         layer = QgsVectorLayer(uri, "Scratch point layer",  "memory")
+         layer.startEditing()
+         dialog = QgsFieldCalculator(layer)
+         dialog.exec_()
 %End
 
 %TypeHeaderCode
@@ -23,16 +33,14 @@ A dialog class that provides calculation of new fields using existing fields, va
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0 );
 
     int changedAttributeId() const;
+%Docstring
+Returns the field index of the field for which new attribute values were calculated.
+@return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
+%End
 
   public slots:
     virtual void accept();
 
-
-    void mNewFieldGroupBox_toggled( bool on );
-    void mUpdateExistingGroupBox_toggled( bool on );
-    void mCreateVirtualFieldCheckbox_stateChanged( int state );
-    void mOutputFieldNameLineEdit_textChanged( const QString &text );
-    void mOutputFieldTypeComboBox_activated( int index );
 
 };
 

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -36,7 +36,7 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
 %Docstring
 Returns the field index of the field for which new attribute values were calculated.
 
-@return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
+:return: The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
 %End
 
   public slots:

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -35,6 +35,7 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
     int changedAttributeId() const;
 %Docstring
 Returns the field index of the field for which new attribute values were calculated.
+
 @return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
 %End
 

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -1,0 +1,46 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/vector/qgsfieldcalculator.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsFieldCalculator: QDialog
+{
+%Docstring(signature="appended")
+
+A dialog class that provides calculation of new fields using existing fields, values and a set of operators
+%End
+
+%TypeHeaderCode
+#include "qgsfieldcalculator.h"
+%End
+  public:
+    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0 );
+
+    int changedAttributeId() const;
+
+  public slots:
+    virtual void accept();
+
+
+    void mNewFieldGroupBox_toggled( bool on );
+    void mUpdateExistingGroupBox_toggled( bool on );
+    void mCreateVirtualFieldCheckbox_stateChanged( int state );
+    void mOutputFieldNameLineEdit_textChanged( const QString &text );
+    void mOutputFieldTypeComboBox_activated( int index );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/vector/qgsfieldcalculator.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsFieldCalculator: QDialog
 {
 %Docstring(signature="appended")

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -398,6 +398,7 @@
 %Include auto_generated/raster/qgssinglebandpseudocolorrendererwidget.sip
 %Include auto_generated/raster/qgsrasterlayerproperties.sip
 %Include auto_generated/raster/qgsrasterlayertemporalpropertieswidget.sip
+%Include auto_generated/vector/qgsfieldcalculator.sip
 %Include auto_generated/vector/qgsvectorlayerproperties.sip
 %Include auto_generated/symbology/characterwidget.sip
 %Include auto_generated/symbology/qgs25drendererwidget.sip

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -17,7 +17,7 @@
 #define QGSFIELDCALCULATOR_H
 
 // We don't want to expose this in the public API
-#define SIP_NO_FILE
+// #define SIP_NO_FILE
 
 #include "ui_qgsfieldcalculatorbase.h"
 #include "qgshelp.h"

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -16,9 +16,6 @@
 #ifndef QGSFIELDCALCULATOR_H
 #define QGSFIELDCALCULATOR_H
 
-// We don't want to expose this in the public API
-// #define SIP_NO_FILE
-
 #include "ui_qgsfieldcalculatorbase.h"
 #include "qgshelp.h"
 #include "qgsfields.h"

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -48,7 +48,7 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     /**
      * \brief Returns the field index of the field for which new attribute values were calculated.
      *
-     * @return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
+     * \returns The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
      */
     int changedAttributeId() const { return mAttributeId; }
 

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -46,7 +46,8 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr );
 
     /**
-     * @brief Returns the field index of the field for which new attribute values were calculated.
+     * \brief Returns the field index of the field for which new attribute values were calculated.
+     *
      * @return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
      */
     int changedAttributeId() const { return mAttributeId; }

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -28,6 +28,16 @@ class QgsVectorLayer;
  * \class QgsFieldCalculator
  *
  * \brief A dialog class that provides calculation of new fields using existing fields, values and a set of operators
+ *
+ * Sample usage of the QgsFieldCalculator class:
+ *
+ * \code{.py}
+ *     uri = "point?crs=epsg:4326&field=id:integer"
+ *     layer = QgsVectorLayer(uri, "Scratch point layer",  "memory")
+ *     layer.startEditing()
+ *     dialog = QgsFieldCalculator(layer)
+ *     dialog.exec_()
+ * \endcode
  */
 class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalculatorBase
 {
@@ -35,18 +45,22 @@ class GUI_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
   public:
     QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr );
 
+    /**
+     * @brief Returns the field index of the field for which new attribute values were calculated.
+     * @return The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
+     */
     int changedAttributeId() const { return mAttributeId; }
 
   public slots:
     void accept() override;
 
+  private slots:
     void mNewFieldGroupBox_toggled( bool on );
     void mUpdateExistingGroupBox_toggled( bool on );
     void mCreateVirtualFieldCheckbox_stateChanged( int state );
     void mOutputFieldNameLineEdit_textChanged( const QString &text );
     void mOutputFieldTypeComboBox_activated( int index );
 
-  private slots:
     //! Sets the OK button enabled / disabled
     void setOkButtonState();
     void setPrecisionMinMax();


### PR DESCRIPTION

The QgsFieldCalculator is a powerful widget. In Mar 2020 it was moved from `src/app` to `src/gui/vector `(84bd5797f784b7758ae66e42010abb27e464987b).  Unfortunatelley it remained hidden in the public QGIS API. 
So far, the only way to use it on a vector layer requires to 

1 add the vector layer to the QGIS layer tree,  
2 ensure that the vector layer is the "active layer",  
3 call `iface.actionOpenFieldCalculator().trigger()`

This PR brings the QgsFieldCalculator to the public API and makes it usable in customized applications, e.g. calling `QgsFieldCalculator(myVectorLayer).exec_()`

