### PR TITLE
ALWAYS use smooth wheel zoom for canvas

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2250,14 +2250,10 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
 
   double zoomFactor = e->angleDelta().y() > 0 ? 1. / zoomInFactor() : zoomOutFactor();
 
-  // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
-  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 120.0 * std::fabs( e->angleDelta().y() );
+  constexpr double ZOOM_SPEED = 20.0;
 
-  if ( e->modifiers() & Qt::ControlModifier )
-  {
-    //holding ctrl while wheel zooming results in a finer zoom
-    zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 20.0;
-  }
+  // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
+  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 120.0 * std::fabs( e->angleDelta().y() ) / ZOOM_SPEED;
 
   double signedWheelFactor = e->angleDelta().y() > 0 ? 1 / zoomFactor : zoomFactor;
 


### PR DESCRIPTION
Instead of requiring users to hold ctrl to get the smooth zoom,
just make it the default always. Recent improvements with rendering
of previously cached map results mean that this behaviour is
silky smooth, and looks so much more modern than the old "jumpy"
zoom!
