### PR TITLE
WFS GetFeature document and exceptions

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -185,6 +185,15 @@ namespace QgsWfs
       }
     }
 
+    // check if all typename are valid
+    for ( const QString &typeName : typeNameList )
+    {
+      if ( !mapLayerMap.contains( typeName ) )
+      {
+        throw QgsRequestNotWellFormedException( QStringLiteral( "TypeName '%1' unknown" ).arg( typeName ) );
+      }
+    }
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
     //scoped pointer to restore all original layer filters (subsetStrings) when pointer goes out of scope
@@ -204,11 +213,6 @@ namespace QgsWfs
     {
       getFeatureQuery &query = *qIt;
       QString typeName = query.typeName;
-
-      if ( !mapLayerMap.contains( typeName ) )
-      {
-        throw QgsRequestNotWellFormedException( QStringLiteral( "TypeName '%1' unknown" ).arg( typeName ) );
-      }
 
       QgsMapLayer *layer = mapLayerMap[typeName];
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -190,7 +190,7 @@ namespace QgsWfs
     {
       if ( !mapLayerMap.contains( typeName ) )
       {
-        throw QgsRequestNotWellFormedException( QStringLiteral( "TypeName '%1' unknown" ).arg( typeName ) );
+        throw QgsRequestNotWellFormedException( QStringLiteral( "TypeName '%1' could not be found" ).arg( typeName ) );
       }
     }
 

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -143,7 +143,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         }.items())])
         header, body = self._execute_request(qs)
 
-        self.assertTrue(b"TypeName 'invalid' unknown" in body)
+        self.assertTrue(b"TypeName 'invalid' could not be found" in body)
 
         # an invalid typename preceded by a valid one
         qs = "?" + "&".join(["%s=%s" % i for i in list({
@@ -154,7 +154,7 @@ class TestQgsServerWFS(QgsServerTestBase):
         }.items())])
         header, body = self._execute_request(qs)
 
-        self.assertTrue(b"TypeName 'invalid' unknown" in body)
+        self.assertTrue(b"TypeName 'invalid' could not be found" in body)
 
     def test_getfeature(self):
 

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -131,6 +131,31 @@ class TestQgsServerWFS(QgsServerTestBase):
             header, body
         )
 
+    def test_getfeature_invalid_typename(self):
+        project = self.testdata_path + "test_project_wfs.qgs"
+
+        # a single invalid typename
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(project),
+            "SERVICE": "WFS",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "invalid"
+        }.items())])
+        header, body = self._execute_request(qs)
+
+        self.assertTrue(b"TypeName 'invalid' unknown" in body)
+
+        # an invalid typename preceded by a valid one
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(project),
+            "SERVICE": "WFS",
+            "REQUEST": "GetFeature",
+            "TYPENAME": "testlayer,invalid"
+        }.items())])
+        header, body = self._execute_request(qs)
+
+        self.assertTrue(b"TypeName 'invalid' unknown" in body)
+
     def test_getfeature(self):
 
         tests = []


### PR DESCRIPTION
## Description

When an invalid typename is used in a `GetFeature` request in first position, an exception is correctly raised:

``` bash
$ curl "http://localhost/qgisserver?SERVICE=WFS&REQUEST=GetFeature&TYPENAME=invalid,places"
<ServiceExceptionReport xmlns="http://www.opengis.net/ogc" version="1.2.0">
 <ServiceException code="RequestNotWellFormed">TypeName 'invalid' unknown</ServiceException>
</ServiceExceptionReport>
``` 

But as soon as the invalid typename is not in first position, QGIS Server currently returns a not terminated document (note the missing `</wfs:FeatureCollection>` tag at the end) and the underlying error is ignored:

``` bash
$ curl "http://localhost/qgisserver?SERVICE=WFS&REQUEST=GetFeature&TYPENAME=places,invalid"
....
...
...
  <qgs:cityalt xsi:nil="true"></qgs:cityalt>
 </qgs:places>
</gml:featureMember>
```

It's due to the fact that the response is flushed one by one (ie per typename) and there's actually an explicit comment in source code: `// Stream partial content`. Is it really wanted? If not, this PR fixes that issue and the proper exception is returned whatever the place of the invalid typename:

``` bash
$ curl "http://localhost/qgisserver?SERVICE=WFS&REQUEST=GetFeature&TYPENAME=places,invalid"
<ServiceExceptionReport xmlns="http://www.opengis.net/ogc" version="1.2.0">
 <ServiceException code="RequestNotWellFormed">TypeName 'invalid' unknown</ServiceException>
</ServiceExceptionReport>
``` 