### PR TITLE
Limit 3D view drag to avoid object disappearing

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -457,6 +457,14 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
       mDragPointCalculated = true;
     }
 
+    // Make sure we apply grab move when the cursor is inside the view port
+    if ( !mViewport.contains( mouse->x(), mouse->y() ) )
+      return;
+
+    // Make sure to restrict dragging so that the clicked object stays on screen
+    if ( mCamera->farPlane() > 2 * mCameraBeforeDrag->farPlane() )
+      return;
+
     QVector3D cameraBeforeDragPos = mCameraBeforeDrag->position();
 
     QVector3D moveToPosition = Qgs3DUtils::screenPointToWorldPos( mMousePos, mDragDepth, mViewport.size(), mCameraBeforeDrag.get() );


### PR DESCRIPTION
## Description
When the user clicks with the left mouse button and drags the 3D abjects around if the scene is rotated to look at it from horizontal direction, the dragging movement can make the objects disappear because of the distance.
This PR makes sure that we stop the movement one we reach a certain distance and limit the movement to the viewport area.