### PR TITLE
Relation editor widget get list of editing features

### DIFF
--- a/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractrelationeditorwidget.sip.in
@@ -144,6 +144,16 @@ If it's empty it takes the relation id as label
     QgsFeature feature() const;
 %Docstring
 Returns the widget's current feature
+If the widget is in multiedit mode only the first is returned
+
+.. seealso:: :py:func:`features`
+%End
+
+    QList<QgsFeature> features() const;
+%Docstring
+Returns the widget's current features
+
+.. versionadded:: 3.24
 %End
 
     bool forceSuppressFormPopup() const;

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -187,6 +187,11 @@ QgsFeature QgsAbstractRelationEditorWidget::feature() const
   return QgsFeature();
 }
 
+QList<QgsFeature> QgsAbstractRelationEditorWidget::features() const
+{
+
+}
+
 void QgsAbstractRelationEditorWidget::toggleEditing( bool state )
 {
   if ( state )

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -189,7 +189,7 @@ QgsFeature QgsAbstractRelationEditorWidget::feature() const
 
 QList<QgsFeature> QgsAbstractRelationEditorWidget::features() const
 {
-
+  return mFeatureList;
 }
 
 void QgsAbstractRelationEditorWidget::toggleEditing( bool state )

--- a/src/gui/qgsabstractrelationeditorwidget.h
+++ b/src/gui/qgsabstractrelationeditorwidget.h
@@ -153,8 +153,16 @@ class GUI_EXPORT QgsAbstractRelationEditorWidget : public QWidget
 
     /**
      * Returns the widget's current feature
+     * If the widget is in multiedit mode only the first is returned
+     * \see features
      */
     QgsFeature feature() const;
+
+    /**
+     * Returns the widget's current features
+     * \since QGIS 3.24
+     */
+    QList<QgsFeature> features() const;
 
     /**
        * Determines the force suppress form popup status that is configured for this widget


### PR DESCRIPTION
Get list of editing features. In multiedit mode they can be more than one.
This public method is necessary to have access to the features in plugins re-implementing QgsAbstracRelationEditorWidget