### PR TITLE
accept "true" as a valid value in the "hasProcessingProvider" metadata  (fix #41120)

### DIFF
--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -185,7 +185,8 @@ class PYTHON_EXPORT QgsPythonUtils
     /**
      * Returns TRUE if a plugin implements a Processing provider.
      *
-     * This is determined by checking the plugin metadata for the "hasProcessingProvider=yes" line.
+     * This is determined by checking the plugin metadata for the "hasProcessingProvider=yes"
+     * or "hasProcessingProvider=true" line.
      *
      * \see startProcessingPlugin()
      * \since QGIS 3.8

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -637,7 +637,7 @@ QString QgsPythonUtilsImpl::getPluginMetadata( const QString &pluginName, const 
 
 bool QgsPythonUtilsImpl::pluginHasProcessingProvider( const QString &pluginName )
 {
-  return getPluginMetadata( pluginName, QStringLiteral( "hasProcessingProvider" ) ).compare( QLatin1String( "yes" ), Qt::CaseInsensitive ) == 0;
+  return getPluginMetadata( pluginName, QStringLiteral( "hasProcessingProvider" ) ).compare( QLatin1String( "yes" ), Qt::CaseInsensitive ) == 0 || getPluginMetadata( pluginName, QStringLiteral( "hasProcessingProvider" ) ).compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
 }
 
 bool QgsPythonUtilsImpl::loadPlugin( const QString &packageName )

--- a/tests/src/app/testqgisapppython.cpp
+++ b/tests/src/app/testqgisapppython.cpp
@@ -124,6 +124,9 @@ void TestQgisAppPython::pluginMetadata()
   QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "name" ) ), QStringLiteral( "processing plugin test" ) );
   QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "hasProcessingProvider" ) ), QStringLiteral( "yes" ) );
   QVERIFY( mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "ProcessingPluginTest" ) ) );
+  // hasProcessingProvider also accepts true/True
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest2" ), QStringLiteral( "hasProcessingProvider" ) ), QStringLiteral( "True" ) );
+  QVERIFY( mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "ProcessingPluginTest2" ) ) );
 }
 
 void TestQgisAppPython::pythonPluginDependencyOrder()

--- a/tests/testdata/test_plugin_path/ProcessingPluginTest2/__init__.py
+++ b/tests/testdata/test_plugin_path/ProcessingPluginTest2/__init__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    __init__.py
+    ---------------------
+    Date                 : July 2013
+    Copyright            : (C) 2013 by Hugo Mercier
+    Email                : hugo dot mercier at oslandia dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Hugo Mercier'
+__date__ = 'July 2013'
+__copyright__ = '(C) 2013, Hugo Mercier'
+
+import os
+
+
+class Test:
+
+    def __init__(self, iface):
+        pass
+
+    def initGui(self):
+        assert False
+
+    def initProcessing(self):
+        pass
+
+    def unload(self):
+        pass
+
+
+def classFactory(iface):
+    # load Test class from file Test
+    return Test(iface)

--- a/tests/testdata/test_plugin_path/ProcessingPluginTest2/metadata.txt
+++ b/tests/testdata/test_plugin_path/ProcessingPluginTest2/metadata.txt
@@ -1,0 +1,7 @@
+[general]
+name=processing plugin test 2
+qgisMinimumVersion=3.8
+description=desc
+version=0.1
+author=matt cauthin
+hasProcessingProvider=True


### PR DESCRIPTION
## Description

The `hasProcessingProvider` metadata entry currently accepts only `yes` value, this causes confusion and not consistent with the rest of metadata entries which accept "true" or "True".

Fixes #41120.