### PR TITLE
[vector file writer] Preserve array fields when saving as geopackage

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -683,6 +683,14 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
           case QVariant::StringList:
           {
+            // handle GPKG conversion to JSON
+            if ( mOgrDriverName == QLatin1String( "GPKG" ) )
+            {
+              ogrType = OFTString;
+              ogrSubType = OFSTJSON;
+              break;
+            }
+
             const char *pszDataTypes = GDALGetMetadataItem( poDriver, GDAL_DMD_CREATIONFIELDDATATYPES, nullptr );
             if ( pszDataTypes && strstr( pszDataTypes, "StringList" ) )
             {
@@ -2550,7 +2558,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
           QString jsonString;
           if ( !doc.isNull() )
           {
-            jsonString = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).data() );
+            jsonString = QString::fromUtf8( doc.toJson( QJsonDocument::Compact ).constData() );
           }
           OGR_F_SetFieldString( poFeature.get(), ogrField, mCodec->fromUnicode( jsonString.constData() ) );
           break;

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -542,11 +542,14 @@ void TestQgsVectorFileWriter::testExportArrayToGpkg()
   QTemporaryFile tmpFile( QDir::tempPath() +  "/test_qgsvectorfilewriter3_XXXXXX.gpkg" );
   tmpFile.open();
   const QString fileName( tmpFile.fileName( ) );
-  QgsVectorLayer vl( "Point?field=arrayfield:integerlist", "test", "memory" );
+  QgsVectorLayer vl( "Point?field=arrayfield:integerlist&field=arrayfield2:stringlist", "test", "memory" );
   QCOMPARE( vl.fields().at( 0 ).type(), QVariant::List );
   QCOMPARE( vl.fields().at( 0 ).subType(), QVariant::Int );
+  QCOMPARE( vl.fields().at( 1 ).type(), QVariant::StringList );
+  QCOMPARE( vl.fields().at( 1 ).subType(), QVariant::String );
   QgsFeature f { vl.fields() };
   f.setAttribute( 0, QVariantList() << 1 << 2 << 3 );
+  f.setAttribute( 1, QStringList() << "a" << "b" << "c" );
   f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "point(9 45)" ) ) );
   QVERIFY( vl.startEditing() );
   QVERIFY( vl.addFeature( f ) );
@@ -568,7 +571,11 @@ void TestQgsVectorFileWriter::testExportArrayToGpkg()
   QCOMPARE( vl2.fields().at( 1 ).type(), QVariant::Map );
   QCOMPARE( vl2.fields().at( 1 ).subType(), QVariant::String );
   QCOMPARE( vl2.fields().at( 1 ).typeName(), QStringLiteral( "JSON" ) );
+  QCOMPARE( vl2.fields().at( 2 ).type(), QVariant::Map );
+  QCOMPARE( vl2.fields().at( 2 ).subType(), QVariant::String );
+  QCOMPARE( vl2.fields().at( 2 ).typeName(), QStringLiteral( "JSON" ) );
   QCOMPARE( vl2.getFeature( 1 ).attribute( 1 ).toList(), QVariantList() << 1 << 2 << 3 );
+  QCOMPARE( vl2.getFeature( 1 ).attribute( 2 ).toStringList(), QStringList() << "a" << "b" << "c" );
 }
 
 void TestQgsVectorFileWriter::_testExportToGpx( const QString &geomTypeName,

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -92,6 +92,8 @@ class TestQgsVectorFileWriter: public QObject
     void prepareWriteAsVectorFormat();
     //! Test regression #21714 (Exported GeoPackages have wrong field definitions)
     void testTextFieldLength();
+    //! Test export of array fields to GeoPackages
+    void testExportArrayToGpkg();
     //! Test https://github.com/qgis/QGIS/issues/29819
     void testExportToGpxPoint();
     //! Test https://github.com/qgis/QGIS/issues/29819
@@ -533,6 +535,40 @@ void TestQgsVectorFileWriter::testTextFieldLength()
   QCOMPARE( vl2.fields().at( 1 ).length(), 1024 );
   QCOMPARE( vl2.getFeature( 1 ).attribute( 1 ).toString(), QString( 1024, 'x' ) );
 
+}
+
+void TestQgsVectorFileWriter::testExportArrayToGpkg()
+{
+  QTemporaryFile tmpFile( QDir::tempPath() +  "/test_qgsvectorfilewriter3_XXXXXX.gpkg" );
+  tmpFile.open();
+  const QString fileName( tmpFile.fileName( ) );
+  QgsVectorLayer vl( "Point?field=arrayfield:integerlist", "test", "memory" );
+  QCOMPARE( vl.fields().at( 0 ).type(), QVariant::List );
+  QCOMPARE( vl.fields().at( 0 ).subType(), QVariant::Int );
+  QgsFeature f { vl.fields() };
+  f.setAttribute( 0, QVariantList() << 1 << 2 << 3 );
+  f.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "point(9 45)" ) ) );
+  QVERIFY( vl.startEditing() );
+  QVERIFY( vl.addFeature( f ) );
+  QgsVectorFileWriter::SaveVectorOptions options;
+  options.driverName = "GPKG";
+  options.layerName = "test";
+  QString newFilename;
+  const QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV3(
+        &vl,
+        fileName,
+        vl.transformContext(),
+        options, nullptr,
+        &newFilename ) );
+  QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );
+  QCOMPARE( newFilename, fileName );
+  const QgsVectorLayer vl2( QStringLiteral( "%1|layername=test" ).arg( fileName ), "src_test", "ogr" );
+  QVERIFY( vl2.isValid() );
+  QCOMPARE( vl2.featureCount(), 1L );
+  QCOMPARE( vl2.fields().at( 1 ).type(), QVariant::Map );
+  QCOMPARE( vl2.fields().at( 1 ).subType(), QVariant::String );
+  QCOMPARE( vl2.fields().at( 1 ).typeName(), QStringLiteral( "JSON" ) );
+  QCOMPARE( vl2.getFeature( 1 ).attribute( 1 ).toList(), QVariantList() << 1 << 2 << 3 );
 }
 
 void TestQgsVectorFileWriter::_testExportToGpx( const QString &geomTypeName,


### PR DESCRIPTION
## Description

This PR tweaks the vector file writer to do a better job at preserving array fields when saving as geopackage. While the format doesn't have proper array field support, it does support JSON fields, and that can handle arrays.

For string lists, it can be a pretty good fix. ATM, we were merely merging string lists using a ',' chart without escaping any comma from individual string items. 

@rouault , @nyalldawson , are you OK with this approach?

_Funded by SwissTierras Colombia_