### PR TITLE
Use docked widget size when undocking the first time

### DIFF
--- a/src/app/qgsdockablewidgethelper.cpp
+++ b/src/app/qgsdockablewidgethelper.cpp
@@ -23,7 +23,7 @@
 QgsDockableWidgetHelper::QgsDockableWidgetHelper( bool isDocked, const QString &windowTitle, QWidget *widget, QMainWindow *ownerWindow )
   : QObject( nullptr )
   , mWidget( widget )
-  , mDialogGeometry( 0, 0, 200, 200 )
+  , mDialogGeometry( 0, 0, 0, 0 )
   , mDockGeometry( QRect() )
   , mIsDockFloating( true )
   , mDockArea( Qt::RightDockWidgetArea )
@@ -190,7 +190,10 @@ void QgsDockableWidgetHelper::toggleDockMode( bool docked )
     QVBoxLayout *vl = new QVBoxLayout();
     vl->setContentsMargins( 0, 0, 0, 0 );
     vl->addWidget( mWidget );
-    mDialog->setGeometry( mDialogGeometry );
+    if ( mDialogGeometry.isEmpty() )
+      mDialog->setGeometry( mDockGeometry );
+    else
+      mDialog->setGeometry( mDialogGeometry );
     mDialog->setLayout( vl );
     mDialog->raise();
     mDialog->show();


### PR DESCRIPTION
## Description
Instead of opening the undocked window in the top left of the screen the first time the widget is undocked, we should use the same size of the docked widget instead.