### PR TITLE
Allow proper renaming of input parameters in graphical models

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -247,6 +247,15 @@ is deleted.
 .. seealso:: :py:func:`updateModelParameter`
 %End
 
+    void changeParameterName( const QString &oldName, const QString &newName );
+%Docstring
+Changes a model parameter's internal name from ``oldName`` to ``newName``.
+
+This method will automatically update all model components to relink using the new name.
+
+.. versionadded:: 3.26
+%End
+
     bool childAlgorithmsDependOnParameter( const QString &name ) const;
 %Docstring
 Returns ``True`` if any child algorithms depend on the model parameter

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -80,6 +80,9 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
 
     def edit(self, edit_comment=False):
         existing_param = self.model().parameterDefinition(self.component().parameterName())
+        old_name = existing_param.name()
+        old_description = existing_param.description()
+
         comment = self.component().comment().description()
         comment_color = self.component().comment().color()
         new_param = None
@@ -116,9 +119,30 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
                 comment = dlg.comments()
                 comment_color = dlg.commentColor()
 
+                validChars = \
+                    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+                safeName = ''.join(c for c in new_param.description() if c in validChars)
+                new_param.setName(safeName.lower())
+
         if new_param is not None:
             self.aboutToChange.emit(self.tr('Edit {}').format(new_param.description()))
             self.model().removeModelParameter(self.component().parameterName())
+
+            if new_param.description() != old_description:
+                # only update name if user has changed the description -- we don't force this, as it may cause
+                # unwanted name updates which could potentially break the model's API
+                name = new_param.name()
+
+                base_name = name
+                i = 2
+                while self.model().parameterDefinition(name):
+                    name = base_name + str(i)
+                    i += 1
+
+                new_param.setName(name)
+
+                self.model().changeParameterName(old_name, new_param.name())
+
             self.component().setParameterName(new_param.name())
             self.component().setDescription(new_param.name())
             self.component().comment().setDescription(comment)

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -198,17 +198,11 @@ class ModelerParameterDefinitionDialog(QDialog):
             QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                 self.tr('Invalid parameter name'))
             return
-        if self.param is None:
-            validChars = \
-                'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-            safeName = ''.join(c for c in description if c in validChars)
-            name = safeName.lower()
-            i = 2
-            while self.alg.parameterDefinition(name):
-                name = safeName.lower() + str(i)
-                i += 1
-        else:
-            name = self.param.name()
+
+        validChars = \
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+        safeName = ''.join(c for c in description if c in validChars)
+        name = safeName.lower()
 
         # Destination parameter
         if (isinstance(self.param, QgsProcessingParameterFeatureSink)):

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -218,6 +218,15 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     void removeModelParameter( const QString &name );
 
     /**
+     * Changes a model parameter's internal name from \a oldName to \a newName.
+     *
+     * This method will automatically update all model components to relink using the new name.
+     *
+     * \since QGIS 3.26
+     */
+    void changeParameterName( const QString &oldName, const QString &newName );
+
+    /**
      * Returns TRUE if any child algorithms depend on the model parameter
      * with the specified \a name.
      * \see otherParametersDependOnParameter()


### PR DESCRIPTION
When an input parameter is renamed in the model designer, also update the internal name of that parameter and all child algorithms in the model accordingly

Before we just "faked" this by changing the parameter's description only, but that meant that the old name was permenantly stuck and had to be used in qgis_process or when calling the model via python.

Refs NRCan Contract#3000739399