### PR TITLE
Fix atlas sorting with complex field names

### DIFF
--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -314,7 +314,7 @@ Given a string which may either directly match a field name from a layer, OR may
 be an expression which consists only of a single field reference for that layer, this
 method will return the quoted field.
 
-:return: the ``expression`` if not a field or quotes are not required, otherwise requite a quoted field.
+:return: the ``expression`` if not a field or quotes are not required, otherwise returns a quoted field.
 
 .. seealso:: :py:func:`expressionToLayerFieldIndex`
 

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -306,6 +306,21 @@ method will return the corresponding field index.
 .. versionadded:: 3.22
 %End
 
+    static QString quoteFieldExpression( const QString &expression, const QgsVectorLayer *layer );
+%Docstring
+Validate if the expression is a field in the ``layer`` and ensure it is quoted.
+
+Given a string which may either directly match a field name from a layer, OR may
+be an expression which consists only of a single field reference for that layer, this
+method will return the quoted field.
+
+:return: the ``expression`` if not a field or quotes are not required, otherwise requite a quoted field.
+
+.. seealso:: :py:func:`expressionToLayerFieldIndex`
+
+.. versionadded:: 3.24
+%End
+
     static bool checkExpression( const QString &text, const QgsExpressionContext *context, QString &errorMessage /Out/ );
 %Docstring
 Tests whether a string is a valid expression.

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1371,6 +1371,13 @@ int QgsExpression::expressionToLayerFieldIndex( const QString &expression, const
   return -1;
 }
 
+QString QgsExpression::quoteFieldExpression( const QString &expression, const QgsVectorLayer *layer )
+{
+  if ( !expression.contains( '\"' ) && QgsExpression::expressionToLayerFieldIndex( expression, layer ) != -1 )
+    return QgsExpression::quotedColumnRef( expression );
+  return expression;
+}
+
 QList<const QgsExpressionNode *> QgsExpression::nodes() const
 {
   if ( !d->mRootNode )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1373,9 +1373,19 @@ int QgsExpression::expressionToLayerFieldIndex( const QString &expression, const
 
 QString QgsExpression::quoteFieldExpression( const QString &expression, const QgsVectorLayer *layer )
 {
-  if ( !expression.contains( '\"' ) && QgsExpression::expressionToLayerFieldIndex( expression, layer ) != -1 )
-    return QgsExpression::quotedColumnRef( expression );
-  return expression;
+  if ( !layer )
+    return expression;
+
+  const int fieldIndex = QgsExpression::expressionToLayerFieldIndex( expression, layer );
+  if ( !expression.contains( '\"' ) && fieldIndex != -1 )
+  {
+    // retrieve actual field name from layer, so that we correctly remove any unwanted leading/trailing whitespace
+    return QgsExpression::quotedColumnRef( layer->fields().at( fieldIndex ).name() );
+  }
+  else
+  {
+    return expression;
+  }
 }
 
 QList<const QgsExpressionNode *> QgsExpression::nodes() const

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -376,7 +376,7 @@ class CORE_EXPORT QgsExpression
      * be an expression which consists only of a single field reference for that layer, this
      * method will return the quoted field.
      *
-     * \returns the \a expression if not a field or quotes are not required, otherwise requite a quoted field.
+     * \returns the \a expression if not a field or quotes are not required, otherwise returns a quoted field.
      *
      * \see expressionToLayerFieldIndex()
      * \since QGIS 3.24

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -370,6 +370,20 @@ class CORE_EXPORT QgsExpression
     static int expressionToLayerFieldIndex( const QString &expression, const QgsVectorLayer *layer );
 
     /**
+     * Validate if the expression is a field in the \a layer and ensure it is quoted.
+     *
+     * Given a string which may either directly match a field name from a layer, OR may
+     * be an expression which consists only of a single field reference for that layer, this
+     * method will return the quoted field.
+     *
+     * \returns the \a expression if not a field or quotes are not required, otherwise requite a quoted field.
+     *
+     * \see expressionToLayerFieldIndex()
+     * \since QGIS 3.24
+     */
+    static QString quoteFieldExpression( const QString &expression, const QgsVectorLayer *layer );
+
+    /**
      * Tests whether a string is a valid expression.
      * \param text string to test
      * \param context optional expression context

--- a/src/gui/layout/qgslayoutatlaswidget.cpp
+++ b/src/gui/layout/qgslayoutatlaswidget.cpp
@@ -240,7 +240,8 @@ void QgsLayoutAtlasWidget::changesSortFeatureExpression( const QString &expressi
 
   mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Sort" ) );
-  mAtlas->setSortExpression( expression );
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mAtlasCoverageLayerComboBox->currentLayer() );
+  mAtlas->setSortExpression( QgsExpression::quoteFieldExpression( expression, vlayer ) );
   mLayout->undoStack()->endCommand();
   mBlockUpdates = false;
   updateAtlasFeatures();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4110,23 +4110,25 @@ class TestQgsExpression: public QObject
                                               QgsField( QStringLiteral( "another FIELD" ), QVariant::String ) } );
       layer->updateFields();
 
-      QCOMPARE( QgsExpression::quoteFieldExpression( "", layer.get() ), "" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "42", layer.get() ), "42" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "foo", layer.get() ), "foo" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "\"foo bar\"", layer.get() ), "\"foo bar\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "sqrt(foo)", layer.get() ), "sqrt(foo)" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "foo + bar", layer.get() ), "foo + bar" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "field1", layer.get() ), "\"field1\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "FIELD1", layer.get() ), "\"FIELD1\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "\"field1\"", layer.get() ), "\"field1\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "\"FIELD1\"", layer.get() ), "\"FIELD1\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "  (  \"field1\"   )   ", layer.get() ), "  (  \"field1\"   )   " );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "another FIELD", layer.get() ), "\"another FIELD\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "ANOTHER field", layer.get() ), "\"ANOTHER field\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "  ANOTHER field  ", layer.get() ), "\"  ANOTHER field  \"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "\"another field\"", layer.get() ), "\"another field\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "\"ANOTHER FIELD\"", layer.get() ), "\"ANOTHER FIELD\"" );
-      QCOMPARE( QgsExpression::quoteFieldExpression( "  (  \"ANOTHER FIELD\"   )   ", layer.get() ), "  (  \"ANOTHER FIELD\"   )   " );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QString(), layer.get() ), QString() );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QString(), nullptr ), QString() );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "42" ), layer.get() ), QStringLiteral( "42" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "foo" ), layer.get() ), QStringLiteral( "foo" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "foo" ), nullptr ), QStringLiteral( "foo" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "\"foo bar\"" ), layer.get() ), QStringLiteral( "\"foo bar\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "sqrt(foo)" ), layer.get() ), QStringLiteral( "sqrt(foo)" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "foo + bar" ), layer.get() ), QStringLiteral( "foo + bar" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "field1" ), layer.get() ), QStringLiteral( "\"field1\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "FIELD1" ), layer.get() ), QStringLiteral( "\"field1\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "\"field1\"" ), layer.get() ), QStringLiteral( "\"field1\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "\"FIELD1\"" ), layer.get() ), QStringLiteral( "\"FIELD1\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "  (  \"field1\"   )   " ), layer.get() ), QStringLiteral( "  (  \"field1\"   )   " ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "another FIELD" ), layer.get() ), QStringLiteral( "\"another FIELD\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "ANOTHER field" ), layer.get() ), QStringLiteral( "\"another FIELD\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "  ANOTHER field  " ), layer.get() ), QStringLiteral( "\"another FIELD\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "\"another field\"" ), layer.get() ), QStringLiteral( "\"another field\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "\"ANOTHER FIELD\"" ), layer.get() ), QStringLiteral( "\"ANOTHER FIELD\"" ) );
+      QCOMPARE( QgsExpression::quoteFieldExpression( QStringLiteral( "  (  \"ANOTHER FIELD\"   )   " ), layer.get() ), QStringLiteral( "  (  \"ANOTHER FIELD\"   )   " ) );
     }
 
     void test_implicitSharing()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4103,6 +4103,32 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression::expressionToLayerFieldIndex( "  (  \"ANOTHER FIELD\"   )   ", layer.get() ), 1 );
     }
 
+    void test_quoteFieldExpression()
+    {
+      std::unique_ptr layer = std::make_unique< QgsVectorLayer >( QStringLiteral( "Point" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+      layer->dataProvider()->addAttributes( { QgsField( QStringLiteral( "field1" ), QVariant::String ),
+                                              QgsField( QStringLiteral( "another FIELD" ), QVariant::String ) } );
+      layer->updateFields();
+
+      QCOMPARE( QgsExpression::quoteFieldExpression( "", layer.get() ), "" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "42", layer.get() ), "42" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "foo", layer.get() ), "foo" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "\"foo bar\"", layer.get() ), "\"foo bar\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "sqrt(foo)", layer.get() ), "sqrt(foo)" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "foo + bar", layer.get() ), "foo + bar" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "field1", layer.get() ), "\"field1\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "FIELD1", layer.get() ), "\"FIELD1\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "\"field1\"", layer.get() ), "\"field1\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "\"FIELD1\"", layer.get() ), "\"FIELD1\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "  (  \"field1\"   )   ", layer.get() ), "  (  \"field1\"   )   " );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "another FIELD", layer.get() ), "\"another FIELD\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "ANOTHER field", layer.get() ), "\"ANOTHER field\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "  ANOTHER field  ", layer.get() ), "\"  ANOTHER field  \"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "\"another field\"", layer.get() ), "\"another field\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "\"ANOTHER FIELD\"", layer.get() ), "\"ANOTHER FIELD\"" );
+      QCOMPARE( QgsExpression::quoteFieldExpression( "  (  \"ANOTHER FIELD\"   )   ", layer.get() ), "  (  \"ANOTHER FIELD\"   )   " );
+    }
+
     void test_implicitSharing()
     {
       QgsExpression *exp = new QgsExpression( QStringLiteral( "Pilots > 2" ) );


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/46561 by fixing the behaviour of whitespace padded field names