### PR TITLE
[processing] don't try to dissolve buffer results if there are no features (fix #46396)

### DIFF
--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -161,7 +161,7 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
     current++;
   }
 
-  if ( dissolve )
+  if ( dissolve && !bufferedGeometriesForDissolve.isEmpty() )
   {
     QgsGeometry finalGeometry = QgsGeometry::unaryUnion( bufferedGeometriesForDissolve );
     finalGeometry.convertToMultiType();

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -202,6 +202,7 @@ class TestQgsProcessingAlgs: public QObject
     void extractLabels();
 
     void splitVectorLayer();
+    void buffer();
 
   private:
 
@@ -7254,7 +7255,6 @@ void TestQgsProcessingAlgs::splitVectorLayer()
   std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:splitvectorlayer" ) ) );
   QVERIFY( alg != nullptr );
 
-  //const QString outputDir = QDir::tempPath() + "/split_vector/";
   QDir outputDir( QDir::tempPath() + "/split_vector/" );
   if ( outputDir.exists() )
     outputDir.removeRecursively();
@@ -7276,6 +7276,52 @@ void TestQgsProcessingAlgs::splitVectorLayer()
   QDir dataDir( outputDir );
   QStringList entries = dataDir.entryList( QStringList(), QDir::Files | QDir::NoDotAndDotDot );
   QCOMPARE( entries.count(), 3 );
+}
+
+void TestQgsProcessingAlgs::buffer()
+{
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( layer->isValid() );
+
+  std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:buffer" ) ) );
+  QVERIFY( alg != nullptr );
+
+  // buffering empty layer should produce an empty layer
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "INPUT" ), QVariant::fromValue( layer ) );
+  parameters.insert( QStringLiteral( "DISTANCE" ), 2.0 );
+  parameters.insert( QStringLiteral( "SEGMENTS" ), 5 );
+  parameters.insert( QStringLiteral( "END_CAP_STYLE" ), 0 );
+  parameters.insert( QStringLiteral( "JOIN_STYLE" ), 0 );
+  parameters.insert( QStringLiteral( "MITER_LIMIT" ), 0 );
+  parameters.insert( QStringLiteral( "DISSOLVE" ), false );
+  parameters.insert( QStringLiteral( "OUTPUT" ), QStringLiteral( "memory:" ) );
+
+  bool ok = false;
+  std::unique_ptr< QgsProcessingContext > context = std::make_unique< QgsProcessingContext >();
+  QgsProcessingFeedback feedback;
+  QVariantMap results;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QVERIFY( !results.value( QStringLiteral( "OUTPUT" ) ).toString().isEmpty() );
+  QgsVectorLayer *bufferedLayer = qobject_cast< QgsVectorLayer * >( context->getMapLayer( results.value( QStringLiteral( "OUTPUT" ) ).toString() ) );
+  QVERIFY( bufferedLayer->isValid() );
+  QCOMPARE( bufferedLayer->wkbType(), QgsWkbTypes::MultiPolygon );
+  QCOMPARE( bufferedLayer->featureCount(), layer->featureCount() );
+
+  // buffering empty layer with dissolve should produce an empty layer
+  parameters.insert( QStringLiteral( "DISSOLVE" ), true );
+
+  ok = false;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QVERIFY( !results.value( QStringLiteral( "OUTPUT" ) ).toString().isEmpty() );
+  bufferedLayer = qobject_cast< QgsVectorLayer * >( context->getMapLayer( results.value( QStringLiteral( "OUTPUT" ) ).toString() ) );
+  QVERIFY( bufferedLayer->isValid() );
+  QCOMPARE( bufferedLayer->wkbType(), QgsWkbTypes::MultiPolygon );
+  QCOMPARE( bufferedLayer->featureCount(), layer->featureCount() );
 }
 
 bool TestQgsProcessingAlgs::imageCheck( const QString &testName, const QString &renderedImage )


### PR DESCRIPTION
## Description

Buffering an empty layer with native "Buffer" algorithm produces empty output layer, while the same operation with enabled "Dissolve result" option ends with error message
```
Feature could not be written to Buffered_a03cb901_262a_4ed5_b22c_23aeb10000b1: Could not add feature with geometry type GeometryCollection to layer of type MultiPolygon
Could not write feature into OUTPUT
Execution failed after 0.01 seconds
```
This creates problems when algorithm is used as part of a model. For consistence it is better to produce empty layer in both cases.

Fixes #46396.