### PR TITLE
[console] Use a more modern approach to running script files

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -462,8 +462,8 @@ class Editor(QgsCodeEditorPython):
                 tmpFile = self.createTempFile()
                 filename = tmpFile
 
-            self.parent.pc.shell.runCommand("exec(open('{0}'.encode('{1}')).read())"
-                                            .format(filename.replace("\\", "/"), sys.getfilesystemencoding()))
+            self.parent.pc.shell.runCommand("exec(Path('{0}').read_text())"
+                                            .format(filename.replace("\\", "/")))
 
     def runSelectedCode(self):  # spellok
         cmd = self.selectedText()

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -40,7 +40,7 @@ from qgis.gui import QgsCodeEditor
 
 from .ui_console_history_dlg import Ui_HistoryDialogPythonConsole
 
-_init_commands = ["import sys", "import os", "import re", "import math", "from qgis.core import *",
+_init_commands = ["import sys", "import os", "from pathlib import Path", "import re", "import math", "from qgis.core import *",
                   "from qgis.gui import *", "from qgis.analysis import *", "from qgis._3d import *",
                   "import processing", "import qgis.utils",
                   "from qgis.utils import iface", "from qgis.PyQt.QtCore import *", "from qgis.PyQt.QtGui import *",


### PR DESCRIPTION
to avoid 'unclosed file' warnings dumped whenever script files are run through the Python console
