### PR TITLE
Fix 3D view crash on deep chunks hierarchy or small replacement queue 

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -153,16 +153,22 @@ void QgsChunkedEntity::update( const SceneState &state )
     }
     else
     {
-      node->entity()->setEnabled( true );
-      ++enabled;
+      if ( Qt3DCore::QEntity *entity = node->entity() )
+      {
+        entity->setEnabled( true );
+        ++enabled;
+      }
     }
   }
 
   // disable those that were active but will not be anymore
   for ( QgsChunkNode *node : activeBefore )
   {
-    node->entity()->setEnabled( false );
-    ++disabled;
+    if ( Qt3DCore::QEntity *entity = node->entity() )
+    {
+      entity->setEnabled( false );
+      ++disabled;
+    }
   }
 
   // unload those that are over the limit for replacement


### PR DESCRIPTION
## Description
- Fix crash when we hit QgsChunkedEntity::mMaxLoadedChunks limit
- The reason is that it might happen that some tiles and queued for load and didn't have their entities created yet and we might enable/disable these entities.
- The bug will be triggered if the point cloud nodes hierarchy is deep enough or the replacement queue size is made to be small enough
