### PR TITLE
manual backport fixes in MDAL 0.9.2 to 3.22

### DIFF
--- a/external/mdal/frmts/mdal_cf.cpp
+++ b/external/mdal/frmts/mdal_cf.cpp
@@ -527,6 +527,7 @@ void MDAL::DriverCF::setProjection( MDAL::Mesh *mesh )
       }
       else
       {
+        wkt = MDAL::replace( wkt, "\n", "" );
         mesh->setSourceCrsFromWKT( wkt );
       }
     }

--- a/external/mdal/frmts/mdal_flo2d.cpp
+++ b/external/mdal/frmts/mdal_flo2d.cpp
@@ -996,7 +996,7 @@ MDAL::DriverFlo2D::DriverFlo2D()
   : Driver(
       "FLO2D",
       "Flo2D",
-      "*.nc;;*.DAT",
+      "*.nc;;*.DAT;;*.OUT",
       Capability::ReadMesh | Capability::ReadDatasets | Capability::WriteDatasetsOnFaces )
 {
 

--- a/external/mdal/frmts/mdal_netcdf.cpp
+++ b/external/mdal/frmts/mdal_netcdf.cpp
@@ -180,12 +180,14 @@ std::vector<double> NetCDFFile::readDoubleArr( int arr_id,
   std::vector<double> arr_val( count_dim );
 
   nc_type typep;
-  if ( nc_inq_vartype( mNcid, arr_id, &typep ) != NC_NOERR ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
+  if ( nc_inq_vartype( mNcid, arr_id, &typep ) != NC_NOERR )
+    throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
 
   if ( typep == NC_FLOAT )
   {
     std::vector<float> arr_val_f( count_dim );
-    if ( nc_get_vars_float( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val_f.data() ) != NC_NOERR ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
+    if ( nc_get_vars_float( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val_f.data() ) != NC_NOERR )
+      throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
     for ( size_t i = 0; i < count_dim; ++i )
     {
       const float val = arr_val_f[i];
@@ -195,9 +197,20 @@ std::vector<double> NetCDFFile::readDoubleArr( int arr_id,
         arr_val[i] = static_cast<double>( val );
     }
   }
+  else if ( typep == NC_INT )
+  {
+    std::vector<int> arr_val_int( count_dim );
+    if ( nc_get_vars_int( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val_int.data() ) != NC_NOERR )
+      throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
+    for ( size_t i = 0; i < count_dim; ++i )
+    {
+      arr_val[i] = static_cast<double>( arr_val_int[i] );
+    }
+  }
   else if ( typep == NC_DOUBLE )
   {
-    if ( nc_get_vars_double( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val.data() ) != NC_NOERR ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
+    if ( nc_get_vars_double( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val.data() ) != NC_NOERR )
+      throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Could not read double array" );
   }
   else
   {

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -21,7 +21,7 @@ static const char *EMPTY_STR = "";
 
 const char *MDAL_Version()
 {
-  return "0.9.1";
+  return "0.9.2";
 }
 
 MDAL_Status MDAL_LastStatus()


### PR DESCRIPTION
Manual backport fixes  of MDAL 0.9.2.
Not sure it is the good way to manual backport, but as CI of master seems broken for now and release time of 3.22 is coming.