### PR TITLE
Fix remove unloaded chunks from replacement queue

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -177,6 +177,7 @@ void QgsChunkedEntity::update( const SceneState &state )
   {
     QgsChunkListEntry *entry = mReplacementQueue->takeLast();
     entry->chunk->unloadChunk();  // also deletes the entry
+    mActiveNodes.removeOne( entry->chunk );
     ++unloaded;
   }
 

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -153,22 +153,26 @@ void QgsChunkedEntity::update( const SceneState &state )
     }
     else
     {
-      if ( Qt3DCore::QEntity *entity = node->entity() )
+      if ( !node->entity() )
       {
-        entity->setEnabled( true );
-        ++enabled;
+        QgsDebugMsg( "Active node has null entity - this should never happen!" );
+        continue;
       }
+      node->entity()->setEnabled( true );
+      ++enabled;
     }
   }
 
   // disable those that were active but will not be anymore
   for ( QgsChunkNode *node : activeBefore )
   {
-    if ( Qt3DCore::QEntity *entity = node->entity() )
+    if ( !node->entity() )
     {
-      entity->setEnabled( false );
-      ++disabled;
+      QgsDebugMsg( "Active node has null entity - this should never happen!" );
+      continue;
     }
+    node->entity()->setEnabled( false );
+    ++disabled;
   }
 
   // unload those that are over the limit for replacement


### PR DESCRIPTION
## Description
Followup to https://github.com/qgis/QGIS/pull/47096 .
A better fix is to remove the unloaded chunks from the active nodes when the replacement queue is full.