### PR TITLE
reload output layer on successful execution of GDAL rasterize algorithm (fix #45729)

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -125,3 +125,25 @@ class rasterize_over(GdalAlgorithm):
         arguments.append(inLayer.source())
 
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+
+    def postProcessAlgorithm(self, context, feedback):
+        fileName = self.output_values.get(self.OUTPUT)
+        if not fileName:
+            return {}
+
+        if context.project():
+            for l in context.project().mapLayers().values():
+                if l.source() != fileName:
+                    continue
+
+                l.dataProvider().reloadData()
+                l.triggerRepaint()
+
+        for l in context.temporaryLayerStore().mapLayers().values():
+            if l.source() != fileName:
+                continue
+
+            l.dataProvider().reloadData()
+            context.temporaryLayerStore().addMapLayer(l)
+
+        return {}

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -144,6 +144,5 @@ class rasterize_over(GdalAlgorithm):
                 continue
 
             l.dataProvider().reloadData()
-            context.temporaryLayerStore().addMapLayer(l)
 
         return {}

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -142,6 +142,5 @@ class rasterize_over_fixed_value(GdalAlgorithm):
                 continue
 
             l.dataProvider().reloadData()
-            context.temporaryLayerStore().addMapLayer(l)
 
         return {}

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -26,6 +26,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRasterFileWriter,
+                       QgsProcessingContext,
                        QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
@@ -122,3 +123,25 @@ class rasterize_over_fixed_value(GdalAlgorithm):
         arguments.append(inLayer.source())
 
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+
+    def postProcessAlgorithm(self, context, feedback):
+        fileName = self.output_values.get(self.OUTPUT)
+        if not fileName:
+            return {}
+
+        if context.project():
+            for l in context.project().mapLayers().values():
+                if l.source() != fileName:
+                    continue
+
+                l.dataProvider().reloadData()
+                l.triggerRepaint()
+
+        for l in context.temporaryLayerStore().mapLayers().values():
+            if l.source() != fileName:
+                continue
+
+            l.dataProvider().reloadData()
+            context.temporaryLayerStore().addMapLayer(l)
+
+        return {}

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -34,6 +34,7 @@ from qgis.core import (QgsProcessingContext,
                        QgsRasterLayer,
                        QgsProject,
                        QgsProjUtils,
+                       QgsPointXY,
                        QgsCoordinateReferenceSystem)
 
 from qgis.testing import (start_app,
@@ -166,7 +167,6 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
 
             rlayer = QgsRasterLayer(fake_dem, "Fake dem")
             self.assertTrue(rlayer.isValid())
-
             self.assertEqual(rlayer.crs().authid(), 'EPSG:4326')
 
             project = QgsProject()
@@ -1719,6 +1719,75 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['gdal_rasterize',
                  '-l polys2 -burn 100.0 -i ' +
                  vector + ' ' + raster])
+
+    def testRasterizeOverRun(self):
+        # Check that rasterize over tools update QgsRasterLayer
+
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source_vector = os.path.join(testDataPath, 'rasterize_zones.gml')
+        source_raster = os.path.join(testDataPath, 'dem.tif')
+
+        with tempfile.TemporaryDirectory() as outdir:
+            # fixed value
+            alg = rasterize_over_fixed_value()
+            alg.initAlgorithm()
+
+            test_dem = os.path.join(outdir, 'rasterize-fixed.tif')
+            shutil.copy(source_raster, test_dem)
+            self.assertTrue(os.path.exists(test_dem))
+
+            layer = QgsRasterLayer(test_dem, 'test')
+            self.assertTrue(layer.isValid())
+
+            val, ok = layer.dataProvider().sample(QgsPointXY(18.68704, 45.79568), 1)
+            self.assertEqual(val, 172.2267303466797)
+
+            project = QgsProject()
+            project.setFileName(os.path.join(outdir, 'rasterize-fixed.qgs'))
+            project.addMapLayer(layer)
+            self.assertEqual(project.count(), 1)
+
+            context.setProject(project)
+
+            alg.run({'INPUT': source_vector,
+                     'INPUT_RASTER': test_dem,
+                     'BURN': 200
+                     }, context, feedback)
+
+            val, ok = layer.dataProvider().sample(QgsPointXY(18.68704, 45.79568), 1)
+            self.assertTrue(ok)
+            self.assertEqual(val, 200.0)
+
+            # attribute value
+            alg = rasterize_over()
+            alg.initAlgorithm()
+
+            test_dem = os.path.join(outdir, 'rasterize-over.tif')
+            shutil.copy(source_raster, test_dem)
+            self.assertTrue(os.path.exists(test_dem))
+
+            layer = QgsRasterLayer(test_dem, 'test')
+            self.assertTrue(layer.isValid())
+
+            val, ok = layer.dataProvider().sample(QgsPointXY(18.68704, 45.79568), 1)
+            self.assertEqual(val, 172.2267303466797)
+
+            project = QgsProject()
+            project.setFileName(os.path.join(outdir, 'rasterize-over.qgs'))
+            project.addMapLayer(layer)
+            self.assertEqual(project.count(), 1)
+
+            context.setProject(project)
+
+            alg.run({'INPUT': source_vector,
+                     'INPUT_RASTER': test_dem,
+                     'FIELD': 'value'
+                     }, context, feedback)
+
+            val, ok = layer.dataProvider().sample(QgsPointXY(18.68704, 45.79568), 1)
+            self.assertTrue(ok)
+            self.assertEqual(val, 100.0)
 
     def testRetile(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/testdata/rasterize_zones.gml
+++ b/python/plugins/processing/tests/testdata/rasterize_zones.gml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ rasterize_zones.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.79297234061 18.6828584793171</gml:lowerCorner><gml:upperCorner>45.7978887285699 18.6908476097518</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                    
+  <ogr:featureMember>
+    <ogr:rasterize_zones gml:id="rasterize_zones.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45.79297234061 18.6828584793171</gml:lowerCorner><gml:upperCorner>45.7978887285699 18.6908476097518</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="rasterize_zones.geom.0"><gml:exterior><gml:LinearRing><gml:posList>45.7978272737204 18.6828584793171 45.7978887285699 18.6908476097518 45.79297234061 18.6907861549023 45.7931567051585 18.682981389016 45.7978272737204 18.6828584793171</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:value>100.000000</ogr:value>
+    </ogr:rasterize_zones>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/rasterize_zones.xsd
+++ b/python/plugins/processing/tests/testdata/rasterize_zones.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="rasterize_zones" type="ogr:rasterize_zones_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="rasterize_zones_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="value" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="11"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
## Description

GDAL algorithms "Rasterize (overwrite with fixed value)" and "Rasterize (overwrite with attribute)" alter input raster but does not refresh it. As a result if raster already added to canvas user continues to work with the old "snapshot" of raster layer.

Fixes #45729.
