### PR TITLE
empty XYZ usage when unknown

### DIFF
--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -118,7 +118,7 @@ bool QgsVectorTileLayerRenderer::render()
         mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
         break;
       case Qgis::RendererUsage::Unknown:
-        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "unknown" ) );
+        mSourcePath.replace( QLatin1String( "{usage}" ), QString() );
         break;
     }
   }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1444,7 +1444,7 @@ void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const Q
           turl.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
           break;
         case Qgis::RendererUsage::Unknown:
-          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "unknown" ) );
+          turl.replace( QLatin1String( "{usage}" ), QString() );
           break;
       }
     }


### PR DESCRIPTION
Following #46731: do not set the usage when the usage is unknown.