### PR TITLE
Fix a geonode provider layers fetching crasher

### DIFF
--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -293,7 +293,7 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::parseLayers( con
     {
       if ( wmsURLFormat.isEmpty() && wfsURLFormat.isEmpty() && wcsURLFormat.isEmpty() && xyzURLFormat.isEmpty() )
       {
-        bool success = requestBlocking( QStringLiteral( "/api/layers/" ) + layerStruct.id );
+        bool success = requestBlocking( QStringLiteral( "/api/layers/%1/" ).arg( layerStruct.id ) );
         if ( success )
         {
           const QJsonDocument resourceUriDocument = QJsonDocument::fromJson( this->lastResponse() );

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -54,18 +54,22 @@ void QgsGeoNodeRequest::abort()
 void QgsGeoNodeRequest::fetchLayers()
 {
   request( QStringLiteral( "/api/layers/" ) );
-  QObject *obj = new QObject( this );
 
+  QObject *obj = new QObject( this );
   connect( this, &QgsGeoNodeRequest::requestFinished, obj, [obj, this ]
   {
-    QList<QgsGeoNodeRequest::ServiceLayerDetail> layers;
-    if ( mError.isEmpty() )
+    if ( !mParsingLayers )
     {
-      layers = parseLayers( this->lastResponse() );
+      mParsingLayers = true;
+      QList<QgsGeoNodeRequest::ServiceLayerDetail> layers;
+      if ( mError.isEmpty() )
+      {
+        layers = parseLayers( this->lastResponse() );
+      }
+      emit layersFetched( layers );
+      mParsingLayers = false;
+      obj->deleteLater();
     }
-    emit layersFetched( layers );
-
-    obj->deleteLater();
   } );
 }
 
@@ -74,11 +78,11 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::fetchLayersBlock
   QList<QgsGeoNodeRequest::ServiceLayerDetail> layers;
 
   QEventLoop loop;
-  connect( this, &QgsGeoNodeRequest::requestFinished, &loop, &QEventLoop::quit );
   QObject *obj = new QObject( this );
   connect( this, &QgsGeoNodeRequest::layersFetched, obj, [&]( const QList<QgsGeoNodeRequest::ServiceLayerDetail> &fetched )
   {
     layers = fetched;
+    loop.exit();
   } );
   fetchLayers();
   loop.exec( QEventLoop::ExcludeUserInputEvents );
@@ -546,10 +550,10 @@ void QgsGeoNodeRequest::request( const QString &endPoint )
 
 bool QgsGeoNodeRequest::requestBlocking( const QString &endPoint )
 {
-  request( endPoint );
-
   QEventLoop loop;
   connect( this, &QgsGeoNodeRequest::requestFinished, &loop, &QEventLoop::quit );
+
+  request( endPoint );
   loop.exec( QEventLoop::ExcludeUserInputEvents );
 
   return mError.isEmpty();

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -64,7 +64,7 @@ void QgsGeoNodeRequest::fetchLayers()
       QList<QgsGeoNodeRequest::ServiceLayerDetail> layers;
       if ( mError.isEmpty() )
       {
-        layers = parseLayers( this->lastResponse() );
+        layers = parseLayers( lastResponse() );
       }
       emit layersFetched( layers );
       mParsingLayers = false;

--- a/src/core/geocms/geonode/qgsgeonoderequest.h
+++ b/src/core/geocms/geonode/qgsgeonoderequest.h
@@ -284,6 +284,7 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
 
     bool mIsAborted = false;
     bool mForceRefresh = false;
+    bool mParsingLayers = false;
 
     QList<QgsGeoNodeRequest::ServiceLayerDetail> parseLayers( const QByteArray &layerResponse );
     QgsGeoNodeStyle retrieveStyle( const QString &styleUrl );


### PR DESCRIPTION
## Description

This PR fixes a crash in the geonode provider's layers fetching code. Long story short there is that everything was listening to the same signal, leading the individual layers parser request triggering an early end to the overall layers fetching process.

I've also fixed the URL string for individual layer fetching by appending a "/" at the end, to avoid needless redirect by the server (which comes at the cost of extra seconds).