### PR TITLE
Include the developer_name in the appdata file

### DIFF
--- a/linux/org.qgis.qgis.appdata.xml.in
+++ b/linux/org.qgis.qgis.appdata.xml.in
@@ -2,6 +2,7 @@
 <component type="desktop">
   <id>org.qgis.qgis.desktop</id>
   <name>QGIS Desktop</name>
+  <developer_name>QGIS Development Team</developer_name>
   <summary>A Free and Open Source Geographic Information System</summary>
   <screenshots>
     <screenshot><image type="source">https://qgis.org/en/_static/images/about-screenshot.png</image></screenshot>


### PR DESCRIPTION
This way it's not listed as "unknown" in software centres and such.

## Description

Fixes https://github.com/flathub/org.qgis.qgis/issues/105