### PR TITLE
Disable data-defined buttons for incompatible SVG pictures in Layout item (fix #26524)

### DIFF
--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -383,6 +383,7 @@ void QgsLayoutPictureWidget::updateSvgParamGui( bool resetValues )
     mFillColorButton->setColor( fill );
   }
   mFillColorButton->setEnabled( hasFillParam );
+  mFillColorDDBtn->setEnabled( hasFillParam );
   mFillColorButton->setAllowOpacity( hasFillOpacityParam );
   if ( resetValues )
   {
@@ -396,12 +397,14 @@ void QgsLayoutPictureWidget::updateSvgParamGui( bool resetValues )
     mStrokeColorButton->setColor( stroke );
   }
   mStrokeColorButton->setEnabled( hasStrokeParam );
+  mStrokeColorDDBtn->setEnabled( hasStrokeParam );
   mStrokeColorButton->setAllowOpacity( hasStrokeOpacityParam );
   if ( hasDefaultStrokeWidth && resetValues )
   {
     mStrokeWidthSpinBox->setValue( defaultStrokeWidth );
   }
   mStrokeWidthSpinBox->setEnabled( hasStrokeWidthParam );
+  mStrokeWidthDDBtn->setEnabled( hasStrokeWidthParam );
 }
 
 void QgsLayoutPictureWidget::mFillColorButton_colorChanged( const QColor &color )


### PR DESCRIPTION
## Description

When using images or not parameterized SVG files in the Picture item in the Layout, data-defined buttons for fill, stroke width and stroke color are not disabled, while corresponding editing widgets are. This is a bit confusing and better to have both edit widgets and data-defined buttons disabled.

Fixes #26524.