### PR TITLE
[processing] Add a bunch of mixing field types to the {add field,field calculator} algorithms

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/add_field_datetime.gml
+++ b/python/plugins/processing/tests/testdata/expected/add_field_datetime.gml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ add_field_datetime.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>3 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 1</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.0"><gml:pos>1 1</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>3 3</gml:lowerCorner><gml:upperCorner>3 3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.1"><gml:pos>3 3</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.1</ogr:fid>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 2</gml:lowerCorner><gml:upperCorner>2 2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.2"><gml:pos>2 2</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.2</ogr:fid>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 5</gml:lowerCorner><gml:upperCorner>2 5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.3"><gml:pos>2 5</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 4</gml:lowerCorner><gml:upperCorner>1 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.4"><gml:pos>1 4</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.4</ogr:fid>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>-5 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.5"><gml:pos>-5 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.6">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 8</gml:lowerCorner><gml:upperCorner>-1 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.6"><gml:pos>-1 8</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.6</ogr:fid>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.7">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>-1 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.7"><gml:pos>-1 7</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_datetime gml:id="add_field_datetime.8">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>-1 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_datetime.geom.8"><gml:pos>-1 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.8</ogr:fid>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_datetime>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/add_field_datetime.xsd
+++ b/python/plugins/processing/tests/testdata/expected/add_field_datetime.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="add_field_datetime" type="ogr:add_field_datetime_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="add_field_datetime_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="field" nillable="true" minOccurs="0" maxOccurs="1" type="xs:dateTime">
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/add_field_doublelist.gml
+++ b/python/plugins/processing/tests/testdata/expected/add_field_doublelist.gml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ add_field_doublelist.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>3 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 1</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.0"><gml:pos>1 1</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>3 3</gml:lowerCorner><gml:upperCorner>3 3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.1"><gml:pos>3 3</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.1</ogr:fid>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 2</gml:lowerCorner><gml:upperCorner>2 2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.2"><gml:pos>2 2</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.2</ogr:fid>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 5</gml:lowerCorner><gml:upperCorner>2 5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.3"><gml:pos>2 5</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 4</gml:lowerCorner><gml:upperCorner>1 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.4"><gml:pos>1 4</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.4</ogr:fid>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>-5 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.5"><gml:pos>-5 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.6">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 8</gml:lowerCorner><gml:upperCorner>-1 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.6"><gml:pos>-1 8</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.6</ogr:fid>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.7">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>-1 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.7"><gml:pos>-1 7</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_doublelist gml:id="add_field_doublelist.8">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>-1 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_doublelist.geom.8"><gml:pos>-1 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.8</ogr:fid>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_doublelist>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/add_field_doublelist.xsd
+++ b/python/plugins/processing/tests/testdata/expected/add_field_doublelist.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>1</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="add_field_doublelist" type="ogr:add_field_doublelist_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="add_field_doublelist_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="field" nillable="true" minOccurs="0" maxOccurs="unbounded">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="10"/>
+              <xs:fractionDigits value="0"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/add_field_stringlist.gml
+++ b/python/plugins/processing/tests/testdata/expected/add_field_stringlist.gml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ add_field_stringlist.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>3 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 1</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.0"><gml:pos>1 1</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>3 3</gml:lowerCorner><gml:upperCorner>3 3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.1"><gml:pos>3 3</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.1</ogr:fid>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 2</gml:lowerCorner><gml:upperCorner>2 2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.2"><gml:pos>2 2</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.2</ogr:fid>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 5</gml:lowerCorner><gml:upperCorner>2 5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.3"><gml:pos>2 5</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 4</gml:lowerCorner><gml:upperCorner>1 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.4"><gml:pos>1 4</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.4</ogr:fid>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>-5 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.5"><gml:pos>-5 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.6">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 8</gml:lowerCorner><gml:upperCorner>-1 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.6"><gml:pos>-1 8</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.6</ogr:fid>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.7">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>-1 7</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.7"><gml:pos>-1 7</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:add_field_stringlist gml:id="add_field_stringlist.8">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>-1 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="add_field_stringlist.geom.8"><gml:pos>-1 0</gml:pos></gml:Point></ogr:geometryProperty>
+      <ogr:fid>points.8</ogr:fid>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:field xsi:nil="true"/>
+    </ogr:add_field_stringlist>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/add_field_stringlist.xsd
+++ b/python/plugins/processing/tests/testdata/expected/add_field_stringlist.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>1</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="add_field_stringlist" type="ogr:add_field_stringlist_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="add_field_stringlist_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="field" nillable="true" minOccurs="0" maxOccurs="unbounded">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -594,6 +594,60 @@ tests:
         name: expected/add_field.gml
         type: vector
 
+  - algorithm: native:addfieldtoattributestable
+    name: add datetime field
+    params:
+      FIELD_LENGTH: 10
+      FIELD_NAME: field
+      FIELD_PRECISION: 2
+      FIELD_TYPE: '6'
+      INPUT:
+        name: custom/points.shp
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/add_field_datetime.gml
+        type: vector
+        compare:
+          fields:
+            gml_id: skip
+
+  - algorithm: native:addfieldtoattributestable
+    name: add stringlist field
+    params:
+      FIELD_LENGTH: 10
+      FIELD_NAME: field
+      FIELD_PRECISION: 2
+      FIELD_TYPE: '8'
+      INPUT:
+        name: custom/points.shp
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/add_field_stringlist.gml
+        type: vector
+        compare:
+          fields:
+            gml_id: skip
+
+  - algorithm: native:addfieldtoattributestable
+    name: add doublelist field
+    params:
+      FIELD_LENGTH: 10
+      FIELD_NAME: field
+      FIELD_PRECISION: 2
+      FIELD_TYPE: '10'
+      INPUT:
+        name: custom/points.shp
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/add_field_doublelist.gml
+        type: vector
+        compare:
+          fields:
+            gml_id: skip
+
   - algorithm: native:orderbyexpression
     name: Order by expression
     params:

--- a/src/analysis/processing/qgsalgorithmaddtablefield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddtablefield.cpp
@@ -75,7 +75,10 @@ void QgsAddTableFieldAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterString( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Field name" ) ) );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "FIELD_TYPE" ), QObject::tr( "Field type" ),
-                QStringList() << QObject::tr( "Integer" ) << QObject::tr( "Float" ) << QObject::tr( "String" ), false, 0 ) );
+                QStringList() << QObject::tr( "Integer" ) << QObject::tr( "Float" ) << QObject::tr( "String" )
+                << QObject::tr( "Boolean" ) << QObject::tr( "Date" ) << QObject::tr( "Time" )
+                << QObject::tr( "DateTime" ) << QObject::tr( "Binary" )
+                << QObject::tr( "StringList" ) << QObject::tr( "IntegerList" ) << QObject::tr( "DoubleList" ), false, 0 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "FIELD_LENGTH" ), QObject::tr( "Field length" ),
                 QgsProcessingParameterNumber::Integer, 10, false, 1, 255 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "FIELD_PRECISION" ), QObject::tr( "Field precision" ),
@@ -102,14 +105,41 @@ bool QgsAddTableFieldAlgorithm::prepareAlgorithm( const QVariantMap &parameters,
 
   switch ( type )
   {
-    case 0:
+    case 0: // Integer
       mField.setType( QVariant::Int );
       break;
-    case 1:
+    case 1: // Float
       mField.setType( QVariant::Double );
       break;
-    case 2:
+    case 2: // String
       mField.setType( QVariant::String );
+      break;
+    case 3: // Boolean
+      mField.setType( QVariant::Bool );
+      break;
+    case 4: // Date
+      mField.setType( QVariant::Date );
+      break;
+    case 5: // Time
+      mField.setType( QVariant::Time );
+      break;
+    case 6: // DateTime
+      mField.setType( QVariant::DateTime );
+      break;
+    case 7: // Binary
+      mField.setType( QVariant::ByteArray );
+      break;
+    case 8: // StringList
+      mField.setType( QVariant::StringList );
+      mField.setSubType( QVariant::String );
+      break;
+    case 9: // IntegerList
+      mField.setType( QVariant::List );
+      mField.setSubType( QVariant::Int );
+      break;
+    case 10: // DoubleList
+      mField.setType( QVariant::List );
+      mField.setSubType( QVariant::Double );
       break;
   }
 

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -65,9 +65,9 @@ void QgsFieldCalculatorAlgorithm::initParameters( const QVariantMap &configurati
 {
   Q_UNUSED( configuration );
 
-  const QStringList fieldTypes =  QStringList() << QObject::tr( "Integer" ) << QObject::tr( "Float" ) << QObject::tr( "String" )
-                                  << QObject::tr( "Boolean" ) << QObject::tr( "Date" ) << QObject::tr( "Time" )
-                                  << QObject::tr( "DateTime" ) << QObject::tr( "Binary" )
+  const QStringList fieldTypes =  QStringList() << QObject::tr( "Float" ) << QObject::tr( "Integer" ) << QObject::tr( "String" )
+                                  << QObject::tr( "Date" ) << QObject::tr( "Time" ) << QObject::tr( "DateTime" )
+                                  << QObject::tr( "Boolean" ) << QObject::tr( "Binary" )
                                   << QObject::tr( "StringList" ) << QObject::tr( "IntegerList" ) << QObject::tr( "DoubleList" );
 
   std::unique_ptr< QgsProcessingParameterString > fieldName = std::make_unique< QgsProcessingParameterString > ( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Field name" ), QVariant(), false );
@@ -121,26 +121,26 @@ bool QgsFieldCalculatorAlgorithm::prepareAlgorithm( const QVariantMap &parameter
   QVariant::Type fieldSubType;
   switch ( fieldTypeIdx )
   {
-    case 0: // Integer
-      fieldType = QVariant::Int;
-      break;
-    case 1: // Float
+    case 0: // Float
       fieldType = QVariant::Double;
+      break;
+    case 1: // Integer
+      fieldType = QVariant::Int;
       break;
     case 2: // String
       fieldType = QVariant::String;
       break;
-    case 3: // Boolean
-      fieldType = QVariant::Bool;
-      break;
-    case 4: // Date
+    case 3: // Date
       fieldType = QVariant::Date;
       break;
-    case 5: // Time
+    case 4: // Time
       fieldType = QVariant::Time;
       break;
-    case 6: // DateTime
+    case 5: // DateTime
       fieldType = QVariant::DateTime;
+      break;
+    case 6: // Boolean
+      fieldType = QVariant::Bool;
       break;
     case 7: // Binary
       fieldType = QVariant::ByteArray;


### PR DESCRIPTION
## Description

This PR adds a bunch of missing field types to processing's add field to the attributes table algorithm. Missing types goes from the most basic (boolean) to the widely adopted (datetime) and exciting ones (arrays).

![image](https://user-images.githubusercontent.com/1728657/151647249-e76adae8-4ffb-49b3-b8e1-768fb676a735.png)

Super, super helpful as part of models.

Edit: OK, this is a rabbit hole :) while doing this field type cleanup, noticed field calculator alg. also is missing a bunch of types. Fixed:

![image](https://user-images.githubusercontent.com/1728657/151648917-5cc58a50-2c48-46f8-9663-02799be1671f.png)

QGIS 4.0 TODO: harmonize the value ordering across those two algs (possibly through creating a field type parameter)