### PR TITLE
Temporarily add smani/mingw-extras COPR repo for dependencies missing in rawhide

### DIFF
--- a/ms-windows/mingw/mingwdeps.sh
+++ b/ms-windows/mingw/mingwdeps.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+dnf install -y 'dnf-command(config-manager)' && \
+dnf config-manager --add-repo https://copr.fedorainfracloud.org/coprs/smani/mingw-extras/repo/fedora-rawhide/smani-mingw-extras-fedora-rawhide.repo && \
 dnf install -y --nogpgcheck \
   mingw64-dlfcn \
   mingw64-exiv2 \


### PR DESCRIPTION
Two dependencies are pending review and not yet in the rawhide repos, so I've temporarily built them in a separate COPR repo to unbreak the mingw CI job.

Note: if there are any Fedora packagers reading this, I'd very much welcome the review of

- https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2053753 - mingw-python-charset-normalizer - needed for mingw-python-requests
- https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2053761 - mingw-pyproj - needed for mingw-python-OWSLib
