### PR TITLE
Fix silent loss of models if file save name dialog is canceled (Backport)

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -82,7 +82,7 @@ Raise, unminimize and activate this window.
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
-    virtual void saveModel( bool saveAs = false ) = 0;
+    virtual bool saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar();
     QAction *actionOpen();

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -178,9 +178,9 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.setDirty(False)
         QgsProject.instance().setDirty(True)
 
-    def saveModel(self, saveAs):
+    def saveModel(self, saveAs) -> bool:
         if not self.validateSave():
-            return
+            return False
         if self.model().sourceFilePath() and not saveAs:
             filename = self.model().sourceFilePath()
         else:
@@ -203,7 +203,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                                             "This model can't be saved in its original location (probably you do not "
                                             "have permission to do it). Please, use the 'Save as…' option."))
                                         )
-                return
+                return False
             self.update_model.emit()
             if saveAs:
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(
@@ -213,6 +213,9 @@ class ModelerDialog(QgsModelDesignerDialog):
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
             self.setDirty(False)
+            return True
+        else:
+            return False
 
     def openModel(self):
         if not self.checkForUnsavedChanges():

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -560,8 +560,7 @@ bool QgsModelDesignerDialog::checkForUnsavedChanges()
     switch ( ret )
     {
       case QMessageBox::Save:
-        saveModel( false );
-        return true;
+        return saveModel( false );
 
       case QMessageBox::Discard:
         return true;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -111,7 +111,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
     // cppcheck-suppress pureVirtualCall
-    virtual void saveModel( bool saveAs = false ) = 0;
+    virtual bool saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar() { return mToolbar; }
     QAction *actionOpen() { return mActionOpen; }


### PR DESCRIPTION
When closing a model with unsaved changes, if the user accepts the prompt to save the changes BUT then cancels the file dialog asking for the destination file name, don't treat this as though the user has opted to discard the model

Manual backport of https://github.com/qgis/QGIS/pull/47215
