### PR TITLE
[mssql] Use correct capitalisation for queries involving INFORMATION_SCHEMA tables

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -377,9 +377,9 @@ void QgsMssqlProvider::loadFields()
   // Field has unique constraint
   QSet<QString> setColumnUnique;
   {
-    if ( !query.exec( QStringLiteral( "SELECT * FROM information_schema.table_constraints TC"
-                                      " INNER JOIN information_schema.constraint_column_usage CC ON TC.Constraint_Name = CC.Constraint_Name"
-                                      " WHERE TC.CONSTRAINT_SCHEMA = '%1' AND TC.TABLE_NAME = '%2' AND TC.constraint_type = 'unique'" )
+    if ( !query.exec( QStringLiteral( "SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC"
+                                      " INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE CC ON TC.CONSTRAINT_NAME = CC.CONSTRAINT_NAME"
+                                      " WHERE TC.CONSTRAINT_SCHEMA = '%1' AND TC.TABLE_NAME = '%2' AND TC.CONSTRAINT_TYPE = 'unique'" )
                       .arg( mSchemaName, mTableName ) ) )
     {
       pushError( query.lastError().text() );
@@ -2457,7 +2457,7 @@ bool QgsMssqlProviderMetadata::saveStyle( const QString &uri,
 
   QSqlQuery query = QSqlQuery( db->db() );
   query.setForwardOnly( true );
-  if ( !query.exec( QStringLiteral( "SELECT COUNT(*) FROM information_schema.tables WHERE table_name= N'layer_styles'" ) ) )
+  if ( !query.exec( QStringLiteral( "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME= N'layer_styles'" ) ) )
   {
     QgsDebugMsg( query.lastError().text() );
     return false;
@@ -2666,7 +2666,7 @@ int QgsMssqlProviderMetadata::listStyles( const QString &uri,
   query.setForwardOnly( true );
 
   // check if layer_styles table already exist
-  if ( !query.exec( QStringLiteral( "SELECT COUNT(*) FROM information_schema.tables WHERE table_name= N'layer_styles'" ) ) )
+  if ( !query.exec( QStringLiteral( "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME= N'layer_styles'" ) ) )
   {
     const QString msg = query.lastError().text();
     errCause = msg;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -124,7 +124,7 @@ void QgsMssqlProviderConnection::dropTablePrivate( const QString &schema, const 
   set @schema = N%3
 
   DECLARE @sql nvarchar(255)
-  WHILE EXISTS(select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS where constraint_catalog = @database and table_name = @table AND table_schema = @schema )
+  WHILE EXISTS(select * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS where CONSTRAINT_CATALOG = @database and TABLE_NAME = @table AND TABLE_SCHEMA = @schema )
   BEGIN
       select    @sql = 'ALTER TABLE ' + @table + ' DROP CONSTRAINT ' + CONSTRAINT_NAME
       from    INFORMATION_SCHEMA.TABLE_CONSTRAINTS


### PR DESCRIPTION
or queries will not run on case-sensitive databases

Fixes #46907
