### PR TITLE
Don't show 'model was correctly saved' notification when saving models

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -227,11 +227,9 @@ class ModelerDialog(QgsModelDesignerDialog):
 
         self.update_model.emit()
         if saveAs:
-            self.messageBar().pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(
+            self.messageBar().pushMessage("", self.tr("Model was saved to <a href=\"{}\">{}</a>").format(
                 QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success,
                 duration=5)
-        else:
-            self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
         self.setDirty(False)
         return True


### PR DESCRIPTION
We don't do this elsewhere (e.g. saving QGIS projects), and it makes
it sound like it's suprising that the save worked correctly..!
