### PR TITLE
fix relation editor not taking the whole vertical space in form

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1659,6 +1659,9 @@ void QgsAttributeForm::init()
         c->addWidget( collapsibleGroupBox );
         layout->addLayout( c, row, column, 1, 2 );
         column += 2;
+
+        // we consider all relation editors should be expanding
+        addSpacer = false;
       }
       else
       {

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -245,6 +245,8 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
 
   // Set initial state for add/remove etc. buttons
   updateButtons();
+
+  setLayout( rootLayout );
 }
 
 void QgsRelationEditorWidget::initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request )


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/127259/152320006-e2c4addd-5931-4a3e-a79f-6a46e98353c5.png)

after
![image](https://user-images.githubusercontent.com/127259/152320056-a5a0d0d9-cff8-4fe6-86ad-cc5f472fd820.png)

bug was introduced here I believe: https://github.com/qgis/QGIS/pull/45990