### PR TITLE
[bugfix] force full GCP number display

### DIFF
--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -43,7 +43,8 @@ class QgsStandardItem : public QStandardItem
     {
       setData( QVariant( value ), Qt::UserRole );
       //show the full precision when editing points
-      setData( QVariant( value ), Qt::EditRole );
+      int prec = abs( value ) < 360 ? 8 : 2;
+      setData( QVariant( QString::number( value, 'f', prec ) ), Qt::EditRole );
       setData( QVariant( value ), Qt::ToolTipRole );
       setTextAlignment( Qt::AlignRight );
     }


### PR DESCRIPTION
## Description
proposal to fix #46835

This converts the gcp value to a formatted text instead of letting QT do it. I chose to display 8 decimal values when the number is probably in geographic coords and only two when working with projected coords. This should provide enough precision in most instances. Maybe 8 is too much and should be set to 6 or 7...

The edit value is used to simply display it and when editing, the other two values set in that function seem unused.

Edit:
and fix #32960