### PR TITLE
Fix wording in some Processing messages to make them more precise

### DIFF
--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -505,10 +505,9 @@ class Grass7Utils:
                 cmdpath = os.path.join(Grass7Utils.path, 'bin', 'r.out.gdal.exe')
                 if not os.path.exists(cmdpath):
                     return Grass7Utils.tr(
-                        'The specified GRASS 7 folder "{}" does not contain '
-                        'a valid set of GRASS 7 modules.\nPlease, go to the '
-                        'Processing settings dialog, and check that the '
-                        'GRASS 7\nfolder is correctly configured'.format(os.path.join(Grass7Utils.path, 'bin')))
+                        'The GRASS GIS folder "{}" does not contain a valid set '
+                        'of GRASS modules.\nPlease, check that GRASS is correctly '
+                        'installed and available on your system.'.format(os.path.join(Grass7Utils.path, 'bin')))
             Grass7Utils.isGrassInstalled = True
             return
         # Return error messages
@@ -517,8 +516,9 @@ class Grass7Utils:
             if isWindows() or isMac():
                 if Grass7Utils.path is None:
                     return Grass7Utils.tr(
-                        'GRASS GIS 7 folder is not configured. Please configure '
-                        'it before running GRASS GIS 7 algorithms.')
+                        'Could not locate GRASS GIS folder. Please make '
+                        'sure that GRASS GIS is correctly installed before '
+                        'running GRASS algorithms.')
                 if Grass7Utils.command is None:
                     return Grass7Utils.tr(
                         'GRASS GIS 7 binary {0} can\'t be found on this system from a shell. '

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -84,9 +84,9 @@ std::function<void ( const QgsFeature & )> QgsProcessingContext::defaultInvalidG
       auto callback = [sourceName]( const QgsFeature & feature )
       {
         if ( !sourceName.isEmpty() )
-          throw QgsProcessingException( QObject::tr( "Feature (%1) from “%2” has invalid geometry. Please fix the geometry or change the Processing setting to the “Ignore invalid input features” option." ).arg( feature.id() ).arg( sourceName ) );
+          throw QgsProcessingException( QObject::tr( "Feature (%1) from “%2” has invalid geometry. Please fix the geometry or change the “Invalid features filtering” option for this input or globally in Processing settings." ).arg( feature.id() ).arg( sourceName ) );
         else
-          throw QgsProcessingException( QObject::tr( "Feature (%1) has invalid geometry. Please fix the geometry or change the Processing setting to the “Ignore invalid input features” option." ).arg( feature.id() ) );
+          throw QgsProcessingException( QObject::tr( "Feature (%1) has invalid geometry. Please fix the geometry or change the “Invalid features filtering” option for input layers or globally in Processing settings." ).arg( feature.id() ) );
       };
       return callback;
     }
@@ -98,9 +98,9 @@ std::function<void ( const QgsFeature & )> QgsProcessingContext::defaultInvalidG
         if ( mFeedback )
         {
           if ( !sourceName.isEmpty() )
-            mFeedback->reportError( QObject::tr( "Feature (%1) from “%2” has invalid geometry and has been skipped. Please fix the geometry or change the Processing setting to the “Ignore invalid input features” option." ).arg( feature.id() ).arg( sourceName ) );
+            mFeedback->reportError( QObject::tr( "Feature (%1) from “%2” has invalid geometry and has been skipped. Please fix the geometry or change the “Invalid features filtering” option for this input or globally in Processing settings." ).arg( feature.id() ).arg( sourceName ) );
           else
-            mFeedback->reportError( QObject::tr( "Feature (%1) has invalid geometry and has been skipped. Please fix the geometry or change the Processing setting to the “Ignore invalid input features” option." ).arg( feature.id() ) );
+            mFeedback->reportError( QObject::tr( "Feature (%1) has invalid geometry and has been skipped. Please fix the geometry or change the “Invalid features filtering” option for input layers or globally in Processing settings." ).arg( feature.id() ) );
         }
       };
       return callback;


### PR DESCRIPTION
## Description

Reword error message shown when GRASS algorithm can not be run. We don't support configurable GRASS path, so asking user to configure GRASS folder makes no sense. Fixes #46052

When there are features with invalid geometries in input layer(s), Processing shows message "Please fix the geometry or change the Processing setting to the “Ignore invalid input features” option.", but there is no "Ignore invalid input features" option in the settings. Instead we how have "Invalid feature filtering" setting in the global Processing settings as well as in the advanced settings of the vector input. Fixes #42557.