### PR TITLE
fix 3d maximum texture size

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -918,11 +918,22 @@ int Qgs3DMapScene::maximumTextureSize() const
   QSurface *surface = mEngine->surface();
   QOpenGLContext context;
   context.create();
-  context.makeCurrent( surface );
-  QOpenGLFunctions openglFunctions( &context );
-  GLint size;
-  openglFunctions.glGetIntegerv( GL_MAX_TEXTURE_SIZE, &size );
-  return int( size );
+  bool success =  context.makeCurrent( surface );
+
+  if ( success )
+  {
+    QOpenGLFunctions openglFunctions = QOpenGLFunctions( &context );
+
+    GLint size;
+    openglFunctions.initializeOpenGLFunctions();
+    openglFunctions.glGetIntegerv( GL_MAX_TEXTURE_SIZE, &size );
+    return int( size );
+  }
+  else
+  {
+    return 4096; //we can't have a context to defined the max texture size, we use this reasonable value
+  }
+
 }
 
 void Qgs3DMapScene::addCameraViewCenterEntity( Qt3DRender::QCamera *camera )


### PR DESCRIPTION
Following great work of @NEDJIMAbelgacem related to 3D map view, in certain cases, opening a project or a view with a 3d mesh could lead to a QGIS crash.
Maybe, this is due to a QSurface not initialized when creation of QOpenGLFunctions.

This PR fixes this crash.