### PR TITLE
Update wms layer title each time a new layer is selected

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -986,31 +986,26 @@ void QgsWMSSourceSelect::updateButtons()
     }
   }
 
-  if ( leLayerName->text().isEmpty() || leLayerName->text() == mLastLayerName )
+  if ( addButton()->isEnabled() )
   {
-    if ( addButton()->isEnabled() )
+    if ( !lstTilesets->selectedItems().isEmpty() )
     {
-      if ( !lstTilesets->selectedItems().isEmpty() )
-      {
-        QTableWidgetItem *item = lstTilesets->selectedItems().first();
-        mLastLayerName = item->data( Qt::UserRole + 5 ).toString();
-        if ( mLastLayerName.isEmpty() )
-          mLastLayerName = item->data( Qt::UserRole + 0 ).toString();
-        leLayerName->setText( mLastLayerName );
-      }
-      else
-      {
-        QStringList layers, styles, titles;
-        collectSelectedLayers( layers, styles, titles );
-        mLastLayerName = titles.join( QLatin1Char( '/' ) );
-        leLayerName->setText( mLastLayerName );
-      }
+      QTableWidgetItem *item = lstTilesets->selectedItems().first();
+      QString tileLayerName = item->data( Qt::UserRole + 5 ).toString();
+      if ( tileLayerName.isEmpty() )
+        tileLayerName = item->data( Qt::UserRole + 0 ).toString();
+      leLayerName->setText( tileLayerName );
     }
     else
     {
-      mLastLayerName.clear();
-      leLayerName->setText( mLastLayerName );
+      QStringList layers, styles, titles;
+      collectSelectedLayers( layers, styles, titles );
+      leLayerName->setText( titles.join( QLatin1Char( '/' ) ) );
     }
+  }
+  else
+  {
+    leLayerName->setText( "" );
   }
 }
 

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -160,9 +160,6 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     //! URI for selected connection
     QgsDataSourceUri mUri;
 
-    //! layer name derived from latest layer selection (updated as long it's not edited manually)
-    QString mLastLayerName;
-
     //! The widget that controls the image format radio buttons
     QButtonGroup *mImageFormatGroup = nullptr;
 


### PR DESCRIPTION
previously, if the wms layer title was manually modified, it would never get
updated anymore until qgis was restarted.

Fixes #28858 #40421

## Description

the existing behaviour of not updating the field anymore feels like a bug.. and nobody has been able to explain why this choice had been made.