### PR TITLE
[bug] Fix cad tool when combinin relative values and distance

### DIFF
--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -263,14 +263,14 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
       // perform both to detect errors in constraints
       if ( ctx.xConstraint.locked )
       {
-        const QgsPointXY verticalPt0( ctx.xConstraint.value, point.y() );
-        const QgsPointXY verticalPt1( ctx.xConstraint.value, point.y() + 1 );
+        const QgsPointXY verticalPt0( point.x(), point.y() );
+        const QgsPointXY verticalPt1( point.x(), point.y() + 1 );
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, verticalPt0, verticalPt1, point );
       }
       if ( ctx.yConstraint.locked )
       {
-        const QgsPointXY horizontalPt0( point.x(), ctx.yConstraint.value );
-        const QgsPointXY horizontalPt1( point.x() + 1, ctx.yConstraint.value );
+        const QgsPointXY horizontalPt0( point.x(), point.y() );
+        const QgsPointXY horizontalPt1( point.x() + 1, point.y() );
         res.valid &= QgsGeometryUtils::lineCircleIntersection( previousPt, ctx.distanceConstraint.value, horizontalPt0, horizontalPt1, point );
       }
     }

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -241,7 +241,7 @@ void TestQgsCadUtils::testCommonAngle()
 void TestQgsCadUtils::testDistance()
 {
   QgsCadUtils::AlignMapPointContext context( baseContext() );
-
+  const double distance = 5.0;
   // without distance constraint
   const QgsCadUtils::AlignMapPointOutput res0 = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 20 ), context );
   QVERIFY( res0.valid );
@@ -249,13 +249,13 @@ void TestQgsCadUtils::testDistance()
   QCOMPARE( res0.finalMapPoint, QgsPointXY( 45, 20 ) );
 
   // dist
-  context.distanceConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 5 );
+  context.distanceConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, distance );
   const QgsCadUtils::AlignMapPointOutput res1 = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 20 ), context );
   QVERIFY( res1.valid );
   QCOMPARE( res1.finalMapPoint, QgsPointXY( 35, 20 ) );
 
   // dist+x
-  const double d = 5 * sqrt( 2 ) / 2.;   // sine/cosine of 45 times radius of our distance constraint
+  const double d = distance * sqrt( 2 ) / 2.;   // sine/cosine of 45 times radius of our distance constraint
   const double expectedX1 = 30 + d;
   const double expectedY1 = 20 + d;
   context.xConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, expectedX1 );
@@ -267,6 +267,12 @@ void TestQgsCadUtils::testDistance()
   context.xConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 1000 );
   const QgsCadUtils::AlignMapPointOutput res2x = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 25 ), context );
   QVERIFY( !res2x.valid );
+
+  // dist+rel x
+  context.xConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 0 );
+  const QgsCadUtils::AlignMapPointOutput res2r = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 25 ), context );
+  QVERIFY( res2r.valid );
+  QCOMPARE( res2r.finalMapPoint, QgsPointXY( 30, 20 + distance ) );
 
   // dist+y
   const double expectedX2 = 30 + d;
@@ -281,6 +287,13 @@ void TestQgsCadUtils::testDistance()
   context.yConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 1000 );
   const QgsCadUtils::AlignMapPointOutput res3x = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 15 ), context );
   QVERIFY( !res3x.valid );
+
+  // dist+rel y
+  context.xConstraint = QgsCadUtils::AlignMapPointConstraint();
+  context.yConstraint = QgsCadUtils::AlignMapPointConstraint( true, true, 0 );
+  const QgsCadUtils::AlignMapPointOutput res3r = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 15 ), context );
+  QVERIFY( res3r.valid );
+  QCOMPARE( res3r.finalMapPoint, QgsPointXY( 30 + distance, 20 ) );
 
   // dist+angle
   context.yConstraint = QgsCadUtils::AlignMapPointConstraint();


### PR DESCRIPTION
## Description

This is a proposal for #47013 

The current implementation used the value of the constraint as the x or y value when calculating the intersection. Which lead to no matches despite the rubberbands showing an intersection.

This changes simply uses the values from the point instead of the constraint value. As the values stored in the point previously already take into account wether the value is relative or not, reusing them solves the problem.

TODO test