### PR TITLE
Avoid modal dialogs in relation reference /  relation editor

### DIFF
--- a/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -28,7 +28,7 @@ This method calls the addFeature method of the backend :py:class:`QgsVectorLayer
 :param layer: The layer to which the feature should be added
 :param defaultValues: Default values for the feature to add
 :param defaultGeometry: A default geometry to add to the feature
-:param feat: A pointer to the feature
+:param feature: A pointer to the feature
 :param parentWidget: The widget calling this function to be passed to the used dialog
 :param showModal: If the used dialog should be modal or not
 :param hideParent: If the parent widget should be hidden, when the used dialog is opened

--- a/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -20,7 +20,7 @@ class QgsTrackedVectorLayerTools : QgsVectorLayerTools
 Constructor for QgsTrackedVectorLayerTools.
 %End
 
-    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature ) const;
+    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature, QWidget *parentWidget = 0, bool showModal = true, bool hideParent = false ) const;
 
     virtual bool startEditing( QgsVectorLayer *layer ) const;
 

--- a/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgstrackedvectorlayertools.sip.in
@@ -22,6 +22,19 @@ Constructor for QgsTrackedVectorLayerTools.
 
     virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature, QWidget *parentWidget = 0, bool showModal = true, bool hideParent = false ) const;
 
+%Docstring
+This method calls the addFeature method of the backend :py:class:`QgsVectorLayerTools`
+
+:param layer: The layer to which the feature should be added
+:param defaultValues: Default values for the feature to add
+:param defaultGeometry: A default geometry to add to the feature
+:param feat: A pointer to the feature
+:param parentWidget: The widget calling this function to be passed to the used dialog
+:param showModal: If the used dialog should be modal or not
+:param hideParent: If the parent widget should be hidden, when the used dialog is opened
+
+:return: ``True`` in case of success, ``False`` if the operation failed/was aborted
+%End
     virtual bool startEditing( QgsVectorLayer *layer ) const;
 
     virtual bool stopEditing( QgsVectorLayer *layer, bool allowCancel ) const;

--- a/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
@@ -35,6 +35,9 @@ This method should/will be called, whenever a new feature will be added to the l
 :param layer: The layer to which the feature should be added
 :param defaultValues: Default values for the feature to add
 :param defaultGeometry: A default geometry to add to the feature
+:param parentWidget: The widget calling this function to be passed to the used dialog
+:param showModal: If the used dialog should be modal or not
+:param hideParent: If the parent widget should be hidden, when the used dialog is opened
 
 :return: - ``True`` in case of success, ``False`` if the operation failed/was aborted
          - feature: Updated feature after adding will be written back to this

--- a/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayertools.sip.in
@@ -28,7 +28,7 @@ in your application.
     QgsVectorLayerTools();
 
 
-    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues = QgsAttributeMap(), const QgsGeometry &defaultGeometry = QgsGeometry(), QgsFeature *feature /Out/ = 0 ) const = 0;
+    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues = QgsAttributeMap(), const QgsGeometry &defaultGeometry = QgsGeometry(), QgsFeature *feature /Out/ = 0, QWidget *parentWidget = 0, bool showModal = true, bool hideParent = false ) const = 0;
 %Docstring
 This method should/will be called, whenever a new feature will be added to the layer
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -320,21 +320,23 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
 
 void QgsFeatureAction::hideParentWidget()
 {
-  if ( parentWidget() )
+  QWidget *dialog = parentWidget();
+  if ( dialog )
   {
-    QWidget *dialog = parentWidget()->parentWidget();
-    if ( dialog && dialog->window()->objectName() != QStringLiteral( "QgisApp" ) )
-      dialog->window()->setVisible( false );
+    QWidget *triggerWidget = dialog->parentWidget();
+    if ( triggerWidget && triggerWidget->window()->objectName() != QStringLiteral( "QgisApp" ) )
+      triggerWidget->window()->setVisible( false );
   }
 }
 
 void QgsFeatureAction::unhideParentWidget()
 {
-  if ( parentWidget() )
+  QWidget *dialog = parentWidget();
+  if ( dialog )
   {
-    QWidget *dialog = parentWidget()->parentWidget();
-    if ( dialog )
-      dialog->window()->setVisible( true );
+    QWidget *triggerWidget = dialog->parentWidget();
+    if ( triggerWidget )
+      triggerWidget->window()->setVisible( true );
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -320,17 +320,21 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
 
 void QgsFeatureAction::hideParentWidget()
 {
-  if ( parentWidget() && parentWidget()->parentWidget() && parentWidget()->parentWidget()->window()->objectName() != QStringLiteral( "QgisApp" ) )
+  if ( parentWidget() )
   {
-    parentWidget()->parentWidget()->window()->setVisible( false );
+    QWidget *dialog = parentWidget()->parentWidget();
+    if ( dialog && dialog->window()->objectName() != QStringLiteral( "QgisApp" ) )
+      dialog->window()->setVisible( false );
   }
 }
 
 void QgsFeatureAction::unhideParentWidget()
 {
-  if ( parentWidget() && parentWidget()->parentWidget() )
+  if ( parentWidget() )
   {
-    parentWidget()->parentWidget()->window()->setVisible( true );
+    QWidget *dialog = parentWidget()->parentWidget();
+    if ( dialog )
+      dialog->window()->setVisible( true );
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -99,7 +99,6 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
         connect( pb, &QAbstractButton::clicked, a, &QgsFeatureAction::execute );
     }
   }
-
   return dialog;
 }
 
@@ -168,7 +167,7 @@ bool QgsFeatureAction::editFeature( bool showModal )
   return true;
 }
 
-bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, QgsExpressionContextScope *scope SIP_TRANSFER )
+bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, bool showModal, QgsExpressionContextScope *scope SIP_TRANSFER, bool hideParent )
 {
   if ( !mLayer || !mLayer->isEditable() )
     return false;
@@ -254,7 +253,6 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
   }
   else
   {
-
     QgsAttributeDialog *dialog = newDialog( false );
     // delete the dialog when it is closed
     dialog->setAttribute( Qt::WA_DeleteOnClose );
@@ -270,6 +268,12 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap &defaultAttributes, boo
       setParent( dialog ); // keep dialog until the dialog is closed and destructed
       connect( dialog, &QgsAttributeDialog::finished, this, &QgsFeatureAction::addFeatureFinished );
       dialog->show();
+
+      if ( hideParent )
+      {
+        connect( this, &QgsFeatureAction::addFeatureFinished, this, &QgsFeatureAction::unhideParentWidget );
+        hideParentWidget();
+      }
       mFeature = nullptr;
       return true;
     }
@@ -311,6 +315,22 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
       QgsDebugMsg( QStringLiteral( "saving %1 for %2" ).arg( ( *sLastUsedValues() )[ mLayer ][idx].toString() ).arg( idx ) );
       ( *sLastUsedValues() )[ mLayer ][idx] = newValues.at( idx );
     }
+  }
+}
+
+void QgsFeatureAction::hideParentWidget()
+{
+  if ( parentWidget() && parentWidget()->parentWidget() )
+  {
+    parentWidget()->parentWidget()->window()->setVisible( false );
+  }
+}
+
+void QgsFeatureAction::unhideParentWidget()
+{
+  if ( parentWidget() && parentWidget()->parentWidget() )
+  {
+    parentWidget()->parentWidget()->window()->setVisible( true );
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -320,7 +320,7 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
 
 void QgsFeatureAction::hideParentWidget()
 {
-  if ( parentWidget() && parentWidget()->parentWidget() )
+  if ( parentWidget() && parentWidget()->parentWidget() && parentWidget()->parentWidget()->window()->objectName() != QStringLiteral( "QgisApp" ) )
   {
     parentWidget()->parentWidget()->window()->setVisible( false );
   }

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -49,6 +49,9 @@ class APP_EXPORT QgsFeatureAction : public QAction
      * and override with values in defaultAttributes if provided.
      *
      * \param defaultAttributes  Provide some default attributes here if desired.
+     * \param scope              Scope of the expression
+     * \param showModal          If the used dialog should be modal or not
+     * \param hideParent         If the parent widget should be hidden, when the used dialog is opened
      *
      * \returns TRUE if feature was added if showModal is true. If showModal is FALSE, returns TRUE in every case
      */
@@ -88,7 +91,6 @@ class APP_EXPORT QgsFeatureAction : public QAction
     QgsVectorLayer *mLayer = nullptr;
     QgsFeature *mFeature = nullptr;
     QUuid mActionId;
-    QWidget *mParentWidget = nullptr;
     int mIdx;
 
     bool mFeatureSaved;

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
      *
      * \returns TRUE if feature was added if showModal is true. If showModal is FALSE, returns TRUE in every case
      */
-    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true, QgsExpressionContextScope *scope = nullptr );
+    bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true, QgsExpressionContextScope *scope = nullptr, bool hideParent = false );
 
     /**
      * Sets whether to force suppression of the attribute form popup after creating a new feature.
@@ -79,6 +79,8 @@ class APP_EXPORT QgsFeatureAction : public QAction
 
   private slots:
     void onFeatureSaved( const QgsFeature &feature );
+    void unhideParentWidget();
+    void hideParentWidget();
 
   private:
     QgsAttributeDialog *newDialog( bool cloneFeature );
@@ -86,6 +88,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
     QgsVectorLayer *mLayer = nullptr;
     QgsFeature *mFeature = nullptr;
     QUuid mActionId;
+    QWidget *mParentWidget = nullptr;
     int mIdx;
 
     bool mFeatureSaved;

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -38,11 +38,10 @@ bool QgsGuiVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttribu
   f->setGeometry( defaultGeometry );
   QgsFeatureAction *a = new QgsFeatureAction( tr( "Add feature" ), *f, layer, QString(), -1, parentWidget );
   a->setForceSuppressFormPopup( forceSuppressFormPopup() );
+  connect( a, &QgsFeatureAction::addFeatureFinished, a, &QObject::deleteLater );
   const bool added = a->addFeature( defaultValues, showModal, nullptr, hideParent );
   if ( !feat )
     delete f;
-  if ( showModal )
-    delete a;
   return added;
 }
 

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -29,19 +29,20 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 
-bool QgsGuiVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat ) const
+bool QgsGuiVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat, QWidget *parentWidget, bool showModal, bool hideParent ) const
 {
   QgsFeature *f = feat;
   if ( !feat )
     f = new QgsFeature();
 
   f->setGeometry( defaultGeometry );
-  QgsFeatureAction a( tr( "Add feature" ), *f, layer );
-  a.setForceSuppressFormPopup( forceSuppressFormPopup() );
-  const bool added = a.addFeature( defaultValues );
+  QgsFeatureAction *a = new QgsFeatureAction( tr( "Add feature" ), *f, layer, QString(), -1, parentWidget );
+  a->setForceSuppressFormPopup( forceSuppressFormPopup() );
+  const bool added = a->addFeature( defaultValues, showModal, nullptr, hideParent );
   if ( !feat )
     delete f;
-
+  if ( showModal )
+    delete a;
   return added;
 }
 

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -43,7 +43,7 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools
      *
      * \returns                TRUE in case of success, FALSE if the operation failed/was aborted
      */
-    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat = nullptr ) const override;
+    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat = nullptr, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const ;
 
     /**
      * This should be called, whenever a vector layer should be switched to edit mode. If successful

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -40,10 +40,14 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools
      * \param layer           The layer to which the feature should be added
      * \param defaultValues   Default values for the feature to add
      * \param defaultGeometry A default geometry to add to the feature
+     * \param feat            A pointer to the feature
+     * \param parentWidget    The widget calling this function to be passed to the used dialog
+     * \param showModal       If the used dialog should be modal or not
+     * \param hideParent      If the parent widget should be hidden, when the used dialog is opened
      *
      * \returns                TRUE in case of success, FALSE if the operation failed/was aborted
      */
-    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat = nullptr, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const ;
+    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feat = nullptr, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const override;
 
     /**
      * This should be called, whenever a vector layer should be switched to edit mode. If successful

--- a/src/core/qgstrackedvectorlayertools.cpp
+++ b/src/core/qgstrackedvectorlayertools.cpp
@@ -17,7 +17,7 @@
 #include "qgsvectorlayer.h"
 
 
-bool QgsTrackedVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature ) const
+bool QgsTrackedVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature, QWidget *parentWidget, bool showModal, bool hideParent ) const
 {
   QgsFeature *f = feature;
   if ( !feature )
@@ -25,7 +25,7 @@ bool QgsTrackedVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAtt
 
   const_cast<QgsVectorLayerTools *>( mBackend )->setForceSuppressFormPopup( forceSuppressFormPopup() );
 
-  if ( mBackend->addFeature( layer, defaultValues, defaultGeometry, f ) )
+  if ( mBackend->addFeature( layer, defaultValues, defaultGeometry, f, parentWidget, showModal, hideParent ) )
   {
     mAddedFeatures[layer].insert( f->id() );
     if ( !feature )

--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
      * \param layer           The layer to which the feature should be added
      * \param defaultValues   Default values for the feature to add
      * \param defaultGeometry A default geometry to add to the feature
-     * \param feat            A pointer to the feature
+     * \param feature         A pointer to the feature
      * \param parentWidget    The widget calling this function to be passed to the used dialog
      * \param showModal       If the used dialog should be modal or not
      * \param hideParent      If the parent widget should be hidden, when the used dialog is opened

--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -33,6 +33,19 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
      */
     QgsTrackedVectorLayerTools() = default;
 
+    /**
+     * This method calls the addFeature method of the backend QgsVectorLayerTools
+     *
+     * \param layer           The layer to which the feature should be added
+     * \param defaultValues   Default values for the feature to add
+     * \param defaultGeometry A default geometry to add to the feature
+     * \param feat            A pointer to the feature
+     * \param parentWidget    The widget calling this function to be passed to the used dialog
+     * \param showModal       If the used dialog should be modal or not
+     * \param hideParent      If the parent widget should be hidden, when the used dialog is opened
+     *
+     * \returns               TRUE in case of success, FALSE if the operation failed/was aborted
+     */
     bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const override;
     bool startEditing( QgsVectorLayer *layer ) const override;
     bool stopEditing( QgsVectorLayer *layer, bool allowCancel ) const override;

--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -33,7 +33,7 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
      */
     QgsTrackedVectorLayerTools() = default;
 
-    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature ) const override;
+    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues, const QgsGeometry &defaultGeometry, QgsFeature *feature, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const override;
     bool startEditing( QgsVectorLayer *layer ) const override;
     bool stopEditing( QgsVectorLayer *layer, bool allowCancel ) const override;
     bool saveEdits( QgsVectorLayer *layer ) const override;

--- a/src/core/vector/qgsvectorlayertools.h
+++ b/src/core/vector/qgsvectorlayertools.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      * \returns                TRUE in case of success, FALSE if the operation failed/was aborted
      *
      */
-    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues = QgsAttributeMap(), const QgsGeometry &defaultGeometry = QgsGeometry(), QgsFeature *feature SIP_OUT = nullptr ) const = 0;
+    virtual bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &defaultValues = QgsAttributeMap(), const QgsGeometry &defaultGeometry = QgsGeometry(), QgsFeature *feature SIP_OUT = nullptr, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const = 0;
 
     // TODO QGIS 4: remove const qualifier
 

--- a/src/core/vector/qgsvectorlayertools.h
+++ b/src/core/vector/qgsvectorlayertools.h
@@ -52,6 +52,9 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      * \param defaultValues   Default values for the feature to add
      * \param defaultGeometry A default geometry to add to the feature
      * \param feature         Updated feature after adding will be written back to this
+     * \param parentWidget    The widget calling this function to be passed to the used dialog
+     * \param showModal       If the used dialog should be modal or not
+     * \param hideParent      If the parent widget should be hidden, when the used dialog is opened
      * \returns                TRUE in case of success, FALSE if the operation failed/was aborted
      *
      */

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -536,8 +536,8 @@ void QgsRelationReferenceWidget::openForm()
     return;
 
   QgsAttributeEditorContext context( mEditorContext, mRelation, QgsAttributeEditorContext::Single, QgsAttributeEditorContext::StandaloneDialog );
-  QgsAttributeDialog attributeDialog( mReferencedLayer, new QgsFeature( feat ), true, this, true, context );
-  attributeDialog.exec();
+  QgsAttributeDialog *attributeDialog = new QgsAttributeDialog( mReferencedLayer, new QgsFeature( feat ), true, this, true, context );
+  attributeDialog->show();
 }
 
 void QgsRelationReferenceWidget::highlightFeature( QgsFeature f, CanvasExtent canvasExtent )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -908,7 +908,7 @@ void QgsRelationReferenceWidget::entryAdded( const QgsFeature &feat )
     }
   }
 
-  if ( mEditorContext.vectorLayerTools()->addFeature( mReferencedLayer, attributes, f.geometry(), &f ) )
+  if ( mEditorContext.vectorLayerTools()->addFeature( mReferencedLayer, attributes, f.geometry(), &f, this, false, true ) )
   {
     QVariantList attrs;
     for ( const QString &fieldName : std::as_const( mReferencedFields ) )

--- a/src/gui/qgsabstractrelationeditorwidget.cpp
+++ b/src/gui/qgsabstractrelationeditorwidget.cpp
@@ -241,7 +241,7 @@ QgsFeatureIds QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &ge
     // n:m Relation: first let the user create a new feature on the other table
     // and autocreate a new linking feature.
     QgsFeature finalFeature;
-    if ( !vlTools->addFeature( mNmRelation.referencedLayer(), QgsAttributeMap(), geometry, &finalFeature ) )
+    if ( !vlTools->addFeature( mNmRelation.referencedLayer(), QgsAttributeMap(), geometry, &finalFeature, this, false, true ) )
       return QgsFeatureIds();
 
     addedFeatureIds.insert( finalFeature.id() );
@@ -280,7 +280,7 @@ QgsFeatureIds QgsAbstractRelationEditorWidget::addFeature( const QgsGeometry &ge
       keyAttrs.insert( fields.indexFromName( fieldPair.referencingField() ), mFeatureList.first().attribute( fieldPair.referencedField() ) );
 
     QgsFeature linkFeature;
-    if ( !vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry, &linkFeature ) )
+    if ( !vlTools->addFeature( mRelation.referencingLayer(), keyAttrs, geometry, &linkFeature, this, false, true ) )
       return QgsFeatureIds();
 
     addedFeatureIds.insert( linkFeature.id() );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -430,7 +430,10 @@ void QgsRelationEditorWidget::addFeatureGeometry()
   mMapToolDigitize->setLayer( layer );
 
   // window is always on top, so we hide it to digitize without seeing it
-  window()->setVisible( false );
+  if ( window()->objectName() != QStringLiteral( "QgisApp" ) )
+  {
+    window()->setVisible( false );
+  }
   setMapTool( mMapToolDigitize );
 
   connect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
@@ -450,9 +453,6 @@ void QgsRelationEditorWidget::addFeatureGeometry()
 
 void QgsRelationEditorWidget::onDigitizingCompleted( const QgsFeature &feature )
 {
-  window()->setVisible( true );
-  window()->raise();
-  window()->activateWindow();
   QgsAbstractRelationEditorWidget::addFeature( feature.geometry() );
 
   unsetMapTool();

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -450,6 +450,9 @@ void QgsRelationEditorWidget::addFeatureGeometry()
 
 void QgsRelationEditorWidget::onDigitizingCompleted( const QgsFeature &feature )
 {
+  window()->setVisible( true );
+  window()->raise();
+  window()->activateWindow();
   QgsAbstractRelationEditorWidget::addFeature( feature.geometry() );
 
   unsetMapTool();
@@ -780,16 +783,15 @@ void QgsRelationEditorWidget::onKeyPressed( QKeyEvent *e )
 {
   if ( e->key() == Qt::Key_Escape )
   {
+    window()->setVisible( true );
+    window()->raise();
+    window()->activateWindow();
     unsetMapTool();
   }
 }
 
 void QgsRelationEditorWidget::mapToolDeactivated()
 {
-  window()->setVisible( true );
-  window()->raise();
-  window()->activateWindow();
-
   if ( mEditorContext.mainMessageBar() && mMessageBarItem )
   {
     mEditorContext.mainMessageBar()->popWidget( mMessageBarItem );

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -582,8 +582,11 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
 // referenced layer
 class DummyVectorLayerTools : public QgsVectorLayerTools // clazy:exclude=missing-qobject-macro
 {
-    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &, const QgsGeometry &, QgsFeature *feat = nullptr ) const override
+    bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &, const QgsGeometry &, QgsFeature *feat = nullptr, QWidget *parentWidget = nullptr, bool showModal = true, bool hideParent = false ) const override
     {
+      Q_UNUSED( parentWidget );
+      Q_UNUSED( showModal );
+      Q_UNUSED( hideParent );
       feat->setAttribute( QStringLiteral( "pk" ), 13 );
       feat->setAttribute( QStringLiteral( "material" ), QStringLiteral( "steel" ) );
       feat->setAttribute( QStringLiteral( "diameter" ), 140 );

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -342,7 +342,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         # Mock vector layer tool to just set default value on created feature
         class DummyVlTools(QgsVectorLayerTools):
 
-            def addFeature(self, layer, defaultValues, defaultGeometry):
+            def addFeature(self, layer, defaultValues, defaultGeometry, parentWidget=None, showModal=True, hideParent=False):
                 f = QgsFeature(layer.fields())
                 for idx, value in defaultValues.items():
                     f.setAttribute(idx, value)
@@ -441,7 +441,7 @@ class VlTools(QgsVectorLayerTools):
         """
         self.values = values
 
-    def addFeature(self, layer, defaultValues, defaultGeometry):
+    def addFeature(self, layer, defaultValues, defaultGeometry, parentWidget=None, showModal=True, hideParent=False):
         """
         Overrides the addFeature method
         :param layer: vector layer


### PR DESCRIPTION
## Description
The dialogs opened over relation reference widget / relation editor widget used to be modal. This means only the one on top stayed active and the rest was disabled. This leaded to issues when you need to use the map canvas. Like on adding child or parent features with geometries. First level worked, but not when you needed to add a child of a child (or a child of a parent etc.) It ended up in a crash on the relation editor dialog and on a blocked canvas in the relation reference dialog. See #47193

This implementation provides the possibility to create a non-modal dialog over the `QgsGuiVectorTools` by passing the parent widget to the `QgsFeatureAction`. With this the dialog created in `QgsFeatureAction` receives the same parent widget and is now the parent of `QgsFeatureAction`. So if one gets closed, the child object close as well.

To avoid confusions with several opened dialog (when you create a child of a child etc.) the parent widget's widow is hidden immediately on opening the new dialog. This will look like this:
![visibility](https://user-images.githubusercontent.com/28384354/154247122-8fa56920-8632-4e21-a873-adbd34265363.gif)


This implementation fixes:
- #47193
- #47388
