### PR TITLE
[Test] Add toString functions for each geometry classes

### DIFF
--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -17,8 +17,27 @@
 #define QGSTEST_H
 
 #include <QtTest/QTest>
-#include "qgsrectangle.h"
 #include "qgsapplication.h"
+
+#include "qgsabstractgeometry.h"
+#include "qgscurve.h"
+#include "qgscircularstring.h"
+#include "qgscompoundcurve.h"
+#include "qgslinestring.h"
+#include "qgsgeometrycollection.h"
+#include "qgsmulticurve.h"
+#include "qgsmultilinestring.h"
+#include "qgsmultipoint.h"
+#include "qgsmultisurface.h"
+#include "qgsmultipolygon.h"
+#include "qgspoint.h"
+#include "qgssurface.h"
+#include "qgscurvepolygon.h"
+#include "qgspolygon.h"
+#include "qgstriangle.h"
+#include "qgsrectangle.h"
+#include "qgsregularpolygon.h"
+
 
 #define QGSTEST_MAIN(TestObject) \
   QT_BEGIN_NAMESPACE \
@@ -90,12 +109,111 @@ namespace QgsTest
 }
 
 /**
- * Formatting QgsRectangle for QCOMPARE pretty printing
+ * For QCOMPARE pretty printing
  */
-char *toString( const QgsRectangle &r )
+char *toString( const QgsAbstractGeometry &geom )
 {
-  return QTest::toString( QStringLiteral( "QgsRectangle(%1, %2, %3, %4)" ).arg( QString::number( r.xMinimum() ), QString::number( r.yMinimum() ), QString::number( r.xMaximum() ), QString::number( r.yMaximum() ) ) );
+  return QTest::toString( geom.asWkt() );
 }
 
+char *toString( const QgsCurve &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsCircularString &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsCompoundCurve &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsLineString &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsGeometryCollection &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsMultiCurve &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsMultiLineString &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsMultiPoint &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsMultiSurface &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsMultiPolygon &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsPoint &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsPointXY &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsSurface &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsCurvePolygon &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsPolygon &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsRegularPolygon &geom )
+{
+  return QTest::toString( geom.toString() );
+}
+
+char *toString( const QgsTriangle &geom )
+{
+  return QTest::toString( geom.asWkt() );
+}
+
+char *toString( const QgsRectangle &geom )
+{
+  return QTest::toString( geom.toString() );
+}
+
+char *toString( const QgsEllipse &geom )
+{
+  return QTest::toString( geom.toString() );
+}
+
+char *toString( const QgsCircle &geom )
+{
+  return QTest::toString( geom.toString() );
+}
 
 #endif // QGSTEST_H


### PR DESCRIPTION
## Description
Currently, when a test comparing 2 geometries fails, no information is given on the value of these 2 geometries. It is possible to have more verbose QCOMPAREs by comparing the WKT that is a `QString`. But it can have problems with floats, compilers, GEOS, etc. Another solution is to add `toString` functions (see https://doc.qt.io/qt-5/qtest.html#QCOMPARE).

This PR proposes to add these functions for the geometry classes.

An example :
```C++
void  TestVerboser::test1()
{
  QgsPoint pt1 = QgsPoint(5, 0);
  QgsPoint pt2 = QgsPoint(5, 0, 1);
  QCOMPARE( pt1, pt2 );
}

void  TestVerboser::test2()
{
  QgsMultiLineString mls1;

  QgsLineString part;
  part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 5, 50, 1, 4 )
                  << QgsPoint( QgsWkbTypes::PointZM, 6, 61, 3, 5 ) ) ;
  mls1.addGeometry( part.clone() );

  QgsMultiLineString mls2;

  part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 7, 4, 1, 4 )
                  << QgsPoint( QgsWkbTypes::PointZM, 6, 61, 3 ) ) ;
  mls2.addGeometry( part.clone() );

  QCOMPARE( mls1, mls2 );
}
```

Currently
```
282: ********* Start testing of TestVerboser *********
282: Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.3.0), ubuntu 21.04
282: PASS   : TestVerboser::initTestCase()
282: FAIL!  : TestVerboser::test1() Compared values are not the same
282:    Loc: [../tests/src/core/testverbose.cpp(41)]
282: FAIL!  : TestVerboser::test2() Compared values are not the same
282:    Loc: [../tests/src/core/testverbose.cpp(59)]
282: PASS   : TestVerboser::cleanupTestCase()
282: Totals: 2 passed, 2 failed, 0 skipped, 0 blacklisted, 1ms
282: ********* Finished testing of TestVerboser *********

```

With this PR
```
282: ********* Start testing of TestVerboser *********
282: Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.3.0), ubuntu 21.04
282: PASS   : TestVerboser::initTestCase()
282: FAIL!  : TestVerboser::test1() Compared values are not the same
282:    Actual   (pt1): "Point (5 0)"
282:    Expected (pt2): "PointZ (5 0 1)"
282:    Loc: [../tests/src/core/testverbose.cpp(41)]
282: FAIL!  : TestVerboser::test2() Compared values are not the same
282:    Actual   (mls1): "MultiLineStringZM ((5 50 1 4, 6 61 3 5))"
282:    Expected (mls2): "MultiLineStringZM ((7 4 1 4, 6 61 3 0))"
282:    Loc: [../tests/src/core/testverbose.cpp(59)]
282: PASS   : TestVerboser::cleanupTestCase()
282: Totals: 2 passed, 2 failed, 0 skipped, 0 blacklisted, 1ms
282: ********* Finished testing of TestVerboser *********
```