### PR TITLE
Hide qmessagebar warnings related to QXcbClipboard

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -411,7 +411,8 @@ void myMessageOutput( QtMsgType type, const QMessageLogContext &, const QString 
        *  we have no control over and have low value anyway);
        * - QtSVG warnings with regards to lack of implementation beyond Tiny SVG 1.2
        */
-      if ( msg.startsWith( QLatin1String( "libpng warning: iCCP: known incorrect sRGB profile" ), Qt::CaseInsensitive ) ||
+      if ( msg.contains( QLatin1String( "QXcbClipboard" ), Qt::CaseInsensitive ) ||
+           msg.startsWith( QLatin1String( "libpng warning: iCCP: known incorrect sRGB profile" ), Qt::CaseInsensitive ) ||
            msg.contains( QLatin1String( "Could not add child element to parent element because the types are incorrect" ), Qt::CaseInsensitive ) ||
            msg.contains( QLatin1String( "OpenType support missing for" ), Qt::CaseInsensitive ) )
         break;


### PR DESCRIPTION
## Description

This is a simple patch to hide spurious messages relating to QXcbClipboard when in debug mode. Thanks to @nyalldawson for the 'code by proxy' fix here.