### PR TITLE
[core] Fix conversion of array and map values for json fields

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -550,6 +550,18 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
     }
   }
 
+  if ( d->type == QVariant::String && ( d->typeName.compare( QLatin1String( "json" ), Qt::CaseInsensitive ) == 0 || d->typeName == QLatin1String( "jsonb" ) ) )
+  {
+    const QJsonDocument doc = QJsonDocument::fromVariant( v );
+    if ( !doc.isNull() )
+    {
+      v = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).data() );
+      return true;
+    }
+    v = QVariant( d->type );
+    return false;
+  }
+
   if ( !v.convert( d->type ) )
   {
     v = QVariant( d->type );

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -555,7 +555,7 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
     const QJsonDocument doc = QJsonDocument::fromVariant( v );
     if ( !doc.isNull() )
     {
-      v = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).data() );
+      v = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).constData() );
       return true;
     }
     v = QVariant( d->type );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -740,6 +740,20 @@ void TestQgsField::convertCompatible()
   intField = QgsField( QStringLiteral( "int" ), QVariant::Int, QStringLiteral( "Integer" ), 10 );
   QVariant vZero = 0;
   QVERIFY( intField.convertCompatible( vZero ) );
+
+  // Test json field conversion
+  const QgsField jsonField( QStringLiteral( "json" ), QVariant::String, QStringLiteral( "json" ) );
+  QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
+  QVERIFY( jsonField.convertCompatible( jsonValue ) );
+  QCOMPARE( jsonValue.type(), QVariant::String );
+  QCOMPARE( jsonValue, QString( "[1,5,8]" ) );
+  QVariantMap variantMap;
+  variantMap.insert( QStringLiteral( "a" ), 1 );
+  variantMap.insert( QStringLiteral( "c" ), 3 );
+  jsonValue = QVariant::fromValue( variantMap );
+  QVERIFY( jsonField.convertCompatible( jsonValue ) );
+  QCOMPARE( jsonValue.type(), QVariant::String );
+  QCOMPARE( jsonValue, QString( "{\"a\":1,\"c\":3}" ) );
 }
 
 void TestQgsField::dataStream()


### PR DESCRIPTION
## Description

This PR fixes the conversion of QVariantMap and QVariantList values to JSON strings (i.e. geopackage json field). Tests included.

With the fix, users can use expressions such as `array(1,2,3)` or `map('key1','value','key2','value')` expressions in the field calculator and the attribute table's field bar to update values.

_Funded by SwissTierras Colombia_