### PR TITLE
propagate error from XYZ raster tile and vector tile to UI

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4975,8 +4975,7 @@ void QgisApp::initLayerTreeView()
   connect( mMapCanvas, &QgsMapCanvas::renderErrorOccurred, badLayerIndicatorProvider, &QgsLayerTreeViewBadLayerIndicatorProvider::reportLayerError );
   connect( mMapCanvas, &QgsMapCanvas::renderErrorOccurred, mInfoBar, [this]( const QString & error, QgsMapLayer * layer )
   {
-    QString message = layer->name() + QStringLiteral( ": " ) + error;
-    mInfoBar->pushItem( new QgsMessageBarItem( message, Qgis::MessageLevel::Warning, 60 ) );
+    mInfoBar->pushItem( new QgsMessageBarItem( layer->name(), QgsStringUtils::insertLinks( error ), Qgis::MessageLevel::Warning ) );
   } );
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4973,6 +4973,11 @@ void QgisApp::initLayerTreeView()
 
   connect( mMapCanvas, &QgsMapCanvas::mapCanvasRefreshed, this, &QgisApp::updateFilterLegend );
   connect( mMapCanvas, &QgsMapCanvas::renderErrorOccurred, badLayerIndicatorProvider, &QgsLayerTreeViewBadLayerIndicatorProvider::reportLayerError );
+  connect( mMapCanvas, &QgsMapCanvas::renderErrorOccurred, mInfoBar, [this]( const QString & error, QgsMapLayer * layer )
+  {
+    QString message = layer->name() + QStringLiteral( ": " ) + error;
+    mInfoBar->pushItem( new QgsMessageBarItem( message, Qgis::MessageLevel::Warning, 60 ) );
+  } );
 }
 
 void QgisApp::setupLayerTreeViewFromSettings()

--- a/src/app/qgslayertreeviewbadlayerindicator.cpp
+++ b/src/app/qgslayertreeviewbadlayerindicator.cpp
@@ -82,7 +82,7 @@ void QgsLayerTreeViewBadLayerIndicatorProvider::onIndicatorClicked( const QModel
       QgsMessageViewer *m = new QgsMessageViewer( QgisApp::instance() );
       m->setWindowTitle( tr( "Layer Error" ) );
       if ( thisLayerErrors.count() == 1 )
-        m->setMessageAsPlainText( thisLayerErrors.at( 0 ) );
+        m->setMessageAsHtml( thisLayerErrors.at( 0 ) );
       else
       {
         QString message = QStringLiteral( "<ul>" );

--- a/src/app/qgslayertreeviewbadlayerindicator.cpp
+++ b/src/app/qgslayertreeviewbadlayerindicator.cpp
@@ -82,7 +82,7 @@ void QgsLayerTreeViewBadLayerIndicatorProvider::onIndicatorClicked( const QModel
       QgsMessageViewer *m = new QgsMessageViewer( QgisApp::instance() );
       m->setWindowTitle( tr( "Layer Error" ) );
       if ( thisLayerErrors.count() == 1 )
-        m->setMessageAsHtml( thisLayerErrors.at( 0 ) );
+        m->setMessageAsPlainText( thisLayerErrors.at( 0 ) );
       else
       {
         QString message = QStringLiteral( "<ul>" );

--- a/src/core/qgstiledownloadmanager.cpp
+++ b/src/core/qgstiledownloadmanager.cpp
@@ -109,13 +109,11 @@ void QgsTileDownloadManagerReplyWorkerObject::replyFinished()
   QgsDebugMsgLevel( QStringLiteral( "Tile download manager: internal reply finished: " ) + mRequest.url().toString(), 2 );
 
   QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
-  QByteArray data;
+  QByteArray data = reply->readAll();;
 
   if ( reply->error() == QNetworkReply::NoError )
   {
     ++mManager->mStats.networkRequestsOk;
-
-    data = reply->readAll();
   }
   else
   {

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -183,6 +183,8 @@ bool QgsVectorTileLayerRenderer::render()
     // Block until tiles are fetched and rendered. If the rendering gets canceled at some point,
     // the async loader will catch the signal, abort requests and return from downloadBlocking()
     asyncLoader->downloadBlocking();
+    if ( !asyncLoader->error().isEmpty() )
+      mErrors.append( asyncLoader->error() );
   }
 
   mRenderer->stopRender( ctx );

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -130,6 +130,13 @@ void QgsVectorTileLoader::tileReplyFinished()
   }
   else
   {
+    if ( reply->error() == QNetworkReply::ContentAccessDenied )
+    {
+      mError = tr( "Access denied" );
+      if ( !reply->data().isEmpty() )
+        mError.append( QStringLiteral( ": " ) + reply->data() );
+    }
+
     QgsDebugMsg( QStringLiteral( "Tile download failed! " ) + reply->errorString() );
     mReplies.removeOne( reply );
     reply->deleteLater();
@@ -153,6 +160,11 @@ void QgsVectorTileLoader::canceled()
   // stop blocking download
   mEventLoop->quit();
 
+}
+
+QString QgsVectorTileLoader::error() const
+{
+  return mError;
 }
 
 //////

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -132,9 +132,11 @@ void QgsVectorTileLoader::tileReplyFinished()
   {
     if ( reply->error() == QNetworkReply::ContentAccessDenied )
     {
-      mError = tr( "Access denied" );
-      if ( !reply->data().isEmpty() )
-        mError.append( QStringLiteral( ": " ) + reply->data() );
+
+      if ( reply->data().isEmpty() )
+        mError = tr( "Access denied" );
+      else
+        mError = tr( "Access denied: %1" ).arg( QString( reply->data() ) );
     }
 
     QgsDebugMsg( QStringLiteral( "Tile download failed! " ) + reply->errorString() );

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -91,6 +91,9 @@ class QgsVectorTileLoader : public QObject
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
     void downloadBlocking();
 
+    //! Returns a eventual error that occured during loading, void if no error.
+    QString error() const;
+
   private:
     void loadFromNetworkAsync( const QgsTileXYZ &id, const QgsTileMatrix &tileMatrix, const QString &requestUrl );
 
@@ -113,6 +116,8 @@ class QgsVectorTileLoader : public QObject
 
     //! Running tile requests
     QList<QgsTileDownloadManagerReply *> mReplies;
+
+    QString mError;
 
 };
 

--- a/src/core/vectortile/qgsvectortileloader.h
+++ b/src/core/vectortile/qgsvectortileloader.h
@@ -91,7 +91,7 @@ class QgsVectorTileLoader : public QObject
     //! Blocks the caller until all asynchronous requests are finished (with a success or a failure)
     void downloadBlocking();
 
-    //! Returns a eventual error that occured during loading, void if no error.
+    //! Returns a eventual error that occurred during loading, void if no error.
     QString error() const;
 
   private:

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -467,8 +467,10 @@ void QgsLayerTreeView::addIndicator( QgsLayerTreeNode *node, QgsLayerTreeViewInd
     connect( indicator, &QgsLayerTreeViewIndicator::changed, this, [ = ]
     {
       update();
+      viewport()->repaint();
     } );
     update();
+    viewport()->repaint(); //update() does not automatically trigger a repaint()
   }
 }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1049,15 +1049,8 @@ void QgsMapCanvas::notifyRendererErrors( const QgsMapRendererJob::Errors &errors
 
     mRendererErrors[errorKey] = currentTime;
 
-    QString message = error.message;
-    const QRegularExpression regEx( QStringLiteral( "(https?:\\/\\/+[\\/\\{\\}\\?=a-zA-Z0-9_.~-]*)" ), QRegularExpression::CaseInsensitiveOption );
-    QRegularExpressionMatch match = regEx.match( message );
-    if ( match.hasMatch() )
-      message.replace( regEx, "<a href=\"\\1\">\\1</a>" );
-
-    QgsMapLayer *layer = QgsProject::instance()->mapLayer( error.layerID );
-    emit renderErrorOccurred( message, layer );
-    QgsMessageLog::logMessage( error.layerID + " :: " + message, tr( "Rendering" ) );
+    if ( QgsMapLayer *layer = QgsProject::instance()->mapLayer( error.layerID ) )
+      emit renderErrorOccurred( error.message, layer );
   }
 }
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -30,6 +30,7 @@
 #include "qgsmapcanvasinteractionblocker.h"
 #include "qgsproject.h"
 #include "qgsdistancearea.h"
+#include "qgsmaprendererjob.h"
 
 #include <QDomDocument>
 #include <QGraphicsView>
@@ -1423,6 +1424,15 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     std::unique_ptr< QgsTemporaryCursorOverride > mTemporaryCursorOverride;
 
     /**
+     * This attribute maps error strings occured during rendering with time.
+     * The string contains the layerId with the error message ("layerId:error").
+     * This is used to avoid propagatation of repeated error message from renderer
+     * in a short time range (\see notifyRendererErrors())
+     *
+     */
+    QMap <QString, QDateTime> mRendererErrors;
+
+    /**
      * Returns the last cursor position on the canvas in geographical coordinates
      * \since QGIS 3.4
      */
@@ -1491,6 +1501,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     void clearElevationCache();
 
     void showContextMenu( QgsMapMouseEvent *event );
+
+    /**
+     * This private method is used to emit rendering error from map layer without throwing it for every render.
+     * It contains a mechanism that does not emit the error if the same error from the same layer was emitted less than 1 mn ago.
+     */
+    void notifyRendererErrors( const QgsMapRendererJob::Errors &errors );
 
     friend class TestQgsMapCanvas;
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1424,7 +1424,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     std::unique_ptr< QgsTemporaryCursorOverride > mTemporaryCursorOverride;
 
     /**
-     * This attribute maps error strings occured during rendering with time.
+     * This attribute maps error strings occurred during rendering with time.
      * The string contains the layerId with the error message ("layerId:error").
      * This is used to avoid propagatation of repeated error message from renderer
      * in a short time range (\see notifyRendererErrors())

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -634,6 +634,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
 
     void downloadBlocking();
 
+    QString error() const;
+
   protected slots:
     void tileReplyFinished();
     void canceled();
@@ -652,7 +654,7 @@ class QgsWmsTiledImageDownloadHandler : public QObject
     void finish() { QMetaObject::invokeMethod( mEventLoop, "quit", Qt::QueuedConnection ); }
 
     QString mProviderUri;
-
+    QString mBaseUrl;
     QgsWmsAuthorization mAuth;
 
     QImage *mImage = nullptr;
@@ -667,6 +669,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
     QList<QNetworkReply *> mReplies;
 
     QgsRasterBlockFeedback *mFeedback = nullptr;
+
+    QString mError;
 };
 
 

--- a/tests/src/core/testqgstiledownloadmanager.cpp
+++ b/tests/src/core/testqgstiledownloadmanager.cpp
@@ -86,6 +86,7 @@ void TestQgsTileDownloadManager::testOneRequest()
   spy.wait();
   QCOMPARE( spy.count(), 1 );
   QVERIFY( !r->data().isEmpty() );
+  QVERIFY( r->error() == QNetworkReply::NoError );
 
   QVERIFY( !manager.hasPendingRequests() );
 
@@ -157,7 +158,9 @@ void TestQgsTileDownloadManager::testOneRequestTwice()
   QCOMPARE( spy1.count(), 1 );
   QCOMPARE( spy2.count(), 1 );
   QVERIFY( !r1->data().isEmpty() );
+  QVERIFY( r1->error() == QNetworkReply::NoError );
   QVERIFY( !r2->data().isEmpty() );
+  QVERIFY( r2->error() == QNetworkReply::NoError );
 
   QVERIFY( !manager.hasPendingRequests() );
 
@@ -194,6 +197,7 @@ void TestQgsTileDownloadManager::testOneRequestTwiceAndEarlyDelete()
   spy.wait();
   QCOMPARE( spy.count(), 1 );
   QVERIFY( !r2->data().isEmpty() );
+  QVERIFY( r2->error() == QNetworkReply::NoError );
 
   QVERIFY( !manager.hasPendingRequests() );
 
@@ -222,7 +226,7 @@ void TestQgsTileDownloadManager::testOneRequestFailure()
   QSignalSpy spy( r.get(), &QgsTileDownloadManagerReply::finished );
   spy.wait();
   QCOMPARE( spy.count(), 1 );
-  QVERIFY( r->data().isEmpty() );
+  QVERIFY( r->error() != QNetworkReply::NoError );
 
   QVERIFY( !manager.hasPendingRequests() );
 
@@ -260,7 +264,9 @@ void TestQgsTileDownloadManager::testTwoRequests()
   QCOMPARE( spy1.count(), 1 );
   QCOMPARE( spy2.count(), 1 );
   QVERIFY( !r1->data().isEmpty() );
+  QVERIFY( r1->error() == QNetworkReply::NoError );
   QVERIFY( !r2->data().isEmpty() );
+  QVERIFY( r2->error() == QNetworkReply::NoError );
 
   QVERIFY( !manager.hasPendingRequests() );
 


### PR DESCRIPTION
With this PR, server errors occurred during XYZ vector tile requests or WMS requests can be propagated to the message bar of the map canvas and to the layer indicator of the related layer. The displayed message contains eventual text in the server reply.


![errorVectoreTile](https://user-images.githubusercontent.com/7416892/148805312-003de748-25ac-486e-9291-2f8c0fc79f8d.gif)

![errorWMS](https://user-images.githubusercontent.com/7416892/148805326-a4540ab7-8dd3-4cf7-89b5-07cf9c7c1f79.gif)

Funded by [MapTiler](https://www.maptiler.com/)
