### PR TITLE
Server: some parameters for external wms layers are case sensitive

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1900,6 +1900,34 @@ namespace QgsWms
         for ( const QString &value : values )
           wmsUri.setParam( paramName, value );
       }
+      else if ( paramName == QLatin1String( "ignorereportedlayerextents" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "IgnoreReportedLayerExtents" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "smoothpixmaptransform" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "SmoothPixmapTransform" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "ignoregetmapurl" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "IgnoreGetMapUrl" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "ignoregetfeatureinfourl" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "IgnoreGetFeatureInfoUrl" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "ignoreaxisorientation" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "IgnoreAxisOrientation" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "invertaxisorientation" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "InvertAxisOrientation" ), paramIt.value() );
+      }
+      else if ( paramName == QLatin1String( "dpimode" ) )
+      {
+        wmsUri.setParam( QStringLiteral( "dpiMode" ), paramIt.value() );
+      }
       else
       {
         wmsUri.setParam( paramName, paramIt.value() );


### PR DESCRIPTION
The WMS http parameters are case insensitive. However some parameters for external WMS layers are case sensitive (the ones controlling QGIS WMS client options). This PR converts them back to upper/lowercase