### PR TITLE
[backport release-3_22][processing] save NULL and empty values into different files in Split Vector Layer algorithm (fix #38105)

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -119,12 +119,25 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
     if ( feedback->isCanceled() )
       break;
 
-    QString fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
+    QString fileName;
+    if ( ( *it ).isNull() )
+    {
+      fileName = QStringLiteral( "%1_NULL.%2" ).arg( baseName ).arg( outputFormat );
+    }
+    else if ( ( *it ).toString().isEmpty() )
+    {
+      fileName = QStringLiteral( "%1_EMPTY.%2" ).arg( baseName ).arg( outputFormat );
+    }
+    else
+    {
+      fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
+    }
     feedback->pushInfo( QObject::tr( "Creating layer: %1" ).arg( fileName ) );
 
     sink.reset( QgsProcessingUtils::createFeatureSink( fileName, context, fields, geometryType, crs ) );
     const QString expr = QgsExpression::createFieldEqualityExpression( fieldName, *it );
     QgsFeatureIterator features = source->getFeatures( QgsFeatureRequest().setFilterExpression( expr ) );
+    count = 0;
     while ( features.nextFeature( feat ) )
     {
       if ( feedback->isCanceled() )

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -193,6 +193,8 @@ class TestQgsProcessingAlgs: public QObject
     void uploadGpsData();
     void transferMainAnnotationLayer();
 
+    void splitVectorLayer();
+
   private:
 
     bool imageCheck( const QString &testName, const QString &renderedImage );
@@ -7074,6 +7076,47 @@ void TestQgsProcessingAlgs::exportMeshTimeSeries()
   outputFile.close();
 }
 
+void TestQgsProcessingAlgs::splitVectorLayer()
+{
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( layer->isValid() );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << 1 << QVariant() );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Point (0 0)" ) ) );
+  layer->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 2 << QString( "" ) );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Point (0 1)" ) ) );
+  layer->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 3 << QStringLiteral( "value" ) );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Point (0 2)" ) ) );
+  layer->dataProvider()->addFeature( f );
+
+  std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:splitvectorlayer" ) ) );
+  QVERIFY( alg != nullptr );
+
+  QDir outputDir( QDir::tempPath() + "/split_vector/" );
+  if ( outputDir.exists() )
+    outputDir.removeRecursively();
+
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "INPUT" ), QVariant::fromValue( layer ) );
+  parameters.insert( QStringLiteral( "FIELD" ), QStringLiteral( "col1" ) );
+  parameters.insert( QStringLiteral( "FILE_TYPE" ), QStringLiteral( "gpkg" ) );
+  parameters.insert( QStringLiteral( "OUTPUT" ), outputDir.absolutePath() );
+
+  bool ok = false;
+  std::unique_ptr< QgsProcessingContext > context = std::make_unique< QgsProcessingContext >();
+  QgsProcessingFeedback feedback;
+  QVariantMap results;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( results.value( QStringLiteral( "OUTPUT_LAYERS" ) ).toList().count(), 3 );
+  QDir dataDir( outputDir );
+  QStringList entries = dataDir.entryList( QStringList(), QDir::Files | QDir::NoDotAndDotDot );
+  QCOMPARE( entries.count(), 3 );
+}
 
 bool TestQgsProcessingAlgs::imageCheck( const QString &testName, const QString &renderedImage )
 {


### PR DESCRIPTION
## Description
Manual backport of the Split Vector Layer algorithm fix from #46997.

The Split Vector Layer algorithm exports both NULL and empty attribute values to the same filename, as a result one file overwrites another and some results are lost. Proposed PR assigns different suffixes for such files (_EMPTY and _NULL).

Fixes #38105.

Also fix unreported bug with displaying incorrect number of features written to each output file.