### PR TITLE
make labeling Edit Rule widget a full-featured dialog (fix #36761)

### DIFF
--- a/src/gui/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.h
@@ -174,14 +174,24 @@ class GUI_EXPORT QgsLabelingRulePropsWidget : public QgsPanelWidget, private Ui:
     //! Returns the rule being edited
     QgsRuleBasedLabeling::Rule *rule() { return mRule; }
 
+    /**
+     * Set the widget in dock mode.
+     * \param dockMode TRUE for dock mode.
+     */
     void setDockMode( bool dockMode ) override;
 
   public slots:
     //! Apply any changes from the widget to the set rule.
     void apply();
 
-  public slots:
+    /**
+     * Test the filter that is set in the widget
+     */
     void testFilter();
+
+    /**
+     * Open the expression builder widget
+     */
     void buildExpression();
 
   private:
@@ -197,6 +207,10 @@ class GUI_EXPORT QgsLabelingRulePropsWidget : public QgsPanelWidget, private Ui:
 /**
  * \ingroup gui
  * \class QgsLabelingRulePropsDialog
+ * \brief Dialog for editing labeling rule
+ *
+ * \note This class is not a part of public API
+ * \since QGIS 3.24
  */
 class GUI_EXPORT QgsLabelingRulePropsDialog : public QDialog
 {
@@ -214,11 +228,27 @@ class GUI_EXPORT QgsLabelingRulePropsDialog : public QDialog
     QgsLabelingRulePropsDialog( QgsRuleBasedLabeling::Rule *rule, QgsVectorLayer *layer,
                                 QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr );
 
+    /**
+     * Returns the current set rule.
+     * \returns The current rule.
+     */
     QgsRuleBasedLabeling::Rule *rule() { return mPropsWidget->rule(); }
 
   public slots:
+
+    /**
+     * Test the filter that is set in the widget
+     */
     void testFilter();
+
+    /**
+     * Open the expression builder widget
+     */
     void buildExpression();
+
+    /**
+     * Apply any changes from the widget to the set rule.
+     */
     void accept() override;
 
   private slots:

--- a/src/gui/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.h
@@ -148,7 +148,11 @@ class GUI_EXPORT QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui:
 
 class QgsLabelingGui;
 
+#include <QDialog>
+#include <QDialogButtonBox>
+
 #include "ui_qgslabelingrulepropswidget.h"
+#include "qgsgui.h"
 
 /**
  * \ingroup gui
@@ -176,7 +180,7 @@ class GUI_EXPORT QgsLabelingRulePropsWidget : public QgsPanelWidget, private Ui:
     //! Apply any changes from the widget to the set rule.
     void apply();
 
-  private slots:
+  public slots:
     void testFilter();
     void buildExpression();
 
@@ -190,5 +194,39 @@ class GUI_EXPORT QgsLabelingRulePropsWidget : public QgsPanelWidget, private Ui:
     QgsMapCanvas *mMapCanvas = nullptr;
 };
 
+/**
+ * \ingroup gui
+ * \class QgsLabelingRulePropsDialog
+ */
+class GUI_EXPORT QgsLabelingRulePropsDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsLabelingRulePropsDialog
+     * \param rule associated rule based labeling rule
+     * \param layer source vector layer
+     * \param parent parent widget
+     * \param mapCanvas map canvas
+     */
+    QgsLabelingRulePropsDialog( QgsRuleBasedLabeling::Rule *rule, QgsVectorLayer *layer,
+                                QWidget *parent = nullptr, QgsMapCanvas *mapCanvas = nullptr );
+
+    QgsRuleBasedLabeling::Rule *rule() { return mPropsWidget->rule(); }
+
+  public slots:
+    void testFilter();
+    void buildExpression();
+    void accept() override;
+
+  private slots:
+    void showHelp();
+
+  private:
+    QgsLabelingRulePropsWidget *mPropsWidget = nullptr;
+    QDialogButtonBox *buttonBox = nullptr;
+};
 
 #endif // QGSRULEBASEDLABELINGWIDGET_H


### PR DESCRIPTION
## Description

Make Edit Rule for rule-based labeling a full-featured dialog with Cancel and Help buttons instead of simple QgsPanel with just Ok button. This makes it consistent with the similar dialog in rule-based rendered and improves UX by allowing users to access manual and close dialog with Esc.

Fixes #36761.