### PR TITLE
Show total dash pattern length in custom dash pattern panel

### DIFF
--- a/src/gui/symbology/qgsdashspacedialog.cpp
+++ b/src/gui/symbology/qgsdashspacedialog.cpp
@@ -27,13 +27,13 @@ QgsDashSpaceWidget::QgsDashSpaceWidget( const QVector<qreal> &vectorPattern, QWi
   mAddButton->setIcon( QgsApplication::getThemeIcon( "symbologyAdd.svg" ) );
   mRemoveButton->setIcon( QgsApplication::getThemeIcon( "symbologyRemove.svg" ) );
 
-  double dash = 0;
-  double space = 0;
+  double total = 0;
   for ( int i = 0; i < ( vectorPattern.size() - 1 ); ++i )
   {
-    dash = vectorPattern.at( i );
+    const double dash = vectorPattern.at( i );
     ++i;
-    space = vectorPattern.at( i );
+    const double space = vectorPattern.at( i );
+    total += dash + space;
     QTreeWidgetItem *entry = new QTreeWidgetItem();
     entry->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled );
     entry->setText( 0, QLocale().toString( dash ) );
@@ -41,9 +41,22 @@ QgsDashSpaceWidget::QgsDashSpaceWidget( const QVector<qreal> &vectorPattern, QWi
     mDashSpaceTreeWidget->addTopLevelItem( entry );
   }
 
+  mPatternLengthLabel->setText( QLocale().toString( total, 'f', 6 ) );
+
   connect( mAddButton, &QPushButton::clicked, this, &QgsDashSpaceWidget::mAddButton_clicked );
   connect( mRemoveButton, &QPushButton::clicked, this, &QgsDashSpaceWidget::mRemoveButton_clicked );
   connect( mDashSpaceTreeWidget, &QTreeWidget::itemChanged, this, [ this ] { emit widgetChanged(); } );
+
+  connect( this, &QgsPanelWidget::widgetChanged, this, [ = ]
+  {
+    const QVector<qreal> pattern = dashDotVector();
+    double total = 0;
+    for ( qreal part : pattern )
+    {
+      total += part;
+    }
+    mPatternLengthLabel->setText( QLocale().toString( total, 'f', 6 ) );
+  } );
 }
 
 void QgsDashSpaceWidget::mAddButton_clicked()
@@ -72,6 +85,7 @@ QVector<qreal> QgsDashSpaceWidget::dashDotVector() const
 {
   QVector<qreal> dashVector;
   const int nTopLevelItems = mDashSpaceTreeWidget->topLevelItemCount();
+  dashVector.reserve( nTopLevelItems * 2 );
   for ( int i = 0; i < nTopLevelItems; ++i )
   {
     QTreeWidgetItem *currentItem = mDashSpaceTreeWidget->topLevelItem( i );

--- a/src/ui/symbollayer/qgsdashspacewidgetbase.ui
+++ b/src/ui/symbollayer/qgsdashspacewidgetbase.ui
@@ -62,6 +62,30 @@
      </column>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Pattern length</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="mPatternLengthLabel">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextBrowserInteraction</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -69,7 +93,9 @@
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
This is handy when you need to match the overall pattern length with sizes from other parts of a symbol!

![image](https://user-images.githubusercontent.com/1829991/156279080-f7df1866-222a-4027-8baf-8bc0f1d84f7b.png)
