### PR TITLE
Don't show empty errors for xyz tiles

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -990,7 +990,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
 
       handler.downloadBlocking();
 
-      if ( feedback )
+      if ( feedback && !handler.error().isEmpty() )
         feedback->appendError( handler.error() );
     }
 


### PR DESCRIPTION
@vcloarec this is needed following your recent work -- right now loading any xyz layer shows a blank error in the messagebar