### PR TITLE
[arcgis rest] Try to retrieve detailed error messages from network replies when an error occurs

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -161,6 +161,16 @@ QByteArray QgsArcGisRestQueryUtils::queryService( const QUrl &u, const QString &
     QgsDebugMsg( QStringLiteral( "Network error: %1" ).arg( networkRequest.errorMessage() ) );
     errorTitle = QStringLiteral( "Network error" );
     errorText = networkRequest.errorMessage();
+
+    // try to get detailed error message from reply
+    const QString content = networkRequest.reply().content();
+    const thread_local QRegularExpression errorRx( QStringLiteral( "Error: <.*?>(.*?)<" ) );
+    const QRegularExpressionMatch match = errorRx.match( content );
+    if ( match.hasMatch() )
+    {
+      errorText = match.captured( 1 );
+    }
+
     return QByteArray();
   }
 


### PR DESCRIPTION
When these occur, the http error string is set to a very generic "error
occurred" message, while the reply content contains a user-useful
error explanation in html format. So we do a very simple attempt to parse
the better error message from the reply and if successful, use that
instead of the generic one.
