### PR TITLE
Add support for field subtype to QgsFields::iconForFieldType

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2591,6 +2591,17 @@ class QgsProcessingParameterEnum : QgsProcessingParameterDefinition
 %Docstring(signature="appended")
 An enum based parameter for processing algorithms, allowing for selection from predefined values.
 
+Since QGIS 3.24 a list of icons corresponding to the enum values can be specified by setting the
+widget wrapper metadata "icons" option, as demonstrated below. The "icons" value should be
+set to a list of QIcon values.
+
+.. code-block:: python
+
+       param = QgsProcessingParameterEnum( 'FIELD_TYPE', 'Field type', ['Integer', 'String'])
+       param.setMetadata( {'widget_wrapper':
+         { 'icons': [QIcon('integer.svg'), QIcon('string.svg')] }
+       })
+
 .. versionadded:: 3.0
 %End
 

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -336,9 +336,11 @@ Returns an icon corresponding to a field index, based on the field's type and so
     }
 %End
 
-    static QIcon iconForFieldType( const QVariant::Type &type ) /Factory/;
+    static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid );
 %Docstring
 Returns an icon corresponding to a field ``type``
+
+Since QGIS 3.24, the optional ``subType`` argument can be used to specify the type of variant list or map values.
 
 .. versionadded:: 3.16
 %End

--- a/src/analysis/processing/qgsalgorithmaddtablefield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddtablefield.cpp
@@ -75,19 +75,45 @@ QgsAddTableFieldAlgorithm *QgsAddTableFieldAlgorithm::createInstance() const
 void QgsAddTableFieldAlgorithm::initParameters( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterString( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Field name" ) ) );
-  addParameter( new QgsProcessingParameterEnum( QStringLiteral( "FIELD_TYPE" ), QObject::tr( "Field type" ),
-                QStringList() << QgsVariantUtils::typeToDisplayString( QVariant::Int )
-                << QgsVariantUtils::typeToDisplayString( QVariant::Double )
-                << QgsVariantUtils::typeToDisplayString( QVariant::String )
-                << QgsVariantUtils::typeToDisplayString( QVariant::Bool )
-                << QgsVariantUtils::typeToDisplayString( QVariant::Date )
-                << QgsVariantUtils::typeToDisplayString( QVariant::Time )
-                << QgsVariantUtils::typeToDisplayString( QVariant::DateTime )
-                << QgsVariantUtils::typeToDisplayString( QVariant::ByteArray )
-                << QgsVariantUtils::typeToDisplayString( QVariant::StringList )
-                << QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Int )
-                << QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ),
-                false, 0 ) );
+
+  QStringList typeStrings;
+  QVariantList icons;
+  typeStrings.reserve( 11 );
+  icons.reserve( 11 );
+  for ( const auto &type :
+        std::vector < std::pair< QVariant::Type, QVariant::Type > >
+{
+  {QVariant::Int, QVariant::Invalid },
+  {QVariant::Double, QVariant::Invalid },
+  {QVariant::String, QVariant::Invalid },
+  {QVariant::Bool, QVariant::Invalid },
+  {QVariant::Date, QVariant::Invalid },
+  {QVariant::Time, QVariant::Invalid },
+  {QVariant::DateTime, QVariant::Invalid },
+  {QVariant::ByteArray, QVariant::Invalid },
+  {QVariant::StringList, QVariant::Invalid },
+  {QVariant::List, QVariant::Int },
+  {QVariant::List, QVariant::Double }
+} )
+  {
+    typeStrings << QgsVariantUtils::typeToDisplayString( type.first, type.second );
+    icons << QgsFields::iconForFieldType( type.first, type.second );
+  }
+
+  std::unique_ptr< QgsProcessingParameterEnum> fieldTypes = std::make_unique< QgsProcessingParameterEnum> ( QStringLiteral( "FIELD_TYPE" ), QObject::tr( "Field type" ),
+      typeStrings, false, 0 );
+  fieldTypes->setMetadata(
+  {
+    QVariantMap( {{
+        QStringLiteral( "widget_wrapper" ),
+        QVariantMap(
+        { {
+            QStringLiteral( "icons" ), icons
+          }}
+        )
+      }} )
+  } );
+  addParameter( fieldTypes.release() );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "FIELD_LENGTH" ), QObject::tr( "Field length" ),
                 QgsProcessingParameterNumber::Integer, 10, false, 1, 255 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "FIELD_PRECISION" ), QObject::tr( "Field precision" ),

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -66,20 +66,44 @@ void QgsFieldCalculatorAlgorithm::initParameters( const QVariantMap &configurati
 {
   Q_UNUSED( configuration )
 
-  const QStringList fieldTypes =  QStringList() << QgsVariantUtils::typeToDisplayString( QVariant::Double )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::Int )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::String )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::Date )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::Time )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::DateTime )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::Bool )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::ByteArray )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::StringList )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Int )
-                                  << QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double );
+  QStringList fieldTypes;
+  QVariantList icons;
+  fieldTypes.reserve( 11 );
+  icons.reserve( 11 );
+  for ( const auto &type :
+        std::vector < std::pair< QVariant::Type, QVariant::Type > >
+{
+  {QVariant::Double, QVariant::Invalid },
+  {QVariant::Int, QVariant::Invalid },
+  {QVariant::String, QVariant::Invalid },
+  {QVariant::Date, QVariant::Invalid },
+  {QVariant::Time, QVariant::Invalid },
+  {QVariant::DateTime, QVariant::Invalid },
+  {QVariant::Bool, QVariant::Invalid },
+  {QVariant::ByteArray, QVariant::Invalid },
+  {QVariant::StringList, QVariant::Invalid },
+  {QVariant::List, QVariant::Int },
+  {QVariant::List, QVariant::Double }
+} )
+  {
+    fieldTypes << QgsVariantUtils::typeToDisplayString( type.first, type.second );
+    icons << QgsFields::iconForFieldType( type.first, type.second );
+  }
 
   std::unique_ptr< QgsProcessingParameterString > fieldName = std::make_unique< QgsProcessingParameterString > ( QStringLiteral( "FIELD_NAME" ), QObject::tr( "Field name" ), QVariant(), false );
   std::unique_ptr< QgsProcessingParameterEnum > fieldType = std::make_unique< QgsProcessingParameterEnum > ( QStringLiteral( "FIELD_TYPE" ), QObject::tr( "Result field type" ), fieldTypes, false, 0 );
+  fieldType->setMetadata(
+  {
+    QVariantMap( {{
+        QStringLiteral( "widget_wrapper" ),
+        QVariantMap(
+        { {
+            QStringLiteral( "icons" ), icons
+          }}
+        )
+      }} )
+  } );
+
   std::unique_ptr< QgsProcessingParameterNumber > fieldLength = std::make_unique< QgsProcessingParameterNumber > ( QStringLiteral( "FIELD_LENGTH" ), QObject::tr( "Result field length" ), QgsProcessingParameterNumber::Integer, QVariant( 0 ), false, 0 );
   std::unique_ptr< QgsProcessingParameterNumber > fieldPrecision = std::make_unique< QgsProcessingParameterNumber > ( QStringLiteral( "FIELD_PRECISION" ), QObject::tr( "Result field precision" ), QgsProcessingParameterNumber::Integer, QVariant( 0 ), false, 0 );
   std::unique_ptr< QgsProcessingParameterExpression > expression = std::make_unique< QgsProcessingParameterExpression> ( QStringLiteral( "FORMULA" ), QObject::tr( "Formula" ), QVariant(), QStringLiteral( "INPUT" ), false );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -74,11 +74,11 @@ QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::W
 
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "real" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "timestamp" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "real" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Date ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::DateTime ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "timestamp" );
 
   mDatabaseComboBox->setProvider( QStringLiteral( "spatialite" ) );
 

--- a/src/core/browser/qgsfieldsitem.cpp
+++ b/src/core/browser/qgsfieldsitem.cpp
@@ -195,7 +195,7 @@ QIcon QgsFieldItem::icon()
         return QgsIconUtils::iconDefaultLayer();
     }
   }
-  const QIcon icon { QgsFields::iconForFieldType( mField.type() ) };
+  const QIcon icon { QgsFields::iconForFieldType( mField.type(), mField.subType() ) };
   // Try subtype if icon is null
   if ( icon.isNull() )
   {

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2523,7 +2523,19 @@ class CORE_EXPORT QgsProcessingParameterRasterLayer : public QgsProcessingParame
  * \class QgsProcessingParameterEnum
  * \ingroup core
  * \brief An enum based parameter for processing algorithms, allowing for selection from predefined values.
-  * \since QGIS 3.0
+ *
+ * Since QGIS 3.24 a list of icons corresponding to the enum values can be specified by setting the
+ * widget wrapper metadata "icons" option, as demonstrated below. The "icons" value should be
+ * set to a list of QIcon values.
+ *
+ * \code{.py}
+ *   param = QgsProcessingParameterEnum( 'FIELD_TYPE', 'Field type', ['Integer', 'String'])
+ *   param.setMetadata( {'widget_wrapper':
+ *     { 'icons': [QIcon('integer.svg'), QIcon('string.svg')] }
+ *   })
+ * \endcode
+ *
+ * \since QGIS 3.0
  */
 class CORE_EXPORT QgsProcessingParameterEnum : public QgsProcessingParameterDefinition
 {

--- a/src/core/qgsfields.cpp
+++ b/src/core/qgsfields.cpp
@@ -280,56 +280,61 @@ QIcon QgsFields::iconForField( int fieldIdx, bool considerOrigin ) const
     {
       case QgsFields::OriginExpression:
         return QgsApplication::getThemeIcon( QStringLiteral( "/mIconExpression.svg" ) );
-        break;
 
       case QgsFields::OriginJoin:
         return QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/join.svg" ) );
 
       default:
-        return iconForFieldType( d->fields.at( fieldIdx ).field.type() );
+        return iconForFieldType( d->fields.at( fieldIdx ).field.type(), d->fields.at( fieldIdx ).field.subType() );
     }
   }
-  return iconForFieldType( d->fields.at( fieldIdx ).field.type() );
+  return iconForFieldType( d->fields.at( fieldIdx ).field.type(), d->fields.at( fieldIdx ).field.subType() );
 }
 
-QIcon QgsFields::iconForFieldType( const QVariant::Type &type )
+QIcon QgsFields::iconForFieldType( QVariant::Type type, QVariant::Type subType )
 {
   switch ( type )
   {
     case QVariant::Bool:
-      return QgsApplication::getThemeIcon( "/mIconFieldBool.svg" );
-
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBool.svg" ) );
     case QVariant::Int:
     case QVariant::UInt:
     case QVariant::LongLong:
     case QVariant::ULongLong:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldInteger.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) );
     case QVariant::Double:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldFloat.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) );
     case QVariant::String:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldText.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) );
     case QVariant::Date:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldDate.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) );
     case QVariant::DateTime:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldDateTime.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) );
     case QVariant::Time:
-    {
-      return QgsApplication::getThemeIcon( "/mIconFieldTime.svg" );
-    }
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldTime.svg" ) );
     case QVariant::ByteArray:
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBinary.svg" ) );
+    case QVariant::List:
     {
-      return QgsApplication::getThemeIcon( "/mIconFieldBinary.svg" );
+      switch ( subType )
+      {
+        case QVariant::Int:
+        case QVariant::UInt:
+        case QVariant::LongLong:
+        case QVariant::ULongLong:
+          return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayInteger.svg" ) );
+        case QVariant::Double:
+          return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayFloat.svg" ) );
+        case QVariant::String:
+          return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayString.svg" ) );
+        default:
+          return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArray.svg" ) );
+      }
     }
+    case QVariant::StringList:
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayString.svg" ) );
+    case QVariant::Map:
+      return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldJson.svg" ) );
     default:
       return QIcon();
   }

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -421,9 +421,12 @@ class CORE_EXPORT  QgsFields
 
     /**
      * Returns an icon corresponding to a field \a type
+     *
+     * Since QGIS 3.24, the optional ``subType`` argument can be used to specify the type of variant list or map values.
+     *
      * \since QGIS 3.16
      */
-    static QIcon iconForFieldType( const QVariant::Type &type ) SIP_FACTORY;
+    static QIcon iconForFieldType( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid );
 
     //! Allows direct construction of QVariants from fields.
     operator QVariant() const

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2712,12 +2712,15 @@ QWidget *QgsProcessingEnumWidgetWrapper::createWidget()
         if ( expParam->flags() & QgsProcessingParameterDefinition::FlagOptional )
           mComboBox->addItem( tr( "[Not selected]" ), QVariant() );
         const QStringList options = expParam->options();
+        const QVariantList iconList = expParam->metadata().value( QStringLiteral( "widget_wrapper" ) ).toMap().value( QStringLiteral( "icons" ) ).toList();
         for ( int i = 0; i < options.count(); ++i )
         {
+          const QIcon icon = iconList.value( i ).value< QIcon >();
+
           if ( expParam->usesStaticStrings() )
-            mComboBox->addItem( options.at( i ), options.at( i ) );
+            mComboBox->addItem( icon, options.at( i ), options.at( i ) );
           else
-            mComboBox->addItem( options.at( i ), i );
+            mComboBox->addItem( icon, options.at( i ), i );
         }
 
         mComboBox->setToolTip( parameterDefinition()->toolTip() );

--- a/src/gui/qgsaddattrdialog.cpp
+++ b/src/gui/qgsaddattrdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 #include "qgslogger.h"
+#include "qgsfields.h"
 
 #include <QMessageBox>
 
@@ -37,14 +38,15 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
   const QList< QgsVectorDataProvider::NativeType > &typelist = vlayer->dataProvider()->nativeTypes();
   for ( int i = 0; i < typelist.size(); i++ )
   {
-    QgsDebugMsg( QStringLiteral( "name:%1 type:%2 typeName:%3 length:%4-%5 prec:%6-%7" )
-                 .arg( typelist[i].mTypeDesc )
-                 .arg( typelist[i].mType )
-                 .arg( typelist[i].mTypeName )
-                 .arg( typelist[i].mMinLen ).arg( typelist[i].mMaxLen )
-                 .arg( typelist[i].mMinPrec ).arg( typelist[i].mMaxPrec ) );
+    QgsDebugMsgLevel( QStringLiteral( "name:%1 type:%2 typeName:%3 length:%4-%5 prec:%6-%7" )
+                      .arg( typelist[i].mTypeDesc )
+                      .arg( typelist[i].mType )
+                      .arg( typelist[i].mTypeName )
+                      .arg( typelist[i].mMinLen ).arg( typelist[i].mMaxLen )
+                      .arg( typelist[i].mMinPrec ).arg( typelist[i].mMaxPrec ), 2 );
 
-    whileBlocking( mTypeBox )->addItem( typelist[i].mTypeDesc );
+    whileBlocking( mTypeBox )->addItem( QgsFields::iconForFieldType( typelist[i].mType, typelist[i].mSubType ),
+                                        typelist[i].mTypeDesc );
     mTypeBox->setItemData( i, static_cast<int>( typelist[i].mType ), Qt::UserRole );
     mTypeBox->setItemData( i, typelist[i].mTypeName, Qt::UserRole + 1 );
     mTypeBox->setItemData( i, typelist[i].mMinLen, Qt::UserRole + 2 );
@@ -127,14 +129,14 @@ void QgsAddAttrDialog::accept()
 QgsField QgsAddAttrDialog::field() const
 {
 
-  QgsDebugMsg( QStringLiteral( "idx:%1 name:%2 type:%3 typeName:%4 length:%5 prec:%6 comment:%7" )
-               .arg( mTypeBox->currentIndex() )
-               .arg( mNameEdit->text() )
-               .arg( mTypeBox->currentData( Qt::UserRole ).toInt() )
-               .arg( mTypeBox->currentData( Qt::UserRole + 1 ).toString() )
-               .arg( mLength->value() )
-               .arg( mPrec->value() )
-               .arg( mCommentEdit->text() ) );
+  QgsDebugMsgLevel( QStringLiteral( "idx:%1 name:%2 type:%3 typeName:%4 length:%5 prec:%6 comment:%7" )
+                    .arg( mTypeBox->currentIndex() )
+                    .arg( mNameEdit->text() )
+                    .arg( mTypeBox->currentData( Qt::UserRole ).toInt() )
+                    .arg( mTypeBox->currentData( Qt::UserRole + 1 ).toString() )
+                    .arg( mLength->value() )
+                    .arg( mPrec->value() )
+                    .arg( mCommentEdit->text() ), 2 );
 
   return QgsField(
            mNameEdit->text(),

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -311,7 +311,7 @@ QWidget *QgsFieldMappingWidget::TypeDelegate::createEditor( QWidget *parent, con
   const QList<QgsVectorDataProvider::NativeType> typeList = QgsFieldMappingModel::supportedDataTypes();
   for ( int i = 0; i < typeList.size(); i++ )
   {
-    editor->addItem( typeList[i].mTypeDesc );
+    editor->addItem( QgsFields::iconForFieldType( typeList[i].mType, typeList[i].mSubType ), typeList[i].mTypeDesc );
     editor->setItemData( i, typeList[i].mTypeName, Qt::UserRole );
   }
 

--- a/src/gui/qgsnewauxiliaryfielddialog.cpp
+++ b/src/gui/qgsnewauxiliaryfielddialog.cpp
@@ -32,9 +32,9 @@ QgsNewAuxiliaryFieldDialog::QgsNewAuxiliaryFieldDialog( const QgsPropertyDefinit
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
-  mType->addItem( QgsApplication::getThemeIcon( "/mIconFieldText.svg" ), QgsVariantUtils::typeToDisplayString( QVariant::String ), QgsPropertyDefinition::DataTypeString );
-  mType->addItem( QgsApplication::getThemeIcon( "/mIconFieldFloat.svg" ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), QgsPropertyDefinition::DataTypeNumeric );
-  mType->addItem( QgsApplication::getThemeIcon( "/mIconFieldInteger.svg" ), tr( "Integer" ), QgsPropertyDefinition::DataTypeBoolean );
+  mType->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), QgsPropertyDefinition::DataTypeString );
+  mType->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), QgsPropertyDefinition::DataTypeNumeric );
+  mType->addItem( QgsFields::iconForFieldType( QVariant::Int ), tr( "Integer" ), QgsPropertyDefinition::DataTypeBoolean );
 
   mType->setCurrentIndex( mType->findData( def.dataType() ) );
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -103,15 +103,15 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mCrsSelector->setEnabled( false );
   mCrsSelector->setShowAccuracyWarnings( true );
 
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), "integer64" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "real" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBool.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBinary.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), "binary" );
-  mFieldTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldJson.svg" ) ), tr( "JSON" ), "json" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), "integer64" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "real" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Date ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::DateTime ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Bool ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::ByteArray ), QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), "binary" );
+  mFieldTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Map ), tr( "JSON" ), "json" );
 
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   mOkButton->setEnabled( false );

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -83,18 +83,18 @@ QgsNewMemoryLayerDialog::QgsNewMemoryLayerDialog( QWidget *parent, Qt::WindowFla
   mCrsSelector->setEnabled( false );
   mCrsSelector->setShowAccuracyWarnings( true );
 
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "string" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "double" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBool.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Time ), "time" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBinary.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), "binary" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayString.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::StringList ), "stringlist" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Int ), "integerlist" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ), "doublelist" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldArrayInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), "integer64list" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "string" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "double" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Bool ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Date ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Time ), QgsVariantUtils::typeToDisplayString( QVariant::Time ), "time" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::DateTime ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::ByteArray ), QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), "binary" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::StringList ), QgsVariantUtils::typeToDisplayString( QVariant::StringList ), "stringlist" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Int ), "integerlist" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ), "doublelist" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::List, QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), "integer64list" );
   mTypeBox_currentIndexChanged( 1 );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -51,10 +51,10 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFla
   mAddAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewAttribute.svg" ) ) );
   mRemoveAttributeButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDeleteAttribute.svg" ) ) );
 
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "String" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "Integer" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "Real" );
-  mTypeBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "Date" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "String" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "Integer" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "Real" );
+  mTypeBox->addItem( QgsFields::iconForFieldType( QVariant::Date ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "Date" );
 
   mWidth->setValidator( new QIntValidator( 1, 255, this ) );
   mPrecision->setValidator( new QIntValidator( 0, 15, this ) );

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -382,7 +382,7 @@ void QgsFieldCalculator::populateOutputFieldTypes()
   mOutputFieldTypeComboBox->clear();
   for ( int i = 0; i < typelist.size(); i++ )
   {
-    mOutputFieldTypeComboBox->addItem( QgsFields::iconForFieldType( typelist[i].mType ), typelist[i].mTypeDesc );
+    mOutputFieldTypeComboBox->addItem( QgsFields::iconForFieldType( typelist[i].mType, typelist[i].mSubType ), typelist[i].mTypeDesc );
     mOutputFieldTypeComboBox->setItemData( i, static_cast<int>( typelist[i].mType ), Qt::UserRole + FTC_TYPE_ROLE_IDX );
     mOutputFieldTypeComboBox->setItemData( i, typelist[i].mTypeName, Qt::UserRole + FTC_TYPE_NAME_IDX );
     mOutputFieldTypeComboBox->setItemData( i, typelist[i].mMinLen, Qt::UserRole + FTC_MINLEN_IDX );

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -504,14 +504,14 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
   for ( int column = 0; column < tblSample->columnCount(); column++ )
   {
     QComboBox *typeCombo = new QComboBox( tblSample );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldText.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldInteger.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), "longlong" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldFloat.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "double" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldBool.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDate.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::Time ), "time" );
-    typeCombo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconFieldDateTime.svg" ) ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::String ), QgsVariantUtils::typeToDisplayString( QVariant::String ), "text" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::Int ), QgsVariantUtils::typeToDisplayString( QVariant::Int ), "integer" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::LongLong ), QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), "longlong" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::Double ), QgsVariantUtils::typeToDisplayString( QVariant::Double ), "double" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::Bool ), QgsVariantUtils::typeToDisplayString( QVariant::Bool ), "bool" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::Date ), QgsVariantUtils::typeToDisplayString( QVariant::Date ), "date" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::Time ), QgsVariantUtils::typeToDisplayString( QVariant::Time ), "time" );
+    typeCombo->addItem( QgsFields::iconForFieldType( QVariant::DateTime ), QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), "datetime" );
     connect( typeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
     {
       mOverriddenFields.insert( column );


### PR DESCRIPTION
Adds support for showing array field type icons correctly, and shows field type icons in more contexts

Fixes https://github.com/qgis/QGIS/issues/47078
