### PR TITLE
[RPM] Backport a downstream spec fix for GRASS' libgrass_imagery

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -242,6 +242,14 @@ gzip ChangeLog
       %{configure_with_sha} \
       .
 
+%if 0%{?fedora} >= 36
+# FIXME from downstream
+# No idea why libgrass_imagery appears as -lgrass_imagery and not as %%{_libdir}/grass/lib/libgrass_imagery.8.0.so
+# like all other grass libs... But it results in a Requires on libgrass_imagery.so rather than libgrass_imagery.8.0.so
+# and the former is not provided by grass-libs, hence results in broken dependencies...
+find %{_vpath_builddir} -type f -name link.txt -exec sed -i 's|-lgrass_imagery|%{_libdir}/grass80/lib/libgrass_imagery.8.0.so|' {} \;
+%endif
+
 %cmake_build
 
 %install


### PR DESCRIPTION
## Description

Include a downstream fix from @manisandro for picking up the right path of `libgrass_imagery` from GRASS8: https://src.fedoraproject.org/rpms/qgis/blob/rawhide/f/qgis.spec#_185

```
# FIXME
# No idea why libgrass_imagery appears as -lgrass_imagery and not as %%{_libdir}/grass/lib/libgrass_imagery.8.0.so
# like all other grass libs... But it results in a Requires on libgrass_imagery.so rather than libgrass_imagery.8.0.so	
# and the former is not provided by grass-libs, hence results in broken dependencies...
```

Regression log: [dnf_install_b97193e7d9.txt](https://github.com/qgis/QGIS/files/8156728/dnf_install_b97193e7d9.txt)

I will also work in the next days to sync our upstream with downstream as much as possible.

Needs backport to `release-3_22` and `release-3_24`