### PR TITLE
Update r.water.outlet.txt to tell the user what kind of input raster is needed

### DIFF
--- a/python/plugins/grassprovider/description/r.water.outlet.txt
+++ b/python/plugins/grassprovider/description/r.water.outlet.txt
@@ -1,6 +1,6 @@
 r.water.outlet
 Watershed basin creation program.
 Raster (r.*)
-QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
+QgsProcessingParameterRasterLayer|input|Drainage direction raster|None|False
 QgsProcessingParameterPoint|coordinates|Coordinates of outlet point|0.0,0.0|False
 QgsProcessingParameterRasterDestination|output|Basin


### PR DESCRIPTION
## Description

The current label "Name of input raster map" does not tell the user anything about what the input raster layer is supposed to be - the occasional user will probably either try using their DEM, or have to go and read the grass documentation every time they use this algorithm.

## Discussion

Perhaps instead of "Drainage direction raster" it should just say "Drainage direction".
Or maybe something like "Drainage direction (created as optional output of r.watershed)"