### PR TITLE
[vectortile] Fix Q_ASSERT_X crasher in the vector tile basic renderer

### DIFF
--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -197,7 +197,10 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
         {
           scope->setFeature( f );
           if ( filterExpression.isValid() && !filterExpression.evaluate( &context.expressionContext() ).toBool() )
+          {
+            sym->stopRender( context );
             continue;
+          }
 
           const QgsWkbTypes::GeometryType featureType = QgsWkbTypes::geometryType( f.geometry().wkbType() );
           if ( featureType == layerStyle.geometryType() )
@@ -231,7 +234,10 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
       {
         scope->setFeature( f );
         if ( filterExpression.isValid() && !filterExpression.evaluate( &context.expressionContext() ).toBool() )
+        {
+          sym->stopRender( context );
           continue;
+        }
 
         const QgsWkbTypes::GeometryType featureType = QgsWkbTypes::geometryType( f.geometry().wkbType() );
         if ( featureType == layerStyle.geometryType() )


### PR DESCRIPTION
## Description

This PR fixes a Q_ASSERT_X crasher in the vector tile basic renderer. The loop that goes through the styles can leave the QgsSymbol in a started state that's not stopped, which subsequently triggers this assert (https://github.com/qgis/QGIS/blob/master/src/core/symbology/qgssymbol.cpp#L491).

