### PR TITLE
QgsProperty::setExpressionString with empty string deactivates the entire QgsProperty

### DIFF
--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -371,7 +371,7 @@ void QgsProperty::setExpressionString( const QString &expression )
 {
   d.detach();
   d->expressionString = expression;
-  d->expression = QgsExpression(expression);
+  d->expression = QgsExpression( expression );
   d->expressionPrepared = false;
   d->expressionIsInvalid = false;
 

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -375,7 +375,7 @@ void QgsProperty::setExpressionString( const QString &expression )
   d->expression = QgsExpression( expression );
   d->expressionPrepared = false;
   d->expressionIsInvalid = false;
-  if (d->expressionString.isEmpty())
+  if ( d->expressionString.isEmpty() )
     d->active = false;
 }
 

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -383,7 +383,7 @@ void QgsProperty::setExpressionString( const QString &expression )
   else
   {
     d->type = ExpressionBasedProperty;
-  }  
+  }
 }
 
 QString QgsProperty::expressionString() const

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -370,13 +370,20 @@ QgsProperty::operator bool() const
 void QgsProperty::setExpressionString( const QString &expression )
 {
   d.detach();
-  d->type = ExpressionBasedProperty;
   d->expressionString = expression;
-  d->expression = QgsExpression( expression );
+  d->expression = QgsExpression(expression);
   d->expressionPrepared = false;
   d->expressionIsInvalid = false;
+
   if ( d->expressionString.isEmpty() )
+  {
     d->active = false;
+    d->type = InvalidProperty;
+  }
+  else
+  {
+    d->type = ExpressionBasedProperty;
+  }  
 }
 
 QString QgsProperty::expressionString() const

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -375,6 +375,8 @@ void QgsProperty::setExpressionString( const QString &expression )
   d->expression = QgsExpression( expression );
   d->expressionPrepared = false;
   d->expressionIsInvalid = false;
+  if (d->expressionString.isEmpty())
+    d->active = false;
 }
 
 QString QgsProperty::expressionString() const

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -575,6 +575,8 @@ void TestQgsProperty::expressionBasedProperty()
   QVERIFY( property.referencedFields( context ).isEmpty() );
   // unset expression
   QgsProperty defaultProperty = QgsProperty::fromExpression( QString() );
+  // an invalid expression (empty string) should return an invalid property
+  QCOMPARE( defaultProperty.propertyType(), QgsProperty::InvalidProperty );
   QCOMPARE( defaultProperty.value( context, -1 ).toInt(), -1 );
   QVERIFY( defaultProperty.referencedFields( context ).isEmpty() );
   defaultProperty.setActive( true );


### PR DESCRIPTION
## Description

This PR addresses issue #47127

If QgsProperty::setExpressionString called with an empty string the QgsProperty will be deactivated.

This way setExpressionString follows the logic that is already implemented in 
`bool QgsProperty::loadVariant( const QVariant &property )`