### PR TITLE
[QgsQuick] Add signal when user interacts with map canvas

### DIFF
--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -65,7 +65,6 @@ Item {
   signal longPressReleased()
 
   //! Emitted when user does some interaction with map canvas (pan, zoom)
-  //! This is helpful to determine whether the map extent changed programatically or by user interaction
   signal userInteractedWithMap()
 
   /**

--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -64,6 +64,10 @@ Item {
   //! Emitted when a release happens after a long press
   signal longPressReleased()
 
+  //! Emitted when user does some interaction with map canvas (pan, zoom)
+  //! This is helpful to determine whether the map extent changed programatically or by user interaction
+  signal userInteractedWithMap()
+
   /**
    * Freezes the map canvas refreshes.
    *
@@ -78,6 +82,8 @@ Item {
   function freeze(id) {
     mapCanvasWrapper.__freezecount[id] = true
     mapCanvasWrapper.freeze = true
+
+    userInteractedWithMap()
   }
 
   function unfreeze(id) {
@@ -329,6 +335,8 @@ Item {
       {
         zoomOut(point.position)
       }
+
+      userInteractedWithMap()
     }
   }
 }


### PR DESCRIPTION
Added new (missing) signal to `qgsquickmapcanvas.qml` component that is emitted when user interacts with map canvas.
This signal is handy to determine whether map canvas's extent was changed programatically or by user interaction.

It is a QML only change.

Would love to see it in 3.22 if possible, thanks!