### PR TITLE
QgsVectorFileWriter::createFeature(): remove useless and broken processing of feature id

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2426,20 +2426,6 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
 
   gdal::ogr_feature_unique_ptr poFeature( OGR_F_Create( OGR_L_GetLayerDefn( mLayer ) ) );
 
-  qint64 fid = FID_TO_NUMBER( feature.id() );
-  if ( fid > std::numeric_limits<int>::max() )
-  {
-    QgsDebugMsg( QStringLiteral( "feature id %1 too large." ).arg( fid ) );
-    OGRErr err = OGR_F_SetFID( poFeature.get(), static_cast<long>( fid ) );
-    if ( err != OGRERR_NONE )
-    {
-      QgsDebugMsg( QStringLiteral( "Failed to set feature id to %1: %2 (OGR error: %3)" )
-                   .arg( feature.id() )
-                   .arg( err ).arg( CPLGetLastErrorMsg() )
-                 );
-    }
-  }
-
   // attribute handling
   for ( QMap<int, int>::const_iterator it = mAttrIdxToOgrIdx.constBegin(); it != mAttrIdxToOgrIdx.constEnd(); ++it )
   {


### PR DESCRIPTION
https://github.com/qgis/QGIS/commit/891e66523fdf21283ca15533684a57dd8c27f955 changed the historical logic of always assigning the QGIS feature id as
a OGR feature id before calling OGR_L_CreateFeature(). But it actually changed it in
a broken way by doing it only when the QGIS feature id was >
INT_MAX, and then it assigned the result of the cast of the value to long (which is
32 bit on windows), resulting in a negative value.

Just remove all that logic which is useless.

This is the root cause for an issue of exporting a subset of a very
large layer to XLSX/ODS reported in
https://lists.osgeo.org/pipermail/gdal-dev/2022-January/055202.html
