### PR TITLE
Test and fix QgsRectangle::isNull

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -27,7 +27,10 @@ Examples are storing a layer extent or the current view extent of a map
 %End
   public:
 
-    QgsRectangle(); // optimised constructor for null rectangle - no need to call normalize here
+    QgsRectangle();
+%Docstring
+Constructor for a null rectangle
+%End
 
     explicit QgsRectangle( double xMin, double yMin = 0, double xMax = 0, double yMax = 0, bool normalize = true ) /HoldGIL/;
 %Docstring

--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -132,13 +132,14 @@ class ClipRasterByExtent(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        arguments = [
-            '-projwin',
-            str(bbox.xMinimum()),
-            str(bbox.yMaximum()),
-            str(bbox.xMaximum()),
-            str(bbox.yMinimum()),
-        ]
+        arguments = []
+
+        if not bbox.isNull():
+            arguments.append('-projwin')
+            arguments.append(str(bbox.xMinimum()))
+            arguments.append(str(bbox.yMaximum()))
+            arguments.append(str(bbox.xMaximum()))
+            arguments.append(str(bbox.yMinimum()))
 
         crs = inLayer.crs()
         if override_crs and crs.isValid():

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -186,6 +186,8 @@ QgsBox3d QgsRectangle::toBox3d( double zMin, double zMax ) const
 
 QgsRectangle QgsRectangle::snappedToGrid( double spacing ) const
 {
+  if ( isNull() ) return *this;
+
   // helper function
   auto gridifyValue = []( double value, double spacing ) -> double
   {

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -140,7 +140,9 @@ QString QgsRectangle::toString( int precision ) const
     }
   }
 
-  if ( isEmpty() )
+  if ( isNull() )
+    rep = QStringLiteral( "Null" );
+  else if ( isEmpty() )
     rep = QStringLiteral( "Empty" );
   else
     rep = QStringLiteral( "%1,%2 : %3,%4" )

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -43,7 +43,12 @@ class CORE_EXPORT QgsRectangle
   public:
 
     //! Constructor for a null rectangle
-    QgsRectangle() = default; // optimised constructor for null rectangle - no need to call normalize here
+    QgsRectangle()
+      : mXmin( std::numeric_limits<double>::max() )
+      , mYmin( std::numeric_limits<double>::max() )
+      , mXmax( -std::numeric_limits<double>::max() )
+      , mYmax( -std::numeric_limits<double>::max() )
+    {}
 
     /**
      * Constructs a QgsRectangle from a set of x and y minimum and maximum coordinates.
@@ -479,8 +484,7 @@ class CORE_EXPORT QgsRectangle
     bool isNull() const
     {
       // rectangle created QgsRectangle() or with rect.setMinimal() ?
-      return ( qgsDoubleNear( mXmin, 0.0 ) && qgsDoubleNear( mXmax, 0.0 ) && qgsDoubleNear( mYmin, 0.0 ) && qgsDoubleNear( mYmax, 0.0 ) ) ||
-             ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
+      return ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
                qgsDoubleNear( mXmax, -std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmax, -std::numeric_limits<double>::max() ) );
     }
 

--- a/tests/src/core/geometry/testqgsmultipoint.cpp
+++ b/tests/src/core/geometry/testqgsmultipoint.cpp
@@ -771,7 +771,7 @@ void TestQgsMultiPoint::boundingBox()
   QCOMPARE( mp.boundingBox(), QgsRectangle( 0, 0, 1, 2 ) );
 
   mp.clear();
-  QCOMPARE( mp.boundingBox(), QgsRectangle( 0, 0, 0, 0 ) );
+  QCOMPARE( mp.boundingBox(), QgsRectangle() );
 
   mp.addGeometry( new QgsPoint( 1, 2 ) );
   QCOMPARE( mp.boundingBox(), QgsRectangle( 1, 2, 1, 2 ) );

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -26,6 +26,7 @@ class TestQgsRectangle: public QObject
     Q_OBJECT
   private slots:
     void isEmpty();
+    void isNull();
     void fromWkt();
     void constructor();
     void constructorTwoPoints();
@@ -66,6 +67,23 @@ void TestQgsRectangle::isEmpty()
   r.setYMaximum( 1 );
   QVERIFY( r.isEmpty() );
 }
+
+void TestQgsRectangle::isNull()
+{
+  QgsRectangle r0;
+  QVERIFY( r0.isNull() );
+  QVERIFY( r0.isEmpty() );
+
+  QgsRectangle r2( 1, 1, 1, 1 );
+  QVERIFY( ! r2.isNull() );
+  QVERIFY( r2.isEmpty() );
+
+  QgsRectangle r1( 0, 0, 0, 0 );
+  QVERIFY( ! r1.isNull() );
+  QVERIFY( r1.isEmpty() );
+
+}
+
 
 void TestQgsRectangle::fromWkt()
 {

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -449,7 +449,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             provider_extent = self.source.extent()
             self.source.setSubsetString(None)
             self.assertEqual(count, 0)
-            self.assertTrue(provider_extent.isNull())
+            self.assertTrue(provider_extent.isEmpty())
             self.assertEqual(self.source.featureCount(), 5)
 
     def testUnique(self):

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -128,7 +128,7 @@ class TestQgsRectangle(unittest.TestCase):
 
     def testToString(self):
         """Test the different string representations"""
-        self.assertEqual(QgsRectangle().toString(), 'Empty')
+        self.assertEqual(QgsRectangle().toString(), 'Null')
         rect = QgsRectangle(0, 0.1, 0.2, 0.3)
         self.assertEqual(rect.toString(), '0.0000000000000000,0.1000000000000000 : 0.2000000000000000,0.3000000000000000')
 


### PR DESCRIPTION
Adds tests for QgsRectangle::isNull, improve toString to show the difference between Null and Empty, eventually fix the 0,0,0, rectangle case to still be Empty and NOT Null (to match documentation).

Superceeds #45607

Aims at closing #45563