### PR TITLE
QgsDistanceArea::bearing can raise QgsCsExceptions, so ensure that these are always gracefully caught

### DIFF
--- a/python/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/core/auto_generated/qgsdistancearea.sip.in
@@ -282,9 +282,11 @@ Returns the units of area for areal calculations made by this object.
 Measures the area of the polygon described by a set of points.
 %End
 
-    double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const;
+    double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const throw( QgsCsException );
 %Docstring
 Computes the bearing (in radians) between two points.
+
+:raises QgsCsException: on invalid input coordinates
 %End
 
     static QString formatDistance( double distance, int decimals, QgsUnitTypes::DistanceUnit unit, bool keepBaseUnit = false );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -1042,7 +1042,15 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     }
     else
     {
-      bearing = 180 * mDistanceCalculator.bearing( mSecondLastGpsPosition, mLastGpsPosition ) / M_PI;
+      try
+      {
+        bearing = 180 * mDistanceCalculator.bearing( mSecondLastGpsPosition, mLastGpsPosition ) / M_PI;
+      }
+      catch ( QgsCsException & )
+      {
+
+      }
+
     }
 
     const double adjustment = settings.value( QStringLiteral( "gps/bearingAdjustment" ), 0.0, QgsSettings::App ).toDouble();
@@ -1665,13 +1673,20 @@ void QgsGpsInformationWidget::updateGpsDistanceStatusMessage( bool forceDisplay 
 
   const double distance = mDistanceCalculator.convertLengthMeasurement( mDistanceCalculator.measureLine( QVector< QgsPointXY >() << mLastCursorPosWgs84 << mLastGpsPosition ),
                           QgsProject::instance()->distanceUnits() );
-  const double bearing = 180 * mDistanceCalculator.bearing( mLastGpsPosition, mLastCursorPosWgs84 ) / M_PI;
-  const int distanceDecimalPlaces = QgsSettings().value( QStringLiteral( "qgis/measure/decimalplaces" ), "3" ).toInt();
-  const QString distanceString = QgsDistanceArea::formatDistance( distance, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );
-  const QString bearingString = mBearingNumericFormat->formatDouble( bearing, QgsNumericFormatContext() );
+  try
+  {
+    const double bearing = 180 * mDistanceCalculator.bearing( mLastGpsPosition, mLastCursorPosWgs84 ) / M_PI;
+    const int distanceDecimalPlaces = QgsSettings().value( QStringLiteral( "qgis/measure/decimalplaces" ), "3" ).toInt();
+    const QString distanceString = QgsDistanceArea::formatDistance( distance, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );
+    const QString bearingString = mBearingNumericFormat->formatDouble( bearing, QgsNumericFormatContext() );
 
-  QgisApp::instance()->statusBarIface()->showMessage( tr( "%1 (%2) from GPS location" ).arg( distanceString, bearingString ), forceDisplay ? GPS_DISTANCE_MESSAGE_TIMEOUT_MS
-      : GPS_DISTANCE_MESSAGE_TIMEOUT_MS - mLastForcedStatusUpdate.elapsed() );
+    QgisApp::instance()->statusBarIface()->showMessage( tr( "%1 (%2) from GPS location" ).arg( distanceString, bearingString ), forceDisplay ? GPS_DISTANCE_MESSAGE_TIMEOUT_MS
+        : GPS_DISTANCE_MESSAGE_TIMEOUT_MS - mLastForcedStatusUpdate.elapsed() );
+  }
+  catch ( QgsCsException & )
+  {
+
+  }
 }
 
 void QgsGpsInformationWidget::updateTimestampDestinationFields( QgsMapLayer *mapLayer )

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -56,6 +56,18 @@ void QgsMapToolMeasureAngle::canvasMoveEvent( QgsMapMouseEvent *e )
   mRubberBand->movePoint( point );
   if ( mAnglePoints.size() == 2 )
   {
+    double azimuthOne = 0;
+    double azimuthTwo = 0;
+    try
+    {
+      azimuthOne = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 0 ) );
+      azimuthTwo = mDa.bearing( mAnglePoints.at( 1 ), point );
+    }
+    catch ( QgsCsException & )
+    {
+      return;
+    }
+
     if ( !mResultDisplay->isVisible() )
     {
       mResultDisplay->move( e->pos() - QPoint( 100, 100 ) );
@@ -63,8 +75,6 @@ void QgsMapToolMeasureAngle::canvasMoveEvent( QgsMapMouseEvent *e )
     }
 
     //angle calculation
-    const double azimuthOne = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 0 ) );
-    const double azimuthTwo = mDa.bearing( mAnglePoints.at( 1 ), point );
     double resultAngle = azimuthTwo - azimuthOne;
     QgsDebugMsg( QString::number( std::fabs( resultAngle ) ) );
     QgsDebugMsg( QString::number( M_PI ) );
@@ -193,8 +203,17 @@ void QgsMapToolMeasureAngle::updateSettings()
   configureDistanceArea();
 
   //angle calculation
-  const double azimuthOne = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 0 ) );
-  const double azimuthTwo = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 2 ) );
+  double azimuthOne = 0;
+  double azimuthTwo = 0;
+  try
+  {
+    azimuthOne = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 0 ) );
+    azimuthTwo = mDa.bearing( mAnglePoints.at( 1 ), mAnglePoints.at( 2 ) );
+  }
+  catch ( QgsCsException & )
+  {
+    return;
+  }
   double resultAngle = azimuthTwo - azimuthOne;
   QgsDebugMsg( QString::number( std::fabs( resultAngle ) ) );
   QgsDebugMsg( QString::number( M_PI ) );

--- a/src/app/qgsmaptoolmeasurebearing.cpp
+++ b/src/app/qgsmaptoolmeasurebearing.cpp
@@ -56,14 +56,21 @@ void QgsMapToolMeasureBearing::canvasMoveEvent( QgsMapMouseEvent *e )
   mRubberBand->movePoint( point );
   if ( mAnglePoints.size() == 1 )
   {
-    if ( !mResultDisplay->isVisible() )
+    try
     {
-      mResultDisplay->move( e->pos() - QPoint( 100, 100 ) );
-      mResultDisplay->show();
-    }
+      const double bearing = mDa.bearing( mAnglePoints.at( 0 ), point );
+      mResultDisplay->setBearingInRadians( bearing );
 
-    const double bearing = mDa.bearing( mAnglePoints.at( 0 ), point );
-    mResultDisplay->setBearingInRadians( bearing );
+      if ( !mResultDisplay->isVisible() )
+      {
+        mResultDisplay->move( e->pos() - QPoint( 100, 100 ) );
+        mResultDisplay->show();
+      }
+    }
+    catch ( QgsCsException & )
+    {
+
+    }
   }
 }
 
@@ -176,8 +183,13 @@ void QgsMapToolMeasureBearing::updateSettings()
 
   configureDistanceArea();
 
-  const double bearing = mDa.bearing( mAnglePoints.at( 0 ), mAnglePoints.at( 1 ) );
-  mResultDisplay->setBearingInRadians( bearing );
+  try
+  {
+    const double bearing = mDa.bearing( mAnglePoints.at( 0 ), mAnglePoints.at( 1 ) );
+    mResultDisplay->setBearingInRadians( bearing );
+  }
+  catch ( QgsCsException & )
+  {}
 }
 
 void QgsMapToolMeasureBearing::configureDistanceArea()

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -234,8 +234,10 @@ class CORE_EXPORT QgsDistanceArea
 
     /**
      * Computes the bearing (in radians) between two points.
+     *
+     * \throws QgsCsException on invalid input coordinates
      */
-    double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const;
+    double bearing( const QgsPointXY &p1, const QgsPointXY &p2 ) const SIP_THROW( QgsCsException );
 
     /**
      * Returns an distance formatted as a friendly string.

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2677,7 +2677,12 @@ void QgsMapCanvas::panAction( QMouseEvent *e )
 
   QgsPointXY currentMapPoint = getCoordinateTransform()->toMapCoordinates( e->pos() );
   QgsPointXY startMapPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->rubberStartPoint );
-  emit panDistanceBearingChanged( mDa.measureLine( currentMapPoint, startMapPoint ), mDa.lengthUnits(), mDa.bearing( currentMapPoint, startMapPoint ) * 180 / M_PI );
+  try
+  {
+    emit panDistanceBearingChanged( mDa.measureLine( currentMapPoint, startMapPoint ), mDa.lengthUnits(), mDa.bearing( currentMapPoint, startMapPoint ) * 180 / M_PI );
+  }
+  catch ( QgsCsException & )
+  {}
 
   // move all map canvas items
   moveCanvasContents();

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -101,7 +101,12 @@ void QgsMapToolPan::canvasReleaseEvent( QgsMapMouseEvent *e )
           QgsDistanceArea da;
           da.setEllipsoid( QgsProject::instance()->ellipsoid() );
           da.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
-          emit panDistanceBearingChanged( da.measureLine( center, prevCenter ), da.lengthUnits(), da.bearing( center, prevCenter ) * 180 / M_PI );
+          try
+          {
+            emit panDistanceBearingChanged( da.measureLine( center, prevCenter ), da.lengthUnits(), da.bearing( center, prevCenter ) * 180 / M_PI );
+          }
+          catch ( QgsCsException & )
+          {}
         }
       }
     }


### PR DESCRIPTION
Avoids some unwanted "unhandled exception" message boxes which
can pop up while moving the mouse around outside of the valid bounds
of the current map projection
