### PR TITLE
Rename "MSSQL" text to "MS SQL Server" in browser/data source manager

### DIFF
--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -676,7 +676,7 @@ int QgsMssqlDataItemProvider::capabilities() const
 QgsDataItem *QgsMssqlDataItemProvider::createDataItem( const QString &pathIn, QgsDataItem *parentItem )
 {
   Q_UNUSED( pathIn )
-  return new QgsMssqlRootItem( parentItem, QStringLiteral( "MSSQL" ), QStringLiteral( "mssql:" ) );
+  return new QgsMssqlRootItem( parentItem, QObject::tr( "MS SQL Server" ), QStringLiteral( "mssql:" ) );
 }
 
 

--- a/src/providers/mssql/qgsmssqlprovidergui.cpp
+++ b/src/providers/mssql/qgsmssqlprovidergui.cpp
@@ -28,7 +28,7 @@ class QgsMssqlSourceSelectProvider : public QgsSourceSelectProvider
   public:
 
     QString providerKey() const override { return QStringLiteral( "mssql" ); }
-    QString text() const override { return QObject::tr( "MSSQL" ); }
+    QString text() const override { return QObject::tr( "MS SQL Server" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 30; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddMssqlLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override


### PR DESCRIPTION
"mssql" isn't a standard name for this software -- it's actually named
"SQL Server". The new strings give a bit more hints to new users about
connecting to the datasets...
