### PR TITLE
Disabled option section when collapsed mode not checked per #45993

### DIFF
--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -66,6 +66,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
 
     symbol = ddsLegend->symbol() ? ddsLegend->symbol()->clone() : nullptr;  // may be null (undefined)
   }
+  groupBoxOptions->setEnabled( radSeparated->isChecked() );
 
   if ( overrideSymbol )
   {
@@ -129,6 +130,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
   connect( editTitle, &QLineEdit::textChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mLineSymbolButton, &QgsSymbolButton::changed, this, &QgsPanelWidget::widgetChanged );
   connect( this, &QgsPanelWidget::widgetChanged, this, &QgsDataDefinedSizeLegendWidget::updatePreview );
+  connect( radCollapsed, &QRadioButton::toggled, this, [ = ]( bool toggled ) {groupBoxOptions->setEnabled( toggled );} );
   updatePreview();
 }
 

--- a/src/ui/qgsdatadefinedsizelegendwidget.ui
+++ b/src/ui/qgsdatadefinedsizelegendwidget.ui
@@ -218,7 +218,6 @@
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsdatadefinedsizelegendwidget.ui
+++ b/src/ui/qgsdatadefinedsizelegendwidget.ui
@@ -129,9 +129,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="groupBoxOptions">
        <property name="title">
-        <string>Options (collapsed only)</string>
+        <string>Options</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="1">
@@ -217,6 +217,7 @@
   <tabstop>viewLayerTree</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
## Description

Fix the first item from #45993:
> we should either grey out or hide the "Options" section if "collapsed" mode is not selected. And remove the "collapse only" mention from the title. I don't think there's any place we do this

![Peek 2022-02-02 15-41 - disabled collapsed legend options](https://user-images.githubusercontent.com/1421861/152175757-6efecafa-1fd5-45c8-baed-b09eab2c5758.gif)

Funded by Camptocamp https://www.camptocamp.com

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
