### PR TITLE
Fixes WFS EXP_FILTER parsing in GetFeature request

### DIFF
--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -99,6 +99,20 @@ Converts the parameter into a list of geometries.
 :return: A list of geometries
 %End
 
+    QStringList toOgcFilterList() const;
+%Docstring
+Converts the parameter into a list of OGC filters or QGIS expressions.
+
+:param ogc: ``True`` to return OGC filters
+:param expression: ``True`` to return expressions
+
+:return: A list of strings
+
+.. versionadded:: 3.24
+%End
+
+    QStringList toExpressionList() const;
+
     QgsRectangle toRectangle( bool &ok ) const;
 %Docstring
 Converts the parameter into a rectangle.

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -101,10 +101,7 @@ Converts the parameter into a list of geometries.
 
     QStringList toOgcFilterList() const;
 %Docstring
-Converts the parameter into a list of OGC filters or QGIS expressions.
-
-:param ogc: ``True`` to return OGC filters
-:param expression: ``True`` to return expressions
+Converts the parameter into a list of OGC filters.
 
 :return: A list of strings
 
@@ -112,6 +109,13 @@ Converts the parameter into a list of OGC filters or QGIS expressions.
 %End
 
     QStringList toExpressionList() const;
+%Docstring
+Converts the parameter into a list of QGIS expressions.
+
+:return: A list of strings
+
+.. versionadded:: 3.24
+%End
 
     QgsRectangle toRectangle( bool &ok ) const;
 %Docstring

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -179,7 +179,7 @@ QStringList QgsServerParameterDefinition::toExpressionList() const
     if ( posEnd == pos + 1 )
     {
       if ( ! isOgcFilter() )
-        filters.append( QStringLiteral() );
+        filters.append( QString() );
       pos = posEnd;
       continue;
     }
@@ -199,7 +199,7 @@ QStringList QgsServerParameterDefinition::toExpressionList() const
 
   if ( filter.back() == ';' )
   {
-    filters.append( QStringLiteral() );
+    filters.append( QString() );
   }
 
   return filters;

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -121,6 +121,90 @@ QList<QgsGeometry> QgsServerParameterDefinition::toGeomList( bool &ok, const cha
   return geoms;
 }
 
+QStringList QgsServerParameterDefinition::toOgcFilterList() const
+{
+  int pos = 0;
+  QStringList filters;
+  const QString filter = toString();
+
+  while ( pos < filter.size() )
+  {
+    if ( pos + 1 < filter.size() && filter[pos] == '(' && filter[pos + 1] == '<' )
+    {
+      // OGC filter on multiple layers
+      int posEnd = filter.indexOf( "Filter>)", pos );
+      if ( posEnd < 0 )
+      {
+        posEnd = filter.size();
+      }
+      filters.append( filter.mid( pos + 1, posEnd - pos + 6 ) );
+      pos = posEnd + 8;
+    }
+    else if ( pos + 1 < filter.size() && filter[pos] == '(' && filter[pos + 1] == ')' )
+    {
+      // empty OGC filter
+      filters.append( "" );
+      pos += 2;
+    }
+    else if ( filter[pos] == '<' )
+    {
+      // Single OGC filter
+      filters.append( filter.mid( pos ) );
+      break;
+    }
+    else
+    {
+      pos += 1;
+    }
+  }
+
+  return filters;
+}
+
+QStringList QgsServerParameterDefinition::toExpressionList() const
+{
+  int pos = 0;
+  QStringList filters;
+  const QString filter = toString();
+
+  auto isOgcFilter = [filter]()
+  {
+    return filter.contains( QStringLiteral( "<Filter>" ) ) or filter.contains( QStringLiteral( "()" ) );
+  };
+
+  while ( pos < filter.size() )
+  {
+    int posEnd = filter.indexOf( ';', pos );
+
+    if ( posEnd == pos + 1 )
+    {
+      if ( ! isOgcFilter() )
+        filters.append( QStringLiteral() );
+      pos = posEnd;
+      continue;
+    }
+
+    if ( ! isOgcFilter() )
+      filters.append( filter.mid( pos, posEnd - pos ) );
+
+    if ( posEnd < 0 )
+    {
+      pos = filter.size();
+    }
+    else
+    {
+      pos = posEnd + 1;
+    }
+  }
+
+  if ( filter.back() == ';' )
+  {
+    filters.append( QStringLiteral() );
+  }
+
+  return filters;
+}
+
 QList<QColor> QgsServerParameterDefinition::toColorList( bool &ok, const char delimiter ) const
 {
   ok = true;

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -146,7 +146,7 @@ QStringList QgsServerParameterDefinition::toOgcFilterList() const
       filters.append( "" );
       pos += 2;
     }
-    else if ( filter[pos] == '<' )
+    else if ( filter[pos] == '<' && pos + 7 < filter.size() && filter.mid( pos + 1, 6 ).compare( QStringLiteral( "Filter" ) ) == 0 )
     {
       // Single OGC filter
       filters.append( filter.mid( pos ) );

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -105,6 +105,17 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
 
     /**
+     * Converts the parameter into a list of OGC filters or QGIS expressions.
+     * \param ogc TRUE to return OGC filters
+     * \param expression TRUE to return expressions
+     * \returns A list of strings
+     * \since QGIS 3.24
+     */
+    QStringList toOgcFilterList() const;
+
+    QStringList toExpressionList() const;
+
+    /**
      * Converts the parameter into a rectangle.
      * \param ok TRUE if there's no error during the conversion, FALSE otherwise
      * \returns A rectangle

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -105,14 +105,17 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
 
     /**
-     * Converts the parameter into a list of OGC filters or QGIS expressions.
-     * \param ogc TRUE to return OGC filters
-     * \param expression TRUE to return expressions
+     * Converts the parameter into a list of OGC filters.
      * \returns A list of strings
      * \since QGIS 3.24
      */
     QStringList toOgcFilterList() const;
 
+    /**
+     * Converts the parameter into a list of QGIS expressions.
+     * \returns A list of strings
+     * \since QGIS 3.24
+     */
     QStringList toExpressionList() const;
 
     /**

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -715,11 +715,7 @@ namespace QgsWfs
         {
           getFeatureQuery &query = *qIt;
           // Get Filter for this typeName
-          QString expFilter;
-          if ( expFilterIt != expFilterList.constEnd() )
-          {
-            expFilter = *expFilterIt;
-          }
+          const QString expFilter = *expFilterIt++;
           std::shared_ptr<QgsExpression> filter( new QgsExpression( expFilter ) );
           if ( filter )
           {

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -343,7 +343,7 @@ namespace QgsWfs
 
   QStringList QgsWfsParameters::expFilters() const
   {
-    return mWfsParameters[ QgsWfsParameter::EXP_FILTER ].toStringListWithExp( QString( ) );
+    return mWfsParameters[ QgsWfsParameter::EXP_FILTER ].toExpressionList();
   }
 
   QString QgsWfsParameters::geometryNameAsString() const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1384,47 +1384,10 @@ namespace QgsWms
 
   QStringList QgsWmsParameters::filters() const
   {
-    const QString filter = mWmsParameters[ QgsWmsParameter::FILTER ].toString();
-    QStringList results;
-    int pos = 0;
-    while ( pos < filter.size() )
-    {
-      if ( pos + 1 < filter.size() && filter[pos] == '(' && filter[pos + 1] == '<' )
-      {
-        // OGC filter on multiple layers
-        int posEnd = filter.indexOf( "Filter>)", pos );
-        if ( posEnd < 0 )
-        {
-          posEnd = filter.size();
-        }
-        results.append( filter.mid( pos + 1, posEnd - pos + 6 ) );
-        pos = posEnd + 8;
-      }
-      else if ( pos + 1 < filter.size() && filter[pos] == '(' && filter[pos + 1] == ')' )
-      {
-        // empty OGC filter
-        results.append( "" );
-        pos += 2;
-      }
-      else if ( filter[pos] == '<' )
-      {
-        // Single OGC filter
-        results.append( filter.mid( pos ) );
-        break;
-      }
-      else
-      {
-        // QGIS specific filter
-        int posEnd = filter.indexOf( ';', pos + 1 );
-        if ( posEnd < 0 )
-        {
-          posEnd = filter.size();
-        }
-        results.append( filter.mid( pos, posEnd - pos ) );
-        pos = posEnd + 1;
-      }
-    }
-    return results;
+    QStringList filters = mWmsParameters[ QgsWmsParameter::FILTER ].toOgcFilterList();
+    if ( filters.isEmpty() )
+      filters = mWmsParameters[ QgsWmsParameter::FILTER ].toExpressionList();
+    return filters;
   }
 
   QString QgsWmsParameters::filterGeom() const

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -39,10 +39,10 @@ import email
 import difflib
 
 from io import StringIO
-from qgis.server import QgsServer, QgsServerRequest, QgsBufferServerRequest, QgsBufferServerResponse
+from qgis.server import QgsServer, QgsServerRequest, QgsBufferServerRequest, QgsBufferServerResponse, QgsServerParameterDefinition
 from qgis.core import QgsRenderChecker, QgsApplication, QgsFontUtils, QgsMultiRenderChecker
 from qgis.testing import unittest, start_app
-from qgis.PyQt.QtCore import QSize
+from qgis.PyQt.QtCore import QSize, QUrlQuery
 from qgis.PyQt.QtGui import QColor
 from utilities import unitTestDataPath
 
@@ -525,6 +525,118 @@ class TestQgsServer(QgsServerTestBase):
                     self.assertEqual(online_resource in item, True)
                     item_found = True
             self.assertTrue(item_found)
+
+
+class TestQgsServerParameter(unittest.TestCase):
+
+    def test_filter(self):
+        # empty filter
+        param = QgsServerParameterDefinition()
+        param.mValue = ""
+
+        self.assertEqual(len(param.toOgcFilterList()), 0)
+        self.assertEqual(len(param.toExpressionList()), 0)
+
+        # single qgis expression
+        filter = "\"name\"=concat('t', 'wo')"
+
+        param = QgsServerParameterDefinition()
+        param.mValue = filter
+
+        self.assertEqual(len(param.toOgcFilterList()), 0)
+        self.assertEqual(len(param.toExpressionList()), 1)
+
+        self.assertEqual(param.toExpressionList()[0], filter)
+
+        # multiple qgis expressions
+        filter0 = "to_datetime('2017-09-29 12:00:00')"
+        filter1 = "\"name\"=concat('t', 'wo')"
+        filter2 = "\"name\"='three'"
+
+        param = QgsServerParameterDefinition()
+        param.mValue = f"{filter0};{filter1};{filter2}"
+
+        self.assertEqual(len(param.toOgcFilterList()), 0)
+        self.assertEqual(len(param.toExpressionList()), 3)
+
+        self.assertEqual(param.toExpressionList()[0], filter0)
+        self.assertEqual(param.toExpressionList()[1], filter1)
+        self.assertEqual(param.toExpressionList()[2], filter2)
+
+        # multiple qgis expressions with some empty one
+        param = QgsServerParameterDefinition()
+        param.mValue = f";;{filter0};;;{filter2};;"
+
+        self.assertEqual(len(param.toOgcFilterList()), 0)
+        self.assertEqual(len(param.toExpressionList()), 8)
+
+        self.assertEqual(param.toExpressionList()[0], "")
+        self.assertEqual(param.toExpressionList()[1], "")
+        self.assertEqual(param.toExpressionList()[2], filter0)
+        self.assertEqual(param.toExpressionList()[3], "")
+        self.assertEqual(param.toExpressionList()[4], "")
+        self.assertEqual(param.toExpressionList()[5], filter2)
+        self.assertEqual(param.toExpressionList()[6], "")
+        self.assertEqual(param.toExpressionList()[7], "")
+
+        # two empty expressions
+        param = QgsServerParameterDefinition()
+        param.mValue = f";"
+
+        self.assertEqual(len(param.toOgcFilterList()), 0)
+        self.assertEqual(len(param.toExpressionList()), 2)
+
+        # single ogc empty filter
+        param = QgsServerParameterDefinition()
+        param.mValue = "()"
+
+        self.assertEqual(len(param.toExpressionList()), 0)
+        self.assertEqual(len(param.toOgcFilterList()), 1)
+
+        self.assertEqual(param.toOgcFilterList()[0], "")
+
+        # single ogc filter
+        filter = "<Filter><Within><PropertyName>name<PropertyName><gml:Envelope><gml:lowerCorner>43.5707 -79.5797</gml:lowerCorner><gml:upperCorner>43.8219 -79.2693</gml:upperCorner></gml:Envelope></Within></Filter>"
+
+        param = QgsServerParameterDefinition()
+        param.mValue = filter
+
+        self.assertEqual(len(param.toExpressionList()), 0)
+        self.assertEqual(len(param.toOgcFilterList()), 1)
+
+        self.assertEqual(param.toOgcFilterList()[0], filter)
+
+        # multiple ogc filter
+        filter0 = "<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>43.5707 -79.5797</gml:lowerCorner><gml:upperCorner>43.8219 -79.2693</gml:upperCorner></gml:Envelope></Within></Filter>"
+        filter1 = "<Filter><Within><PropertyName>BuiltUpA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>43.5705 -79.5797</gml:lowerCorner><gml:upperCorner>43.8219 -79.2693</gml:upperCorner></gml:Envelope></Within></Filter>"
+
+        param = QgsServerParameterDefinition()
+        param.mValue = f"({filter0})({filter1})"
+
+        self.assertEqual(len(param.toExpressionList()), 0)
+        self.assertEqual(len(param.toOgcFilterList()), 2)
+
+        self.assertEqual(param.toOgcFilterList()[0], filter0)
+        self.assertEqual(param.toOgcFilterList()[1], filter1)
+
+        # multiple ogc filter with some empty one
+        filter0 = "<Filter><Within><PropertyName>InWaterA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>43.5707 -79.5797</gml:lowerCorner><gml:upperCorner>43.8219 -79.2693</gml:upperCorner></gml:Envelope></Within></Filter>"
+        filter1 = "<Filter><Within><PropertyName>BuiltUpA_1M/wkbGeom<PropertyName><gml:Envelope><gml:lowerCorner>43.5705 -79.5797</gml:lowerCorner><gml:upperCorner>43.8219 -79.2693</gml:upperCorner></gml:Envelope></Within></Filter>"
+
+        param = QgsServerParameterDefinition()
+        param.mValue = f"()()({filter0})()()({filter1})()()"
+
+        self.assertEqual(len(param.toExpressionList()), 0)
+        self.assertEqual(len(param.toOgcFilterList()), 8)
+
+        self.assertEqual(param.toOgcFilterList()[0], "")
+        self.assertEqual(param.toOgcFilterList()[1], "")
+        self.assertEqual(param.toOgcFilterList()[2], filter0)
+        self.assertEqual(param.toOgcFilterList()[3], "")
+        self.assertEqual(param.toOgcFilterList()[4], "")
+        self.assertEqual(param.toOgcFilterList()[5], filter1)
+        self.assertEqual(param.toOgcFilterList()[6], "")
+        self.assertEqual(param.toOgcFilterList()[7], "")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -581,7 +581,7 @@ class TestQgsServerParameter(unittest.TestCase):
 
         # two empty expressions
         param = QgsServerParameterDefinition()
-        param.mValue = f";"
+        param.mValue = ";"
 
         self.assertEqual(len(param.toOgcFilterList()), 0)
         self.assertEqual(len(param.toExpressionList()), 2)

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -550,7 +550,7 @@ class TestQgsServerParameter(unittest.TestCase):
 
         # multiple qgis expressions
         filter0 = "to_datetime('2017-09-29 12:00:00')"
-        filter1 = "\"name\"=concat('t', 'wo')"
+        filter1 = "Contours:\"elev\" <= 1200"
         filter2 = "\"name\"='three'"
 
         param = QgsServerParameterDefinition()

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -148,6 +148,13 @@ class TestQgsServerWFS(QgsServerTestBase):
         for id, req in tests:
             self.wfs_getfeature_compare(id, req)
 
+    def test_getfeature_exp_filter(self):
+        # multiple filters
+        exp_filter = "EXP_FILTER=\"name\"='one';\"name\"='two'"
+        req = f"SRSNAME=EPSG:4326&TYPENAME=testlayer,testlayer&{exp_filter}"
+        self.wfs_request_compare(
+            "GetFeature", '1.0.0', req, 'wfs_getFeature_exp_filter_2')
+
     def test_wfs_getcapabilities_100_url(self):
         """Check that URL in GetCapabilities response is complete"""
 

--- a/tests/testdata/qgis_server/wfs_getFeature_exp_filter_2_1_0_0.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_exp_filter_2_1_0_0.txt
@@ -1,0 +1,43 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.203459,44.901395 8.203547,44.901483</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
... for using this kind of request: `TYPENAME=countries,places&EXP_FILTER="name"='France';"name"='Paris'`.

(note that the `;` separator is used to be homogeneous with the filter implementation in WMS 1.3.0 service).

This PR is related to https://www.mail-archive.com/qgis-user@lists.osgeo.org/msg50029.html.