### PR TITLE
[processing] save NULL and empty values into different files in Split Vector Layer algorithm (fix #38105)

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -119,12 +119,25 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
     if ( feedback->isCanceled() )
       break;
 
-    QString fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
+    QString fileName;
+    if ( ( *it ).isNull() )
+    {
+      fileName = QStringLiteral( "%1_NULL.%2" ).arg( baseName ).arg( outputFormat );
+    }
+    else if ( ( *it ).toString().isEmpty() )
+    {
+      fileName = QStringLiteral( "%1_EMPTY.%2" ).arg( baseName ).arg( outputFormat );
+    }
+    else
+    {
+      fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
+    }
     feedback->pushInfo( QObject::tr( "Creating layer: %1" ).arg( fileName ) );
 
     sink.reset( QgsProcessingUtils::createFeatureSink( fileName, context, fields, geometryType, crs ) );
     const QString expr = QgsExpression::createFieldEqualityExpression( fieldName, *it );
     QgsFeatureIterator features = source->getFeatures( QgsFeatureRequest().setFilterExpression( expr ) );
+    count = 0;
     while ( features.nextFeature( feat ) )
     {
       if ( feedback->isCanceled() )


### PR DESCRIPTION
## Description
The Split Vector Layer algorithm exports both NULL and empty attribute values to the same filename, as a result one file overwrites another and some results are lost. Proposed PR assigns different suffixes for such files (`_EMPTY` and `_NULL`).

Fixes #38105.

Also fix unreported bug with displaying incorrect number of features written to each output file.
