### PR TITLE
Fix model designer 'save' action functions like a 'save as' action when editing an existing model opened through the dialog

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -67,6 +67,15 @@ Loads a model into the designer from the specified file ``path``.
 Sets the related ``scene``.
 %End
 
+  public slots:
+
+    void activate();
+%Docstring
+Raise, unminimize and activate this window.
+
+.. versionadded:: 3.24
+%End
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;

--- a/python/plugins/processing/modeler/AddModelFromFileAction.py
+++ b/python/plugins/processing/modeler/AddModelFromFileAction.py
@@ -24,7 +24,7 @@ __copyright__ = '(C) 201, Victor Olaya'
 import os
 import shutil
 from qgis.PyQt.QtWidgets import QFileDialog, QMessageBox
-from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
+from qgis.PyQt.QtCore import QFileInfo, QCoreApplication, QDir
 
 from qgis.core import QgsApplication, QgsSettings, QgsProcessingModelAlgorithm
 
@@ -45,7 +45,7 @@ class AddModelFromFileAction(ToolboxAction):
 
     def execute(self):
         settings = QgsSettings()
-        lastDir = settings.value('Processing/lastModelsDir', '')
+        lastDir = settings.value('Processing/lastModelsDir', QDir.homePath())
         filename, selected_filter = QFileDialog.getOpenFileName(self.toolbox,
                                                                 self.tr('Open Model', 'AddModelFromFileAction'), lastDir,
                                                                 self.tr('Processing models (*.model3 *.MODEL3)', 'AddModelFromFileAction'))

--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -43,6 +43,7 @@ class EditModelAction(ContextAction):
         dlg = ModelerDialog.create(alg)
         dlg.update_model.connect(self.updateModel)
         dlg.show()
+        dlg.activate()
 
     def updateModel(self):
         QgsApplication.processingRegistry().providerById('model').refreshAlgorithms()

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -32,7 +32,8 @@ from qgis.PyQt.QtCore import (
     QPoint,
     QPointF,
     pyqtSignal,
-    QUrl)
+    QUrl,
+    QFileInfo)
 from qgis.PyQt.QtWidgets import (QMessageBox,
                                  QFileDialog)
 from qgis.core import (Qgis,
@@ -218,11 +219,15 @@ class ModelerDialog(QgsModelDesignerDialog):
         if not self.checkForUnsavedChanges():
             return
 
+        settings = QgsSettings()
+        last_dir = settings.value('Processing/lastModelsDir', QDir.homePath())
         filename, selected_filter = QFileDialog.getOpenFileName(self,
                                                                 self.tr('Open Model'),
-                                                                ModelerUtils.modelsFolders()[0],
+                                                                last_dir,
                                                                 self.tr('Processing models (*.model3 *.MODEL3)'))
         if filename:
+            settings.setValue('Processing/lastModelsDir',
+                              QFileInfo(filename).absoluteDir().absolutePath())
             self.loadModel(filename)
 
     def repaintModel(self, showControls=True):

--- a/python/plugins/processing/modeler/OpenModelFromFileAction.py
+++ b/python/plugins/processing/modeler/OpenModelFromFileAction.py
@@ -55,3 +55,4 @@ class OpenModelFromFileAction(ToolboxAction):
             dlg = ModelerDialog.create()
             dlg.loadModel(filename)
             dlg.show()
+            dlg.activate()

--- a/python/plugins/processing/modeler/OpenModelFromFileAction.py
+++ b/python/plugins/processing/modeler/OpenModelFromFileAction.py
@@ -23,7 +23,7 @@ __copyright__ = '(C) 2018, Nyall Dawson'
 
 import os
 from qgis.PyQt.QtWidgets import QFileDialog
-from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
+from qgis.PyQt.QtCore import QFileInfo, QCoreApplication, QDir
 
 from qgis.core import QgsApplication, QgsSettings
 from qgis.utils import iface
@@ -44,7 +44,7 @@ class OpenModelFromFileAction(ToolboxAction):
 
     def execute(self):
         settings = QgsSettings()
-        lastDir = settings.value('Processing/lastModelsDir', '')
+        lastDir = settings.value('Processing/lastModelsDir', QDir.homePath())
         filename, selected_filter = QFileDialog.getOpenFileName(self.toolbox,
                                                                 self.tr('Open Model', 'AddModelFromFileAction'), lastDir,
                                                                 self.tr('Processing models (*.model3 *.MODEL3)', 'AddModelFromFileAction'))

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -464,6 +464,7 @@ void QgsModelDesignerDialog::loadModel( const QString &path )
   if ( alg->fromFile( path ) )
   {
     alg->setProvider( QgsApplication::processingRegistry()->providerById( QStringLiteral( "model" ) ) );
+    alg->setSourceFilePath( path );
     setModel( alg.release() );
   }
   else

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -507,6 +507,14 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
     oldScene->deleteLater();
 }
 
+void QgsModelDesignerDialog::activate()
+{
+  show();
+  raise();
+  setWindowState( windowState() & ~Qt::WindowMinimized );
+  activateWindow();
+}
+
 void QgsModelDesignerDialog::updateVariablesGui()
 {
   mBlockUndoCommands++;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -94,6 +94,15 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     void setModelScene( QgsModelGraphicsScene *scene SIP_TRANSFER );
 
+  public slots:
+
+    /**
+     * Raise, unminimize and activate this window.
+     *
+     * \since QGIS 3.24
+     */
+    void activate();
+
   protected:
 
     // cppcheck-suppress pureVirtualCall


### PR DESCRIPTION
Also fix some other UX papercuts relating to saving/opening existing models

(Unlike #47183 these fixes should be backported)