### PR TITLE
Fix post MultiPart

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -353,11 +353,6 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   {
     content = buffer->buffer();
   }
-  else if ( outgoingData )
-  {
-    content = outgoingData->readAll();
-    outgoingData->seek( 0 );
-  }
 
   emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId, content ) );
   Q_NOWARN_DEPRECATED_PUSH

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -587,12 +587,12 @@ void TestQgsNetworkAccessManager::fetchPostMultiPart()
 
 void TestQgsNetworkAccessManager::fetchPostMultiPart_data()
 {
-  QTest::addColumn<int>( "contentType" );
+  QTest::addColumn<int>( "iContentType" );
 
-  QTest::newRow( "MixedType" ) << QHttpMultiPart::MixedType;
-  QTest::newRow( "FormDataType" ) << QHttpMultiPart::FormDataType;
-  QTest::newRow( "RelatedType" ) << QHttpMultiPart::FormDataType;
-  QTest::newRow( "AlternativeType" ) << QHttpMultiPart::FormDataType;
+  QTest::newRow( "MixedType" ) << static_cast<int>( QHttpMultiPart::MixedType );
+  QTest::newRow( "FormDataType" ) << static_cast<int>( QHttpMultiPart::FormDataType );
+  QTest::newRow( "RelatedType" ) << static_cast<int>( QHttpMultiPart::FormDataType );
+  QTest::newRow( "AlternativeType" ) << static_cast<int>( QHttpMultiPart::FormDataType );
 }
 
 void TestQgsNetworkAccessManager::fetchBadSsl()

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -157,6 +157,7 @@ class TestQgsNetworkAccessManager : public QObject
     void fetchEncodedContent(); //test fetching url content encoded as utf-8
     void fetchPost();
     void fetchPostMultiPart();
+    void fetchPostMultiPart_data();
     void fetchBadSsl();
     void testSslErrorHandler();
     void testAuthRequestHandler();
@@ -560,11 +561,13 @@ void TestQgsNetworkAccessManager::fetchPost()
 
 void TestQgsNetworkAccessManager::fetchPostMultiPart()
 {
-  QUrl u =  QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/post" ) );
+  QFETCH( int, iContentType );
+  QHttpMultiPart::ContentType contentType = static_cast< QHttpMultiPart::ContentType>( iContentType );
+  QUrl u = QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/post" ) );
   QNetworkRequest req( u );
 
   // MultiPart
-  QNetworkReply *reply = QgsNetworkAccessManager::instance()->post( req, new QHttpMultiPart( QHttpMultiPart::MixedType ) );
+  QNetworkReply *reply = QgsNetworkAccessManager::instance()->post( req, new QHttpMultiPart( contentType ) );
 
   QEventLoop el;
   connect( QgsNetworkAccessManager::instance(), &QgsNetworkAccessManager::finished, &el, &QEventLoop::quit );
@@ -573,6 +576,16 @@ void TestQgsNetworkAccessManager::fetchPostMultiPart()
   QCOMPARE( reply->error(), QNetworkReply::NoError );
   QVERIFY( reply->rawHeaderList().contains( "Content-Type" ) );
   QCOMPARE( reply->request().url(), u );
+}
+
+void TestQgsNetworkAccessManager::fetchPostMultiPart_data()
+{
+  QTest::addColumn<int>( "contentType" );
+
+  QTest::newRow( "MixedType" ) << QHttpMultiPart::MixedType;
+  QTest::newRow( "FormDataType" ) << QHttpMultiPart::FormDataType;
+  QTest::newRow( "RelatedType" ) << QHttpMultiPart::FormDataType;
+  QTest::newRow( "AlternativeType" ) << QHttpMultiPart::FormDataType;
 }
 
 void TestQgsNetworkAccessManager::fetchBadSsl()

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -563,11 +563,18 @@ void TestQgsNetworkAccessManager::fetchPostMultiPart()
 {
   QFETCH( int, iContentType );
   QHttpMultiPart::ContentType contentType = static_cast< QHttpMultiPart::ContentType>( iContentType );
+  QHttpMultiPart *multipart = new QHttpMultiPart( contentType );
+  QHttpPart part;
+  part.setHeader( QNetworkRequest::ContentDispositionHeader,
+                  QStringLiteral( "form-data; name=\"param\"" ) );
+  part.setBody( QStringLiteral( "some data" ) .toUtf8() );
+  multipart->append( part );
   QUrl u = QUrl( QStringLiteral( "http://" ) + mHttpBinHost + QStringLiteral( "/post" ) );
   QNetworkRequest req( u );
 
   // MultiPart
-  QNetworkReply *reply = QgsNetworkAccessManager::instance()->post( req, new QHttpMultiPart( contentType ) );
+  QNetworkReply *reply = QgsNetworkAccessManager::instance()->post( req, multipart );
+  multipart->setParent( reply );
 
   QEventLoop el;
   connect( QgsNetworkAccessManager::instance(), &QgsNetworkAccessManager::finished, &el, &QEventLoop::quit );

--- a/tests/src/python/test_qgsaction.py
+++ b/tests/src/python/test_qgsaction.py
@@ -64,42 +64,6 @@ class TestQgsAction(unittest.TestCase):
 
         self.assertEqual(self.body, br"a%26%2Bb=a%20and%20plus%20b&a%3Db=a%20equals%20b")
 
-# TEST DISABLED
-# NONFUNCTIONAL
-
-#    def test_post_multipart_action(self):
-#        """Test multipart"""
-#
-#        self.body = None
-#
-#        def _req_logger(self, params):
-#            self.body = bytes(params.content())
-#
-#        QgsNetworkAccessManager.instance().requestAboutToBeCreated[QgsNetworkRequestParameters].connect(partial(_req_logger, self))
-#
-#        temp_dir = QTemporaryDir()
-#        temp_path = temp_dir.path()
-#        temp_file = os.path.join(temp_path, 'multipart.txt')
-#
-#        action = QgsAction(QgsAction.SubmitUrlMultipart, 'url_encoded', "http://fake_qgis_http_endpoint" + temp_file + r"?[% url_encode(map('a&+b', 'a and plus b', 'a=b', 'a equals b')) %]")
-#        ctx = QgsExpressionContext()
-#        action.run(ctx)
-#
-#        while not self.body:
-#            QgsApplication.instance().processEvents()
-#
-#        self.assertEqual(re.sub(r'\.oOo\.[^\r]*', '.oOo.UUID', self.body.decode('utf8')), '\r\n'.join([
-#            '--boundary_.oOo.UUID',
-#            'Content-Disposition: form-data; name="a&+b"',
-#            '',
-#            'a and plus b',
-#            '--boundary_.oOo.UUID',
-#            'Content-Disposition: form-data; name="a=b"',
-#            '',
-#            'a equals b',
-#            '--boundary_.oOo.UUID',
-#            '']))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsaction.py
+++ b/tests/src/python/test_qgsaction.py
@@ -64,38 +64,41 @@ class TestQgsAction(unittest.TestCase):
 
         self.assertEqual(self.body, br"a%26%2Bb=a%20and%20plus%20b&a%3Db=a%20equals%20b")
 
-    def test_post_multipart_action(self):
-        """Test multipart"""
+# TEST DISABLED
+# NONFUNCTIONAL
 
-        self.body = None
-
-        def _req_logger(self, params):
-            self.body = bytes(params.content())
-
-        QgsNetworkAccessManager.instance().requestAboutToBeCreated[QgsNetworkRequestParameters].connect(partial(_req_logger, self))
-
-        temp_dir = QTemporaryDir()
-        temp_path = temp_dir.path()
-        temp_file = os.path.join(temp_path, 'multipart.txt')
-
-        action = QgsAction(QgsAction.SubmitUrlMultipart, 'url_encoded', "http://fake_qgis_http_endpoint" + temp_file + r"?[% url_encode(map('a&+b', 'a and plus b', 'a=b', 'a equals b')) %]")
-        ctx = QgsExpressionContext()
-        action.run(ctx)
-
-        while not self.body:
-            QgsApplication.instance().processEvents()
-
-        self.assertEqual(re.sub(r'\.oOo\.[^\r]*', '.oOo.UUID', self.body.decode('utf8')), '\r\n'.join([
-            '--boundary_.oOo.UUID',
-            'Content-Disposition: form-data; name="a&+b"',
-            '',
-            'a and plus b',
-            '--boundary_.oOo.UUID',
-            'Content-Disposition: form-data; name="a=b"',
-            '',
-            'a equals b',
-            '--boundary_.oOo.UUID',
-            '']))
+#    def test_post_multipart_action(self):
+#        """Test multipart"""
+#
+#        self.body = None
+#
+#        def _req_logger(self, params):
+#            self.body = bytes(params.content())
+#
+#        QgsNetworkAccessManager.instance().requestAboutToBeCreated[QgsNetworkRequestParameters].connect(partial(_req_logger, self))
+#
+#        temp_dir = QTemporaryDir()
+#        temp_path = temp_dir.path()
+#        temp_file = os.path.join(temp_path, 'multipart.txt')
+#
+#        action = QgsAction(QgsAction.SubmitUrlMultipart, 'url_encoded', "http://fake_qgis_http_endpoint" + temp_file + r"?[% url_encode(map('a&+b', 'a and plus b', 'a=b', 'a equals b')) %]")
+#        ctx = QgsExpressionContext()
+#        action.run(ctx)
+#
+#        while not self.body:
+#            QgsApplication.instance().processEvents()
+#
+#        self.assertEqual(re.sub(r'\.oOo\.[^\r]*', '.oOo.UUID', self.body.decode('utf8')), '\r\n'.join([
+#            '--boundary_.oOo.UUID',
+#            'Content-Disposition: form-data; name="a&+b"',
+#            '',
+#            'a and plus b',
+#            '--boundary_.oOo.UUID',
+#            'Content-Disposition: form-data; name="a=b"',
+#            '',
+#            'a equals b',
+#            '--boundary_.oOo.UUID',
+#            '']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts commit c62a2558e24b335caca53d0769487e0eddf0f0da.

Calling `readAll()` on `outgoingData` breaks multipart post requests.

Fixes https://github.com/qgis/QGIS/issues/46989
