### PR TITLE
Avoid crash with read only QgsCheckableComboBox

### DIFF
--- a/src/gui/qgscheckablecombobox.cpp
+++ b/src/gui/qgscheckablecombobox.cpp
@@ -299,6 +299,10 @@ void QgsCheckableComboBox::updateCheckedItems()
 
 void QgsCheckableComboBox::updateDisplayText()
 {
+  // There is only a line edit if the combobox is in editable state
+  if ( !lineEdit() )
+    return;
+
   QString text;
   const QStringList items = checkedItems();
   if ( items.isEmpty() )

--- a/tests/src/python/test_qgscheckablecombobox.py
+++ b/tests/src/python/test_qgscheckablecombobox.py
@@ -56,6 +56,11 @@ class TestQgsCheckableComboBox(unittest.TestCase):
 
         self.assertEqual(len(checkedItemsChanged_spy), 1)
 
+    def test_readonly(self):
+        w = qgis.gui.QgsCheckableComboBox()
+        w.setEditable(False)
+        w.show()  # Should not crash
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Reported in the mailing list by @ghtmtt 

> Hi all,
> 
> I'm using a QgsCheckableComboBox in an UI of a plugin. If I use the flag
> setEditable = False, bot from UI or from code, QGIS simply explodes
> (3.16 from package, 3.23 compiled on a Debian sid OS).
> 
> What is strange, at least for me, is that even by using in a python
> console the following code, QGIS explodes:
> 
> c = QgsCheckableComboBox()
> c.setEditable(False)
> c.show()
> 
> while without the c.setEditable(False) no problem and also the following
> code is working nice:
> 
> c = QComboBox()
> c.setEditable(False)
> c.show()
> 
> Not sure if it is something related to my system. Should I file a ticket?
> 
> Thanks!

The Qt docs say https://doc.qt.io/qt-5/qcombobox.html#lineEdit

> Returns the line edit used to edit items in the combobox, or nullptr if there is no line edit.
> 
> Only editable combo boxes have a line edit.