### PR TITLE
[bug/feature?] Improve array_remove_at function

### DIFF
--- a/resources/function_help/json/array_remove_at
+++ b/resources/function_help/json/array_remove_at
@@ -2,7 +2,7 @@
   "name": "array_remove_at",
   "type": "function",
   "groups": ["Arrays"],
-  "description": "Returns an array with the item at the given index remove. Supports positive (0 for the first element) and negative (the last -Nth value, -1 for the last element) index.",
+  "description": "Returns an array with the item at the given index removed. Supports positive (0 for the first element) and negative (the last -Nth value, -1 for the last element) index.",
   "arguments": [ {"arg":"array","description":"an array"},
                  {"arg":"pos","description":"the position to remove (0 based)"}],
   "examples": [ { "expression":"array_remove_at(array(1, 2, 3), 1)", "returns":"[1, 3 ]"},

--- a/resources/function_help/json/array_remove_at
+++ b/resources/function_help/json/array_remove_at
@@ -2,9 +2,9 @@
   "name": "array_remove_at",
   "type": "function",
   "groups": ["Arrays"],
-  "description": "Returns an array with the item at the given index remove. Support positive (0 for the first element) and negative( the last -Nth value, -1 for the last element) index.",
+  "description": "Returns an array with the item at the given index remove. Supports positive (0 for the first element) and negative (the last -Nth value, -1 for the last element) index.",
   "arguments": [ {"arg":"array","description":"an array"},
                  {"arg":"pos","description":"the position to remove (0 based)"}],
-  "examples": [ { "expression":"array_remove_at(array(1,2,3),1)", "returns":"[ 1, 3 ]"},
-    { "expression":"array_remove_at(array(1,2,3),-1)", "returns":"[ 1, 2 ]"}]
+  "examples": [ { "expression":"array_remove_at(array(1, 2, 3), 1)", "returns":"[1, 3 ]"},
+    { "expression":"array_remove_at(array(1, 2, 3), -1)", "returns":"[1, 2 ]"}]
 }

--- a/resources/function_help/json/array_remove_at
+++ b/resources/function_help/json/array_remove_at
@@ -2,8 +2,9 @@
   "name": "array_remove_at",
   "type": "function",
   "groups": ["Arrays"],
-  "description": "Returns an array with the given index removed.",
+  "description": "Returns an array with the item at the given index remove. Support positive (0 for the first element) and negative( the last -Nth value, -1 for the last element) index.",
   "arguments": [ {"arg":"array","description":"an array"},
                  {"arg":"pos","description":"the position to remove (0 based)"}],
-  "examples": [ { "expression":"array_remove_at(array(1,2,3),1)", "returns":"[ 1, 3 ]"}]
+  "examples": [ { "expression":"array_remove_at(array(1,2,3),1)", "returns":"[ 1, 3 ]"},
+    { "expression":"array_remove_at(array(1,2,3),-1)", "returns":"[ 1, 2 ]"}]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6190,7 +6190,11 @@ static QVariant fcnArrayInsert( const QVariantList &values, const QgsExpressionC
 static QVariant fcnArrayRemoveAt( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
-  list.removeAt( QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent ) );
+  int position = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  if ( position < 0 && ( list.length() + position ) >= 0 )
+    position = position + list.length();
+  if ( position < list.length() )
+    list.removeAt( position );
   return convertToSameType( list, values.at( 0 ).type() );
 }
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6191,7 +6191,7 @@ static QVariant fcnArrayRemoveAt( const QVariantList &values, const QgsExpressio
 {
   QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   int position = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
-  if ( position < 0 && ( list.length() + position ) >= 0 )
+  if ( position < 0 )
     position = position + list.length();
   if ( position >= 0 && position < list.length() )
     list.removeAt( position );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6193,7 +6193,7 @@ static QVariant fcnArrayRemoveAt( const QVariantList &values, const QgsExpressio
   int position = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
   if ( position < 0 && ( list.length() + position ) >= 0 )
     position = position + list.length();
-  if ( position < list.length() )
+  if ( position >= 0 && position < list.length() )
     list.removeAt( position );
   return convertToSameType( list, values.at( 0 ).type() );
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3748,6 +3748,9 @@ class TestQgsExpression: public QObject
       QStringList removeAtExpected = array;
       removeAtExpected.removeAt( 0 );
       QCOMPARE( QgsExpression( "array_remove_at(\"strings\", 0)" ).evaluate( &context ), QVariant( removeAtExpected ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"strings\", -2)" ).evaluate( &context ), QVariant( removeAtExpected ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"strings\", -4)" ).evaluate( &context ), QVariant( array ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"strings\", 4)" ).evaluate( &context ), QVariant( array ) );
 
       QStringList removeAllExpected;
       removeAllExpected << QStringLiteral( "a" ) << QStringLiteral( "b" ) << QStringLiteral( "d" );
@@ -3832,6 +3835,9 @@ class TestQgsExpression: public QObject
       QVariantList removeAtExpected = array;
       removeAtExpected.removeAt( 0 );
       QCOMPARE( QgsExpression( "array_remove_at(\"ints\", 0)" ).evaluate( &context ), QVariant( removeAtExpected ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"ints\", -2)" ).evaluate( &context ), QVariant( removeAtExpected ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"ints\", -5)" ).evaluate( &context ), QVariant( array ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"ints\", 5)" ).evaluate( &context ), QVariant( array ) );
 
       QVariantList removeAllExpected;
       removeAllExpected << 1 << 2 << 4;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3751,6 +3751,7 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression( "array_remove_at(\"strings\", -2)" ).evaluate( &context ), QVariant( removeAtExpected ) );
       QCOMPARE( QgsExpression( "array_remove_at(\"strings\", -4)" ).evaluate( &context ), QVariant( array ) );
       QCOMPARE( QgsExpression( "array_remove_at(\"strings\", 4)" ).evaluate( &context ), QVariant( array ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"strings\", -40)" ).evaluate( &context ), QVariant( array ) );
 
       QStringList removeAllExpected;
       removeAllExpected << QStringLiteral( "a" ) << QStringLiteral( "b" ) << QStringLiteral( "d" );
@@ -3838,6 +3839,7 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression( "array_remove_at(\"ints\", -2)" ).evaluate( &context ), QVariant( removeAtExpected ) );
       QCOMPARE( QgsExpression( "array_remove_at(\"ints\", -5)" ).evaluate( &context ), QVariant( array ) );
       QCOMPARE( QgsExpression( "array_remove_at(\"ints\", 5)" ).evaluate( &context ), QVariant( array ) );
+      QCOMPARE( QgsExpression( "array_remove_at(\"ints\", -50)" ).evaluate( &context ), QVariant( array ) );
 
       QVariantList removeAllExpected;
       removeAllExpected << 1 << 2 << 4;


### PR DESCRIPTION
## Description

Fixes an undocumented bug where using a value greater than the array size would return a null value instead of the array.

This works also adds support for using a negative index.