### PR TITLE
Fix save style api, crash when saving styles

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -521,7 +521,15 @@ Deletes a layer style defined by ``styleId``
                             const QString &styleName, const QString &styleDescription,
                             const QString &uiFileContent, bool useAsDefault, QString &errCause );
 %Docstring
-Saves a layer style to provider
+Saves a layer style to provider.
+
+.. note::
+
+   Prior to QGIS 3.24, this method would show a message box warning when a
+   style with the same ``styleName`` already existed to confirm replacing the style with the user.
+   Since 3.24, calling this method will ALWAYS overwrite any existing style with the same name.
+   Use :py:func:`~QgsProviderMetadata.styleExists` to test in advance if a style already exists and handle this appropriately
+   in your client code.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -486,14 +486,31 @@ Lists stored layer styles in the provider defined by ``uri``
 .. versionadded:: 3.10
 %End
 
-    virtual QString getStyleById( const QString &uri, QString styleId, QString &errCause );
+    virtual bool styleExists( const QString &uri, const QString &styleId, QString &errorCause /Out/ );
+%Docstring
+Returns ``True`` if a layer style with the specified ``styleId`` exists in the provider defined by ``uri``.
+
+:param uri: provider URI
+:param styleId: style ID to test for
+
+:return: - ``True`` if the layer style already exists
+         - errorCause: will be set to a descriptive error message, if an error occurs while checking if the style exists
+
+.. seealso:: :py:func:`getStyleById`
+
+.. versionadded:: 3.24
+%End
+
+    virtual QString getStyleById( const QString &uri, const QString &styleId, QString &errCause );
 %Docstring
 Gets a layer style defined by ``uri``
+
+.. seealso:: :py:func:`styleExists`
 
 .. versionadded:: 3.10
 %End
 
-    virtual bool deleteStyleById( const QString &uri, QString styleId, QString &errCause );
+    virtual bool deleteStyleById( const QString &uri, const QString &styleId, QString &errCause );
 %Docstring
 Deletes a layer style defined by ``styleId``
 

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -203,14 +203,32 @@ Lists stored layer styles in the provider defined by ``providerKey`` and ``uri``
 .. versionadded:: 3.10
 %End
 
-    QString getStyleById( const QString &providerKey,  const QString &uri, QString styleId, QString &errCause );
+    bool styleExists( const QString &providerKey, const QString &uri, const QString &styleId, QString &errorCause /Out/ );
 %Docstring
-Gets a layer style defined by ``styleId``
+Returns ``True`` if a layer style with the specified ``styleId`` exists in the provider defined by ``providerKey`` and ``uri``.
+
+:param providerKey: provider key
+:param uri: provider URI
+:param styleId: style ID to test for
+
+:return: - ``True`` if the layer style already exists
+         - errorCause: will be set to a descriptive error message, if an error occurs while checking if the style exists
+
+.. seealso:: :py:func:`getStyleById`
+
+.. versionadded:: 3.24
+%End
+
+    QString getStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause );
+%Docstring
+Gets a layer style defined by ``styleId``.
+
+.. seealso:: :py:func:`styleExists`
 
 .. versionadded:: 3.10
 %End
 
-    bool deleteStyleById( const QString &providerKey,  const QString &uri, QString styleId, QString &errCause );
+    bool deleteStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause );
 %Docstring
 Deletes a layer style defined by ``styleId``
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -941,6 +941,14 @@ Saves named and sld style of the layer to the style table in the db.
 :param description: A description of the style
 :param useAsDefault: Set to ``True`` if style should be used as the default style for the layer
 :param uiFileContent:
+
+.. note::
+
+   Prior to QGIS 3.24, this method would show a message box warning when a
+   style with the same ``styleName`` already existed to confirm replacing the style with the user.
+   Since 3.24, calling this method will ALWAYS overwrite any existing style with the same name.
+   Use :py:func:`QgsProviderRegistry.styleExists()` to test in advance if a style already exists and handle this appropriately
+   in your client code.
 %End
 
     virtual int listStylesInDatabase( QStringList &ids /Out/, QStringList &names /Out/,

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9192,6 +9192,22 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
 
             QgsVectorLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
 
+            QString errorMessage;
+            if ( QgsProviderRegistry::instance()->styleExists( vlayer->providerType(), vlayer->source(), dbSettings.name, errorMessage ) )
+            {
+              if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+                                          QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
+                                          QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
+              {
+                return;
+              }
+            }
+            else if ( !errorMessage.isEmpty() )
+            {
+              mInfoBar->pushMessage( infoWindowTitle, errorMessage, Qgis::MessageLevel::Warning );
+              return;
+            }
+
             vlayer->saveStyleToDatabase( dbSettings.name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError );
 
             if ( !msgError.isNull() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -613,7 +613,7 @@ static void customSrsValidation_( QgsCoordinateReferenceSystem &srs )
     // srs is a reference and may be deleted before the queued slot is called.
     // We also can't do ANY gui related stuff here. Best we can do is log
     // a warning and move on...
-    QgsMessageLog::logMessage( QObject::tr( "Layer has unknown CRS" ) );
+    QgsMessageLog::logMessage( tr( "Layer has unknown CRS" ) );
   }
   else
   {
@@ -9187,7 +9187,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
           }
           case QgsVectorLayerProperties::DB:
           {
-            QString infoWindowTitle = QObject::tr( "Save style to DB (%1)" ).arg( vlayer->providerType() );
+            QString infoWindowTitle = tr( "Save style to DB (%1)" ).arg( vlayer->providerType() );
             QString msgError;
 
             QgsVectorLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
@@ -9195,8 +9195,8 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
             QString errorMessage;
             if ( QgsProviderRegistry::instance()->styleExists( vlayer->providerType(), vlayer->source(), dbSettings.name, errorMessage ) )
             {
-              if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                          QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
+              if ( QMessageBox::question( nullptr, tr( "Save style in database" ),
+                                          tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
                                           QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
               {
                 return;
@@ -13979,7 +13979,7 @@ void QgisApp::initLayouts()
   // 3D map item
 #ifdef HAVE_3D
   QgsApplication::layoutItemRegistry()->addLayoutItemType(
-    new QgsLayoutItemMetadata( QgsLayoutItemRegistry::Layout3DMap, QObject::tr( "3D Map" ), QObject::tr( "3D Maps" ), QgsLayoutItem3DMap::create )
+    new QgsLayoutItemMetadata( QgsLayoutItemRegistry::Layout3DMap, tr( "3D Map" ), tr( "3D Maps" ), QgsLayoutItem3DMap::create )
   );
 
   auto createRubberBand = ( []( QgsLayoutView * view )->QgsLayoutViewRubberBand *
@@ -13987,7 +13987,7 @@ void QgisApp::initLayouts()
     return new QgsLayoutViewRectangularRubberBand( view );
   } );
   std::unique_ptr< QgsLayoutItemGuiMetadata > map3dMetadata = std::make_unique< QgsLayoutItemGuiMetadata>(
-        QgsLayoutItemRegistry::Layout3DMap, QObject::tr( "3D Map" ), QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd3DMap.svg" ) ),
+        QgsLayoutItemRegistry::Layout3DMap, tr( "3D Map" ), QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd3DMap.svg" ) ),
         [ = ]( QgsLayoutItem * item )->QgsLayoutItemBaseWidget *
   {
     return new QgsLayout3DMapWidget( qobject_cast< QgsLayoutItem3DMap * >( item ) );
@@ -15032,7 +15032,7 @@ void QgisApp::updateCrsStatusBar()
     if ( !projectCrs.authid().isEmpty() )
       mOnTheFlyProjectionStatusButton->setText( projectCrs.authid() );
     else
-      mOnTheFlyProjectionStatusButton->setText( QObject::tr( "Unknown CRS" ) );
+      mOnTheFlyProjectionStatusButton->setText( tr( "Unknown CRS" ) );
 
     mOnTheFlyProjectionStatusButton->setToolTip(
       tr( "Current CRS: %1" ).arg( projectCrs.userFriendlyIdentifier() ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -613,7 +613,7 @@ static void customSrsValidation_( QgsCoordinateReferenceSystem &srs )
     // srs is a reference and may be deleted before the queued slot is called.
     // We also can't do ANY gui related stuff here. Best we can do is log
     // a warning and move on...
-    QgsMessageLog::logMessage( tr( "Layer has unknown CRS" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer has unknown CRS" ) );
   }
   else
   {

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -35,7 +35,6 @@ email                : nyall dot dawson at gmail dot com
 #include <QFileInfo>
 #include <QFile>
 #include <QDir>
-#include <QMessageBox>
 #include <QRegularExpression>
 #include <QDirIterator>
 
@@ -455,19 +454,6 @@ bool QgsOgrProviderMetadata::saveStyle(
 
   if ( hFeature )
   {
-    QgsSettings settings;
-    // Only used in tests. Do not define it for interactive implication
-    QVariant overwriteStyle = settings.value( QStringLiteral( "qgis/overwriteStyle" ) );
-    if ( ( !overwriteStyle.isNull() && !overwriteStyle.toBool() ) ||
-         ( overwriteStyle.isNull() &&
-           QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                  QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                  .arg( realStyleName ),
-                                  QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No ) )
-    {
-      errCause = QObject::tr( "Operation aborted" );
-      return false;
-    }
     bNew = false;
   }
   else

--- a/src/core/providers/ogr/qgsogrprovidermetadata.h
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.h
@@ -55,14 +55,15 @@ class QgsOgrProviderMetadata final: public QgsProviderMetadata
       const QMap<QString, QVariant> *options ) override;
 
     // -----
+    bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;
     bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,
                     const QString &styleName, const QString &styleDescription,
                     const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;
-    bool deleteStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    bool deleteStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
     QString loadStyle( const QString &uri, QString &errCause ) override;
     int listStyles( const QString &uri, QStringList &ids, QStringList &names,
                     QStringList &descriptions, QString &errCause ) override;
-    QString getStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    QString getStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
     bool saveLayerMetadata( const QString &uri, const QgsLayerMetadata &metadata, QString &errorMessage ) final;
 
     // -----

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -224,13 +224,19 @@ int QgsProviderMetadata::listStyles( const QString &, QStringList &, QStringList
   return -1;
 }
 
-QString QgsProviderMetadata::getStyleById( const QString &, QString, QString &errCause )
+bool QgsProviderMetadata::styleExists( const QString &, const QString &, QString &errorCause )
+{
+  errorCause.clear();
+  return false;
+}
+
+QString QgsProviderMetadata::getStyleById( const QString &, const QString &, QString &errCause )
 {
   errCause = QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "getStyleById" ) );
   return QString();
 }
 
-bool QgsProviderMetadata::deleteStyleById( const QString &, QString, QString &errCause )
+bool QgsProviderMetadata::deleteStyleById( const QString &, const QString &, QString &errCause )
 {
   errCause = QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "deleteStyleById" ) );
   return false;

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -536,16 +536,32 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
                             QStringList &descriptions, QString &errCause );
 
     /**
+     * Returns TRUE if a layer style with the specified \a styleId exists in the provider defined by \a uri.
+     *
+     * \param uri provider URI
+     * \param styleId style ID to test for
+     * \param errorCause will be set to a descriptive error message, if an error occurs while checking if the style exists
+     * \returns TRUE if the layer style already exists
+     *
+     * \see getStyleById()
+     * \since QGIS 3.24
+     */
+    virtual bool styleExists( const QString &uri, const QString &styleId, QString &errorCause SIP_OUT );
+
+    /**
      * Gets a layer style defined by \a uri
+     *
+     * \see styleExists()
+     *
      * \since QGIS 3.10
      */
-    virtual QString getStyleById( const QString &uri, QString styleId, QString &errCause );
+    virtual QString getStyleById( const QString &uri, const QString &styleId, QString &errCause );
 
     /**
      * Deletes a layer style defined by \a styleId
      * \since QGIS 3.10
      */
-    virtual bool deleteStyleById( const QString &uri, QString styleId, QString &errCause );
+    virtual bool deleteStyleById( const QString &uri, const QString &styleId, QString &errCause );
 
     /**
      * Saves a layer style to provider

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -564,7 +564,14 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
     virtual bool deleteStyleById( const QString &uri, const QString &styleId, QString &errCause );
 
     /**
-     * Saves a layer style to provider
+     * Saves a layer style to provider.
+     *
+     * \note Prior to QGIS 3.24, this method would show a message box warning when a
+     * style with the same \a styleName already existed to confirm replacing the style with the user.
+     * Since 3.24, calling this method will ALWAYS overwrite any existing style with the same name.
+     * Use styleExists() to test in advance if a style already exists and handle this appropriately
+     * in your client code.
+     *
      * \since QGIS 3.10
      */
     virtual bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -626,7 +626,22 @@ int QgsProviderRegistry::listStyles( const QString &providerKey, const QString &
   return res;
 }
 
-QString QgsProviderRegistry::getStyleById( const QString &providerKey, const QString &uri, QString styleId, QString &errCause )
+bool QgsProviderRegistry::styleExists( const QString &providerKey, const QString &uri, const QString &styleId, QString &errorCause )
+{
+  errorCause.clear();
+
+  if ( QgsProviderMetadata *meta = findMetadata_( mProviders, providerKey ) )
+  {
+    return meta->styleExists( uri, styleId, errorCause );
+  }
+  else
+  {
+    errorCause = QObject::tr( "Unable to load %1 provider" ).arg( providerKey );
+    return false;
+  }
+}
+
+QString QgsProviderRegistry::getStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause )
 {
   QString ret;
   QgsProviderMetadata *meta = findMetadata_( mProviders, providerKey );
@@ -641,7 +656,7 @@ QString QgsProviderRegistry::getStyleById( const QString &providerKey, const QSt
   return ret;
 }
 
-bool QgsProviderRegistry::deleteStyleById( const QString &providerKey, const QString &uri, QString styleId, QString &errCause )
+bool QgsProviderRegistry::deleteStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause )
 {
   const bool ret( false );
 

--- a/src/core/providers/qgsproviderregistry.h
+++ b/src/core/providers/qgsproviderregistry.h
@@ -237,17 +237,33 @@ class CORE_EXPORT QgsProviderRegistry
                     QString &errCause );
 
     /**
-     * Gets a layer style defined by \a styleId
+     * Returns TRUE if a layer style with the specified \a styleId exists in the provider defined by \a providerKey and \a uri.
+     *
+     * \param providerKey provider key
+     * \param uri provider URI
+     * \param styleId style ID to test for
+     * \param errorCause will be set to a descriptive error message, if an error occurs while checking if the style exists
+     * \returns TRUE if the layer style already exists
+     *
+     * \see getStyleById()
+     * \since QGIS 3.24
+     */
+    bool styleExists( const QString &providerKey, const QString &uri, const QString &styleId, QString &errorCause SIP_OUT );
+
+    /**
+     * Gets a layer style defined by \a styleId.
+     *
+     * \see styleExists()
      *
      * \since QGIS 3.10
      */
-    QString getStyleById( const QString &providerKey,  const QString &uri, QString styleId, QString &errCause );
+    QString getStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause );
 
     /**
      * Deletes a layer style defined by \a styleId
      * \since QGIS 3.10
      */
-    bool deleteStyleById( const QString &providerKey,  const QString &uri, QString styleId, QString &errCause );
+    bool deleteStyleById( const QString &providerKey, const QString &uri, const QString &styleId, QString &errCause );
 
     /**
      * Saves a layer style to provider

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -988,6 +988,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param useAsDefault Set to TRUE if style should be used as the default style for the layer
      * \param uiFileContent
      * \param msgError will be set to a descriptive error message if any occurs
+     *
+     *
+     * \note Prior to QGIS 3.24, this method would show a message box warning when a
+     * style with the same \a styleName already existed to confirm replacing the style with the user.
+     * Since 3.24, calling this method will ALWAYS overwrite any existing style with the same name.
+     * Use QgsProviderRegistry::styleExists() to test in advance if a style already exists and handle this appropriately
+     * in your client code.
      */
     virtual void saveStyleToDatabase( const QString &name, const QString &description,
                                       bool useAsDefault, const QString &uiFileContent,

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -215,8 +215,8 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
           QString errorMessage;
           if ( QgsProviderRegistry::instance()->styleExists( layer->providerType(), layer->source(), QString(), errorMessage ) )
           {
-            if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                        QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
+            if ( QMessageBox::question( nullptr, tr( "Save style in database" ),
+                                        tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
                                         QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
             {
               return;
@@ -224,7 +224,7 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
           }
           else if ( !errorMessage.isEmpty() )
           {
-            QMessageBox::warning( nullptr, QObject::tr( "Save style in database" ),
+            QMessageBox::warning( nullptr, tr( "Save style in database" ),
                                   errorMessage );
             return;
           }

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -31,6 +31,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
 #include "qgsapplication.h"
+#include "qgsproviderregistry.h"
 
 QgsMapLayerStyleManagerWidget::QgsMapLayerStyleManagerWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )
@@ -210,12 +211,31 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
         case 0:
           return;
         case 2:
+        {
+          QString errorMessage;
+          if ( QgsProviderRegistry::instance()->styleExists( layer->providerType(), layer->source(), QString(), errorMessage ) )
+          {
+            if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+                                        QObject::tr( "A matching style already exists in the database for this layer. Do you want to overwrite it?" ),
+                                        QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
+            {
+              return;
+            }
+          }
+          else if ( !errorMessage.isEmpty() )
+          {
+            QMessageBox::warning( nullptr, QObject::tr( "Save style in database" ),
+                                  errorMessage );
+            return;
+          }
+
           layer->saveStyleToDatabase( QString(), QString(), true, QString(), errorMsg );
           if ( errorMsg.isNull() )
           {
             return;
           }
           break;
+        }
         default:
           break;
       }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -25,7 +25,6 @@
 #include <QFileInfo>
 #include <QDataStream>
 #include <QStringList>
-#include <QMessageBox>
 #include <QSettings>
 #include <QRegularExpression>
 #include <QUrl>
@@ -2600,16 +2599,6 @@ bool QgsMssqlProviderMetadata::saveStyle( const QString &uri,
   }
   if ( query.isActive() && query.next() && query.value( 0 ).toString() == styleName )
   {
-    if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
-    {
-      errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
-      QgsDebugMsg( QStringLiteral( "User selected not to overwrite styles" ) );
-      return false;
-    }
-
     QgsDebugMsgLevel( QStringLiteral( "Updating styles" ), 2 );
     sql = QString( "UPDATE layer_styles "
                    " SET useAsDefault=%1"

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -296,9 +296,10 @@ class QgsMssqlProviderMetadata final: public QgsProviderMetadata
 {
   public:
     QgsMssqlProviderMetadata();
-    QString getStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    QString getStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
     int listStyles( const QString &uri, QStringList &ids, QStringList &names, QStringList &descriptions, QString &errCause ) override;
     QString loadStyle( const QString &uri, QString &errCause ) override;
+    bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;
     bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,
                     const QString &styleName, const QString &styleDescription,
                     const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -45,7 +45,6 @@
 
 #include <QSqlRecord>
 #include <QSqlField>
-#include <QMessageBox>
 #include <QUuid>
 
 #include "ocispatial/wkbptr.h"
@@ -3506,16 +3505,6 @@ bool QgsOracleProviderMetadata::saveStyle( const QString &uri,
   }
   else if ( qry.next() )
   {
-    if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
-    {
-      errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
-      conn->disconnect();
-      return false;
-    }
-
     id = qry.value( 0 ).toInt();
 
     sql = QString( "UPDATE layer_styles"

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -3396,9 +3396,6 @@ bool QgsOracleProviderMetadata::styleExists( const QString &uri, const QString &
     return false;
   }
 
-  int id;
-  QString sql;
-
   if ( !qry.prepare( QStringLiteral( "SELECT id,stylename FROM layer_styles"
                                      " WHERE f_table_catalog=?"
                                      " AND f_table_schema=?"

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -3371,6 +3371,66 @@ QVariantList QgsOracleSharedData::lookupKey( QgsFeatureId featureId )
   return QVariantList();
 }
 
+bool QgsOracleProviderMetadata::styleExists( const QString &uri, const QString &styleId, QString &errorCause )
+{
+  errorCause.clear();
+
+  QgsDataSourceUri dsUri( uri );
+
+  QgsOracleConn *conn = QgsOracleConn::connectDb( dsUri, false );
+  if ( !conn )
+  {
+    errorCause = QObject::tr( "Could not connect to database" );
+    return false;
+  }
+
+  QSqlQuery qry = QSqlQuery( *conn );
+  if ( !qry.exec( "SELECT COUNT(*) FROM user_tables WHERE table_name='LAYER_STYLES'" ) || !qry.next() )
+  {
+    errCause = QObject::tr( "Unable to check layer style existence [%1]" ).arg( qry.lastError().text() );
+    conn->disconnect();
+    return false;
+  }
+  else if ( qry.value( 0 ).toInt() == 0 )
+  {
+    // layer styles table does not exist
+    return false;
+  }
+
+  int id;
+  QString sql;
+
+  if ( !qry.prepare( QStringLiteral( "SELECT id,stylename FROM layer_styles"
+                                     " WHERE f_table_catalog=?"
+                                     " AND f_table_schema=?"
+                                     " AND f_table_name=?"
+                                     " AND f_geometry_column=?"
+                                     " AND styleName=?" ) ) ||
+       !(
+         qry.addBindValue( dsUri.database() ),
+         qry.addBindValue( dsUri.schema() ),
+         qry.addBindValue( dsUri.table() ),
+         qry.addBindValue( dsUri.geometryColumn() ),
+         qry.addBindValue( styleId.isEmpty() ? dsUri.table() : styleId ),
+         qry.exec()
+       ) )
+  {
+    errorCause = QObject::tr( "Unable to check style existence [%1]" ).arg( qry.lastError().text() );
+    conn->disconnect();
+    return false;
+  }
+  else if ( qry.next() )
+  {
+    conn->disconnect();
+    return true;
+  }
+  else
+  {
+    conn->disconnect();
+    return false;
+  }
+}
+
 bool QgsOracleProviderMetadata::saveStyle( const QString &uri,
     const QString &qmlStyle,
     const QString &sldStyle,
@@ -3682,7 +3742,7 @@ int QgsOracleProviderMetadata::listStyles( const QString &uri,
   return res;
 }
 
-QString QgsOracleProviderMetadata::getStyleById( const QString &uri, QString styleId, QString &errCause )
+QString QgsOracleProviderMetadata::getStyleById( const QString &uri, const QString &styleId, QString &errCause )
 {
   QString style;
   QgsDataSourceUri dsUri( uri );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -3386,7 +3386,7 @@ bool QgsOracleProviderMetadata::styleExists( const QString &uri, const QString &
   QSqlQuery qry = QSqlQuery( *conn );
   if ( !qry.exec( "SELECT COUNT(*) FROM user_tables WHERE table_name='LAYER_STYLES'" ) || !qry.next() )
   {
-    errCause = QObject::tr( "Unable to check layer style existence [%1]" ).arg( qry.lastError().text() );
+    errorCause = QObject::tr( "Unable to check layer style existence [%1]" ).arg( qry.lastError().text() );
     conn->disconnect();
     return false;
   }

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -418,9 +418,10 @@ class QgsOracleProviderMetadata final: public QgsProviderMetadata
 
   public:
     QgsOracleProviderMetadata();
-    QString getStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    QString getStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
     int listStyles( const QString &uri, QStringList &ids, QStringList &names, QStringList &descriptions, QString &errCause ) override;
     QString loadStyle( const QString &uri, QString &errCause ) override;
+    bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;
     bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle, const QString &styleName,
                     const QString &styleDescription, const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;
     void cleanupProvider() override;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5637,12 +5637,18 @@ QString QgsPostgresProviderMetadata::loadStyle( const QString &uri, QString &err
 int QgsPostgresProviderMetadata::listStyles( const QString &uri, QStringList &ids, QStringList &names,
     QStringList &descriptions, QString &errCause )
 {
+  errCause.clear();
   QgsDataSourceUri dsUri( uri );
 
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
+    return -1;
+  }
+
+  if ( !tableExists( *conn, QStringLiteral( "layer_styles" ) ) )
+  {
     return -1;
   }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4882,7 +4882,7 @@ QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QS
     }
     i += match.captured( 1 ).length() + 2;
     jumpSpace( txt, i );
-    if ( !QStringView{txt} .mid( i ).startsWith( sep ) && i < txt.length() )
+    if ( !QStringView{txt}.mid( i ).startsWith( sep ) && i < txt.length() )
     {
       QgsMessageLog::logMessage( tr( "Cannot find separator: %1" ).arg( txt.mid( i ) ), tr( "PostGIS" ) );
       return QString();
@@ -4895,9 +4895,9 @@ QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QS
     int start = i;
     for ( ; i < txt.length(); i++ )
     {
-      if ( QStringView{txt} .mid( i ).startsWith( sep ) )
+      if ( QStringView{txt}.mid( i ).startsWith( sep ) )
       {
-        QStringView v( QStringView{txt} .mid( start, i - start ) );
+        QStringView v( QStringView{txt}.mid( start, i - start ) );
         i += sep.length();
         return v.trimmed().toString();
       }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -46,7 +46,6 @@
 #include "qgsprovidermetadata.h"
 #include "qgspostgresproviderconnection.h"
 
-#include <QMessageBox>
 #include <QRegularExpression>
 
 const QString QgsPostgresProvider::POSTGRES_KEY = QStringLiteral( "postgres" );
@@ -5488,16 +5487,6 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
   QgsPostgresResult res( conn->PQexec( checkQuery ) );
   if ( res.PQntuples() > 0 )
   {
-    if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
-    {
-      errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
-      conn->unref();
-      return false;
-    }
-
     sql = QString( "UPDATE layer_styles"
                    " SET useAsDefault=%1"
                    ",styleQML=XMLPARSE(DOCUMENT %12)"

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -608,13 +608,15 @@ class QgsPostgresProviderMetadata final: public QgsProviderMetadata
         bool overwrite,
         QMap<int, int> &oldToNewAttrIdxMap, QString &errorMessage,
         const QMap<QString, QVariant> *options ) override;
+
+    bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;
     bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle, const QString &styleName,
                     const QString &styleDescription, const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;
     QString loadStyle( const QString &uri, QString &errCause ) override;
     int listStyles( const QString &uri, QStringList &ids,
                     QStringList &names, QStringList &descriptions, QString &errCause ) override;
-    bool deleteStyleById( const QString &uri, QString styleId, QString &errCause ) override;
-    QString getStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    bool deleteStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
+    QString getStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
     QgsTransaction *createTransaction( const QString &connString ) override;
     QMap<QString, QgsAbstractProviderConnection *> connections( bool cached = true ) override;
     QgsAbstractProviderConnection *createConnection( const QString &name ) override;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -39,7 +39,6 @@ email                : a.furieri@lqt.it
 
 #include "qgsprovidermetadata.h"
 
-#include <QMessageBox>
 #include <QFileInfo>
 #include <QDir>
 #include <QRegularExpression>
@@ -6236,16 +6235,6 @@ bool QgsSpatiaLiteProviderMetadata::saveStyle( const QString &uri, const QString
   if ( 0 != rows )
   {
     sqlite3_free_table( results );
-    if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
-    {
-      QgsSqliteHandle::closeDb( handle );
-      errCause = QObject::tr( "Operation aborted" );
-      return false;
-    }
-
     sql = QString( "UPDATE layer_styles"
                    " SET useAsDefault=%1"
                    ",styleQML=%2"

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -114,7 +114,7 @@ class QgsSpatiaLiteProvider final: public QgsVectorDataProvider
                                        QgsFeedback *feedback = nullptr ) const override;
 
     bool isValid() const override;
-    bool isSaveAndLoadStyleToDatabaseSupported() const override { return true; }
+    bool isSaveAndLoadStyleToDatabaseSupported() const override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool truncate() override;

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -425,7 +425,8 @@ class QgsSpatiaLiteProviderMetadata final: public QgsProviderMetadata
     QgsSpatiaLiteProviderMetadata();
 
     void cleanupProvider() override;
-    QString getStyleById( const QString &uri, QString styleId, QString &errCause ) override;
+    QString getStyleById( const QString &uri, const QString &styleId, QString &errCause ) override;
+    bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;
     bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,
                     const QString &styleName, const QString &styleDescription,
                     const QString &uiFileContent, bool useAsDefault, QString &errCause ) override;

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -584,17 +584,17 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertEqual(idlist, [])
         self.assertEqual(namelist, [])
         self.assertEqual(desclist, [])
-        self.assertNotEqual(errmsg, "")
+        self.assertTrue(errmsg)
 
         qml, errmsg = vl.getStyleFromDatabase("1")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         qml, success = vl.loadNamedStyle('/idont/exist.gpkg')
         self.assertFalse(success)
 
         errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
-        self.assertNotEqual(errorMsg, "")
+        self.assertTrue(errorMsg)
 
         # Now with valid URI
         tmpfile = os.path.join(self.basetestpath, 'testStyle.gpkg')
@@ -634,17 +634,17 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertEqual(idlist, [])
         self.assertEqual(namelist, [])
         self.assertEqual(desclist, [])
-        self.assertNotEqual(errmsg, "")
+        self.assertTrue(errmsg)
 
         qml, errmsg = vl.getStyleFromDatabase("not_existing")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         qml, success = vl.loadNamedStyle('{}|layerid=0'.format(tmpfile))
         self.assertFalse(success)
 
         errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), '')
         self.assertFalse(res)
@@ -657,29 +657,27 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertFalse(err)
 
         qml, errmsg = vl.getStyleFromDatabase("not_existing")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
         self.assertEqual(idlist, ['1'])
         self.assertEqual(namelist, ['name'])
         self.assertEqual(desclist, ['description'])
 
         qml, errmsg = vl.getStyleFromDatabase("100")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         qml, errmsg = vl.getStyleFromDatabase("1")
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
 
-        # Try overwrite it but simulate answer no
-        settings = QgsSettings()
-        settings.setValue("/qgis/overwriteStyle", False)
+        # Try overwriting an existing style
         errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
-        self.assertNotEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name')
         self.assertTrue(res)
@@ -687,44 +685,27 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
-        self.assertEqual(errmsg, "")
-        self.assertEqual(idlist, ['1'])
-        self.assertEqual(namelist, ['name'])
-        self.assertEqual(desclist, ['description'])
-
-        # Try overwrite it and simulate answer yes
-        settings = QgsSettings()
-        settings.setValue("/qgis/overwriteStyle", True)
-        errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
-        self.assertEqual(errorMsg, "")
-
-        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name')
-        self.assertTrue(res)
-        self.assertFalse(err)
-
-        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
-        self.assertEqual(related_count, 1)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
         self.assertEqual(idlist, ['1'])
         self.assertEqual(namelist, ['name'])
         self.assertEqual(desclist, ['description_bis'])
 
         errorMsg = vl2.saveStyleToDatabase("name_test2", "description_test2", True, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         res, err = QgsProviderRegistry.instance().styleExists('ogr', vl2.source(), 'name_test2')
         self.assertTrue(res)
         self.assertFalse(err)
 
         errorMsg = vl.saveStyleToDatabase("name2", "description2", True, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name2')
         self.assertTrue(res)
         self.assertFalse(err)
 
         errorMsg = vl.saveStyleToDatabase("name3", "description3", True, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name3')
         self.assertTrue(res)
@@ -732,7 +713,7 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 3)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
         self.assertEqual(idlist, ['1', '3', '4', '2'])
         self.assertEqual(namelist, ['name', 'name2', 'name3', 'name_test2'])
         self.assertEqual(desclist, ['description_bis', 'description2', 'description3', 'description_test2'])

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -572,6 +572,13 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         self.assertFalse(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
 
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', '/idont/exist.gpkg', '')
+        self.assertFalse(res)
+        self.assertTrue(err)
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', '/idont/exist.gpkg', 'a style')
+        self.assertFalse(res)
+        self.assertTrue(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, -1)
         self.assertEqual(idlist, [])
@@ -614,6 +621,14 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
 
+        # style tables don't exist yet
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl2.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 0)
         self.assertEqual(idlist, [])
@@ -630,6 +645,16 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
 
         errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
         self.assertEqual(errorMsg, "")
+
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
 
         qml, errmsg = vl.getStyleFromDatabase("not_existing")
         self.assertEqual(qml, "")
@@ -656,6 +681,10 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
         self.assertNotEqual(errorMsg, "")
 
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
         self.assertEqual(errmsg, "")
@@ -669,6 +698,10 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
         self.assertEqual(errorMsg, "")
 
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
         self.assertEqual(errmsg, "")
@@ -679,11 +712,23 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         errorMsg = vl2.saveStyleToDatabase("name_test2", "description_test2", True, "")
         self.assertEqual(errorMsg, "")
 
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl2.source(), 'name_test2')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
         errorMsg = vl.saveStyleToDatabase("name2", "description2", True, "")
         self.assertEqual(errorMsg, "")
 
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name2')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
         errorMsg = vl.saveStyleToDatabase("name3", "description3", True, "")
         self.assertEqual(errorMsg, "")
+
+        res, err = QgsProviderRegistry.instance().styleExists('ogr', vl.source(), 'name3')
+        self.assertTrue(res)
+        self.assertFalse(err)
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 3)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1882,7 +1882,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
         self.assertTrue(vl.dataProvider().isDeleteStyleFromDatabaseSupported())
 
-        # table layer_styles does not exit
+        # table layer_styles does not exist
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, -1)
         self.assertEqual(idlist, [])

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1883,16 +1883,24 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.dataProvider().isDeleteStyleFromDatabaseSupported())
 
         # table layer_styles does not exist
+
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, -1)
         self.assertEqual(idlist, [])
         self.assertEqual(namelist, [])
         self.assertEqual(desclist, [])
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(errmsg)
 
         qml, errmsg = vl.getStyleFromDatabase("1")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         mFilePath = QDir.toNativeSeparators(
             '%s/symbol_layer/%s.qml' % (unitTestDataPath(), "singleSymbol"))
@@ -1902,27 +1910,37 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # The style is saved as non-default
         errorMsg = vl.saveStyleToDatabase(
             "by day", "faded greens and elegant patterns", False, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errorMsg)
 
         # the style id should be "1", not "by day"
         qml, errmsg = vl.getStyleFromDatabase("by day")
         self.assertEqual(qml, "")
         self.assertNotEqual(errmsg, "")
 
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'by day')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 1)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
         self.assertEqual(idlist, ["1"])
         self.assertEqual(namelist, ["by day"])
         self.assertEqual(desclist, ["faded greens and elegant patterns"])
 
         qml, errmsg = vl.getStyleFromDatabase("100")
-        self.assertEqual(qml, "")
-        self.assertNotEqual(errmsg, "")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
 
         qml, errmsg = vl.getStyleFromDatabase("1")
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
 
         res, errmsg = vl.deleteStyleFromDatabase("100")
         self.assertTrue(res)
@@ -1930,15 +1948,31 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         res, errmsg = vl.deleteStyleFromDatabase("1")
         self.assertTrue(res)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
 
         # We save now the style again twice but with one as default
-        errorMsg = vl.saveStyleToDatabase(
+        errmsg = vl.saveStyleToDatabase(
             "related style", "faded greens and elegant patterns", False, "")
-        self.assertEqual(errorMsg, "")
-        errorMsg = vl.saveStyleToDatabase(
+        self.assertEqual(errmsg, "")
+        errmsg = vl.saveStyleToDatabase(
             "default style", "faded greens and elegant patterns", True, "")
-        self.assertEqual(errorMsg, "")
+        self.assertFalse(errmsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'default style')
+        self.assertTrue(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'related style')
+        self.assertTrue(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'by day')
+        self.assertFalse(res)
+        self.assertFalse(err)
 
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 2)
@@ -1950,18 +1984,31 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # We remove these 2 styles
         res, errmsg = vl.deleteStyleFromDatabase("2")
         self.assertTrue(res)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
         res, errmsg = vl.deleteStyleFromDatabase("3")
         self.assertTrue(res)
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
 
-        # table layer_styles does exit, but is now empty
+        # table layer_styles does exist, but is now empty
         related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
         self.assertEqual(related_count, 0)
         self.assertEqual(idlist, [])
         self.assertEqual(namelist, [])
         self.assertEqual(desclist, [])
-        self.assertEqual(errmsg, "")
+        self.assertFalse(errmsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'default style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('postgres', vl.source(), 'related style')
+        self.assertFalse(res)
+        self.assertFalse(err)
 
     def testStyleWithGeometryType(self):
         """Test saving styles with the additional geometry type

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1082,6 +1082,183 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         err, ok = vl.loadDefaultStyle()
         self.assertTrue(ok)
 
+    def testStyleStorage(self):
+
+        # First test with invalid URI
+        vl = QgsVectorLayer('/idont/exist.sqlite', 'test', 'spatialite')
+
+        self.assertFalse(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', '/idont/exist.sqlite', '')
+        self.assertFalse(res)
+        self.assertTrue(err)
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', '/idont/exist.sqlite', 'a style')
+        self.assertFalse(res)
+        self.assertTrue(err)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, -1)
+        self.assertEqual(idlist, [])
+        self.assertEqual(namelist, [])
+        self.assertEqual(desclist, [])
+        self.assertTrue(errmsg)
+
+        qml, errmsg = vl.getStyleFromDatabase("1")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
+
+        qml, success = vl.loadNamedStyle('/idont/exist.sqlite')
+        self.assertFalse(success)
+
+        errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
+        self.assertTrue(errorMsg)
+
+        # create test db
+        dbname = os.path.join(tempfile.gettempdir(), "test_stylehandling.sqlite")
+        if os.path.exists(dbname):
+            os.remove(dbname)
+        con = spatialite_connect(dbname, isolation_level=None)
+        cur = con.cursor()
+        cur.execute("BEGIN")
+        sql = "SELECT InitSpatialMetadata()"
+        cur.execute(sql)
+
+        # simple table with primary key
+        sql = "CREATE TABLE test_pg (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL)"
+        cur.execute(sql)
+
+        sql = "SELECT AddGeometryColumn('test_pg', 'geometry', 4326, 'POLYGON', 'XY')"
+        cur.execute(sql)
+
+        sql = "INSERT INTO test_pg (id, name, geometry) "
+        sql += "VALUES (1, 'toto', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
+        cur.execute(sql)
+
+        cur.execute("COMMIT")
+        con.close()
+
+        testPath = "dbname=%s table='test_pg' (geometry) key='id'" % dbname
+        vl = QgsVectorLayer(testPath, 'test', 'spatialite')
+        self.assertTrue(vl.isValid())
+
+        self.assertTrue(vl.dataProvider().isSaveAndLoadStyleToDatabaseSupported())
+
+        # style tables don't exist yet
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, 0)
+        self.assertEqual(idlist, [])
+        self.assertEqual(namelist, [])
+        self.assertEqual(desclist, [])
+        self.assertTrue(errmsg)
+
+        qml, errmsg = vl.getStyleFromDatabase("not_existing")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
+
+        qml, success = vl.loadNamedStyle('{}|layerid=0'.format(dbname))
+        self.assertFalse(success)
+
+        errorMsg = vl.saveStyleToDatabase("name", "description", False, "")
+        self.assertEqual(errorMsg, "")
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), '')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'a style')
+        self.assertFalse(res)
+        self.assertFalse(err)
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        qml, errmsg = vl.getStyleFromDatabase("not_existing")
+        self.assertFalse(qml)
+        self.assertTrue(errmsg)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, 1)
+        self.assertFalse(errmsg)
+        self.assertEqual(idlist, ['1'])
+        self.assertEqual(namelist, ['name'])
+        self.assertEqual(desclist, ['description'])
+
+        qml, errmsg = vl.getStyleFromDatabase("100")
+        self.assertEqual(qml, "")
+        self.assertNotEqual(errmsg, "")
+
+        qml, errmsg = vl.getStyleFromDatabase("1")
+        self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
+        self.assertFalse(errmsg)
+
+        # Try overwrite it but simulate answer no
+        settings = QgsSettings()
+        settings.setValue("/qgis/overwriteStyle", False)
+        errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
+        self.assertTrue(errorMsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, 1)
+        self.assertFalse(errmsg)
+        self.assertEqual(idlist, ['1'])
+        self.assertEqual(namelist, ['name'])
+        self.assertEqual(desclist, ['description'])
+
+        # Try overwrite it and simulate answer yes
+        settings = QgsSettings()
+        settings.setValue("/qgis/overwriteStyle", True)
+        errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
+        self.assertFalse(errorMsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, 1)
+        self.assertFalse(errmsg)
+        self.assertEqual(idlist, ['1'])
+        self.assertEqual(namelist, ['name'])
+        self.assertEqual(desclist, ['description_bis'])
+
+        errorMsg = vl.saveStyleToDatabase("name_test2", "description_test2", True, "")
+        self.assertFalse(errmsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name_test2')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        errorMsg = vl.saveStyleToDatabase("name2", "description2", True, "")
+        self.assertFalse(errmsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name2')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        errorMsg = vl.saveStyleToDatabase("name3", "description3", True, "")
+        self.assertFalse(errmsg)
+
+        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name3')
+        self.assertTrue(res)
+        self.assertFalse(err)
+
+        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
+        self.assertEqual(related_count, 4)
+        self.assertFalse(errmsg)
+        self.assertCountEqual(idlist, ['1', '3', '4', '2'])
+        self.assertCountEqual(namelist, ['name', 'name2', 'name3', 'name_test2'])
+        self.assertCountEqual(desclist, ['description_bis', 'description2', 'description3', 'description_test2'])
+
     def _aliased_sql_helper(self, dbname):
         queries = (
             '(SELECT * FROM (SELECT * from \\"some view\\"))',

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -1197,24 +1197,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(qml.startswith('<!DOCTYPE qgis'), qml)
         self.assertFalse(errmsg)
 
-        # Try overwrite it but simulate answer no
-        settings = QgsSettings()
-        settings.setValue("/qgis/overwriteStyle", False)
-        errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")
-        self.assertTrue(errorMsg)
-
-        res, err = QgsProviderRegistry.instance().styleExists('spatialite', vl.source(), 'name')
-        self.assertTrue(res)
-        self.assertFalse(err)
-
-        related_count, idlist, namelist, desclist, errmsg = vl.listStylesInDatabase()
-        self.assertEqual(related_count, 1)
-        self.assertFalse(errmsg)
-        self.assertEqual(idlist, ['1'])
-        self.assertEqual(namelist, ['name'])
-        self.assertEqual(desclist, ['description'])
-
-        # Try overwrite it and simulate answer yes
+        # overwrite existing style
         settings = QgsSettings()
         settings.setValue("/qgis/overwriteStyle", True)
         errorMsg = vl.saveStyleToDatabase("name", "description_bis", False, "")


### PR DESCRIPTION
This PR reworks the API for saving styles to database to remove the unsafe use of widgets (a confirmation QMessageBox) from the provider code. This was shown when a matching style already exists in the database, and causes a crash if this method is ever called from a non-main thread.

Now determining if a matching style already exists is a separate method, and the messagebox questions are only present in the client (app) code. 

Fixes #46954
Fixes #46914