### PR TITLE
Facilitate to split a line by a point via splitGeometry() , improve segmentSide(), add pointOnSegment() 

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -909,9 +909,9 @@ Rotate this geometry around the Z axis
 
  Qgis::GeometryOperationResult splitGeometry( const QVector<QgsPointXY> &splitLine, QVector<QgsGeometry> &newGeometries /Out/, bool topological, QVector<QgsPointXY> &topologyTestPoints /Out/, bool splitFeature = true ) /Deprecated/;
 %Docstring
-Splits this geometry according to a given line.
+Splits this geometry according to a given line or point.
 
-:param splitLine: the line that splits the geometry
+:param splitLine: the line or point that splits the geometry
 \param[out] newGeometries list of new geometries that have been created with the split
 :param topological: ``True`` if topological editing is enabled
 \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
@@ -925,9 +925,9 @@ Splits this geometry according to a given line.
 
     Qgis::GeometryOperationResult splitGeometry( const QgsPointSequence &splitLine, QVector<QgsGeometry> &newGeometries /Out/, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true);
 %Docstring
-Splits this geometry according to a given line.
+Splits this geometry according to a given line or point.
 
-:param splitLine: the line that splits the geometry
+:param splitLine: the line or point that splits the geometry
 \param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
 :param topological: ``True`` if topological editing is enabled
 \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -418,6 +418,15 @@ Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 li
 .. versionadded:: 3.0
 %End
 
+    static bool pointOnSegment( const QgsPoint &segmentPoint1, const QgsPoint &segmentPoint2, const QgsPoint &point ) /HoldGIL/;
+%Docstring
+For a segment defined by points pt1 and pt3, find out if point pt3 is on that segment.
+
+:return: ``True`` if point pt2 lies on the segment between pt1 and pt2, ``False`` - otherwise.
+
+.. versionadded:: 3.24
+%End
+
     static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /HoldGIL/;
 %Docstring
 Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) at three different angles (a1, a2, a3).

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -410,10 +410,10 @@ angular deviation (in radians) allowed when testing for regular point spacing.
 .. versionadded:: 3.14
 %End
 
-    static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) /HoldGIL/;
+    static int segmentSide( const QgsPoint &linePoint1, const QgsPoint &linePoint2, const QgsPoint &point ) /HoldGIL/;
 %Docstring
-For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+For a line defined by points linePoint1 and linePoint2, find out on which side of the line is point.
+Returns -1 if the point on the left side, 1 if the point is on the right side or 0 if the point lies on the line.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -420,11 +420,11 @@ Returns -1 if the point on the left side, 1 if the point is on the right side or
 
     static bool pointOnSegment( const QgsPoint &segmentPoint1, const QgsPoint &segmentPoint2, const QgsPoint &point ) /HoldGIL/;
 %Docstring
-For a segment defined by points pt1 and pt3, find out if point pt3 is on that segment.
+For a segment defined by points segmentPoint1 and segmentPoint2, find out if point is on that segment.
 
-:return: ``True`` if point pt2 lies on the segment between pt1 and pt2, ``False`` - otherwise.
+:return: ``True`` if point lies on the segment between segmentPoint1 and segmentPoint2, ``False`` - otherwise.
 
-.. versionadded:: 3.24
+.. versionadded:: 3.25
 %End
 
     static double interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) /HoldGIL/;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -942,8 +942,8 @@ class CORE_EXPORT QgsGeometry
     Qgis::GeometryOperationResult rotate( double rotation, const QgsPointXY &center );
 
     /**
-     * Splits this geometry according to a given line.
-     * \param splitLine the line that splits the geometry
+     * Splits this geometry according to a given line or point.
+     * \param splitLine the line or point that splits the geometry
      * \param[out] newGeometries list of new geometries that have been created with the split
      * \param topological TRUE if topological editing is enabled
      * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
@@ -954,8 +954,8 @@ class CORE_EXPORT QgsGeometry
     Q_DECL_DEPRECATED Qgis::GeometryOperationResult splitGeometry( const QVector<QgsPointXY> &splitLine, QVector<QgsGeometry> &newGeometries SIP_OUT, bool topological, QVector<QgsPointXY> &topologyTestPoints SIP_OUT, bool splitFeature = true ) SIP_DEPRECATED;
 
     /**
-     * Splits this geometry according to a given line.
-     * \param splitLine the line that splits the geometry
+     * Splits this geometry according to a given line or point.
+     * \param splitLine the line or point that splits the geometry
      * \param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
      * \param topological TRUE if topological editing is enabled
      * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1074,6 +1074,7 @@ void QgsGeometryUtils::segmentizeArc( const QgsPoint &p1, const QgsPoint &p2, co
 
 int QgsGeometryUtils::segmentSide( const QgsPoint &linePoint1, const QgsPoint &linePoint2, const QgsPoint &point )
 {
+  // Vector product calculation method
   const double side = ( ( point.x() - linePoint1.x() ) * ( linePoint2.y() - linePoint1.y() ) - ( linePoint2.x() - linePoint1.x() ) * ( point.y() - linePoint1.y() ) );
   if ( side == 0.0 )
   {
@@ -1100,12 +1101,12 @@ bool QgsGeometryUtils::pointOnSegment( const QgsPoint &segmentPoint1, const QgsP
   {
     if (
       // point between segPoint1 and segPoint2 x-wise
-      ( ( segmentPoint1.x() < point.x() && point.x() < segmentPoint2.x() ) ||
-        ( segmentPoint2.x() < point.x() && point.x() < segmentPoint1.x() ) )
+      ( ( segmentPoint1.x() <= point.x() && point.x() <= segmentPoint2.x() ) ||
+        ( segmentPoint2.x() <= point.x() && point.x() <= segmentPoint1.x() ) )
       &&
       // point between segPoint1 and segPoint2 y-wise
-      ( ( segmentPoint1.y() < point.y() && point.y() < segmentPoint2.y() ) ||
-        ( segmentPoint2.y() < point.y() && point.y() < segmentPoint1.y() ) )
+      ( ( segmentPoint1.y() <= point.y() && point.y() <= segmentPoint2.y() ) ||
+        ( segmentPoint2.y() <= point.y() && point.y() <= segmentPoint1.y() ) )
     )
     {
       return true;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1111,10 +1111,11 @@ bool QgsGeometryUtils::pointOnSegment( const QgsPoint &segmentPoint1, const QgsP
     {
       return true;
     }
+    else
+      return false;
   }
   else
     return false;
-
 }
 
 double QgsGeometryUtils::interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1072,9 +1072,9 @@ void QgsGeometryUtils::segmentizeArc( const QgsPoint &p1, const QgsPoint &p2, co
   points.append( stringPoints );
 }
 
-int QgsGeometryUtils::segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 )
+int QgsGeometryUtils::segmentSide( const QgsPoint &linePoint1, const QgsPoint &linePoint2, const QgsPoint &point )
 {
-  const double side = ( ( pt2.x() - pt1.x() ) * ( pt3.y() - pt1.y() ) - ( pt3.x() - pt1.x() ) * ( pt2.y() - pt1.y() ) );
+  const double side = ( ( point.x() - linePoint1.x() ) * ( linePoint2.y() - linePoint1.y() ) - ( linePoint2.x() - linePoint1.x() ) * ( point.y() - linePoint1.y() ) );
   if ( side == 0.0 )
   {
     return 0;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1093,6 +1093,29 @@ int QgsGeometryUtils::segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, con
   }
 }
 
+bool QgsGeometryUtils::pointOnSegment( const QgsPoint &segmentPoint1, const QgsPoint &segmentPoint2, const QgsPoint &point )
+{
+  int pointSegmentSide = QgsGeometryUtils::segmentSide( segmentPoint1, segmentPoint2, point );
+  if ( pointSegmentSide == 0 )
+  {
+    if (
+      // point between segPoint1 and segPoint2 x-wise
+      ( ( segmentPoint1.x() < point.x() && point.x() < segmentPoint2.x() ) ||
+        ( segmentPoint2.x() < point.x() && point.x() < segmentPoint1.x() ) )
+      &&
+      // point between segPoint1 and segPoint2 y-wise
+      ( ( segmentPoint1.y() < point.y() && point.y() < segmentPoint2.y() ) ||
+        ( segmentPoint2.y() < point.y() && point.y() < segmentPoint1.y() ) )
+    )
+    {
+      return true;
+    }
+  }
+  else
+    return false;
+
+}
+
 double QgsGeometryUtils::interpolateArcValue( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 )
 {
   /* Counter-clockwise sweep */

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -423,11 +423,11 @@ class CORE_EXPORT QgsGeometryUtils
                                    double pointSpacingAngleTolerance ) SIP_HOLDGIL;
 
     /**
-     * For line defined by points pt1 and pt3, find out on which side of the line is point pt3.
-     * Returns -1 if pt3 on the left side, 1 if pt3 is on the right side or 0 if pt3 lies on the line.
+     * For a line defined by points linePoint1 and linePoint2, find out on which side of the line is point.
+     * Returns -1 if the point on the left side, 1 if the point is on the right side or 0 if the point lies on the line.
      * \since 3.0
      */
-    static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) SIP_HOLDGIL;
+    static int segmentSide( const QgsPoint &linePoint1, const QgsPoint &linePoint2, const QgsPoint &point ) SIP_HOLDGIL;
 
     /**
      * For a segment defined by points pt1 and pt3, find out if point pt3 is on that segment.

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -430,9 +430,9 @@ class CORE_EXPORT QgsGeometryUtils
     static int segmentSide( const QgsPoint &linePoint1, const QgsPoint &linePoint2, const QgsPoint &point ) SIP_HOLDGIL;
 
     /**
-     * For a segment defined by points pt1 and pt3, find out if point pt3 is on that segment.
-     * \return TRUE if point pt2 lies on the segment between pt1 and pt2, FALSE - otherwise.
-     * \since 3.24
+     * For a segment defined by points segmentPoint1 and segmentPoint2, find out if point is on that segment.
+     * \return TRUE if point lies on the segment between segmentPoint1 and segmentPoint2, FALSE - otherwise.
+     * \since 3.25
      */
     static bool pointOnSegment( const QgsPoint &segmentPoint1, const QgsPoint &segmentPoint2, const QgsPoint &point ) SIP_HOLDGIL;
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -430,6 +430,13 @@ class CORE_EXPORT QgsGeometryUtils
     static int segmentSide( const QgsPoint &pt1, const QgsPoint &pt3, const QgsPoint &pt2 ) SIP_HOLDGIL;
 
     /**
+     * For a segment defined by points pt1 and pt3, find out if point pt3 is on that segment.
+     * \return TRUE if point pt2 lies on the segment between pt1 and pt2, FALSE - otherwise.
+     * \since 3.24
+     */
+    static bool pointOnSegment( const QgsPoint &segmentPoint1, const QgsPoint &segmentPoint2, const QgsPoint &point ) SIP_HOLDGIL;
+
+    /**
      * Interpolate a value at given angle on circular arc given values (zm1, zm2, zm3) at three different angles (a1, a2, a3).
      * \since 3.0
      */

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -940,36 +940,38 @@ geos::unique_ptr QgsGeos::linePointDifference( GEOSGeometry *GEOSsplitPoint ) co
     if ( line )
     {
       //For each segment
-      QgsLineString newLine;
-      newLine.addVertex( line->pointN( 0 ) );
+      QgsLineString lineBeforeSplit, lineAfterSplit;
+      lineBeforeSplit.addVertex( line->pointN( 0 ) );
       int nVertices = line->numPoints();
       for ( int j = 1; j < ( nVertices - 1 ); ++j )
       {
         QgsPoint currentPoint = line->pointN( j );
-        newLine.addVertex( currentPoint );
+        lineBeforeSplit.addVertex( currentPoint );
         // if point coincides with one of the line's vertices
         if ( currentPoint == *splitPoint )
         {
-          lines.addGeometry( newLine.clone() );
-          newLine = QgsLineString();
-          newLine.addVertex( currentPoint );
+            lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
+            // lineAfterSplit = QgsLineString();
+            lineAfterSplit.addVertex( currentPoint );
         }
         else
         {
-          //if point is on a segment between the line's vertices
-          QgsPoint previousPoint = line->pointN( j - 1 );
-          int pointIsOnLine = QgsGeometryUtils::segmentSide( previousPoint, currentPoint, *splitPoint ); // *splitPoint mit oder ohne Pointer???
-          if ( pointIsOnLine == 0 )
-          {
-            //use the point directly
-            lines.addGeometry( newLine.clone() );
-            newLine = QgsLineString();
-            newLine.addVertex( currentPoint );
-          }
+            QgsPoint previousPoint = line->pointN( j-1 );
+            int pointSegmentSide=QgsGeometryUtils::segmentSide(previousPoint, currentPoint, *splitPoint ); // *splitPoint mit oder ohne Pointer???
+
+            // if point is on a segment between the line's vertices
+            if ( pointSegmentSide == 0)
+            {
+              lineBeforeSplit.addVertex( *splitPoint );
+
+              lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
+              // newLine = QgsLineString();
+              lineAfterSplit.addVertex( *splitPoint );
+            }
         }
       }
-      newLine.addVertex( line->pointN( nVertices - 1 ) );
-      lines.addGeometry( newLine.clone() );
+      lineAfterSplit.addVertex( line->pointN( nVertices - 1 ) );
+      lines.addGeometry( lineAfterSplit.clone() );
     }
   }
 

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -950,24 +950,23 @@ geos::unique_ptr QgsGeos::linePointDifference( GEOSGeometry *GEOSsplitPoint ) co
         // if point coincides with one of the line's vertices
         if ( currentPoint == *splitPoint )
         {
-            lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
-            // lineAfterSplit = QgsLineString();
-            lineAfterSplit.addVertex( currentPoint );
+          lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
+          // lineAfterSplit = QgsLineString();
+          lineAfterSplit.addVertex( currentPoint );
         }
         else
         {
-            QgsPoint previousPoint = line->pointN( j-1 );
-            int pointSegmentSide=QgsGeometryUtils::segmentSide(previousPoint, currentPoint, *splitPoint ); // *splitPoint mit oder ohne Pointer???
+          QgsPoint previousPoint = line->pointN( j - 1 );
 
-            // if point is on a segment between the line's vertices
-            if ( pointSegmentSide == 0)
-            {
-              lineBeforeSplit.addVertex( *splitPoint );
+          // if point is on a segment between the line's vertices
+          if ( QgsGeometryUtils::pointOnSegment( previousPoint, currentPoint, *splitPoint ) )
+          {
+            lineBeforeSplit.addVertex( *splitPoint );
 
-              lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
-              // newLine = QgsLineString();
-              lineAfterSplit.addVertex( *splitPoint );
-            }
+            lines.addGeometry( lineBeforeSplit.clone() ); // clone -> pointer
+            // newLine = QgsLineString();
+            lineAfterSplit.addVertex( *splitPoint );
+          }
         }
       }
       lineAfterSplit.addVertex( line->pointN( nVertices - 1 ) );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -945,46 +945,46 @@ geos::unique_ptr QgsGeos::linePointDifference( GEOSGeometry *GEOSsplitPoint ) co
 
       QgsPointSequence vertexPoints;
       int nVertices = line->numPoints();
-      line->points(vertexPoints);
-      bool splittableOnVertex=vertexPoints.contains(*splitPoint);
+      line->points( vertexPoints );
+      bool splittableOnVertex = vertexPoints.contains( *splitPoint );
 
       // if point coincides with one of the line's vertices
-      if (splittableOnVertex)
+      if ( splittableOnVertex )
       {
-          for ( int j = 1; j < ( nVertices - 1 ); ++j )
+        for ( int j = 1; j < ( nVertices - 1 ); ++j )
+        {
+          QgsPoint currentPoint = line->pointN( j );
+          newLine.addVertex( currentPoint );
+          if ( currentPoint == *splitPoint )
           {
-            QgsPoint currentPoint = line->pointN( j );
+            lines.addGeometry( newLine.clone() );
+            // newLine now turns from a newLine before the split into a new newLine after the split
+            newLine = QgsLineString();
             newLine.addVertex( currentPoint );
-            if ( currentPoint == *splitPoint )
-                {
-                  lines.addGeometry( newLine.clone() );
-                  // newLine now turns from a newLine before the split into a new newLine after the split
-                  newLine = QgsLineString();
-                  newLine.addVertex( currentPoint );
-                }
           }
-          newLine.addVertex( line->pointN( nVertices - 1 ) );
-          lines.addGeometry( newLine.clone() );
+        }
+        newLine.addVertex( line->pointN( nVertices - 1 ) );
+        lines.addGeometry( newLine.clone() );
       }
       // if point is on a segment between the line's vertices
       else
       {
-          for ( int j = 1; j < ( nVertices - 1 ); ++j )
+        for ( int j = 1; j < ( nVertices - 1 ); ++j )
+        {
+          QgsPoint currentPoint = line->pointN( j );
+          QgsPoint previousPoint = line->pointN( j - 1 );
+          if ( QgsGeometryUtils::pointOnSegment( previousPoint, currentPoint, *splitPoint ) )
           {
-              QgsPoint currentPoint = line->pointN( j );
-              QgsPoint previousPoint = line->pointN( j - 1 );
-              if ( QgsGeometryUtils::pointOnSegment( previousPoint, currentPoint, *splitPoint ) )
-              {
-                newLine.addVertex( *splitPoint );
-                lines.addGeometry( newLine.clone() );
-                // newLine now turns from a newLine before the split into a new newLine after the split
-                newLine = QgsLineString();
-                newLine.addVertex( *splitPoint );
-              }
-              newLine.addVertex( currentPoint );
+            newLine.addVertex( *splitPoint );
+            lines.addGeometry( newLine.clone() );
+            // newLine now turns from a newLine before the split into a new newLine after the split
+            newLine = QgsLineString();
+            newLine.addVertex( *splitPoint );
           }
-          newLine.addVertex( line->pointN( nVertices - 1 ) );
-          lines.addGeometry( newLine.clone() );
+          newLine.addVertex( currentPoint );
+        }
+        newLine.addVertex( line->pointN( nVertices - 1 ) );
+        lines.addGeometry( newLine.clone() );
       }
     }
   }

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -2320,6 +2320,29 @@ void TestQgsGeometry::splitGeometry()
   QVERIFY( QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 42.0, 100.0 42.0)" ) ).touches( QgsGeometry::fromPointXY( testPointsXY.at( 0 ) ) ) );
   QVERIFY( QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 42.0, 100.0 42.0)" ) ).touches( QgsGeometry::fromPointXY( testPointsXY.at( 1 ) ) ) );
 
+  //Test split parts for line by point split
+
+  testPointsXY.clear();
+  testPoints.clear();
+  newGeoms.clear();
+  g1 = QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 1.0, 1.0 100.0, 100.0 100.0, 100.0 1.0, 1.0 1.0)" ) );
+  QCOMPARE( g1.splitGeometry( QgsPointSequence() << QgsPoint( 1.0, 42.0 ), newGeoms, true, testPoints, false ), Qgis::GeometryOperationResult::Success );
+  QCOMPARE( newGeoms.count(), 2 );
+  QCOMPARE( testPoints.count(), 1 );
+  QgsGeometry::convertPointList( testPoints, testPointsXY );
+  QVERIFY( QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 42.0, 100.0 42.0)" ) ).touches( QgsGeometry::fromPointXY( testPointsXY.at( 0 ) ) ) );
+
+  testPointsXY.clear();
+  testPoints.clear();
+  newGeoms.clear();
+  g1 = QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 1.0, 2.0 2.0, 5.0 5.0, 6.0 6.0, 7.0 7.0)" ) );
+  QCOMPARE( g1.splitGeometry( QgsPointSequence() << QgsPoint( 3.0, 3.0 ), newGeoms, true, testPoints, false ), Qgis::GeometryOperationResult::Success );
+  QCOMPARE( newGeoms.count(), 2 );
+  QCOMPARE( testPoints.count(), 1 );
+  QgsGeometry::convertPointList( testPoints, testPointsXY );
+  QVERIFY( QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 1.0, 3.0 3.0)" ) ).touches( QgsGeometry::fromPointXY( testPointsXY.at( 0 ) ) ) );
+  //QVERIFY( QgsGeometry::fromWkt( QStringLiteral( "Linestring (1.0 42.0, 100.0 42.0)" ) ).touches( QgsGeometry::fromPointXY( testPointsXY.at( 1 ) ) ) );
+
   // Repeat previous tests with QVector<QgsPointXY> instead of QgsPointSequence
   // Those tests are for the deprecated QgsGeometry::splitGeometry() variant and should be removed in QGIS 4.0
   Q_NOWARN_DEPRECATED_PUSH

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -1296,7 +1296,7 @@ void TestQgsGeometryUtils::testPointOnSegment()
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 0, 2 ) ), false );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 2, 0 ) ), false );
 
-  //QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 0 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 0 ) ), true );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 4, 0 ) ), true );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( -1, 0 ) ), false );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 6, 0 ) ), false );

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -75,6 +75,7 @@ class TestQgsGeometryUtils: public QObject
     void testPointOnLineWithDistance();
     void testPointOnSegment();
     void interpolatePointOnArc();
+    void testSegmentSide();
     void testSegmentizeArcHalfCircle();
     void testSegmentizeArcHalfCircleOtherDirection();
     void testSegmentizeArcFullCircle();
@@ -1358,6 +1359,25 @@ void TestQgsGeometryUtils::interpolatePointOnArc()
   p = QgsGeometryUtils::interpolatePointOnArc( QgsPoint( 10, 0 ), QgsPoint( 8, 2 ), QgsPoint( 6, 0 ), 3.141592 * 3 );
   QGSCOMPARENEAR( p.x(), 8.0, 0.00001 );
   QGSCOMPARENEAR( p.y(), -2.0, 0.00001 );
+}
+
+void TestQgsGeometryUtils::testSegmentSide()
+{
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 3, 2 ) ), 1 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 0, 0 ) ), 0 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( -1, 2 ) ), -1 );
+
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( -3, -2 ) ), 1 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 0, 0 ) ), 0 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 3, 2 ) ), -1 );
+
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 0, 4 ) ), -1 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 3, 3 ) ), 0 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 4, 2 ) ), 1 );
+
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( -1, 1 ), QgsPoint( -5, 5 ), QgsPoint( -3, 2 ) ), -1 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( -1, 1 ), QgsPoint( -5, 5 ), QgsPoint( -4.4, 4.4 ) ), 0 );
+  QCOMPARE( QgsGeometryUtils::segmentSide( QgsPoint( -1, 1 ), QgsPoint( -5, 5 ), QgsPoint( 3, 2 ) ), 1 );
 }
 
 void TestQgsGeometryUtils::testSegmentizeArcHalfCircle()

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -73,6 +73,7 @@ class TestQgsGeometryUtils: public QObject
     void testInterpolatePointOnLine();
     void testInterpolatePointOnLineByValue();
     void testPointOnLineWithDistance();
+    void testPointOnSegment();
     void interpolatePointOnArc();
     void testSegmentizeArcHalfCircle();
     void testSegmentizeArcHalfCircleOtherDirection();
@@ -1282,6 +1283,31 @@ void TestQgsGeometryUtils::testPointOnLineWithDistance()
   QgsGeometryUtils::pointOnLineWithDistance( 0, 0, -10, -6, -10, x, y );
   QGSCOMPARENEAR( x, 8.57493, 0.0001 );
   QGSCOMPARENEAR( y, 5.14496, 0.0001 );
+
+}
+
+void TestQgsGeometryUtils::testPointOnSegment()
+{
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 2, 2 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 4, 4 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( -1, -1 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 11, 11 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 0, 2 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 2, 0 ) ), false );
+
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 0 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 4, 0 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( -1, 0 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 6, 0 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 0, 3 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 3 ) ), false );
+
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 0, 2 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 0, 4 ) ), true );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 0, -1 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 0, 6 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 3, 0 ) ), false );
+  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 0, 1 ), QgsPoint( 0, 5 ), QgsPoint( 3, 2 ) ), false );
 
 }
 

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -1295,7 +1295,7 @@ void TestQgsGeometryUtils::testPointOnSegment()
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 0, 2 ) ), false );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 1 ), QgsPoint( 5, 5 ), QgsPoint( 2, 0 ) ), false );
 
-  QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 0 ) ), true );
+  //QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2, 0 ) ), true );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 4, 0 ) ), true );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( -1, 0 ) ), false );
   QCOMPARE( QgsGeometryUtils::pointOnSegment( QgsPoint( 1, 0 ), QgsPoint( 5, 0 ), QgsPoint( 6, 0 ) ), false );


### PR DESCRIPTION
- **QgsGeometry::splitGeometry()** has been facilitated to split a line by a given point by extending **QgsGeos::linePointDifference()**
  - Unit tests have been added for relevant changes
  - Doxygen documentation has been extended
- **QgsGeometryUtils::segmentSide()** has been improved
  - Test cases have been added
  - Confusing  variable names in signature have been renamed for a clear understanding
  - Doxygen documentation has been updated
- The new helper function **QgsGeometryUtils::pointOnSegment()** has been introduced to test if a point is on a given segment. 
  - Doxygen documentation has been added
  - Test cases have been added