### PR TITLE
Text improvements for crash handler dialog

### DIFF
--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -29,17 +29,18 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   setupUi( this );
   setWindowTitle( tr( "Uh-oh!" ) );
 
-  mCrashHeaderMessage->setText( tr( "QGIS unexpectedly ended" ) );
+  mCrashHeaderMessage->setText( tr( "QGIS ended unexpectedly" ) );
   connect( mReloadQGISButton, &QPushButton::clicked, this, &QgsCrashDialog::reloadQGIS );
   connect( mCopyReportButton, &QPushButton::clicked, this, &QgsCrashDialog::createBugReport );
   mCopyReportButton->setEnabled( false );
 
-  mCrashMessage->setText( tr( "Sorry :( It looks something unexpected happened that we didn't handle and QGIS ended unexpectedly."
+  mCrashMessage->setText( tr( "Oh dear! Something unexpected happened and QGIS ended without being able to handle the error gracefully."
                               "<br><br>" )
-                          +  tr( "Keen to help us fix bugs? "
-                                 "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Follow the steps to help our developers</a>."
+                          +  tr( "Are you keen to help us fix bugs? QGIS relies on donations to pay developers to do funded bug fixing to improve the stability of the software. "
+                                 "We also have a team of enthusiastic volunteers who are all working hard to improve the quality of QGIS. To do that, we need your help. "
+                                 "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Find out how to help our developers</a>."
                                  "<br><br>"
-                                 "You can also send us a helpful bug report using the Copy Report button <br>and opening a ticket at "
+                                 "Send us a helpful bug report by using the 'Copy Report' button below, <br>then open a ticket on the "
                                  "<a href=\"https://github.com/qgis/QGIS/issues\">QGIS Issue Tracker</a>." ) );
   mCrashMessage->setTextInteractionFlags( Qt::TextBrowserInteraction );
   mCrashMessage->setOpenExternalLinks( true );
@@ -67,8 +68,8 @@ void QgsCrashDialog::setPythonFault( const QgsCrashReport::PythonFault &fault )
       break;
 
     case QgsCrashReport::LikelyPythonFaultCause::ProcessingScript:
-      mCrashHeaderMessage->setText( tr( "User script crashed QGIS" ).arg( fault.title ) );
-      mCrashMessage->setText( tr( "The user script <b>%1</b> caused QGIS to crash." ).arg( fault.filePath )
+      mCrashHeaderMessage->setText( tr( "A user script crashed QGIS" ).arg( fault.title ) );
+      mCrashMessage->setText( tr( "This user script <b>%1</b> caused QGIS to crash." ).arg( fault.filePath )
                               + "<br><br>"
                               +  tr( "This is a third party custom script, and this issue should be reported to the author of that script." ) );
       splitter->setSizes( { 0, splitter->width() } );
@@ -79,7 +80,7 @@ void QgsCrashDialog::setPythonFault( const QgsCrashReport::PythonFault &fault )
       mCrashHeaderMessage->setText( tr( "Plugin %1 crashed QGIS" ).arg( fault.title ) );
       mCrashMessage->setText( tr( "The plugin <b>%1</b> caused QGIS to crash." ).arg( fault.title )
                               + "<br><br>"
-                              +  tr( "Please report this issue to the author of that plugin." ) );
+                              +  tr( "Please report this issue to the author of this plugin." ) );
       splitter->setSizes( { 0, splitter->width() } );
       mCopyReportButton->setEnabled( true );
       break;

--- a/src/crashhandler/qgscrashdialog.ui
+++ b/src/crashhandler/qgscrashdialog.ui
@@ -515,7 +515,7 @@
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
           <property name="leftMargin">
            <number>0</number>
@@ -526,7 +526,7 @@
           <item>
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about when you got the crash.&lt;/p&gt;&lt;p&gt;Include as much information as you can as well as steps to reproduce the issue if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about what you were doing when QGIS crashed.&lt;/p&gt;&lt;p&gt;Please include as much information as you can, as well as any steps we can follow to reproduce the issue, if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -554,7 +554,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
            <widget class="QLabel" name="label_3">
@@ -565,7 +565,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Report Details</string>
+             <string>Report details</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>


### PR DESCRIPTION
## Description

The crash handler text was a bit awkward to read so I gave it a bit of an overhaul. This is how it looked before:

![image](https://user-images.githubusercontent.com/178003/151889634-dadbd0cb-99d5-4fbc-bd09-8aea55906a91.png)

And this is how it looks with my changes:

![crashhandler](https://user-images.githubusercontent.com/178003/151889688-660bbd26-ff07-49f6-acab-80ad5fd3b46c.png)

