### PR TITLE
WFS GetFeature GML3: When SRSNAME param was empty, srsName attributes were empty too

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1225,16 +1225,9 @@ namespace QgsWfs
           QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( rect, doc, srsName, invertAxis, prec );
           if ( !envElem.isNull() )
           {
-            if ( crs.isValid() )
+            if ( crs.isValid() && srsName.isEmpty() )
             {
-              if ( mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) )
-              {
-                envElem.setAttribute( QStringLiteral( "srsName" ), srsName );
-              }
-              else
-              {
-                envElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
-              }
+              envElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
             }
             bbElem.appendChild( envElem );
             doc.appendChild( bbElem );
@@ -1508,9 +1501,13 @@ namespace QgsWfs
           QDomElement bbElem = doc.createElement( QStringLiteral( "gml:boundedBy" ) );
           QDomElement boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc, params.srsName, params.hasAxisInverted, prec );
 
-          if ( crs.isValid() )
+          if ( crs.isValid() && params.srsName.isEmpty() )
           {
-            boxElem.setAttribute( QStringLiteral( "srsName" ), params.srsName );
+            boxElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+            gmlElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+          }
+          else if ( !params.srsName.isEmpty() )
+          {
             gmlElem.setAttribute( QStringLiteral( "srsName" ), params.srsName );
           }
 
@@ -1623,6 +1620,3 @@ namespace QgsWfs
   } // namespace
 
 } // namespace QgsWfs
-
-
-

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -27,7 +27,6 @@ import urllib.error
 from qgis.server import QgsServerRequest
 
 from qgis.testing import unittest
-from qgis.PyQt.QtCore import QSize
 from qgis.core import (
     QgsVectorLayer,
     QgsFeatureRequest,
@@ -543,6 +542,11 @@ class TestQgsServerWFS(QgsServerTestBase):
 
         self.wfs_request_compare(
             "GetFeature", '1.1.0', "SRSNAME=urn:ogc:def:crs:EPSG::4326&TYPENAME=testlayer&FEATUREID=testlayer.0", 'wfs_getFeature_1_1_0_featureid_0_1_1_0')
+
+    def test_get_feature_srsname_empty(self):
+        """Test GetFeature with an empty SRSNAME."""
+        self.wfs_request_compare(
+            "GetFeature", '1.1.0', "TYPENAME=testlayer&FEATUREID=testlayer.0", 'wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname')
 
     def test_getFeature_EXP_FILTER_regression_20927(self):
         """Test expressions with EXP_FILTER"""

--- a/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
@@ -1,0 +1,28 @@
+Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=text/xml; subtype%3Dgml/3.1.1">
+<gml:boundedBy>
+ <gml:Envelope srsName="EPSG:4326">
+  <gml:lowerCorner>44.90139484 8.20345931</gml:lowerCorner>
+  <gml:upperCorner>44.90148253 8.20354699</gml:upperCorner>
+ </gml:Envelope>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer gml:id="testlayer.0">
+  <gml:boundedBy>
+   <gml:Envelope srsName="EPSG:4326">
+    <gml:lowerCorner>44.90148253 8.20349634</gml:lowerCorner>
+    <gml:upperCorner>44.90148253 8.20349634</gml:upperCorner>
+   </gml:Envelope>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90148253 8.20349634</pos>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
WFS GetFeature GML3: When SRSNAME param was empty, srsName attributes were empty too

If the SRSNAME WFS parameter was empty, the srsName attributes of GML3 elements were empty too even if the layer CRS or the CRS used to build the GML elements was valid.

* Funded by Ifremer