### PR TITLE
Fix crash when opening projects and a custom bad layer handler has been set

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -942,7 +942,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
       tr( "Multiple instances of QGIS application object detected.\nPlease contact the developers.\n" ) );
     abort();
   }
-  mSkipBadLayers = skipBadLayers;
+
   sInstance = this;
   QgsRuntimeProfiler *profiler = QgsApplication::profiler();
 
@@ -1488,7 +1488,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsHtmlDataItemProvider() );
 
   // set handler for missing layers (will be owned by QgsProject)
-  if ( !mSkipBadLayers )
+  if ( !skipBadLayers )
   {
     QgsDebugMsgLevel( QStringLiteral( "Creating bad layers handler" ), 2 );
     mAppBadLayersHandler = new QgsHandleBadLayersHandler();
@@ -7042,9 +7042,8 @@ bool QgisApp::addProject( const QString &projectFile )
   QObject connectionScope; // manually control scope of layersChanged lambda connection - we need the connection automatically destroyed when this function finishes
 
   bool badLayersHandled = false;
-  if ( !mSkipBadLayers )
+  if ( mAppBadLayersHandler )
   {
-    QgsDebugMsg( QStringLiteral( "NOT Skipping bad layers" ) );
     connect( mAppBadLayersHandler, &QgsHandleBadLayersHandler::layersChanged, &connectionScope, [&badLayersHandled] { badLayersHandled = true; } );
   }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2141,8 +2141,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activeLayerChanged( QgsMapLayer *layer );
 
   private:
-    //Flag to allow user to bypass badlayer checks.
-    bool mSkipBadLayers;
+
     void createPreviewImage( const QString &path, const QIcon &overlayIcon = QIcon() );
     void startProfile( const QString &name );
     void endProfile();
@@ -2763,7 +2762,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     std::unique_ptr<QgsGeometryValidationService> mGeometryValidationService;
     QgsGeometryValidationModel *mGeometryValidationModel = nullptr;
     QgsGeometryValidationDock *mGeometryValidationDock = nullptr;
-    QgsHandleBadLayersHandler *mAppBadLayersHandler = nullptr;
+    QPointer< QgsHandleBadLayersHandler > mAppBadLayersHandler;
 
     std::unique_ptr< QgsBearingNumericFormat > mBearingNumericFormat;
 


### PR DESCRIPTION
Since setting a custom bad layer handler via QgsProject::setBadLayerHandler will delete the previous bad layer handler, we can't be sure that the QgisApp::mAppBadLayersHandler pointer is pointing to an object which still exists.

Change QgisApp::mAppBadLayersHandler to a weak pointer instead, and cleanup some related code to suit.

(not a new regression, can be reproduced back in 3.16 too)
