### PR TITLE
Don't set background color on QgsFileWidget

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -36,9 +36,6 @@
 QgsFileWidget::QgsFileWidget( QWidget *parent )
   : QWidget( parent )
 {
-  setBackgroundRole( QPalette::Window );
-  setAutoFillBackground( true );
-
   mLayout = new QHBoxLayout();
   mLayout->setContentsMargins( 0, 0, 0, 0 );
 


### PR DESCRIPTION
The file widget is showing an incorrect background color on the widget, see below:

![image](https://user-images.githubusercontent.com/1829991/156300384-6ff19059-c0a3-4518-9723-2ff822971c5b.png)

@3nids do you recall why this code was necessary?