### PR TITLE
[vectortile] Add a symbol pointer null check

### DIFF
--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -170,7 +170,7 @@ void QgsVectorTileBasicRenderer::renderTile( const QgsVectorTileRendererData &ti
 
   for ( const QgsVectorTileBasicRendererStyle &layerStyle : std::as_const( mStyles ) )
   {
-    if ( !layerStyle.isActive( zoomLevel ) )
+    if ( !layerStyle.isActive( zoomLevel ) || !layerStyle.symbol() )
       continue;
 
     QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Layer" ) ); // will be deleted by popper


### PR DESCRIPTION
## Description

This PR adds a symbol pointer null check to be extra safe and avoid crashers such as (https://github.com/qgis/QGIS/issues/47315)