### PR TITLE
fix loading of file-based mbtiles vector MVT package via Data Source Manager (fix #36449)

### DIFF
--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -20,12 +20,25 @@
 #include "qgssettings.h"
 #include "qgshttpheaders.h"
 
+#include <QFileInfo>
+
 ///@cond PRIVATE
 
 QString QgsVectorTileProviderConnection::encodedUri( const QgsVectorTileProviderConnection::Data &conn )
 {
   QgsDataSourceUri uri;
-  uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+
+  const QFileInfo info( conn.url );
+  QString suffix = info.suffix().toLower();
+  if ( suffix.startsWith( QStringLiteral( "mbtiles" ) ) )
+  {
+    uri.setParam( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
+  }
+  else
+  {
+    uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  }
+
   uri.setParam( QStringLiteral( "url" ), conn.url );
   if ( conn.zMin != -1 )
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );
@@ -82,7 +95,18 @@ QString QgsVectorTileProviderConnection::encodedLayerUri( const QgsVectorTilePro
 {
   // compared to encodedUri() this one also adds type=xyz to the URI
   QgsDataSourceUri uri;
-  uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+
+  const QFileInfo info( conn.url );
+  QString suffix = info.suffix().toLower();
+  if ( suffix.startsWith( QStringLiteral( "mbtiles" ) ) )
+  {
+    uri.setParam( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
+  }
+  else
+  {
+    uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  }
+
   uri.setParam( QStringLiteral( "url" ), conn.url );
   if ( conn.zMin != -1 )
     uri.setParam( QStringLiteral( "zmin" ), QString::number( conn.zMin ) );

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -193,6 +193,7 @@ set(TESTS
  testqgsvectorlayerjoinbuffer.cpp
  testqgsvectorlayerutils.cpp
  testqgsvectortilelayer.cpp
+ testqgsvectortileconnection.cpp
  testqgsvectortileutils.cpp
  testqgsvectortilewriter.cpp
  testqgstiles.cpp

--- a/tests/src/core/testqgsvectortileconnection.cpp
+++ b/tests/src/core/testqgsvectortileconnection.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+  testqgsvectortileconnection.cpp
+  --------------------------------------
+  Date                 : January 2022
+  Copyright            : (C) 2022 by Alexander Bruy
+  Email                : alexander dot bruy at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+//qgis includes...
+#include "qgsapplication.h"
+#include "qgsvectortileconnection.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the vector tile provider connection class
+ */
+class TestQgsVectorTileConnection : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsVectorTileConnection() = default;
+
+  private:
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+
+    void test_encodedUri();
+};
+
+
+void TestQgsVectorTileConnection::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsVectorTileConnection::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVectorTileConnection::test_encodedUri()
+{
+  QgsVectorTileProviderConnection::Data conn;
+  conn.url = QStringLiteral( "https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf?key=abcdef12345" );
+  conn.zMin = 0;
+  conn.zMax = 18;
+  QString uri = QgsVectorTileProviderConnection::encodedUri( conn );
+  QCOMPARE( uri, QStringLiteral( "type=xyz&url=https://api.maptiler.com/tiles/v3/%7Bz%7D/%7Bx%7D/%7By%7D.pbf?key%3Dabcdef12345&zmax=18&zmin=0" ) );
+
+  conn.url = QStringLiteral( "file:///home/user/tiles.mbtiles" );
+  conn.zMin = 0;
+  conn.zMax = 18;
+  uri = QgsVectorTileProviderConnection::encodedUri( conn );
+  QCOMPARE( uri, QStringLiteral( "type=mbtiles&url=file:///home/user/tiles.mbtiles&zmax=18&zmin=0" ) );
+}
+
+
+QGSTEST_MAIN( TestQgsVectorTileConnection )
+#include "testqgsvectortileconnection.moc"


### PR DESCRIPTION
## Description

After configuring file-based vector MVT connection with the url like `file:///path/to/file.mbtiles` in the "Vector Tile" tab of the Data Source Manager it is not possible to add layer to project.

Seems for file-based MVT packages we should use `type=mbtiles` instead of `type=xyz`.

Fixes #36449.