### PR TITLE
Fix Qt5Core.so error in Singularity containers

### DIFF
--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -59,6 +59,9 @@ RUN SUCCESS=OK \
 # Additional run-time dependencies
 RUN pip3 install jinja2 pygments pexpect && apt install -y expect
 
+# Fix a Qt library bug that prevents Singularity containers from running
+RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
+
 ################################################################################
 # Python testing environment setup
 


### PR DESCRIPTION
## Description

Hopefully fixes #46841 with bizarre error when converting QGIS docker image into a Singularity container.

Sorry, I do not have suitable Docker infrastructure to test the build.
