### PR TITLE
point cloud triangulation in 3D view

### DIFF
--- a/external/delaunator-cpp/LICENSE
+++ b/external/delaunator-cpp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Volodymyr Bilonenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external/delaunator-cpp/delaunator.hpp
+++ b/external/delaunator-cpp/delaunator.hpp
@@ -1,0 +1,585 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace delaunator {
+
+//@see https://stackoverflow.com/questions/33333363/built-in-mod-vs-custom-mod-function-improve-the-performance-of-modulus-op/33333636#33333636
+inline size_t fast_mod(const size_t i, const size_t c) {
+    return i >= c ? i % c : i;
+}
+
+// Kahan and Babuska summation, Neumaier variant; accumulates less FP error
+inline double sum(const std::vector<double>& x) {
+    double sum = x[0];
+    double err = 0.0;
+
+    for (size_t i = 1; i < x.size(); i++) {
+        const double k = x[i];
+        const double m = sum + k;
+        err += std::fabs(sum) >= std::fabs(k) ? sum - m + k : k - m + sum;
+        sum = m;
+    }
+    return sum + err;
+}
+
+inline double dist(
+    const double ax,
+    const double ay,
+    const double bx,
+    const double by) {
+    const double dx = ax - bx;
+    const double dy = ay - by;
+    return dx * dx + dy * dy;
+}
+
+inline double circumradius(
+    const double ax,
+    const double ay,
+    const double bx,
+    const double by,
+    const double cx,
+    const double cy) {
+    const double dx = bx - ax;
+    const double dy = by - ay;
+    const double ex = cx - ax;
+    const double ey = cy - ay;
+
+    const double bl = dx * dx + dy * dy;
+    const double cl = ex * ex + ey * ey;
+    const double d = dx * ey - dy * ex;
+
+    const double x = (ey * bl - dy * cl) * 0.5 / d;
+    const double y = (dx * cl - ex * bl) * 0.5 / d;
+
+    if ((bl > 0.0 || bl < 0.0) && (cl > 0.0 || cl < 0.0) && (d > 0.0 || d < 0.0)) {
+        return x * x + y * y;
+    } else {
+        return std::numeric_limits<double>::max();
+    }
+}
+
+inline bool orient(
+    const double px,
+    const double py,
+    const double qx,
+    const double qy,
+    const double rx,
+    const double ry) {
+    return (qy - py) * (rx - qx) - (qx - px) * (ry - qy) < 0.0;
+}
+
+inline std::pair<double, double> circumcenter(
+    const double ax,
+    const double ay,
+    const double bx,
+    const double by,
+    const double cx,
+    const double cy) {
+    const double dx = bx - ax;
+    const double dy = by - ay;
+    const double ex = cx - ax;
+    const double ey = cy - ay;
+
+    const double bl = dx * dx + dy * dy;
+    const double cl = ex * ex + ey * ey;
+    const double d = dx * ey - dy * ex;
+
+    const double x = ax + (ey * bl - dy * cl) * 0.5 / d;
+    const double y = ay + (dx * cl - ex * bl) * 0.5 / d;
+
+    return std::make_pair(x, y);
+}
+
+struct compare {
+
+    std::vector<double> const& coords;
+    double cx;
+    double cy;
+
+    bool operator()(std::size_t i, std::size_t j) {
+        const double d1 = dist(coords[2 * i], coords[2 * i + 1], cx, cy);
+        const double d2 = dist(coords[2 * j], coords[2 * j + 1], cx, cy);
+        const double diff1 = d1 - d2;
+        const double diff2 = coords[2 * i] - coords[2 * j];
+        const double diff3 = coords[2 * i + 1] - coords[2 * j + 1];
+
+        if (diff1 > 0.0 || diff1 < 0.0) {
+            return diff1 < 0;
+        } else if (diff2 > 0.0 || diff2 < 0.0) {
+            return diff2 < 0;
+        } else {
+            return diff3 < 0;
+        }
+    }
+};
+
+inline bool in_circle(
+    const double ax,
+    const double ay,
+    const double bx,
+    const double by,
+    const double cx,
+    const double cy,
+    const double px,
+    const double py) {
+    const double dx = ax - px;
+    const double dy = ay - py;
+    const double ex = bx - px;
+    const double ey = by - py;
+    const double fx = cx - px;
+    const double fy = cy - py;
+
+    const double ap = dx * dx + dy * dy;
+    const double bp = ex * ex + ey * ey;
+    const double cp = fx * fx + fy * fy;
+
+    return (dx * (ey * cp - bp * fy) -
+            dy * (ex * cp - bp * fx) +
+            ap * (ex * fy - ey * fx)) < 0.0;
+}
+
+constexpr double EPSILON = std::numeric_limits<double>::epsilon();
+constexpr std::size_t INVALID_INDEX = std::numeric_limits<std::size_t>::max();
+
+inline bool check_pts_equal(double x1, double y1, double x2, double y2) {
+    return std::fabs(x1 - x2) <= EPSILON &&
+           std::fabs(y1 - y2) <= EPSILON;
+}
+
+// monotonically increases with real angle, but doesn't need expensive trigonometry
+inline double pseudo_angle(const double dx, const double dy) {
+    const double p = dx / (std::abs(dx) + std::abs(dy));
+    return (dy > 0.0 ? 3.0 - p : 1.0 + p) / 4.0; // [0..1)
+}
+
+struct DelaunatorPoint {
+    std::size_t i;
+    double x;
+    double y;
+    std::size_t t;
+    std::size_t prev;
+    std::size_t next;
+    bool removed;
+};
+
+class Delaunator {
+
+public:
+    std::vector<double> const& coords;
+    std::vector<std::size_t> triangles;
+    std::vector<std::size_t> halfedges;
+    std::vector<std::size_t> hull_prev;
+    std::vector<std::size_t> hull_next;
+    std::vector<std::size_t> hull_tri;
+    std::size_t hull_start;
+
+    Delaunator(std::vector<double> const& in_coords);
+
+    double get_hull_area();
+
+private:
+    std::vector<std::size_t> m_hash;
+    double m_center_x;
+    double m_center_y;
+    std::size_t m_hash_size;
+    std::vector<std::size_t> m_edge_stack;
+
+    std::size_t legalize(std::size_t a);
+    std::size_t hash_key(double x, double y) const;
+    std::size_t add_triangle(
+        std::size_t i0,
+        std::size_t i1,
+        std::size_t i2,
+        std::size_t a,
+        std::size_t b,
+        std::size_t c);
+    void link(std::size_t a, std::size_t b);
+};
+
+Delaunator::Delaunator(std::vector<double> const& in_coords)
+    : coords(in_coords),
+      triangles(),
+      halfedges(),
+      hull_prev(),
+      hull_next(),
+      hull_tri(),
+      hull_start(),
+      m_hash(),
+      m_center_x(),
+      m_center_y(),
+      m_hash_size(),
+      m_edge_stack() {
+    std::size_t n = coords.size() >> 1;
+
+    double max_x = std::numeric_limits<double>::min();
+    double max_y = std::numeric_limits<double>::min();
+    double min_x = std::numeric_limits<double>::max();
+    double min_y = std::numeric_limits<double>::max();
+    std::vector<std::size_t> ids;
+    ids.reserve(n);
+
+    for (std::size_t i = 0; i < n; i++) {
+        const double x = coords[2 * i];
+        const double y = coords[2 * i + 1];
+
+        if (x < min_x) min_x = x;
+        if (y < min_y) min_y = y;
+        if (x > max_x) max_x = x;
+        if (y > max_y) max_y = y;
+
+        ids.push_back(i);
+    }
+    const double cx = (min_x + max_x) / 2;
+    const double cy = (min_y + max_y) / 2;
+    double min_dist = std::numeric_limits<double>::max();
+
+    std::size_t i0 = INVALID_INDEX;
+    std::size_t i1 = INVALID_INDEX;
+    std::size_t i2 = INVALID_INDEX;
+
+    // pick a seed point close to the centroid
+    for (std::size_t i = 0; i < n; i++) {
+        const double d = dist(cx, cy, coords[2 * i], coords[2 * i + 1]);
+        if (d < min_dist) {
+            i0 = i;
+            min_dist = d;
+        }
+    }
+
+    const double i0x = coords[2 * i0];
+    const double i0y = coords[2 * i0 + 1];
+
+    min_dist = std::numeric_limits<double>::max();
+
+    // find the point closest to the seed
+    for (std::size_t i = 0; i < n; i++) {
+        if (i == i0) continue;
+        const double d = dist(i0x, i0y, coords[2 * i], coords[2 * i + 1]);
+        if (d < min_dist && d > 0.0) {
+            i1 = i;
+            min_dist = d;
+        }
+    }
+
+    double i1x = coords[2 * i1];
+    double i1y = coords[2 * i1 + 1];
+
+    double min_radius = std::numeric_limits<double>::max();
+
+    // find the third point which forms the smallest circumcircle with the first two
+    for (std::size_t i = 0; i < n; i++) {
+        if (i == i0 || i == i1) continue;
+
+        const double r = circumradius(
+            i0x, i0y, i1x, i1y, coords[2 * i], coords[2 * i + 1]);
+
+        if (r < min_radius) {
+            i2 = i;
+            min_radius = r;
+        }
+    }
+
+    if (!(min_radius < std::numeric_limits<double>::max())) {
+        throw std::runtime_error("not triangulation");
+    }
+
+    double i2x = coords[2 * i2];
+    double i2y = coords[2 * i2 + 1];
+
+    if (orient(i0x, i0y, i1x, i1y, i2x, i2y)) {
+        std::swap(i1, i2);
+        std::swap(i1x, i2x);
+        std::swap(i1y, i2y);
+    }
+
+    std::tie(m_center_x, m_center_y) = circumcenter(i0x, i0y, i1x, i1y, i2x, i2y);
+
+    // sort the points by distance from the seed triangle circumcenter
+    std::sort(ids.begin(), ids.end(), compare{ coords, m_center_x, m_center_y });
+
+    // initialize a hash table for storing edges of the advancing convex hull
+    m_hash_size = static_cast<std::size_t>(std::llround(std::ceil(std::sqrt(n))));
+    m_hash.resize(m_hash_size);
+    std::fill(m_hash.begin(), m_hash.end(), INVALID_INDEX);
+
+    // initialize arrays for tracking the edges of the advancing convex hull
+    hull_prev.resize(n);
+    hull_next.resize(n);
+    hull_tri.resize(n);
+
+    hull_start = i0;
+
+    size_t hull_size = 3;
+
+    hull_next[i0] = hull_prev[i2] = i1;
+    hull_next[i1] = hull_prev[i0] = i2;
+    hull_next[i2] = hull_prev[i1] = i0;
+
+    hull_tri[i0] = 0;
+    hull_tri[i1] = 1;
+    hull_tri[i2] = 2;
+
+    m_hash[hash_key(i0x, i0y)] = i0;
+    m_hash[hash_key(i1x, i1y)] = i1;
+    m_hash[hash_key(i2x, i2y)] = i2;
+
+    std::size_t max_triangles = n < 3 ? 1 : 2 * n - 5;
+    triangles.reserve(max_triangles * 3);
+    halfedges.reserve(max_triangles * 3);
+    add_triangle(i0, i1, i2, INVALID_INDEX, INVALID_INDEX, INVALID_INDEX);
+    double xp = std::numeric_limits<double>::quiet_NaN();
+    double yp = std::numeric_limits<double>::quiet_NaN();
+    for (std::size_t k = 0; k < n; k++) {
+        const std::size_t i = ids[k];
+        const double x = coords[2 * i];
+        const double y = coords[2 * i + 1];
+
+        // skip near-duplicate points
+        if (k > 0 && check_pts_equal(x, y, xp, yp)) continue;
+        xp = x;
+        yp = y;
+
+        // skip seed triangle points
+        if (
+            check_pts_equal(x, y, i0x, i0y) ||
+            check_pts_equal(x, y, i1x, i1y) ||
+            check_pts_equal(x, y, i2x, i2y)) continue;
+
+        // find a visible edge on the convex hull using edge hash
+        std::size_t start = 0;
+
+        size_t key = hash_key(x, y);
+        for (size_t j = 0; j < m_hash_size; j++) {
+            start = m_hash[fast_mod(key + j, m_hash_size)];
+            if (start != INVALID_INDEX && start != hull_next[start]) break;
+        }
+
+        start = hull_prev[start];
+        size_t e = start;
+        size_t q;
+
+        while (q = hull_next[e], !orient(x, y, coords[2 * e], coords[2 * e + 1], coords[2 * q], coords[2 * q + 1])) { //TODO: does it works in a same way as in JS
+            e = q;
+            if (e == start) {
+                e = INVALID_INDEX;
+                break;
+            }
+        }
+
+        if (e == INVALID_INDEX) continue; // likely a near-duplicate point; skip it
+
+        // add the first triangle from the point
+        std::size_t t = add_triangle(
+            e,
+            i,
+            hull_next[e],
+            INVALID_INDEX,
+            INVALID_INDEX,
+            hull_tri[e]);
+
+        hull_tri[i] = legalize(t + 2);
+        hull_tri[e] = t;
+        hull_size++;
+
+        // walk forward through the hull, adding more triangles and flipping recursively
+        std::size_t next = hull_next[e];
+        while (
+            q = hull_next[next],
+            orient(x, y, coords[2 * next], coords[2 * next + 1], coords[2 * q], coords[2 * q + 1])) {
+            t = add_triangle(next, i, q, hull_tri[i], INVALID_INDEX, hull_tri[next]);
+            hull_tri[i] = legalize(t + 2);
+            hull_next[next] = next; // mark as removed
+            hull_size--;
+            next = q;
+        }
+
+        // walk backward from the other side, adding more triangles and flipping
+        if (e == start) {
+            while (
+                q = hull_prev[e],
+                orient(x, y, coords[2 * q], coords[2 * q + 1], coords[2 * e], coords[2 * e + 1])) {
+                t = add_triangle(q, i, e, INVALID_INDEX, hull_tri[e], hull_tri[q]);
+                legalize(t + 2);
+                hull_tri[q] = t;
+                hull_next[e] = e; // mark as removed
+                hull_size--;
+                e = q;
+            }
+        }
+
+        // update the hull indices
+        hull_prev[i] = e;
+        hull_start = e;
+        hull_prev[next] = i;
+        hull_next[e] = i;
+        hull_next[i] = next;
+
+        m_hash[hash_key(x, y)] = i;
+        m_hash[hash_key(coords[2 * e], coords[2 * e + 1])] = e;
+    }
+}
+
+double Delaunator::get_hull_area() {
+    std::vector<double> hull_area;
+    size_t e = hull_start;
+    do {
+        hull_area.push_back((coords[2 * e] - coords[2 * hull_prev[e]]) * (coords[2 * e + 1] + coords[2 * hull_prev[e] + 1]));
+        e = hull_next[e];
+    } while (e != hull_start);
+    return sum(hull_area);
+}
+
+std::size_t Delaunator::legalize(std::size_t a) {
+    std::size_t i = 0;
+    std::size_t ar = 0;
+    m_edge_stack.clear();
+
+    // recursion eliminated with a fixed-size stack
+    while (true) {
+        const size_t b = halfedges[a];
+
+        /* if the pair of triangles doesn't satisfy the Delaunay condition
+        * (p1 is inside the circumcircle of [p0, pl, pr]), flip them,
+        * then do the same check/flip recursively for the new pair of triangles
+        *
+        *           pl                    pl
+        *          /||\                  /  \
+        *       al/ || \bl            al/    \a
+        *        /  ||  \              /      \
+        *       /  a||b  \    flip    /___ar___\
+        *     p0\   ||   /p1   =>   p0\---bl---/p1
+        *        \  ||  /              \      /
+        *       ar\ || /br             b\    /br
+        *          \||/                  \  /
+        *           pr                    pr
+        */
+        const size_t a0 = 3 * (a / 3);
+        ar = a0 + (a + 2) % 3;
+
+        if (b == INVALID_INDEX) {
+            if (i > 0) {
+                i--;
+                a = m_edge_stack[i];
+                continue;
+            } else {
+                //i = INVALID_INDEX;
+                break;
+            }
+        }
+
+        const size_t b0 = 3 * (b / 3);
+        const size_t al = a0 + (a + 1) % 3;
+        const size_t bl = b0 + (b + 2) % 3;
+
+        const std::size_t p0 = triangles[ar];
+        const std::size_t pr = triangles[a];
+        const std::size_t pl = triangles[al];
+        const std::size_t p1 = triangles[bl];
+
+        const bool illegal = in_circle(
+            coords[2 * p0],
+            coords[2 * p0 + 1],
+            coords[2 * pr],
+            coords[2 * pr + 1],
+            coords[2 * pl],
+            coords[2 * pl + 1],
+            coords[2 * p1],
+            coords[2 * p1 + 1]);
+
+        if (illegal) {
+            triangles[a] = p1;
+            triangles[b] = p0;
+
+            auto hbl = halfedges[bl];
+
+            // edge swapped on the other side of the hull (rare); fix the halfedge reference
+            if (hbl == INVALID_INDEX) {
+                std::size_t e = hull_start;
+                do {
+                    if (hull_tri[e] == bl) {
+                        hull_tri[e] = a;
+                        break;
+                    }
+                    e = hull_next[e];
+                } while (e != hull_start);
+            }
+            link(a, hbl);
+            link(b, halfedges[ar]);
+            link(ar, bl);
+            std::size_t br = b0 + (b + 1) % 3;
+
+            if (i < m_edge_stack.size()) {
+                m_edge_stack[i] = br;
+            } else {
+                m_edge_stack.push_back(br);
+            }
+            i++;
+
+        } else {
+            if (i > 0) {
+                i--;
+                a = m_edge_stack[i];
+                continue;
+            } else {
+                break;
+            }
+        }
+    }
+    return ar;
+}
+
+inline std::size_t Delaunator::hash_key(const double x, const double y) const {
+    const double dx = x - m_center_x;
+    const double dy = y - m_center_y;
+    return fast_mod(
+        static_cast<std::size_t>(std::llround(std::floor(pseudo_angle(dx, dy) * static_cast<double>(m_hash_size)))),
+        m_hash_size);
+}
+
+std::size_t Delaunator::add_triangle(
+    std::size_t i0,
+    std::size_t i1,
+    std::size_t i2,
+    std::size_t a,
+    std::size_t b,
+    std::size_t c) {
+    std::size_t t = triangles.size();
+    triangles.push_back(i0);
+    triangles.push_back(i1);
+    triangles.push_back(i2);
+    link(t, a);
+    link(t + 1, b);
+    link(t + 2, c);
+    return t;
+}
+
+void Delaunator::link(const std::size_t a, const std::size_t b) {
+    std::size_t s = halfedges.size();
+    if (a == s) {
+        halfedges.push_back(b);
+    } else if (a < s) {
+        halfedges[a] = b;
+    } else {
+        throw std::runtime_error("Cannot link edge");
+    }
+    if (b != INVALID_INDEX) {
+        std::size_t s2 = halfedges.size();
+        if (b == s2) {
+            halfedges.push_back(a);
+        } else if (b < s2) {
+            halfedges[b] = a;
+        } else {
+            throw std::runtime_error("Cannot link edge");
+        }
+    }
+}
+
+} //namespace delaunator

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -72,14 +72,14 @@ Sets the point size
 Returns the byte stride for the geometries used to for the vertex buffer
 %End
 
-    bool triangulate() const;
+    bool renderAsTriangles() const;
 %Docstring
 Returns whether points are triangulated to render solid surface
 
 .. versionadded:: 3.26
 %End
 
-    void setTriangulate( bool triangulate );
+    void setRenderAsTriangles( bool asTriangles );
 %Docstring
 Sets whether points are triangulated to render solid surface
 
@@ -104,7 +104,7 @@ than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbo
 
     float triangleSizeThreshold() const;
 %Docstring
-Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a size greater
+Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
 than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
 
 .. versionadded:: 3.26
@@ -112,7 +112,7 @@ than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSy
 
     void setTriangleSizeThreshold( float triangleSizeThreshold );
 %Docstring
-Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a size greater
+Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
 than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
 
 .. versionadded:: 3.26

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -88,7 +88,7 @@ Sets whether points are triangulated to render solid surface
 
     bool filterTrianglesBySize() const;
 %Docstring
-Returns whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+Returns whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
 than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.triangleSizeThreshold`.
 
 .. versionadded:: 3.26
@@ -96,7 +96,7 @@ than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbo
 
     void setFilterTrianglesBySize( bool filterTriangleBySize );
 %Docstring
-Sets whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+Sets whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
 than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
 
 .. versionadded:: 3.26
@@ -104,16 +104,48 @@ than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbo
 
     float triangleSizeThreshold() const;
 %Docstring
-Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+Returns the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.filterTrianglesBySize`.
 
 .. versionadded:: 3.26
 %End
 
     void setTriangleSizeThreshold( float triangleSizeThreshold );
 %Docstring
-Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+Sets the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setFilterTrianglesBySize`.
+
+.. versionadded:: 3.26
+%End
+
+    bool filterTrianglesByHeight() const;
+%Docstring
+Returns whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.triangleHeightThreshold`.
+
+.. versionadded:: 3.26
+%End
+
+    void setFilterTrianglesByHeight( bool filterTriangleByHeight );
+%Docstring
+Sets whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleHeightThreshold`.
+
+.. versionadded:: 3.26
+%End
+
+    float triangleHeightThreshold() const;
+%Docstring
+Returns the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.filterTrianglesByHeight`.
+
+.. versionadded:: 3.26
+%End
+
+    void setTriangleHeightThreshold( float triangleHeightThreshold );
+%Docstring
+Sets the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setFilterTrianglesByHeight`.
 
 .. versionadded:: 3.26
 %End

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -37,7 +37,9 @@ class QgsPointCloud3DSymbol : QgsAbstract3DSymbol /Abstract/
       //! Render the point cloud with a color ramp
       ColorRamp,
       //! Render the RGB colors of the point cloud
-      RgbRendering
+      RgbRendering,
+      //! Render the point cloud with classified colors
+      Classification
     };
 
     QgsPointCloud3DSymbol();

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -86,66 +86,66 @@ Sets whether points are triangulated to render solid surface
 .. versionadded:: 3.26
 %End
 
-    bool filterTrianglesBySize() const;
+    bool horizontalTriangleFilter() const;
 %Docstring
-Returns whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
-than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.triangleSizeThreshold`.
+Returns whether triangles are filtered by horizontal size for rendering. If the triangles are horizontally filtered by size,
+triangles with a horizontal side size greater than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.horizontalFilterThreshold`.
 
 .. versionadded:: 3.26
 %End
 
-    void setFilterTrianglesBySize( bool filterTriangleBySize );
+    void setHorizontalTriangleFilter( bool horizontalTriangleFilter );
 %Docstring
-Sets whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
-than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+Sets whether whether triangles are filtered by horizontal size for rendering. If the triangles are horizontally filtered by size,
+triangles with a horizontal side size greater than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setHorizontalFilterThreshold`.
 
 .. versionadded:: 3.26
 %End
 
-    float triangleSizeThreshold() const;
+    float horizontalFilterThreshold() const;
 %Docstring
-Returns the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.filterTrianglesBySize`.
+Returns the threshold horizontal size value for filtering triangles. If the triangles are horizontally filtered by size,
+triangles with a horizontal side size greater than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.horizontalTriangleFilter`.
 
 .. versionadded:: 3.26
 %End
 
-    void setTriangleSizeThreshold( float triangleSizeThreshold );
+    void setHorizontalFilterThreshold( float horizontalFilterThreshold );
 %Docstring
-Sets the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setFilterTrianglesBySize`.
+Sets the threshold horizontal size value for filtering triangles. If the triangles are horizontally filtered by size,
+triangles with a horizontal side size greater than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setHorizontalTriangleFilter`.
 
 .. versionadded:: 3.26
 %End
 
-    bool filterTrianglesByHeight() const;
+    bool verticalTriangleFilter() const;
 %Docstring
-Returns whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
-than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.triangleHeightThreshold`.
+Returns whether triangles are filtered by vertical height for rendering. If the triangles are vertically filtered, triangles with a vertical height greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.verticalFilterThreshold`.
 
 .. versionadded:: 3.26
 %End
 
-    void setFilterTrianglesByHeight( bool filterTriangleByHeight );
+    void setVerticalTriangleFilter( bool verticalTriangleFilter );
 %Docstring
-Sets whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
-than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleHeightThreshold`.
+Sets whether triangles are filtered by vertical height for rendering. If the triangles are vertically filtered, triangles with a vertical height greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setVerticalFilterThreshold`.
 
 .. versionadded:: 3.26
 %End
 
-    float triangleHeightThreshold() const;
+    float verticalFilterThreshold() const;
 %Docstring
-Returns the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.filterTrianglesByHeight`.
+Returns the threshold vertical height value for filtering triangles. If the triangles are filtered vertically, triangles with a vertical height greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.verticalTriangleFilter`.
 
 .. versionadded:: 3.26
 %End
 
-    void setTriangleHeightThreshold( float triangleHeightThreshold );
+    void setVerticalFilterThreshold( float verticalFilterThreshold );
 %Docstring
-Sets the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
-than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setFilterTrianglesByHeight`.
+Sets the threshold vertical height value for filtering triangles. If the triangles are filtered vertically, triangles with a vertical height greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setVerticalTriangleFilter`.
 
 .. versionadded:: 3.26
 %End

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -153,7 +153,18 @@ than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSy
   protected:
 
     void writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
+%Docstring
+Writes symbol configuration of this class to the given DOM element
+
+.. versionadded:: 3.26
+%End
+
     void readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context );
+%Docstring
+Reads symbol configuration of this class from the given DOM element
+
+.. versionadded:: 3.26
+%End
 
     virtual void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
 

--- a/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
+++ b/python/3d/auto_generated/symbols/qgspointcloud3dsymbol.sip.in
@@ -72,7 +72,59 @@ Sets the point size
 Returns the byte stride for the geometries used to for the vertex buffer
 %End
 
+    bool triangulate() const;
+%Docstring
+Returns whether points are triangulated to render solid surface
+
+.. versionadded:: 3.26
+%End
+
+    void setTriangulate( bool triangulate );
+%Docstring
+Sets whether points are triangulated to render solid surface
+
+.. versionadded:: 3.26
+%End
+
+    bool filterTrianglesBySize() const;
+%Docstring
+Returns whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.triangleSizeThreshold`.
+
+.. versionadded:: 3.26
+%End
+
+    void setFilterTrianglesBySize( bool filterTriangleBySize );
+%Docstring
+Sets whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+than a threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+
+.. versionadded:: 3.26
+%End
+
+    float triangleSizeThreshold() const;
+%Docstring
+Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+
+.. versionadded:: 3.26
+%End
+
+    void setTriangleSizeThreshold( float triangleSizeThreshold );
+%Docstring
+Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a size greater
+than this threshold value will not be rendered, see :py:func:`~QgsPointCloud3DSymbol.setTriangleSizeThreshold`.
+
+.. versionadded:: 3.26
+%End
+
   protected:
+
+    void writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
+    void readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context );
+
+    virtual void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
+
 };
 
 class QgsSingleColorPointCloud3DSymbol : QgsPointCloud3DSymbol

--- a/python/core/auto_generated/3d/qgsabstract3dsymbol.sip.in
+++ b/python/core/auto_generated/3d/qgsabstract3dsymbol.sip.in
@@ -88,7 +88,7 @@ Sets the symbol layer's property collection, used for data defined overrides.
 
   protected:
 
-    void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
+    virtual void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
 %Docstring
 Copies base class settings from this object to a ``destination`` object.
 %End

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -181,8 +181,6 @@ set(QGIS_3D_PRIVATE_HDRS
   mesh/qgsmesh3dgeometry_p.h
   mesh/qgsmesh3dmaterial_p.h
   qgscolorramptexture.h
-
-#  ${CMAKE_SOURCE_DIR}/external/delaunator-cpp/delaunator.hpp
 )
 
 set (QGIS_3D_RCCS  shaders.qrc  ../../resources/3d/textures/textures.qrc)

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -181,6 +181,8 @@ set(QGIS_3D_PRIVATE_HDRS
   mesh/qgsmesh3dgeometry_p.h
   mesh/qgsmesh3dmaterial_p.h
   qgscolorramptexture.h
+
+#  ${CMAKE_SOURCE_DIR}/external/delaunator-cpp/delaunator.hpp
 )
 
 set (QGIS_3D_RCCS  shaders.qrc  ../../resources/3d/textures/textures.qrc)
@@ -216,6 +218,7 @@ target_include_directories(qgis_3d PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/terrain
 
   ${CMAKE_BINARY_DIR}/src/3d
+  ${CMAKE_SOURCE_DIR}/external/delaunator-cpp
 )
 
 if (WITH_QT6)

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -361,7 +361,6 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneState &state )
         residencyRequests.push_back( ResidencyRequest( children[i], dist, children[i]->level() ) );
       }
     }
-
     if ( becomesActive )
     {
       mActiveNodes << node;

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -145,7 +145,7 @@ void QgsChunkedEntity::update( const SceneState &state )
 
   int enabled = 0, disabled = 0, unloaded = 0;
 
-  for ( QgsChunkNode *node : mActiveNodes )
+  for ( QgsChunkNode *node : std::as_const( mActiveNodes ) )
   {
     if ( activeBefore.contains( node ) )
     {
@@ -361,6 +361,7 @@ void QgsChunkedEntity::update( QgsChunkNode *root, const SceneState &state )
         residencyRequests.push_back( ResidencyRequest( children[i], dist, children[i]->level() ) );
       }
     }
+
     if ( becomesActive )
     {
       mActiveNodes << node;

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -82,7 +82,8 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   mFutureWatcher = new QFutureWatcher<void>( this );
   connect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
 
-  const QFuture<void> future = QtConcurrent::run( [pc, pcNode, this]
+  const QgsAABB bbox = node->bbox();
+  const QFuture<void> future = QtConcurrent::run( [pc, pcNode, bbox, this]
   {
     const QgsEventTracing::ScopedEvent e( QStringLiteral( "3D" ), QStringLiteral( "PC chunk load" ) );
 
@@ -91,7 +92,10 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
       QgsDebugMsgLevel( QStringLiteral( "canceled" ), 2 );
       return;
     }
+
     mHandler->processNode( pc, pcNode, mContext );
+    if ( mContext.symbol()->triangulate() )
+      mHandler->triangulate( pc, pcNode, mContext, bbox );
   } );
 
   // emit finished() as soon as the handler is populated with features
@@ -227,7 +231,7 @@ QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( QgsPointCloudI
   : QgsChunkedEntity( maximumScreenSpaceError,
                       new QgsPointCloudLayerChunkLoaderFactory( map, coordinateTransform, pc, symbol, zValueScale, zValueOffset, pointBudget ), true, pointBudget )
 {
-  setUsingAdditiveStrategy( true );
+  setUsingAdditiveStrategy( !symbol->triangulate() );
   setShowBoundingBoxes( showBoundingBoxes );
 }
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -94,7 +94,7 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
     }
 
     mHandler->processNode( pc, pcNode, mContext );
-    if ( mContext.symbol()->triangulate() )
+    if ( mContext.symbol()->renderAsTriangles() )
       mHandler->triangulate( pc, pcNode, mContext, bbox );
   } );
 
@@ -231,7 +231,7 @@ QgsPointCloudLayerChunkedEntity::QgsPointCloudLayerChunkedEntity( QgsPointCloudI
   : QgsChunkedEntity( maximumScreenSpaceError,
                       new QgsPointCloudLayerChunkLoaderFactory( map, coordinateTransform, pc, symbol, zValueScale, zValueOffset, pointBudget ), true, pointBudget )
 {
-  setUsingAdditiveStrategy( !symbol->triangulate() );
+  setUsingAdditiveStrategy( !symbol->renderAsTriangles() );
   setShowBoundingBoxes( showBoundingBoxes );
 }
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -31,7 +31,6 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgspointcloudattribute.h"
 #include "qgspointcloudrequest.h"
-#include "qgscolorramptexture.h"
 #include "qgspointcloud3dsymbol_p.h"
 
 #include <QtConcurrent>

--- a/src/3d/qgspointcloudlayerchunkloader_p.h
+++ b/src/3d/qgspointcloudlayerchunkloader_p.h
@@ -74,6 +74,7 @@ class QgsPointCloudLayerChunkLoaderFactory : public QgsChunkLoaderFactory
     double mZValueScale = 1.0;
     double mZValueOffset = 0;
     int mPointBudget = 1000000;
+    bool mTriangulate = false;
 };
 
 

--- a/src/3d/shaders/pointcloud.frag
+++ b/src/3d/shaders/pointcloud.frag
@@ -3,13 +3,14 @@
 uniform bool triangulate;
 
 in float parameter;
+flat in int classParameter;
 
 in vec3 pointColor;
 in vec3 worldPosition; //used when points are triangulated
 in vec3 vertNorm; //used when points are triangulated
 out vec4 color;
 
-// Sets the redering style, 0: unique color, 1: color ramp shader of terrain, 2: color ramp shader of 2D rendering
+// Sets the redering style, 0: unique color, 1: color ramp shader of terrain, 2: color ramp shader of 2D rendering, 3 : RGB, 4 : Classification
 uniform int u_renderingStyle;
 // Sets the unique mesh color
 uniform vec3 u_singleColor;
@@ -86,10 +87,16 @@ vec4 exactColorRamp()
     vec4 colorRampLine = texelFetch( u_colorRampTexture, i, 0 );
     vec3 color=colorRampLine.yzw;
     float value=colorRampLine.x;
-    if ( abs( parameter - value ) < 0.01 )
+    if ( abs( float(parameter) - value ) < 0.01 )
       return vec4( color, 1.0f );
   }
   return vec4(0.0, 0.0, 0.0, 1.0f);
+}
+
+vec4 classification()
+{
+  vec4 colorRampLine = texelFetch( u_colorRampTexture, classParameter - 1, 0 );
+  return vec4(colorRampLine.yzw,1.0);
 }
 
 vec4 colorRamp()
@@ -130,6 +137,9 @@ void main(void)
   case 3: // RGB
     color = vec4(pointColor, 1.0f);
     break;
+  case 4: // classification
+    color = classification();
+    break;
   }
 
   //Apply light
@@ -138,7 +148,7 @@ void main(void)
       float ambianceFactor=0.15;
       vec3 diffuseColor;
       adModel(worldPosition, vertNorm, diffuseColor);
-      color = vec4(  color.xyz * (diffuseColor+ambianceFactor), 1 );
+      color =vec4( color.xyz * (diffuseColor+ambianceFactor), 1 );
   }
 
 }

--- a/src/3d/shaders/pointcloud.frag
+++ b/src/3d/shaders/pointcloud.frag
@@ -1,8 +1,12 @@
 #version 150
 
+uniform bool triangulate;
+
 in float parameter;
 
 in vec3 pointColor;
+in vec3 worldPosition;
+in vec3 vertNorm;
 out vec4 color;
 
 // Sets the redering style, 0: unique color, 1: color ramp shader of terrain, 2: color ramp shader of 2D rendering
@@ -15,6 +19,8 @@ uniform int u_colorRampType;
 uniform sampler1D u_colorRampTexture; //
 // Sets the color ramp value count, used to check the if not void
 uniform int u_colorRampCount;
+
+#pragma include light.inc.frag
 
 vec4 linearColorRamp()
 {
@@ -125,4 +131,14 @@ void main(void)
     color = vec4(pointColor, 1.0f);
     break;
   }
+
+  //Apply light
+  if (triangulate)
+  {
+      float ambianceFactor=0.15;
+      vec3 diffuseColor;
+      adModel(worldPosition, vertNorm, diffuseColor);
+      color = vec4(  color.xyz * (diffuseColor+ambianceFactor), 1 );
+  }
+
 }

--- a/src/3d/shaders/pointcloud.frag
+++ b/src/3d/shaders/pointcloud.frag
@@ -145,7 +145,7 @@ void main(void)
   //Apply light
   if (triangulate)
   {
-      float ambianceFactor=0.15;
+      float ambianceFactor=0.15; //value defined empircally by visual check to avoid too dark scene
       vec3 diffuseColor;
       adModel(worldPosition, vertNorm, diffuseColor);
       color =vec4( color.xyz * (diffuseColor+ambianceFactor), 1 );

--- a/src/3d/shaders/pointcloud.frag
+++ b/src/3d/shaders/pointcloud.frag
@@ -5,8 +5,8 @@ uniform bool triangulate;
 in float parameter;
 
 in vec3 pointColor;
-in vec3 worldPosition;
-in vec3 vertNorm;
+in vec3 worldPosition; //used when points are triangulated
+in vec3 vertNorm; //used when points are triangulated
 out vec4 color;
 
 // Sets the redering style, 0: unique color, 1: color ramp shader of terrain, 2: color ramp shader of 2D rendering

--- a/src/3d/shaders/pointcloud.vert
+++ b/src/3d/shaders/pointcloud.vert
@@ -30,8 +30,8 @@ void main(void)
     //gl_PointSize = viewportMatrix[1][1] * projectionMatrix[1][1] * 1.0 / gl_Position.w;
     //gl_PointSize = 100.0;
 
-    worldPosition =vec3 (modelMatrix * vec4 (vertexPosition,1));
-    vertNorm=vertexNormal;
+    worldPosition = vec3 (modelMatrix * vec4 (vertexPosition,1));
+    vertNorm = vertexNormal;
     parameter = vertexParameter;
     pointColor = vertexColor;
 }

--- a/src/3d/shaders/pointcloud.vert
+++ b/src/3d/shaders/pointcloud.vert
@@ -12,12 +12,12 @@ uniform int u_renderingParameter;
 in vec3 vertexPosition;
 in float vertexParameter;
 in vec3 vertexColor;
-in vec3 vertexNormal;
+in vec3 vertexNormal; //used when points are triangulated
 
 out float parameter;
 out vec3 pointColor;
-out vec3 worldPosition;
-out vec3 vertNorm;
+out vec3 worldPosition; //used when points are triangulated
+out vec3 vertNorm; //used when points are triangulated
 
 void main(void)
 {

--- a/src/3d/shaders/pointcloud.vert
+++ b/src/3d/shaders/pointcloud.vert
@@ -9,29 +9,41 @@ uniform float u_pointSize;
 // used parameter to choose point cloud points color: 0 for height, 1 for classID
 uniform int u_renderingParameter;
 
+uniform int u_renderingStyle;
+
 in vec3 vertexPosition;
 in float vertexParameter;
 in vec3 vertexColor;
 in vec3 vertexNormal; //used when points are triangulated
 
 out float parameter;
+flat out int classParameter;
 out vec3 pointColor;
 out vec3 worldPosition; //used when points are triangulated
 out vec3 vertNorm; //used when points are triangulated
 
 void main(void)
 {
-    //if (abs(cls-5) < 0.1)
-    //    gl_Position = vec4(0,0,0,0);
-    //else
-        gl_Position = modelViewProjection * vec4(vertexPosition, 1);
+    gl_Position = modelViewProjection * vec4(vertexPosition, 1);
 
-    gl_PointSize = u_pointSize; //5 + vertexPosition.x * 10 + vertexPosition.y * 10;
-    //gl_PointSize = viewportMatrix[1][1] * projectionMatrix[1][1] * 1.0 / gl_Position.w;
-    //gl_PointSize = 100.0;
+    gl_PointSize = u_pointSize;
 
     worldPosition = vec3 (modelMatrix * vec4 (vertexPosition,1));
     vertNorm = vertexNormal;
-    parameter = vertexParameter;
-    pointColor = vertexColor;
+
+    switch (u_renderingStyle)
+    {
+    case 0: //  no rendering
+    case 1: // single color
+      break;
+    case 2: // color ramp
+      parameter = vertexParameter;
+      break;
+    case 3: // RGB
+      pointColor = vertexColor;
+      break;
+    case 4: // classification
+      classParameter = int(vertexParameter);
+      break;
+    }
 }

--- a/src/3d/shaders/pointcloud.vert
+++ b/src/3d/shaders/pointcloud.vert
@@ -4,6 +4,7 @@ uniform mat4 modelViewProjection;
 
 uniform mat4 projectionMatrix;
 uniform mat4 viewportMatrix;
+uniform mat4 modelMatrix;
 uniform float u_pointSize;
 // used parameter to choose point cloud points color: 0 for height, 1 for classID
 uniform int u_renderingParameter;
@@ -11,9 +12,12 @@ uniform int u_renderingParameter;
 in vec3 vertexPosition;
 in float vertexParameter;
 in vec3 vertexColor;
+in vec3 vertexNormal;
 
 out float parameter;
 out vec3 pointColor;
+out vec3 worldPosition;
+out vec3 vertNorm;
 
 void main(void)
 {
@@ -26,6 +30,8 @@ void main(void)
     //gl_PointSize = viewportMatrix[1][1] * projectionMatrix[1][1] * 1.0 / gl_Position.w;
     //gl_PointSize = 100.0;
 
+    worldPosition =vec3 (modelMatrix * vec4 (vertexPosition,1));
+    vertNorm=vertexNormal;
     parameter = vertexParameter;
     pointColor = vertexColor;
 }

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -47,44 +47,44 @@ void QgsPointCloud3DSymbol::setRenderAsTriangles( bool asTriangles )
   mRenderAsTriangles = asTriangles;
 }
 
-bool QgsPointCloud3DSymbol::filterTrianglesBySize() const
+bool QgsPointCloud3DSymbol::horizontalTriangleFilter() const
 {
-  return mFilterTrianglesBySize;
+  return mHorizontalTriangleFilter;
 }
 
-void QgsPointCloud3DSymbol::setFilterTrianglesBySize( bool filterTriangleBySize )
+void QgsPointCloud3DSymbol::setHorizontalTriangleFilter( bool horizontalTriangleFilter )
 {
-  mFilterTrianglesBySize = filterTriangleBySize;
+  mHorizontalTriangleFilter = horizontalTriangleFilter;
 }
 
-float QgsPointCloud3DSymbol::triangleSizeThreshold() const
+float QgsPointCloud3DSymbol::horizontalFilterThreshold() const
 {
-  return mTriangleSizeThreshold;
+  return mHorizontalFilterThreshold;
 }
 
-void QgsPointCloud3DSymbol::setTriangleSizeThreshold( float triangleSizeThreshold )
+void QgsPointCloud3DSymbol::setHorizontalFilterThreshold( float horizontalFilterThreshold )
 {
-  mTriangleSizeThreshold = triangleSizeThreshold;
+  mHorizontalFilterThreshold = horizontalFilterThreshold;
 }
 
-bool QgsPointCloud3DSymbol::filterTrianglesByHeight() const
+bool QgsPointCloud3DSymbol::verticalTriangleFilter() const
 {
-  return mFilterTrianglesByHeight;
+  return mVerticalTriangleFilter;
 }
 
-void QgsPointCloud3DSymbol::setFilterTrianglesByHeight( bool filterTriangleByHeight )
+void QgsPointCloud3DSymbol::setVerticalTriangleFilter( bool verticalTriangleFilter )
 {
-  mFilterTrianglesByHeight = filterTriangleByHeight;
+  mVerticalTriangleFilter = verticalTriangleFilter;
 }
 
-float QgsPointCloud3DSymbol::triangleHeightThreshold() const
+float QgsPointCloud3DSymbol::verticalFilterThreshold() const
 {
-  return mTriangleHeightThreshold;
+  return mVerticalFilterThreshold;
 }
 
-void QgsPointCloud3DSymbol::setTriangleHeightThreshold( float triangleHeightThreshold )
+void QgsPointCloud3DSymbol::setVerticalFilterThreshold( float verticalFilterThreshold )
 {
-  mTriangleHeightThreshold = triangleHeightThreshold;
+  mVerticalFilterThreshold = verticalFilterThreshold;
 }
 
 void QgsPointCloud3DSymbol::writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const
@@ -93,10 +93,10 @@ void QgsPointCloud3DSymbol::writeBaseXml( QDomElement &elem, const QgsReadWriteC
 
   elem.setAttribute( QStringLiteral( "point-size" ), mPointSize );
   elem.setAttribute( QStringLiteral( "render-as-triangles" ), mRenderAsTriangles ? 1 : 0 );
-  elem.setAttribute( QStringLiteral( "filter-triangle-by-size" ), mFilterTrianglesBySize ? 1 : 0 );
-  elem.setAttribute( QStringLiteral( "triangle-size-threshold" ), mTriangleSizeThreshold );
-  elem.setAttribute( QStringLiteral( "filter-triangle-by-height" ), mFilterTrianglesByHeight ? 1 : 0 );
-  elem.setAttribute( QStringLiteral( "triangle-height-threshold" ), mTriangleHeightThreshold );
+  elem.setAttribute( QStringLiteral( "horizontal-triangle-filter" ), mHorizontalTriangleFilter ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "horizontal-filter-threshold" ), mHorizontalFilterThreshold );
+  elem.setAttribute( QStringLiteral( "vertical-triangle-filter" ), mVerticalTriangleFilter ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "vertical-filter-threshold" ), mVerticalFilterThreshold );
 }
 
 void QgsPointCloud3DSymbol::readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context )
@@ -105,10 +105,10 @@ void QgsPointCloud3DSymbol::readBaseXml( const QDomElement &elem, const QgsReadW
 
   mPointSize = elem.attribute( QStringLiteral( "point-size" ), QStringLiteral( "2.0" ) ).toFloat();
   mRenderAsTriangles = elem.attribute( QStringLiteral( "render-as-triangles" ), QStringLiteral( "0" ) ).toInt() == 1;
-  mFilterTrianglesBySize = elem.attribute( QStringLiteral( "filter-triangle-by-size" ), QStringLiteral( "0" ) ).toInt() == 1;
-  mTriangleSizeThreshold = elem.attribute( QStringLiteral( "triangle-size-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
-  mFilterTrianglesByHeight = elem.attribute( QStringLiteral( "filter-triangle-by-height" ), QStringLiteral( "0" ) ).toInt() == 1;
-  mTriangleHeightThreshold = elem.attribute( QStringLiteral( "triangle-height-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
+  mHorizontalTriangleFilter = elem.attribute( QStringLiteral( "horizontal-triangle-filter" ), QStringLiteral( "0" ) ).toInt() == 1;
+  mHorizontalFilterThreshold = elem.attribute( QStringLiteral( "horizontal-filter-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
+  mVerticalTriangleFilter = elem.attribute( QStringLiteral( "vertical-triangle-filter" ), QStringLiteral( "0" ) ).toInt() == 1;
+  mVerticalFilterThreshold = elem.attribute( QStringLiteral( "vertical-filter-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
 }
 
 void QgsPointCloud3DSymbol::copyBaseSettings( QgsAbstract3DSymbol *destination ) const
@@ -117,10 +117,10 @@ void QgsPointCloud3DSymbol::copyBaseSettings( QgsAbstract3DSymbol *destination )
   QgsPointCloud3DSymbol *pcDestination = static_cast<QgsPointCloud3DSymbol *>( destination );
   pcDestination->mPointSize = mPointSize;
   pcDestination->mRenderAsTriangles = mRenderAsTriangles;
-  pcDestination->mTriangleSizeThreshold = mTriangleSizeThreshold;
-  pcDestination->mFilterTrianglesBySize = mFilterTrianglesBySize;
-  pcDestination->mTriangleHeightThreshold = mTriangleHeightThreshold;
-  pcDestination->mFilterTrianglesByHeight = mFilterTrianglesByHeight;
+  pcDestination->mHorizontalFilterThreshold = mHorizontalFilterThreshold;
+  pcDestination->mHorizontalTriangleFilter = mHorizontalTriangleFilter;
+  pcDestination->mVerticalFilterThreshold = mVerticalFilterThreshold;
+  pcDestination->mVerticalTriangleFilter = mVerticalTriangleFilter;
 }
 
 // QgsSingleColorPointCloud3DSymbol
@@ -484,7 +484,6 @@ void QgsClassificationPointCloud3DSymbol::writeXml( QDomElement &elem, const Qgs
   writeBaseXml( elem, context );
 
   elem.setAttribute( QStringLiteral( "rendering-parameter" ), mRenderingParameter );
-  elem.setAttribute( QStringLiteral( "triangulate" ), mRenderAsTriangles ? 1 : 0 );
 
   // categories
   QDomElement catsElem = doc.createElement( QStringLiteral( "categories" ) );

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -546,28 +546,38 @@ QgsColorRampShader QgsClassificationPointCloud3DSymbol::colorRampShader() const
 
 void QgsClassificationPointCloud3DSymbol::fillMaterial( Qt3DRender::QMaterial *mat )
 {
-  const QgsColorRampShader mColorRampShader = colorRampShader();
-  Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::ColorRamp );
-  mat->addParameter( renderingStyle );
   Qt3DRender::QParameter *pointSizeParameter = new Qt3DRender::QParameter( "u_pointSize", QVariant::fromValue( mPointSize ) );
   mat->addParameter( pointSizeParameter );
-  // Create the texture to pass the color ramp
-  Qt3DRender::QTexture1D *colorRampTexture = nullptr;
-  if ( mColorRampShader.colorRampItemList().count() > 0 )
-  {
-    colorRampTexture = new Qt3DRender::QTexture1D( mat );
-    colorRampTexture->addTextureImage( new QgsColorRampTexture( mColorRampShader, 1 ) );
-    colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
-    colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
-  }
 
-  // Parameters
-  Qt3DRender::QParameter *colorRampTextureParameter = new Qt3DRender::QParameter( "u_colorRampTexture", colorRampTexture );
-  mat->addParameter( colorRampTextureParameter );
-  Qt3DRender::QParameter *colorRampCountParameter = new Qt3DRender::QParameter( "u_colorRampCount", mColorRampShader.colorRampItemList().count() );
-  mat->addParameter( colorRampCountParameter );
-  const int colorRampType = mColorRampShader.colorRampType();
-  Qt3DRender::QParameter *colorRampTypeParameter = new Qt3DRender::QParameter( "u_colorRampType", colorRampType );
-  mat->addParameter( colorRampTypeParameter );
+  if ( !mRenderAsTriangles )
+  {
+    // Create the texture to pass the color ramp
+    const QgsColorRampShader mColorRampShader = colorRampShader();
+    Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::ColorRamp );
+    mat->addParameter( renderingStyle );
+    Qt3DRender::QTexture1D *colorRampTexture = nullptr;
+    if ( mColorRampShader.colorRampItemList().count() > 0 )
+    {
+      colorRampTexture = new Qt3DRender::QTexture1D( mat );
+      colorRampTexture->addTextureImage( new QgsColorRampTexture( mColorRampShader, 1 ) );
+      colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
+      colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
+    }
+
+    // Parameters
+    Qt3DRender::QParameter *colorRampTextureParameter = new Qt3DRender::QParameter( "u_colorRampTexture", colorRampTexture );
+    mat->addParameter( colorRampTextureParameter );
+    Qt3DRender::QParameter *colorRampCountParameter = new Qt3DRender::QParameter( "u_colorRampCount", mColorRampShader.colorRampItemList().count() );
+    mat->addParameter( colorRampCountParameter );
+    const int colorRampType = mColorRampShader.colorRampType();
+    Qt3DRender::QParameter *colorRampTypeParameter = new Qt3DRender::QParameter( "u_colorRampType", colorRampType );
+    mat->addParameter( colorRampTypeParameter );
+  }
+  else
+  {
+    // When we triangulate, the color is passed to the shader instead of the parameter
+    Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::RgbRendering );
+    mat->addParameter( renderingStyle );
+  }
 }
 

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -571,38 +571,28 @@ QgsColorRampShader QgsClassificationPointCloud3DSymbol::colorRampShader() const
 
 void QgsClassificationPointCloud3DSymbol::fillMaterial( Qt3DRender::QMaterial *mat )
 {
+  const QgsColorRampShader mColorRampShader = colorRampShader();
+  Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::ColorRamp );
+  mat->addParameter( renderingStyle );
   Qt3DRender::QParameter *pointSizeParameter = new Qt3DRender::QParameter( "u_pointSize", QVariant::fromValue( mPointSize ) );
   mat->addParameter( pointSizeParameter );
-
-  if ( !mRenderAsTriangles )
+  // Create the texture to pass the color ramp
+  Qt3DRender::QTexture1D *colorRampTexture = nullptr;
+  if ( mColorRampShader.colorRampItemList().count() > 0 )
   {
-    // Create the texture to pass the color ramp
-    const QgsColorRampShader mColorRampShader = colorRampShader();
-    Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::ColorRamp );
-    mat->addParameter( renderingStyle );
-    Qt3DRender::QTexture1D *colorRampTexture = nullptr;
-    if ( mColorRampShader.colorRampItemList().count() > 0 )
-    {
-      colorRampTexture = new Qt3DRender::QTexture1D( mat );
-      colorRampTexture->addTextureImage( new QgsColorRampTexture( mColorRampShader, 1 ) );
-      colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
-      colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
-    }
+    colorRampTexture = new Qt3DRender::QTexture1D( mat );
+    colorRampTexture->addTextureImage( new QgsColorRampTexture( mColorRampShader, 1 ) );
+    colorRampTexture->setMinificationFilter( Qt3DRender::QTexture1D::Linear );
+    colorRampTexture->setMagnificationFilter( Qt3DRender::QTexture1D::Linear );
+  }
 
-    // Parameters
-    Qt3DRender::QParameter *colorRampTextureParameter = new Qt3DRender::QParameter( "u_colorRampTexture", colorRampTexture );
-    mat->addParameter( colorRampTextureParameter );
-    Qt3DRender::QParameter *colorRampCountParameter = new Qt3DRender::QParameter( "u_colorRampCount", mColorRampShader.colorRampItemList().count() );
-    mat->addParameter( colorRampCountParameter );
-    const int colorRampType = mColorRampShader.colorRampType();
-    Qt3DRender::QParameter *colorRampTypeParameter = new Qt3DRender::QParameter( "u_colorRampType", colorRampType );
-    mat->addParameter( colorRampTypeParameter );
-  }
-  else
-  {
-    // When we triangulate, the color is passed to the shader instead of the parameter
-    Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::RgbRendering );
-    mat->addParameter( renderingStyle );
-  }
+  // Parameters
+  Qt3DRender::QParameter *colorRampTextureParameter = new Qt3DRender::QParameter( "u_colorRampTexture", colorRampTexture );
+  mat->addParameter( colorRampTextureParameter );
+  Qt3DRender::QParameter *colorRampCountParameter = new Qt3DRender::QParameter( "u_colorRampCount", mColorRampShader.colorRampItemList().count() );
+  mat->addParameter( colorRampCountParameter );
+  const int colorRampType = mColorRampShader.colorRampType();
+  Qt3DRender::QParameter *colorRampTypeParameter = new Qt3DRender::QParameter( "u_colorRampType", colorRampType );
+  mat->addParameter( colorRampTypeParameter );
 }
 

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -37,6 +37,16 @@ void QgsPointCloud3DSymbol::setPointSize( float size )
   mPointSize = size;
 }
 
+bool QgsPointCloud3DSymbol::triangulate() const
+{
+  return mTriangulate;
+}
+
+void QgsPointCloud3DSymbol::setTriangulate( bool triangulate )
+{
+  mTriangulate = triangulate;
+}
+
 // QgsSingleColorPointCloud3DSymbol
 
 QgsSingleColorPointCloud3DSymbol::QgsSingleColorPointCloud3DSymbol()
@@ -55,6 +65,7 @@ QgsAbstract3DSymbol *QgsSingleColorPointCloud3DSymbol::clone() const
   QgsSingleColorPointCloud3DSymbol *result = new QgsSingleColorPointCloud3DSymbol;
   result->mPointSize = mPointSize;
   result->mSingleColor = mSingleColor;
+  result->mTriangulate = mTriangulate;
   copyBaseSettings( result );
   return result;
 }
@@ -65,6 +76,7 @@ void QgsSingleColorPointCloud3DSymbol::writeXml( QDomElement &elem, const QgsRea
 
   elem.setAttribute( QStringLiteral( "point-size" ), mPointSize );
   elem.setAttribute( QStringLiteral( "single-color" ), QgsSymbolLayerUtils::encodeColor( mSingleColor ) );
+  elem.setAttribute( QStringLiteral( "triangulate" ), mTriangulate ? 1 : 0 );
 }
 
 void QgsSingleColorPointCloud3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
@@ -73,6 +85,7 @@ void QgsSingleColorPointCloud3DSymbol::readXml( const QDomElement &elem, const Q
 
   mPointSize = elem.attribute( QStringLiteral( "point-size" ), QStringLiteral( "2.0" ) ).toFloat();
   mSingleColor = QgsSymbolLayerUtils::decodeColor( elem.attribute( QStringLiteral( "single-color" ), QStringLiteral( "0,0,255" ) ) );
+  mTriangulate = elem.attribute( QStringLiteral( "triangulate" ), QStringLiteral( "0" ) ).toInt() == 1;
 }
 
 void QgsSingleColorPointCloud3DSymbol::setSingleColor( QColor color )
@@ -106,6 +119,7 @@ QgsAbstract3DSymbol *QgsColorRampPointCloud3DSymbol::clone() const
   result->mColorRampShader = mColorRampShader;
   result->mColorRampShaderMin = mColorRampShaderMin;
   result->mColorRampShaderMax = mColorRampShaderMax;
+  result->mTriangulate = mTriangulate;
   copyBaseSettings( result );
   return result;
 }
@@ -123,6 +137,7 @@ void QgsColorRampPointCloud3DSymbol::writeXml( QDomElement &elem, const QgsReadW
   elem.setAttribute( QStringLiteral( "rendering-parameter" ), mRenderingParameter );
   elem.setAttribute( QStringLiteral( "color-ramp-shader-min" ), mColorRampShaderMin );
   elem.setAttribute( QStringLiteral( "color-ramp-shader-max" ), mColorRampShaderMax );
+  elem.setAttribute( QStringLiteral( "triangulate" ), mTriangulate ? 1 : 0 );
   QDomDocument doc = elem.ownerDocument();
   const QDomElement elemColorRampShader = mColorRampShader.writeXml( doc );
   elem.appendChild( elemColorRampShader );
@@ -136,6 +151,7 @@ void QgsColorRampPointCloud3DSymbol::readXml( const QDomElement &elem, const Qgs
   mRenderingParameter = elem.attribute( "rendering-parameter", QString() );
   mColorRampShaderMin = elem.attribute( QStringLiteral( "color-ramp-shader-min" ), QStringLiteral( "0.0" ) ).toDouble();
   mColorRampShaderMax = elem.attribute( QStringLiteral( "color-ramp-shader-max" ), QStringLiteral( "1.0" ) ).toDouble();
+  mTriangulate = elem.attribute( QStringLiteral( "triangulate" ), QStringLiteral( "0" ) ).toInt() == 1;
   mColorRampShader.readXml( elem );
 }
 
@@ -211,6 +227,7 @@ QgsAbstract3DSymbol *QgsRgbPointCloud3DSymbol::clone() const
   result->mRedAttribute = mRedAttribute;
   result->mGreenAttribute = mGreenAttribute;
   result->mBlueAttribute = mBlueAttribute;
+  result->mTriangulate = mTriangulate;
 
   if ( mRedContrastEnhancement )
   {
@@ -236,6 +253,7 @@ void QgsRgbPointCloud3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteCo
   elem.setAttribute( QStringLiteral( "red" ), mRedAttribute );
   elem.setAttribute( QStringLiteral( "green" ), mGreenAttribute );
   elem.setAttribute( QStringLiteral( "blue" ), mBlueAttribute );
+  elem.setAttribute( QStringLiteral( "triangulate" ), mTriangulate ? 1 : 0 );
 
   QDomDocument doc = elem.ownerDocument();
 
@@ -268,6 +286,7 @@ void QgsRgbPointCloud3DSymbol::readXml( const QDomElement &elem, const QgsReadWr
   setRedAttribute( elem.attribute( QStringLiteral( "red" ), QStringLiteral( "Red" ) ) );
   setGreenAttribute( elem.attribute( QStringLiteral( "green" ), QStringLiteral( "Green" ) ) );
   setBlueAttribute( elem.attribute( QStringLiteral( "blue" ), QStringLiteral( "Blue" ) ) );
+  mTriangulate = elem.attribute( QStringLiteral( "triangulate" ), QStringLiteral( "0" ) ).toInt() == 1;
 
   //contrast enhancements
   QgsContrastEnhancement *redContrastEnhancement = nullptr;
@@ -382,6 +401,7 @@ QgsAbstract3DSymbol *QgsClassificationPointCloud3DSymbol::clone() const
   result->mPointSize = mPointSize;
   result->mRenderingParameter = mRenderingParameter;
   result->mCategoriesList = mCategoriesList;
+  result->mTriangulate = mTriangulate;
   copyBaseSettings( result );
   return result;
 }
@@ -398,6 +418,7 @@ void QgsClassificationPointCloud3DSymbol::writeXml( QDomElement &elem, const Qgs
 
   elem.setAttribute( QStringLiteral( "point-size" ), mPointSize );
   elem.setAttribute( QStringLiteral( "rendering-parameter" ), mRenderingParameter );
+  elem.setAttribute( QStringLiteral( "triangulate" ), mTriangulate ? 1 : 0 );
 
   // categories
   QDomElement catsElem = doc.createElement( QStringLiteral( "categories" ) );
@@ -419,6 +440,7 @@ void QgsClassificationPointCloud3DSymbol::readXml( const QDomElement &elem, cons
 
   mPointSize = elem.attribute( "point-size", QStringLiteral( "2.0" ) ).toFloat();
   mRenderingParameter = elem.attribute( "rendering-parameter", QString() );
+  mTriangulate = elem.attribute( QStringLiteral( "triangulate" ), QStringLiteral( "0" ) ).toInt() == 1;
 
   const QDomElement catsElem = elem.firstChildElement( QStringLiteral( "categories" ) );
   if ( !catsElem.isNull() )

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -572,7 +572,7 @@ QgsColorRampShader QgsClassificationPointCloud3DSymbol::colorRampShader() const
 void QgsClassificationPointCloud3DSymbol::fillMaterial( Qt3DRender::QMaterial *mat )
 {
   const QgsColorRampShader mColorRampShader = colorRampShader();
-  Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::ColorRamp );
+  Qt3DRender::QParameter *renderingStyle = new Qt3DRender::QParameter( "u_renderingStyle", QgsPointCloud3DSymbol::Classification );
   mat->addParameter( renderingStyle );
   Qt3DRender::QParameter *pointSizeParameter = new Qt3DRender::QParameter( "u_pointSize", QVariant::fromValue( mPointSize ) );
   mat->addParameter( pointSizeParameter );

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -59,12 +59,32 @@ void QgsPointCloud3DSymbol::setFilterTrianglesBySize( bool filterTriangleBySize 
 
 float QgsPointCloud3DSymbol::triangleSizeThreshold() const
 {
-  return mTriangleSizesThreshold;
+  return mTriangleSizeThreshold;
 }
 
 void QgsPointCloud3DSymbol::setTriangleSizeThreshold( float triangleSizeThreshold )
 {
-  mTriangleSizesThreshold = triangleSizeThreshold;
+  mTriangleSizeThreshold = triangleSizeThreshold;
+}
+
+bool QgsPointCloud3DSymbol::filterTrianglesByHeight() const
+{
+  return mFilterTrianglesByHeight;
+}
+
+void QgsPointCloud3DSymbol::setFilterTrianglesByHeight( bool filterTriangleByHeight )
+{
+  mFilterTrianglesByHeight = filterTriangleByHeight;
+}
+
+float QgsPointCloud3DSymbol::triangleHeightThreshold() const
+{
+  return mTriangleHeightThreshold;
+}
+
+void QgsPointCloud3DSymbol::setTriangleHeightThreshold( float triangleHeightThreshold )
+{
+  mTriangleHeightThreshold = triangleHeightThreshold;
 }
 
 void QgsPointCloud3DSymbol::writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const
@@ -74,7 +94,9 @@ void QgsPointCloud3DSymbol::writeBaseXml( QDomElement &elem, const QgsReadWriteC
   elem.setAttribute( QStringLiteral( "point-size" ), mPointSize );
   elem.setAttribute( QStringLiteral( "render-as-triangles" ), mRenderAsTriangles ? 1 : 0 );
   elem.setAttribute( QStringLiteral( "filter-triangle-by-size" ), mFilterTrianglesBySize ? 1 : 0 );
-  elem.setAttribute( QStringLiteral( "triangle-size-threshold" ), mTriangleSizesThreshold );
+  elem.setAttribute( QStringLiteral( "triangle-size-threshold" ), mTriangleSizeThreshold );
+  elem.setAttribute( QStringLiteral( "filter-triangle-by-height" ), mFilterTrianglesByHeight ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "triangle-height-threshold" ), mTriangleHeightThreshold );
 }
 
 void QgsPointCloud3DSymbol::readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context )
@@ -84,7 +106,9 @@ void QgsPointCloud3DSymbol::readBaseXml( const QDomElement &elem, const QgsReadW
   mPointSize = elem.attribute( QStringLiteral( "point-size" ), QStringLiteral( "2.0" ) ).toFloat();
   mRenderAsTriangles = elem.attribute( QStringLiteral( "render-as-triangles" ), QStringLiteral( "0" ) ).toInt() == 1;
   mFilterTrianglesBySize = elem.attribute( QStringLiteral( "filter-triangle-by-size" ), QStringLiteral( "0" ) ).toInt() == 1;
-  mTriangleSizesThreshold = elem.attribute( QStringLiteral( "triangle-size-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
+  mTriangleSizeThreshold = elem.attribute( QStringLiteral( "triangle-size-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
+  mFilterTrianglesByHeight = elem.attribute( QStringLiteral( "filter-triangle-by-height" ), QStringLiteral( "0" ) ).toInt() == 1;
+  mTriangleHeightThreshold = elem.attribute( QStringLiteral( "triangle-height-threshold" ), QStringLiteral( "10.0" ) ).toFloat();
 }
 
 void QgsPointCloud3DSymbol::copyBaseSettings( QgsAbstract3DSymbol *destination ) const
@@ -93,8 +117,10 @@ void QgsPointCloud3DSymbol::copyBaseSettings( QgsAbstract3DSymbol *destination )
   QgsPointCloud3DSymbol *pcDestination = static_cast<QgsPointCloud3DSymbol *>( destination );
   pcDestination->mPointSize = mPointSize;
   pcDestination->mRenderAsTriangles = mRenderAsTriangles;
-  pcDestination->mTriangleSizesThreshold = mTriangleSizesThreshold;
+  pcDestination->mTriangleSizeThreshold = mTriangleSizeThreshold;
   pcDestination->mFilterTrianglesBySize = mFilterTrianglesBySize;
+  pcDestination->mTriangleHeightThreshold = mTriangleHeightThreshold;
+  pcDestination->mFilterTrianglesByHeight = mFilterTrianglesByHeight;
 }
 
 // QgsSingleColorPointCloud3DSymbol

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -98,76 +98,76 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     void setRenderAsTriangles( bool asTriangles );
 
     /**
-     * Returns whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
-     * than a threshold value will not be rendered, see triangleSizeThreshold().
+     * Returns whether triangles are filtered by horizontal size for rendering. If the triangles are horizontally filtered by size,
+     * triangles with a horizontal side size greater than a threshold value will not be rendered, see horizontalFilterThreshold().
      *
      * \since QGIS 3.26
      */
-    bool filterTrianglesBySize() const;
+    bool horizontalTriangleFilter() const;
 
     /**
-     * Sets whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
-     * than a threshold value will not be rendered, see setTriangleSizeThreshold().
+     * Sets whether whether triangles are filtered by horizontal size for rendering. If the triangles are horizontally filtered by size,
+     * triangles with a horizontal side size greater than a threshold value will not be rendered, see setHorizontalFilterThreshold().
      *
      * \since QGIS 3.26
      */
-    void setFilterTrianglesBySize( bool filterTriangleBySize );
+    void setHorizontalTriangleFilter( bool horizontalTriangleFilter );
 
     /**
-     * Returns the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
-     * than this threshold value will not be rendered, see filterTrianglesBySize().
+     * Returns the threshold horizontal size value for filtering triangles. If the triangles are horizontally filtered by size,
+     * triangles with a horizontal side size greater than a threshold value will not be rendered, see horizontalTriangleFilter().
      *
      * \since QGIS 3.26
      */
-    float triangleSizeThreshold() const;
+    float horizontalFilterThreshold() const;
 
     /**
-     * Sets the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
-     * than this threshold value will not be rendered, see setFilterTrianglesBySize().
+     * Sets the threshold horizontal size value for filtering triangles. If the triangles are horizontally filtered by size,
+     * triangles with a horizontal side size greater than a threshold value will not be rendered, see setHorizontalTriangleFilter().
      *
      * \since QGIS 3.26
      */
-    void setTriangleSizeThreshold( float triangleSizeThreshold );
+    void setHorizontalFilterThreshold( float horizontalFilterThreshold );
 
     /**
-     * Returns whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
-     * than a threshold value will not be rendered, see triangleHeightThreshold().
+     * Returns whether triangles are filtered by vertical height for rendering. If the triangles are vertically filtered, triangles with a vertical height greater
+     * than a threshold value will not be rendered, see verticalFilterThreshold().
      *
      * \since QGIS 3.26
      */
-    bool filterTrianglesByHeight() const;
+    bool verticalTriangleFilter() const;
 
     /**
-     * Sets whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
-     * than a threshold value will not be rendered, see setTriangleHeightThreshold().
+     * Sets whether triangles are filtered by vertical height for rendering. If the triangles are vertically filtered, triangles with a vertical height greater
+     * than a threshold value will not be rendered, see setVerticalFilterThreshold().
      *
      * \since QGIS 3.26
      */
-    void setFilterTrianglesByHeight( bool filterTriangleByHeight );
+    void setVerticalTriangleFilter( bool verticalTriangleFilter );
 
     /**
-     * Returns the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
-     * than this threshold value will not be rendered, see filterTrianglesByHeight().
+     * Returns the threshold vertical height value for filtering triangles. If the triangles are filtered vertically, triangles with a vertical height greater
+     * than this threshold value will not be rendered, see verticalTriangleFilter().
      *
      * \since QGIS 3.26
      */
-    float triangleHeightThreshold() const;
+    float verticalFilterThreshold() const;
 
     /**
-     * Sets the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
-     * than this threshold value will not be rendered, see setFilterTrianglesByHeight().
+     * Sets the threshold vertical height value for filtering triangles. If the triangles are filtered vertically, triangles with a vertical height greater
+     * than this threshold value will not be rendered, see setVerticalTriangleFilter().
      *
      * \since QGIS 3.26
      */
-    void setTriangleHeightThreshold( float triangleHeightThreshold );
+    void setVerticalFilterThreshold( float verticalFilterThreshold );
 
   protected:
     float mPointSize = 2.0;
     bool mRenderAsTriangles = false;
-    bool mFilterTrianglesBySize = false;
-    float mTriangleSizeThreshold = 10.0;
-    bool mFilterTrianglesByHeight = false;
-    float mTriangleHeightThreshold = 10.0;
+    bool mHorizontalTriangleFilter = false;
+    float mHorizontalFilterThreshold = 10.0;
+    bool mVerticalTriangleFilter = false;
+    float mVerticalFilterThreshold = 10.0;
 
     /**
      * Writes symbol configuration of this class to the given DOM element

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -98,7 +98,7 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     void setRenderAsTriangles( bool asTriangles );
 
     /**
-     * Returns whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+     * Returns whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
      * than a threshold value will not be rendered, see triangleSizeThreshold().
      *
      * \since QGIS 3.26
@@ -106,7 +106,7 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     bool filterTrianglesBySize() const;
 
     /**
-     * Sets whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+     * Sets whether triangles are filtered by size for rendering. If the triangles are filtered by size, triangles with a size greater
      * than a threshold value will not be rendered, see setTriangleSizeThreshold().
      *
      * \since QGIS 3.26
@@ -114,26 +114,60 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     void setFilterTrianglesBySize( bool filterTriangleBySize );
 
     /**
-     * Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
-     * than this threshold value will not be rendered, see setTriangleSizeThreshold().
+     * Returns the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
+     * than this threshold value will not be rendered, see filterTrianglesBySize().
      *
      * \since QGIS 3.26
      */
     float triangleSizeThreshold() const;
 
     /**
-     * Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
-     * than this threshold value will not be rendered, see setTriangleSizeThreshold().
+     * Sets the threshold size value for filtering triangles. If the triangles are filtered by size, triangles with a side's size greater
+     * than this threshold value will not be rendered, see setFilterTrianglesBySize().
      *
      * \since QGIS 3.26
      */
     void setTriangleSizeThreshold( float triangleSizeThreshold );
 
+    /**
+     * Returns whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
+     * than a threshold value will not be rendered, see triangleHeightThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    bool filterTrianglesByHeight() const;
+
+    /**
+     * Sets whether triangles are filtered by 3D height for rendering. If the triangles are filtered by height, triangles with a 3D height greater
+     * than a threshold value will not be rendered, see setTriangleHeightThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    void setFilterTrianglesByHeight( bool filterTriangleByHeight );
+
+    /**
+     * Returns the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
+     * than this threshold value will not be rendered, see filterTrianglesByHeight().
+     *
+     * \since QGIS 3.26
+     */
+    float triangleHeightThreshold() const;
+
+    /**
+     * Sets the threshold 3D height value for filtering triangles. If the triangles are filtered by height, triangles with a side's size greater
+     * than this threshold value will not be rendered, see setFilterTrianglesByHeight().
+     *
+     * \since QGIS 3.26
+     */
+    void setTriangleHeightThreshold( float triangleHeightThreshold );
+
   protected:
     float mPointSize = 2.0;
     bool mRenderAsTriangles = false;
     bool mFilterTrianglesBySize = false;
-    float mTriangleSizesThreshold = 10.0;
+    float mTriangleSizeThreshold = 10.0;
+    bool mFilterTrianglesByHeight = false;
+    float mTriangleHeightThreshold = 10.0;
 
     void writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
     void readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context );

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -83,15 +83,62 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     //! Used to fill material object with necessary QParameters (and consequently opengl uniforms)
     virtual void fillMaterial( Qt3DRender::QMaterial *material ) = 0 SIP_SKIP;
 
-    //! Returns whether points are triangulated to render solid surface
-    bool triangulate() const;
+    /**
+     * Returns whether points are triangulated to render solid surface
+     *
+     * \since QGIS 3.26
+     */
+    bool renderAsTriangles() const;
 
-    //! Sets whether points are triangulated to render solid surface
-    void setTriangulate( bool triangulate );
+    /**
+     * Sets whether points are triangulated to render solid surface
+     *
+     * \since QGIS 3.26
+     */
+    void setRenderAsTriangles( bool asTriangles );
+
+    /**
+     * Returns whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+     * than a threshold value will not be rendered, see triangleSizeThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    bool filterTrianglesBySize() const;
+
+    /**
+     * Sets whether triangles are filtered by size for rendering. If the triangles are filtered, triangles with a size greater
+     * than a threshold value will not be rendered, see setTriangleSizeThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    void setFilterTrianglesBySize( bool filterTriangleBySize );
+
+    /**
+     * Returns the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
+     * than this threshold value will not be rendered, see setTriangleSizeThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    float triangleSizeThreshold() const;
+
+    /**
+     * Sets the threshold size value for filtering triangles. If the triangles are filtered, triangles with a side's size greater
+     * than this threshold value will not be rendered, see setTriangleSizeThreshold().
+     *
+     * \since QGIS 3.26
+     */
+    void setTriangleSizeThreshold( float triangleSizeThreshold );
 
   protected:
     float mPointSize = 2.0;
-    bool mTriangulate = false;
+    bool mRenderAsTriangles = false;
+    bool mFilterTrianglesBySize = false;
+    float mTriangleSizesThreshold = 10.0;
+
+    void writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
+    void readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context );
+
+    void copyBaseSettings( QgsAbstract3DSymbol *destination ) const override;
 };
 
 /**

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -169,7 +169,18 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     bool mFilterTrianglesByHeight = false;
     float mTriangleHeightThreshold = 10.0;
 
+    /**
+     * Writes symbol configuration of this class to the given DOM element
+     *
+     * \since QGIS 3.26
+     */
     void writeBaseXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
+
+    /**
+     * Reads symbol configuration of this class from the given DOM element
+     *
+     * \since QGIS 3.26
+     */
     void readBaseXml( const QDomElement &elem, const QgsReadWriteContext &context );
 
     void copyBaseSettings( QgsAbstract3DSymbol *destination ) const override;

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -83,8 +83,15 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     //! Used to fill material object with necessary QParameters (and consequently opengl uniforms)
     virtual void fillMaterial( Qt3DRender::QMaterial *material ) = 0 SIP_SKIP;
 
+    //! Returns whether points are triangulated to render solid surface
+    bool triangulate() const;
+
+    //! Sets whether points are triangulated to render solid surface
+    void setTriangulate( bool triangulate );
+
   protected:
     float mPointSize = 2.0;
+    bool mTriangulate = false;
 };
 
 /**

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -51,7 +51,9 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
       //! Render the point cloud with a color ramp
       ColorRamp,
       //! Render the RGB colors of the point cloud
-      RgbRendering
+      RgbRendering,
+      //! Render the point cloud with classified colors
+      Classification
     };
 
     //! Constructor for QgsPointCloud3DSymbol

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -466,7 +466,7 @@ class _3D_EXPORT QgsClassificationPointCloud3DSymbol : public QgsPointCloud3DSym
      */
     QgsPointCloudCategoryList getFilteredOutCategories() const;
 
-    unsigned int byteStride() override { return 4 * sizeof( float ); }
+    unsigned int byteStride() override { return ( mRenderAsTriangles ? 6 : 4 ) * sizeof( float ); }
     void fillMaterial( Qt3DRender::QMaterial *material ) override SIP_SKIP;
 
   private:

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -511,7 +511,7 @@ class _3D_EXPORT QgsClassificationPointCloud3DSymbol : public QgsPointCloud3DSym
      */
     QgsPointCloudCategoryList getFilteredOutCategories() const;
 
-    unsigned int byteStride() override { return ( mRenderAsTriangles ? 6 : 4 ) * sizeof( float ); }
+    unsigned int byteStride() override { return 4 * sizeof( float ); }
     void fillMaterial( Qt3DRender::QMaterial *material ) override SIP_SKIP;
 
   private:

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -302,12 +302,12 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
   double extraZ = extraBoxFactor * bbox.zExtent();
 
   // We keep all points in vertical direction to avoid odd triangulation if points are isolated on top
-  const QgsAABB extentedBBox( bbox.xMin - extraX, -std::numeric_limits<float>::max(), bbox.zMin - extraZ, bbox.xMax + extraX, std::numeric_limits<float>::max(), bbox.zMax + extraZ );
+  const QgsAABB extendedBBox( bbox.xMin - extraX, -std::numeric_limits<float>::max(), bbox.zMin - extraZ, bbox.xMax + extraX, std::numeric_limits<float>::max(), bbox.zMax + extraZ );
 
   for ( int i = properPointsCount; i < outNormal.positions.count(); ++i )
   {
     const  QVector3D pos = outNormal.positions.at( i );
-    if ( extentedBBox.intersects( pos.x(), pos.y(), pos.z() ) )
+    if ( extendedBBox.intersects( pos.x(), pos.y(), pos.z() ) )
     {
       filteredExtraPointData.positions.append( pos );
       vertices.push_back( pos.x() );
@@ -383,8 +383,8 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
     for ( size_t i = 0; i < triangleIndexes.size() / 3; ++i )
     {
       bool atLeastOneInBox = false;
-      bool greaterThanSizeThreshold = false;
-      bool greaterThanHeighThreshold = false;
+      bool greaterThanSize = false;
+      bool greaterThanHeigh = false;
       for ( size_t j = 0; j < 3; j++ )
       {
         QVector3D pos = outNormal.positions.at( triangleIndexes.at( i * 3 + j ) );
@@ -396,21 +396,21 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
           pos2 = outNormal.positions.at( triangleIndexes.at( i * 3 + ( j + 1 ) % 3 ) );
 
         if ( heightFilter )
-          greaterThanHeighThreshold |= std::fabs( pos.y() - pos2.y() ) > heightThreshold;
+          greaterThanHeigh |= std::fabs( pos.y() - pos2.y() ) > heightThreshold;
 
-        if ( sizeFilter && ! greaterThanHeighThreshold )
+        if ( sizeFilter && ! greaterThanHeigh )
         {
           QVector3D pos2 = outNormal.positions.at( triangleIndexes.at( i * 3 + ( j + 1 ) % 3 ) );
           // filter only in the horizontal plan, it is a 2.5D triangulation.
           pos2.setY( 0 );
           pos.setY( 0 );
-          greaterThanSizeThreshold |= pos2.distanceToPoint( pos ) > sizeThreshold;
+          greaterThanSize |= pos2.distanceToPoint( pos ) > sizeThreshold;
         }
 
-        if ( greaterThanSizeThreshold || greaterThanHeighThreshold )
+        if ( greaterThanSize || greaterThanHeigh )
           break;
       }
-      if ( atLeastOneInBox && !greaterThanSizeThreshold && !greaterThanHeighThreshold )
+      if ( atLeastOneInBox && !greaterThanSize && !greaterThanHeigh )
       {
         for ( size_t j = 0; j < 3; j++ )
         {

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -384,7 +384,7 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
     {
       bool atLeastOneInBox = false;
       bool greaterThanSize = false;
-      bool greaterThanHeigh = false;
+      bool greaterThanHeight = false;
       for ( size_t j = 0; j < 3; j++ )
       {
         QVector3D pos = outNormal.positions.at( triangleIndexes.at( i * 3 + j ) );
@@ -396,9 +396,9 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
           pos2 = outNormal.positions.at( triangleIndexes.at( i * 3 + ( j + 1 ) % 3 ) );
 
         if ( heightFilter )
-          greaterThanHeigh |= std::fabs( pos.y() - pos2.y() ) > heightThreshold;
+          greaterThanHeight |= std::fabs( pos.y() - pos2.y() ) > heightThreshold;
 
-        if ( sizeFilter && ! greaterThanHeigh )
+        if ( sizeFilter && ! greaterThanHeight )
         {
           QVector3D pos2 = outNormal.positions.at( triangleIndexes.at( i * 3 + ( j + 1 ) % 3 ) );
           // filter only in the horizontal plan, it is a 2.5D triangulation.
@@ -407,10 +407,10 @@ void QgsPointCloud3DSymbolHandler::triangulate( QgsPointCloudIndex *pc, const In
           greaterThanSize |= pos2.distanceToPoint( pos ) > sizeThreshold;
         }
 
-        if ( greaterThanSize || greaterThanHeigh )
+        if ( greaterThanSize || greaterThanHeight )
           break;
       }
-      if ( atLeastOneInBox && !greaterThanSize && !greaterThanHeigh )
+      if ( atLeastOneInBox && !greaterThanSize && !greaterThanHeight )
       {
         for ( size_t j = 0; j < 3; j++ )
         {

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -22,6 +22,7 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgspointcloudattribute.h"
 #include "qgspointcloudrequest.h"
+#include "qgscolorramptexture.h"
 #include "qgs3dmapsettings.h"
 #include "qgspointcloudindex.h"
 #include "qgspointcloudblockrequest.h"

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.h
@@ -73,6 +73,7 @@ class QgsPointCloud3DSymbolHandler // : public QgsFeature3DHandler
     // outputs
     PointData outNormal;  //!< Features that are not selected
 
+  private:
     //! Returns all vertices of the node \a n, and of its parents contained in \a bbox and in an extension of this box depending of the density of the points
     std::vector<double> getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
 
@@ -81,8 +82,10 @@ class QgsPointCloud3DSymbolHandler // : public QgsFeature3DHandler
 
     /**
      * Applies a filter on triangles to improve the rendering:
+     *
      * - keeps only triangles that have a least one point in the bounding box \a bbox
      * - if options are selected, skips triangles with horizontale or vertical size greater than a threshold
+     *
      * Must be used only in the method triangulate().
      */
     void filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );

--- a/src/3d/symbols/qgspointcloud3dsymbol_p.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.h
@@ -72,6 +72,20 @@ class QgsPointCloud3DSymbolHandler // : public QgsFeature3DHandler
 
     // outputs
     PointData outNormal;  //!< Features that are not selected
+
+    //! Returns all vertices of the node \a n, and of its parents contained in \a bbox and in an extension of this box depending of the density of the points
+    std::vector<double> getVertices( QgsPointCloudIndex *pc, const IndexedPointCloudNode &n, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
+
+    //! Calculates the normals of triangles dedined by index contained in \a triangles. Must be used only in the method triangulate().
+    void calculateNormals( const std::vector<size_t> &triangles );
+
+    /**
+     * Applies a filter on triangles to improve the rendering:
+     * - keeps only triangles that have a least one point in the bounding box \a bbox
+     * - if options are selected, skips triangles with horizontale or vertical size greater than a threshold
+     * Must be used only in the method triangulate().
+     */
+    void filterTriangles( const std::vector<size_t> &triangleIndexes, const QgsPointCloud3DRenderContext &context, const QgsAABB &bbox );
 };
 
 class QgsSingleColorPointCloud3DSymbolHandler : public QgsPointCloud3DSymbolHandler

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -111,19 +111,19 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mTriangulateGroupBox, &QGroupBox::toggled, this, [&]() { emitChangedSignal(); } );
   connect( mTriangulateGroupBox, &QGroupBox::toggled, this, [&]() {mPointSizeSpinBox->setEnabled( !mTriangulateGroupBox->isChecked() ); } );
 
-  connect( mFilterTriangleBySizeCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
-  connect( mFilterTriangleBySizeCheckBox, &QCheckBox::stateChanged, this, [&]()
-  { mTriangleSizeThresholdSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() ); } );
-  connect( mTriangleSizeThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+  connect( mHorizontalTriangleCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
+  connect( mHorizontalTriangleCheckBox, &QCheckBox::stateChanged, this, [&]()
+  { mHorizontalTriangleThresholdSpinBox->setEnabled( mHorizontalTriangleCheckBox->isChecked() ); } );
+  connect( mHorizontalTriangleThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
 
-  connect( mFilterTriangleByHeightCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
-  connect( mFilterTriangleByHeightCheckBox, &QCheckBox::stateChanged, this, [&]()
-  { mTriangleHeightThresholdSpinBox->setEnabled( mFilterTriangleByHeightCheckBox->isChecked() ); } );
-  connect( mTriangleHeightThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+  connect( mVerticalTriangleCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
+  connect( mVerticalTriangleCheckBox, &QCheckBox::stateChanged, this, [&]()
+  { mVerticalTriangleThresholdSpinBox->setEnabled( mVerticalTriangleCheckBox->isChecked() ); } );
+  connect( mVerticalTriangleThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
 
   mPointSizeSpinBox->setEnabled( !mTriangulateGroupBox->isChecked() );
-  mTriangleSizeThresholdSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() );
-  mTriangleHeightThresholdSpinBox->setEnabled( mFilterTriangleByHeightCheckBox->isChecked() );
+  mHorizontalTriangleThresholdSpinBox->setEnabled( mHorizontalTriangleCheckBox->isChecked() );
+  mHorizontalTriangleThresholdSpinBox->setEnabled( mVerticalTriangleCheckBox->isChecked() );
 
   if ( !symbol ) // if we have a symbol, this was already handled in setSymbol above
     rampAttributeChanged();
@@ -149,10 +149,10 @@ void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
   mRenderingStyleComboBox->setCurrentIndex( mRenderingStyleComboBox->findData( symbol->symbolType() ) );
   mPointSizeSpinBox->setValue( symbol->pointSize() );
   mTriangulateGroupBox->setChecked( symbol->renderAsTriangles() );
-  mFilterTriangleBySizeCheckBox->setChecked( symbol->filterTrianglesBySize() );
-  mTriangleSizeThresholdSpinBox->setValue( symbol->triangleSizeThreshold() );
-  mFilterTriangleByHeightCheckBox->setChecked( symbol->filterTrianglesByHeight() );
-  mTriangleHeightThresholdSpinBox->setValue( symbol->triangleHeightThreshold() );
+  mHorizontalTriangleCheckBox->setChecked( symbol->horizontalTriangleFilter() );
+  mHorizontalTriangleThresholdSpinBox->setValue( symbol->horizontalFilterThreshold() );
+  mVerticalTriangleCheckBox->setChecked( symbol->verticalTriangleFilter() );
+  mVerticalTriangleThresholdSpinBox->setValue( symbol->verticalFilterThreshold() );
 
   if ( symbol->symbolType() == QLatin1String( "single-color" ) )
   {
@@ -251,10 +251,10 @@ QgsPointCloud3DSymbol *QgsPointCloud3DSymbolWidget::symbol() const
   {
     retSymb->setPointSize( mPointSizeSpinBox->value() );
     retSymb->setRenderAsTriangles( mTriangulateGroupBox->isChecked() );
-    retSymb->setFilterTrianglesBySize( mFilterTriangleBySizeCheckBox->isChecked() );
-    retSymb->setTriangleSizeThreshold( mTriangleSizeThresholdSpinBox->value() );
-    retSymb->setFilterTrianglesByHeight( mFilterTriangleByHeightCheckBox->isChecked() );
-    retSymb->setTriangleHeightThreshold( mTriangleHeightThresholdSpinBox->value() );
+    retSymb->setHorizontalTriangleFilter( mHorizontalTriangleCheckBox->isChecked() );
+    retSymb->setHorizontalFilterThreshold( mHorizontalTriangleThresholdSpinBox->value() );
+    retSymb->setVerticalTriangleFilter( mVerticalTriangleCheckBox->isChecked() );
+    retSymb->setVerticalFilterThreshold( mVerticalTriangleThresholdSpinBox->value() );
   }
 
   return retSymb;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -107,15 +107,23 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mMaxScreenErrorSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
   connect( mShowBoundingBoxesCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
   connect( mPointBudgetSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+
   connect( mTriangulateGroupBox, &QGroupBox::toggled, this, [&]() { emitChangedSignal(); } );
   connect( mTriangulateGroupBox, &QGroupBox::toggled, this, [&]() {mPointSizeSpinBox->setEnabled( !mTriangulateGroupBox->isChecked() ); } );
+
   connect( mFilterTriangleBySizeCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
   connect( mFilterTriangleBySizeCheckBox, &QCheckBox::stateChanged, this, [&]()
-  { mTriangleSizeThresholdDoubleSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() ); } );
-  connect( mTriangleSizeThresholdDoubleSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+  { mTriangleSizeThresholdSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() ); } );
+  connect( mTriangleSizeThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+
+  connect( mFilterTriangleByHeightCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
+  connect( mFilterTriangleByHeightCheckBox, &QCheckBox::stateChanged, this, [&]()
+  { mTriangleHeightThresholdSpinBox->setEnabled( mFilterTriangleByHeightCheckBox->isChecked() ); } );
+  connect( mTriangleHeightThresholdSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
 
   mPointSizeSpinBox->setEnabled( !mTriangulateGroupBox->isChecked() );
-  mTriangleSizeThresholdDoubleSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() );
+  mTriangleSizeThresholdSpinBox->setEnabled( mFilterTriangleBySizeCheckBox->isChecked() );
+  mTriangleHeightThresholdSpinBox->setEnabled( mFilterTriangleByHeightCheckBox->isChecked() );
 
   if ( !symbol ) // if we have a symbol, this was already handled in setSymbol above
     rampAttributeChanged();
@@ -142,7 +150,9 @@ void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
   mPointSizeSpinBox->setValue( symbol->pointSize() );
   mTriangulateGroupBox->setChecked( symbol->renderAsTriangles() );
   mFilterTriangleBySizeCheckBox->setChecked( symbol->filterTrianglesBySize() );
-  mTriangleSizeThresholdDoubleSpinBox->setValue( symbol->triangleSizeThreshold() );
+  mTriangleSizeThresholdSpinBox->setValue( symbol->triangleSizeThreshold() );
+  mFilterTriangleByHeightCheckBox->setChecked( symbol->filterTrianglesByHeight() );
+  mTriangleHeightThresholdSpinBox->setValue( symbol->triangleHeightThreshold() );
 
   if ( symbol->symbolType() == QLatin1String( "single-color" ) )
   {
@@ -242,7 +252,9 @@ QgsPointCloud3DSymbol *QgsPointCloud3DSymbolWidget::symbol() const
     retSymb->setPointSize( mPointSizeSpinBox->value() );
     retSymb->setRenderAsTriangles( mTriangulateGroupBox->isChecked() );
     retSymb->setFilterTrianglesBySize( mFilterTriangleBySizeCheckBox->isChecked() );
-    retSymb->setTriangleSizeThreshold( mTriangleSizeThresholdDoubleSpinBox->value() );
+    retSymb->setTriangleSizeThreshold( mTriangleSizeThresholdSpinBox->value() );
+    retSymb->setFilterTrianglesByHeight( mFilterTriangleByHeightCheckBox->isChecked() );
+    retSymb->setTriangleHeightThreshold( mTriangleHeightThresholdSpinBox->value() );
   }
 
   return retSymb;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -107,6 +107,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mMaxScreenErrorSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
   connect( mShowBoundingBoxesCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
   connect( mPointBudgetSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [&]() { emitChangedSignal(); } );
+  connect( mTriangulateCheckBox, &QCheckBox::stateChanged, this, [&]() { emitChangedSignal(); } );
 
   if ( !symbol ) // if we have a symbol, this was already handled in setSymbol above
     rampAttributeChanged();
@@ -131,6 +132,7 @@ void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )
 
   mRenderingStyleComboBox->setCurrentIndex( mRenderingStyleComboBox->findData( symbol->symbolType() ) );
   mPointSizeSpinBox->setValue( symbol->pointSize() );
+  mTriangulateCheckBox->setChecked( symbol->triangulate() );
 
   if ( symbol->symbolType() == QLatin1String( "single-color" ) )
   {
@@ -231,6 +233,9 @@ QgsPointCloud3DSymbol *QgsPointCloud3DSymbolWidget::symbol() const
     symb->setCategoriesList( mClassifiedRendererWidget->categoriesList() );
     retSymb = symb;
   }
+
+  if ( retSymb )
+    retSymb->setTriangulate( mTriangulateCheckBox->isChecked() );
 
   return retSymb;
 }
@@ -636,3 +641,4 @@ void QgsPointCloud3DSymbolWidget::connectChildPanels( QgsPanelWidget *parent )
 {
   parent->connectChildPanel( mClassifiedRendererWidget );
 }
+

--- a/src/core/3d/qgsabstract3dsymbol.h
+++ b/src/core/3d/qgsabstract3dsymbol.h
@@ -95,7 +95,7 @@ class CORE_EXPORT QgsAbstract3DSymbol
     /**
      * Copies base class settings from this object to a \a destination object.
      */
-    void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
+    virtual void copyBaseSettings( QgsAbstract3DSymbol *destination ) const;
     QgsPropertyCollection mDataDefinedProperties;
 
   private:

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * Called when the feature has been digitized.
      * \param geometry the digitized geometry
      */
-    void layerGeometryCaptured( const QgsGeometry &geometry ) override;
+    void layerGeometryCaptured( const QgsGeometry &geometry ) override FINAL;
 
     /**
      * Called when the feature has been digitized

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * Called when the feature has been digitized.
      * \param geometry the digitized geometry
      */
-    void layerGeometryCaptured( const QgsGeometry &geometry ) override FINAL;
+    void layerGeometryCaptured( const QgsGeometry &geometry ) override;
 
     /**
      * Called when the feature has been digitized

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -135,7 +135,7 @@
       <item row="2" column="0">
        <widget class="QgsCollapsibleGroupBox" name="mTriangulateGroupBox">
         <property name="title">
-         <string>Triangulate Points</string>
+         <string>Render as a Surface (Triangulate)</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
@@ -154,14 +154,14 @@
           <number>0</number>
          </property>
          <item row="0" column="0">
-          <widget class="QCheckBox" name="mFilterTriangleBySizeCheckBox">
+          <widget class="QCheckBox" name="mHorizontalTriangleCheckBox">
            <property name="text">
-            <string>Maximum triangle size</string>
+            <string>Skip triangles longer than</string>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QgsDoubleSpinBox" name="mTriangleSizeThresholdSpinBox">
+          <widget class="QgsDoubleSpinBox" name="mHorizontalTriangleThresholdSpinBox">
            <property name="toolTip">
             <string>Maximum Triangle Side Size in Horizontal Plan</string>
            </property>
@@ -171,14 +171,14 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QCheckBox" name="mFilterTriangleByHeightCheckBox">
+          <widget class="QCheckBox" name="mVerticalTriangleCheckBox">
            <property name="text">
-            <string>Maximum triangle height</string>
+            <string>Skip triangles taller than</string>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QgsDoubleSpinBox" name="mTriangleHeightThresholdSpinBox">
+          <widget class="QgsDoubleSpinBox" name="mVerticalTriangleThresholdSpinBox">
            <property name="toolTip">
             <string>Maximum Triangle Side 3D Height</string>
            </property>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -132,6 +132,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="mTriangulateCheckBox">
+        <property name="text">
+         <string>Triangulate</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>581</width>
-    <height>534</height>
+    <height>551</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -161,9 +161,26 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QgsDoubleSpinBox" name="mTriangleSizeThresholdDoubleSpinBox">
+          <widget class="QgsDoubleSpinBox" name="mTriangleSizeThresholdSpinBox">
            <property name="toolTip">
             <string>Maximum Triangle Side Size in Horizontal Plan</string>
+           </property>
+           <property name="maximum">
+            <double>10000000000000000000000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="mFilterTriangleByHeightCheckBox">
+           <property name="text">
+            <string>Maximum triangle height</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QgsDoubleSpinBox" name="mTriangleHeightThresholdSpinBox">
+           <property name="toolTip">
+            <string>Maximum Triangle Side 3D Height</string>
            </property>
            <property name="maximum">
             <double>10000000000000000000000.000000000000000</double>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>581</width>
-    <height>491</height>
+    <height>534</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -43,39 +43,6 @@
       </property>
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_7">
-        <item row="0" column="1" colspan="2">
-         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>2.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QgsDoubleSpinBox" name="mMaxScreenErrorSpinBox">
-          <property name="maximum">
-           <double>100000.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QLabel" name="mPointCloudSizeLabel">
-          <property name="text">
-           <string>10000</string>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="1" colspan="2">
          <widget class="QDoubleSpinBox" name="mPointBudgetSpinBox">
           <property name="enabled">
@@ -89,10 +56,17 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>Maximum screen space error</string>
+           <string>Point budget</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="2">
+         <widget class="QLabel" name="mPointCloudSizeLabel">
+          <property name="text">
+           <string>10000</string>
           </property>
          </widget>
         </item>
@@ -116,10 +90,36 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Point budget</string>
+           <string>Maximum screen space error</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" colspan="2">
+         <widget class="QgsDoubleSpinBox" name="mMaxScreenErrorSpinBox">
+          <property name="maximum">
+           <double>100000.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>2.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -133,10 +133,44 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="mTriangulateCheckBox">
-        <property name="text">
-         <string>Triangulate</string>
+       <widget class="QgsCollapsibleGroupBox" name="mTriangulateGroupBox">
+        <property name="title">
+         <string>Triangulate Points</string>
         </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_8">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="mFilterTriangleBySizeCheckBox">
+           <property name="text">
+            <string>Maximum triangle size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QgsDoubleSpinBox" name="mTriangleSizeThresholdDoubleSpinBox">
+           <property name="toolTip">
+            <string>Maximum Triangle Side Size in Horizontal Plan</string>
+           </property>
+           <property name="maximum">
+            <double>10000000000000000000000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -558,6 +592,12 @@ enhancement</string>
    <class>QgsPointCloudAttributeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspointcloudattributecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
This PR allows to render point cloud layer in the 3D view with a solid surface obtained by triangulation. This triangulation is made by a third party, delaunator-cpp, a very fast Delaunay triangulation algoritm. The triangulation is 2.5D.

To activate the triangulation, the user checks a checkbox. Then, for now, two options allow to eventually improve the rendering by removing triangles that have a horizontal side size or a 3D height greater than thresholds.

This triangulation is available for all the 3D pont cloud renderer: unique color, ramp color, classification and RGB.

![pc_mesh](https://user-images.githubusercontent.com/7416892/157350115-331bcde6-c301-4f83-9fad-c59de1287ef7.gif)

![trianglePointCloud_r](https://user-images.githubusercontent.com/7416892/156040391-05d6144a-7641-4147-86a5-cb70436db1ba.gif)

