### PR TITLE
[processing] Improve summary text for multi enum/field widgets

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2475,8 +2475,40 @@ void QgsProcessingEnumPanelWidget::showDialog()
 
 void QgsProcessingEnumPanelWidget::updateSummaryText()
 {
-  if ( mParam )
-    mLineEdit->setText( tr( "%1 options selected" ).arg( mValue.count() ) );
+  if ( !mParam )
+    return;
+
+  if ( mValue.empty() )
+  {
+    mLineEdit->setText( tr( "%1 options selected" ).arg( 0 ) );
+  }
+  else
+  {
+    QStringList values;
+    values.reserve( mValue.size() );
+    if ( mParam->usesStaticStrings() )
+    {
+      for ( const QVariant &val : std::as_const( mValue ) )
+      {
+        values << val.toString();
+      }
+    }
+    else
+    {
+      const QStringList options = mParam->options();
+      for ( const QVariant &val : std::as_const( mValue ) )
+      {
+        const int i = val.toInt();
+        values << ( options.size() > i ? options.at( i ) : QString() );
+      }
+    }
+
+    const QString concatenated = values.join( tr( "," ) );
+    if ( concatenated.length() < 100 )
+      mLineEdit->setText( concatenated );
+    else
+      mLineEdit->setText( tr( "%1 options selected" ).arg( mValue.count() ) );
+  }
 }
 
 
@@ -4058,7 +4090,7 @@ QgsProcessingFieldPanelWidget::QgsProcessingFieldPanelWidget( QWidget *parent, c
 
   if ( mParam )
   {
-    mLineEdit->setText( tr( "%1 options selected" ).arg( 0 ) );
+    mLineEdit->setText( tr( "%1 fields selected" ).arg( 0 ) );
   }
 
   connect( mToolButton, &QToolButton::clicked, this, &QgsProcessingFieldPanelWidget::showDialog );
@@ -4125,8 +4157,28 @@ void QgsProcessingFieldPanelWidget::showDialog()
 
 void QgsProcessingFieldPanelWidget::updateSummaryText()
 {
-  if ( mParam )
-    mLineEdit->setText( tr( "%1 options selected" ).arg( mValue.count() ) );
+  if ( !mParam )
+    return;
+
+  if ( mValue.empty() )
+  {
+    mLineEdit->setText( tr( "%1 fields selected" ).arg( 0 ) );
+  }
+  else
+  {
+    QStringList values;
+    values.reserve( mValue.size() );
+    for ( const QVariant &val : std::as_const( mValue ) )
+    {
+      values << val.toString();
+    }
+
+    const QString concatenated = values.join( tr( "," ) );
+    if ( concatenated.length() < 100 )
+      mLineEdit->setText( concatenated );
+    else
+      mLineEdit->setText( tr( "%1 fields selected" ).arg( mValue.count() ) );
+  }
 }
 
 

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -2956,21 +2956,21 @@ void TestProcessingGui::testFieldSelectionPanel()
   QgsProcessingFieldPanelWidget w( nullptr, &fieldParam );
   QSignalSpy spy( &w, &QgsProcessingFieldPanelWidget::changed );
 
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "0 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "0 fields selected" ) );
   w.setValue( QStringLiteral( "aa" ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( w.value().toList(), QVariantList() << QStringLiteral( "aa" ) );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "1 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "aa" ) );
 
   w.setValue( QVariantList() << QStringLiteral( "bb" ) << QStringLiteral( "aa" ) );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( w.value().toList(), QVariantList() << QStringLiteral( "bb" ) << QStringLiteral( "aa" ) );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "2 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "bb,aa" ) );
 
   w.setValue( QVariant() );
   QCOMPARE( spy.count(), 3 );
   QCOMPARE( w.value().toList(), QVariantList() );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "0 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "0 fields selected" ) );
 
 }
 
@@ -4125,12 +4125,12 @@ void TestProcessingGui::testEnumSelectionPanel()
   w.setValue( 1 );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( w.value().toList(), QVariantList() << 1 );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "1 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "b" ) );
 
   w.setValue( QVariantList() << 2 << 0 );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( w.value().toList(), QVariantList() << 2 << 0 );
-  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "2 options selected" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "c,a" ) );
 
   w.setValue( QVariant() );
   QCOMPARE( spy.count(), 3 );
@@ -4146,12 +4146,12 @@ void TestProcessingGui::testEnumSelectionPanel()
   w2.setValue( QStringLiteral( "a" ) );
   QCOMPARE( spy2.count(), 1 );
   QCOMPARE( w2.value().toList(), QVariantList() << QStringLiteral( "a" ) );
-  QCOMPARE( w2.mLineEdit->text(), QStringLiteral( "1 options selected" ) );
+  QCOMPARE( w2.mLineEdit->text(), QStringLiteral( "a" ) );
 
   w2.setValue( QVariantList() << QStringLiteral( "c" ) << QStringLiteral( "a" ) );
   QCOMPARE( spy2.count(), 2 );
   QCOMPARE( w2.value().toList(), QVariantList() << QStringLiteral( "c" ) << QStringLiteral( "a" ) );
-  QCOMPARE( w2.mLineEdit->text(), QStringLiteral( "2 options selected" ) );
+  QCOMPARE( w2.mLineEdit->text(), QStringLiteral( "c,a" ) );
 
   w2.setValue( QVariant() );
   QCOMPARE( spy2.count(), 3 );


### PR DESCRIPTION
Instead of just saying "n Options Selected", we now explicitly list the selected options/fields in the main widget. (Unless
there's a large number of selected options, in which case we fallback to the 'n Options Selected' string)
