### PR TITLE
[themes] Fix push button flat property not taken into account

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -227,7 +227,7 @@ QToolButton
     color:@text;
 }
 
-QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
+QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
     border:1px solid rgba(0,0,0,0);
     background-color:transparent;
 }
@@ -965,6 +965,11 @@ QHeaderView::up-arrow {
 
 QToolButton:focus, QPushButton:focus, QCheckBox:focus, QRadioButton:focus, QGroupBox:focus {
     outline:1px solid @focusdark;
+    outline-radius: 0.2em;
+}
+
+QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
+    outline:1px solid rgba(0,0,0,0);
     outline-radius: 0.2em;
 }
 

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -237,7 +237,7 @@ QToolButton
     color:@text;
 }
 
-QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
+QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
     border:1px solid rgba(0,0,0,0);
     background-color:transparent;
 }
@@ -991,6 +991,11 @@ QHeaderView::up-arrow {
 
 QToolButton:focus, QPushButton:focus, QCheckBox:focus, QRadioButton:focus, QGroupBox:focus {
     outline:1px solid @focusdark;
+    outline-radius: 0;
+}
+
+QPushButton[flat=true], QPushButton[autoRaise=true], QToolButton[autoRaise=true] {
+    outline:1px solid rgba(0,0,0,0);
     outline-radius: 0;
 }
 


### PR DESCRIPTION
## Description

Before (top) vs. PR (bottom):
![image](https://user-images.githubusercontent.com/1728657/151146428-8bf5beaf-f957-46ad-b1eb-97f863cc149c.png)

This PR insures that non-default themes behave properly when a QPushButton has a flat property set to true. This avoids visual inconsistencies across default and non-default themes.