### PR TITLE
Show full traceback on Python expression function exception

### DIFF
--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -20,6 +20,7 @@
 
 import inspect
 import string
+import traceback
 from builtins import str
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis._core import QgsExpressionFunction, QgsExpression, QgsMessageLog, QgsFeatureRequest, Qgis
@@ -83,7 +84,10 @@ def register_function(function, arg_count, group, usesgeometry=False,
                         self.function(values, feature, parent, context)
                     return self.function(values, feature, parent)
             except Exception as ex:
-                parent.setEvalErrorString(str(ex))
+                tb = traceback.format_exception(None, ex, ex.__traceback__)
+                formatted_traceback = ''.join(tb)
+                formatted_exception = f"{ex}:<pre>{formatted_traceback}</pre>"
+                parent.setEvalErrorString(formatted_exception)
                 return None
 
         def usesGeometry(self, node):

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -294,11 +294,11 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         e.setExpression("foo = 1")
         self.assertTrue(e.isValid())
         self.assertEqual(len(e.referencedAttributeIndexes(QgsFields())), 0)
-        
+
     def testSuccessfulEvaluationReturnsNoEvalErrorString(self):
         exp = QgsExpression("True is False")  # the result does not matter
         self.assertEqual(exp.evalErrorString(), "")
-        
+
     def testExceptionDuringEvalReturnsTraceback(self):
         QgsExpression.registerFunction(self.raise_exception)
         exp = QgsExpression('raise_exception()')

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -70,6 +70,10 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         vals = [val for val in values if val != NULL]
         return sum(vals) / len(vals)
 
+    @qgsfunction(group='testing', register=False)
+    def raise_exception(feature, parent):
+        foo  # an undefined variable
+
     def tearDown(self):
         QgsExpression.unregisterFunction('testfun')
 
@@ -290,6 +294,26 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         e.setExpression("foo = 1")
         self.assertTrue(e.isValid())
         self.assertEqual(len(e.referencedAttributeIndexes(QgsFields())), 0)
+        
+    def testSuccessfulEvaluationReturnsNoEvalErrorString(self):
+        exp = QgsExpression("True is False")  # the result does not matter
+        self.assertEqual(exp.evalErrorString(), "")
+        
+    def testExceptionDuringEvalReturnsTraceback(self):
+        QgsExpression.registerFunction(self.raise_exception)
+        exp = QgsExpression('raise_exception()')
+        result = exp.evaluate()
+        # The file paths and line offsets are dynamic
+        regex = (
+            "name 'foo' is not defined:<pre>Traceback \\(most recent call last\\):\n"
+            "  File \".*qgsfunction.py\", line [0-9]+, in func\n"
+            "    return self.function\\(\\*values\\)\n"
+            "  File \".*test_qgsexpression.py\", line [0-9]+, in raise_exception\n"
+            "    foo  # an undefined variable\n"
+            "NameError: name \'foo\' is not defined"
+            "\n</pre>"
+        )
+        self.assertRegex(exp.evalErrorString(), regex)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -310,7 +310,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
             "  File \".*qgsfunction.py\", line [0-9]+, in func\n"
             "    return self.function\\(\\*values\\)\n"
             "  File \".*test_qgsexpression.py\", line [0-9]+, in raise_exception\n"
-            "    foo  # an undefined variable\n"
+            "    foo  # noqa: F821\n"
             "NameError: name \'foo\' is not defined"
             "\n</pre>"
         )

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -72,7 +72,8 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
 
     @qgsfunction(group='testing', register=False)
     def raise_exception(feature, parent):
-        foo  # an undefined variable
+        # an undefined variable
+        foo  # noqa: F821
 
     def tearDown(self):
         QgsExpression.unregisterFunction('testfun')


### PR DESCRIPTION
## Description
When developing broken Python expression functions, QGIS currently only shows the exception message which is sometimes not very helpful. We have a full traceback available so let's use it!

# Example
For example an undefined variable "asd" in this function:

```
@qgsfunction(args='auto', group='Custom', referenced_columns=[])
def my_sum(value1, value2, feature, parent):
    return asd
```

## Before
![before_hover](https://user-images.githubusercontent.com/7661092/152406485-c1aba549-88e5-4088-afef-d530bc785959.png)
![before_window](https://user-images.githubusercontent.com/7661092/152406495-b2a07185-bd34-472a-9d2f-1e0958b92296.png)

## After
![after_hover](https://user-images.githubusercontent.com/7661092/152406510-8c9461ca-5bea-4ef9-9e1c-6c81b6cfbfed.png)
![after_window](https://user-images.githubusercontent.com/7661092/152406514-ae2ccc18-e8ae-4faf-a3f4-e5fd816e8571.png)

