### PR TITLE
Move custom projections dialog to a tab in the main settings dialog

### DIFF
--- a/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -39,7 +39,16 @@ help will be retrieved.
 %End
 
 
+    virtual bool isValid();
+%Docstring
+Validates the current state of the widget.
 
+Subclasses should return ``True`` if the widget state is currently valid and acceptable to :py:func:`~QgsOptionsPageWidget.apply`.
+
+The default implementation returns ``True``.
+
+.. versionadded:: 3.24
+%End
 
   public slots:
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -26,7 +26,6 @@ set(QGIS_APP_SRCS
   qgsbookmarkeditordialog.cpp
   qgsclipboard.cpp
   qgscustomization.cpp
-  qgscustomprojectiondialog.cpp
   qgsdatumtransformtablewidget.cpp
   qgsdevtoolspanelwidget.cpp
   qgsdiscoverrelationsdialog.cpp
@@ -228,6 +227,7 @@ set(QGIS_APP_SRCS
 
   options/qgsadvancedoptions.cpp
   options/qgscodeeditoroptions.cpp
+  options/qgscustomprojectionoptions.cpp
   options/qgsgpsdeviceoptions.cpp
   options/qgsoptions.cpp
   options/qgsoptionsutils.cpp

--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -418,7 +418,7 @@ QString QgsCustomProjectionOptionsWidget::helpKey() const
 // QgsCustomProjectionOptionsFactory
 //
 QgsCustomProjectionOptionsFactory::QgsCustomProjectionOptionsFactory()
-  : QgsOptionsWidgetFactory( tr( "Custom Projections" ), QIcon() )
+  : QgsOptionsWidgetFactory( tr( "User Defined CRS" ), QIcon() )
 {
 
 }

--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          qgscustomprojectiondialog.cpp
+                          qgscustomprojectionoptions.cpp
 
                              -------------------
     begin                : 2005
@@ -16,43 +16,30 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgscustomprojectiondialog.h"
-
-//qgis includes
-#include "qgis.h" //<--magick numbers
-#include "qgisapp.h" //<--theme icons
+#include "qgscustomprojectionoptions.h"
 #include "qgsapplication.h"
-#include "qgslogger.h"
-#include "qgsprojectionselectiondialog.h"
-#include "qgssettings.h"
-#include "qgsgui.h"
 #include "qgscoordinatereferencesystemregistry.h"
 
-//qt includes
-#include <QFileInfo>
 #include <QMessageBox>
 #include <QLocale>
 #include <QRegularExpression>
+#include <QFileInfo>
 
-QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WindowFlags fl )
-  : QDialog( parent, fl )
+QgsCustomProjectionOptionsWidget::QgsCustomProjectionOptionsWidget( QWidget *parent )
+  : QgsOptionsPageWidget( parent )
 {
   setupUi( this );
-  QgsGui::enableAutoGeometryRestore( this );
+  setObjectName( QStringLiteral( "QgsCustomProjectionOptionsWidget" ) );
 
-  connect( pbnAdd, &QPushButton::clicked, this, &QgsCustomProjectionDialog::pbnAdd_clicked );
-  connect( pbnRemove, &QPushButton::clicked, this, &QgsCustomProjectionDialog::pbnRemove_clicked );
-  connect( leNameList, &QTreeWidget::currentItemChanged, this, &QgsCustomProjectionDialog::leNameList_currentItemChanged );
-  connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsCustomProjectionDialog::buttonBox_accepted );
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsCustomProjectionDialog::showHelp );
+  connect( pbnAdd, &QPushButton::clicked, this, &QgsCustomProjectionOptionsWidget::pbnAdd_clicked );
+  connect( pbnRemove, &QPushButton::clicked, this, &QgsCustomProjectionOptionsWidget::pbnRemove_clicked );
+  connect( leNameList, &QTreeWidget::currentItemChanged, this, &QgsCustomProjectionOptionsWidget::leNameList_currentItemChanged );
 
   leNameList->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
   // user database is created at QGIS startup in QgisApp::createDB
   // we just check whether there is our database [MD]
-  QFileInfo fileInfo;
-  fileInfo.setFile( QgsApplication::qgisSettingsDirPath() );
-  if ( !fileInfo.exists() )
+  if ( !QFileInfo::exists( QgsApplication::qgisSettingsDirPath() ) )
   {
     QgsDebugMsg( QStringLiteral( "The qgis.db does not exist" ) );
   }
@@ -72,7 +59,7 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::Windo
 
   QgsCoordinateReferenceSystem crs;
   Qgis::CrsDefinitionFormat format;
-  if ( mDefinitions[0].wkt.isEmpty() )
+  if ( mDefinitions.at( 0 ).wkt.isEmpty() )
   {
     crs.createFromProj( mDefinitions[0].proj );
     format = Qgis::CrsDefinitionFormat::Proj;
@@ -90,7 +77,7 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::Windo
 
   leNameList->hideColumn( QgisCrsIdColumn );
 
-  connect( leName, &QLineEdit::textChanged, this, &QgsCustomProjectionDialog::updateListFromCurrentItem );
+  connect( leName, &QLineEdit::textChanged, this, &QgsCustomProjectionOptionsWidget::updateListFromCurrentItem );
   connect( mCrsDefinitionWidget, &QgsCrsDefinitionWidget::crsChanged, this, [ = ]
   {
     if ( !mBlockUpdates )
@@ -98,7 +85,7 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::Windo
   } );
 }
 
-void QgsCustomProjectionDialog::populateList()
+void QgsCustomProjectionOptionsWidget::populateList()
 {
   const QList< QgsCoordinateReferenceSystemRegistry::UserCrsDetails > userCrsList = QgsApplication::coordinateReferenceSystemRegistry()->userCrsList();
 
@@ -136,7 +123,7 @@ void QgsCustomProjectionDialog::populateList()
   }
 }
 
-bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem crs, const QString &name, const QString &existingId, bool newEntry, Qgis::CrsDefinitionFormat format )
+bool QgsCustomProjectionOptionsWidget::saveCrs( const QgsCoordinateReferenceSystem &crs, const QString &name, const QString &existingId, bool newEntry, Qgis::CrsDefinitionFormat format )
 {
   QString id = existingId;
   if ( newEntry )
@@ -162,7 +149,7 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem crs, const
   return true;
 }
 
-void QgsCustomProjectionDialog::pbnAdd_clicked()
+void QgsCustomProjectionOptionsWidget::pbnAdd_clicked()
 {
   QString name = tr( "new CRS" );
 
@@ -183,7 +170,7 @@ void QgsCustomProjectionDialog::pbnAdd_clicked()
   mCrsDefinitionWidget->setFormat( Qgis::CrsDefinitionFormat::Wkt );
 }
 
-void QgsCustomProjectionDialog::pbnRemove_clicked()
+void QgsCustomProjectionOptionsWidget::pbnRemove_clicked()
 {
   const QModelIndexList selection = leNameList->selectionModel()->selectedRows();
   if ( selection.empty() )
@@ -218,7 +205,7 @@ void QgsCustomProjectionDialog::pbnRemove_clicked()
   }
 }
 
-void QgsCustomProjectionDialog::leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
+void QgsCustomProjectionOptionsWidget::leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
 {
   //Store the modifications made to the current element before moving on
   int currentIndex, previousIndex;
@@ -252,7 +239,7 @@ void QgsCustomProjectionDialog::leNameList_currentItemChanged( QTreeWidgetItem *
 
     mBlockUpdates++;
     mCrsDefinitionWidget->setDefinitionString( !mDefinitions[currentIndex].wkt.isEmpty() ? current->data( 0, FormattedWktRole ).toString() : mDefinitions[currentIndex].proj );
-    mCrsDefinitionWidget->setFormat( mDefinitions[currentIndex].wkt.isEmpty() ? Qgis::CrsDefinitionFormat::Proj : Qgis::CrsDefinitionFormat::Wkt );
+    mCrsDefinitionWidget->setFormat( mDefinitions.at( currentIndex ).wkt.isEmpty() ? Qgis::CrsDefinitionFormat::Proj : Qgis::CrsDefinitionFormat::Wkt );
     mBlockUpdates--;
   }
   else
@@ -267,11 +254,9 @@ void QgsCustomProjectionDialog::leNameList_currentItemChanged( QTreeWidgetItem *
   }
 }
 
-void QgsCustomProjectionDialog::buttonBox_accepted()
+bool QgsCustomProjectionOptionsWidget::isValid()
 {
   updateListFromCurrentItem();
-
-  QgsDebugMsgLevel( QStringLiteral( "We save the modified CRS." ), 4 );
 
   //Check if all CRS are valid:
   QgsCoordinateReferenceSystem crs;
@@ -296,7 +281,7 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
 
       QMessageBox::warning( this, tr( "Custom Coordinate Reference System" ),
                             tr( "The definition of '%1' is not valid." ).arg( def.name ) );
-      return;
+      return false;
     }
     else if ( !crs.authid().isEmpty() && !crs.authid().startsWith( QLatin1String( "USER" ), Qt::CaseInsensitive ) )
     {
@@ -334,12 +319,19 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
                                 tr( "Cannot save '%1' — the definition is equivalent to %2." ).arg( def.name, crs.authid() ) );
         }
       }
-      return;
+      return false;
     }
   }
+  return true;
+}
+
+void QgsCustomProjectionOptionsWidget::apply()
+{
+  // note that isValid() will have already been called prior to this, so we don't need to re-validate!
 
   //Modify the CRS changed:
   bool saveSuccess = true;
+  QgsCoordinateReferenceSystem crs;
   for ( const Definition &def : std::as_const( mDefinitions ) )
   {
     if ( !def.wkt.isEmpty() )
@@ -373,16 +365,12 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
     saveSuccess &= QgsApplication::coordinateReferenceSystemRegistry()->removeUserCrs( mDeletedCRSs[i].toLong() );
     if ( ! saveSuccess )
     {
-      QgsDebugMsg( QStringLiteral( "Error deleting CRS for '%1'" ).arg( mDefinitions[i].name ) );
+      QgsDebugMsg( QStringLiteral( "Error deleting CRS for '%1'" ).arg( mDefinitions.at( i ).name ) );
     }
-  }
-  if ( saveSuccess )
-  {
-    accept();
   }
 }
 
-void QgsCustomProjectionDialog::updateListFromCurrentItem()
+void QgsCustomProjectionOptionsWidget::updateListFromCurrentItem()
 {
   QTreeWidgetItem *item = leNameList->currentItem();
   if ( !item )
@@ -411,17 +399,42 @@ void QgsCustomProjectionDialog::updateListFromCurrentItem()
   item->setData( 0, FormattedWktRole, mCrsDefinitionWidget->definitionString() );
 }
 
-void QgsCustomProjectionDialog::showHelp()
-{
-  QgsHelp::openHelp( QStringLiteral( "working_with_projections/working_with_projections.html" ) );
-}
-
-QString QgsCustomProjectionDialog::multiLineWktToSingleLine( const QString &wkt )
+QString QgsCustomProjectionOptionsWidget::multiLineWktToSingleLine( const QString &wkt )
 {
   QString res = wkt;
   QRegularExpression re( QStringLiteral( "\\s*\\n\\s*" ) );
   re.setPatternOptions( QRegularExpression::MultilineOption );
   res.replace( re, QString() );
   return res;
+}
+
+QString QgsCustomProjectionOptionsWidget::helpKey() const
+{
+  return QStringLiteral( "working_with_projections/working_with_projections.html" );
+}
+
+
+//
+// QgsCustomProjectionOptionsFactory
+//
+QgsCustomProjectionOptionsFactory::QgsCustomProjectionOptionsFactory()
+  : QgsOptionsWidgetFactory( tr( "Custom Projections" ), QIcon() )
+{
+
+}
+
+QIcon QgsCustomProjectionOptionsFactory::icon() const
+{
+  return QgsApplication::getThemeIcon( QStringLiteral( "mActionCustomProjection.svg" ) );
+}
+
+QgsOptionsPageWidget *QgsCustomProjectionOptionsFactory::createWidget( QWidget *parent ) const
+{
+  return new QgsCustomProjectionOptionsWidget( parent );
+}
+
+QStringList QgsCustomProjectionOptionsFactory::path() const
+{
+  return {QStringLiteral( "crs_and_transforms" ) };
 }
 

--- a/src/app/options/qgscustomprojectionoptions.h
+++ b/src/app/options/qgscustomprojectionoptions.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          qgscustomprojectiondialog.h
+                          qgscustomprojectionoptions.h
 
                              -------------------
     begin                : 2005
@@ -15,10 +15,11 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSCUSTOMCRSDIALOG_H
-#define QGSCUSTOMCRSDIALOG_H
+#ifndef QGSCUSTOMPROJECTIONOPTIONS_H
+#define QGSCUSTOMPROJECTIONOPTIONS_H
 
 #include "ui_qgscustomprojectiondialogbase.h"
+#include "qgsoptionswidgetfactory.h"
 #include "qgshelp.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgis_app.h"
@@ -26,31 +27,33 @@
 class QDir;
 
 /**
- * The custom projection widget is used to define the projection family, ellipsoid and parameters needed by proj4 to assemble a customized projection definition.
+ * \ingroup app
+ * \class QgsCustomProjectionOptionsWidget
+ * \brief The custom projection widget is used to define the projection family, ellipsoid and parameters needed by proj to assemble a customized projection definition.
  *
  * The resulting projection will be stored in an sqlite backend.
-*/
-class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCustomProjectionDialogBase
+ */
+class QgsCustomProjectionOptionsWidget: public QgsOptionsPageWidget, private Ui::QgsCustomProjectionWidgetBase
 {
     Q_OBJECT
   public:
-    QgsCustomProjectionDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
+    QgsCustomProjectionOptionsWidget( QWidget *parent = nullptr );
 
-  public slots:
+    QString helpKey() const override;
+    bool isValid() override;
+    void apply() override;
+
+  private slots:
     void pbnAdd_clicked();
     void pbnRemove_clicked();
     void leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
-    void buttonBox_accepted();
-
-  private slots:
-
     void updateListFromCurrentItem();
+
   private:
 
     //helper functions
     void populateList();
-    bool saveCrs( QgsCoordinateReferenceSystem crs, const QString &name, const QString &id, bool newEntry, Qgis::CrsDefinitionFormat format );
-    void showHelp();
+    bool saveCrs( const QgsCoordinateReferenceSystem &crs, const QString &name, const QString &id, bool newEntry, Qgis::CrsDefinitionFormat format );
     QString multiLineWktToSingleLine( const QString &wkt );
 
     //These two QMap store the values as they are on the database when loading
@@ -81,8 +84,22 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
 
     int mBlockUpdates = 0;
 
+};
+
+
+class QgsCustomProjectionOptionsFactory : public QgsOptionsWidgetFactory
+{
+    Q_OBJECT
+
+  public:
+
+    QgsCustomProjectionOptionsFactory();
+
+    QIcon icon() const override;
+    QgsOptionsPageWidget *createWidget( QWidget *parent = nullptr ) const override;
+    QStringList path() const override;
 
 };
 
 
-#endif
+#endif // QGSCUSTOMPROJECTIONOPTIONS_H

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -113,7 +113,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   crsGroup->setData( QStringLiteral( "crs_and_transforms" ) );
   crsGroup->setToolTip( tr( "CRS and Transforms" ) );
   crsGroup->setSelectable( false );
-  crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );
+  crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "CRS Handling" ), QCoreApplication::translate( "QgsOptionsBase", "General CRS handling" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );
   crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QCoreApplication::translate( "QgsOptionsBase", "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
   mTreeModel->appendRow( crsGroup );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -114,7 +114,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   crsGroup->setToolTip( tr( "CRS and Transforms" ) );
   crsGroup->setSelectable( false );
   crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "CRS Handling" ), QCoreApplication::translate( "QgsOptionsBase", "General CRS handling" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );
-  crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QCoreApplication::translate( "QgsOptionsBase", "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
+  crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "Coordinate Transforms" ), QCoreApplication::translate( "QgsOptionsBase", "Coordinate transformations and operations" ), QStringLiteral( "transformation.svg" ) ) );
   mTreeModel->appendRow( crsGroup );
 
   QStandardItem *dataSources = createItem( QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QCoreApplication::translate( "QgsOptionsBase", "Data sources" ), QStringLiteral( "propertyicons/attributes.svg" ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -110,6 +110,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mTreeModel->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "System" ), QCoreApplication::translate( "QgsOptionsBase", "System" ), QStringLiteral( "propertyicons/system.svg" ) ) );
 
   QStandardItem *crsGroup = new QStandardItem( QCoreApplication::translate( "QgsOptionsBase", "CRS and Transforms" ) );
+  crsGroup->setData( QStringLiteral( "crs_and_transforms" ) );
   crsGroup->setToolTip( tr( "CRS and Transforms" ) );
   crsGroup->setSelectable( false );
   crsGroup->appendRow( createItem( QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "propertyicons/CRS.svg" ) ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -175,7 +175,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
     for ( QgsOptionsPageWidget *widget : std::as_const( mAdditionalOptionWidgets ) )
     {
       if ( !widget->isValid() )
+      {
+        setCurrentPage( widget->objectName() );
         return;
+      }
     }
     accept();
   } );
@@ -1547,7 +1550,10 @@ void QgsOptions::saveOptions()
   for ( QgsOptionsPageWidget *widget : std::as_const( mAdditionalOptionWidgets ) )
   {
     if ( !widget->isValid() )
+    {
+      setCurrentPage( widget->objectName() );
       return;
+    }
   }
 
   QgsSettings settings;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13145,7 +13145,7 @@ QMap<QString, QString> QgisApp::optionsPagesMap()
   {
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "General" ), QStringLiteral( "mOptionsPageGeneral" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "System" ), QStringLiteral( "mOptionsPageSystem" ) );
-    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "CRS" ), QStringLiteral( "mOptionsPageCRS" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "CRS Handling" ), QStringLiteral( "mOptionsPageCRS" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QStringLiteral( "mOptionsPageTransformations" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QStringLiteral( "mOptionsPageDataSources" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -114,6 +114,7 @@
 
 #include "options/qgscodeeditoroptions.h"
 #include "options/qgsgpsdeviceoptions.h"
+#include "options/qgscustomprojectionoptions.h"
 
 #ifdef HAVE_3D
 #include "qgs3d.h"
@@ -215,7 +216,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgscustomprojectopenhandler.h"
 #include "qgscustomization.h"
 #include "qgscustomlayerorderwidget.h"
-#include "qgscustomprojectiondialog.h"
 #include "qgsdataitemproviderregistry.h"
 #include "qgsdataitemguiproviderregistry.h"
 #include "qgsdatasourceuri.h"
@@ -1817,6 +1817,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
 
   mCodeEditorWidgetFactory.reset( std::make_unique< QgsCodeEditorOptionsFactory >() );
   mBabelGpsDevicesWidgetFactory.reset( std::make_unique< QgsGpsDeviceOptionsFactory >() );
+  mCustomProjectionsWidgetFactory.reset( std::make_unique< QgsCustomProjectionOptionsFactory >() );
 
 #ifdef HAVE_3D
   m3DOptionsWidgetFactory.reset( std::make_unique< Qgs3DOptionsFactory >() );
@@ -16584,11 +16585,7 @@ void QgisApp::mapCanvas_keyPressed( QKeyEvent *e )
 
 void QgisApp::customProjection()
 {
-  // Create an instance of the Custom Projection Designer modeless dialog.
-  // Autodelete the dialog when closing since a pointer is not retained.
-  QgsCustomProjectionDialog *myDialog = new QgsCustomProjectionDialog( this );
-  myDialog->setAttribute( Qt::WA_DeleteOnClose );
-  myDialog->show();
+  showOptionsDialog( this, QStringLiteral( "QgsCustomProjectionOptionsWidget" ) );
 }
 
 void QgisApp::newBookmark( bool inProject )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13146,7 +13146,7 @@ QMap<QString, QString> QgisApp::optionsPagesMap()
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "General" ), QStringLiteral( "mOptionsPageGeneral" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "System" ), QStringLiteral( "mOptionsPageSystem" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "CRS Handling" ), QStringLiteral( "mOptionsPageCRS" ) );
-    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Transformations" ), QStringLiteral( "mOptionsPageTransformations" ) );
+    sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Coordinate Transforms" ), QStringLiteral( "mOptionsPageTransformations" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Data Sources" ), QStringLiteral( "mOptionsPageDataSources" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "GDAL" ), QStringLiteral( "mOptionsPageGDAL" ) );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Rendering" ), QStringLiteral( "mOptionsPageRendering" ) );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2753,6 +2753,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsScopedOptionsWidgetFactory mCodeEditorWidgetFactory;
     QgsScopedOptionsWidgetFactory mBabelGpsDevicesWidgetFactory;
     QgsScopedOptionsWidgetFactory m3DOptionsWidgetFactory;
+    QgsScopedOptionsWidgetFactory mCustomProjectionsWidgetFactory;
 
     QMap< QString, QToolButton * > mAnnotationItemGroupToolButtons;
     QAction *mAnnotationsItemInsertBefore = nullptr; // Used to insert annotation items at the appropriate location in the annotations toolbar

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -52,13 +52,22 @@ class GUI_EXPORT QgsOptionsPageWidget : public QWidget
      */
     virtual QString helpKey() const { return QString(); }
 
-
     /**
      * Returns the registered highlight widgets used to search and highlight text in
      * options dialogs.
      */
     QHash<QWidget *, QgsOptionsDialogHighlightWidget *> registeredHighlightWidgets() {return mHighlightWidgets;} SIP_SKIP
 
+    /**
+     * Validates the current state of the widget.
+     *
+     * Subclasses should return TRUE if the widget state is currently valid and acceptable to apply().
+     *
+     * The default implementation returns TRUE.
+     *
+     * \since QGIS 3.24
+     */
+    virtual bool isValid() { return true; }
 
   public slots:
 

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QgsCustomProjectionDialogBase</class>
- <widget class="QDialog" name="QgsCustomProjectionDialogBase">
+ <class>QgsCustomProjectionWidgetBase</class>
+ <widget class="QWidget" name="QgsCustomProjectionWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -19,24 +19,17 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <property name="leftMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="focusPolicy">
@@ -53,11 +46,20 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>536</width>
-        <height>611</height>
+        <width>542</width>
+        <height>650</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item row="2" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
@@ -194,22 +196,5 @@
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsCustomProjectionDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>270</x>
-     <y>590</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>270</x>
-     <y>306</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
Avoids an isolated settings dialog and helps consolidate all settings in the one place.

For now the top-level Custom Projections menu action remains and just opens the options dialog at the corresponding page, but in a few releases time (or in 4.0) we could safely remove this.

![image](https://user-images.githubusercontent.com/1829991/149445437-d4bebbf3-f242-4a66-8b45-6e67ce8f635a.png)
