### PR TITLE
[Bugfix] Refine rule, last category handle null.

### DIFF
--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1212,7 +1212,7 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
       value = QString::number( cat.value().toDouble(), 'f', 4 );
     else
       value = QgsExpression::quotedString( cat.value().toString() );
-    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, value == "NULL" ? "IS" : "=" , value );
+    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, value == "NULL" ? "IS" : "=", value );
     const QString label = !cat.label().isEmpty() ? cat.label() :
                           cat.value().isValid() ? value : QString();
     initialRule->appendChild( new Rule( cat.symbol()->clone(), 0, 0, filter, label ) );

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1212,7 +1212,7 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
       value = QString::number( cat.value().toDouble(), 'f', 4 );
     else
       value = QgsExpression::quotedString( cat.value().toString() );
-    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, value == "NULL" ? "IS" : "=", value );
+    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, cat.value().isNull() ? QStringLiteral( "IS" ) : QStringLiteral( "=" ), value );
     const QString label = !cat.label().isEmpty() ? cat.label() :
                           cat.value().isValid() ? value : QString();
     initialRule->appendChild( new Rule( cat.symbol()->clone(), 0, 0, filter, label ) );

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1202,7 +1202,9 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
   {
     QString value;
     // not quoting numbers saves a type cast
-    if ( cat.value().type() == QVariant::Int )
+    if ( cat.value().isNull() )
+      value = "NULL";
+    else if ( cat.value().type() == QVariant::Int )
       value = cat.value().toString();
     else if ( cat.value().type() == QVariant::Double )
       // we loose precision here - so we may miss some categories :-(
@@ -1210,7 +1212,7 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
       value = QString::number( cat.value().toDouble(), 'f', 4 );
     else
       value = QgsExpression::quotedString( cat.value().toString() );
-    const QString filter = QStringLiteral( "%1 = %2" ).arg( attr, value );
+    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, value == "NULL" ? "IS" : "=" , value );
     const QString label = !cat.label().isEmpty() ? cat.label() :
                           cat.value().isValid() ? value : QString();
     initialRule->appendChild( new Rule( cat.symbol()->clone(), 0, 0, filter, label ) );

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -208,6 +208,7 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         QgsRuleBasedRenderer.refineRuleCategories(self.r2, c)
         self.assertEqual(self.r2.children()[0].filterExpression(), '"id" = 1')
         self.assertEqual(self.r2.children()[1].filterExpression(), '"id" = 2')
+        self.assertEqual(self.r2.children()[2].filterExpression(), '"id" IS NULL')
         self.assertEqual(self.r2.children()[0].label(), 'id 1')
         self.assertEqual(self.r2.children()[1].label(), '2')
         self.assertEqual(self.r2.children()[2].label(), '')


### PR DESCRIPTION
## Description

When using Refine as categories the 'catch-all' item is made as `"field" = '' `, this doesn't quite catch all other cases, mostly nothing. 

The proposed approach generate `"field" IS NULL` as a better catch-all. I was hesitating between than and `ELSE`, both are ok to me.

For reference:
![image](https://user-images.githubusercontent.com/12854129/150530646-9f8c52e7-eed6-443f-8cbf-da22c7fe490c.png)


