### PR TITLE
[backport] don't try to dissolve buffer results if there are no features (fix #46396)

### DIFF
--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -161,7 +161,7 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
     current++;
   }
 
-  if ( dissolve )
+  if ( dissolve && !bufferedGeometriesForDissolve.isEmpty() )
   {
     QgsGeometry finalGeometry = QgsGeometry::unaryUnion( bufferedGeometriesForDissolve );
     finalGeometry.convertToMultiType();


### PR DESCRIPTION
## Description

Buffering an empty layer with native "Buffer" algorithm produces empty output layer, while the same operation with enabled "Dissolve result" option ends with error message
```
Feature could not be written to Buffered_a03cb901_262a_4ed5_b22c_23aeb10000b1: Could not add feature with geometry type GeometryCollection to layer of type MultiPolygon
Could not write feature into OUTPUT
Execution failed after 0.01 seconds
```
This creates problems when algorithm is used as part of a model. For consistence it is better to produce empty layer in both cases. Fixes #46396.

Manual backport of #47348.