### PR TITLE
Re-use possibly cached postgis_version from pgsql description method

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4842,17 +4842,14 @@ QString  QgsPostgresProvider::description() const
   {
     QgsPostgresResult result;
 
+    /* TODO: expose a cached QgsPostgresConn::version() ? */
     result = lConnectionRO->PQexec( QStringLiteral( "SELECT version()" ) );
     if ( result.PQresultStatus() == PGRES_TUPLES_OK )
     {
       pgVersion = result.PQgetvalue( 0, 0 );
     }
 
-    result = lConnectionRO->PQexec( QStringLiteral( "SELECT postgis_version()" ) );
-    if ( result.PQresultStatus() == PGRES_TUPLES_OK )
-    {
-      postgisVersion = result.PQgetvalue( 0, 0 );
-    }
+    postgisVersion = lConnectionRO->postgisVersion();
   }
   else
   {


### PR DESCRIPTION
While trying to fix multiple `postgis_version()` queries from DBManager TopoViewer plugin I spotted code in qgspostgresprovider.cpp locally calling `postgis_version()` rather than fetching that info from the QgsPostgresConn associated object (which is possibly cached).

This change does NOT fix #47391 but seems to be a good change to me, in general (reduces code duplication).