### PR TITLE
Fix server GML with geometry types

### DIFF
--- a/src/core/geometry/qgsmultipolygon.cpp
+++ b/src/core/geometry/qgsmultipolygon.cpp
@@ -91,7 +91,7 @@ QDomElement QgsMultiPolygon::asGml2( QDomDocument &doc, int precision, const QSt
 
 QDomElement QgsMultiPolygon::asGml3( QDomDocument &doc, int precision, const QString &ns, const QgsAbstractGeometry::AxisOrder axisOrder ) const
 {
-  QDomElement elemMultiSurface = doc.createElementNS( ns, QStringLiteral( "MultiPolygon" ) );
+  QDomElement elemMultiSurface = doc.createElementNS( ns, QStringLiteral( "MultiSurface" ) );
 
   if ( isEmpty() )
     return elemMultiSurface;
@@ -100,7 +100,7 @@ QDomElement QgsMultiPolygon::asGml3( QDomDocument &doc, int precision, const QSt
   {
     if ( qgsgeometry_cast<const QgsPolygon *>( geom ) )
     {
-      QDomElement elemSurfaceMember = doc.createElementNS( ns, QStringLiteral( "polygonMember" ) );
+      QDomElement elemSurfaceMember = doc.createElementNS( ns, QStringLiteral( "surfaceMember" ) );
       elemSurfaceMember.appendChild( geom->asGml3( doc, precision, ns, axisOrder ) );
       elemMultiSurface.appendChild( elemSurfaceMember );
     }

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -170,12 +170,12 @@ namespace QgsWfs
       {
         continue;
       }
-      setSchemaLayer( schemaElement, doc, const_cast<QgsVectorLayer *>( vLayer ) );
+      setSchemaLayer( schemaElement, doc, const_cast<QgsVectorLayer *>( vLayer ), oFormat );
     }
     return doc;
   }
 
-  void setSchemaLayer( QDomElement &parentElement, QDomDocument &doc, const QgsVectorLayer *layer )
+  void setSchemaLayer( QDomElement &parentElement, QDomDocument &doc, const QgsVectorLayer *layer, QgsWfsParameters::Format format )
   {
     const QgsVectorDataProvider *provider = layer->dataProvider();
     if ( !provider )
@@ -215,44 +215,7 @@ namespace QgsWfs
     {
       QDomElement geomElem = doc.createElement( QStringLiteral( "element" )/*xsd:element*/ );
       geomElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "geometry" ) );
-
-      const QgsWkbTypes::Type wkbType = layer->wkbType();
-      switch ( wkbType )
-      {
-        case QgsWkbTypes::Point25D:
-        case QgsWkbTypes::Point:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:PointPropertyType" ) );
-          break;
-        case QgsWkbTypes::LineString25D:
-        case QgsWkbTypes::LineString:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:LineStringPropertyType" ) );
-          break;
-        case QgsWkbTypes::Polygon25D:
-        case QgsWkbTypes::Polygon:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:PolygonPropertyType" ) );
-          break;
-        case QgsWkbTypes::MultiPoint25D:
-        case QgsWkbTypes::MultiPoint:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiPointPropertyType" ) );
-          break;
-        case QgsWkbTypes::MultiCurve:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiCurvePropertyType" ) );
-          break;
-        case QgsWkbTypes::MultiLineString25D:
-        case QgsWkbTypes::MultiLineString:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiLineStringPropertyType" ) );
-          break;
-        case QgsWkbTypes::MultiSurface:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiSurfacePropertyType" ) );
-          break;
-        case QgsWkbTypes::MultiPolygon25D:
-        case QgsWkbTypes::MultiPolygon:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:MultiPolygonPropertyType" ) );
-          break;
-        default:
-          geomElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "gml:GeometryPropertyType" ) );
-          break;
-      }
+      geomElem.setAttribute( QStringLiteral( "type" ), getGmlGeometryType( layer, format ) );
       geomElem.setAttribute( QStringLiteral( "minOccurs" ), QStringLiteral( "0" ) );
       geomElem.setAttribute( QStringLiteral( "maxOccurs" ), QStringLiteral( "1" ) );
       sequenceElem.appendChild( geomElem );
@@ -362,6 +325,83 @@ namespace QgsWfs
       {
         attElem.setAttribute( QStringLiteral( "alias" ), alias );
       }
+    }
+  }
+
+  QString getGmlGeometryType( const QgsVectorLayer *layer, QgsWfsParameters::Format format )
+  {
+    const QgsWkbTypes::Type wkbType = layer->wkbType();
+    switch ( format )
+    {
+      case QgsWfsParameters::Format::GML2:
+        switch ( wkbType )
+        {
+          case QgsWkbTypes::Point25D:
+          case QgsWkbTypes::Point:
+            return QStringLiteral( "gml:PointPropertyType" );
+
+          case QgsWkbTypes::LineString25D:
+          case QgsWkbTypes::LineString:
+            return QStringLiteral( "gml:LineStringPropertyType" );
+
+          case QgsWkbTypes::Polygon25D:
+          case QgsWkbTypes::Polygon:
+            return QStringLiteral( "gml:PolygonPropertyType" );
+
+          case QgsWkbTypes::MultiPoint25D:
+          case QgsWkbTypes::MultiPoint:
+            return QStringLiteral( "gml:MultiPointPropertyType" );
+
+          case QgsWkbTypes::MultiCurve:
+          case QgsWkbTypes::MultiLineString25D:
+          case QgsWkbTypes::MultiLineString:
+            return QStringLiteral( "gml:MultiLineStringPropertyType" );
+
+          case QgsWkbTypes::MultiSurface:
+          case QgsWkbTypes::MultiPolygon25D:
+          case QgsWkbTypes::MultiPolygon:
+            return QStringLiteral( "gml:MultiPolygonPropertyType" );
+
+          default:
+            return QStringLiteral( "gml:GeometryPropertyType" );
+
+        }
+      case QgsWfsParameters::Format::GML3:
+        switch ( wkbType )
+        {
+          case QgsWkbTypes::Point25D:
+          case QgsWkbTypes::Point:
+            return QStringLiteral( "gml:PointPropertyType" );
+
+          case QgsWkbTypes::LineString25D:
+          case QgsWkbTypes::LineString:
+            return QStringLiteral( "gml:LineStringPropertyType" );
+
+          case QgsWkbTypes::Polygon25D:
+          case QgsWkbTypes::Polygon:
+            return QStringLiteral( "gml:PolygonPropertyType" );
+
+          case QgsWkbTypes::MultiPoint25D:
+          case QgsWkbTypes::MultiPoint:
+            return QStringLiteral( "gml:MultiPointPropertyType" );
+
+          case QgsWkbTypes::MultiCurve:
+          case QgsWkbTypes::MultiLineString25D:
+          case QgsWkbTypes::MultiLineString:
+            return QStringLiteral( "gml:MultiCurvePropertyType" );
+
+          case QgsWkbTypes::MultiSurface:
+            return QStringLiteral( "gml:MultiSurfacePropertyType" );
+
+          case QgsWkbTypes::MultiPolygon25D:
+          case QgsWkbTypes::MultiPolygon:
+            return QStringLiteral( "gml:MultiPolygonPropertyType" );
+
+          default:
+            return QStringLiteral( "gml:GeometryPropertyType" );
+        }
+      default:
+        return QStringLiteral( "gml:GeometryPropertyType" );
     }
   }
 

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -391,11 +391,9 @@ namespace QgsWfs
             return QStringLiteral( "gml:MultiCurvePropertyType" );
 
           case QgsWkbTypes::MultiSurface:
-            return QStringLiteral( "gml:MultiSurfacePropertyType" );
-
           case QgsWkbTypes::MultiPolygon25D:
           case QgsWkbTypes::MultiPolygon:
-            return QStringLiteral( "gml:MultiPolygonPropertyType" );
+            return QStringLiteral( "gml:MultiSurfacePropertyType" );
 
           default:
             return QStringLiteral( "gml:GeometryPropertyType" );

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.h
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.h
@@ -26,9 +26,18 @@
 #include <QDomDocument>
 #include <QDomElement>
 
+#include "qgsserverinterface.h"
+#include "qgswfsparameters.h"
+
 namespace QgsWfs
 {
-  void setSchemaLayer( QDomElement &parentElement, QDomDocument &doc, const QgsVectorLayer *layer );
+
+  /**
+  * Returns the GML geometry type.
+  */
+  QString getGmlGeometryType( const QgsVectorLayer *layer, QgsWfsParameters::Format format );
+
+  void setSchemaLayer( QDomElement &parentElement, QDomDocument &doc, const QgsVectorLayer *layer, QgsWfsParameters::Format format );
 
   /**
    * Create get capabilities document
@@ -45,4 +54,3 @@ namespace QgsWfs
 } // namespace QgsWfs
 
 #endif
-

--- a/tests/src/core/geometry/testqgsmultipolygon.cpp
+++ b/tests/src/core/geometry/testqgsmultipolygon.cpp
@@ -1155,11 +1155,11 @@ void TestQgsMultiPolygon::exportImport()
   QGSCOMPAREGML( elemToString( QgsMultiPolygon().asGml2( doc ) ), expectedGML2empty );
 
   //as GML3
-  QString expectedSimpleGML3( QStringLiteral( "<MultiPolygon xmlns=\"gml\"><polygonMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">7 17 3 13 7 21 7 17</posList></LinearRing></exterior></Polygon></polygonMember><polygonMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">27 37 43 43 41 39 27 37</posList></LinearRing></exterior></Polygon></polygonMember></MultiPolygon>" ) );
+  QString expectedSimpleGML3( QStringLiteral( "<MultiSurface xmlns=\"gml\"><surfaceMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">7 17 3 13 7 21 7 17</posList></LinearRing></exterior></Polygon></surfaceMember><surfaceMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">27 37 43 43 41 39 27 37</posList></LinearRing></exterior></Polygon></surfaceMember></MultiSurface>" ) );
   res = elemToString( mp.asGml3( doc ) );
   QCOMPARE( res, expectedSimpleGML3 );
 
-  QString expectedGML3empty( QStringLiteral( "<MultiPolygon xmlns=\"gml\"/>" ) );
+  QString expectedGML3empty( QStringLiteral( "<MultiSurface xmlns=\"gml\"/>" ) );
   QGSCOMPAREGML( elemToString( QgsMultiPolygon().asGml3( doc ) ), expectedGML3empty );
 
   // as JSON
@@ -1205,7 +1205,7 @@ void TestQgsMultiPolygon::exportImport()
   QGSCOMPAREGML( res, expectedGML2prec3 );
 
   //as GML3
-  QString expectedGML3prec3( "<MultiPolygon xmlns=\"gml\"><polygonMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">2.333 5.667 0.6 4.333 2.667 9 2.333 5.667</posList></LinearRing></exterior></Polygon></polygonMember><polygonMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">9 4.111 1.049 1.024 9 4.111</posList></LinearRing></exterior></Polygon></polygonMember></MultiPolygon>" );
+  QString expectedGML3prec3( "<MultiSurface xmlns=\"gml\"><surfaceMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">2.333 5.667 0.6 4.333 2.667 9 2.333 5.667</posList></LinearRing></exterior></Polygon></surfaceMember><surfaceMember xmlns=\"gml\"><Polygon xmlns=\"gml\"><exterior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><posList xmlns=\"gml\" srsDimension=\"2\">9 4.111 1.049 1.024 9 4.111</posList></LinearRing></exterior></Polygon></surfaceMember></MultiSurface>" );
   res = elemToString( mp.asGml3( doc, 3 ) );
   QCOMPARE( res, expectedGML3prec3 );
 

--- a/tests/testdata/qgis_server/wfs_describeFeatureType_1_1_0_typename_as_areas.txt
+++ b/tests/testdata/qgis_server/wfs_describeFeatureType_1_1_0_typename_as_areas.txt
@@ -8,7 +8,7 @@ Content-Type: text/xml; charset=utf-8
   <complexContent>
    <extension base="gml:AbstractFeatureType">
     <sequence>
-     <element maxOccurs="1" type="gml:MultiPolygonPropertyType" minOccurs="0" name="geometry"/>
+     <element maxOccurs="1" type="gml:MultiSurfacePropertyType" minOccurs="0" name="geometry"/>
      <element type="long" name="fid"/>
      <element type="int" nillable="true" name="gid"/>
      <element type="string" nillable="true" name="datum"/>

--- a/tests/testdata/qgis_server/wfs_describeFeatureType_1_1_0_typename_empty.txt
+++ b/tests/testdata/qgis_server/wfs_describeFeatureType_1_1_0_typename_empty.txt
@@ -8,7 +8,7 @@ Content-Type: text/xml; charset=utf-8
   <complexContent>
    <extension base="gml:AbstractFeatureType">
     <sequence>
-     <element maxOccurs="1" type="gml:MultiPolygonPropertyType" minOccurs="0" name="geometry"/>
+     <element maxOccurs="1" type="gml:MultiSurfacePropertyType" minOccurs="0" name="geometry"/>
      <element type="long" name="fid"/>
      <element type="int" nillable="true" name="gid"/>
      <element type="string" nillable="true" name="datum"/>


### PR DESCRIPTION
## Description

In http://schemas.opengis.net/gml/3.1.1/base/geometryAggregates.xsd the MultiPolygon is included for backwards compatibility with GML2.
It is deprecated with GML3 and has to be replaced by MultiSurface.
It is the same for MultiLineString replaced by MultiCurve in GML3.

I might split these two commits for an easier review
