### PR TITLE
GH_WORKSPACE -> QGIS_WORKSPACE

### DIFF
--- a/.docker/docker-compose-testing-oracle.yml
+++ b/.docker/docker-compose-testing-oracle.yml
@@ -15,7 +15,7 @@ services:
     tty: true
     image: qgis3-build-deps-binary-image
     volumes:
-      - ${GH_WORKSPACE}:/root/QGIS
+      - ${QGIS_WORKSPACE}:/root/QGIS
     links:
       - oracle
     env_file:

--- a/.docker/docker-compose-testing-postgres.yml
+++ b/.docker/docker-compose-testing-postgres.yml
@@ -15,7 +15,7 @@ services:
     tty: true
     image: qgis3-build-deps-binary-image
     volumes:
-      - ${GH_WORKSPACE}:/root/QGIS
+      - ${QGIS_WORKSPACE}:/root/QGIS
     links:
       - postgres
     env_file:

--- a/.docker/docker-compose-testing.yml
+++ b/.docker/docker-compose-testing.yml
@@ -14,15 +14,15 @@ services:
   webdav:
     image: nginx
     volumes:
-      - ${GH_WORKSPACE}/.docker/webdav/nginx.conf:/etc/nginx/conf.d/default.conf
-      - ${GH_WORKSPACE}/.docker/webdav/passwords.list:/etc/nginx/.passwords.list
+      - ${QGIS_WORKSPACE}/.docker/webdav/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ${QGIS_WORKSPACE}/.docker/webdav/passwords.list:/etc/nginx/.passwords.list
       - /tmp/webdav_tests:/tmp/webdav_tests_root/webdav_tests
 
   qgis-deps:
     tty: true
     image: qgis3-build-deps-binary-image
     volumes:
-      - ${GH_WORKSPACE}:/root/QGIS
+      - ${QGIS_WORKSPACE}:/root/QGIS
     links:
     #  - mssql
       - webdav

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      GH_WORKSPACE: ${{ github.workspace }} # used in docker compose
+      QGIS_WORKSPACE: ${{ github.workspace }} # used in docker compose
       RUN_FLAKY_TESTS: ${{ contains( github.event.pull_request.labels.*.name, 'run flaky tests') }}
 
     runs-on: ubuntu-latest
@@ -280,7 +280,7 @@ jobs:
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      GH_WORKSPACE: ${{ github.workspace }} # used in docker compose
+      QGIS_WORKSPACE: ${{ github.workspace }} # used in docker compose
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Drop the GH suffix from the WORKSPACE variable used in Docker setup.
This is a step toward allowing `make check` to setup the testing environment locally