### PR TITLE
Add English translation

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -17,6 +17,7 @@ trans.eo = i18n/qgis_eo.ts
 trans.es = i18n/qgis_es.ts
 trans.et = i18n/qgis_et.ts
 trans.eu = i18n/qgis_eu.ts
+trans.en_US = i18n/qgis_en_US.ts
 trans.fi = i18n/qgis_fi.ts
 trans.fr = i18n/qgis_fr.ts
 trans.gl = i18n/qgis_gl.ts

--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -23,7 +23,7 @@ endmacro(ADD_TRANSLATION_FILES)
 file(MAKE_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/i18n)
 
 
-set(TS_FILES qgis_ar.ts qgis_bg.ts qgis_bs.ts qgis_ca.ts qgis_cs.ts qgis_da.ts qgis_de.ts qgis_el.ts qgis_es.ts qgis_et.ts qgis_eu.ts qgis_fa.ts qgis_fi.ts qgis_fr.ts qgis_gl.ts qgis_hu.ts qgis_id.ts qgis_is.ts qgis_it.ts qgis_ja.ts qgis_ko.ts qgis_ky.ts qgis_lt.ts qgis_lv.ts qgis_nb.ts qgis_nl.ts qgis_pl.ts qgis_pt_BR.ts qgis_pt_PT.ts qgis_ro.ts qgis_ru.ts qgis_sc.ts qgis_sl.ts qgis_sv.ts qgis_tr.ts qgis_uk.ts qgis_vi.ts qgis_zh-Hans.ts qgis_zh-Hant.ts)
+set(TS_FILES qgis_ar.ts qgis_bg.ts qgis_bs.ts qgis_ca.ts qgis_cs.ts qgis_da.ts qgis_de.ts qgis_en_US.ts qgis_el.ts qgis_es.ts qgis_et.ts qgis_eu.ts qgis_fa.ts qgis_fi.ts qgis_fr.ts qgis_gl.ts qgis_hu.ts qgis_id.ts qgis_is.ts qgis_it.ts qgis_ja.ts qgis_ko.ts qgis_ky.ts qgis_lt.ts qgis_lv.ts qgis_nb.ts qgis_nl.ts qgis_pl.ts qgis_pt_BR.ts qgis_pt_PT.ts qgis_ro.ts qgis_ru.ts qgis_sc.ts qgis_sl.ts qgis_sv.ts qgis_tr.ts qgis_uk.ts qgis_vi.ts qgis_zh-Hans.ts qgis_zh-Hant.ts)
 
 ADD_TRANSLATION_FILES (QM_FILES ${TS_FILES})
 


### PR DESCRIPTION
Finally QGIS will have an English translation. As the main language used
in international communication and most QGIS channels, this is an
important added value.
Jokes aside: this allows to have dedicated translations for plurals like
`1 feature deleted` vs `5 features deleted`.

What we still need is a team that will update [the strings containing
`%n` on the transifex en_US language](https://www.transifex.com/qgis/QGIS/translate/#en_US/qgis-application/114102351?q=text%3A%25n).

And a solution for the current requirement for a minimum of 35% translation to be published.