### PR TITLE
Fix checkbox search wdgt wrapper bools

### DIFF
--- a/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.cpp
@@ -43,7 +43,7 @@ QVariant QgsCheckboxSearchWidgetWrapper::value() const
   QVariant v;
 
   if ( mCheckBox )
-    v = mCheckBox->isChecked() ? config( QStringLiteral( "CheckedState" ) ) : config( QStringLiteral( "UncheckedState" ) );
+    v = mCheckBox->isChecked() ? config( QStringLiteral( "CheckedState" ), true ) : config( QStringLiteral( "UncheckedState" ), false );
 
   return v;
 }
@@ -82,6 +82,7 @@ QString QgsCheckboxSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
     case QVariant::Double:
     case QVariant::LongLong:
     case QVariant::ULongLong:
+    case QVariant::Bool:
     {
       if ( flags & EqualTo )
         return fieldName + '=' + v.toString();

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -251,7 +251,7 @@ class PyQgsCheckboxSearchWidgetWrapper(unittest.TestCase):
 
     def testCreateExpression(self):
         """ Test creating an expression using the widget"""
-        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer", "test", "memory")
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer&field=fieldbool:bool", "test", "memory")
 
         w = QgsCheckboxSearchWidgetWrapper(layer, 0)
         config = {"CheckedState": 5,
@@ -281,6 +281,16 @@ class PyQgsCheckboxSearchWidgetWrapper(unittest.TestCase):
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNull), '"fldint" IS NULL')
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.IsNotNull), '"fldint" IS NOT NULL')
         self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fldint"=9')
+
+        # Check boolean expression
+        parent = QWidget()
+        w = QgsCheckboxSearchWidgetWrapper(layer, 2)
+        w.initWidget(parent)
+        c = w.widget()
+        c.setChecked(True)
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fieldbool"=true')
+        c.setChecked(False)
+        self.assertEqual(w.createExpression(QgsSearchWidgetWrapper.EqualTo), '"fieldbool"=false')
 
 
 class PyQgsDateTimeSearchWidgetWrapper(unittest.TestCase):


### PR DESCRIPTION
Because 'true'/'false' literals might well work with QgsExpression but
don't work with compiled SQL while the boolean QVariant plays well with both.

Fix #47507
