### PR TITLE
Fix value relation widget can silently change attribute values to NULL

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -27,6 +27,7 @@
 #include "qgsattributes.h"
 #include "qgsjsonutils.h"
 #include "qgspostgresstringutils.h"
+#include "qgsapplication.h"
 
 #include <QHeaderView>
 #include <QComboBox>
@@ -56,13 +57,13 @@ QVariant QgsValueRelationWidgetWrapper::value() const
     if ( cbxIdx > -1 )
     {
       v = mComboBox->currentData();
+      if ( v.isNull() )
+        v = QVariant( field().type() );
     }
   }
-
-  const int nofColumns = columnCount();
-
-  if ( mTableWidget )
+  else if ( mTableWidget )
   {
+    const int nofColumns = columnCount();
     QStringList selection;
     for ( int j = 0; j < mTableWidget->rowCount(); j++ )
     {
@@ -114,8 +115,7 @@ QVariant QgsValueRelationWidgetWrapper::value() const
       v = QgsPostgresStringUtils::buildArray( vl );
     }
   }
-
-  if ( mLineEdit )
+  else if ( mLineEdit )
   {
     for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : std::as_const( mCache ) )
     {
@@ -248,7 +248,24 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
         break;
       }
     }
-    mComboBox->setCurrentIndex( idx );
+
+    if ( idx == -1 )
+    {
+      // if value doesn't exist, we show it in '(...)' (just like value map widget)
+      if ( value.isNull( ) )
+      {
+        mComboBox->setCurrentIndex( -1 );
+      }
+      else
+      {
+        mComboBox->addItem( value.toString().prepend( '(' ).append( ')' ), value );
+        mComboBox->setCurrentIndex( mComboBox->findData( value ) );
+      }
+    }
+    else
+    {
+      mComboBox->setCurrentIndex( idx );
+    }
   }
   else if ( mLineEdit )
   {

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -209,8 +209,12 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   // Move the point to 1.5 0.5
   f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT( 1.5 0.5)" ) ) );
   w_municipality.setFeature( f3 );
-  QCOMPARE( w_municipality.mComboBox->count(), 1 );
+  // this shouldn't force change the existing value, but rather show it as a "invalid" value surrounded by (...)
+  QCOMPARE( w_municipality.value().toInt(), 1 );
+  QCOMPARE( w_municipality.mComboBox->count(), 2 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
+  QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "(1)" ) );
+  QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
 
   // Enlarge the buffer
   cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 3 ), $geometry)" );
@@ -219,6 +223,8 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->count(), 2 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
   QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.value().toInt(), 1 );
+  QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
 
   // Check with allow null
   cfg_municipality[QStringLiteral( "AllowNull" )] = true;
@@ -1643,18 +1649,21 @@ void TestQgsValueRelationWidgetWrapper::testRegressionGH42003()
   w_municipality.setEnabled( true );
 
   w_municipality.setFeature( QgsFeature( vl2.fields() ) );
-  QCoreApplication::processEvents();
+  while ( w_municipality.mComboBox->currentIndex() != 0 )
+    QCoreApplication::processEvents();
 
   // Check first is selected (fid 2 because of OrderByValue)
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 0 );
   QCOMPARE( w_municipality.mComboBox->count(), 2 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
-  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "2" ) );
+  QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.value().toInt(), 2 );
 
   // Simulate what happens in the attribute form initialization
   w_municipality.setFeature( QgsFeature( vl2.fields() ) );
   w_municipality.setFeature( vl2.getFeature( 1 ) );
-  QCoreApplication::processEvents();
+  while ( w_municipality.mComboBox->currentIndex() != 1 )
+    QCoreApplication::processEvents();
 
   // Check fid 1 is selected
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );


### PR DESCRIPTION
if those values are not present in the related table and the user clicks on the attribute cell in an editable attribute table

Copy the same method of handling not present values as we use for the value map editor widget, where these values are shown in the combo box with a "(value)" format.

And add lots of tests covering this.
