### PR TITLE
Fix different terms used for PostgreSQL/PostGIS between browser/data source manager

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -584,7 +584,7 @@ int QgsPostgresDataItemProvider::capabilities() const
 QgsDataItem *QgsPostgresDataItemProvider::createDataItem( const QString &pathIn, QgsDataItem *parentItem )
 {
   Q_UNUSED( pathIn )
-  return new QgsPGRootItem( parentItem, QStringLiteral( "PostGIS" ), QStringLiteral( "pg:" ) );
+  return new QgsPGRootItem( parentItem, QObject::tr( "PostgreSQL" ), QStringLiteral( "pg:" ) );
 }
 
 

--- a/tests/src/gui/testqgsnewdatabasetablewidget.cpp
+++ b/tests/src/gui/testqgsnewdatabasetablewidget.cpp
@@ -132,7 +132,7 @@ void TestQgsNewDatabaseTableNameWidget::testWidgetSignalsPostgres()
 
   index = w->mBrowserProxyModel.mapToSource( w->mBrowserProxyModel.index( 0, 0 ) );
   QVERIFY( index.isValid() );
-  QCOMPARE( w->mBrowserModel->data( index, Qt::DisplayRole ).toString(), QString( "PostGIS" ) );
+  QCOMPARE( w->mBrowserModel->data( index, Qt::DisplayRole ).toString(), QString( "PostgreSQL" ) );
   QRect rect = w->mBrowserTreeView->visualRect( w->mBrowserProxyModel.mapFromSource( index ) );
   QVERIFY( rect.isValid() );
   QTest::mouseClick( w->mBrowserTreeView->viewport(), Qt::LeftButton, Qt::KeyboardModifiers(), rect.topLeft() );


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/1829991/152908036-3dbf1401-d6c6-4439-8f05-f99e493e8bb8.png)

