### PR TITLE
Default to "Model Input" sources for map layer parameters when configuring a new algorithm

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -173,6 +173,13 @@ Sets the parent ``dialog`` in which the widget is shown.
     virtual QgsExpressionContext createExpressionContext() const;
 
 
+    void setSourceType( QgsProcessingModelChildParameterSource::Source type );
+%Docstring
+Sets the current source ``type`` for the parameter.
+
+.. versionadded:: 3.24
+%End
+
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -602,6 +602,13 @@ and should give helpful text to users to indicate the expected results from the 
 This is purely a text format and no expression validation is made against it.
 %End
 
+    virtual QgsProcessingModelChildParameterSource::Source defaultModelSource( const QgsProcessingParameterDefinition *parameter ) const;
+%Docstring
+Returns the default source type to use for the widget for the specified ``parameter``.
+
+.. versionadded:: 3.24
+%End
+
 };
 
 class QgsProcessingHiddenWidgetWrapper: QgsAbstractProcessingParameterWidgetWrapper

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -193,6 +193,13 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
 
     QgsExpressionContext createExpressionContext() const override;
 
+    /**
+     * Sets the current source \a type for the parameter.
+     *
+     * \since QGIS 3.24
+     */
+    void setSourceType( QgsProcessingModelChildParameterSource::Source type );
+
   private slots:
 
     void sourceMenuAboutToShow();
@@ -212,7 +219,6 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
 
     SourceType currentSourceType() const;
 
-    void setSourceType( QgsProcessingModelChildParameterSource::Source type );
     void updateUi();
 
     QgsProcessingModelAlgorithm *mModel = nullptr;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -368,6 +368,12 @@ QgsProcessingModelerParameterWidget *QgsProcessingParameterWidgetFactoryInterfac
   std::unique_ptr< QgsProcessingModelerParameterWidget > widget = std::make_unique< QgsProcessingModelerParameterWidget >( model, childId, parameter, context );
   widget->populateSources( compatibleParameterTypes(), compatibleOutputTypes(), compatibleDataTypes( parameter ) );
   widget->setExpressionHelpText( modelerExpressionFormatString() );
+
+  if ( parameter->isDestination() )
+    widget->setSourceType( QgsProcessingModelChildParameterSource::ModelOutput );
+  else
+    widget->setSourceType( defaultModelSource( parameter ) );
+
   return widget.release();
 }
 
@@ -386,6 +392,11 @@ QList<int> QgsProcessingParameterWidgetFactoryInterface::compatibleDataTypes( co
 QString QgsProcessingParameterWidgetFactoryInterface::modelerExpressionFormatString() const
 {
   return QString();
+}
+
+QgsProcessingModelChildParameterSource::Source QgsProcessingParameterWidgetFactoryInterface::defaultModelSource( const QgsProcessingParameterDefinition * ) const
+{
+  return QgsProcessingModelChildParameterSource::StaticValue;
 }
 
 //

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -26,6 +26,7 @@
 #include "qgis_sip.h"
 #include "qgsprocessinggui.h"
 #include "qgsvectorlayer.h"
+#include "qgsprocessingmodelchildparametersource.h"
 
 class QgsProcessingParameterDefinition;
 class QgsProcessingContext;
@@ -660,6 +661,13 @@ class GUI_EXPORT QgsProcessingParameterWidgetFactoryInterface
      * This is purely a text format and no expression validation is made against it.
      */
     virtual QString modelerExpressionFormatString() const;
+
+    /**
+     * Returns the default source type to use for the widget for the specified \a parameter.
+     *
+     * \since QGIS 3.24
+     */
+    virtual QgsProcessingModelChildParameterSource::Source defaultModelSource( const QgsProcessingParameterDefinition *parameter ) const;
 
 };
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -5999,6 +5999,11 @@ QString QgsProcessingMapLayerWidgetWrapper::modelerExpressionFormatString() cons
   return tr( "path to a map layer" );
 }
 
+QgsProcessingModelChildParameterSource::Source QgsProcessingMapLayerWidgetWrapper::defaultModelSource( const QgsProcessingParameterDefinition * ) const
+{
+  return QgsProcessingModelChildParameterSource::ModelParameter;
+}
+
 QString QgsProcessingMapLayerWidgetWrapper::parameterType() const
 {
   return QgsProcessingParameterMapLayer::typeName();

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -1780,6 +1780,7 @@ class GUI_EXPORT QgsProcessingMapLayerWidgetWrapper : public QgsAbstractProcessi
 
     QStringList compatibleOutputTypes() const override;
     QString modelerExpressionFormatString() const override;
+    QgsProcessingModelChildParameterSource::Source defaultModelSource( const QgsProcessingParameterDefinition *parameter ) const override;
 
   private:
 

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -738,6 +738,9 @@ void TestProcessingGui::testModelerWrapper()
   model.addModelParameter( new TestParamType( "test_type", "p2" ), testParam );
   QgsProcessingModelParameter testDestParam( "p3" );
   model.addModelParameter( new QgsProcessingParameterFileDestination( "test_dest", "p3" ), testDestParam );
+  QgsProcessingModelParameter testLayerParam( "p4" );
+  model.addModelParameter( new QgsProcessingParameterMapLayer( "p4", "test_layer" ), testLayerParam );
+
   // try to create a parameter widget, no factories registered
   QgsProcessingGuiRegistry registry;
   QgsProcessingContext context;
@@ -750,9 +753,21 @@ void TestProcessingGui::testModelerWrapper()
   QVERIFY( w );
   delete w;
 
+  w = registry.createModelerParameterWidget( &model, QStringLiteral( "a" ), model.parameterDefinition( "p1" ), context );
+  QVERIFY( w );
+  // should default to static value
+  QCOMPARE( w->value().value< QgsProcessingModelChildParameterSource>().source(), QgsProcessingModelChildParameterSource::StaticValue );
+  delete w;
+
+  w = registry.createModelerParameterWidget( &model, QStringLiteral( "a" ), model.parameterDefinition( "p4" ), context );
+  QVERIFY( w );
+  // a layer parameter should default to "model input" type
+  QCOMPARE( w->value().value< QgsProcessingModelChildParameterSource>().source(), QgsProcessingModelChildParameterSource::ModelParameter );
+  delete w;
 
   // widget tests
   w = new QgsProcessingModelerParameterWidget( &model, "alg1", model.parameterDefinition( "p1" ), context );
+  QCOMPARE( w->value().value< QgsProcessingModelChildParameterSource>().source(), QgsProcessingModelChildParameterSource::StaticValue );
   QCOMPARE( w->parameterDefinition()->name(), QStringLiteral( "p1" ) );
   QLabel *l = w->createLabel();
   QVERIFY( l );


### PR DESCRIPTION
While the previous behaviour of defaulting to a static value makes sense for things like numeric parameters, this is a very rare use case for map layer parameters. For better new user experience we can default instead to showing model inputs for these parameter types.
