### PR TITLE
replace comma in layer name with underscore when exporting layer to DXF (fix #47381)

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2124,6 +2124,9 @@ QString QgsDxfExport::dxfLayerName( const QString &name )
   layerName.replace( '|', '_' );
   layerName.replace( '=', '_' );
   layerName.replace( '\'', '_' );
+  // if layer name contains comma, resulting file is unreadable in AutoCAD
+  // see https://github.com/qgis/QGIS/issues/47381
+  layerName.replace( ',', '_' );
 
   // also remove newline characters (#15067)
   layerName.replace( QLatin1String( "\r\n" ), QLatin1String( "_" ) );


### PR DESCRIPTION
## Description
Commas in layer names result in a DXF file that is unreadable in AutoCAD. Although other non-Autodesk software can read such DXF without issues, better to produce files which are compatible also with AutoCAD.

Fixes #47381.