### PR TITLE
Drag and drop forms group collapsed

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -52,6 +52,28 @@ Returns if this container is going to be rendered as a group box
 :return: ``True`` if it will be a group box, ``False`` if it will be a tab
 %End
 
+    bool collapsed() const;
+%Docstring
+For containers rendedered a group box returns if this group box is collapsed.
+
+:return: ``True`` if the group box, ``False`` otherwise.
+
+.. seealso:: :py:func:`collapsed`
+
+.. seealso:: :py:func:`setCollapsed`
+
+.. versionadded:: 3.26
+%End
+    void setCollapsed( bool collapsed );
+%Docstring
+For containers rendedered a group box sets if this group box is ``collapsed``.
+
+.. seealso:: :py:func:`collapsed`
+
+.. seealso:: :py:func:`setCollapsed`
+
+.. versionadded:: 3.26
+%End
     QList<QgsAttributeEditorElement *> children() const;
 %Docstring
 Gets a list of the children elements of this container
@@ -112,6 +134,26 @@ show or hide this container based on an expression incorporating
 the field value controlled by editor widgets.
 
 .. versionadded:: 3.0
+%End
+
+    QgsOptionalExpression collapsedExpression() const;
+%Docstring
+The collapsed expression is used in the attribute form to
+set the collapsed status of the group box container container based on an expression incorporating
+the field value controlled by editor widgets. This property is ignored if the container is not
+rendered as a group box.
+
+.. versionadded:: 3.26
+%End
+
+    void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
+%Docstring
+The visibility expression is used in the attribute form to
+set the collapsed status of the group box of this container based on an expression incorporating
+the field value controlled by editor widgets. This property is ignored if the container is not
+rendered as a group box.
+
+.. versionadded:: 3.26
 %End
 
     QColor backgroundColor() const;

--- a/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -143,15 +143,19 @@ set the collapsed status of the group box container container based on an expres
 the field value controlled by editor widgets. This property is ignored if the container is not
 rendered as a group box.
 
+.. seealso:: :py:func:`setCollapsedExpression`
+
 .. versionadded:: 3.26
 %End
 
     void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
 %Docstring
-The visibility expression is used in the attribute form to
+The collapsed expression is used in the attribute form to
 set the collapsed status of the group box of this container based on an expression incorporating
 the field value controlled by editor widgets. This property is ignored if the container is not
 rendered as a group box.
+
+.. seealso:: :py:func:`collapsedExpression`
 
 .. versionadded:: 3.26
 %End

--- a/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -47,16 +47,16 @@ Determines if this container is rendered as collapsible group box or tab in a ta
 
     virtual bool isGroupBox() const;
 %Docstring
-Returns if this container is going to be rendered as a group box
+Returns if this container is going to be a group box
 
 :return: ``True`` if it will be a group box, ``False`` if it will be a tab
 %End
 
     bool collapsed() const;
 %Docstring
-For containers rendedered a group box returns if this group box is collapsed.
+For group box containers  returns if this group box is collapsed.
 
-:return: ``True`` if the group box, ``False`` otherwise.
+:return: ``True`` if the group box is collapsed, ``False`` otherwise.
 
 .. seealso:: :py:func:`collapsed`
 
@@ -66,7 +66,7 @@ For containers rendedered a group box returns if this group box is collapsed.
 %End
     void setCollapsed( bool collapsed );
 %Docstring
-For containers rendedered a group box sets if this group box is ``collapsed``.
+For group box containers  sets if this group box is ``collapsed``.
 
 .. seealso:: :py:func:`collapsed`
 
@@ -136,29 +136,7 @@ the field value controlled by editor widgets.
 .. versionadded:: 3.0
 %End
 
-    QgsOptionalExpression collapsedExpression() const;
-%Docstring
-The collapsed expression is used in the attribute form to
-set the collapsed status of the group box container container based on an expression incorporating
-the field value controlled by editor widgets. This property is ignored if the container is not
-rendered as a group box.
 
-.. seealso:: :py:func:`setCollapsedExpression`
-
-.. versionadded:: 3.26
-%End
-
-    void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
-%Docstring
-The collapsed expression is used in the attribute form to
-set the collapsed status of the group box of this container based on an expression incorporating
-the field value controlled by editor widgets. This property is ignored if the container is not
-rendered as a group box.
-
-.. seealso:: :py:func:`collapsedExpression`
-
-.. versionadded:: 3.26
-%End
 
     QColor backgroundColor() const;
 %Docstring

--- a/src/core/editform/qgsattributeeditorcontainer.cpp
+++ b/src/core/editform/qgsattributeeditorcontainer.cpp
@@ -45,6 +45,19 @@ void QgsAttributeEditorContainer::setVisibilityExpression( const QgsOptionalExpr
   mVisibilityExpression = visibilityExpression;
 }
 
+QgsOptionalExpression QgsAttributeEditorContainer::collapsedExpression() const
+{
+  return mCollapsedExpression;
+}
+
+void QgsAttributeEditorContainer::setCollapsedExpression( const QgsOptionalExpression &collapsedExpression )
+{
+  if ( collapsedExpression == mCollapsedExpression )
+    return;
+
+  mCollapsedExpression = collapsedExpression;
+}
+
 QColor QgsAttributeEditorContainer::backgroundColor() const
 {
   return mBackgroundColor;
@@ -107,6 +120,7 @@ QgsAttributeEditorElement *QgsAttributeEditorContainer::clone( QgsAttributeEdito
   element->mIsGroupBox = mIsGroupBox;
   element->mColumnCount = mColumnCount;
   element->mVisibilityExpression = mVisibilityExpression;
+  element->mCollapsed = mCollapsed;
 
   return element;
 }
@@ -116,6 +130,9 @@ void QgsAttributeEditorContainer::saveConfiguration( QDomElement &elem, QDomDocu
   Q_UNUSED( doc )
   elem.setAttribute( QStringLiteral( "columnCount" ), mColumnCount );
   elem.setAttribute( QStringLiteral( "groupBox" ), mIsGroupBox ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "collapsed" ), mCollapsed );
+  elem.setAttribute( QStringLiteral( "collapsedExpressionEnabled" ), mCollapsedExpression.enabled() ? 1 : 0 );
+  elem.setAttribute( QStringLiteral( "collapsedExpression" ), mCollapsedExpression->expression() );
   elem.setAttribute( QStringLiteral( "visibilityExpressionEnabled" ), mVisibilityExpression.enabled() ? 1 : 0 );
   elem.setAttribute( QStringLiteral( "visibilityExpression" ), mVisibilityExpression->expression() );
   if ( mBackgroundColor.isValid() )
@@ -142,6 +159,22 @@ void QgsAttributeEditorContainer::loadConfiguration( const QDomElement &element,
     setIsGroupBox( isGroupBox );
   else
     setIsGroupBox( mParent );
+
+  const bool isCollapsed = element.attribute( QStringLiteral( "collapsed" ) ).toInt( &ok );
+  if ( ok )
+    setCollapsed( isCollapsed );
+  else
+    setCollapsed( false );
+
+  const bool collapsedExpressionEnabled = element.attribute( QStringLiteral( "collapsedExpressionEnabled" ) ).toInt( &ok );
+  QgsOptionalExpression collapsedExpression;
+  if ( ok )
+  {
+    collapsedExpression.setEnabled( collapsedExpressionEnabled );
+    collapsedExpression.setData( QgsExpression( element.attribute( QStringLiteral( "collapsedExpression" ) ) ) );
+  }
+  setCollapsedExpression( collapsedExpression );
+
 
   const bool visibilityExpressionEnabled = element.attribute( QStringLiteral( "visibilityExpressionEnabled" ) ).toInt( &ok );
   QgsOptionalExpression visibilityExpression;

--- a/src/core/editform/qgsattributeeditorcontainer.cpp
+++ b/src/core/editform/qgsattributeeditorcontainer.cpp
@@ -121,6 +121,7 @@ QgsAttributeEditorElement *QgsAttributeEditorContainer::clone( QgsAttributeEdito
   element->mColumnCount = mColumnCount;
   element->mVisibilityExpression = mVisibilityExpression;
   element->mCollapsed = mCollapsed;
+  element->mCollapsedExpression = mCollapsedExpression;
 
   return element;
 }

--- a/src/core/editform/qgsattributeeditorcontainer.h
+++ b/src/core/editform/qgsattributeeditorcontainer.h
@@ -60,16 +60,16 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     virtual void setIsGroupBox( bool isGroupBox ) { mIsGroupBox = isGroupBox; }
 
     /**
-     * Returns if this container is going to be rendered as a group box
+     * Returns if this container is going to be a group box
      *
      * \returns TRUE if it will be a group box, FALSE if it will be a tab
      */
     virtual bool isGroupBox() const { return mIsGroupBox; }
 
     /**
-     * For containers rendedered a group box returns if this group box is collapsed.
+     * For group box containers  returns if this group box is collapsed.
      *
-     * \returns TRUE if the group box, FALSE otherwise.
+     * \returns TRUE if the group box is collapsed, FALSE otherwise.
      * \see collapsed()
      * \see setCollapsed()
      * \since QGIS 3.26
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     bool collapsed() const { return mCollapsed; };
 
     /**
-     * For containers rendedered a group box sets if this group box is \a collapsed.
+     * For group box containers  sets if this group box is \a collapsed.
      *
      * \see collapsed()
      * \see setCollapsed()
@@ -150,23 +150,25 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
      * The collapsed expression is used in the attribute form to
      * set the collapsed status of the group box container container based on an expression incorporating
      * the field value controlled by editor widgets. This property is ignored if the container is not
-     * rendered as a group box.
+     * a group box.
      *
+     * \note Not available in Python bindings
      * \see setCollapsedExpression()
      * \since QGIS 3.26
      */
-    QgsOptionalExpression collapsedExpression() const;
+    QgsOptionalExpression collapsedExpression() const SIP_SKIP;
 
     /**
      * The collapsed expression is used in the attribute form to
      * set the collapsed status of the group box of this container based on an expression incorporating
      * the field value controlled by editor widgets. This property is ignored if the container is not
-     * rendered as a group box.
+     * a group box.
      *
+     * \note Not available in Python bindings
      * \see collapsedExpression()
      * \since QGIS 3.26
      */
-    void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
+    void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression ) SIP_SKIP;
 
     /**
      * \brief backgroundColor

--- a/src/core/editform/qgsattributeeditorcontainer.h
+++ b/src/core/editform/qgsattributeeditorcontainer.h
@@ -152,16 +152,18 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
      * the field value controlled by editor widgets. This property is ignored if the container is not
      * rendered as a group box.
      *
+     * \see setCollapsedExpression()
      * \since QGIS 3.26
      */
     QgsOptionalExpression collapsedExpression() const;
 
     /**
-     * The visibility expression is used in the attribute form to
+     * The collapsed expression is used in the attribute form to
      * set the collapsed status of the group box of this container based on an expression incorporating
      * the field value controlled by editor widgets. This property is ignored if the container is not
      * rendered as a group box.
      *
+     * \see collapsedExpression()
      * \since QGIS 3.26
      */
     void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );

--- a/src/core/editform/qgsattributeeditorcontainer.h
+++ b/src/core/editform/qgsattributeeditorcontainer.h
@@ -67,6 +67,25 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     virtual bool isGroupBox() const { return mIsGroupBox; }
 
     /**
+     * For containers rendedered a group box returns if this group box is collapsed.
+     *
+     * \returns TRUE if the group box, FALSE otherwise.
+     * \see collapsed()
+     * \see setCollapsed()
+     * \since QGIS 3.26
+     */
+    bool collapsed() const { return mCollapsed; };
+
+    /**
+     * For containers rendedered a group box sets if this group box is \a collapsed.
+     *
+     * \see collapsed()
+     * \see setCollapsed()
+     * \since QGIS 3.26
+     */
+    void setCollapsed( bool collapsed ) { mCollapsed = collapsed; };
+
+    /**
      * Gets a list of the children elements of this container
      *
      * \returns A list of elements
@@ -128,6 +147,26 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     void setVisibilityExpression( const QgsOptionalExpression &visibilityExpression );
 
     /**
+     * The collapsed expression is used in the attribute form to
+     * set the collapsed status of the group box container container based on an expression incorporating
+     * the field value controlled by editor widgets. This property is ignored if the container is not
+     * rendered as a group box.
+     *
+     * \since QGIS 3.26
+     */
+    QgsOptionalExpression collapsedExpression() const;
+
+    /**
+     * The visibility expression is used in the attribute form to
+     * set the collapsed status of the group box of this container based on an expression incorporating
+     * the field value controlled by editor widgets. This property is ignored if the container is not
+     * rendered as a group box.
+     *
+     * \since QGIS 3.26
+     */
+    void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
+
+    /**
      * \brief backgroundColor
      * \return background color of the container
      * \since QGIS 3.8
@@ -149,6 +188,8 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
     int mColumnCount;
     QgsOptionalExpression mVisibilityExpression;
     QColor mBackgroundColor;
+    bool mCollapsed = false;
+    QgsOptionalExpression mCollapsedExpression;
 };
 
 

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -52,9 +52,9 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mCollapsedExpressionWidget->setExpression( itemData.collapsedExpression()->expression() );
 
   // show label makes sense for group box, not for tabs
-  connect( mShowAsGroupBox, &QCheckBox::toggled, mShowLabelCheckBox, &QCheckBox::setEnabled );
-  connect( mShowAsGroupBox, &QCheckBox::toggled, mCollapsedCheckBox, &QCheckBox::setEnabled );
-  connect( mShowAsGroupBox, &QCheckBox::toggled, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mShowLabelCheckBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mCollapsedCheckBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
 }
 
 void QgsAttributeFormContainerEdit::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -31,28 +31,36 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   {
     // only top level items can be tabs
     // i.e. it's always a group box if it's a nested container
-    mShowAsGroupBoxCheckBox->hide();
-    mShowAsGroupBoxCheckBox->setEnabled( false );
+    mShowAsGroupBox->hide();
+    mShowAsGroupBox->setEnabled( false );
   }
 
   mTitleLineEdit->setText( itemData.name() );
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
   mShowLabelCheckBox->setEnabled( itemData.showAsGroupBox() ); // show label makes sense for group box, not for tabs
-  mShowAsGroupBoxCheckBox->setChecked( itemData.showAsGroupBox() );
+  mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
   mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
   mVisibilityExpressionWidget->setLayer( layer );
   mVisibilityExpressionWidget->setExpression( itemData.visibilityExpression()->expression() );
   mColumnCountSpinBox->setValue( itemData.columnCount() );
   mBackgroundColorButton->setColor( itemData.backgroundColor() );
+  mCollapsedCheckBox->setChecked( itemData.collapsed() );
+  mCollapsedCheckBox->setEnabled( itemData.showAsGroupBox() );
+  mControlCollapsedGroupBox->setChecked( itemData.collapsedExpression().enabled() );
+  mControlCollapsedGroupBox->setEnabled( itemData.showAsGroupBox() );
+  mCollapsedExpressionWidget->setExpression( itemData.collapsedExpression()->expression() );
 
   // show label makes sense for group box, not for tabs
-  connect( mShowAsGroupBoxCheckBox, &QCheckBox::stateChanged, mShowLabelCheckBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::toggled, mShowLabelCheckBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::toggled, mCollapsedCheckBox, &QCheckBox::setEnabled );
+  connect( mShowAsGroupBox, &QCheckBox::toggled, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
 }
 
 void QgsAttributeFormContainerEdit::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
 {
   mVisibilityExpressionWidget->registerExpressionContextGenerator( generator );
+  mCollapsedExpressionWidget->registerExpressionContextGenerator( generator );
 }
 
 void QgsAttributeFormContainerEdit::updateItemData()
@@ -60,7 +68,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
   QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
 
   itemData.setColumnCount( mColumnCountSpinBox->value() );
-  itemData.setShowAsGroupBox( mShowAsGroupBoxCheckBox->isEnabled() ? mShowAsGroupBoxCheckBox->isChecked() : false );
+  itemData.setShowAsGroupBox( mShowAsGroupBox->isEnabled() ? mShowAsGroupBox->isChecked() : false );
   itemData.setName( mTitleLineEdit->text() );
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setBackgroundColor( mBackgroundColorButton->color() );
@@ -69,6 +77,12 @@ void QgsAttributeFormContainerEdit::updateItemData()
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );
   visibilityExpression.setEnabled( mControlVisibilityGroupBox->isChecked() );
   itemData.setVisibilityExpression( visibilityExpression );
+
+  QgsOptionalExpression collapsedExpression;
+  collapsedExpression.setData( QgsExpression( mCollapsedExpressionWidget->expression() ) );
+  collapsedExpression.setEnabled( mControlCollapsedGroupBox->isChecked() );
+  itemData.setCollapsedExpression( collapsedExpression );
+  itemData.setCollapsed( mCollapsedCheckBox->isEnabled() ? mCollapsedCheckBox->isChecked() : false );
 
   mTreeItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, itemData );
   mTreeItem->setText( 0, itemData.name() );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2701,8 +2701,7 @@ void QgsAttributeForm::ContainerInformation::apply( QgsExpressionContext *expres
   if ( collapsedExpression.isValid() && ! collapsedExpression.hasEvalError() && newCollapsedState != isCollapsed )
   {
 
-    QgsCollapsibleGroupBoxBasic *collapsibleGroupBox { qobject_cast<QgsCollapsibleGroupBoxBasic *>( widget ) };
-    if ( collapsibleGroupBox )
+    if ( QgsCollapsibleGroupBoxBasic * collapsibleGroupBox { qobject_cast<QgsCollapsibleGroupBoxBasic *>( widget ) } )
     {
       collapsibleGroupBox->setCollapsed( newCollapsedState );
       isCollapsed = newCollapsedState;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -488,10 +488,21 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
         , isVisible( true )
       {}
 
+      ContainerInformation( QWidget *widget, const QgsExpression &visibilityExpression, bool collapsed, const QgsExpression &collapsedExpression )
+        : widget( widget )
+        , expression( visibilityExpression )
+        , isVisible( true )
+        , isCollapsed( collapsed )
+        , collapsedExpression( collapsedExpression )
+      {}
+
+
       QgsTabWidget *tabWidget = nullptr;
       QWidget *widget = nullptr;
       QgsExpression expression;
       bool isVisible;
+      bool isCollapsed = false;
+      QgsExpression collapsedExpression;
 
       void apply( QgsExpressionContext *expressionContext );
     };
@@ -502,8 +513,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     void reloadIcon( const QString &file, const QString &tooltip, QSvgWidget *sw );
 
-    // Contains information about tabs and groupboxes, their visibility state visibility conditions
-    QVector<ContainerInformation *> mContainerVisibilityInformation;
+    // Contains information about tabs and groupboxes, their visibility/collapsed state conditions
+    QVector<ContainerInformation *> mContainerVisibilityCollapsedInformation;
     QMap<QString, QVector<ContainerInformation *> > mContainerInformationDependency;
 
     // Variables below are used for Python

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -479,6 +479,8 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       itemData.setShowAsGroupBox( container->isGroupBox() );
       itemData.setBackgroundColor( container->backgroundColor() );
       itemData.setVisibilityExpression( container->visibilityExpression() );
+      itemData.setCollapsedExpression( container->collapsedExpression() );
+      itemData.setCollapsed( container->collapsed() );
       newWidget = tree->addItem( parent, itemData );
 
       const QList<QgsAttributeEditorElement *> children = container->children();
@@ -733,6 +735,8 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
       QgsAttributeEditorContainer *container = new QgsAttributeEditorContainer( item->text( 0 ), parent, itemData.backgroundColor() );
       container->setColumnCount( itemData.columnCount() );
       container->setIsGroupBox( forceGroup ? true : itemData.showAsGroupBox() );
+      container->setCollapsed( itemData.collapsed() );
+      container->setCollapsedExpression( itemData.collapsedExpression() );
       container->setVisibilityExpression( itemData.visibilityExpression() );
       container->setBackgroundColor( itemData.backgroundColor( ) );
 
@@ -1540,6 +1544,16 @@ QgsOptionalExpression QgsAttributesFormProperties::DnDTreeItemData::visibilityEx
 void QgsAttributesFormProperties::DnDTreeItemData::setVisibilityExpression( const QgsOptionalExpression &visibilityExpression )
 {
   mVisibilityExpression = visibilityExpression;
+}
+
+QgsOptionalExpression QgsAttributesFormProperties::DnDTreeItemData::collapsedExpression() const
+{
+  return mCollapsedExpression;
+}
+
+void QgsAttributesFormProperties::DnDTreeItemData::setCollapsedExpression( const QgsOptionalExpression &collapsedExpression )
+{
+  mCollapsedExpression = collapsedExpression;
 }
 
 QgsAttributesFormProperties::RelationEditorConfiguration QgsAttributesFormProperties::DnDTreeItemData::relationEditorConfiguration() const

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -137,11 +137,33 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         bool showAsGroupBox() const;
         void setShowAsGroupBox( bool showAsGroupBox );
 
+        /**
+         * For containers rendedered a group box returns if this group box is collapsed.
+         *
+         * \returns TRUE if the group box, FALSE otherwise.
+         * \see collapsed()
+         * \see setCollapsed()
+         * \since QGIS 3.26
+         */
+        bool collapsed() const { return mCollapsed; };
+
+        /**
+         * For containers rendedered a group box sets if this group box is \a collapsed.
+         *
+         * \see collapsed()
+         * \see setCollapsed()
+         * \since QGIS 3.26
+         */
+        void setCollapsed( bool collapsed ) { mCollapsed = collapsed; };
+
         bool showLabel() const;
         void setShowLabel( bool showLabel );
 
         QgsOptionalExpression visibilityExpression() const;
-        void setVisibilityExpression( const QgsOptionalExpression &visibilityExpression );
+        void setVisibilityExpression( const QgsOptionalExpression &collapsedExpression );
+
+        QgsOptionalExpression collapsedExpression() const;
+        void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
 
         RelationEditorConfiguration relationEditorConfiguration() const;
         void setRelationEditorConfiguration( RelationEditorConfiguration relationEditorConfiguration );
@@ -167,6 +189,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         QmlElementEditorConfiguration mQmlElementEditorConfiguration;
         HtmlElementEditorConfiguration mHtmlElementEditorConfiguration;
         QColor mBackgroundColor;
+        bool mCollapsed = false;
+        QgsOptionalExpression mCollapsedExpression;
     };
 
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -160,9 +160,33 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         void setShowLabel( bool showLabel );
 
         QgsOptionalExpression visibilityExpression() const;
-        void setVisibilityExpression( const QgsOptionalExpression &collapsedExpression );
 
+        /**
+         * Sets the optional \a visibilityExpression that dynamically controls the visibility status of a container.
+         *
+         * \see visibilityExpression()
+         * \since QGIS 3.26
+         */
+        void setVisibilityExpression( const QgsOptionalExpression &visibilityExpression );
+
+        /**
+         * Returns the optional expression that dynamically constrols the collapsed status of a group box container.
+         *
+         * \see collapsed()
+         * \see setCollapsed()
+         * \see setCollapsedExpression()
+         * \since QGIS 3.26
+         */
         QgsOptionalExpression collapsedExpression() const;
+
+        /**
+         * Sets the optional \a collapsedExpression that dynamically controls the collapsed status of a group box container.
+         *
+         * \see collapsed()
+         * \see setCollapsed()
+         * \see collapsedExpression()
+         * \since QGIS 3.26
+         */
         void setCollapsedExpression( const QgsOptionalExpression &collapsedExpression );
 
         RelationEditorConfiguration relationEditorConfiguration() const;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -138,9 +138,9 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         void setShowAsGroupBox( bool showAsGroupBox );
 
         /**
-         * For containers rendedered a group box returns if this group box is collapsed.
+         * For group box containers  returns if this group box is collapsed.
          *
-         * \returns TRUE if the group box, FALSE otherwise.
+         * \returns TRUE if the group box is collapsed, FALSE otherwise.
          * \see collapsed()
          * \see setCollapsed()
          * \since QGIS 3.26
@@ -148,7 +148,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         bool collapsed() const { return mCollapsed; };
 
         /**
-         * For containers rendedered a group box sets if this group box is \a collapsed.
+         * For group box containers  sets if this group box is \a collapsed.
          *
          * \see collapsed()
          * \see setCollapsed()

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -170,7 +170,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         void setVisibilityExpression( const QgsOptionalExpression &visibilityExpression );
 
         /**
-         * Returns the optional expression that dynamically constrols the collapsed status of a group box container.
+         * Returns the optional expression that dynamically controls the collapsed status of a group box container.
          *
          * \see collapsed()
          * \see setCollapsed()

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -7,48 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>401</width>
-    <height>303</height>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="mShowLabelCheckBox">
-     <property name="text">
-      <string>Show label</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Title</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="3">
+   <item row="4" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
      <property name="title">
       <string>Control Visibility by Expression</string>
@@ -63,27 +29,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="mTitleLineEdit"/>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QCheckBox" name="mShowAsGroupBoxCheckBox">
-     <property name="text">
-      <string>Show as group box</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Style</string>
@@ -102,19 +48,95 @@
      </layout>
     </widget>
    </item>
+   <item row="10" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QCheckBox" name="mShowLabelCheckBox">
+     <property name="text">
+      <string>Show label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Columns</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsSpinBox" name="mColumnCountSpinBox">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="mShowAsGroupBox">
+     <property name="text">
+      <string>Show as Group Box</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="mTitleLineEdit"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Title</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="mCollapsedCheckBox">
+     <property name="text">
+      <string>Collapsed</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mControlCollapsedGroupBox">
+     <property name="title">
+      <string>Control Collapsed by Expression</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QgsFieldExpressionWidget" name="mCollapsedExpressionWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
@@ -131,10 +153,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mShowLabelCheckBox</tabstop>
-  <tabstop>mShowAsGroupBoxCheckBox</tabstop>
   <tabstop>mTitleLineEdit</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
-  <tabstop>mControlVisibilityGroupBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -155,6 +155,10 @@
   <tabstop>mShowLabelCheckBox</tabstop>
   <tabstop>mTitleLineEdit</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
+  <tabstop>mControlVisibilityGroupBox</tabstop>
+  <tabstop>mShowAsGroupBox</tabstop>
+  <tabstop>mCollapsedCheckBox</tabstop>
+  <tabstop>mControlCollapsedGroupBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
  </tabstops>
  <resources/>

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -204,7 +204,7 @@ set(TESTS
  testqgsweakrelation.cpp
  testqgsziputils.cpp
  testqobjectuniqueptr.cpp
- testziplayer.cpp 
+ testziplayer.cpp
 )
 
 if(WITH_QTWEBKIT)

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -172,6 +172,7 @@ set(TESTS
  testqgsspatialindexkdbush.cpp
  testqgssqliteexpressioncompiler.cpp
  testqgssqliteutils.cpp
+ testqgsrelation.cpp
  testqgsstatisticalsummary.cpp
  testqgsstoredexpressionmanager.cpp
  testqgsstringutils.cpp
@@ -203,7 +204,7 @@ set(TESTS
  testqgsweakrelation.cpp
  testqgsziputils.cpp
  testqobjectuniqueptr.cpp
- testziplayer.cpp
+ testziplayer.cpp 
 )
 
 if(WITH_QTWEBKIT)

--- a/tests/src/core/testqgsrelation.cpp
+++ b/tests/src/core/testqgsrelation.cpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+     testqgssettings.cpp
+     --------------------------------------
+    Date                 : 8.03.2022
+    Copyright            : (C) 2022 by Alessandro Pasotti
+    Email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QObject>
+
+
+#include "qgsproject.h"
+#include "qgsattributeeditorelement.h"
+#include "qgsattributeeditorcontainer.h"
+#include "qgsattributeeditorrelation.h"
+#include "qgsmaplayerstylemanager.h"
+#include "qgstest.h"
+#include "qgsvectorlayer.h"
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the QgsRelation changing style
+ */
+class TestQgsRelation: public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void testValidRelationAfterChangingStyle();
+};
+
+void TestQgsRelation::initTestCase()
+{
+  // Runs once before any tests are run
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsSettings().clear();
+}
+
+
+void TestQgsRelation::cleanupTestCase()
+{
+  // Runs once after all tests are run
+  QgsApplication::exitQgis();
+}
+
+void TestQgsRelation::testValidRelationAfterChangingStyle()
+{
+  const QString projectPath = QStringLiteral( TEST_DATA_DIR ) + "/relations.qgs";
+
+  QgsProject *p = QgsProject::instance();
+
+  QVERIFY( p->read( projectPath ) );
+
+  const auto layers { p->mapLayers().values( ) };
+  for ( const auto &l : std::as_const( layers ) )
+  {
+    QVERIFY( l->isValid() );
+  }
+
+  auto relations = p->relationManager()->relations();
+  auto relation = relations.first();
+  QVERIFY( relation.isValid() );
+  auto referencedLayer = relation.referencedLayer();
+
+  bool valid { false };
+  QCOMPARE( static_cast<QgsAttributeEditorContainer *>( referencedLayer->editFormConfig().tabs()[0] )->children().count(), 7 );
+  auto tabs { static_cast<QgsAttributeEditorContainer *>( referencedLayer->editFormConfig().tabs()[0] )->children() };
+  for ( const auto &tab : tabs )
+  {
+    if ( tab->type() == QgsAttributeEditorElement::AeTypeRelation )
+    {
+      valid = static_cast<QgsAttributeEditorRelation *>( tab )->relation().isValid();
+    }
+  }
+
+  QVERIFY( valid );
+
+  QVERIFY( referencedLayer->styleManager()->setCurrentStyle( "custom" ) );
+
+  valid = false;
+  QCOMPARE( static_cast<QgsAttributeEditorContainer *>( referencedLayer->editFormConfig().tabs()[0] )->children().count(), 7 );
+  tabs = static_cast<QgsAttributeEditorContainer *>( referencedLayer->editFormConfig().tabs()[0] )->children();
+  for ( const auto &tab : std::as_const( tabs ) )
+  {
+    if ( tab->type() == QgsAttributeEditorElement::AeTypeRelation )
+    {
+      valid = static_cast<QgsAttributeEditorRelation *>( tab )->relation().isValid();
+    }
+  }
+
+  QVERIFY( valid );
+
+}
+
+QGSTEST_MAIN( TestQgsRelation )
+#include "testqgsrelation.moc"

--- a/tests/src/core/testqgsrelation.cpp
+++ b/tests/src/core/testqgsrelation.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-     testqgssettings.cpp
+     testqgsrelation.cpp
      --------------------------------------
     Date                 : 8.03.2022
     Copyright            : (C) 2022 by Alessandro Pasotti

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -196,8 +196,11 @@ class TestQgsRelation(unittest.TestCase):
         self.assertTrue(valid)
 
         # update style
-        # Note: the project is re-read because of a subtle bug with bidings involving
-        #
+        # Note: the project is re-read because of a subtle bug with bindings involving
+        # QgsOptionalExpression mCollapsedExpressionv that makes the tab loose the information
+        # about the children. The issue couldn't be reproduced when the test is run from QGIS
+        # console and the new test testqgsrelation.cpp now covers this behavior without reloading
+        # the project.
         self.assertTrue(p.read(myPath))
         relations = QgsProject.instance().relationManager().relations()
         relation = relations[list(relations.keys())[0]]

--- a/tests/src/python/test_qgsrelation.py
+++ b/tests/src/python/test_qgsrelation.py
@@ -196,6 +196,13 @@ class TestQgsRelation(unittest.TestCase):
         self.assertTrue(valid)
 
         # update style
+        # Note: the project is re-read because of a subtle bug with bidings involving
+        #
+        self.assertTrue(p.read(myPath))
+        relations = QgsProject.instance().relationManager().relations()
+        relation = relations[list(relations.keys())[0]]
+        referencedLayer = relation.referencedLayer()
+
         referencedLayer.styleManager().setCurrentStyle("custom")
 
         for l in p.mapLayers().values():


### PR DESCRIPTION
## Description

This PR adds a new configuration options for D&D form group boxes: it is now possible to collapse the groups and control the collapsed status with an expression:

![image](https://user-images.githubusercontent.com/142164/157067258-d71ca6ef-7377-478a-991d-836b094c66b1.png)


Funded by: ARPA Piemonte