### PR TITLE
User defined field names in export

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -377,6 +377,8 @@ Constructor
 
         QgsAttributeList attributes;
 
+        QStringList attributesExportNames;
+
         QgsVectorFileWriter::SymbologyExport symbologyExport;
 
         double symbologyScale;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9296,6 +9296,7 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
     options.forceMulti = dialog->forceMulti();
     options.includeZ = dialog->includeZ();
     options.attributes = dialog->selectedAttributes();
+    options.attributesExportNames = dialog->attributesExportNames();
     options.fieldValueConverter = converterPtr;
     options.saveMetadata = dialog->persistMetadata();
     options.layerMetadata = vlayer->metadata();

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3092,9 +3092,16 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
   {
     for ( int attrIdx : std::as_const( details.attributes ) )
     {
-      QgsField field = details.sourceFields.at( attrIdx );
-      field.setName( options.attributesExportNames.value( attrIdx, field.name() ) );
-      details.outputFields.append( field );
+      if ( details.sourceFields.exists( attrIdx ) )
+      {
+        QgsField field = details.sourceFields.at( attrIdx );
+        field.setName( options.attributesExportNames.value( attrIdx, field.name() ) );
+        details.outputFields.append( field );
+      }
+      else
+      {
+        QgsDebugMsg( QStringLiteral( "No such source field with index '%1' available." ).arg( attrIdx ) );
+      }
     }
   }
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3093,9 +3093,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
     for ( int attrIdx : std::as_const( details.attributes ) )
     {
       QgsField field = details.sourceFields.at( attrIdx );
-      if ( !options.attributesExportNames.isEmpty() &&
-           field.name() != options.attributesExportNames.at( attrIdx ) )
-        field.setName( options.attributesExportNames.at( attrIdx ) );
+      field.setName( options.attributesExportNames.value( attrIdx, field.name() ) );
       details.outputFields.append( field );
     }
   }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3092,7 +3092,11 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
   {
     for ( int attrIdx : std::as_const( details.attributes ) )
     {
-      details.outputFields.append( details.sourceFields.at( attrIdx ) );
+      QgsField field = details.sourceFields.at( attrIdx );
+      if ( !options.attributesExportNames.isEmpty() &&
+           field.name() != options.attributesExportNames.at( attrIdx ) )
+        field.setName( options.attributesExportNames.at( attrIdx ) );
+      details.outputFields.append( field );
     }
   }
 

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -496,6 +496,9 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         //! Attributes to export (empty means all unless skipAttributeCreation is set)
         QgsAttributeList attributes;
 
+        //! Attributes export names
+        QStringList attributesExportNames;
+
         //! Symbology to export
         QgsVectorFileWriter::SymbologyExport symbologyExport = NoSymbology;
 

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -679,7 +679,10 @@ void QgsVectorLayerSaveAsDialog::mUseAliasesForExportedName_stateChanged( int st
       {
         if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->text()
              != mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->data( Qt::UserRole ).toString() )
+        {
           modifiedEntries = true;
+          break;
+        }
       }
 
       if ( modifiedEntries )
@@ -807,6 +810,15 @@ void QgsVectorLayerSaveAsDialog::mAttributeTable_itemChanged( QTableWidgetItem *
     break;
     case ColumnIndex::ExportName:
     {
+      // Check empty export name
+      if ( item->text().isEmpty() )
+      {
+        QMessageBox::warning( this,
+                              tr( "Empty export name" ),
+                              tr( "Empty export name are not allowed." ) );
+        return;
+      }
+
       // Rename eventually duplicated names
       QStringList names = attributesExportNames();
       while ( names.count( item->text() ) > 1 )

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -568,10 +568,7 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
       }
     }
 
-    {
-      const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
-      mReplaceRawFieldValues->setChecked( checkReplaceRawFieldValues );
-    }
+    whileBlocking( mReplaceRawFieldValues )->setChecked( checkReplaceRawFieldValues );
     mReplaceRawFieldValues->setEnabled( selectAllFields );
     mReplaceRawFieldValues->setVisible( foundFieldThatCanBeExportedAsDisplayedValue );
 
@@ -692,8 +689,7 @@ void QgsVectorLayerSaveAsDialog::mUseAliasesForExportedName_stateChanged( int st
                                     tr( "Some names where modified and will be overridden. Do you want to continue?" ) )
              == QMessageBox::No )
         {
-          const QSignalBlocker signalBlockerCheckbox( mUseAliasesForExportedName );
-          mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
+          whileBlocking( mUseAliasesForExportedName )->setCheckState( Qt::PartiallyChecked );
           return;
         }
       }
@@ -723,8 +719,7 @@ void QgsVectorLayerSaveAsDialog::mUseAliasesForExportedName_stateChanged( int st
                                     tr( "Some names where modified and will be overridden. Do you want to continue?" ) )
              == QMessageBox::No )
         {
-          const QSignalBlocker signalBlockerCheckbox( mUseAliasesForExportedName );
-          mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
+          whileBlocking( mUseAliasesForExportedName )->setCheckState( Qt::PartiallyChecked );
           return;
         }
       }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -37,16 +37,9 @@
 #include "qgsproviderregistry.h"
 #include "qgsprovidersublayerdetails.h"
 
-static const int COLUMN_IDX_NAME = 0;
-static const int COLUMN_IDX_EXPORT_NAME = 1;
-static const int COLUMN_IDX_TYPE = 2;
-static const int COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE = 3;
-
 QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
   , mSelectedCrs( QgsCoordinateReferenceSystem::fromSrsId( srsid ) )
-  , mAttributeTableItemChangedSlotEnabled( true )
-  , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
   , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
 {
   setup();
@@ -55,8 +48,6 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget *par
 QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, Options options, QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
   , mLayer( layer )
-  , mAttributeTableItemChangedSlotEnabled( true )
-  , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
   , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
   , mOptions( options )
 {
@@ -521,66 +512,66 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
         break;
       }
     }
-    mAttributeTable->setColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE,
+    mAttributeTable->setColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ),
                                       ! foundFieldThatCanBeExportedAsDisplayedValue );
 
-    mAttributeTableItemChangedSlotEnabled = false;
-
     bool checkReplaceRawFieldValues = selectAllFields && isFormatForFieldsAsDisplayedValues;
-    for ( int i = 0; i < mLayer->fields().size(); ++i )
+    const QSignalBlocker signalBlockerAttributeTable( mAttributeTable );
     {
-      QgsField fld = mLayer->fields().at( i );
-      Qt::ItemFlags flags = mLayer->providerType() != QLatin1String( "oracle" ) || !fld.typeName().contains( QLatin1String( "SDO_GEOMETRY" ) ) ? Qt::ItemIsEnabled : Qt::NoItemFlags;
-      QTableWidgetItem *item = nullptr;
-      item = new QTableWidgetItem( fld.name() );
-      item->setFlags( flags | Qt::ItemIsUserCheckable );
-      item->setCheckState( ( selectAllFields ) ? Qt::Checked : Qt::Unchecked );
-      mAttributeTable->setItem( i, COLUMN_IDX_NAME, item );
-
-      item = new QTableWidgetItem( fld.name() );
-      item->setFlags( flags | Qt::ItemIsEditable );
-      item->setData( Qt::UserRole, fld.displayName() );
-      mAttributeTable->setItem( i, COLUMN_IDX_EXPORT_NAME, item );
-
-      item = new QTableWidgetItem( fld.typeName() );
-      item->setFlags( flags );
-      mAttributeTable->setItem( i, COLUMN_IDX_TYPE, item );
-
-      if ( foundFieldThatCanBeExportedAsDisplayedValue )
+      for ( int i = 0; i < mLayer->fields().size(); ++i )
       {
-        const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, mLayer->fields()[i].name() );
-        QgsEditorWidgetFactory *factory = nullptr;
-        const QString widgetId( setup.type() );
-        if ( flags == Qt::ItemIsEnabled &&
-             widgetId != QLatin1String( "TextEdit" ) &&
-             ( factory = QgsGui::editorWidgetRegistry()->factory( widgetId ) ) )
+        QgsField fld = mLayer->fields().at( i );
+        Qt::ItemFlags flags = mLayer->providerType() != QLatin1String( "oracle" ) || !fld.typeName().contains( QLatin1String( "SDO_GEOMETRY" ) ) ? Qt::ItemIsEnabled : Qt::NoItemFlags;
+        QTableWidgetItem *item = nullptr;
+        item = new QTableWidgetItem( fld.name() );
+        item->setFlags( flags | Qt::ItemIsUserCheckable );
+        item->setCheckState( ( selectAllFields ) ? Qt::Checked : Qt::Unchecked );
+        mAttributeTable->setItem( i, static_cast<int>( ColumnIndex::Name ), item );
+
+        item = new QTableWidgetItem( fld.name() );
+        item->setFlags( flags | Qt::ItemIsEditable );
+        item->setData( Qt::UserRole, fld.displayName() );
+        mAttributeTable->setItem( i, static_cast<int>( ColumnIndex::ExportName ), item );
+
+        item = new QTableWidgetItem( fld.typeName() );
+        item->setFlags( flags );
+        mAttributeTable->setItem( i, static_cast<int>( ColumnIndex::Type ), item );
+
+        if ( foundFieldThatCanBeExportedAsDisplayedValue )
         {
-          item = new QTableWidgetItem( tr( "Use %1" ).arg( factory->name() ) );
-          item->setFlags( ( selectAllFields ) ? ( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable ) : Qt::ItemIsUserCheckable );
-          const bool checkItem = ( selectAllFields && isFormatForFieldsAsDisplayedValues &&
-                                   ( widgetId == QLatin1String( "ValueMap" ) ||
-                                     widgetId == QLatin1String( "ValueRelation" ) ||
-                                     widgetId == QLatin1String( "CheckBox" ) ||
-                                     widgetId == QLatin1String( "RelationReference" ) ) );
-          checkReplaceRawFieldValues &= checkItem;
-          item->setCheckState( checkItem ?
-                               Qt::Checked : Qt::Unchecked );
-          mAttributeTable->setItem( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE, item );
-        }
-        else
-        {
-          item = new QTableWidgetItem();
-          item->setFlags( Qt::NoItemFlags );
-          mAttributeTable->setItem( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE, item );
+          const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, mLayer->fields()[i].name() );
+          QgsEditorWidgetFactory *factory = nullptr;
+          const QString widgetId( setup.type() );
+          if ( flags == Qt::ItemIsEnabled &&
+               widgetId != QLatin1String( "TextEdit" ) &&
+               ( factory = QgsGui::editorWidgetRegistry()->factory( widgetId ) ) )
+          {
+            item = new QTableWidgetItem( tr( "Use %1" ).arg( factory->name() ) );
+            item->setFlags( ( selectAllFields ) ? ( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable ) : Qt::ItemIsUserCheckable );
+            const bool checkItem = ( selectAllFields && isFormatForFieldsAsDisplayedValues &&
+                                     ( widgetId == QLatin1String( "ValueMap" ) ||
+                                       widgetId == QLatin1String( "ValueRelation" ) ||
+                                       widgetId == QLatin1String( "CheckBox" ) ||
+                                       widgetId == QLatin1String( "RelationReference" ) ) );
+            checkReplaceRawFieldValues &= checkItem;
+            item->setCheckState( checkItem ?
+                                 Qt::Checked : Qt::Unchecked );
+            mAttributeTable->setItem( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ), item );
+          }
+          else
+          {
+            item = new QTableWidgetItem();
+            item->setFlags( Qt::NoItemFlags );
+            mAttributeTable->setItem( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ), item );
+          }
         }
       }
     }
 
-    mAttributeTableItemChangedSlotEnabled = true;
-
-    mReplaceRawFieldValuesStateChangedSlotEnabled = false;
-    mReplaceRawFieldValues->setChecked( checkReplaceRawFieldValues );
-    mReplaceRawFieldValuesStateChangedSlotEnabled = true;
+    {
+      const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
+      mReplaceRawFieldValues->setChecked( checkReplaceRawFieldValues );
+    }
     mReplaceRawFieldValues->setEnabled( selectAllFields );
     mReplaceRawFieldValues->setVisible( foundFieldThatCanBeExportedAsDisplayedValue );
 
@@ -676,122 +667,179 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
 
 void QgsVectorLayerSaveAsDialog::mUseAliasesForExportedName_stateChanged( int state )
 {
-  mAttributeTableItemChangedSlotEnabled = false;
+  const QSignalBlocker signalBlocker( mAttributeTable );
 
-  for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+  switch ( state )
   {
-    switch ( state )
+    case Qt::Unchecked:
     {
-      case Qt::Unchecked:
+      // Check for modified entries
+      bool modifiedEntries = false;
+      for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
       {
-        mUseAliasesForExportedName->setTristate( false );
-        mAttributeTable->item( i, COLUMN_IDX_EXPORT_NAME )->setText( mAttributeTable->item( i, COLUMN_IDX_NAME )->text() );
+        if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->text()
+             != mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->data( Qt::UserRole ).toString() )
+          modifiedEntries = true;
       }
-      break;
-      case Qt::Checked:
-      {
-        mUseAliasesForExportedName->setTristate( false );
-        const QString alias = mAttributeTable->item( i, COLUMN_IDX_EXPORT_NAME )->data( Qt::UserRole ).toString();
-        mAttributeTable->item( i, COLUMN_IDX_EXPORT_NAME )->setText( alias );
-      }
-      break;
-      case Qt::PartiallyChecked:
-        // Do nothing
-        break;
-    }
-  }
 
-  mAttributeTableItemChangedSlotEnabled = true;
+      if ( modifiedEntries )
+      {
+        if ( QMessageBox::question( this,
+                                    tr( "Modified names" ),
+                                    tr( "Some names where modified and will be overridden. Do you want to continue?" ) )
+             == QMessageBox::No )
+        {
+          const QSignalBlocker signalBlockerCheckbox( mUseAliasesForExportedName );
+          mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
+          return;
+        }
+      }
+
+      for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+      {
+        mUseAliasesForExportedName->setTristate( false );
+        mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->setText( mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->text() );
+      }
+    }
+    break;
+    case Qt::Checked:
+    {
+      // Check for modified entries
+      bool modifiedEntries = false;
+      for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+      {
+        if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->text()
+             != mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->text() )
+          modifiedEntries = true;
+      }
+
+      if ( modifiedEntries )
+      {
+        if ( QMessageBox::question( this,
+                                    tr( "Modified names" ),
+                                    tr( "Some names where modified and will be overridden. Do you want to continue?" ) )
+             == QMessageBox::No )
+        {
+          const QSignalBlocker signalBlockerCheckbox( mUseAliasesForExportedName );
+          mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
+          return;
+        }
+      }
+
+      for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+      {
+        mUseAliasesForExportedName->setTristate( false );
+        const QString alias = mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->data( Qt::UserRole ).toString();
+        mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->setText( alias );
+      }
+    }
+    break;
+    case Qt::PartiallyChecked:
+      // Do nothing
+      break;
+  }
 }
 
 void QgsVectorLayerSaveAsDialog::mReplaceRawFieldValues_stateChanged( int )
 {
-  if ( !mReplaceRawFieldValuesStateChangedSlotEnabled )
+  if ( mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) )
     return;
-  if ( mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) )
-    return;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = false;
-  mAttributeTableItemChangedSlotEnabled = false;
+
+  const QSignalBlocker signalBlockerAttributeTable( mAttributeTable );
+  const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
+
   if ( mReplaceRawFieldValues->checkState() != Qt::PartiallyChecked )
   {
     for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
     {
-      if ( mAttributeTable->item( i, COLUMN_IDX_NAME )->checkState() == Qt::Checked &&
-           mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-           mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsEnabled )
+      if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->checkState() == Qt::Checked &&
+           mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+           mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsEnabled )
       {
-        mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setCheckState( mReplaceRawFieldValues->checkState() );
+        mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setCheckState( mReplaceRawFieldValues->checkState() );
       }
     }
   }
   mReplaceRawFieldValues->setTristate( false );
-  mAttributeTableItemChangedSlotEnabled = true;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = true;
 }
 
 void QgsVectorLayerSaveAsDialog::mAttributeTable_itemChanged( QTableWidgetItem *item )
 {
-  if ( !mAttributeTableItemChangedSlotEnabled )
-    return;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = false;
-  mAttributeTableItemChangedSlotEnabled = false;
+  const QSignalBlocker signalBlockerAttributeTable( mAttributeTable );
+  const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
+
   int row = item->row();
   int column = item->column();
-  if ( column == COLUMN_IDX_NAME &&
-       mAttributeTable->item( row, column )->checkState() == Qt::Unchecked &&
-       ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-       mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-       ( mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsUserCheckable ) )
+
+  switch ( static_cast<ColumnIndex>( column ) )
   {
-    mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setCheckState( Qt::Unchecked );
-    mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setFlags( Qt::ItemIsUserCheckable );
-    bool checkBoxEnabled = false;
-    for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+    case ColumnIndex::Name:
     {
-      if ( mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-           mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsEnabled )
+      if ( mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) ||
+           ! mAttributeTable->item( row, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) ||
+           !( mAttributeTable->item( row, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsUserCheckable ) )
+        return;
+
+      if ( mAttributeTable->item( row, column )->checkState() == Qt::Unchecked )
       {
-        checkBoxEnabled = true;
-        break;
+        mAttributeTable->item( row, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setCheckState( Qt::Unchecked );
+        mAttributeTable->item( row, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setFlags( Qt::ItemIsUserCheckable );
+        bool checkBoxEnabled = false;
+        for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+        {
+          if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+               mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsEnabled )
+          {
+            checkBoxEnabled = true;
+            break;
+          }
+        }
+        mReplaceRawFieldValues->setEnabled( checkBoxEnabled );
+        if ( !checkBoxEnabled )
+          mReplaceRawFieldValues->setCheckState( Qt::Unchecked );
+      }
+      else if ( mAttributeTable->item( row, column )->checkState() == Qt::Checked )
+      {
+        mAttributeTable->item( row, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );
+        mReplaceRawFieldValues->setEnabled( true );
       }
     }
-    mReplaceRawFieldValues->setEnabled( checkBoxEnabled );
-    if ( !checkBoxEnabled )
-      mReplaceRawFieldValues->setCheckState( Qt::Unchecked );
-  }
-  else if ( column == COLUMN_IDX_NAME &&
-            mAttributeTable->item( row, column )->checkState() == Qt::Checked &&
-            ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-            mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-            ( mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsUserCheckable ) )
-  {
-    mAttributeTable->item( row, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );
-    mReplaceRawFieldValues->setEnabled( true );
-  }
-  else if ( column == COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE &&
-            ( mAttributeTable->item( row, column )->flags() & Qt::ItemIsUserCheckable ) )
-  {
-    bool allChecked = true;
-    bool allUnchecked = true;
-    for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+    break;
+    case ColumnIndex::ExportName:
     {
-      if ( mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-           mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsEnabled )
+      // Rename eventually duplicated names
+      QStringList names = attributesExportNames();
+      while ( names.count( item->text() ) > 1 )
+        item->setText( QString( "%1_2" ).arg( item->text() ) );
+
+      mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
+    }
+    break;
+    case ColumnIndex::Type:
+      // Nothing to do
+      break;
+    case ColumnIndex::ExportAsDisplayedValue:
+    {
+      if ( mAttributeTable->item( row, column )->flags() & Qt::ItemIsUserCheckable )
       {
-        if ( mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->checkState() == Qt::Unchecked )
-          allChecked = false;
-        else
-          allUnchecked = false;
+        bool allChecked = true;
+        bool allUnchecked = true;
+        for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
+        {
+          if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+               mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsEnabled )
+          {
+            if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->checkState() == Qt::Unchecked )
+              allChecked = false;
+            else
+              allUnchecked = false;
+          }
+        }
+        mReplaceRawFieldValues->setCheckState( ( !allChecked && !allUnchecked ) ? Qt::PartiallyChecked : ( allChecked ) ? Qt::Checked : Qt::Unchecked );
       }
     }
-    mReplaceRawFieldValues->setCheckState( ( !allChecked && !allUnchecked ) ? Qt::PartiallyChecked : ( allChecked ) ? Qt::Checked : Qt::Unchecked );
+    break;
   }
-  else if ( column == COLUMN_IDX_EXPORT_NAME )
-  {
-    mUseAliasesForExportedName->setCheckState( Qt::PartiallyChecked );
-  }
-  mAttributeTableItemChangedSlotEnabled = true;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = true;
 }
 
 void QgsVectorLayerSaveAsDialog::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
@@ -954,7 +1002,7 @@ QgsAttributeList QgsVectorLayerSaveAsDialog::selectedAttributes() const
 
   for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
   {
-    if ( mAttributeTable->item( i, COLUMN_IDX_NAME )->checkState() == Qt::Checked )
+    if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->checkState() == Qt::Checked )
     {
       attributes.append( i );
     }
@@ -969,9 +1017,9 @@ QgsAttributeList QgsVectorLayerSaveAsDialog::attributesAsDisplayedValues() const
 
   for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
   {
-    if ( mAttributeTable->item( i, COLUMN_IDX_NAME )->checkState() == Qt::Checked &&
-         ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-         mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->checkState() == Qt::Checked )
+    if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->checkState() == Qt::Checked &&
+         ! mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+         mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->checkState() == Qt::Checked )
     {
       attributes.append( i );
     }
@@ -984,7 +1032,7 @@ QStringList QgsVectorLayerSaveAsDialog::attributesExportNames() const
 {
   QStringList exportNames;
   for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
-    exportNames.append( mAttributeTable->item( i, COLUMN_IDX_EXPORT_NAME )->text() );
+    exportNames.append( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportName ) )->text() );
 
   return exportNames;
 }
@@ -1116,49 +1164,47 @@ void QgsVectorLayerSaveAsDialog::mGeometryTypeComboBox_currentIndexChanged( int 
 
 void QgsVectorLayerSaveAsDialog::mSelectAllAttributes_clicked()
 {
-  mAttributeTableItemChangedSlotEnabled = false;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = false;
+  const QSignalBlocker signalBlockerAttributeTable( mAttributeTable );
+  const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
+
   for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
   {
-    if ( mAttributeTable->item( i, COLUMN_IDX_NAME )->flags() & Qt::ItemIsEnabled )
+    if ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->flags() & Qt::ItemIsEnabled )
     {
-      if ( ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-           ( mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsUserCheckable ) )
+      if ( ! mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+           ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsUserCheckable ) )
       {
-        mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );
+        mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );
       }
-      mAttributeTable->item( i, COLUMN_IDX_NAME )->setCheckState( Qt::Checked );
+      mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->setCheckState( Qt::Checked );
     }
   }
-  if ( ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) )
+  if ( ! mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) )
   {
     mReplaceRawFieldValues->setEnabled( true );
   }
-  mAttributeTableItemChangedSlotEnabled = true;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = true;
 }
 
 void QgsVectorLayerSaveAsDialog::mDeselectAllAttributes_clicked()
 {
-  mAttributeTableItemChangedSlotEnabled = false;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = false;
+  const QSignalBlocker signalBlockerAttributeTable( mAttributeTable );
+  const QSignalBlocker signalBlockerReplaceRawFieldValues( mReplaceRawFieldValues );
+
   for ( int i = 0; i < mAttributeTable->rowCount(); i++ )
   {
-    mAttributeTable->item( i, COLUMN_IDX_NAME )->setCheckState( Qt::Unchecked );
-    if ( ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) &&
-         ( mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->flags() & Qt::ItemIsUserCheckable ) )
+    mAttributeTable->item( i, static_cast<int>( ColumnIndex::Name ) )->setCheckState( Qt::Unchecked );
+    if ( ! mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) &&
+         ( mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->flags() & Qt::ItemIsUserCheckable ) )
     {
-      mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setFlags( Qt::ItemIsUserCheckable );
-      mAttributeTable->item( i, COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE )->setCheckState( Qt::Unchecked );
+      mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setFlags( Qt::ItemIsUserCheckable );
+      mAttributeTable->item( i, static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) )->setCheckState( Qt::Unchecked );
     }
   }
-  if ( ! mAttributeTable->isColumnHidden( COLUMN_IDX_EXPORT_AS_DISPLAYED_VALUE ) )
+  if ( ! mAttributeTable->isColumnHidden( static_cast<int>( ColumnIndex::ExportAsDisplayedValue ) ) )
   {
     mReplaceRawFieldValues->setCheckState( Qt::Unchecked );
     mReplaceRawFieldValues->setEnabled( false );
   }
-  mAttributeTableItemChangedSlotEnabled = true;
-  mReplaceRawFieldValuesStateChangedSlotEnabled = true;
 }
 
 void QgsVectorLayerSaveAsDialog::showHelp()

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -243,6 +243,15 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     void mAttributeTable_itemChanged( QTableWidgetItem *item );
 
   private:
+
+    enum class ColumnIndex : int
+    {
+      Name = 0,
+      ExportName = 1,
+      Type = 2,
+      ExportAsDisplayedValue = 3
+    };
+
     void setup();
     QList< QPair< QLabel *, QWidget * > > createControls( const QMap<QString, QgsVectorFileWriter::Option *> &options );
 
@@ -252,8 +261,6 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsCoordinateReferenceSystem mLayerCrs;
     QgsVectorLayer *mLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
-    bool mAttributeTableItemChangedSlotEnabled;
-    bool mReplaceRawFieldValuesStateChangedSlotEnabled;
     QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
     Options mOptions = AllOptions;
 };

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -122,6 +122,11 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsAttributeList attributesAsDisplayedValues() const;
 
     /**
+     * Returns a list of export names for attributes
+     */
+    QStringList attributesExportNames() const;
+
+    /**
      * Returns TRUE if the "add to canvas" checkbox is checked.
      *
      * \see setAddToCanvas()
@@ -233,6 +238,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     void accept() override;
     void mSelectAllAttributes_clicked();
     void mDeselectAllAttributes_clicked();
+    void mUseAliasesForExportedName_stateChanged( int state );
     void mReplaceRawFieldValues_stateChanged( int state );
     void mAttributeTable_itemChanged( QTableWidgetItem *item );
 

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -182,6 +182,13 @@
            </layout>
           </item>
           <item>
+           <widget class="QCheckBox" name="mUseAliasesForExportedName">
+            <property name="text">
+             <string>Use aliases for exported name</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="mReplaceRawFieldValues">
             <property name="text">
              <string>Replace all selected raw field values by displayed values</string>

--- a/tests/src/app/testqgsvectorlayersaveasdialog.cpp
+++ b/tests/src/app/testqgsvectorlayersaveasdialog.cpp
@@ -89,16 +89,16 @@ void TestQgsVectorLayerSaveAsDialog::testAttributesAsDisplayedValues()
   QCheckBox *mReplaceRawFieldValues = d.findChild<QCheckBox *>( QStringLiteral( "mReplaceRawFieldValues" ) );
 
   QCOMPARE( mAttributeTable->rowCount(), 2 );
-  QCOMPARE( mAttributeTable->columnCount(), 3 );
+  QCOMPARE( mAttributeTable->isColumnHidden( 3 ), false );
 
   QCOMPARE( d.attributesAsDisplayedValues().size(), 0 );
 
   QCOMPARE( mReplaceRawFieldValues->checkState(), Qt::Unchecked );
   QCOMPARE( mReplaceRawFieldValues->isEnabled(), false );
   QCOMPARE( mAttributeTable->item( 0, 0 )->checkState(), Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsUserCheckable );
-  QCOMPARE( mAttributeTable->item( 1, 2 )->flags(), 0 );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->checkState(), Qt::Unchecked );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->flags(), Qt::ItemIsUserCheckable );
+  QCOMPARE( mAttributeTable->item( 1, 3 )->flags(), 0 );
 
   // Activate item
   mAttributeTable->item( 0, 0 )->setCheckState( Qt::Checked );
@@ -106,32 +106,32 @@ void TestQgsVectorLayerSaveAsDialog::testAttributesAsDisplayedValues()
   QCOMPARE( mReplaceRawFieldValues->checkState(), Qt::Unchecked );
   QCOMPARE( mReplaceRawFieldValues->isEnabled(), true );
   QCOMPARE( mAttributeTable->item( 0, 0 )->checkState(), Qt::Checked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->checkState(), Qt::Unchecked );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
 
   // Activate "Replace with displayed value" column
-  mAttributeTable->item( 0, 2 )->setCheckState( Qt::Checked );
+  mAttributeTable->item( 0, 3 )->setCheckState( Qt::Checked );
 
   QCOMPARE( mReplaceRawFieldValues->checkState(), Qt::Checked );
   QCOMPARE( mReplaceRawFieldValues->isEnabled(), true );
 
   // Uncheck mReplaceRawFieldValues
   mReplaceRawFieldValues->setCheckState( Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->checkState(), Qt::Unchecked );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
 
   // Check mReplaceRawFieldValues
   mReplaceRawFieldValues->setCheckState( Qt::Checked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Checked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->checkState(), Qt::Checked );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->flags(), Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
 
   QCOMPARE( d.attributesAsDisplayedValues().size(), 1 );
   QCOMPARE( d.attributesAsDisplayedValues()[0], 0 );
 
   // Disable item
   mAttributeTable->item( 0, 0 )->setCheckState( Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->checkState(), Qt::Unchecked );
-  QCOMPARE( mAttributeTable->item( 0, 2 )->flags(), Qt::ItemIsUserCheckable );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->checkState(), Qt::Unchecked );
+  QCOMPARE( mAttributeTable->item( 0, 3 )->flags(), Qt::ItemIsUserCheckable );
 
   // Check that we can get a custom CRS with crsObject()
   QCOMPARE( d.crsObject(), crs ) ;

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -108,6 +108,8 @@ class TestQgsVectorFileWriter: public QObject
     void testExportToGpxMultiLineString();
     //! Test https://github.com/qgis/QGIS/issues/29819
     void testExportToGpxMultiLineStringForceRoute();
+    //! Test export using custom field names
+    void testExportCustomFieldNames();
 
   private:
     // a little util fn used by all tests
@@ -682,6 +684,25 @@ void TestQgsVectorFileWriter::testExportToGpxMultiLineStringForceRoute()
                     QStringLiteral( "routes" ),
                     QStringLiteral( "test" ),
                     QStringList() << QStringLiteral( "FORCE_GPX_ROUTE=YES" ) );
+}
+
+void TestQgsVectorFileWriter::testExportCustomFieldNames()
+{
+  QgsVectorFileWriter::PreparedWriterDetails details;
+  QgsVectorFileWriter::SaveVectorOptions options;
+  QgsVectorLayer ml( "Point?field=firstfield:int&field=secondfield:int", "test", "memory" );
+  QgsFeature ft( ml.fields( ) );
+  ft.setAttribute( 0, 4 );
+  ft.setAttribute( 1, -10 );
+  ml.dataProvider()->addFeature( ft );
+  QVERIFY( ml.isValid() );
+  options.driverName = "GPKG";
+  options.layerName = "test";
+  options.attributesExportNames << "firstfield" << "customfieldname";
+  QString newFilename;
+  QgsVectorFileWriter::prepareWriteAsVectorFormat( &ml, options, details );
+  QCOMPARE( details.outputFields.at( 0 ).name(), "firstfield" );
+  QCOMPARE( details.outputFields.at( 1 ).name(), "customfieldname" );
 }
 
 QGSTEST_MAIN( TestQgsVectorFileWriter )


### PR DESCRIPTION
Allow user to override field names in layer export.
- New column "Export names" in fields table
- New column can be edited
- Convenience checkbox to take over field aliases or revert to field names
- When a name is edited by hand the checkbox show a "PartiallyChecked" state
![Peek 2022-03-04 06-52 Export names](https://user-images.githubusercontent.com/9881900/156719947-6e2183f0-27cb-41c4-a65b-9855822da233.gif)

This feature is sponsored by the Swiss QGIS User Group