### PR TITLE
Workaround broken inactive window coloring applies incorrectly to list/tree/dock widgets in the active window (3.22 backport)

### DIFF
--- a/src/gui/qgsproxystyle.cpp
+++ b/src/gui/qgsproxystyle.cpp
@@ -89,21 +89,24 @@ QPixmap QgsAppStyle::generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &p
 void QgsAppStyle::polish( QWidget *widget )
 {
   QProxyStyle::polish( widget );
-
 #if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
-  // fix broken inactive window coloring applying to unfocused docks or list/tree widgets
-  // see eg https://github.com/FedoraQt/adwaita-qt/issues/126
-  // the detection used by themes to determine if a widget belongs to an activated window is fragile, which
-  // results in unfocused list/tree views or widget children being shown in the "deactivated window" palette coloring.
-  // Gnome (adwaita) defaults to a coloring which makes widgets looks disabled in this inactive state.
-  // So the best we can do here is force disable the inactive palette coloring to prevent this unwanted behavior.
-  QPalette pal = widget->palette();
-  pal.setColor( QPalette::Inactive, QPalette::Text, pal.color( QPalette::Active, QPalette::Text ) );
-  pal.setColor( QPalette::Inactive, QPalette::Window, pal.color( QPalette::Active, QPalette::Window ) );
-  pal.setColor( QPalette::Inactive, QPalette::WindowText, pal.color( QPalette::Active, QPalette::WindowText ) );
-  pal.setColor( QPalette::Inactive, QPalette::Button, pal.color( QPalette::Active, QPalette::Button ) );
-  pal.setColor( QPalette::Inactive, QPalette::ButtonText, pal.color( QPalette::Active, QPalette::ButtonText ) );
-  widget->setPalette( pal );
+  if ( mBaseStyle.contains( QLatin1String( "fusion" ), Qt::CaseInsensitive )
+       || mBaseStyle.contains( QLatin1String( "adwaita" ), Qt::CaseInsensitive ) )
+  {
+    // fix broken inactive window coloring applying to unfocused docks or list/tree widgets
+    // see eg https://github.com/FedoraQt/adwaita-qt/issues/126
+    // the detection used by themes to determine if a widget belongs to an activated window is fragile, which
+    // results in unfocused list/tree views or widget children being shown in the "deactivated window" palette coloring.
+    // Gnome (adwaita) defaults to a coloring which makes widgets looks disabled in this inactive state.
+    // So the best we can do here is force disable the inactive palette coloring to prevent this unwanted behavior.
+    QPalette pal = widget->palette();
+    pal.setColor( QPalette::Inactive, QPalette::Text, pal.color( QPalette::Active, QPalette::Text ) );
+    pal.setColor( QPalette::Inactive, QPalette::Window, pal.color( QPalette::Active, QPalette::Window ) );
+    pal.setColor( QPalette::Inactive, QPalette::WindowText, pal.color( QPalette::Active, QPalette::WindowText ) );
+    pal.setColor( QPalette::Inactive, QPalette::Button, pal.color( QPalette::Active, QPalette::Button ) );
+    pal.setColor( QPalette::Inactive, QPalette::ButtonText, pal.color( QPalette::Active, QPalette::ButtonText ) );
+    widget->setPalette( pal );
+  }
 #endif
 }
 

--- a/src/gui/qgsproxystyle.h
+++ b/src/gui/qgsproxystyle.h
@@ -56,6 +56,7 @@ class GUI_EXPORT QgsAppStyle : public QProxyStyle
 
     explicit QgsAppStyle( const QString &base );
     QPixmap generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt ) const override;
+    void polish( QWidget *widget ) override;
 
     QString baseStyle() const { return mBaseStyle; }
 


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/46847