### PR TITLE
Handle camera movement when the clicked position is void

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -674,7 +674,7 @@ QVector2D Qgs3DUtils::textureToScreenCoordinates( QVector2D textureXY, QSize win
   return QVector2D( textureXY.x() * winSize.width(), ( 1 - textureXY.y() ) * winSize.height() );
 }
 
-double Qgs3DUtils::decodeDepth( const QColor &pixel )
+double Qgs3DUtils::decodeDepth( const QRgb &pixel )
 {
-  return pixel.redF() / 255.0 / 255.0 + pixel.greenF() / 255.0 + pixel.blueF();
+  return ( ( qRed( pixel ) / 255.0 + qGreen( pixel ) ) / 255.0 + qBlue( pixel ) ) / 255.0;
 }

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -673,8 +673,3 @@ QVector2D Qgs3DUtils::textureToScreenCoordinates( QVector2D textureXY, QSize win
 {
   return QVector2D( textureXY.x() * winSize.width(), ( 1 - textureXY.y() ) * winSize.height() );
 }
-
-double Qgs3DUtils::decodeDepth( const QRgb &pixel )
-{
-  return ( ( qRed( pixel ) / 255.0 + qGreen( pixel ) ) / 255.0 + qBlue( pixel ) ) / 255.0;
-}

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -225,7 +225,10 @@ class _3D_EXPORT Qgs3DUtils
      *
      * \since QGIS 3.24
      */
-    static inline double decodeDepth( const QRgb &pixel );
+    static double decodeDepth( const QRgb &pixel )
+    {
+      return ( ( qRed( pixel ) / 255.0 + qGreen( pixel ) ) / 255.0 + qBlue( pixel ) ) / 255.0;
+    }
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -225,7 +225,7 @@ class _3D_EXPORT Qgs3DUtils
      *
      * \since QGIS 3.24
      */
-    static inline double decodeDepth( const QColor &pixel );
+    static inline double decodeDepth( const QRgb &pixel );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -225,7 +225,7 @@ class _3D_EXPORT Qgs3DUtils
      *
      * \since QGIS 3.24
      */
-    static double decodeDepth( const QColor &pixel );
+    static inline double decodeDepth( const QColor &pixel );
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -334,7 +334,6 @@ double QgsCameraController::sampleDepthBuffer( const QImage &buffer, int px, int
   {
     for ( int y = 0; y < mDepthBufferImage.height(); ++y )
     {
-      const QRgb &pixel = buffer.pixel( x, y );
       double d = Qgs3DUtils::decodeDepth( buffer.pixel( x, y ) );
       if ( d < 1 )
       {

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -395,9 +395,20 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
 
     if ( !mRotationCenterCalculated )
     {
-      double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mMiddleButtonClickPos.x(), mMiddleButtonClickPos.y() ) );
+      double depth = 1;
+
+      // Sample the neighbouring pixels for the closest point to the camera
+      for ( int x = std::max( mMiddleButtonClickPos.x() - 3, 0 ); x <= std::max( mMiddleButtonClickPos.x() + 3, mDepthBufferImage.width() ); ++x )
+      {
+        for ( int y = std::max( mMiddleButtonClickPos.y() - 3, 0 ); y <= std::min( mMiddleButtonClickPos.y() + 3, mDepthBufferImage.height() ); ++y )
+        {
+          depth = std::min( depth, Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mMiddleButtonClickPos.x(), mMiddleButtonClickPos.y() ) ) );
+        }
+      }
+
+      // If the user clicks on a void area anyway, use closer point of rotation istead of the far plane
       if ( depth >= 1 )
-        return;
+        depth = 0.5;
 
       mRotationCenter = Qgs3DUtils::screenPointToWorldPos( mMiddleButtonClickPos, depth, mViewport.size(), mCameraBeforeRotation.get() );
 
@@ -455,8 +466,6 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( !mDragPointCalculated )
     {
       mDragDepth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mDragButtonClickPos.x(), mDragButtonClickPos.y() ) );
-      if ( mDragDepth >= 1 )
-        return;
 
       mDragPoint = Qgs3DUtils::screenPointToWorldPos( mDragButtonClickPos, mDragDepth, mViewport.size(), mCameraBeforeDrag.get() );
       mDragPointCalculated = true;
@@ -500,8 +509,6 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( !mDragPointCalculated )
     {
       double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mDragButtonClickPos.x(), mDragButtonClickPos.y() ) );
-      if ( depth >= 1 )
-        return;
 
       mDragPoint = Qgs3DUtils::screenPointToWorldPos( mDragButtonClickPos, depth, mViewport.size(), mCameraBeforeDrag.get() );
       mDragPointCalculated = true;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -319,7 +319,7 @@ double QgsCameraController::sampleDepthBuffer( const QImage &buffer, int px, int
     {
       if ( buffer.valid( x, y ) )
       {
-        depth = std::min( depth, Qgs3DUtils::decodeDepth( buffer.pixelColor( x, y ) ) );
+        depth = std::min( depth, Qgs3DUtils::decodeDepth( buffer.pixel( x, y ) ) );
       }
     }
   }
@@ -335,7 +335,7 @@ double QgsCameraController::sampleDepthBuffer( const QImage &buffer, int px, int
     for ( int y = 0; y < mDepthBufferImage.height(); ++y )
     {
       const QRgb &pixel = buffer.pixel( x, y );
-      double d = ( ( qRed( pixel ) / 255.0 + qGreen( pixel ) ) / 255.0 + qBlue( pixel ) ) / 255.0;
+      double d = Qgs3DUtils::decodeDepth( buffer.pixel( x, y ) );
       if ( d < 1 )
       {
         depth += d;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -396,6 +396,8 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( !mRotationCenterCalculated )
     {
       double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mMiddleButtonClickPos.x(), mMiddleButtonClickPos.y() ) );
+      if ( depth >= 1 )
+        return;
 
       mRotationCenter = Qgs3DUtils::screenPointToWorldPos( mMiddleButtonClickPos, depth, mViewport.size(), mCameraBeforeRotation.get() );
 
@@ -453,6 +455,9 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( !mDragPointCalculated )
     {
       mDragDepth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mDragButtonClickPos.x(), mDragButtonClickPos.y() ) );
+      if ( mDragDepth >= 1 )
+        return;
+
       mDragPoint = Qgs3DUtils::screenPointToWorldPos( mDragButtonClickPos, mDragDepth, mViewport.size(), mCameraBeforeDrag.get() );
       mDragPointCalculated = true;
     }
@@ -495,6 +500,9 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( !mDragPointCalculated )
     {
       double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mDragButtonClickPos.x(), mDragButtonClickPos.y() ) );
+      if ( depth >= 1 )
+        return;
+
       mDragPoint = Qgs3DUtils::screenPointToWorldPos( mDragButtonClickPos, depth, mViewport.size(), mCameraBeforeDrag.get() );
       mDragPointCalculated = true;
     }
@@ -565,6 +573,9 @@ void QgsCameraController::handleTerrainNavigationWheelZoom()
   if ( !mZoomPointCalculated )
   {
     double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mMousePos.x(), mMousePos.y() ) );
+    if ( depth >= 1 )
+      return;
+
     mZoomPoint = Qgs3DUtils::screenPointToWorldPos( mMousePos, depth, mViewport.size(), mCameraBeforeZoom.get() );
     mZoomPointCalculated = true;
   }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -573,8 +573,6 @@ void QgsCameraController::handleTerrainNavigationWheelZoom()
   if ( !mZoomPointCalculated )
   {
     double depth = Qgs3DUtils::decodeDepth( mDepthBufferImage.pixelColor( mMousePos.x(), mMousePos.y() ) );
-    if ( depth >= 1 )
-      return;
 
     mZoomPoint = Qgs3DUtils::screenPointToWorldPos( mMousePos, depth, mViewport.size(), mCameraBeforeZoom.get() );
     mZoomPointCalculated = true;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -277,7 +277,10 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     double cameraCenterElevation();
 
-    // Returns the minimum depth value in the square [px - 3, px + 3] * [py - 3, py + 3]
+    /**
+     * Returns the minimum depth value in the square [px - 3, px + 3] * [py - 3, py + 3]
+     * If the value is 1, the average depth of all non void pixels is returned instead.
+     */
     double sampleDepthBuffer( const QImage &buffer, int px, int py );
 
   private:

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -279,8 +279,6 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     // Returns the minimum depth value in the square [px - 3, px + 3] * [py - 3, py + 3]
     double sampleDepthBuffer( const QImage &buffer, int px, int py );
-    // Returns the average of depth values that are not 1 (void area)
-    double calculateAverageDepth( const QImage &buffer );
 
   private:
     //! Camera that is being controlled

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -277,6 +277,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     double cameraCenterElevation();
 
+    // Returns the minimum depth value in the square [px - 3, px + 3] * [py - 3, py + 3]
+    double sampleDepthBuffer( const QImage &buffer, int px, int py );
+    // Returns the average of depth values that are not 1 (void area)
+    double calculateAverageDepth( const QImage &buffer );
+
   private:
     //! Camera that is being controlled
     Qt3DRender::QCamera *mCamera = nullptr;


### PR DESCRIPTION
## Description
When the clicked area has nothing rendered (a void area), the camera behaves weirdly as it picks a very far point as a rotation center or a drag point. This PR disables the camera movement when that picked point is void. 