### PR TITLE
Fix maptiler hmac sha256 signature when URL contains spaces

### DIFF
--- a/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
+++ b/src/auth/maptiler_hmacsha256/core/qgsauthmaptilerhmacsha256method.cpp
@@ -94,7 +94,7 @@ bool QgsAuthMapTilerHmacSha256Method::updateNetworkRequest( QNetworkRequest &req
   query.setQueryItems( queryItems );
   url.setQuery( query );
 
-  QString signature = calculateSignature( secret, url.url() );
+  QString signature = calculateSignature( secret, url.toEncoded() );
   request.setUrl( QString( url.url() + QStringLiteral( "&signature=" ) + signature ) );
 
   return true;


### PR DESCRIPTION
The url() method decodes URLs, so e.g.
```
http://example.com/?q=hello%20world
```
would get decoded to
```
http://example.com/?q=hello world
```
 and the generated signature would be incorrect. The toEncoded() takes care of it.
