### PR TITLE
[processing] fix signature of the QgsMeshDatasetGroups parameter when exporting to Python code

### DIFF
--- a/src/core/processing/qgsprocessingparametermeshdataset.cpp
+++ b/src/core/processing/qgsprocessingparametermeshdataset.cpp
@@ -77,7 +77,7 @@ QString QgsProcessingParameterMeshDatasetGroups::asPythonString( QgsProcessing::
         dt.append( QStringLiteral( "QgsMeshDatasetGroupMetadata.DataOnEdges" ) );
       if ( !dt.isEmpty() )
       {
-        code += QLatin1String( ", dataType=[" );
+        code += QLatin1String( ", supportedDataType=[" );
         code += dt.join( ',' );
         code += ']';
       }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9725,7 +9725,7 @@ void TestQgsProcessing::parameterMeshDatasetGroups()
   QVERIFY( ok );
 
   QString pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMeshDatasetGroups('dataset groups', 'groups', dataType=[QgsMeshDatasetGroupMetadata.DataOnVertices])" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMeshDatasetGroups('dataset groups', 'groups', supportedDataType=[QgsMeshDatasetGroupMetadata.DataOnVertices])" ) );
 
   // optional, layer parameter and data on faces
   supportedData << QgsMeshDatasetGroupMetadata::DataOnFaces;
@@ -9766,7 +9766,7 @@ void TestQgsProcessing::parameterMeshDatasetGroups()
   QCOMPARE( def->meshLayerParameterName(), QStringLiteral( "layer parameter" ) );
 
   pythonCode = def->asPythonString();
-  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMeshDatasetGroups('dataset groups', 'groups', meshLayerParameterName='layer parameter', dataType=[QgsMeshDatasetGroupMetadata.DataOnFaces,QgsMeshDatasetGroupMetadata.DataOnVertices], optional=True)" ) );
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterMeshDatasetGroups('dataset groups', 'groups', meshLayerParameterName='layer parameter', supportedDataType=[QgsMeshDatasetGroupMetadata.DataOnFaces,QgsMeshDatasetGroupMetadata.DataOnVertices], optional=True)" ) );
 }
 
 void TestQgsProcessing::parameterMeshDatasetTime()


### PR DESCRIPTION
## Description

Constructor of the `QgsProcessingParameterMeshDatasetGroups` has `supportedDataType` argument while when parameter is exported to Python a wrong keyword argument `dataType` is used.

This is not a regression, but results in broken Python algorithms so IMHO backporting to release-3_22 is desirable.