### PR TITLE
Fix infinite tiles reloading of chunked entites

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -176,20 +176,15 @@ void QgsChunkedEntity::update( const SceneState &state )
   }
 
   // unload nodes that have their entities disabled or can be culled
-  while ( mReplacementQueue->count() + mChunkLoaderQueue->count() > mMaxLoadedChunks )
+  while ( mReplacementQueue->count() > mMaxLoadedChunks )
   {
     QgsChunkListEntry *entry = mReplacementQueue->last();
-    if ( ( entry->chunk->entity() && !entry->chunk->entity()->isEnabled() ) || Qgs3DUtils::isCullable( entry->chunk->bbox(), state.viewProjectionMatrix ) )
-    {
-      entry = mReplacementQueue->takeLast();
-      entry->chunk->unloadChunk();  // also deletes the entry
-      mActiveNodes.removeOne( entry->chunk );
-      ++unloaded;
-    }
-    else
-    {
+    if ( !entry->chunk->entity() || entry->chunk->entity()->isEnabled() )
       break;
-    }
+    entry = mReplacementQueue->takeLast();
+    entry->chunk->unloadChunk();  // also deletes the entry
+    mActiveNodes.removeOne( entry->chunk );
+    ++unloaded;
   }
 
   // Disable loading nodes from mChunkLoaderQueue

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -192,7 +192,6 @@ void QgsChunkedEntity::update( const SceneState &state )
   {
     QgsChunkListEntry *entry = mChunkLoaderQueue->takeLast();
     entry->chunk->cancelQueuedForLoad();
-    mActiveNodes.removeOne( entry->chunk );
   }
 
   if ( mBboxesEntity )


### PR DESCRIPTION
## Description
When the maximum loaded chunks value is too small for a scene (the scene contains too many nodes), the tiles keep on loading and unloading.
### Before:
https://youtu.be/FLpKTl72qNA
### After:
https://youtu.be/52dqVfkF4g8

Now if the tiles are too many to be loaded at once, the 3D viewer will converge to a state where no infinite reloading fliquer happens.

### Technical detail:
- Once we find that the number of loaded chunks in an idle state (no entries in mChunkLoaderQueue since all mChunkLoaderQueue entries will be put progressively into mReplacementQueue), we try to remove the nodes that have disabled entites or are cullable and at the end of mReplacementQueue.
- If this is not enough to make the number of nodes in an idle state verifies mReplacementQueue->Count() + mChunkLoaderQueue->count() < mMaxLoadedChunks, we cancel queueing chunks from mChunkLoaderQueue for load.

