### PR TITLE
Don't show AddFeatureButton for spatial layer (only AddFeatureGeometry)

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -100,6 +100,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   : QgsAbstractRelationEditorWidget( config, parent )
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
   , mShowFirstFeature( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() )
+  , mAddFeatureWithGeometryOnly( config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool() )
 {
   QVBoxLayout *rootLayout = new QVBoxLayout( this );
   rootLayout->setContentsMargins( 0, 9, 0, 0 );
@@ -377,7 +378,7 @@ void QgsRelationEditorWidget::updateButtons()
   mLinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Link ) );
   mUnlinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Unlink ) );
   mSaveEditsButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) && !mLayerInSameTransactionGroup );
-  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && !spatial );
+  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && !( spatial && mAddFeatureWithGeometryOnly ) );
   mAddFeatureGeometryButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
   mDuplicateFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DuplicateChildFeature ) );
   mDeleteFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );
@@ -803,13 +804,15 @@ void QgsRelationEditorWidget::mapToolDeactivated()
 QVariantMap QgsRelationEditorWidget::config() const
 {
   return QVariantMap( {{"buttons", qgsFlagValueToKeys( visibleButtons() )},
-    {"show_first_feature", mShowFirstFeature}} );
+    {"show_first_feature", mShowFirstFeature},
+    {"add_feature_with_geometry_only", mAddFeatureWithGeometryOnly }} );
 }
 
 void QgsRelationEditorWidget::setConfig( const QVariantMap &config )
 {
   mButtonsVisibility = qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons );
   mShowFirstFeature = config.value( QStringLiteral( "show_first_feature" ), true ).toBool();
+  mAddFeatureWithGeometryOnly = config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool();
   updateButtons();
 }
 
@@ -940,7 +943,8 @@ QVariantMap QgsRelationEditorConfigWidget::config()
   return QVariantMap(
   {
     {"buttons", qgsFlagValueToKeys( buttons )},
-    {"show_first_feature", mShowFirstFeature->isChecked()}
+    {"show_first_feature", mShowFirstFeature->isChecked()},
+    {"add_feature_with_geometry_only", mAddFeatureWithGeometryOnly->isChecked()}
   } );
 }
 
@@ -956,6 +960,7 @@ void QgsRelationEditorConfigWidget::setConfig( const QVariantMap &config )
   mRelationDeleteChildFeatureCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );
   mRelationShowSaveChildEditsCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) );
   mShowFirstFeature->setChecked( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() );
+  mAddFeatureWithGeometryOnly->setChecked( config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool() );
 }
 
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -377,7 +377,7 @@ void QgsRelationEditorWidget::updateButtons()
   mLinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Link ) );
   mUnlinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Unlink ) );
   mSaveEditsButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) && !mLayerInSameTransactionGroup );
-  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) );
+  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && !spatial );
   mAddFeatureGeometryButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
   mDuplicateFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DuplicateChildFeature ) );
   mDeleteFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -100,7 +100,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( const QVariantMap &config, QWi
   : QgsAbstractRelationEditorWidget( config, parent )
   , mButtonsVisibility( qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons ) )
   , mShowFirstFeature( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() )
-  , mAddFeatureWithGeometryOnly( config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool() )
+  , mAllowAddChildFeatureWithNoGeometry( config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool() )
 {
   QVBoxLayout *rootLayout = new QVBoxLayout( this );
   rootLayout->setContentsMargins( 0, 9, 0, 0 );
@@ -378,7 +378,7 @@ void QgsRelationEditorWidget::updateButtons()
   mLinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Link ) );
   mUnlinkFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::Unlink ) );
   mSaveEditsButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) && !mLayerInSameTransactionGroup );
-  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && !( spatial && mAddFeatureWithGeometryOnly ) );
+  mAddFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && !( spatial && !mAllowAddChildFeatureWithNoGeometry ) );
   mAddFeatureGeometryButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::AddChildFeature ) && mEditorContext.mapCanvas() && mEditorContext.cadDockWidget() && spatial );
   mDuplicateFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DuplicateChildFeature ) );
   mDeleteFeatureButton->setVisible( mButtonsVisibility.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );
@@ -805,14 +805,14 @@ QVariantMap QgsRelationEditorWidget::config() const
 {
   return QVariantMap( {{"buttons", qgsFlagValueToKeys( visibleButtons() )},
     {"show_first_feature", mShowFirstFeature},
-    {"add_feature_with_geometry_only", mAddFeatureWithGeometryOnly }} );
+    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry }} );
 }
 
 void QgsRelationEditorWidget::setConfig( const QVariantMap &config )
 {
   mButtonsVisibility = qgsFlagKeysToValue( config.value( QStringLiteral( "buttons" ) ).toString(), QgsRelationEditorWidget::Button::AllButtons );
   mShowFirstFeature = config.value( QStringLiteral( "show_first_feature" ), true ).toBool();
-  mAddFeatureWithGeometryOnly = config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool();
+  mAllowAddChildFeatureWithNoGeometry = config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool();
   updateButtons();
 }
 
@@ -944,7 +944,7 @@ QVariantMap QgsRelationEditorConfigWidget::config()
   {
     {"buttons", qgsFlagValueToKeys( buttons )},
     {"show_first_feature", mShowFirstFeature->isChecked()},
-    {"add_feature_with_geometry_only", mAddFeatureWithGeometryOnly->isChecked()}
+    {"allow_add_child_feature_with_no_geometry", mAllowAddChildFeatureWithNoGeometry->isChecked()}
   } );
 }
 
@@ -960,7 +960,7 @@ void QgsRelationEditorConfigWidget::setConfig( const QVariantMap &config )
   mRelationDeleteChildFeatureCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::DeleteChildFeature ) );
   mRelationShowSaveChildEditsCheckBox->setChecked( buttons.testFlag( QgsRelationEditorWidget::Button::SaveChildEdits ) );
   mShowFirstFeature->setChecked( config.value( QStringLiteral( "show_first_feature" ), true ).toBool() );
-  mAddFeatureWithGeometryOnly->setChecked( config.value( QStringLiteral( "add_feature_with_geometry_only" ), true ).toBool() );
+  mAllowAddChildFeatureWithNoGeometry->setChecked( config.value( QStringLiteral( "allow_add_child_feature_with_no_geometry" ), false ).toBool() );
 }
 
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -260,7 +260,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     Buttons mButtonsVisibility = Button::AllButtons;
     bool mShowFirstFeature = true;
-    bool mAddFeatureWithGeometryOnly = true;
+    bool mAllowAddChildFeatureWithNoGeometry = true;
 
     QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
     QgsFeatureIds mMultiEdit1NJustAddedIds;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -260,6 +260,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
 
     Buttons mButtonsVisibility = Button::AllButtons;
     bool mShowFirstFeature = true;
+    bool mAddFeatureWithGeometryOnly = true;
 
     QList<QTreeWidgetItem *> mMultiEditPreviousSelectedItems;
     QgsFeatureIds mMultiEdit1NJustAddedIds;

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -85,7 +85,7 @@
         <item>
          <widget class="QCheckBox" name="mAllowAddChildFeatureWithNoGeometry">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is not possible to add a feature whitout geometry to a spatial layer. Otherwise two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is possible to add a feature whitout geometry to a spatial layer. Two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string> Allow add child feature with no geometry (for spatial layer)</string>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -85,7 +85,7 @@
         <item>
          <widget class="QCheckBox" name="mAllowAddChildFeatureWithNoGeometry">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is possible to add a feature whitout geometry to a spatial layer. Two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, it is possible to add a feature without geometry to a spatial layer. Two &amp;quot;Add child feature&amp;quot; buttons are showed: with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Allow add child feature with no geometry (for spatial layer)</string>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -88,7 +88,7 @@
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is possible to add a feature whitout geometry to a spatial layer. Two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
-           <string> Allow add child feature with no geometry (for spatial layer)</string>
+           <string>Allow add child feature with no geometry (for spatial layer)</string>
           </property>
          </widget>
         </item>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>472</width>
-    <height>288</height>
+    <width>422</width>
+    <height>272</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -63,6 +63,36 @@
          <string>Add child feature</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>10</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="mAddFeatureWithGeometryOnly">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is not possible to add a feature whitout geometry to a spatial layer. Otherwise two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string> Add child feature with geometry only (for spatial layer)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QCheckBox" name="mRelationShowDuplicateChildFeatureCheckBox">

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -83,12 +83,12 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="mAddFeatureWithGeometryOnly">
+         <widget class="QCheckBox" name="mAllowAddChildFeatureWithNoGeometry">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked it is not possible to add a feature whitout geometry to a spatial layer. Otherwise two &amp;quot;Add child feature&amp;quot; buttons are showed with and without geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
-           <string> Add child feature with geometry only (for spatial layer)</string>
+           <string> Allow add child feature with no geometry (for spatial layer)</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Don't show AddFeatureButton for spatial layer by default (only AddFeatureGeometry)
Fixes #47283

The AddFeatureButton can still be shown activating a new configuration option:
![image](https://user-images.githubusercontent.com/9881900/157674808-6562f978-ac3d-421a-835d-20c131843179.png)

