### PR TITLE
handle percent-encoded font references in SLD (fix #27263)

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -3046,7 +3046,7 @@ bool QgsSymbolLayerUtils::onlineResourceFromSldElement( QDomElement &element, QS
   if ( onlineResourceElem.isNull() )
     return false;
 
-  path = onlineResourceElem.attributeNS( QStringLiteral( "http://www.w3.org/1999/xlink" ), QStringLiteral( "href" ) );
+  path = QUrl::fromPercentEncoding( onlineResourceElem.attributeNS( QStringLiteral( "http://www.w3.org/1999/xlink" ), QStringLiteral( "href" ) ).toUtf8() );
 
   const QDomElement formatElem = element.firstChildElement( QStringLiteral( "Format" ) );
   if ( formatElem.isNull() )

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -368,6 +368,15 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         self.assertEqual(unit, QgsUnitTypes.RenderPixels)
         self.assertEqual(size, sld_size_px)
 
+        # test percent encoding  for QgsFontMarkerSymbolLayer
+        sld = 'symbol_layer/QgsFontMarkerSymbolLayerPercentEncoding.sld'
+        mFilePath = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(mFilePath)
+
+        sl = layer.renderer().symbol().symbolLayers()[0]
+        self.assertTrue(isinstance(sl, QgsFontMarkerSymbolLayer))
+        self.assertEqual(sl.fontFamily(), 'MapInfo Miscellaneous')
+
     def testSymbolSizeAfterReload(self):
         # create a layer
         layer = createLayerWithOnePoint()

--- a/tests/testdata/symbol_layer/QgsFontMarkerSymbolLayerPercentEncoding.sld
+++ b/tests/testdata/symbol_layer/QgsFontMarkerSymbolLayerPercentEncoding.sld
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <se:Name>022cs000</se:Name>
+    <UserStyle>
+      <se:Name>022cs000</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <OnlineResource xlink:type="simple" xlink:href="ttf://MapInfo%20Miscellaneous"/>
+                <Format>ttf</Format>
+                <se:MarkIndex>77</se:MarkIndex>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#000000</se:SvgParameter>
+                </se:Fill>
+              </se:Mark>
+              <se:Size>6.23</se:Size>
+              <se:Rotation>
+                <ogc:Literal>3</ogc:Literal>
+              </se:Rotation>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Description

If SLD style contains TTF percent-encodede TTF font reference like
```
<se:OnlineResource xlink:type="simple" xlink:href="ttf://MapInfo%20Miscellaneous" />
```
then QGIS don't recognize it and replace with the default font.

Fixes #27263.