### PR TITLE
Fix attribute name in get_feature docs

### DIFF
--- a/resources/function_help/json/get_feature
+++ b/resources/function_help/json/get_feature
@@ -27,7 +27,7 @@
       "arg": "layer",
       "description": "layer name or ID"
     }, {
-      "arg": "map",
+      "arg": "attribute",
       "description": "Map containing the column and value pairs to use"
     }],
     "examples": [{


### PR DESCRIPTION
@roya0045 small followup to your fix -- the argument name in the help needs to match the name usable in the expression for named nodes