### PR TITLE
Wrong text in warning message

### DIFF
--- a/src/gui/qgscrsdefinitionwidget.cpp
+++ b/src/gui/qgscrsdefinitionwidget.cpp
@@ -228,7 +228,7 @@ void QgsCrsDefinitionWidget::pbnCalculate_clicked()
   if ( !okN || !okE )
   {
     QMessageBox::warning( this, tr( "Custom Coordinate Reference System" ),
-                          tr( "Northing and Easting must be in decimal form." ) );
+                          tr( "Latitude and Longitude must be in decimal form." ) );
     mProjectedXLabel->clear();
     mProjectedYLabel->clear();
     return;


### PR DESCRIPTION
There are northing/easting instead of latitude/longitude. Parent dialog has labels "Latitude" and "Longitude" (and they are controlled in this warning), not "Northing" and "Easting".

![image](https://user-images.githubusercontent.com/9954197/154061035-c3da55f4-3bf3-49c5-abea-66f9210ddcf0.png)
