### PR TITLE
Fix silent loss of models if file save name dialog is canceled, add a 'New Model' action to model designer dialog, fix 

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -88,7 +88,7 @@ Raise, unminimize and activate this window.
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
-    virtual void saveModel( bool saveAs = false ) = 0;
+    virtual bool saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar();
     QAction *actionOpen();

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -182,9 +182,9 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.setDirty(False)
         QgsProject.instance().setDirty(True)
 
-    def saveModel(self, saveAs):
+    def saveModel(self, saveAs) -> bool:
         if not self.validateSave(QgsModelDesignerDialog.SaveAction.SaveAsFile):
-            return
+            return False
 
         model_name_matched_file_name = self.model().modelNameMatchesFilePath()
         if self.model().sourceFilePath() and not saveAs:
@@ -202,7 +202,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                                                       initial_path.as_posix(),
                                                       self.tr('Processing models (*.model3 *.MODEL3)'))
             if not filename:
-                return
+                return False
 
             filename = QgsFileUtils.ensureFileNameHasExtension(filename, ['model3'])
             self.model().setSourceFilePath(filename)
@@ -223,7 +223,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                                     self.tr(
                                         "This model can't be saved in its original location (probably you do not "
                                         "have permission to do it). Please, use the 'Save as…' option."))
-            return
+            return False
 
         self.update_model.emit()
         if saveAs:
@@ -234,6 +234,7 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
         self.setDirty(False)
+        return True
 
     def openModel(self):
         if not self.checkForUnsavedChanges():

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -134,6 +134,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   QgsSettings settings;
 
   connect( mActionClose, &QAction::triggered, this, &QWidget::close );
+  connect( mActionNew, &QAction::triggered, this, &QgsModelDesignerDialog::newModel );
   connect( mActionZoomIn, &QAction::triggered, this, &QgsModelDesignerDialog::zoomIn );
   connect( mActionZoomOut, &QAction::triggered, this, &QgsModelDesignerDialog::zoomOut );
   connect( mActionZoomActual, &QAction::triggered, this, &QgsModelDesignerDialog::zoomActual );
@@ -634,6 +635,16 @@ void QgsModelDesignerDialog::zoomFull()
   QRectF totalRect = mView->scene()->itemsBoundingRect();
   totalRect.adjust( -10, -10, 10, 10 );
   mView->fitInView( totalRect, Qt::KeepAspectRatio );
+}
+
+void QgsModelDesignerDialog::newModel()
+{
+  if ( !checkForUnsavedChanges() )
+    return;
+
+  std::unique_ptr< QgsProcessingModelAlgorithm > alg = std::make_unique< QgsProcessingModelAlgorithm >();
+  alg->setProvider( QgsApplication::processingRegistry()->providerById( QStringLiteral( "model" ) ) );
+  setModel( alg.release() );
 }
 
 void QgsModelDesignerDialog::exportToImage()

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -567,8 +567,7 @@ bool QgsModelDesignerDialog::checkForUnsavedChanges()
     switch ( ret )
     {
       case QMessageBox::Save:
-        saveModel( false );
-        return true;
+        return saveModel( false );
 
       case QMessageBox::Discard:
         return true;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -170,6 +170,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void zoomOut();
     void zoomActual();
     void zoomFull();
+    void newModel();
     void exportToImage();
     void exportToPdf();
     void exportToSvg();

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -122,7 +122,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
     // cppcheck-suppress pureVirtualCall
-    virtual void saveModel( bool saveAs = false ) = 0;
+    virtual bool saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar() { return mToolbar; }
     QAction *actionOpen() { return mActionOpen; }

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -62,6 +62,7 @@
     <addaction name="mActionRun"/>
     <addaction name="mActionReorderInputs"/>
     <addaction name="separator"/>
+    <addaction name="mActionNew"/>
     <addaction name="mActionOpen"/>
     <addaction name="mActionSave"/>
     <addaction name="mActionSaveAs"/>
@@ -112,6 +113,7 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
+   <addaction name="mActionNew"/>
    <addaction name="mActionOpen"/>
    <addaction name="mActionSave"/>
    <addaction name="mActionSaveAs"/>
@@ -743,6 +745,15 @@
    </property>
    <property name="shortcut">
     <string>V</string>
+   </property>
+  </action>
+  <action name="mActionNew">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileNew.svg</normaloff>:/images/themes/default/mActionFileNew.svg</iconset>
+   </property>
+   <property name="text">
+    <string>New Model…</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR fixes two issues in the model designer dialog:

1. If a user is prompted to save unsaved changes to a model (e.g. by closing the dialog), then clicking "save" but then cancelling the file save as filename dialog resulted in the unsaved changes being silently discarded
2. The dialog is missing a "New" action to accompany the existing "Open"/"Save"/"Save As" actions

(The first fix will be backported manually.)

Refs NRCan Contract#3000739399