### PR TITLE
allow plain/text error message for XYZ raster tile

### DIFF
--- a/src/core/qgstiledownloadmanager.cpp
+++ b/src/core/qgstiledownloadmanager.cpp
@@ -109,15 +109,19 @@ void QgsTileDownloadManagerReplyWorkerObject::replyFinished()
   QgsDebugMsgLevel( QStringLiteral( "Tile download manager: internal reply finished: " ) + mRequest.url().toString(), 2 );
 
   QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
-  QByteArray data = reply->readAll();;
+  QByteArray data;
 
   if ( reply->error() == QNetworkReply::NoError )
   {
     ++mManager->mStats.networkRequestsOk;
+    data = reply->readAll();
   }
   else
   {
     ++mManager->mStats.networkRequestsFailed;
+    const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+    if ( contentType.startsWith( QStringLiteral( "text/plain" ) ) )
+      data = reply->readAll();
   }
 
   emit finished( data, reply->error(), reply->errorString() );

--- a/src/core/vectortile/qgsvectortileloader.cpp
+++ b/src/core/vectortile/qgsvectortileloader.cpp
@@ -132,7 +132,6 @@ void QgsVectorTileLoader::tileReplyFinished()
   {
     if ( reply->error() == QNetworkReply::ContentAccessDenied )
     {
-
       if ( reply->data().isEmpty() )
         mError = tr( "Access denied" );
       else

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4552,8 +4552,16 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 
         if ( reply->error() == QNetworkReply::ContentAccessDenied )
         {
+          const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
+
+          QString errorMessage;
+          if ( contentType.startsWith( QStringLiteral( "text/plain" ) ) )
+            errorMessage = reply->readAll();
+          else
+            errorMessage = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString();
+
           mError = tr( "Access denied: %1" ).
-                   arg( reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString() );
+                   arg( errorMessage );
         }
       }
     }


### PR DESCRIPTION
Following https://github.com/qgis/QGIS/pull/46776, this PR allows extracting error from plain text content of WMS tiled reply.
Also add a filter to take error from XYZ vector tile error from data only if the content is plain text.