### PR TITLE
Gcp table update

### DIFF
--- a/src/app/georeferencer/qgsgcplist.cpp
+++ b/src/app/georeferencer/qgsgcplist.cpp
@@ -33,7 +33,7 @@ QgsGCPList::QgsGCPList( const QgsGCPList &list )
   }
 }
 
-void QgsGCPList::createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords, const QgsCoordinateReferenceSystem targetCrs )
+void QgsGCPList::createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords )
 {
   mapCoords   = QVector<QgsPointXY>( size() );
   pixelCoords = QVector<QgsPointXY>( size() );
@@ -43,11 +43,11 @@ void QgsGCPList::createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPo
     QgsGeorefDataPoint *pt = at( i );
     if ( pt->isEnabled() )
     {
-      if ( targetCrs.isValid() )
+      if ( mTargetCrs.isValid() )
       {
         try
         {
-          transCoords =  QgsCoordinateTransform( pt->crs(), targetCrs,
+          transCoords =  QgsCoordinateTransform( pt->crs(), mTargetCrs,
                                                  QgsProject::instance() ).transform( pt->mapCoords() );
           mapCoords[j] = transCoords;
           pt->setTransCoords( transCoords );

--- a/src/app/georeferencer/qgsgcplist.cpp
+++ b/src/app/georeferencer/qgsgcplist.cpp
@@ -24,6 +24,7 @@
 QgsGCPList::QgsGCPList( const QgsGCPList &list )
   :  QList<QgsGeorefDataPoint *>()
 {
+  mTargetCrs = QgsCoordinateReferenceSystem();
   clear();
   QgsGCPList::const_iterator it = list.constBegin();
   for ( ; it != list.constEnd(); ++it )

--- a/src/app/georeferencer/qgsgcplist.h
+++ b/src/app/georeferencer/qgsgcplist.h
@@ -29,17 +29,17 @@ class QgsGCPList : public QList<QgsGeorefDataPoint *>
   public:
     QgsGCPList() = default;
     QgsGCPList( const QgsGCPList &list );
-    void setTargetCrs( QgsCoordinateReferenceSystem crs ){ mTargetCRS = crs; }
+    void setTargetCrs( QgsCoordinateReferenceSystem crs ){ mTargetCrs = crs; }
 
     void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords );
     int size() const;
     int sizeAll() const;
 
     QgsGCPList &operator =( const QgsGCPList &list );
-    const QgsCoordinateReferenceSystem targerCRS(){ return mTargetCRS; }
+    const QgsCoordinateReferenceSystem targetCRS(){ return mTargetCrs; }
 
   private:
-    QgsCoordinateReferenceSystem mTargetCRS;
+    QgsCoordinateReferenceSystem mTargetCrs;
 };
 
 #endif

--- a/src/app/georeferencer/qgsgcplist.h
+++ b/src/app/georeferencer/qgsgcplist.h
@@ -29,14 +29,14 @@ class QgsGCPList : public QList<QgsGeorefDataPoint *>
   public:
     QgsGCPList() = default;
     QgsGCPList( const QgsGCPList &list );
-    void setTargetCrs( QgsCoordinateReferenceSystem crs ){ mTargetCrs = crs; }
+    void setTargetCrs( QgsCoordinateReferenceSystem crs ) { mTargetCrs = crs; }
 
     void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords );
     int size() const;
     int sizeAll() const;
 
     QgsGCPList &operator =( const QgsGCPList &list );
-    const QgsCoordinateReferenceSystem targetCRS(){ return mTargetCrs; }
+    const QgsCoordinateReferenceSystem targetCRS() { return mTargetCrs; }
 
   private:
     QgsCoordinateReferenceSystem mTargetCrs;

--- a/src/app/georeferencer/qgsgcplist.h
+++ b/src/app/georeferencer/qgsgcplist.h
@@ -18,10 +18,10 @@
 
 #include <QList>
 #include <QVector>
+#include "qgscoordinatereferencesystem.h"
 
 class QgsGeorefDataPoint;
 class QgsPointXY;
-class QgsCoordinateReferenceSystem;
 
 // what is better use inherid or agrigate QList?
 class QgsGCPList : public QList<QgsGeorefDataPoint *>
@@ -29,12 +29,17 @@ class QgsGCPList : public QList<QgsGeorefDataPoint *>
   public:
     QgsGCPList() = default;
     QgsGCPList( const QgsGCPList &list );
+    void setTargetCrs( QgsCoordinateReferenceSystem crs ){ mTargetCRS = crs; }
 
-    void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords, const QgsCoordinateReferenceSystem targetCrs );
+    void createGCPVectors( QVector<QgsPointXY> &mapCoords, QVector<QgsPointXY> &pixelCoords );
     int size() const;
     int sizeAll() const;
 
     QgsGCPList &operator =( const QgsGCPList &list );
+    const QgsCoordinateReferenceSystem targerCRS(){ return mTargetCRS; }
+
+  private:
+    QgsCoordinateReferenceSystem mTargetCRS;
 };
 
 #endif

--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -43,12 +43,12 @@ class QgsStandardItem : public QStandardItem
     {
       setData( QVariant( value ), Qt::UserRole );
       //show the full precision when editing points
-      if ( value > 1000000 )
-        setData( QVariant( QString::number( value, 'f', 2 ), Qt::EditRole );
-      else if ( value < 10 )
+      if ( abs( value ) > 1000000 )
+        setData( QVariant( QString::number( value, 'f', 2 ) ), Qt::EditRole );
+      else if ( abs( value ) < 1000 )
         setData( QVariant( QString::number( value, 'f', 7 ) ), Qt::EditRole );
       else
-        setData( QVariant( value ), Qt::EditRole );
+        setData( QVariant( QString::number( value, 'f', 4 ) ), Qt::EditRole );
       setData( QVariant( value ), Qt::ToolTipRole );
       setTextAlignment( Qt::AlignRight );
     }
@@ -91,7 +91,7 @@ void QgsGCPListModel::updateModel()
 
   QgsCoordinateReferenceSystem storedCrs( s.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString() );
   if ( storedCrs != mGCPList->targetCRS() )
-    mGCPList->setTargetCrs( stored Crs );
+    mGCPList->setTargetCrs( storedCrs );
   mGCPList->createGCPVectors( mapCoords, pixelCoords );
 
   if ( mGeorefTransform )
@@ -111,7 +111,7 @@ void QgsGCPListModel::updateModel()
 
   itemLabels << tr( "Visible" )
              << tr( "ID" )
-             << tr( ."Crs" )
+             << tr( "Crs" )
              << tr( "Source X" )
              << tr( "Source Y" )
              << tr( "GCP X" )

--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -84,8 +84,10 @@ void QgsGCPListModel::updateModel()
   bool mapUnitsPossible = false;
   QVector<QgsPointXY> mapCoords, pixelCoords;
 
-  mGCPList->createGCPVectors( mapCoords, pixelCoords,
-                              QgsCoordinateReferenceSystem( s.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString() ) );
+  QgsCoordinateReferenceSystem storedCrs( s.value( QStringLiteral( "/Plugin-GeoReferencer/targetsrs" ) ).toString() );
+  if ( storedCrs != mGCPList->targetCRS() )
+    mGCPList->setTargetCrs( stored Crs );
+  mGCPList->createGCPVectors( mapCoords, pixelCoords );
 
   if ( mGeorefTransform )
   {
@@ -104,8 +106,11 @@ void QgsGCPListModel::updateModel()
 
   itemLabels << tr( "Visible" )
              << tr( "ID" )
+             << tr( ."Crs" )
              << tr( "Source X" )
              << tr( "Source Y" )
+             << tr( "GCP X" )
+             << tr( "GCP Y" )
              << tr( "Dest. X" )
              << tr( "Dest. Y" )
              << tr( "dX (%1)" ).arg( unitType )
@@ -134,9 +139,13 @@ void QgsGCPListModel::updateModel()
       si->setCheckState( Qt::Unchecked );
 
     setItem( i, j++, si );
+
     setItem( i, j++, new QgsStandardItem( i ) );
+    setItem( i, j++, new QgsStandardItem( p->crs().authid() ) );
     setItem( i, j++, new QgsStandardItem( p->pixelCoords().x() ) );
     setItem( i, j++, new QgsStandardItem( p->pixelCoords().y() ) );
+    setItem( i, j++, new QgsStandardItem( p->mapCoords().x() ) );
+    setItem( i, j++, new QgsStandardItem( p->mapCoords().y() ) );
     setItem( i, j++, new QgsStandardItem( p->transCoords().x() ) );
     setItem( i, j++, new QgsStandardItem( p->transCoords().y() ) );
 

--- a/src/app/georeferencer/qgsgcplistmodel.cpp
+++ b/src/app/georeferencer/qgsgcplistmodel.cpp
@@ -43,7 +43,12 @@ class QgsStandardItem : public QStandardItem
     {
       setData( QVariant( value ), Qt::UserRole );
       //show the full precision when editing points
-      setData( QVariant( value ), Qt::EditRole );
+      if ( value > 1000000 )
+        setData( QVariant( QString::number( value, 'f', 2 ), Qt::EditRole );
+      else if ( value < 10 )
+        setData( QVariant( QString::number( value, 'f', 7 ) ), Qt::EditRole );
+      else
+        setData( QVariant( value ), Qt::EditRole );
       setData( QVariant( value ), Qt::ToolTipRole );
       setTextAlignment( Qt::AlignRight );
     }

--- a/src/app/georeferencer/qgsgcplistwidget.cpp
+++ b/src/app/georeferencer/qgsgcplistwidget.cpp
@@ -226,8 +226,12 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
     switch ( mPrevColumn )
     {
       case 3:
+      {
         changeX = true;
+        FALLTHROUGH
+      }
       case 4:
+      {
         tempPoint = dataPoint->pixelCoords();
         if ( changeX )
           tempPoint.setX( value );
@@ -235,10 +239,15 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
           tempPoint.setY( value );
         dataPoint->setPixelCoords( tempPoint );
         break;
+      }
 
       case 5:
+      {
         changeX = true;
+        FALLTHROUGH
+      }
       case 6:
+      {
         tempPoint = dataPoint->mapCoords();
         if ( changeX )
           tempPoint.setX( value );
@@ -246,10 +255,15 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
           tempPoint.setY( value );
         dataPoint->setMapCoords( tempPoint );
         break;
+      }
 
       case 7:
+      {
         changeX = true;
+        FALLTHROUGH
+      }
       case 8:
+      {
         tempPoint = dataPoint->transCoords();
         if ( changeX )
           tempPoint.setX( value );
@@ -258,7 +272,7 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
         try
         {
           tempPoint =  QgsCoordinateTransform( mGCPList->targetCRS(), dataPoint->crs(),
-                                                 QgsProject::instance() ).transform( tempPoint );
+                                               QgsProject::instance() ).transform( tempPoint );
         }
         catch ( const QgsException &e )
         {
@@ -267,6 +281,7 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
         }
         dataPoint->setMapCoords( tempPoint );
         break;
+      }
 
       default:
         return;

--- a/src/app/georeferencer/qgsgcplistwidget.cpp
+++ b/src/app/georeferencer/qgsgcplistwidget.cpp
@@ -20,6 +20,9 @@
 #include <QMenu>
 #include <QSortFilterProxyModel>
 
+#include "qgsproject.h"
+#include "qgsexception.h"
+#include "qgscoordinatetransform.h"
 #include "qgsgeorefdelegates.h"
 #include "qgsgeorefdatapoint.h"
 #include "qgsgcplist.h"
@@ -222,33 +225,33 @@ void QgsGCPListWidget::updateItemCoords( QWidget *editor )
 
     switch ( mPrevColumn )
     {
-      case 2:
-        changeX = true;
       case 3:
-        tempPoint( dataPoint->pixelCoords() );
-        if changeX:
+        changeX = true;
+      case 4:
+        tempPoint = dataPoint->pixelCoords();
+        if ( changeX )
           tempPoint.setX( value );
         else
           tempPoint.setY( value );
         dataPoint->setPixelCoords( tempPoint );
         break;
 
-      case 4:
-        changeX = true;
       case 5:
-        tempPoint( dataPoint->mapCoords() );
-        if changeX:
+        changeX = true;
+      case 6:
+        tempPoint = dataPoint->mapCoords();
+        if ( changeX )
           tempPoint.setX( value );
         else
           tempPoint.setY( value );
         dataPoint->setMapCoords( tempPoint );
         break;
 
-      case 6:
-        changeX = true;
       case 7:
-        tempPoint( dataPoint->transCoords() );
-        if changeX:
+        changeX = true;
+      case 8:
+        tempPoint = dataPoint->transCoords();
+        if ( changeX )
           tempPoint.setX( value );
         else
           tempPoint.setY( value );

--- a/src/app/georeferencer/qgsgcplistwidget.h
+++ b/src/app/georeferencer/qgsgcplistwidget.h
@@ -36,7 +36,6 @@ class QgsGCPListWidget : public QTableView
 
     void setGCPList( QgsGCPList *theGCPList );
     void setGeorefTransform( QgsGeorefTransform *georefTransform );
-
     QgsGCPList *gcpList() { return mGCPList; }
     void updateGCPList();
     void closeEditors();
@@ -74,8 +73,6 @@ class QgsGCPListWidget : public QTableView
 
     int mPrevRow = 0;
     int mPrevColumn = 0;
-
-    QgsCoordinateReferenceSystem mTargerCRS;
 };
 
 #endif

--- a/src/app/georeferencer/qgsgcplistwidget.h
+++ b/src/app/georeferencer/qgsgcplistwidget.h
@@ -36,6 +36,7 @@ class QgsGCPListWidget : public QTableView
 
     void setGCPList( QgsGCPList *theGCPList );
     void setGeorefTransform( QgsGeorefTransform *georefTransform );
+
     QgsGCPList *gcpList() { return mGCPList; }
     void updateGCPList();
     void closeEditors();
@@ -73,6 +74,8 @@ class QgsGCPListWidget : public QTableView
 
     int mPrevRow = 0;
     int mPrevColumn = 0;
+
+    QgsCoordinateReferenceSystem mTargerCRS;
 };
 
 #endif

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -2004,7 +2004,11 @@ bool QgsGeoreferencerMainWindow::updateGeorefTransform()
 {
   QVector<QgsPointXY> mapCoords, pixelCoords;
   if ( mGCPListWidget->gcpList() )
-    mGCPListWidget->gcpList()->createGCPVectors( mapCoords, pixelCoords, mProjection );
+  {
+    mGCPListWidget-­>gcpList()->setTargetCrs( mProjection );
+    mGCPListWidget->gcpList()->createGCPVectors( mapCoords, pixelCoords );
+  }
+
   else
     return false;
 

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1761,8 +1761,9 @@ bool QgsGeoreferencerMainWindow::writePDFReportFile( const QString &fileName, co
   gcpTable->setContentTextFormat( tableContentFormat );
   gcpTable->setHeaderMode( QgsLayoutTable::AllFrames );
   QgsLayoutTableColumns columns;
-  columns << QgsLayoutTableColumn( tr( "ID" ) )
-          << QgsLayoutTableColumn( tr( "Enabled" ) )
+  columns << QgsLayoutTableColumn( tr( "Enabled" ) )
+          << QgsLayoutTableColumn( tr( "ID" ) )
+          << QgsLayoutTableColumn( tr( "CRS" ) )
           << QgsLayoutTableColumn( tr( "Pixel X" ) )
           << QgsLayoutTableColumn( tr( "Pixel Y" ) )
           << QgsLayoutTableColumn( tr( "Map X" ) )
@@ -2005,7 +2006,7 @@ bool QgsGeoreferencerMainWindow::updateGeorefTransform()
   QVector<QgsPointXY> mapCoords, pixelCoords;
   if ( mGCPListWidget->gcpList() )
   {
-    mGCPListWidget-­>gcpList()->setTargetCrs( mProjection );
+    mGCPListWidget->gcpList()->setTargetCrs( mProjection );
     mGCPListWidget->gcpList()->createGCPVectors( mapCoords, pixelCoords );
   }
 


### PR DESCRIPTION
## Description

This works extends the GCP table by showing the crs of the point and the stored 'raw' points.

It allows the used to modifiy both the destination coords and the raw point coords and have them both keep in sync (doing reverse transform when needed).

It also fix #46835  and 'fixes' #46836 

![georef_table_change](https://user-images.githubusercontent.com/12854129/150608164-59cdff07-ef53-4a20-af6e-4c1c05b3f64d.gif)

