### PR TITLE
export usage for when exporting map

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -359,6 +359,8 @@ void QgsMapSaveDialog::applyMapSettings( QgsMapSettings &mapSettings )
                     << QgsExpressionContextUtils::mapSettingsScope( mapSettings );
 
   mapSettings.setExpressionContext( expressionContext );
+
+  mapSettings.setRendererUsage( Qgis::RendererUsage::Export );
 }
 
 void QgsMapSaveDialog::lockChanged( const bool locked )


### PR DESCRIPTION
following #46731, the export usage when saving map (image or PDF) was lacking.