### PR TITLE
export usage when exporting WMS XYZ raster layer

### DIFF
--- a/src/core/raster/qgsrasterfilewritertask.cpp
+++ b/src/core/raster/qgsrasterfilewritertask.cpp
@@ -42,6 +42,9 @@ QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &wri
   , mFeedback( new QgsRasterBlockFeedback() )
   , mTransformContext( transformContext )
 {
+  QgsRenderContext renderContext;
+  renderContext.setRendererUsage( Qgis::RendererUsage::Export );
+  mFeedback->setRenderContext( renderContext );
 }
 
 QgsRasterFileWriterTask::~QgsRasterFileWriterTask() = default;


### PR DESCRIPTION
following #46731, the case of exporting raster file was not cover.
