### PR TITLE
Don't slightly colorise the icons for selected items in lists

### DIFF
--- a/src/gui/qgsproxystyle.cpp
+++ b/src/gui/qgsproxystyle.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsproxystyle.h"
 #include "qgsimageoperation.h"
+#include "qgis.h"
 #include <QStyleFactory>
 #include <QStyle>
 #include <QStyleOption>
@@ -80,9 +81,9 @@ QPixmap QgsAppStyle::generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &p
     case QIcon::Normal:
     case QIcon::Active:
     case QIcon::Selected:
-      break;
-
+      return pixmap;
   }
+  BUILTIN_UNREACHABLE
   return QProxyStyle::generatedIconPixmap( iconMode, pixmap, opt );
 }
 


### PR DESCRIPTION
This can result in misleading symbol icons in the legend, where
the icon will be slightly colorised to match the highlight color
of the selected list row background color.

We have to disable this across the whole application, but I can't
spot any fallout from this.

Also has a nice impact on symbols selected in the style manager
lists, as these no longer get incorrectly colorised either.

Refs #47065
