### PR TITLE
Add QgsFields()['field_name'] getter for PyQGIS

### DIFF
--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -151,6 +151,20 @@ Returns if a field index is valid
       sipRes = new QgsField( sipCpp->operator[]( idx ) );
 %End
 
+    SIP_PYOBJECT __getitem__( const QString &name ) const /TypeHint="QgsField"/;
+%MethodCode
+    const int fieldIdx = sipCpp->lookupField( *a0 );
+    if ( fieldIdx == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, a0->toLatin1() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipRes = sipConvertFromType( new QgsField( sipCpp->at( fieldIdx ) ), sipType_QgsField, Py_None );
+    }
+%End
+
 
     QgsField at( int i ) const /Factory/;
 %Docstring

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -195,6 +195,22 @@ class CORE_EXPORT  QgsFields
     % End
 #endif
 
+#ifdef SIP_RUN
+    SIP_PYOBJECT __getitem__( const QString &name ) const SIP_TYPEHINT( QgsField );
+    % MethodCode
+    const int fieldIdx = sipCpp->lookupField( *a0 );
+    if ( fieldIdx == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, a0->toLatin1() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipRes = sipConvertFromType( new QgsField( sipCpp->at( fieldIdx ) ), sipType_QgsField, Py_None );
+    }
+    % End
+#endif
+
 #ifndef SIP_RUN
 
     /**

--- a/tests/src/python/test_qgsfields.py
+++ b/tests/src/python/test_qgsfields.py
@@ -45,6 +45,13 @@ class TestQgsFields(unittest.TestCase):
             fields[111]
 
         # check no error
+        self.assertEqual("value", fields['value'].name())
+        self.assertEqual("id", fields['ID'].name())
+        # check exceptions raised
+        with self.assertRaises(KeyError):
+            fields['arg']
+
+        # check no error
         fields.at(1)
         # check exceptions raised
         with self.assertRaises(KeyError):


### PR DESCRIPTION
A nice shorthand way to retrieve a field definition by name, instead of having to determine the field index first.
