### PR TITLE
Set display expression when adding fields through attribute table (fix #28353)

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -890,13 +890,17 @@ void QgsAttributeTableDialog::mActionAddAttribute_triggered()
     if ( mLayer->addAttribute( dialog.field() ) )
     {
       mLayer->endEditCommand();
+
+      if ( mLayer->displayExpression().isEmpty() )
+      {
+        mLayer->setDisplayExpression( dialog.field().name() );
+      }
     }
     else
     {
       mLayer->destroyEditCommand();
       QMessageBox::critical( this, tr( "Add Field" ), tr( "Failed to add field '%1' of type '%2'. Is the field name unique?" ).arg( dialog.field().name(), dialog.field().typeName() ) );
     }
-
 
     // update model - a field has been added or updated
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
@@ -919,12 +923,17 @@ void QgsAttributeTableDialog::mActionRemoveAttribute_triggered()
       return;
     }
 
+    // check whether display expression is a single field
+    int fieldIdx = QgsExpression::expressionToLayerFieldIndex( mLayer->displayExpression(), mLayer );
     QgsAttributeTableModel *masterModel = mMainView->masterModel();
 
     mLayer->beginEditCommand( tr( "Deleted attribute" ) );
     if ( mLayer->deleteAttributes( attributes ) )
     {
       mLayer->endEditCommand();
+
+      if ( fieldIdx != -1 && attributes.contains( fieldIdx ) )
+        mLayer->setDisplayExpression( mLayer->fields().count() > 0 ? mLayer->fields().at( 0 ).name() : QString() );
     }
     else
     {


### PR DESCRIPTION
## Description

If vector layer created without any attributes and then new fields are added via attributes table then display expression is not set. As a result "Features in All layers" locator filter shows ` [Please define preview text]` instead of the real values.

Fixes #28353.