### PR TITLE
Use layer name as table name instead of the file name when saving into a container.

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -191,7 +191,7 @@ void QgsVectorLayerSaveAsDialog::setup()
     if ( !filePath.isEmpty() && leLayername->isEnabled() )
     {
       QFileInfo fileInfo( filePath );
-      leLayername->setText( fileInfo.completeBaseName() );
+      leLayername->setText( mLayer->name() );
     }
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !filePath.isEmpty() );
   } );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -190,7 +190,6 @@ void QgsVectorLayerSaveAsDialog::setup()
     settings.setValue( QStringLiteral( "UI/lastVectorFileFilterDir" ), tmplFileInfo.absolutePath() );
     if ( !filePath.isEmpty() && leLayername->isEnabled() )
     {
-      QFileInfo fileInfo( filePath );
       leLayername->setText( mLayer->name() );
     }
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !filePath.isEmpty() );


### PR DESCRIPTION
## Description

This changes propose to use the layer name when doing `Save as` into a container (gpkg and such) instead of using the filename.

This has been nagging me and this can cause the accidental deletion of data so I wanted to propose this small tweak as an improvement.

To me this is a useful upgrade but I  can understand if some would oppose this.
