### PR TITLE
Remove server landingpage entries from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,6 @@ qgis.kdev4
 qgis.supp
 qgis-test.ctest
 qtcreator-build/
-resources/server/api/ogc/static/landingpage
-resources/server/src/landingpage/node_modules
 resources/themes/*/style.qss.auto
 scripts/astyle.exe
 scripts/Debug

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -192,11 +192,12 @@ See [debian-ubuntu](https://qgis.org/en/site/forusers/alldownloads.html#debian-u
 currently supported distributions (plain xenial's GDAL for instance is too old
 and we build with GDAL2 from ubuntugis).
 
-To build QGIS server landingpage webapp additional dependencies are required:
+To build [QGIS server landing page/catalog webapp](https://docs.qgis.org/latest/en/docs/server_manual/services.html#qgis-server-catalog) additional dependencies are required:
 
 Node.js (current LTS recommended): https://nodejs.org/en/download/<br>
 Yarn Package Manager: https://yarnpkg.com/getting-started/install
 
+Additionally, the cmake flag `WITH_SERVER_LANDINGPAGE_WEBAPP` needs to be turned on.
 
 ## 3.4. Setup ccache (Optional, but recommended)
 
@@ -441,11 +442,13 @@ To build QGIS server additional dependencies are required:
 dnf install fcgi-devel
 ```
 
-And for building QGIS server landingpage webapp:
+And for building [QGIS server landing page/catalog webapp](https://docs.qgis.org/latest/en/docs/server_manual/services.html#qgis-server-catalog):
 
 ```bash
 dnf install nodejs yarnpkg
 ```
+
+Additionally, the cmake flag `WITH_SERVER_LANDINGPAGE_WEBAPP` needs to be turned on.
 
 Make sure that your build directory is completely empty when you enter the
 following command. Do never try to "re-use" an existing Qt5 build directory.

--- a/resources/server/src/landingpage/README.md
+++ b/resources/server/src/landingpage/README.md
@@ -19,14 +19,16 @@ export QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/path/to/projectdirectory
 ./output/bin/qgis_mapserver -p /path/to/projectdirectory/test.qgz
 ```
 
-Then open the web browser on http://localhost:8000 (for default port `8000`).
+Then open http://localhost:8000 in a web browser (default port `8000`).
 
 
 ## Development
 
-Development could be done by modifying the source code and building and running the webapp as described above.
+Development is done by modifying the source code and building and running the webapp as described above.
 
-If you want to run `yarn install` manually, e.g. to update `yarn.lock` please make sure to remove the `node_modules` directory from your QGIS source tree before running cmake and building. The same accounts for removing the `landingpage` directory from `resources/server/api/ogc/static/` after running `yarn build` manually.
+#### update `yarn.lock`
+
+To update `yarn.lock` run `yarn install` manually and make sure to remove the `node_modules` directory from your QGIS source tree before running cmake and building.
 
 #### Lints and fixes files
 ```

--- a/resources/server/src/landingpage/README.md
+++ b/resources/server/src/landingpage/README.md
@@ -1,28 +1,37 @@
-# Landing page/catalog
+# Landing page/catalog webapp
 
-Landing page/catalog app source code.
+[Landing page/catalog webapp](https://docs.qgis.org/latest/en/docs/server_manual/services.html#qgis-server-catalog) source code.
 
-## Project setup
+## Building
+
+To build the QGIS server landingpage webapp additional dependencies are required:
+
+Node.js (current LTS recommended): https://nodejs.org/en/download/<br>
+Yarn Package Manager: https://yarnpkg.com/getting-started/install
+
+To build the webapp along with QGIS server just turn the cmake flag `WITH_SERVER_LANDINGPAGE_WEBAPP` on and build as you would normally do.
+
+To test the webapp with a local QGIS project after your build is finished, set the [environment variable](https://docs.qgis.org/latest/en/docs/server_manual/config.html#environment-variables) for your project directory and run the [development server](https://docs.qgis.org/latest/en/docs/server_manual/development_server.html):
+
 ```
-yarn install
+export QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/path/to/projectdirectory
+
+./output/bin/qgis_mapserver -p /path/to/projectdirectory/test.qgz
 ```
 
-### Compiles and hot-reloads for development
-```
-yarn serve
-```
+Then open the web browser on http://localhost:8000 (for default port `8000`).
 
-### Compiles and minifies for production
-```
-yarn build
-```
 
-Built files location: `../../api/ogc/static/landingpage/`
+## Development
 
-### Lints and fixes files
+Development could be done by modifying the source code and building and running the webapp as described above.
+
+If you want to run `yarn install` manually, e.g. to update `yarn.lock` please make sure to remove the `node_modules` directory from your QGIS source tree before running cmake and building. The same accounts for removing the `landingpage` directory from `resources/server/api/ogc/static/` after running `yarn build` manually.
+
+#### Lints and fixes files
 ```
 yarn lint
 ```
 
-### Customize configuration
+#### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).


### PR DESCRIPTION
When running `yarn install` locally, a `node_modules` directory is added to the source tree which, if not removed before running cmake, could lead to a cmake hang because of the countless files inside. 

Removing the server landingpage entries from gitignore, so it would be better noticeable with git commands that unwanted files were added to the source tree.

ref https://github.com/qgis/QGIS/pull/46643#issuecomment-1009939103 