### PR TITLE
Fix layout crash when resizing frames

### DIFF
--- a/src/core/layout/qgslayoutmultiframe.cpp
+++ b/src/core/layout/qgslayoutmultiframe.cpp
@@ -439,6 +439,12 @@ void QgsLayoutMultiFrame::removeFrame( int i, const bool removeEmptyPages )
     mLayout->undoStack()->blockCommands( false );
     mIsRecalculatingSize = false;
   }
+
+  if ( i >= mFrameItems.count() )
+  {
+    return;
+  }
+
   mFrameItems.removeAt( i );
 }
 

--- a/src/core/layout/qgslayoutpagecollection.cpp
+++ b/src/core/layout/qgslayoutpagecollection.cpp
@@ -80,13 +80,24 @@ void QgsLayoutPageCollection::endPageSizeChange()
 {
   for ( auto it = mPreviousItemPositions.constBegin(); it != mPreviousItemPositions.constEnd(); ++it )
   {
-    if ( QgsLayoutItem *item = mLayout->itemByUuid( it.key() ) )
+    const QString key { it.key() };
+    if ( QgsLayoutItem *item = mLayout->itemByUuid( key ) )
     {
       if ( !mBlockUndoCommands )
         item->beginCommand( QString() );
+
       item->attemptMove( it.value().second, true, false, it.value().first );
-      if ( !mBlockUndoCommands )
-        item->endCommand();
+
+      // Item might have been deleted
+      if ( mLayout->itemByUuid( key ) )
+      {
+        if ( !mBlockUndoCommands )
+          item->endCommand();
+      }
+      else
+      {
+        item->cancelCommand();
+      }
     }
   }
   mPreviousItemPositions.clear();


### PR DESCRIPTION
Fix #46575

QgsLayoutPageCollection::endPageSizeChange() calls attemptMove()
which emits sizePositionChanged() which may delete frames inside
QgsLayoutMultiFrame::recalculateFrameSizes(), so we check if the
frame still exists before issuing endCommand() because endCommand()
calls QgsLayoutItemUndoCommand::saveState() that ASSERT to have
a valid item in the layout (but the item was deleted!).

The change in src/core/layout/qgslayoutmultiframe.cpp
suppresses a Qt warning when an invalid list index was used.

