### PR TITLE
[qml] Add an authid and descripton property to the QgsCoordinateReferenceSystem class

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -214,6 +214,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     Q_PROPERTY( QgsUnitTypes::DistanceUnit mapUnits READ mapUnits )
     Q_PROPERTY( bool isGeographic READ isGeographic )
+    Q_PROPERTY( QString authid READ authid )
+    Q_PROPERTY( QString description READ description )
 
   public:
 


### PR DESCRIPTION
## Description

Improving Q_PROPERTY  gap for the QgsCoordinateReferenceSystem. This comes in handy when someone needs to know whether a CRS is WGS84 programmatically within QML (i.e. crs.authid == 'EPSG:4326') or want to display some basic details on a given projection within a QML UI.