### PR TITLE
Generate simpler parameter names for model output parameters

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -219,6 +219,34 @@ external dependencies. If specified, the ``errorMessage`` argument will be fille
 with a localised error message describing why the algorithm cannot execute.
 %End
 
+    QVariant parameterValue( const QVariantMap &parameters, const QString &name ) const;
+%Docstring
+Given a set of ``parameter`` values, retrieves the value corresponding to the
+given parameter name.
+
+This method correctly handles parameter aliases, by also retrieving any values
+set to aliases of the matching parameter definition.
+
+Returns an invalid variant if no matching value is present in ``parameters``.
+
+.. seealso:: :py:func:`hasParameterValue`
+
+.. versionadded:: 3.24
+%End
+
+    bool hasParameterValue( const QVariantMap &parameters, const QString &name ) const;
+%Docstring
+Given a set of ``parameter`` values, returns ``True`` if a value is present for the
+given parameter by name.
+
+This method correctly handles parameter aliases, by also checking any values
+set to aliases of the matching parameter definition.
+
+.. seealso:: :py:func:`parameterValue`
+
+.. versionadded:: 3.24
+%End
+
     virtual bool checkParameterValues( const QVariantMap &parameters,
                                        QgsProcessingContext &context, QString *message /Out/ = 0 ) const;
 %Docstring
@@ -640,6 +668,14 @@ or if an exception was raised by the :py:func:`~QgsProcessingAlgorithm.processAl
 .. seealso:: :py:func:`prepareAlgorithm`
 
 .. seealso:: :py:func:`processAlgorithm`
+%End
+
+    QVariantMap replaceAliases( const QVariantMap &parameters ) const;
+%Docstring
+Updates a parameter map by replacing any keys which correspond to aliases of parameters
+with the actual parameter names.
+
+.. versionadded:: 3.24
 %End
 
     QString parameterAsString( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -373,6 +373,8 @@ Returns the name of the parameter. This is the internal identifier by which
 algorithms access this parameter.
 
 .. seealso:: :py:func:`setName`
+
+.. seealso:: :py:func:`aliases`
 %End
 
     void setName( const QString &name );
@@ -381,6 +383,30 @@ Sets the ``name`` of the parameter. This is the internal identifier by which
 algorithms access this parameter.
 
 .. seealso:: :py:func:`name`
+
+.. seealso:: :py:func:`setAliases`
+%End
+
+    QStringList aliases() const;
+%Docstring
+Returns a list of additional names by which the parameter can be referred to.
+
+.. seealso:: :py:func:`setAliases`
+
+.. seealso:: :py:func:`name`
+
+.. versionadded:: 3.24
+%End
+
+    void setAliases( const QStringList &aliases );
+%Docstring
+Sets a list of additional names by which the parameter can be referred to.
+
+.. seealso:: :py:func:`aliases`
+
+.. seealso:: :py:func:`setName`
+
+.. versionadded:: 3.24
 %End
 
     QString description() const;
@@ -774,6 +800,7 @@ The ``variables`` list should contain the variable names only, without the usual
 %End
 
   protected:
+
 
 
 

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -183,9 +183,9 @@ QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const QgsP
         if ( outputIt->childOutputName() == destParam->name() )
         {
           QString paramName = child.childId() + ':' + outputIt.key();
-          if ( modelParameters.contains( paramName ) )
+          if ( hasParameterValue( modelParameters, paramName ) )
           {
-            QVariant value = modelParameters.value( paramName );
+            QVariant value = parameterValue( modelParameters, paramName );
             if ( value.canConvert<QgsProcessingOutputLayerDefinition>() )
             {
               // make sure layout output name is correctly set

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -546,6 +546,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
 
     QStringList mParameterOrder;
 
+    static QString safeName( const QString &name, bool capitalize );
+
     void dependsOnChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;
     void dependentChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends, const QString &branch ) const;
 

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -99,9 +99,13 @@ bool QgsProcessingAlgorithm::canExecute( QString * ) const
 
 QVariant QgsProcessingAlgorithm::parameterValue( const QVariantMap &parameters, const QString &name ) const
 {
-  QStringList names { name };
+  QSet< QString > names { name };
   if ( const QgsProcessingParameterDefinition *def = parameterDefinition( name ) )
-    names.append( def->aliases() );
+  {
+    names.insert( def->name() );
+    for ( const QString &alias : def->aliases() )
+      names.insert( alias );
+  }
 
   for ( const QString &name : std::as_const( names ) )
   {
@@ -114,9 +118,13 @@ QVariant QgsProcessingAlgorithm::parameterValue( const QVariantMap &parameters, 
 
 bool QgsProcessingAlgorithm::hasParameterValue( const QVariantMap &parameters, const QString &name ) const
 {
-  QStringList names { name };
+  QSet< QString > names { name };
   if ( const QgsProcessingParameterDefinition *def = parameterDefinition( name ) )
-    names.append( def->aliases() );
+  {
+    names.insert( def->name() );
+    for ( const QString &alias : def->aliases() )
+      names.insert( alias );
+  }
 
   for ( const QString &name : std::as_const( names ) )
   {

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -248,6 +248,32 @@ class CORE_EXPORT QgsProcessingAlgorithm
     virtual bool canExecute( QString *errorMessage SIP_OUT = nullptr ) const;
 
     /**
+     * Given a set of \a parameter values, retrieves the value corresponding to the
+     * given parameter name.
+     *
+     * This method correctly handles parameter aliases, by also retrieving any values
+     * set to aliases of the matching parameter definition.
+     *
+     * Returns an invalid variant if no matching value is present in \a parameters.
+     *
+     * \see hasParameterValue()
+     * \since QGIS 3.24
+     */
+    QVariant parameterValue( const QVariantMap &parameters, const QString &name ) const;
+
+    /**
+     * Given a set of \a parameter values, returns TRUE if a value is present for the
+     * given parameter by name.
+     *
+     * This method correctly handles parameter aliases, by also checking any values
+     * set to aliases of the matching parameter definition.
+     *
+     * \see parameterValue()
+     * \since QGIS 3.24
+     */
+    bool hasParameterValue( const QVariantMap &parameters, const QString &name ) const;
+
+    /**
      * Checks the supplied \a parameter values to verify that they satisfy the requirements
      * of this algorithm in the supplied \a context. The \a message parameter will be
      * filled with explanatory text if validation fails.
@@ -649,6 +675,14 @@ class CORE_EXPORT QgsProcessingAlgorithm
      * \see processAlgorithm()
      */
     virtual QVariantMap postProcessAlgorithm( QgsProcessingContext &context, QgsProcessingFeedback *feedback ) SIP_THROW( QgsProcessingException ) SIP_VIRTUALERRORHANDLER( processing_exception_handler );
+
+    /**
+     * Updates a parameter map by replacing any keys which correspond to aliases of parameters
+     * with the actual parameter names.
+     *
+     * \since QGIS 3.24
+     */
+    QVariantMap replaceAliases( const QVariantMap &parameters ) const;
 
     /**
      * Evaluates the parameter with matching \a name to a static string value.

--- a/src/core/processing/qgsprocessingparametermeshdataset.cpp
+++ b/src/core/processing/qgsprocessingparametermeshdataset.cpp
@@ -30,7 +30,7 @@ QgsProcessingParameterMeshDatasetGroups::QgsProcessingParameterMeshDatasetGroups
 
 QgsProcessingParameterDefinition *QgsProcessingParameterMeshDatasetGroups::clone() const
 {
-  return new QgsProcessingParameterMeshDatasetGroups( name(), description(), mMeshLayerParameterName, mSupportedDataType );
+  return new QgsProcessingParameterMeshDatasetGroups( *this );
 }
 
 QString QgsProcessingParameterMeshDatasetGroups::type() const
@@ -179,7 +179,7 @@ QgsProcessingParameterMeshDatasetTime::QgsProcessingParameterMeshDatasetTime( co
 
 QgsProcessingParameterDefinition *QgsProcessingParameterMeshDatasetTime::clone() const
 {
-  return new QgsProcessingParameterMeshDatasetTime( name(), description(), mMeshLayerParameterName, mDatasetGroupParameterName );
+  return new QgsProcessingParameterMeshDatasetTime( *this );
 }
 
 QString QgsProcessingParameterMeshDatasetTime::type() const

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -484,6 +484,7 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * Returns the name of the parameter. This is the internal identifier by which
      * algorithms access this parameter.
      * \see setName()
+     * \see aliases()
      */
     QString name() const { return mName; }
 
@@ -491,8 +492,27 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      * Sets the \a name of the parameter. This is the internal identifier by which
      * algorithms access this parameter.
      * \see name()
+     * \see setAliases()
      */
     void setName( const QString &name ) { mName = name; }
+
+    /**
+     * Returns a list of additional names by which the parameter can be referred to.
+     *
+     * \see setAliases()
+     * \see name()
+     * \since QGIS 3.24
+     */
+    QStringList aliases() const { return mAliases; }
+
+    /**
+     * Sets a list of additional names by which the parameter can be referred to.
+     *
+     * \see aliases()
+     * \see setName()
+     * \since QGIS 3.24
+     */
+    void setAliases( const QStringList &aliases ) { mAliases = aliases; }
 
     /**
      * Returns the description for the parameter. This is the user-visible string
@@ -877,6 +897,9 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Additional expression context variables exposed for use by this parameter
     QStringList mAdditionalExpressionVariables;
+
+    //! List of additional names by which this parameter can be referred to
+    QStringList mAliases;
 
     // To allow access to mAlgorithm. We don't want a public setter for this!
     friend class QgsProcessingAlgorithm;

--- a/src/core/processing/qgsprocessingparametertininputlayers.cpp
+++ b/src/core/processing/qgsprocessingparametertininputlayers.cpp
@@ -22,7 +22,7 @@ QgsProcessingParameterTinInputLayers::QgsProcessingParameterTinInputLayers( cons
 
 QgsProcessingParameterDefinition *QgsProcessingParameterTinInputLayers::clone() const
 {
-  return new QgsProcessingParameterTinInputLayers( name(), description() );
+  return new QgsProcessingParameterTinInputLayers( *this );
 }
 
 QString QgsProcessingParameterTinInputLayers::type() const

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -1112,9 +1112,9 @@ int QgsProcessingExec::execute( const QString &inputId, const QVariantMap &param
   QList< const QgsProcessingParameterDefinition * > missingParams;
   for ( const QgsProcessingParameterDefinition *p : defs )
   {
-    if ( !p->checkValueIsAcceptable( params.value( p->name() ), &context ) )
+    if ( !p->checkValueIsAcceptable( alg->parameterValue( params, p->name() ), &context ) )
     {
-      if ( !( p->flags() & QgsProcessingParameterDefinition::FlagOptional ) && !params.contains( p->name() ) )
+      if ( !( p->flags() & QgsProcessingParameterDefinition::FlagOptional ) && !alg->hasParameterValue( params, p->name() ) )
       {
         missingParams << p;
       }

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -1031,11 +1031,12 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   alg7.addChildAlgorithm( alg7c1 );
   // verify that model has destination parameter created
   QCOMPARE( alg7.destinationParameterDefinitions().count(), 1 );
-  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "cx1:my_output" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->aliases(), QStringList{ QStringLiteral( "cx1:my_output" ) } );
   QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast< const QgsProcessingDestinationParameter * >( alg7.destinationParameterDefinitions().at( 0 ) )->originalProvider()->id(), QStringLiteral( "native" ) );
   QCOMPARE( alg7.outputDefinitions().count(), 1 );
-  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "cx1:my_output" ) );
+  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->type(), QStringLiteral( "outputVector" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
 
@@ -1054,28 +1055,31 @@ void TestQgsProcessingModelAlgorithm::modelerAlgorithm()
   alg7.addChildAlgorithm( alg7c2 );
 
   QCOMPARE( alg7.destinationParameterDefinitions().count(), 2 );
-  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "cx1:my_output" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->aliases(), QStringList{ QStringLiteral( "cx1:my_output" ) } );
   QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
   QVERIFY( alg7.destinationParameterDefinitions().at( 0 )->defaultValue().isNull() );
   QVERIFY( !( alg7.destinationParameterDefinitions().at( 0 )->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
-  QCOMPARE( alg7.destinationParameterDefinitions().at( 1 )->name(), QStringLiteral( "cx2:my_output2" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 1 )->name(), QStringLiteral( "my_output2" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 1 )->aliases(), QStringList{ QStringLiteral( "cx2:my_output2" ) } );
   QCOMPARE( alg7.destinationParameterDefinitions().at( 1 )->description(), QStringLiteral( "my output2" ) );
   QCOMPARE( alg7.destinationParameterDefinitions().at( 1 )->defaultValue().toString(), QStringLiteral( "my value" ) );
   QVERIFY( !( alg7.destinationParameterDefinitions().at( 1 )->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
   QCOMPARE( alg7.outputDefinitions().count(), 2 );
-  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "cx1:my_output" ) );
+  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->type(), QStringLiteral( "outputVector" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
-  QCOMPARE( alg7.outputDefinitions().at( 1 )->name(), QStringLiteral( "cx2:my_output2" ) );
+  QCOMPARE( alg7.outputDefinitions().at( 1 )->name(), QStringLiteral( "my_output2" ) );
   QCOMPARE( alg7.outputDefinitions().at( 1 )->type(), QStringLiteral( "outputVector" ) );
   QCOMPARE( alg7.outputDefinitions().at( 1 )->description(), QStringLiteral( "my output2" ) );
 
   alg7.removeChildAlgorithm( QStringLiteral( "cx1" ) );
   QCOMPARE( alg7.destinationParameterDefinitions().count(), 1 );
-  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "cx2:my_output2" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "my_output2" ) );
+  QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->aliases(), QStringList{ QStringLiteral( "cx2:my_output2" ) } );
   QCOMPARE( alg7.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output2" ) );
   QCOMPARE( alg7.outputDefinitions().count(), 1 );
-  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "cx2:my_output2" ) );
+  QCOMPARE( alg7.outputDefinitions().at( 0 )->name(), QStringLiteral( "my_output2" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->type(), QStringLiteral( "outputVector" ) );
   QCOMPARE( alg7.outputDefinitions().at( 0 )->description(), QStringLiteral( "my output2" ) );
 
@@ -1681,7 +1685,7 @@ void TestQgsProcessingModelAlgorithm::modelWithProviderWithLimitedTypes()
   alg.addChildAlgorithm( algc1 );
   // verify that model has destination parameter created
   QCOMPARE( alg.destinationParameterDefinitions().count(), 3 );
-  QCOMPARE( alg.destinationParameterDefinitions().at( 2 )->name(), QStringLiteral( "cx1:my_vector_output" ) );
+  QCOMPARE( alg.destinationParameterDefinitions().at( 2 )->name(), QStringLiteral( "my_output_3" ) );
   QCOMPARE( alg.destinationParameterDefinitions().at( 2 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast< const QgsProcessingDestinationParameter * >( alg.destinationParameterDefinitions().at( 2 ) )->originalProvider()->id(), QStringLiteral( "dummy4" ) );
   QCOMPARE( static_cast< const QgsProcessingParameterVectorDestination * >( alg.destinationParameterDefinitions().at( 2 ) )->supportedOutputVectorLayerExtensions(), QStringList() << QStringLiteral( "mif" ) );
@@ -1689,7 +1693,7 @@ void TestQgsProcessingModelAlgorithm::modelWithProviderWithLimitedTypes()
   QVERIFY( static_cast< const QgsProcessingParameterVectorDestination * >( alg.destinationParameterDefinitions().at( 2 ) )->generateTemporaryDestination().endsWith( QLatin1String( ".mif" ) ) );
   QVERIFY( !static_cast< const QgsProcessingDestinationParameter * >( alg.destinationParameterDefinitions().at( 2 ) )->supportsNonFileBasedOutput() );
 
-  QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "cx1:my_raster_output" ) );
+  QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
   QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast< const QgsProcessingDestinationParameter * >( alg.destinationParameterDefinitions().at( 0 ) )->originalProvider()->id(), QStringLiteral( "dummy4" ) );
   QCOMPARE( static_cast< const QgsProcessingParameterRasterDestination * >( alg.destinationParameterDefinitions().at( 0 ) )->supportedOutputRasterLayerExtensions(), QStringList() << QStringLiteral( "mig" ) );
@@ -1697,7 +1701,7 @@ void TestQgsProcessingModelAlgorithm::modelWithProviderWithLimitedTypes()
   QVERIFY( static_cast< const QgsProcessingParameterRasterDestination * >( alg.destinationParameterDefinitions().at( 0 ) )->generateTemporaryDestination().endsWith( QLatin1String( ".mig" ) ) );
   QVERIFY( !static_cast< const QgsProcessingDestinationParameter * >( alg.destinationParameterDefinitions().at( 0 ) )->supportsNonFileBasedOutput() );
 
-  QCOMPARE( alg.destinationParameterDefinitions().at( 1 )->name(), QStringLiteral( "cx1:my_sink_output" ) );
+  QCOMPARE( alg.destinationParameterDefinitions().at( 1 )->name(), QStringLiteral( "my_output_2" ) );
   QCOMPARE( alg.destinationParameterDefinitions().at( 1 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast< const QgsProcessingDestinationParameter * >( alg.destinationParameterDefinitions().at( 1 ) )->originalProvider()->id(), QStringLiteral( "dummy4" ) );
   QCOMPARE( static_cast< const QgsProcessingParameterFeatureSink * >( alg.destinationParameterDefinitions().at( 1 ) )->supportedOutputVectorLayerExtensions(), QStringList() << QStringLiteral( "mif" ) );


### PR DESCRIPTION
Instead of complex, unfriendly names like "gdal:polygonize 1:output", generate user-friendly simple output names based on the output descriptions.

And use a new parameter alias API to avoid breaking scripts which use the older complex output naming

Refs NRCan Contract#3000739399