### PR TITLE
Removes separators in Data Source Manager menu and toolbar

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -177,7 +177,6 @@
      <addaction name="mActionNewMemoryLayer"/>
      <addaction name="mActionNewMeshLayer"/>
      <addaction name="mActionNewGpxLayer"/>
-     <addaction name="separator"/>
      <addaction name="mActionNewVirtualLayer"/>
     </widget>
     <widget class="QMenu" name="mAddLayerMenu">
@@ -748,9 +747,7 @@
    <addaction name="mActionNewSpatiaLiteLayer"/>
    <addaction name="mActionNewMemoryLayer"/>
    <addaction name="mActionNewMeshLayer"/>
-   <addaction name="separator"/>
    <addaction name="mActionNewVirtualLayer"/>
-   <addaction name="separator"/>
   </widget>
   <widget class="QToolBar" name="mShapeDigitizeToolBar">
    <property name="windowTitle">


### PR DESCRIPTION
## Description
This removes separators in both the Data Source Manager menu and toolbar. I suppose there is/was a reason for the separators but it looks odd with only one element being separated out. It also causes a (small) issue if someone (me) customise the toolbar and removes the _New Virtual Layer_ button, the vertical separators on both sides staying there wasting space.
![menu](https://user-images.githubusercontent.com/32580398/148657936-7b55039f-958e-4151-819e-97f0cc382c98.png)
![toolbar](https://user-images.githubusercontent.com/32580398/148657937-403e7f52-52ce-449a-8077-d3ad4d698400.png)

## Side note
A better way to handle this (for other toolbars) could be to allow control of the separators via the Interface Customization menu, like the buttons are.
![interface_customization](https://user-images.githubusercontent.com/32580398/148659118-d3c0be06-8dae-4e93-a4c7-fe09b1cd9b92.png)