### PR TITLE
Compute WMS GetLegendGraphics image dimensions in mm when scaling to fit layout WMS legend size constraints

### DIFF
--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1250,8 +1250,7 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
 
   const QImage image = getLegendGraphic();
 
-  // Assume legend images have 72 dpi resolution
-  double px2mm = 25.4 / 72;
+  double px2mm = 1000. / image.dotsPerMeterX();
   double mmWidth = image.width() * px2mm;
   double mmHeight = image.height() * px2mm;
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1268,6 +1268,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
 
   if ( ctx && ctx->painter )
   {
+    QImage smoothImage = image.scaled( targetSize / px2mm, Qt::KeepAspectRatio, Qt::SmoothTransformation );
+
     switch ( settings.symbolAlignment() )
     {
       case Qt::AlignLeft:
@@ -1276,8 +1278,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
                                          ctx->top,
                                          targetSize.width(),
                                          targetSize.height() ),
-                                 image,
-                                 QRectF( QPointF( 0, 0 ), image.size() ) );
+                                 smoothImage,
+                                 QRectF( QPointF( 0, 0 ), smoothImage.size() ) );
         break;
 
       case Qt::AlignRight:
@@ -1285,8 +1287,8 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
                                          ctx->top,
                                          targetSize.width(),
                                          targetSize.height() ),
-                                 image,
-                                 QRectF( QPointF( 0, 0 ), image.size() ) );
+                                 smoothImage,
+                                 QRectF( QPointF( 0, 0 ), smoothImage.size() ) );
         break;
     }
   }

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1250,21 +1250,25 @@ QSizeF QgsWmsLegendNode::drawSymbol( const QgsLegendSettings &settings, ItemCont
 
   const QImage image = getLegendGraphic();
 
-  QSize targetSize = image.size();
-  if ( settings.wmsLegendSize().width() < image.width() )
+  // Assume legend images have 72 dpi resolution
+  double px2mm = 25.4 / 72;
+  double mmWidth = image.width() * px2mm;
+  double mmHeight = image.height() * px2mm;
+
+  QSize targetSize = QSize( mmWidth, mmHeight );
+  if ( settings.wmsLegendSize().width() < mmWidth )
   {
-    double targetHeight = image.height() * settings.wmsLegendSize().width() / image.width();
+    double targetHeight = mmHeight * settings.wmsLegendSize().width() / mmWidth;
     targetSize = QSize( settings.wmsLegendSize().width(), targetHeight );
   }
-  else if ( settings.wmsLegendSize().height() < image.height() )
+  else if ( settings.wmsLegendSize().height() < mmHeight )
   {
-    double targetWidth = image.width() * settings.wmsLegendSize().height() / image.height();
+    double targetWidth = mmWidth * settings.wmsLegendSize().height() / mmHeight;
     targetSize = QSize( targetWidth, settings.wmsLegendSize().height() );
   }
 
   if ( ctx && ctx->painter )
   {
-
     switch ( settings.symbolAlignment() )
     {
       case Qt::AlignLeft:


### PR DESCRIPTION
The previous logic incorrectly compared the image size in pixels to the WMS legend size constraints in mm.