### PR TITLE
explicit message error for WMS connection in the data source manager

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2490,7 +2490,18 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
     }
     else
     {
-      mError = tr( "Download of capabilities failed: %1" ).arg( mCapabilitiesReply->errorString() );
+      const QString contentType = mCapabilitiesReply->header( QNetworkRequest::ContentTypeHeader ).toString();
+
+      QString errorMessage;
+      if ( contentType.startsWith( QStringLiteral( "text/plain" ) ) )
+        errorMessage = mCapabilitiesReply->readAll();
+      else
+        errorMessage = mCapabilitiesReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString();
+
+      if ( errorMessage.isEmpty() )
+        errorMessage = mCapabilitiesReply->errorString();
+
+      mError = tr( "Download of capabilities failed: %1" ).arg( errorMessage );
       QgsMessageLog::logMessage( mError, tr( "WMS" ) );
       mHttpCapabilitiesResponse.clear();
     }

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -488,7 +488,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
     QMessageBox::warning(
       this,
       tr( "WMS Provider" ),
-      tr( "Failed to download capabilities:\n" ) + capDownload.lastError()
+      capDownload.lastError()
     );
     return;
   }


### PR DESCRIPTION
This PR makes more explicit the error message when there is a WMS/WMTS connection error in the data source manager.
Also, avoid a duplicate text.