### PR TITLE
[processing] GDAL "Rasterize (vector to raster)" alg: make the 'EXTENT' parameter optional and transform it to the source layer CRS

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -101,7 +101,8 @@ class rasterize(GdalAlgorithm):
                                                        minValue=0.0,
                                                        defaultValue=0.0))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
-                                                       self.tr('Output extent')))
+                                                       self.tr('Output extent'),
+                                                       optional=True))
         nodataParam = QgsProcessingParameterNumber(self.NODATA,
                                                    self.tr('Assign a specified nodata value to output bands'),
                                                    type=QgsProcessingParameterNumber.Double,

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRasterFileWriter,
+                       QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
@@ -171,6 +172,9 @@ class rasterize(GdalAlgorithm):
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         ogrLayer, layerName = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
+        source = self.parameterAsSource(parameters, self.INPUT, context)
+        if source is None:
+            raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))
 
         arguments = [
             '-l',
@@ -211,7 +215,7 @@ class rasterize(GdalAlgorithm):
             arguments.append('-a_nodata')
             arguments.append(nodata)
 
-        extent = self.parameterAsExtent(parameters, self.EXTENT, context)
+        extent = self.parameterAsExtent(parameters, self.EXTENT, context, source.sourceCrs())
         if not extent.isNull():
             arguments.append('-te')
             arguments.append(extent.xMinimum())

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -171,11 +171,11 @@ class rasterize(GdalAlgorithm):
         return 'gdal_rasterize'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
-        ogrLayer, layerName = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))
 
+        ogrLayer, layerName = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
         arguments = [
             '-l',
             layerName

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1575,6 +1575,8 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
         feedback = QgsProcessingFeedback()
         source = os.path.join(testDataPath, 'polys.gml')
         sourceZ = os.path.join(testDataPath, 'pointsz.gml')
+        extent4326 = QgsReferencedRectangle(QgsRectangle(-1, -3, 10, 6), QgsCoordinateReferenceSystem('EPSG:4326'))
+        extent3857 = QgsReferencedRectangle(QgsRectangle(-111319.491, -334111.171, 1113194.908, 669141.057), QgsCoordinateReferenceSystem('EPSG:3857'))
         alg = rasterize()
         alg.initAlgorithm()
 
@@ -1648,6 +1650,27 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['gdal_rasterize',
                  '-l pointsz -3d -ts 0.0 0.0 -ot Float32 -of JPEG ' +
                  sourceZ + ' ' +
+                 outdir + '/check.jpg'])
+
+            # with EXTENT in the same CRS as the input layer source
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'FIELD': 'id',
+                                        'EXTENT': extent4326,
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id -ts 0.0 0.0 -te -1.0 -3.0 10.0 6.0 -ot Float32 -of JPEG ' +
+                 source + ' ' +
+                 outdir + '/check.jpg'])
+            # with EXTENT in a different CRS than that of the input layer source
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'FIELD': 'id',
+                                        'EXTENT': extent3857,
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id -ts 0.0 0.0 -te -1.000000001857055 -2.9999999963940835 10.000000000604244 5.99999999960471 -ot Float32 -of JPEG ' +
+                 source + ' ' +
                  outdir + '/check.jpg'])
 
     def testRasterizeOver(self):

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_raster_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_raster_tests.yaml
@@ -363,6 +363,28 @@ tests:
         hash: 30409eb496900df4ceeab37200a91552c350dbc7761eb089dd75a329
         type: rasterhash
 
+  - algorithm: gdal:rasterize
+    name: Test extent crs (gdal:rasterize)
+    params:
+      BURN: 0.0
+      DATA_TYPE: 5
+      EXTENT: -111319.491,1113194.908,-334111.171,669141.057 [EPSG:3857]
+      FIELD: intval
+      HEIGHT: 10.0
+      INIT: 0.0
+      INPUT:
+        name: polys.gml
+        type: vector
+      INVERT: false
+      NODATA: 0.0
+      OPTIONS: ''
+      UNITS: 0
+      WIDTH: 10.0
+    results:
+      OUTPUT:
+        hash: 30409eb496900df4ceeab37200a91552c350dbc7761eb089dd75a329
+        type: rasterhash
+
   - algorithm: gdal:roughness
     name: Roughness
     params:


### PR DESCRIPTION
## Description

- Makes the 'EXTENT' ("Output extent") parameter of the GDAL "Rasterize (vector to raster)" processing algorithm optional.
The corresponding '-te' parameter for the [gdal_rasterize](https://gdal.org/programs/gdal_rasterize.html) tool is optional (if not specified, it defaults to the extent of the input vector layer).

- Lets the algorithm automatically transform the specified extent to the source layer CRS when needed (as the "Clip vector by extent" algorithm already does).

Fixes https://github.com/qgis/QGIS/issues/47200

I think this PR needs to be backported.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
