### PR TITLE
[mssql] Fix detection of primary key, likely other issues too

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -491,6 +491,7 @@ void QgsMssqlProvider::loadFields()
   if ( mPrimaryKeyAttrs.isEmpty() )
   {
     query.clear();
+    query.setForwardOnly( true );
     if ( !query.exec( QStringLiteral( "exec sp_pkeys @table_name = N%1, @table_owner = %2 " ).arg( quotedValue( mTableName ), quotedValue( mSchemaName ) ) ) )
     {
       QgsDebugMsg( QStringLiteral( "SQL:%1\n  Error:%2" ).arg( query.lastQuery(), query.lastError().text() ) );
@@ -528,6 +529,7 @@ void QgsMssqlProvider::loadFields()
     for ( const QString &pk : constPkCandidates )
     {
       query.clear();
+      query.setForwardOnly( true );
       if ( !query.exec( QStringLiteral( "select count(distinct [%1]), count([%1]) from [%2].[%3]" )
                         .arg( pk, mSchemaName, mTableName ) ) )
       {
@@ -1869,6 +1871,7 @@ QgsCoordinateReferenceSystem QgsMssqlProvider::crs() const
       query.finish();
     }
     query.clear();
+    query.setForwardOnly( true );
 
     // Look in the system reference table for the data if we can't find it yet
     execOk = query.exec( QStringLiteral( "SELECT well_known_text FROM sys.spatial_reference_systems WHERE spatial_reference_id=%1" ).arg( mSRId ) );
@@ -2484,6 +2487,7 @@ bool QgsMssqlProviderMetadata::saveStyle( const QString &uri,
     }
     query.finish();
     query.clear();
+    query.setForwardOnly( true );
   }
 
   QString uiFileColumn;

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -593,6 +593,7 @@ void QgsMssqlSourceSelect::setConnectionListPosition()
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
   }
+  cmbConnections_activated( cmbConnections->currentIndex() );
 }
 
 void QgsMssqlSourceSelect::setSearchExpression( const QString &regexp )


### PR DESCRIPTION
Calling QSqlQuery::clear() also resets the QSqlQuery::setForwardOnly flag, so we need to ensure that we set this after every time
we clear the query.

Note that there is already tests in place for this which are currently failing (prior to this fix). We don't run SQL server tests on CI, which is how this issue has slipped in...