### PR TITLE
extent MapTiler interpretation converter range to -10000/9000

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4921,7 +4921,7 @@ void QgsWmsInterpretationConverterMapTilerTerrainRGB::convert( const QRgb &color
 QgsRasterBandStats QgsWmsInterpretationConverterMapTilerTerrainRGB::statistics( int, int, const QgsRectangle &, int, QgsRasterBlockFeedback * ) const
 {
   QgsRasterBandStats stat;
-  stat.minimumValue = 0;
+  stat.minimumValue = -10000;
   stat.maximumValue = 9000;
   stat.statsGathered = QgsRasterBandStats::Min | QgsRasterBandStats::Max;
   return stat;


### PR DESCRIPTION
Following https://github.com/qgis/QGIS/pull/46729, this PR fixes the range extent of MapTiler interpretation converter to take account of bathymetry.
