### PR TITLE
Fix missing scrollbars in combo box for value map / relation

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -62,6 +62,7 @@ void QgsValueMapWidgetWrapper::initWidget( QWidget *editor )
   if ( mComboBox )
   {
     QgsValueMapConfigDlg::populateComboBox( mComboBox, config(), false );
+    mComboBox->view()->setVerticalScrollBarPolicy( Qt::ScrollBarAsNeeded );
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),
              this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ) );
   }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -164,6 +164,7 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
 
   if ( mComboBox )
   {
+    mComboBox->view()->setVerticalScrollBarPolicy( Qt::ScrollBarAsNeeded );
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),
              this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ), Qt::UniqueConnection );
   }


### PR DESCRIPTION
If a value map widget or value relation widget has a combo box with many options, the default behavior in Qt is not to add scrollbars, only arrows at the top/bottom of the list. That however makes it quite slow to scroll if the list of choices is long.

This fixes the issue for both value map and value relation. If the list of choices is short that it fits the screen, no scrollbar
gets shown.

Affects at least Windows and Ubuntu users.

To demonstrate the issue - a sample form:

![scrollbar-form](https://user-images.githubusercontent.com/193367/153629084-5390f1d6-8ab9-4ebb-8a4a-2612d65ceb5a.png)

Before (no scrollbar):

![scrollbar-without](https://user-images.githubusercontent.com/193367/153629178-ccb32945-f45c-4bd0-a1f6-43a591df7124.png)

After (with scrollbar):

![scrollbar-with](https://user-images.githubusercontent.com/193367/153629124-04f5638c-e172-407c-b3d6-23c0adf77155.png)

