### PR TITLE
[gui] Fix value map editor widget configuration's load from CSV parsing

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -59,6 +59,13 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
     void updateMap( const QList<QPair<QString, QVariant>> &list, bool insertNull );
 
     /**
+     * Updates the displayed table with the values from a CSV file.
+     * \param filePath the absolute file path of the CSV file.
+     * \since QGIS 3.24
+     */
+    void loadMapFromCSV( const QString &filePath );
+
+    /**
      * Populates a \a comboBox with the appropriate entries based on a value map \a configuration.
      *
      * If \a skipNull is TRUE, then NULL entries will not be added.

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TESTS
   testqgslayoutgui.cpp
   testqgslayoutview.cpp
   testqgsvaluemapwidgetwrapper.cpp
+  testqgsvaluemapconfigdlg.cpp
   testqgsvaluerelationwidgetwrapper.cpp
   testqgsrelationeditorwidget.cpp
   testqgsrelationreferencewidget.cpp

--- a/tests/src/gui/testqgsvaluemapconfigdlg.cpp
+++ b/tests/src/gui/testqgsvaluemapconfigdlg.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+    testqgsvaluemapconfigdlg.cpp
+     --------------------------------------
+    Date                 : 14 02 2021
+    Copyright            : (C) 2019 Stephen Knox
+    Email                : stephenknox73 at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+#include "editorwidgets/qgsvaluemapconfigdlg.h"
+#include "qgsgui.h"
+#include "qgseditorwidgetregistry.h"
+#include "qgsapplication.h"
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+
+class TestQgsValueMapConfigDlg : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsValueMapConfigDlg() = default;
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testLoadFromCSV();
+};
+
+void TestQgsValueMapConfigDlg::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
+}
+
+void TestQgsValueMapConfigDlg::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsValueMapConfigDlg::init()
+{
+}
+
+void TestQgsValueMapConfigDlg::cleanup()
+{
+}
+
+void TestQgsValueMapConfigDlg::testLoadFromCSV()
+{
+  const QString dataDir( TEST_DATA_DIR );
+  QgsVectorLayer vl( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=name:string" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+
+  QList<QVariant> valueList;
+  QVariantMap value;
+  value.insert( QStringLiteral( "Basic unquoted record" ), QString( "1" ) );
+  valueList << value;
+  value.clear();
+  value.insert( QStringLiteral( "Forest type" ), QString( "2" ) );
+  valueList << value;
+  value.clear();
+  value.insert( QStringLiteral( "So-called \"data\"" ), QString( "three" ) );
+  valueList << value;
+  value.clear();
+  value.insert( QStringLiteral( "444" ), QString( "4" ) );
+  valueList << value;
+  value.clear();
+  value.insert( QStringLiteral( "five" ), QString( "5" ) );
+  valueList << value;
+
+  QgsValueMapConfigDlg *valueMapConfig = static_cast<QgsValueMapConfigDlg *>( QgsGui::editorWidgetRegistry()->createConfigWidget( QStringLiteral( "ValueMap" ), &vl, 1, nullptr ) );
+  valueMapConfig->loadMapFromCSV( dataDir + QStringLiteral( "/valuemapsample.csv" ) );
+  QCOMPARE( valueMapConfig->config().value( QStringLiteral( "map" ) ).toList(), valueList );
+  delete valueMapConfig;
+}
+
+QGSTEST_MAIN( TestQgsValueMapConfigDlg )
+#include "testqgsvaluemapconfigdlg.moc"

--- a/tests/testdata/valuemapsample.csv
+++ b/tests/testdata/valuemapsample.csv
@@ -1,0 +1,5 @@
+1,Basic unquoted record,Some description
+2,Forest type,"Quoted data"
+three,"So-called ""data""",Unquoted remark
+4,"444",No comment
+5,five


### PR DESCRIPTION
## Description

This PR fixes the parsing of CSV files for the value map editor widget configuration panel's [ load values from CSV ] button functionality.

The previous code had two big issues. First, it assumed the CSV being loaded *only* contained two columns on each row. This means that a CSV file set up like this: 
```
"key1","my name for key1","some additional description of key1 for future reference when the current guy retires"
```
wouldn't really work. The key was fine but the display value would end up being: `my name for key1","some additional description of key1 for future reference`.

The previous code also didn't handle escaped quotes, i.e. `"So-called ""fires"""`.