### PR TITLE
Fix issues with edits to model outputs getting discarded 

### DIFF
--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -24,6 +24,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 from qgis.PyQt.QtCore import QCoreApplication
 
 from qgis.core import (QgsProcessingParameterDefinition,
+                       QgsProcessingModelOutput,
                        QgsProject,
                        Qgis)
 from qgis.gui import (
@@ -202,13 +203,22 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
             dlg.switchToCommentTab()
 
         if dlg.exec_():
-            model_output = child_alg.modelOutput(self.component().name())
+            model_outputs = child_alg.modelOutputs()
+
+            model_output = QgsProcessingModelOutput(model_outputs[self.component().name()])
+            del model_outputs[self.component().name()]
+
+            model_output.setName(dlg.param.description())
             model_output.setDescription(dlg.param.description())
             model_output.setDefaultValue(dlg.param.defaultValue())
             model_output.setMandatory(not (dlg.param.flags() & QgsProcessingParameterDefinition.FlagOptional))
             model_output.comment().setDescription(dlg.comments())
             model_output.comment().setColor(dlg.commentColor())
+            model_outputs[model_output.name()] = model_output
+            child_alg.setModelOutputs(model_outputs)
+
             self.aboutToChange.emit(self.tr('Edit {}').format(model_output.description()))
+
             self.model().updateDestinationParameters()
             self.requestModelRepaint.emit()
             self.changed.emit()

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -214,29 +214,29 @@ class ModelerParameterDefinitionDialog(QDialog):
         if (isinstance(self.param, QgsProcessingParameterFeatureSink)):
             self.param = QgsProcessingParameterFeatureSink(
                 name=name,
-                description=self.param.description(),
+                description=description,
                 type=self.param.dataType(),
                 defaultValue=self.defaultWidget.value())
         elif (isinstance(self.param, QgsProcessingParameterFileDestination)):
             self.param = QgsProcessingParameterFileDestination(
                 name=name,
-                description=self.param.description(),
+                description=description,
                 fileFilter=self.param.fileFilter(),
                 defaultValue=self.defaultWidget.value())
         elif (isinstance(self.param, QgsProcessingParameterFolderDestination)):
             self.param = QgsProcessingParameterFolderDestination(
                 name=name,
-                description=self.param.description(),
+                description=description,
                 defaultValue=self.defaultWidget.value())
         elif (isinstance(self.param, QgsProcessingParameterRasterDestination)):
             self.param = QgsProcessingParameterRasterDestination(
                 name=name,
-                description=self.param.description(),
+                description=description,
                 defaultValue=self.defaultWidget.value())
         elif (isinstance(self.param, QgsProcessingParameterVectorDestination)):
             self.param = QgsProcessingParameterVectorDestination(
                 name=name,
-                description=self.param.description(),
+                description=description,
                 type=self.param.dataType(),
                 defaultValue=self.defaultWidget.value())
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -67,6 +67,9 @@ void QgsProcessingModelChildAlgorithm::copyNonDefinitionPropertiesFromModel( Qgs
   int i = 0;
   for ( auto it = mModelOutputs.begin(); it != mModelOutputs.end(); ++it )
   {
+    if ( !existingChild.modelOutputs().contains( it.key() ) )
+      continue;
+
     if ( !existingChild.modelOutputs().value( it.key() ).position().isNull() )
     {
       it.value().setPosition( existingChild.modelOutputs().value( it.key() ).position() );

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -1129,7 +1129,7 @@ QgsModelOutputGraphicItem::QgsModelOutputGraphicItem( QgsProcessingModelOutput *
   QPainter painter( &mPicture );
   svg.render( &painter );
   painter.end();
-  setLabel( output->name() );
+  setLabel( output->description() );
 }
 
 QColor QgsModelOutputGraphicItem::fillColor( QgsModelComponentGraphicItem::State state ) const

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -557,6 +557,11 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   const QgsProcessingModelOutput oo2;
   QMap< QString, QgsProcessingModelOutput > a2Outs2;
   a2Outs2.insert( QStringLiteral( "out1" ), oo2 );
+  // this one didn't already exist in the algorithm
+  QgsProcessingModelOutput oo3;
+  oo3.comment()->setDescription( QStringLiteral( "my comment" ) );
+  a2Outs2.insert( QStringLiteral( "out3" ), oo3 );
+
   a2other.setModelOutputs( a2Outs2 );
 
   a2other.copyNonDefinitionPropertiesFromModel( &alg );
@@ -576,6 +581,8 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   // should be copied for outputs
   QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->description(), QStringLiteral( "c3" ) );
   QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->color(), QColor( 155, 14, 353 ) );
+  // new outputs should not be affected
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out3" ) ).comment()->description(), QStringLiteral( "my comment" ) );
 
   QgsProcessingModelChildAlgorithm a3;
   a3.setChildId( QStringLiteral( "c" ) );


### PR DESCRIPTION
(temporarily includes https://github.com/qgis/QGIS/pull/47183)

Specifically, this fixes two issues

1. If a user edits a dark green output block in a model and changes the name of the output, that new name was always discarded and the only way to change it was by editing the algorithm it was attached to

2. If an output was renamed through the algorithm properties dialog, then any properties previously associated with that output (like comments, coloring, placement, default value, mandatory flag) would get reset back to their default settings

(I don't think these fixes are suitable for backporting)

Refs NRCan Contract#3000739399