### PR TITLE
[AStyle] break-one-line-headers

### DIFF
--- a/scripts/astyle.options
+++ b/scripts/astyle.options
@@ -10,6 +10,7 @@
 --max-instatement-indent=40
 --min-conditional-indent=-1
 --suffix=none
+--break-one-line-headers
 --break-after-logical
 --style=allman
 --align-pointer=name

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -33,7 +33,8 @@ void insertIndexData( QVector<uint> &vertexIndex, const QVector<T> &faceIndex )
 {
   for ( int i = 0; i < faceIndex.size(); i += 3 )
   {
-    if ( i + 2 >= faceIndex.size() ) continue;
+    if ( i + 2 >= faceIndex.size() )
+      continue;
     // skip invalid triangles
     if ( faceIndex[i] == faceIndex[i + 1] || faceIndex[i + 1] == faceIndex[i + 2] || faceIndex[i] == faceIndex[i + 2] )
       continue;
@@ -61,7 +62,8 @@ void Qgs3DExportObject::setupFaces( const QVector<uint> &facesIndexes )
 void Qgs3DExportObject::setupLine( const QVector<uint> &lineIndexes )
 {
   Q_UNUSED( lineIndexes );
-  for ( int i = 0; i < mVertexPosition.size(); i += 3 ) mIndexes << i / 3 + 1;
+  for ( int i = 0; i < mVertexPosition.size(); i += 3 )
+    mIndexes << i / 3 + 1;
 }
 
 void Qgs3DExportObject::setupNormalCoordinates( const QVector<float> &normalsBuffer )
@@ -85,7 +87,8 @@ void Qgs3DExportObject::setupMaterial( QgsAbstractMaterialSettings *material )
 
 void Qgs3DExportObject::objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ )
 {
-  if ( mType != TriangularFaces ) return;
+  if ( mType != TriangularFaces )
+    return;
   for ( const unsigned int vertice : mIndexes )
   {
     const int heightIndex = ( vertice - 1 ) * 3 + 1;
@@ -167,7 +170,8 @@ void Qgs3DExportObject::saveTo( QTextStream &out, float scale, const QVector3D &
   else if ( mType == LineStrip )
   {
     out << "l";
-    for ( const int i : mIndexes ) out << " " << getVertexIndex( i );
+    for ( const int i : mIndexes )
+      out << " " << getVertexIndex( i );
     out << "\n";
   }
   else if ( mType == Points )
@@ -182,7 +186,8 @@ void Qgs3DExportObject::saveTo( QTextStream &out, float scale, const QVector3D &
 QString Qgs3DExportObject::saveMaterial( QTextStream &mtlOut, const QString &folderPath )
 {
   QString materialName = mName + "_material";
-  if ( mMaterialParameters.size() == 0 && ( mTexturesUV.size() == 0 || mTextureImage.isNull() ) ) return QString();
+  if ( mMaterialParameters.size() == 0 && ( mTexturesUV.size() == 0 || mTextureImage.isNull() ) )
+    return QString();
   mtlOut << "newmtl " << materialName << "\n";
   if ( mTexturesUV.size() != 0 && !mTextureImage.isNull() )
   {

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1129,7 +1129,8 @@ void Qgs3DMapScene::exportScene( const Qgs3DMapExportSettings &exportSettings )
 QVector<const QgsChunkNode *> Qgs3DMapScene::getLayerActiveChunkNodes( QgsMapLayer *layer )
 {
   QVector<const QgsChunkNode *> chunks;
-  if ( !mLayerEntities.contains( layer ) ) return chunks;
+  if ( !mLayerEntities.contains( layer ) )
+    return chunks;
   if ( QgsChunkedEntity *c = qobject_cast<QgsChunkedEntity *>( mLayerEntities[ layer ] ) )
   {
     for ( QgsChunkNode *n : c->activeNodes() )

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -157,8 +157,10 @@ Qt3DRender::QAttribute *findAttribute( Qt3DRender::QGeometry *geometry, const QS
 {
   for ( Qt3DRender::QAttribute *attribute : geometry->attributes() )
   {
-    if ( attribute->attributeType() != type ) continue;
-    if ( attribute->name() == name ) return attribute;
+    if ( attribute->attributeType() != type )
+      continue;
+    if ( attribute->name() == name )
+      return attribute;
   }
   return nullptr;
 }
@@ -166,7 +168,8 @@ Qt3DRender::QAttribute *findAttribute( Qt3DRender::QGeometry *geometry, const QS
 template<typename Component>
 Component *findTypedComponent( Qt3DCore::QEntity *entity )
 {
-  if ( entity == nullptr ) return nullptr;
+  if ( entity == nullptr )
+    return nullptr;
   for ( Qt3DCore::QComponent *component : entity->components() )
   {
     Component *typedComponent = qobject_cast<Component *>( component );
@@ -195,9 +198,11 @@ bool Qgs3DSceneExporter::parseVectorLayerEntity( Qt3DCore::QEntity *entity, QgsV
       for ( Qt3DRender::QGeometryRenderer *renderer : renderers )
       {
         Qt3DCore::QEntity *entity = qobject_cast<Qt3DCore::QEntity *>( renderer->parent() );
-        if ( entity == nullptr ) continue;
+        if ( entity == nullptr )
+          continue;
         Qgs3DExportObject *object = processGeometryRenderer( renderer, layer->name() + QStringLiteral( "_" ) );
-        if ( object == nullptr ) continue;
+        if ( object == nullptr )
+          continue;
         if ( mExportTextures )
           processEntityMaterial( entity, object );
         mObjects.push_back( object );
@@ -232,7 +237,8 @@ void Qgs3DSceneExporter::processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3D
     for ( Qt3DRender::QAbstractTextureImage *tex : textureImages )
     {
       imageTexture = dynamic_cast<QgsImageTexture *>( tex );
-      if ( imageTexture != nullptr ) break;
+      if ( imageTexture != nullptr )
+        break;
     }
     if ( imageTexture != nullptr )
     {
@@ -339,7 +345,8 @@ void Qgs3DSceneExporter::parseFlatTile( QgsTerrainTileEntity *tileEntity, const 
   const QVector<uint> indexesBuffer = getIndexData( indexAttribute,  indexBytes );
 
   QString objectNamePrefix = layerName;
-  if ( objectNamePrefix != QString() ) objectNamePrefix += QString();
+  if ( objectNamePrefix != QString() )
+    objectNamePrefix += QString();
 
   Qgs3DExportObject *object = new Qgs3DExportObject( getObjectName( objectNamePrefix + QStringLiteral( "Flat_tile" ) ) );
   mObjects.push_back( object );
@@ -352,7 +359,8 @@ void Qgs3DSceneExporter::parseFlatTile( QgsTerrainTileEntity *tileEntity, const 
   {
     // Everts
     QVector<float> normalsBuffer;
-    for ( int i = 0; i < positionBuffer.size(); i += 3 ) normalsBuffer << 0.0f << 1.0f << 0.0f;
+    for ( int i = 0; i < positionBuffer.size(); i += 3 )
+      normalsBuffer << 0.0f << 1.0f << 0.0f;
     object->setupNormalCoordinates( normalsBuffer );
   }
 
@@ -394,7 +402,8 @@ void Qgs3DSceneExporter::parseDemTile( QgsTerrainTileEntity *tileEntity, const Q
   const QVector<unsigned int> indexBuffer = getIndexData( indexAttribute, indexBytes );
 
   QString objectNamePrefix = layerName;
-  if ( objectNamePrefix != QString() ) objectNamePrefix += QStringLiteral( "_" );
+  if ( objectNamePrefix != QString() )
+    objectNamePrefix += QStringLiteral( "_" );
 
   Qgs3DExportObject *object = new Qgs3DExportObject( getObjectName( layerName + QStringLiteral( "DEM_tile" ) ) );
   mObjects.push_back( object );
@@ -427,13 +436,15 @@ void Qgs3DSceneExporter::parseDemTile( QgsTerrainTileEntity *tileEntity, const Q
 void Qgs3DSceneExporter::parseMeshTile( QgsTerrainTileEntity *tileEntity, const QString &layerName )
 {
   QString objectNamePrefix = layerName;
-  if ( objectNamePrefix != QString() ) objectNamePrefix += QStringLiteral( "_" );
+  if ( objectNamePrefix != QString() )
+    objectNamePrefix += QStringLiteral( "_" );
 
   const QList<Qt3DRender::QGeometryRenderer *> renderers = tileEntity->findChildren<Qt3DRender::QGeometryRenderer *>();
   for ( Qt3DRender::QGeometryRenderer *renderer : renderers )
   {
     Qgs3DExportObject *obj = processGeometryRenderer( renderer, objectNamePrefix );
-    if ( obj == nullptr ) continue;
+    if ( obj == nullptr )
+      continue;
     mObjects << obj;
   }
 }
@@ -498,7 +509,8 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processSceneLoaderGeometries( Q
   {
     Qt3DRender::QGeometryRenderer *mesh = qobject_cast<Qt3DRender::QGeometryRenderer *>( sceneLoader->component( entityName, Qt3DRender::QSceneLoader::GeometryRendererComponent ) );
     Qgs3DExportObject *object = processGeometryRenderer( mesh, objectNamePrefix, sceneScale, sceneTranslation );
-    if ( object == nullptr ) continue;
+    if ( object == nullptr )
+      continue;
     objects.push_back( object );
   }
   return objects;
@@ -507,7 +519,8 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processSceneLoaderGeometries( Q
 Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeometryRenderer *mesh, const QString &objectNamePrefix, float sceneScale, QVector3D sceneTranslation )
 {
   // We only export triangles for now
-  if ( mesh->primitiveType() != Qt3DRender::QGeometryRenderer::Triangles ) return nullptr;
+  if ( mesh->primitiveType() != Qt3DRender::QGeometryRenderer::Triangles )
+    return nullptr;
 
   float scale = 1.0f;
   QVector3D translation( 0.0f, 0.0f, 0.0f );
@@ -591,7 +604,8 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processLines( Qt3DCore::QEntity
   const QList<Qt3DRender::QGeometryRenderer *> renderers = entity->findChildren<Qt3DRender::QGeometryRenderer *>();
   for ( Qt3DRender::QGeometryRenderer *renderer : renderers )
   {
-    if ( renderer->primitiveType() != Qt3DRender::QGeometryRenderer::LineStripAdjacency ) continue;
+    if ( renderer->primitiveType() != Qt3DRender::QGeometryRenderer::LineStripAdjacency )
+      continue;
     Qt3DRender::QGeometry *geom = renderer->geometry();
     Qt3DRender::QAttribute *positionAttribute = findAttribute( geom, Qt3DRender::QAttribute::defaultPositionAttributeName(), Qt3DRender::QAttribute::VertexAttribute );
     Qt3DRender::QAttribute *indexAttribute = nullptr;
@@ -660,7 +674,8 @@ void Qgs3DSceneExporter::save( const QString &sceneName, const QString &sceneFol
 
   float maxfloat = std::numeric_limits<float>::max(), minFloat = std::numeric_limits<float>::lowest();
   float minX = maxfloat, minY = maxfloat, minZ = maxfloat, maxX = minFloat, maxY = minFloat, maxZ = minFloat;
-  for ( Qgs3DExportObject *obj : mObjects ) obj->objectBounds( minX, minY, minZ, maxX, maxY, maxZ );
+  for ( Qgs3DExportObject *obj : mObjects )
+    obj->objectBounds( minX, minY, minZ, maxX, maxY, maxZ );
 
   float diffX = 1.0f, diffY = 1.0f, diffZ = 1.0f;
   diffX = maxX - minX;
@@ -681,7 +696,8 @@ void Qgs3DSceneExporter::save( const QString &sceneName, const QString &sceneFol
   QTextStream mtlOut( &mtlFile );
   for ( Qgs3DExportObject *obj : mObjects )
   {
-    if ( obj == nullptr ) continue;
+    if ( obj == nullptr )
+      continue;
     // Set object name
     const QString material = obj->saveMaterial( mtlOut, sceneFolderPath );
     out << "o " << obj->name() << "\n";

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -492,12 +492,18 @@ static inline uint outcode( QVector4D v )
   // TODO: optimise this with assembler - according to D&P this can
   // be done in one line of assembler on some platforms
   uint code = 0;
-  if ( v.x() < -v.w() ) code |= 0x01;
-  if ( v.x() > v.w() )  code |= 0x02;
-  if ( v.y() < -v.w() ) code |= 0x04;
-  if ( v.y() > v.w() )  code |= 0x08;
-  if ( v.z() < -v.w() ) code |= 0x10;
-  if ( v.z() > v.w() )  code |= 0x20;
+  if ( v.x() < -v.w() )
+    code |= 0x01;
+  if ( v.x() > v.w() )
+    code |= 0x02;
+  if ( v.y() < -v.w() )
+    code |= 0x04;
+  if ( v.y() > v.w() )
+    code |= 0x08;
+  if ( v.z() < -v.w() )
+    code |= 0x10;
+  if ( v.z() > v.w() )
+    code |= 0x20;
   return code;
 }
 
@@ -640,8 +646,10 @@ void Qgs3DUtils::estimateVectorLayerZRange( QgsVectorLayer *layer, double &zMin,
     for ( auto vit = g.vertices_begin(); vit != g.vertices_end(); ++vit )
     {
       const double z = ( *vit ).z();
-      if ( z < zMin ) zMin = z;
-      if ( z > zMax ) zMax = z;
+      if ( z < zMin )
+        zMin = z;
+      if ( z > zMax )
+        zMax = z;
     }
   }
 

--- a/src/3d/qgspreviewquad.cpp
+++ b/src/3d/qgspreviewquad.cpp
@@ -80,7 +80,8 @@ QgsPreviewQuadMaterial::QgsPreviewQuadMaterial( Qt3DRender::QAbstractTexture *te
   addParameter( mTextureParameter );
   addParameter( mCenterTextureCoords );
   addParameter( mSizeTextureCoords );
-  for ( Qt3DRender::QParameter *parameter : additionalShaderParameters ) addParameter( parameter );
+  for ( Qt3DRender::QParameter *parameter : additionalShaderParameters )
+    addParameter( parameter );
 
   mEffect = new Qt3DRender::QEffect;
 

--- a/src/3d/qgsraycastingutils_p.cpp
+++ b/src/3d/qgsraycastingutils_p.cpp
@@ -222,9 +222,12 @@ namespace QgsRayCastingUtils
     box b( aabb );
 
     // intersection() does not like yMin==yMax (excludes borders)
-    if ( b.min[0] == b.max[0] ) b.max[0] += 0.1;
-    if ( b.min[1] == b.max[1] ) b.max[1] += 0.1;
-    if ( b.min[2] == b.max[2] ) b.max[2] += 0.1;
+    if ( b.min[0] == b.max[0] )
+      b.max[0] += 0.1;
+    if ( b.min[1] == b.max[1] )
+      b.max[1] += 0.1;
+    if ( b.min[2] == b.max[2] )
+      b.max[2] += 0.1;
 
     return intersection( b, ray( r ) );
   }

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -132,7 +132,8 @@ bool QgsLine3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::
     for ( Qt3DRender::QGeometryRenderer *r : renderers )
     {
       Qgs3DExportObject *object = exporter->processGeometryRenderer( r, objectNamePrefix );
-      if ( object == nullptr ) continue;
+      if ( object == nullptr )
+        continue;
       object->setupMaterial( material() );
       exporter->mObjects.push_back( object );
     }

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -211,7 +211,8 @@ bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore:
       for ( Qt3DRender::QMesh *mesh : meshes )
       {
         Qgs3DExportObject *object = exporter->processGeometryRenderer( mesh, objectNamePrefix );
-        if ( object == nullptr ) continue;
+        if ( object == nullptr )
+          continue;
         object->setSmoothEdges( exporter->smoothEdges() );
         object->setupMaterial( material() );
         exporter->mObjects << object;
@@ -222,8 +223,10 @@ bool QgsPoint3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore:
   else if ( shape() == QgsPoint3DSymbol::Billboard )
   {
     Qgs3DExportObject *obj = exporter->processPoints( entity, objectNamePrefix );
-    if ( obj != nullptr ) exporter->mObjects << obj;
-    if ( obj != nullptr ) return true;
+    if ( obj != nullptr )
+      exporter->mObjects << obj;
+    if ( obj != nullptr )
+      return true;
   }
   else
   {

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -158,7 +158,8 @@ bool QgsPolygon3DSymbol::exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCor
   for ( Qt3DRender::QGeometryRenderer *r : renderers )
   {
     Qgs3DExportObject *object = exporter->processGeometryRenderer( r, objectNamePrefix );
-    if ( object == nullptr ) continue;
+    if ( object == nullptr )
+      continue;
     exporter->processEntityMaterial( entity, object );
     exporter->mObjects.push_back( object );
   }

--- a/src/3d/terrain/qgsterraindownloader.cpp
+++ b/src/3d/terrain/qgsterraindownloader.cpp
@@ -85,7 +85,8 @@ double QgsTerrainDownloader::findBestTileResolution( double requestedMupp )
       break;
   }
 
-  if ( zoom > 15 ) zoom = 15;
+  if ( zoom > 15 )
+    zoom = 15;
   const double finalMupp = mXSpan / ( 256 * ( 1 << zoom ) );
   return finalMupp;
 }

--- a/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmrandompointsinpolygons.cpp
@@ -304,7 +304,8 @@ QVariantMap QgsRandomPointsInPolygonsAlgorithm::processAlgorithm( const QVariant
         // Local first (if larger than global)
         if ( minDistanceForThisFeature != 0 && mMinDistanceGlobal < minDistanceForThisFeature && localIndexPoints > 0 )
         {
-          const QList<QgsFeatureId> neighbors = localIndex.nearestNeighbor( newPoint, 1, minDistanceForThisFeature );
+          const QList<QgsFeatureId>
+          neighbors = localIndex.nearestNeighbor( newPoint, 1, minDistanceForThisFeature );
           //if ( totNPoints > 0 && !neighbors.empty() )
           if ( !neighbors.empty() )
           {
@@ -314,7 +315,8 @@ QVariantMap QgsRandomPointsInPolygonsAlgorithm::processAlgorithm( const QVariant
         // The global
         if ( mMinDistanceGlobal != 0.0 && indexPoints > 0 )
         {
-          const QList<QgsFeatureId> neighbors = globalIndex.nearestNeighbor( newPoint, 1, mMinDistanceGlobal );
+          const QList<QgsFeatureId>
+          neighbors = globalIndex.nearestNeighbor( newPoint, 1, mMinDistanceGlobal );
           //if ( totNPoints > 0 && !neighbors.empty() )
           if ( !neighbors.empty() )
           {

--- a/src/analysis/raster/qgsalignraster.cpp
+++ b/src/analysis/raster/qgsalignraster.cpp
@@ -288,10 +288,14 @@ bool QgsAlignRaster::checkInputParameters()
     else
     {
       // use intersection of rects
-      if ( extent.xMinimum() > finalExtent[0] ) finalExtent[0] = extent.xMinimum();
-      if ( extent.yMinimum() > finalExtent[1] ) finalExtent[1] = extent.yMinimum();
-      if ( extent.xMaximum() < finalExtent[2] ) finalExtent[2] = extent.xMaximum();
-      if ( extent.yMaximum() < finalExtent[3] ) finalExtent[3] = extent.yMaximum();
+      if ( extent.xMinimum() > finalExtent[0] )
+        finalExtent[0] = extent.xMinimum();
+      if ( extent.yMinimum() > finalExtent[1] )
+        finalExtent[1] = extent.yMinimum();
+      if ( extent.xMaximum() < finalExtent[2] )
+        finalExtent[2] = extent.xMaximum();
+      if ( extent.yMaximum() < finalExtent[3] )
+        finalExtent[3] = extent.yMaximum();
     }
   }
 
@@ -306,10 +310,14 @@ bool QgsAlignRaster::checkInputParameters()
     const double clipY0 = floor_with_tolerance( ( mClipExtent[1] - mGridOffsetY ) / mCellSizeY ) * mCellSizeY + mGridOffsetY;
     const double clipX1 = ceil_with_tolerance( ( mClipExtent[2] - clipX0 ) / mCellSizeX ) * mCellSizeX + clipX0;
     const double clipY1 = ceil_with_tolerance( ( mClipExtent[3] - clipY0 ) / mCellSizeY ) * mCellSizeY + clipY0;
-    if ( clipX0 > finalExtent[0] ) finalExtent[0] = clipX0;
-    if ( clipY0 > finalExtent[1] ) finalExtent[1] = clipY0;
-    if ( clipX1 < finalExtent[2] ) finalExtent[2] = clipX1;
-    if ( clipY1 < finalExtent[3] ) finalExtent[3] = clipY1;
+    if ( clipX0 > finalExtent[0] )
+      finalExtent[0] = clipX0;
+    if ( clipY0 > finalExtent[1] )
+      finalExtent[1] = clipY0;
+    if ( clipX1 < finalExtent[2] )
+      finalExtent[2] = clipX1;
+    if ( clipY1 < finalExtent[3] )
+      finalExtent[3] = clipY1;
   }
 
   // align to grid - shrink the rect if necessary

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -427,7 +427,8 @@ QStringList QgsRasterCalcNode::referencedLayerNames()
   QStringList rasterRef = this->cleanRasterReferences();
   for ( const auto &i : rasterRef )
   {
-    if ( referencedRasters.contains( i.mid( 0, i.lastIndexOf( "@" ) ) ) ) continue;
+    if ( referencedRasters.contains( i.mid( 0, i.lastIndexOf( "@" ) ) ) )
+      continue;
     referencedRasters << i.mid( 0, i.lastIndexOf( "@" ) );
   }
 

--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -317,8 +317,10 @@ QgsSnapIndex::SnapItem *QgsSnapIndex::getSnapItem( const QgsPoint &pos, const do
   }
   snapPoint = minDistPoint < tolerance * tolerance ? snapPoint : nullptr;
   snapSegment = minDistSegment < tolerance * tolerance ? snapSegment : nullptr;
-  if ( pSnapPoint ) *pSnapPoint = snapPoint;
-  if ( pSnapSegment ) *pSnapSegment = snapSegment;
+  if ( pSnapPoint )
+    *pSnapPoint = snapPoint;
+  if ( pSnapSegment )
+    *pSnapSegment = snapSegment;
   return minDistPoint < minDistSegment ? static_cast<QgsSnapIndex::SnapItem *>( snapPoint ) : static_cast<QgsSnapIndex::SnapItem *>( snapSegment );
 }
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -146,13 +146,15 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
     const QString newFile = QgsNewVectorLayerDialog::execAndCreateLayer( error, QgisApp::instance(), dir.filePath( QStringLiteral( "new_layer.shp" ) ), &enc, QgsProject::instance()->defaultCrsForNewLayers() );
     if ( !newFile.isEmpty() )
     {
-      context.messageBar()->pushSuccess( tr( "New ShapeFile" ), tr( "Created <a href=\"%1\">%2</a>" ).arg(
-                                           QUrl::fromLocalFile( newFile ).toString(), QDir::toNativeSeparators( newFile ) ) );
+      context.messageBar()
+      ->pushSuccess( tr( "New ShapeFile" ), tr( "Created <a href=\"%1\">%2</a>" ).arg(
+                       QUrl::fromLocalFile( newFile ).toString(), QDir::toNativeSeparators( newFile ) ) );
       item->refresh();
     }
     else if ( !error.isEmpty() )
     {
-      context.messageBar()->pushCritical( tr( "New ShapeFile" ), tr( "Layer creation failed: %1" ).arg( error ) );
+      context.messageBar()
+      ->pushCritical( tr( "New ShapeFile" ), tr( "Layer creation failed: %1" ).arg( error ) );
     }
   } );
   newMenu->addAction( createShp );
@@ -829,7 +831,8 @@ void QgsProjectHomeItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
     QString newPath = QFileDialog::getExistingDirectory( QgisApp::instance(), tr( "Select Project Home Directory" ), oldHome );
     if ( !newPath.isEmpty() )
     {
-      QgsProject::instance()->setPresetHomePath( newPath );
+      QgsProject::instance()
+      ->setPresetHomePath( newPath );
     }
   } );
 
@@ -860,7 +863,8 @@ void QgsFavoritesItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu 
     QString directory = QFileDialog::getExistingDirectory( QgisApp::instance(), tr( "Add Directory to Favorites" ) );
     if ( !directory.isEmpty() )
     {
-      QgisApp::instance()->browserModel()->addFavoriteDirectory( directory );
+      QgisApp::instance()
+      ->browserModel()->addFavoriteDirectory( directory );
     }
   } );
   menu->addAction( addAction );
@@ -1147,7 +1151,8 @@ void QgsProjectItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
       }
       else if ( context.messageBar() )
       {
-        context.messageBar()->pushWarning( tr( "Extract Symbols" ), tr( "Could not read project file" ) );
+        context.messageBar()
+        ->pushWarning( tr( "Extract Symbols" ), tr( "Could not read project file" ) );
       }
     } );
     menu->addAction( extractAction );
@@ -1371,7 +1376,8 @@ void QgsFieldItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
 
             if ( msgbox.exec() == QMessageBox::Ok )
             {
-              std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2 { static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( fieldsItem->connectionUri(), {} ) ) };
+              std::unique_ptr<QgsAbstractDatabaseProviderConnection>
+              conn2 { static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( fieldsItem->connectionUri(), {} ) ) };
               try
               {
                 conn2->deleteField( itemName, fieldsItem->schema(), fieldsItem->tableName(), supportsCascade && cb->isChecked() );

--- a/src/app/decorations/qgsdecorationgrid.cpp
+++ b/src/app/decorations/qgsdecorationgrid.cpp
@@ -401,7 +401,8 @@ static bool clipByRect( QLineF &line, const QPolygonF &rect )
       }
     }
   }
-  if ( intersectionList.size() < 2 ) return false; // no intersection
+  if ( intersectionList.size() < 2 )
+    return false; // no intersection
 
   line = QLineF( intersectionList.at( 0 ), intersectionList.at( 1 ) );
   return true;

--- a/src/app/decorations/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/decorations/qgsdecorationnortharrowdialog.cpp
@@ -91,7 +91,8 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
     svgDlg.svgSelector()->setSvgPath( mSvgPathLineEdit->text().trimmed() );
     if ( svgDlg.exec() == QDialog::Accepted )
     {
-      const QString svgPath = svgDlg.svgSelector()->currentSvgPath();
+      const QString svgPath = svgDlg.svgSelector()
+      ->currentSvgPath();
       if ( !svgPath.isEmpty() )
       {
         updateSvgPath( svgPath );

--- a/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
@@ -63,7 +63,8 @@ QgsNetworkLoggerTreeView::QgsNetworkLoggerTreeView( QgsNetworkLogger *logger, QW
     if ( mLogger->rowCount() > ( QgsNetworkLogger::MAX_LOGGED_REQUESTS * 1.2 ) ) // 20 % more as buffer
     {
       // never trim expanded nodes
-      const int toTrim = mLogger->rowCount() - QgsNetworkLogger::MAX_LOGGED_REQUESTS;
+      const int toTrim = mLogger->rowCount()
+      - QgsNetworkLogger::MAX_LOGGED_REQUESTS;
       int trimmed = 0;
       QList< int > rowsToTrim;
       rowsToTrim.reserve( toTrim );

--- a/src/app/georeferencer/qgsgeorefmainwindow.cpp
+++ b/src/app/georeferencer/qgsgeorefmainwindow.cpp
@@ -1555,7 +1555,8 @@ bool QgsGeoreferencerMainWindow::georeferenceRaster()
     if ( mLoadInQgis )
     {
       const QString layerSource = mCreateWorldFileOnly ? mFileName : mModifiedFileName;
-      QgisApp::instance()->addRasterLayer( layerSource, QFileInfo( layerSource ).completeBaseName(), QStringLiteral( "gdal" ) );
+      QgisApp::instance()
+      ->addRasterLayer( layerSource, QFileInfo( layerSource ).completeBaseName(), QStringLiteral( "gdal" ) );
     }
 
     loop.quit();
@@ -1637,7 +1638,8 @@ bool QgsGeoreferencerMainWindow::georeferenceVector()
     mMessageBar->pushMessage( tr( "Georeference Successful" ), tr( "Vector layer was successfully georeferenced." ), Qgis::MessageLevel::Success );
     if ( mLoadInQgis )
     {
-      QgisApp::instance()->addVectorLayer( mModifiedFileName, QFileInfo( mModifiedFileName ).completeBaseName(), QStringLiteral( "ogr" ) );
+      QgisApp::instance()
+      ->addVectorLayer( mModifiedFileName, QFileInfo( mModifiedFileName ).completeBaseName(), QStringLiteral( "ogr" ) );
     }
 
     loop.quit();

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -26,7 +26,8 @@
 float _normalizedAngle( float x )
 {
   x = std::fmod( x, 360 );
-  if ( x < 0 ) x += 360;
+  if ( x < 0 )
+    x += 360;
   return x;
 }
 
@@ -45,7 +46,8 @@ void _prepare3DViewsMenu( QMenu *menu, QgsLayout3DMapWidget *w, Func1 slot )
     }
     if ( lst.isEmpty() )
     {
-      menu->addAction( QObject::tr( "No 3D maps defined" ) )->setEnabled( false );
+      menu->addAction( QObject::tr( "No 3D maps defined" ) )
+      ->setEnabled( false );
     }
   } );
 }

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1589,7 +1589,8 @@ void QgsLayoutDesignerDialog::dropEvent( QDropEvent *event )
   {
     for ( const QString &file : std::as_const( files ) )
     {
-      const QVector<QPointer<QgsLayoutCustomDropHandler >> handlers = QgisApp::instance()->customLayoutDropHandlers();
+      const QVector<QPointer<QgsLayoutCustomDropHandler >>
+          handlers = QgisApp::instance()->customLayoutDropHandlers();
       for ( QgsLayoutCustomDropHandler *handler : handlers )
       {
         if ( handler && handler->handleFileDrop( iface(), layoutPoint, file ) )

--- a/src/app/maptools/qgsmaptoolshaperegularpolygonabstract.cpp
+++ b/src/app/maptools/qgsmaptoolshaperegularpolygonabstract.cpp
@@ -21,7 +21,7 @@
 #include "qgisapp.h"
 #include "qgsmaptoolcapture.h"
 
-QgsMapToolShapeRegularPolygonAbstract::QgsMapToolShapeRegularPolygonAbstract(const QString &id, QgsMapToolCapture *parentTool )
+QgsMapToolShapeRegularPolygonAbstract::QgsMapToolShapeRegularPolygonAbstract( const QString &id, QgsMapToolCapture *parentTool )
   : QgsMapToolShapeAbstract( id, parentTool )
 {
 }

--- a/src/app/maptools/qgsmaptoolshaperegularpolygonabstract.h
+++ b/src/app/maptools/qgsmaptoolshaperegularpolygonabstract.h
@@ -28,7 +28,7 @@ class APP_EXPORT QgsMapToolShapeRegularPolygonAbstract: public QgsMapToolShapeAb
     Q_OBJECT
 
   public:
-    QgsMapToolShapeRegularPolygonAbstract(const QString &id, QgsMapToolCapture *parentTool);
+    QgsMapToolShapeRegularPolygonAbstract( const QString &id, QgsMapToolCapture *parentTool );
 
     void clean() override;
 

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1809,7 +1809,8 @@ void QgsMapToolEditMeshFrame::triggerTransformCoordinatesDockWidget( bool checke
     QgsGeometry faceGeometrie;
     if ( faceList.count() == 1 )
     {
-      const QgsMeshFace &face = mCurrentLayer->nativeMesh()->face( faceList.at( 0 ) );
+      const QgsMeshFace &face = mCurrentLayer->nativeMesh()
+      ->face( faceList.at( 0 ) );
       const int faceSize = face.size();
       QVector<QgsPointXY> faceVertices( faceSize );
       for ( int j = 0; j < faceSize; ++j )

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -522,7 +522,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cmbScanItemsInBrowser->addItem( tr( "Check File Contents" ), "contents" ); // 0
   cmbScanItemsInBrowser->addItem( tr( "Check Extension" ), "extension" );    // 1
   int index = cmbScanItemsInBrowser->findData( mSettings->value( QStringLiteral( "/qgis/scanItemsInBrowser2" ), QString() ) );
-  if ( index == -1 ) index = 1;
+  if ( index == -1 )
+    index = 1;
   cmbScanItemsInBrowser->setCurrentIndex( index );
 
   // Scan for contents of compressed files (.zip) in browser dock
@@ -532,7 +533,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cmbScanZipInBrowser->addItem( tr( "Basic Scan" ), QVariant( "basic" ) );
   cmbScanZipInBrowser->addItem( tr( "Full Scan" ), QVariant( "full" ) );
   index = cmbScanZipInBrowser->findData( mSettings->value( QStringLiteral( "/qgis/scanZipInBrowser2" ), QString() ) );
-  if ( index == -1 ) index = 1;
+  if ( index == -1 )
+    index = 1;
   cmbScanZipInBrowser->setCurrentIndex( index );
 
   mCheckMonitorDirectories->setChecked( mSettings->value( QStringLiteral( "/qgis/monitorDirectoriesInBrowser" ), true ).toBool() );
@@ -1714,7 +1716,8 @@ void QgsOptions::saveOptions()
   if ( mSimplifyDrawingGroupBox->isChecked() )
   {
     simplifyHints |= QgsVectorSimplifyMethod::GeometrySimplification;
-    if ( mSimplifyDrawingSpinBox->value() > 1 ) simplifyHints |= QgsVectorSimplifyMethod::AntialiasingSimplification;
+    if ( mSimplifyDrawingSpinBox->value() > 1 )
+      simplifyHints |= QgsVectorSimplifyMethod::AntialiasingSimplification;
   }
   mSettings->setEnumValue( QStringLiteral( "/qgis/simplifyDrawingHints" ), simplifyHints );
   mSettings->setEnumValue( QStringLiteral( "/qgis/simplifyAlgorithm" ), ( QgsVectorSimplifyMethod::SimplifyHints )mSimplifyAlgorithmComboBox->currentData().toInt() );
@@ -2143,7 +2146,8 @@ QStringList QgsOptions::i18nList()
     QString myFileName = myIterator.next();
 
     // Ignore the 'en' translation file, already added as 'en_US'.
-    if ( myFileName.compare( QLatin1String( "qgis_en.qm" ) ) == 0 ) continue;
+    if ( myFileName.compare( QLatin1String( "qgis_en.qm" ) ) == 0 )
+      continue;
 
     myList << myFileName.remove( QStringLiteral( "qgis_" ) ).remove( QStringLiteral( ".qm" ) );
   }

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
@@ -67,7 +67,8 @@ bool QgsPluginSortFilterProxyModel::filterByStatus( QModelIndex &index ) const
 
   QString status = sourceModel()->data( index, PLUGIN_STATUS_ROLE ).toString();
   const QString statusexp = sourceModel()->data( index, PLUGIN_STATUSEXP_ROLE ).toString();
-  if ( status.endsWith( 'Z' ) ) status.chop( 1 );
+  if ( status.endsWith( 'Z' ) )
+    status.chop( 1 );
   if ( ! mAcceptedStatuses.isEmpty()
        && ! mAcceptedStatuses.contains( QStringLiteral( "invalid" ) )
        && !( mAcceptedStatuses.contains( status ) || mAcceptedStatuses.contains( statusexp ) ) )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2079,7 +2079,8 @@ void QgisApp::dropEvent( QDropEvent *event )
       bool handled = false;
 
       // give custom drop handlers first priority at handling the file
-      const QVector<QPointer<QgsCustomDropHandler >> handlers = mCustomDropHandlers;
+      const QVector<QPointer<QgsCustomDropHandler >>
+          handlers = mCustomDropHandlers;
       for ( QgsCustomDropHandler *handler : handlers )
       {
         if ( handler && handler->handleFileDrop( file ) )
@@ -2810,7 +2811,8 @@ void QgisApp::createActions()
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
     if ( !vlayer )
     {
-      visibleMessageBar()->pushMessage(
+      visibleMessageBar()
+      ->pushMessage(
         tr( "No active vector layer" ),
         tr( "To reselect features, choose a vector layer in the legend." ),
         Qgis::MessageLevel::Info );
@@ -3049,7 +3051,8 @@ void QgisApp::createActions()
   // we can't set the shortcut these actions, because we need to restrict their context to the canvas and it's children..
   for ( QWidget *widget :
         {
-          static_cast< QWidget * >( mMapCanvas ),
+          static_cast< QWidget * >
+          ( mMapCanvas ),
           static_cast< QWidget * >( mLayerTreeView )
         } )
   {
@@ -6629,7 +6632,8 @@ void QgisApp::showRasterCalculator()
     for ( const auto &r : QgsRasterCalculatorEntry::rasterEntries() )
     {
       if ( ( ! rLayerDictionaryRef.contains( r.ref ) ) ||
-           uniqueRasterUriTmp.contains( QPair( r.raster->source(), r.ref.mid( 0, r.ref.lastIndexOf( "@" ) ) ) ) ) continue;
+           uniqueRasterUriTmp.contains( QPair( r.raster->source(), r.ref.mid( 0, r.ref.lastIndexOf( "@" ) ) ) ) )
+        continue;
       uniqueRasterUriTmp.insert( QPair( r.raster->source(), r.ref.mid( 0, r.ref.lastIndexOf( "@" ) ) ) );
 
       QgsRasterDataProvider::VirtualRasterInputLayers projectRLayer;

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -97,11 +97,17 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
   // QgisApp-wide font
   const QString fontSize = opts.value( QStringLiteral( "fontPointSize" ) ).toString();
   QgsDebugMsgLevel( QStringLiteral( "fontPointSize: %1" ).arg( fontSize ), 2 );
-  if ( fontSize.isEmpty() ) { return; }
+  if ( fontSize.isEmpty() )
+  {
+    return;
+  }
 
   const QString fontFamily = opts.value( QStringLiteral( "fontFamily" ) ).toString();
   QgsDebugMsgLevel( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ), 2 );
-  if ( fontFamily.isEmpty() ) { return; }
+  if ( fontFamily.isEmpty() )
+  {
+    return;
+  }
 
   const QString defaultSize = QString::number( mDefaultFont.pointSize() );
   const QString defaultFamily = mDefaultFont.family();

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -1050,7 +1050,8 @@ void QgsBookmarksItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu 
       }
       catch ( QgsCsException & )
       {
-        context.messageBar()->pushWarning( tr( "Zoom to Bookmark" ), tr( "Could not reproject bookmark extent to project CRS." ) );
+        context.messageBar()
+        ->pushWarning( tr( "Zoom to Bookmark" ), tr( "Could not reproject bookmark extent to project CRS." ) );
       }
     } );
     menu->addAction( actionZoom );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1649,8 +1649,10 @@ void QgsIdentifyResultsDialog::updateViewModes()
   for ( int i = 0; i < lstResults->topLevelItemCount(); i++ )
   {
     QTreeWidgetItem *item = lstResults->topLevelItem( i );
-    if ( vectorLayer( item ) ) vectorCount++;
-    else if ( rasterLayer( item ) ) rasterCount++;
+    if ( vectorLayer( item ) )
+      vectorCount++;
+    else if ( rasterLayer( item ) )
+      rasterCount++;
   }
 
   lblViewMode->setEnabled( rasterCount > 0 );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -315,7 +315,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
     if ( !path.isEmpty() )
     {
-      QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( path );
+      QgsGui::nativePlatformInterface()
+      ->openFileExplorerAndSelectFile( path );
     }
 
   } );
@@ -989,7 +990,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   for ( const QString &qmFile : qmFileList )
   {
     // Ignore the 'en' translation file, already added as 'en_US'.
-    if ( qmFile.compare( QLatin1String( "qgis_en.qm" ) ) == 0 ) continue;
+    if ( qmFile.compare( QLatin1String( "qgis_en.qm" ) ) == 0 )
+      continue;
 
     QString qmFileName = qmFile;
     QString l = qmFileName.remove( QStringLiteral( "qgis_" ) ).remove( QStringLiteral( ".qm" ) );

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -402,7 +402,8 @@ void QgsRasterCalcDialog::mRasterBandsListWidget_itemDoubleClicked( QListWidgetI
 {
   mExpressionTextEdit->insertPlainText( quoteBandEntry( item->text() ) );
   //to enable the "ok" button if someone checks the virtual provider checkbox before adding a valid expression,
-  if ( expressionValid() && useVirtualProvider() ) setAcceptButtonState();
+  if ( expressionValid() && useVirtualProvider() )
+    setAcceptButtonState();
 }
 
 void QgsRasterCalcDialog::mPlusPushButton_clicked()

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -122,7 +122,8 @@ void QgsTemporalControllerDockWidget::exportAnimation()
     progressDialog.hide();
     if ( !success )
     {
-      QgisApp::instance()->messageBar()->pushMessage( tr( "Export Animation" ), error, Qgis::MessageLevel::Critical );
+      QgisApp::instance()
+      ->messageBar()->pushMessage( tr( "Export Animation" ), error, Qgis::MessageLevel::Critical );
     }
     else
     {

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -584,7 +584,8 @@ QList<QgsAuthOAuth2Config *> QgsAuthOAuth2Config::loadOAuth2Configs(
   else
   {
     QgsDebugMsg( QStringLiteral( "No config files found in: %1" ).arg( configdir.path() ) );
-    if ( ok ) *ok = res;
+    if ( ok )
+      *ok = res;
     return configs;
   }
 
@@ -623,7 +624,8 @@ QList<QgsAuthOAuth2Config *> QgsAuthOAuth2Config::loadOAuth2Configs(
     configs << config;
   }
 
-  if ( ok ) *ok = true;
+  if ( ok )
+    *ok = true;
   return configs;
 }
 

--- a/src/core/diagram/qgspiediagram.cpp
+++ b/src/core/diagram/qgspiediagram.cpp
@@ -105,7 +105,8 @@ void QgsPieDiagram::renderDiagram( const QgsFeature &feature, QgsRenderContext &
     currentVal = expression->evaluate( &expressionContext ).toDouble();
     values.push_back( currentVal );
     valSum += currentVal;
-    if ( currentVal ) valCount++;
+    if ( currentVal )
+      valCount++;
   }
 
   //draw the slices

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5975,7 +5975,8 @@ static QVariant fcnArrayGet( const QVariantList &values, const QgsExpressionCont
 {
   const QVariantList list = QgsExpressionUtils::getListValue( values.at( 0 ), parent );
   const int pos = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
-  if ( pos < list.length() && pos >= 0 ) return list.at( pos );
+  if ( pos < list.length() && pos >= 0 )
+    return list.at( pos );
   else if ( pos < 0 && ( list.length() + pos ) >= 0 )
     return list.at( list.length() + pos );
   return QVariant();

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -78,8 +78,10 @@ QString QgsExpressionNode::NodeList::dump() const
   bool first = true;
   for ( QgsExpressionNode *n : mList )
   {
-    if ( !first ) msg += QLatin1String( ", " );
-    else first = false;
+    if ( !first )
+      msg += QLatin1String( ", " );
+    else
+      first = false;
     msg += n->dump();
   }
   return msg;

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -61,7 +61,8 @@ void QgsGeoNodeRequest::fetchLayers()
     if ( !mParsingLayers )
     {
       mParsingLayers = true;
-      QList<QgsGeoNodeRequest::ServiceLayerDetail> layers;
+      QList<QgsGeoNodeRequest::ServiceLayerDetail>
+      layers;
       if ( mError.isEmpty() )
       {
         layers = parseLayers( lastResponse() );

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -637,7 +637,8 @@ bool QgsCurvePolygon::removeDuplicateNodes( double epsilon, bool useZValues )
   }
   for ( QgsCurve *ring : std::as_const( mInteriorRings ) )
   {
-    if ( cleanRing( ring ) ) result = true;
+    if ( cleanRing( ring ) )
+      result = true;
   }
   return result;
 }

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -152,7 +152,8 @@ bool QgsGeometryCollection::removeDuplicateNodes( double epsilon, bool useZValue
   bool result = false;
   for ( QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
   {
-    if ( geom->removeDuplicateNodes( epsilon, useZValues ) ) result = true;
+    if ( geom->removeDuplicateNodes( epsilon, useZValues ) )
+      result = true;
   }
   return result;
 }

--- a/src/core/geometry/qgsgeometrymakevalid.cpp
+++ b/src/core/geometry/qgsgeometrymakevalid.cpp
@@ -87,8 +87,10 @@ static int compare_by_envarea( const void *g1, const void *g2 )
   double n1 = f1->envarea;
   double n2 = f2->envarea;
 
-  if ( n1 < n2 ) return 1;
-  if ( n1 > n2 ) return -1;
+  if ( n1 < n2 )
+    return 1;
+  if ( n1 > n2 )
+    return -1;
   return 0;
 }
 
@@ -293,7 +295,8 @@ static GEOSGeometry *LWGEOM_GEOS_getPointN( const GEOSGeometry *g_in, uint32_t n
       {
         const GEOSGeometry *g = GEOSGetGeometryN_r( handle, g_in, gn );
         ret = LWGEOM_GEOS_getPointN( g, n );
-        if ( ret ) return ret;
+        if ( ret )
+          return ret;
       }
       break;
     }
@@ -301,12 +304,14 @@ static GEOSGeometry *LWGEOM_GEOS_getPointN( const GEOSGeometry *g_in, uint32_t n
     case GEOS_POLYGON:
     {
       ret = LWGEOM_GEOS_getPointN( GEOSGetExteriorRing_r( handle, g_in ), n );
-      if ( ret ) return ret;
+      if ( ret )
+        return ret;
       for ( gn = 0; gn < GEOSGetNumInteriorRings_r( handle, g_in ); ++gn )
       {
         const GEOSGeometry *g = GEOSGetInteriorRingN_r( handle, g_in, gn );
         ret = LWGEOM_GEOS_getPointN( g, n );
-        if ( ret ) return ret;
+        if ( ret )
+          return ret;
       }
       break;
     }
@@ -319,23 +324,34 @@ static GEOSGeometry *LWGEOM_GEOS_getPointN( const GEOSGeometry *g_in, uint32_t n
   }
 
   seq_in = GEOSGeom_getCoordSeq_r( handle, g_in );
-  if ( ! seq_in ) return nullptr;
-  if ( ! GEOSCoordSeq_getSize_r( handle, seq_in, &sz ) ) return nullptr;
-  if ( ! sz ) return nullptr;
+  if ( ! seq_in )
+    return nullptr;
+  if ( ! GEOSCoordSeq_getSize_r( handle, seq_in, &sz ) )
+    return nullptr;
+  if ( ! sz )
+    return nullptr;
 
-  if ( ! GEOSCoordSeq_getDimensions_r( handle, seq_in, &dims ) ) return nullptr;
+  if ( ! GEOSCoordSeq_getDimensions_r( handle, seq_in, &dims ) )
+    return nullptr;
 
   seq_out = GEOSCoordSeq_create_r( handle, 1, dims );
-  if ( ! seq_out ) return nullptr;
+  if ( ! seq_out )
+    return nullptr;
 
-  if ( ! GEOSCoordSeq_getX_r( handle, seq_in, n, &val ) ) return nullptr;
-  if ( ! GEOSCoordSeq_setX_r( handle, seq_out, n, val ) ) return nullptr;
-  if ( ! GEOSCoordSeq_getY_r( handle, seq_in, n, &val ) ) return nullptr;
-  if ( ! GEOSCoordSeq_setY_r( handle, seq_out, n, val ) ) return nullptr;
+  if ( ! GEOSCoordSeq_getX_r( handle, seq_in, n, &val ) )
+    return nullptr;
+  if ( ! GEOSCoordSeq_setX_r( handle, seq_out, n, val ) )
+    return nullptr;
+  if ( ! GEOSCoordSeq_getY_r( handle, seq_in, n, &val ) )
+    return nullptr;
+  if ( ! GEOSCoordSeq_setY_r( handle, seq_out, n, val ) )
+    return nullptr;
   if ( dims > 2 )
   {
-    if ( ! GEOSCoordSeq_getZ_r( handle, seq_in, n, &val ) ) return nullptr;
-    if ( ! GEOSCoordSeq_setZ_r( handle, seq_out, n, val ) ) return nullptr;
+    if ( ! GEOSCoordSeq_getZ_r( handle, seq_in, n, &val ) )
+      return nullptr;
+    if ( ! GEOSCoordSeq_setZ_r( handle, seq_out, n, val ) )
+      return nullptr;
   }
 
   return GEOSGeom_createPoint_r( handle, seq_out );

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -553,7 +553,8 @@ QVector<QgsGeometryUtils::SelfIntersection> QgsGeometryUtils::selfIntersections(
   {
     const QgsPoint pi = geom->vertexAt( QgsVertexId( part, ring, i ) );
     const QgsPoint pj = geom->vertexAt( QgsVertexId( part, ring, j ) );
-    if ( QgsGeometryUtils::sqrDistance2D( pi, pj ) < tolerance * tolerance ) continue;
+    if ( QgsGeometryUtils::sqrDistance2D( pi, pj ) < tolerance * tolerance )
+      continue;
 
     // Don't test neighboring edges
     const int start = j + 1;
@@ -565,7 +566,8 @@ QVector<QgsGeometryUtils::SelfIntersection> QgsGeometryUtils::selfIntersections(
 
       QgsPoint inter;
       bool intersection = false;
-      if ( !QgsGeometryUtils::segmentIntersection( pi, pj, pk, pl, inter, intersection, tolerance ) ) continue;
+      if ( !QgsGeometryUtils::segmentIntersection( pi, pj, pk, pl, inter, intersection, tolerance ) )
+        continue;
 
       SelfIntersection s;
       s.segment1 = i;
@@ -1007,7 +1009,8 @@ void QgsGeometryUtils::segmentizeArc( const QgsPoint &p1, const QgsPoint &p2, co
   {
     double angle = a3 - a1;
     // angle == 0 when full circle
-    if ( angle <= 0 ) angle += M_PI * 2;
+    if ( angle <= 0 )
+      angle += M_PI * 2;
 
     /* Number of segments in output */
     const int segs = ceil( angle / increment );
@@ -1068,7 +1071,8 @@ void QgsGeometryUtils::segmentizeArc( const QgsPoint &p1, const QgsPoint &p2, co
   {
     std::reverse( stringPoints.begin(), stringPoints.end() );
   }
-  if ( ! points.empty() && stringPoints.front() == points.back() ) stringPoints.pop_front();
+  if ( ! points.empty() && stringPoints.front() == points.back() )
+    stringPoints.pop_front();
   points.append( stringPoints );
 }
 
@@ -1684,7 +1688,8 @@ double QgsGeometryUtils::skewLinesDistance( const QgsVector3D &P1, const QgsVect
   const QgsVector3D u1 = P12 - P1;
   const QgsVector3D u2 = P22 - P2;
   QgsVector3D u3 = QgsVector3D::crossProduct( u1, u2 );
-  if ( u3.length() == 0 ) return 1;
+  if ( u3.length() == 0 )
+    return 1;
   u3.normalize();
   const QgsVector3D dir = P1 - P2;
   return std::fabs( ( QgsVector3D::dotProduct( dir, u3 ) ) ); // u3 is already normalized

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2377,13 +2377,19 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
 {
   if ( !mGeos || mGeometry->dimension() == 0 )
   {
-    if ( errorCode ) { *errorCode = InvalidBaseGeometry; }
+    if ( errorCode )
+    {
+      *errorCode = InvalidBaseGeometry;
+    }
     return nullptr;
   }
 
   if ( reshapeWithLine.numPoints() < 2 )
   {
-    if ( errorCode ) { *errorCode = InvalidInput; }
+    if ( errorCode )
+    {
+      *errorCode = InvalidInput;
+    }
     return nullptr;
   }
 
@@ -2465,7 +2471,10 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
       delete[] newGeoms;
       if ( !newMultiGeom )
       {
-        if ( errorCode ) { *errorCode = EngineError; }
+        if ( errorCode )
+        {
+          *errorCode = EngineError;
+        }
         return nullptr;
       }
 

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -109,7 +109,8 @@ QList< QgsMapLayer * > QgsLabelingEngine::participatingLayers() const
 
     if ( providerA && providerB )
     {
-      return providerA->settings().zIndex < providerB->settings().zIndex ;
+      return providerA->settings()
+      .zIndex < providerB->settings().zIndex ;
     }
     return false;
   } );
@@ -123,7 +124,8 @@ QList< QgsMapLayer * > QgsLabelingEngine::participatingLayers() const
 
     if ( providerA && providerB )
     {
-      return providerA->settings().zIndex < providerB->settings().zIndex ;
+      return providerA->settings()
+      .zIndex < providerB->settings().zIndex ;
     }
     return false;
   } );
@@ -155,7 +157,8 @@ QStringList QgsLabelingEngine::participatingLayerIds() const
 
     if ( providerA && providerB )
     {
-      return providerA->settings().zIndex < providerB->settings().zIndex ;
+      return providerA->settings()
+      .zIndex < providerB->settings().zIndex ;
     }
     return false;
   } );
@@ -169,7 +172,8 @@ QStringList QgsLabelingEngine::participatingLayerIds() const
 
     if ( providerA && providerB )
     {
-      return providerA->settings().zIndex < providerB->settings().zIndex ;
+      return providerA->settings()
+      .zIndex < providerB->settings().zIndex ;
     }
     return false;
   } );

--- a/src/core/labeling/qgslabelingenginesettings.cpp
+++ b/src/core/labeling/qgslabelingenginesettings.cpp
@@ -36,11 +36,16 @@ void QgsLabelingEngineSettings::readSettingsFromProject( QgsProject *prj )
   mMaxPolygonCandidatesPerCmSquared = prj->readDoubleEntry( QStringLiteral( "PAL" ), QStringLiteral( "/CandidatesPolygonPerCM" ), 2.5, &saved );
 
   mFlags = Flags();
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) ) mFlags |= DrawCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) ) mFlags |= DrawLabelRectOnly;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) ) mFlags |= UseAllLabels;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) ) mFlags |= UsePartialCandidates;
-  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), false, &saved ) ) mFlags |= DrawUnplacedLabels;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingCandidates" ), false, &saved ) )
+    mFlags |= DrawCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawRectOnly" ), false, &saved ) )
+    mFlags |= DrawLabelRectOnly;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingAllLabels" ), false, &saved ) )
+    mFlags |= UseAllLabels;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/ShowingPartialsLabels" ), true, &saved ) )
+    mFlags |= UsePartialCandidates;
+  if ( prj->readBoolEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawUnplaced" ), false, &saved ) )
+    mFlags |= DrawUnplacedLabels;
 
   mDefaultTextRenderFormat = Qgis::TextRenderFormat::AlwaysOutlines;
   // if users have disabled the older PAL "DrawOutlineLabels" setting, respect that

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -670,9 +670,12 @@ void QgsLayerTreeModel::setLegendMapViewData( double mapUnitsPerPixel, int dpi, 
 
 void QgsLayerTreeModel::legendMapViewData( double *mapUnitsPerPixel, int *dpi, double *scale ) const
 {
-  if ( mapUnitsPerPixel ) *mapUnitsPerPixel = mLegendMapViewMupp;
-  if ( dpi ) *dpi = mLegendMapViewDpi;
-  if ( scale ) *scale = mLegendMapViewScale;
+  if ( mapUnitsPerPixel )
+    *mapUnitsPerPixel = mLegendMapViewMupp;
+  if ( dpi )
+    *dpi = mLegendMapViewDpi;
+  if ( scale )
+    *scale = mLegendMapViewScale;
 }
 
 QMap<QString, QString> QgsLayerTreeModel::layerStyleOverrides() const

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -372,8 +372,10 @@ QSize QgsSymbolLegendNode::minimumIconSize( QgsRenderContext *context ) const
     const double w = QgsTextRenderer::textWidth( *context, mTextOnSymbolTextFormat, QStringList() << mTextOnSymbolLabel );
     const double h = QgsTextRenderer::textHeight( *context, mTextOnSymbolTextFormat, QStringList() << mTextOnSymbolLabel, QgsTextRenderer::Point );
     int wInt = ceil( w ), hInt = ceil( h );
-    if ( wInt > minSz.width() ) minSz.setWidth( wInt );
-    if ( hInt > minSz.height() ) minSz.setHeight( hInt );
+    if ( wInt > minSz.width() )
+      minSz.setWidth( wInt );
+    if ( hInt > minSz.height() )
+      minSz.setHeight( hInt );
   }
 
   return minSz;

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1263,7 +1263,8 @@ bool QgsCompositionConverter::readLegendXml( QgsLayoutItemLegend *layoutItem, co
     layoutItem->setTitleAlignment( static_cast< Qt::AlignmentFlag >( itemElem.attribute( QStringLiteral( "titleAlignment" ) ).toInt() ) );
   }
   int colCount = itemElem.attribute( QStringLiteral( "columnCount" ), QStringLiteral( "1" ) ).toInt();
-  if ( colCount < 1 ) colCount = 1;
+  if ( colCount < 1 )
+    colCount = 1;
   layoutItem->setColumnCount( colCount );
   layoutItem->setSplitLayer( itemElem.attribute( QStringLiteral( "splitLayer" ), QStringLiteral( "0" ) ).toInt() == 1 );
   layoutItem->setEqualColumnWidth( itemElem.attribute( QStringLiteral( "equalColumnWidth" ), QStringLiteral( "0" ) ).toInt() == 1 );
@@ -1279,12 +1280,18 @@ bool QgsCompositionConverter::readLegendXml( QgsLayoutItemLegend *layoutItem, co
       style.readXml( styleElem, QDomDocument() );
       const QString name = styleElem.attribute( QStringLiteral( "name" ) );
       QgsLegendStyle::Style s;
-      if ( name == QLatin1String( "title" ) ) s = QgsLegendStyle::Title;
-      else if ( name == QLatin1String( "group" ) ) s = QgsLegendStyle::Group;
-      else if ( name == QLatin1String( "subgroup" ) ) s = QgsLegendStyle::Subgroup;
-      else if ( name == QLatin1String( "symbol" ) ) s = QgsLegendStyle::Symbol;
-      else if ( name == QLatin1String( "symbolLabel" ) ) s = QgsLegendStyle::SymbolLabel;
-      else continue;
+      if ( name == QLatin1String( "title" ) )
+        s = QgsLegendStyle::Title;
+      else if ( name == QLatin1String( "group" ) )
+        s = QgsLegendStyle::Group;
+      else if ( name == QLatin1String( "subgroup" ) )
+        s = QgsLegendStyle::Subgroup;
+      else if ( name == QLatin1String( "symbol" ) )
+        s = QgsLegendStyle::Symbol;
+      else if ( name == QLatin1String( "symbolLabel" ) )
+        s = QgsLegendStyle::SymbolLabel;
+      else
+        continue;
       layoutItem->setStyle( s, style );
     }
   }

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -615,7 +615,8 @@ bool QgsLayoutItemLegend::readPropertiesFromElement( const QDomElement &itemElem
     mSettings.setTitleAlignment( static_cast< Qt::AlignmentFlag >( itemElem.attribute( QStringLiteral( "titleAlignment" ) ).toInt() ) );
   }
   int colCount = itemElem.attribute( QStringLiteral( "columnCount" ), QStringLiteral( "1" ) ).toInt();
-  if ( colCount < 1 ) colCount = 1;
+  if ( colCount < 1 )
+    colCount = 1;
   mColumnCount = colCount;
   mSettings.setColumnCount( mColumnCount );
   mSettings.setSplitLayer( itemElem.attribute( QStringLiteral( "splitLayer" ), QStringLiteral( "0" ) ).toInt() == 1 );
@@ -632,12 +633,18 @@ bool QgsLayoutItemLegend::readPropertiesFromElement( const QDomElement &itemElem
       style.readXml( styleElem, doc, context );
       const QString name = styleElem.attribute( QStringLiteral( "name" ) );
       QgsLegendStyle::Style s;
-      if ( name == QLatin1String( "title" ) ) s = QgsLegendStyle::Title;
-      else if ( name == QLatin1String( "group" ) ) s = QgsLegendStyle::Group;
-      else if ( name == QLatin1String( "subgroup" ) ) s = QgsLegendStyle::Subgroup;
-      else if ( name == QLatin1String( "symbol" ) ) s = QgsLegendStyle::Symbol;
-      else if ( name == QLatin1String( "symbolLabel" ) ) s = QgsLegendStyle::SymbolLabel;
-      else continue;
+      if ( name == QLatin1String( "title" ) )
+        s = QgsLegendStyle::Title;
+      else if ( name == QLatin1String( "group" ) )
+        s = QgsLegendStyle::Group;
+      else if ( name == QLatin1String( "subgroup" ) )
+        s = QgsLegendStyle::Subgroup;
+      else if ( name == QLatin1String( "symbol" ) )
+        s = QgsLegendStyle::Symbol;
+      else if ( name == QLatin1String( "symbolLabel" ) )
+        s = QgsLegendStyle::SymbolLabel;
+      else
+        continue;
       setStyle( s, style );
     }
   }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1140,7 +1140,8 @@ int QgsMeshLayer::meshVertexCount() const
     return mMeshEditor->validVerticesCount();
   else if ( mDataProvider )
     return mDataProvider->vertexCount();
-  else return 0;
+  else
+    return 0;
 }
 
 int QgsMeshLayer::meshFaceCount() const
@@ -1149,7 +1150,8 @@ int QgsMeshLayer::meshFaceCount() const
     return mMeshEditor->validFacesCount();
   else if ( mDataProvider )
     return mDataProvider->faceCount();
-  else return 0;
+  else
+    return 0;
 }
 
 int QgsMeshLayer::meshEdgeCount() const
@@ -1158,7 +1160,8 @@ int QgsMeshLayer::meshEdgeCount() const
     return mNativeMesh->edgeCount();
   else if ( mDataProvider )
     return mDataProvider->edgeCount();
-  else return 0;
+  else
+    return 0;
 }
 
 void QgsMeshLayer::updateActiveDatasetGroups()

--- a/src/core/network/qgsnetworkreplyparser.cpp
+++ b/src/core/network/qgsnetworkreplyparser.cpp
@@ -29,7 +29,8 @@ QgsNetworkReplyParser::QgsNetworkReplyParser( QNetworkReply *reply )
   : mReply( reply )
   , mValid( false )
 {
-  if ( !mReply ) return;
+  if ( !mReply )
+    return;
 
   // Content type examples:
   //   multipart/mixed; boundary=wcs
@@ -107,7 +108,8 @@ QgsNetworkReplyParser::QgsNetworkReplyParser( QNetworkReply *reply )
       {
         if ( part.at( pos ) == '\n' && ( part.at( pos + 1 ) == '\n' || part.at( pos + 1 ) == '\r' ) )
         {
-          if ( part.at( pos + 1 ) == '\r' ) pos++;
+          if ( part.at( pos + 1 ) == '\r' )
+            pos++;
           pos += 2;
           break;
         }
@@ -138,7 +140,8 @@ QgsNetworkReplyParser::QgsNetworkReplyParser( QNetworkReply *reply )
 
 bool QgsNetworkReplyParser::isMultipart( QNetworkReply *reply )
 {
-  if ( !reply ) return false;
+  if ( !reply )
+    return false;
 
   const QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
   QgsDebugMsg( "contentType: " + contentType );

--- a/src/core/network/qgsnewsfeedparser.cpp
+++ b/src/core/network/qgsnewsfeedparser.cpp
@@ -284,7 +284,8 @@ void QgsNewsFeedParser::fetchImageForEntry( const QgsNewsFeedParser::Entry &entr
     } );
     if ( findIter != mEntries.end() )
     {
-      const int entryIndex = static_cast< int >( std::distance( mEntries.begin(), findIter ) );
+      const int entryIndex = static_cast< int >
+      ( std::distance( mEntries.begin(), findIter ) );
 
       QImage img = QImage::fromData( fetcher->reply()->readAll() );
 

--- a/src/core/pal/geomfunction.cpp
+++ b/src/core/pal/geomfunction.cpp
@@ -54,7 +54,8 @@ void heapsort( std::vector< int > &sid, int *id, const std::vector< double > &x,
     else
     {
       n--;
-      if ( n == 0 ) return;
+      if ( n == 0 )
+        return;
       tx = sid[n];
       sid[n] = sid[0];
     }
@@ -101,7 +102,8 @@ void heapsort2( int *x, double *heap, std::size_t N )
     else
     {
       n--;
-      if ( n == 0 ) return;
+      if ( n == 0 )
+        return;
       t = heap[n];
       tx = x[n];
       heap[n] = heap[0];

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -196,7 +196,8 @@ namespace pal
       {
         probFeat = probFid;
         id = lpId;
-        if ( mNextPart ) mNextPart->setProblemIds( probFid, lpId );
+        if ( mNextPart )
+          mNextPart->setProblemIds( probFid, lpId );
       }
 
       /**

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -1006,7 +1006,8 @@ void PointSet::getPointByDistance( double *d, double *ad, double dl, double *px,
   i = 0;
   if ( dl >= 0 )
   {
-    while ( i < nbPoints && ad[i] <= dl ) i++;
+    while ( i < nbPoints && ad[i] <= dl )
+      i++;
     i--;
   }
 

--- a/src/core/pal/priorityqueue.cpp
+++ b/src/core/pal/priorityqueue.cpp
@@ -155,7 +155,8 @@ void PriorityQueue::sort()
 {
   int i;
   int pi = 2;
-  while ( size > pi ) pi *= 2;
+  while ( size > pi )
+    pi *= 2;
 
   i = pi / 2 - 2;
 

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -122,7 +122,8 @@ void Problem::reduce()
               {
                 if ( candidatesAreConflicting( lp2, lp ) )
                 {
-                  const_cast< LabelPosition * >( lp )->decrementNumOverlaps();
+                  const_cast< LabelPosition * >
+                  ( lp )->decrementNumOverlaps();
                   lp2->decrementNumOverlaps();
                 }
 
@@ -626,7 +627,8 @@ void Problem::chainSearch( QgsRenderContext & )
           {
             if ( candidatesAreConflicting( old, lp ) )
             {
-              ok[lp->getProblemFeatureId()] = false;
+              ok[lp->getProblemFeatureId()]
+              = false;
             }
 
             return true;

--- a/src/core/pointcloud/expression/qgspointcloudexpressionnodeimpl.cpp
+++ b/src/core/pointcloud/expression/qgspointcloudexpressionnodeimpl.cpp
@@ -53,8 +53,10 @@ QString QgsPointCloudExpressionNode::NodeList::dump() const
   bool first = true;
   for ( QgsPointCloudExpressionNode *n : mList )
   {
-    if ( !first ) msg += QLatin1String( ", " );
-    else first = false;
+    if ( !first )
+      msg += QLatin1String( ", " );
+    else
+      first = false;
     msg += n->dump();
   }
   return msg;

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -312,7 +312,8 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
         }
         finishedLoadingBlock[ i ] = true;
         // If all blocks are loaded, exit the event loop
-        if ( !finishedLoadingBlock.contains( false ) ) loop.exit();
+        if ( !finishedLoadingBlock.contains( false ) )
+          loop.exit();
       } );
     }
     // Wait for all point cloud nodes to finish loading

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -1611,7 +1611,8 @@ Qgis::DataType QgsGdalProvider::dataType( int bandNo ) const
   if ( mMaskBandExposedAsAlpha && bandNo == mBandCount )
     return dataTypeFromGdal( GDT_Byte );
 
-  if ( bandNo <= 0 || bandNo > mGdalDataType.count() ) return Qgis::DataType::UnknownDataType;
+  if ( bandNo <= 0 || bandNo > mGdalDataType.count() )
+    return Qgis::DataType::UnknownDataType;
 
   return dataTypeFromGdal( mGdalDataType[bandNo - 1] );
 }
@@ -2640,7 +2641,8 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
   fileFiltersString.prepend( QObject::tr( "All files" ) + " (*);;" );
 
   // cleanup
-  if ( fileFiltersString.endsWith( QLatin1String( ";;" ) ) ) fileFiltersString.chop( 2 );
+  if ( fileFiltersString.endsWith( QLatin1String( ";;" ) ) )
+    fileFiltersString.chop( 2 );
 
   QgsDebugMsgLevel( "Raster filter list built: " + fileFiltersString, 2 );
   QgsDebugMsgLevel( "Raster extension list built: " + extensions.join( ' ' ), 2 );
@@ -2755,10 +2757,14 @@ bool QgsGdalProvider::hasStatistics( int bandNo,
   double *pdfMean = &dfMean;
   double *pdfStdDev = &dfStdDev;
 
-  if ( !( stats & QgsRasterBandStats::Min ) ) pdfMin = nullptr;
-  if ( !( stats & QgsRasterBandStats::Max ) ) pdfMax = nullptr;
-  if ( !( stats & QgsRasterBandStats::Mean ) ) pdfMean = nullptr;
-  if ( !( stats & QgsRasterBandStats::StdDev ) ) pdfStdDev = nullptr;
+  if ( !( stats & QgsRasterBandStats::Min ) )
+    pdfMin = nullptr;
+  if ( !( stats & QgsRasterBandStats::Max ) )
+    pdfMax = nullptr;
+  if ( !( stats & QgsRasterBandStats::Mean ) )
+    pdfMean = nullptr;
+  if ( !( stats & QgsRasterBandStats::StdDev ) )
+    pdfStdDev = nullptr;
 
   CPLErr myerval = GDALGetRasterStatistics( myGdalBand, bApproxOK, true, pdfMin, pdfMax, pdfMean, pdfStdDev );
 

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
@@ -158,8 +158,10 @@ bool QgsMeshMemoryDataProvider::addMeshFacesOrEdges( const QString &def )
       QgsMeshEdge edge;
       edge.first = vertices[0].toInt();
       edge.second = vertices[1].toInt();
-      if ( !checkVertexId( edge.first ) ) return false;
-      if ( !checkVertexId( edge.second ) ) return false;
+      if ( !checkVertexId( edge.first ) )
+        return false;
+      if ( !checkVertexId( edge.second ) )
+        return false;
       edges.push_back( edge );
     }
     else
@@ -168,7 +170,8 @@ bool QgsMeshMemoryDataProvider::addMeshFacesOrEdges( const QString &def )
       for ( int j = 0; j < vertices.size(); ++j )
       {
         const int vertex_id = vertices[j].toInt();
-        if ( !checkVertexId( vertex_id ) ) return false;
+        if ( !checkVertexId( vertex_id ) )
+          return false;
         face.push_back( vertex_id );
       }
       faces.push_back( face );

--- a/src/core/providers/ogr/qgsogrconnpool.cpp
+++ b/src/core/providers/ogr/qgsogrconnpool.cpp
@@ -23,7 +23,8 @@ QgsOgrConnPool *QgsOgrConnPool::sInstance = nullptr;
 // static public
 QgsOgrConnPool *QgsOgrConnPool::instance()
 {
-  if ( ! sInstance ) sInstance = new QgsOgrConnPool();
+  if ( ! sInstance )
+    sInstance = new QgsOgrConnPool();
   return sInstance;
 }
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3356,7 +3356,8 @@ void QgsOgrProvider::recalculateFeatureCount() const
       {
         OGRwkbGeometryType gType = OGR_G_GetGeometryType( geom );
         gType = QgsOgrProviderUtils::ogrWkbSingleFlatten( gType );
-        if ( gType == flattenGeomTypeFilter ) mFeaturesCounted++;
+        if ( gType == flattenGeomTypeFilter )
+          mFeaturesCounted++;
       }
     }
     mOgrLayer->ResetReading();

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -657,7 +657,8 @@ QString createFilters( const QString &type )
 
 
     // cleanup
-    if ( sFileFilters.endsWith( QLatin1String( ";;" ) ) ) sFileFilters.chop( 2 );
+    if ( sFileFilters.endsWith( QLatin1String( ";;" ) ) )
+      sFileFilters.chop( 2 );
 
     QgsDebugMsgLevel( "myFileFilters: " + sFileFilters, 2 );
   }

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1284,7 +1284,8 @@ void QgsAbstractDatabaseProviderConnection::addFieldDomain( const QgsFieldDomain
 QString QgsAbstractDatabaseProviderConnection::TableProperty::defaultName() const
 {
   QString n = mTableName;
-  if ( mGeometryColumnCount > 1 ) n += '.' + mGeometryColumn;
+  if ( mGeometryColumnCount > 1 )
+    n += '.' + mGeometryColumn;
   return n;
 }
 

--- a/src/core/qgscolorrampimpl.cpp
+++ b/src/core/qgscolorrampimpl.cpp
@@ -635,13 +635,20 @@ QgsColorRamp *QgsLimitedRandomColorRamp::create( const QVariantMap &props )
   int satMin = DEFAULT_RANDOM_SAT_MIN, satMax = DEFAULT_RANDOM_SAT_MAX;
   int valMin = DEFAULT_RANDOM_VAL_MIN, valMax = DEFAULT_RANDOM_VAL_MAX;
 
-  if ( props.contains( QStringLiteral( "count" ) ) ) count = props[QStringLiteral( "count" )].toInt();
-  if ( props.contains( QStringLiteral( "hueMin" ) ) ) hueMin = props[QStringLiteral( "hueMin" )].toInt();
-  if ( props.contains( QStringLiteral( "hueMax" ) ) ) hueMax = props[QStringLiteral( "hueMax" )].toInt();
-  if ( props.contains( QStringLiteral( "satMin" ) ) ) satMin = props[QStringLiteral( "satMin" )].toInt();
-  if ( props.contains( QStringLiteral( "satMax" ) ) ) satMax = props[QStringLiteral( "satMax" )].toInt();
-  if ( props.contains( QStringLiteral( "valMin" ) ) ) valMin = props[QStringLiteral( "valMin" )].toInt();
-  if ( props.contains( QStringLiteral( "valMax" ) ) ) valMax = props[QStringLiteral( "valMax" )].toInt();
+  if ( props.contains( QStringLiteral( "count" ) ) )
+    count = props[QStringLiteral( "count" )].toInt();
+  if ( props.contains( QStringLiteral( "hueMin" ) ) )
+    hueMin = props[QStringLiteral( "hueMin" )].toInt();
+  if ( props.contains( QStringLiteral( "hueMax" ) ) )
+    hueMax = props[QStringLiteral( "hueMax" )].toInt();
+  if ( props.contains( QStringLiteral( "satMin" ) ) )
+    satMin = props[QStringLiteral( "satMin" )].toInt();
+  if ( props.contains( QStringLiteral( "satMax" ) ) )
+    satMax = props[QStringLiteral( "satMax" )].toInt();
+  if ( props.contains( QStringLiteral( "valMin" ) ) )
+    valMin = props[QStringLiteral( "valMin" )].toInt();
+  if ( props.contains( QStringLiteral( "valMax" ) ) )
+    valMax = props[QStringLiteral( "valMax" )].toInt();
 
   return new QgsLimitedRandomColorRamp( count, hueMin, hueMax, satMin, satMax, valMin, valMax );
 }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -315,8 +315,10 @@ QString QgsField::displayString( const QVariant &v ) const
         }
         else
         {
-          if ( dotPosition < 0 ) precision = 0;
-          else precision = s.length() - dotPosition - 1;
+          if ( dotPosition < 0 )
+            precision = 0;
+          else
+            precision = s.length() - dotPosition - 1;
 
           if ( -1 < v.toDouble() && v.toDouble() < 1 )
           {

--- a/src/core/qgsgmlschema.cpp
+++ b/src/core/qgsgmlschema.cpp
@@ -44,7 +44,8 @@ int QgsGmlFeatureClass::fieldIndex( const QString &name )
 {
   for ( int i = 0; i < mFields.size(); i++ )
   {
-    if ( mFields[i].name() == name ) return i;
+    if ( mFields[i].name() == name )
+      return i;
   }
   return -1;
 }
@@ -120,7 +121,8 @@ bool QgsGmlSchema::xsdFeatureClass( const QDomElement &element, const QString &t
 {
   //QgsDebugMsg("typeName = " + typeName );
   const QDomElement complexTypeElement = domElement( element, QStringLiteral( "complexType" ), QStringLiteral( "name" ), typeName );
-  if ( complexTypeElement.isNull() ) return false;
+  if ( complexTypeElement.isNull() )
+    return false;
 
   // extension or restriction
   QDomElement extrest = domElement( complexTypeElement, QStringLiteral( "complexContent.extension" ) );
@@ -128,7 +130,8 @@ bool QgsGmlSchema::xsdFeatureClass( const QDomElement &element, const QString &t
   {
     extrest = domElement( complexTypeElement, QStringLiteral( "complexContent.restriction" ) );
   }
-  if ( extrest.isNull() ) return false;
+  if ( extrest.isNull() )
+    return false;
 
   const QString extrestName = extrest.attribute( QStringLiteral( "base" ) );
   if ( extrestName == QLatin1String( "gml:AbstractFeatureType" ) )
@@ -140,7 +143,8 @@ bool QgsGmlSchema::xsdFeatureClass( const QDomElement &element, const QString &t
   else
   {
     // Get attributes from extrest
-    if ( !xsdFeatureClass( element, stripNS( extrestName ), featureClass ) ) return false;
+    if ( !xsdFeatureClass( element, stripNS( extrestName ), featureClass ) )
+      return false;
   }
 
   // Supported geometry types
@@ -237,14 +241,16 @@ QString QgsGmlSchema::xsdComplexTypeGmlBaseType( const QDomElement &element, con
 {
   //QgsDebugMsg("name = " + name );
   const QDomElement complexTypeElement = domElement( element, QStringLiteral( "complexType" ), QStringLiteral( "name" ), name );
-  if ( complexTypeElement.isNull() ) return QString();
+  if ( complexTypeElement.isNull() )
+    return QString();
 
   QDomElement extrest = domElement( complexTypeElement, QStringLiteral( "complexContent.extension" ) );
   if ( extrest.isNull() )
   {
     extrest = domElement( complexTypeElement, QStringLiteral( "complexContent.restriction" ) );
   }
-  if ( extrest.isNull() ) return QString();
+  if ( extrest.isNull() )
+    return QString();
 
   const QString extrestName = extrest.attribute( QStringLiteral( "base" ) );
   if ( extrestName.startsWith( QLatin1String( "gml:" ) ) )
@@ -266,7 +272,8 @@ QList<QDomElement> QgsGmlSchema::domElements( const QDomElement &element, const 
   QList<QDomElement> list;
 
   QStringList names = path.split( '.' );
-  if ( names.isEmpty() ) return list;
+  if ( names.isEmpty() )
+    return list;
   const QString name = names.value( 0 );
   names.removeFirst();
 
@@ -556,12 +563,14 @@ QStringList QgsGmlSchema::typeNames() const
 
 QList<QgsField> QgsGmlSchema::fields( const QString &typeName )
 {
-  if ( mFeatureClassMap.count( typeName ) == 0 ) return QList<QgsField>();
+  if ( mFeatureClassMap.count( typeName ) == 0 )
+    return QList<QgsField>();
   return mFeatureClassMap[typeName].fields();
 }
 
 QStringList QgsGmlSchema::geometryAttributes( const QString &typeName )
 {
-  if ( mFeatureClassMap.count( typeName ) == 0 ) return QStringList();
+  if ( mFeatureClassMap.count( typeName ) == 0 )
+    return QStringList();
   return mFeatureClassMap[typeName].geometryAttributes();
 }

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -637,7 +637,8 @@ QSizeF QgsLegendRenderer::drawTitle( QgsRenderContext &context, double top, Qt::
 
 double QgsLegendRenderer::spaceAboveGroup( const LegendComponentGroup &group )
 {
-  if ( group.components.isEmpty() ) return 0;
+  if ( group.components.isEmpty() )
+    return 0;
 
   LegendComponent component = group.components.first();
 

--- a/src/core/qgslegendstyle.cpp
+++ b/src/core/qgslegendstyle.cpp
@@ -68,7 +68,8 @@ void QgsLegendStyle::writeXml( const QString &name, QDomElement &elem, QDomDocum
 void QgsLegendStyle::readXml( const QDomElement &elem, const QDomDocument &doc, const QgsReadWriteContext & )
 {
   Q_UNUSED( doc )
-  if ( elem.isNull() ) return;
+  if ( elem.isNull() )
+    return;
 
   if ( !QgsFontUtils::setFromXmlChildNode( mFont, elem, QStringLiteral( "styleFont" ) ) )
   {

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -50,7 +50,8 @@ bool QgsMapToPixelSimplifier::equalSnapToGrid( double x1, double y1, double x2, 
 {
   const int grid_x1 = std::round( ( x1 - gridOriginX ) * gridInverseSizeXY );
   const int grid_x2 = std::round( ( x2 - gridOriginX ) * gridInverseSizeXY );
-  if ( grid_x1 != grid_x2 ) return false;
+  if ( grid_x1 != grid_x2 )
+    return false;
 
   const int grid_y1 = std::round( ( y1 - gridOriginY ) * gridInverseSizeXY );
   const int grid_y2 = std::round( ( y2 - gridOriginY ) * gridInverseSizeXY );

--- a/src/core/qgspostgresstringutils.cpp
+++ b/src/core/qgspostgresstringutils.cpp
@@ -85,8 +85,10 @@ QVariantList QgsPostgresStringUtils::parseArray( const QString &string )
       {
         ++i;
 
-        if ( subarray.at( i ) == '}' && !escaped ) openedBrackets--;
-        else if ( subarray.at( i ) == '{' && !escaped ) openedBrackets++;
+        if ( subarray.at( i ) == '}' && !escaped )
+          openedBrackets--;
+        else if ( subarray.at( i ) == '{' && !escaped )
+          openedBrackets++;
 
         escaped = !escaped ? subarray.at( i ) == '\\' : false;
       }

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -280,7 +280,8 @@ static bool hasRelationWithEqualDefinition( const QList<QgsRelation> &existingRe
 {
   for ( const QgsRelation &cur : std::as_const( existingRelations ) )
   {
-    if ( cur.hasEqualDefinition( relation ) ) return true;
+    if ( cur.hasEqualDefinition( relation ) )
+      return true;
   }
   return false;
 }

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -301,8 +301,10 @@ QString QgsSQLStatement::NodeList::dump() const
   const auto constMList = mList;
   for ( Node *n : constMList )
   {
-    if ( !first ) msg += QLatin1String( ", " );
-    else first = false;
+    if ( !first )
+      msg += QLatin1String( ", " );
+    else
+      first = false;
     msg += n->dump();
   }
   return msg;

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -526,9 +526,12 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
   const float detectionDelta = qDegreesToRadians( 10.0f );
   int facade = 0;
-  if ( radsBetwwenUpNormal > M_PI_2 - detectionDelta && radsBetwwenUpNormal < M_PI_2 + detectionDelta ) facade = 1;
-  else if ( radsBetwwenUpNormal > - M_PI_2 - detectionDelta && radsBetwwenUpNormal < -M_PI_2 + detectionDelta ) facade = 1;
-  else facade = 2;
+  if ( radsBetwwenUpNormal > M_PI_2 - detectionDelta && radsBetwwenUpNormal < M_PI_2 + detectionDelta )
+    facade = 1;
+  else if ( radsBetwwenUpNormal > - M_PI_2 - detectionDelta && radsBetwwenUpNormal < -M_PI_2 + detectionDelta )
+    facade = 1;
+  else
+    facade = 2;
 
   if ( pCount == 4 && polygon.numInteriorRings() == 0 && ( mTessellatedFacade & facade ) )
   {

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -738,7 +738,8 @@ QVector<QgsPointXY> QgsTracer::findShortestPath( const QgsPointXY &p1, const Qgs
   init();  // does nothing if the graph exists already
   if ( !mGraph )
   {
-    if ( error ) *error = ErrTooManyFeatures;
+    if ( error )
+      *error = ErrTooManyFeatures;
     return QVector<QgsPointXY>();
   }
 
@@ -750,12 +751,14 @@ QVector<QgsPointXY> QgsTracer::findShortestPath( const QgsPointXY &p1, const Qgs
 
   if ( v1 == -1 )
   {
-    if ( error ) *error = ErrPoint1;
+    if ( error )
+      *error = ErrPoint1;
     return QVector<QgsPointXY>();
   }
   if ( v2 == -1 )
   {
-    if ( error ) *error = ErrPoint2;
+    if ( error )
+      *error = ErrPoint2;
     return QVector<QgsPointXY>();
   }
 

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -93,7 +93,8 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
       }
       for ( int i = 0; i < mColorRampItemList.count(); ++i )
       {
-        if ( mColorRampItemList.at( i ) != other.mColorRampItemList.at( i ) ) return false;
+        if ( mColorRampItemList.at( i ) != other.mColorRampItemList.at( i ) )
+          return false;
       }
       return true;
     }

--- a/src/core/raster/qgsrasterblock.cpp
+++ b/src/core/raster/qgsrasterblock.cpp
@@ -329,7 +329,8 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
       // top and bottom
       for ( int r = 0; r < mHeight; r++ )
       {
-        if ( r >= top && r <= bottom ) continue; // middle
+        if ( r >= top && r <= bottom )
+          continue; // middle
         const qgssize i = static_cast< qgssize >( r ) * mWidth;
         memcpy( reinterpret_cast< char * >( mData ) + i * dataTypeSize, nodataRow, dataTypeSize * static_cast< qgssize >( mWidth ) );
       }
@@ -377,7 +378,8 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
       // top and bottom
       for ( int r = 0; r < mHeight; r++ )
       {
-        if ( r >= top && r <= bottom ) continue; // middle
+        if ( r >= top && r <= bottom )
+          continue; // middle
         const qgssize i = static_cast< qgssize >( r ) * mNoDataBitmapWidth;
         memcpy( mNoDataBitmap + i, nodataRow, mNoDataBitmapWidth );
       }
@@ -385,7 +387,8 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
       memset( nodataRow, 0, mNoDataBitmapWidth );
       for ( int c = 0; c < mWidth; c ++ )
       {
-        if ( c >= left && c <= right ) continue; // middle
+        if ( c >= left && c <= right )
+          continue; // middle
         const int byte = c / 8;
         const int bit = c % 8;
         const char nodata = 0x80 >> bit;
@@ -435,7 +438,8 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
     // top and bottom
     for ( int r = 0; r < mHeight; r++ )
     {
-      if ( r >= top && r <= bottom ) continue; // middle
+      if ( r >= top && r <= bottom )
+        continue; // middle
       const qgssize i = static_cast< qgssize >( r ) * mWidth;
       memcpy( reinterpret_cast< void * >( mImage->bits() + rgbSize * i ), nodataRow, rgbSize * static_cast< qgssize >( mWidth ) );
     }
@@ -526,8 +530,10 @@ char *QgsRasterBlock::bits()
 
 bool QgsRasterBlock::convert( Qgis::DataType destDataType )
 {
-  if ( isEmpty() ) return false;
-  if ( destDataType == mDataType ) return true;
+  if ( isEmpty() )
+    return false;
+  if ( destDataType == mDataType )
+    return true;
 
   if ( typeIsNumeric( mDataType ) && typeIsNumeric( destDataType ) )
   {
@@ -561,14 +567,18 @@ bool QgsRasterBlock::convert( Qgis::DataType destDataType )
 
 void QgsRasterBlock::applyScaleOffset( double scale, double offset )
 {
-  if ( isEmpty() ) return;
-  if ( !typeIsNumeric( mDataType ) ) return;
-  if ( scale == 1.0 && offset == 0.0 ) return;
+  if ( isEmpty() )
+    return;
+  if ( !typeIsNumeric( mDataType ) )
+    return;
+  if ( scale == 1.0 && offset == 0.0 )
+    return;
 
   const qgssize size = static_cast< qgssize >( mWidth ) * mHeight;
   for ( qgssize i = 0; i < size; ++i )
   {
-    if ( !isNoData( i ) ) setValue( i, value( i ) * scale + offset );
+    if ( !isNoData( i ) )
+      setValue( i, value( i ) * scale + offset );
   }
 }
 

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -259,7 +259,8 @@ class CORE_EXPORT QgsRasterBlock
     */
     QRgb color( int row, int column ) const SIP_HOLDGIL
     {
-      if ( !mImage ) return NO_DATA_COLOR;
+      if ( !mImage )
+        return NO_DATA_COLOR;
 
       return mImage->pixel( column, row );
     }
@@ -770,7 +771,8 @@ inline double QgsRasterBlock::readValue( void *data, Qgis::DataType type, qgssiz
 
 inline void QgsRasterBlock::writeValue( void *data, Qgis::DataType type, qgssize index, double value ) SIP_SKIP
 {
-  if ( !data ) return;
+  if ( !data )
+    return;
 
   switch ( type )
   {

--- a/src/core/raster/qgsrasterchecker.cpp
+++ b/src/core/raster/qgsrasterchecker.cpp
@@ -73,12 +73,14 @@ bool QgsRasterChecker::runTest( const QString &verifiedKey, QString verifiedUri,
 
   compareRow( QStringLiteral( "Extent" ), verifiedProvider->extent().toString(), expectedProvider->extent().toString(), mReport, verifiedProvider->extent() == expectedProvider->extent() );
 
-  if ( verifiedProvider->extent() != expectedProvider->extent() ) ok = false;
+  if ( verifiedProvider->extent() != expectedProvider->extent() )
+    ok = false;
 
 
   mReport += QLatin1String( "</table>\n" );
 
-  if ( !ok ) return false;
+  if ( !ok )
+    return false;
 
   bool allOk = true;
   for ( int band = 1; band <= expectedProvider->bandCount(); band++ )

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -90,8 +90,10 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle  const &b
     providerYRes = extent().height() / ySize();
     tmpXRes = std::max( providerXRes, xRes );
     tmpYRes = std::max( providerYRes, yRes );
-    if ( qgsDoubleNear( tmpXRes, xRes ) ) tmpXRes = xRes;
-    if ( qgsDoubleNear( tmpYRes, yRes ) ) tmpYRes = yRes;
+    if ( qgsDoubleNear( tmpXRes, xRes ) )
+      tmpXRes = xRes;
+    if ( qgsDoubleNear( tmpYRes, yRes ) )
+      tmpYRes = yRes;
   }
   else
   {
@@ -479,10 +481,14 @@ QString QgsRasterDataProvider::identifyFormatLabel( QgsRaster::IdentifyFormat fo
 
 QgsRaster::IdentifyFormat QgsRasterDataProvider::identifyFormatFromName( const QString &formatName )
 {
-  if ( formatName == QLatin1String( "Value" ) ) return QgsRaster::IdentifyFormatValue;
-  if ( formatName == QLatin1String( "Text" ) ) return QgsRaster::IdentifyFormatText;
-  if ( formatName == QLatin1String( "Html" ) ) return QgsRaster::IdentifyFormatHtml;
-  if ( formatName == QLatin1String( "Feature" ) ) return QgsRaster::IdentifyFormatFeature;
+  if ( formatName == QLatin1String( "Value" ) )
+    return QgsRaster::IdentifyFormatValue;
+  if ( formatName == QLatin1String( "Text" ) )
+    return QgsRaster::IdentifyFormatText;
+  if ( formatName == QLatin1String( "Html" ) )
+    return QgsRaster::IdentifyFormatHtml;
+  if ( formatName == QLatin1String( "Feature" ) )
+    return QgsRaster::IdentifyFormatFeature;
   return QgsRaster::IdentifyFormatUndefined;
 }
 
@@ -656,13 +662,15 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   if ( ! query.hasQueryItem( QStringLiteral( "crs" ) ) )
   {
     QgsDebugMsg( "crs is missing" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   if ( ! components.crs.createFromString( query.queryItemValue( QStringLiteral( "crs" ) ) ) )
   {
     QgsDebugMsg( "failed to create crs" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
 
@@ -670,14 +678,16 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   if ( ! query.hasQueryItem( QStringLiteral( "extent" ) ) )
   {
     QgsDebugMsg( "extent is missing" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   QStringList pointValuesList = query.queryItemValue( QStringLiteral( "extent" ) ).split( ',' );
   if ( pointValuesList.size() != 4 )
   {
     QgsDebugMsg( "the extent is not correct" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   components.extent = QgsRectangle( pointValuesList.at( 0 ).toDouble(), pointValuesList.at( 1 ).toDouble(),
@@ -686,7 +696,8 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   if ( ! query.hasQueryItem( QStringLiteral( "width" ) ) )
   {
     QgsDebugMsg( "width is missing" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   bool flagW;
@@ -694,14 +705,16 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   if ( !flagW ||  components.width < 0 )
   {
     QgsDebugMsg( "invalid or negative width input" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
 
   if ( ! query.hasQueryItem( QStringLiteral( "height" ) ) )
   {
     QgsDebugMsg( "height is missing" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   bool flagH;
@@ -709,14 +722,16 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   if ( !flagH ||  components.height < 0 )
   {
     QgsDebugMsg( "invalid or negative width input" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
 
   if ( ! query.hasQueryItem( QStringLiteral( "formula" ) ) )
   {
     QgsDebugMsg( "formula is missing" );
-    if ( ok ) *ok = false;
+    if ( ok )
+      *ok = false;
     return components;
   }
   components.formula = query.queryItemValue( QStringLiteral( "formula" ) );
@@ -736,7 +751,8 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
     if ( rLayer.uri.isNull() || rLayer.provider.isNull() )
     {
       QgsDebugMsg( "One or more raster information are missing" );
-      if ( ok ) *ok = false;
+      if ( ok )
+        *ok = false;
       return components;
     }
 
@@ -744,7 +760,8 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
 
   }
 
-  if ( ok ) *ok = true;
+  if ( ok )
+    *ok = true;
   return components;
 }
 

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -66,8 +66,10 @@ void QgsRasterInterface::initStatistics( QgsRasterBandStats &statistics,
     {
       const double srcXRes = extent().width() / xSize();
       const double srcYRes = extent().height() / ySize();
-      if ( xRes < srcXRes ) xRes = srcXRes;
-      if ( yRes < srcYRes ) yRes = srcYRes;
+      if ( xRes < srcXRes )
+        xRes = srcXRes;
+      if ( yRes < srcYRes )
+        yRes = srcYRes;
     }
     QgsDebugMsgLevel( QStringLiteral( "xRes = %1 yRes = %2" ).arg( xRes ).arg( yRes ), 4 );
 
@@ -96,7 +98,8 @@ bool QgsRasterInterface::hasStatistics( int bandNo,
                                         int sampleSize )
 {
   QgsDebugMsgLevel( QStringLiteral( "theBandNo = %1 stats = %2 sampleSize = %3" ).arg( bandNo ).arg( stats ).arg( sampleSize ), 4 );
-  if ( mStatistics.isEmpty() ) return false;
+  if ( mStatistics.isEmpty() )
+    return false;
 
   QgsRasterBandStats myRasterBandStats;
   initStatistics( myRasterBandStats, bandNo, stats, extent, sampleSize );
@@ -195,7 +198,8 @@ QgsRasterBandStats QgsRasterInterface::bandStatistics( int bandNo,
         myRasterBandStats.sum += myValue;
         myRasterBandStats.elementCount++;
 
-        if ( !std::isfinite( myValue ) ) continue; // inf
+        if ( !std::isfinite( myValue ) )
+          continue; // inf
 
         if ( myFirstIterationFlag )
         {
@@ -313,8 +317,10 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram,
     {
       const double srcXRes = extent().width() / xSize();
       const double srcYRes = extent().height() / ySize();
-      if ( xRes < srcXRes ) xRes = srcXRes;
-      if ( yRes < srcYRes ) yRes = srcYRes;
+      if ( xRes < srcXRes )
+        xRes = srcXRes;
+      if ( yRes < srcYRes )
+        yRes = srcYRes;
     }
     QgsDebugMsgLevel( QStringLiteral( "xRes = %1 yRes = %2" ).arg( xRes ).arg( yRes ), 4 );
 
@@ -384,7 +390,8 @@ bool QgsRasterInterface::hasHistogram( int bandNo,
   QgsDebugMsgLevel( QStringLiteral( "theBandNo = %1 binCount = %2 minimum = %3 maximum = %4 sampleSize = %5" ).arg( bandNo ).arg( binCount ).arg( minimum ).arg( maximum ).arg( sampleSize ), 4 );
   // histogramDefaults() needs statistics if minimum or maximum is NaN ->
   // do other checks which don't need statistics before histogramDefaults()
-  if ( mHistograms.isEmpty() ) return false;
+  if ( mHistograms.isEmpty() )
+    return false;
 
   QgsRasterHistogram myHistogram;
   initHistogram( myHistogram, bandNo, binCount, minimum, maximum, extent, sampleSize, includeOutOfRange );
@@ -496,8 +503,10 @@ QgsRasterHistogram QgsRasterInterface::histogram( int bandNo,
         {
           continue;
         }
-        if ( myBinIndex < 0 ) myBinIndex = 0;
-        if ( myBinIndex > ( myBinCount - 1 ) ) myBinIndex = myBinCount - 1;
+        if ( myBinIndex < 0 )
+          myBinIndex = 0;
+        if ( myBinIndex > ( myBinCount - 1 ) )
+          myBinIndex = myBinCount - 1;
 
         myHistogram.histogramVector[myBinIndex] += 1;
         myHistogram.nonNullCount++;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -228,13 +228,15 @@ typedef QgsDataProvider *classFactoryFunction_t( const QString *, const QgsDataP
 
 int QgsRasterLayer::bandCount() const
 {
-  if ( !mDataProvider ) return 0;
+  if ( !mDataProvider )
+    return 0;
   return mDataProvider->bandCount();
 }
 
 QString QgsRasterLayer::bandName( int bandNo ) const
 {
-  if ( !mDataProvider ) return QString();
+  if ( !mDataProvider )
+    return QString();
   return mDataProvider->generateBandName( bandNo );
 }
 
@@ -1188,13 +1190,17 @@ void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnh
 
   if ( rendererType == QLatin1String( "singlebandgray" ) )
   {
-    if ( myEnhancements.first() ) myGrayRenderer->setContrastEnhancement( myEnhancements.takeFirst() );
+    if ( myEnhancements.first() )
+      myGrayRenderer->setContrastEnhancement( myEnhancements.takeFirst() );
   }
   else if ( rendererType == QLatin1String( "multibandcolor" ) )
   {
-    if ( myEnhancements.first() ) myMultiBandRenderer->setRedContrastEnhancement( myEnhancements.takeFirst() );
-    if ( myEnhancements.first() ) myMultiBandRenderer->setGreenContrastEnhancement( myEnhancements.takeFirst() );
-    if ( myEnhancements.first() ) myMultiBandRenderer->setBlueContrastEnhancement( myEnhancements.takeFirst() );
+    if ( myEnhancements.first() )
+      myMultiBandRenderer->setRedContrastEnhancement( myEnhancements.takeFirst() );
+    if ( myEnhancements.first() )
+      myMultiBandRenderer->setGreenContrastEnhancement( myEnhancements.takeFirst() );
+    if ( myEnhancements.first() )
+      myMultiBandRenderer->setBlueContrastEnhancement( myEnhancements.takeFirst() );
   }
 
   //delete all remaining unused enhancements
@@ -2114,7 +2120,8 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
       closeDataProvider();
       init();
       setDataProvider( mProviderKey );
-      if ( !isValid() ) return false;
+      if ( !isValid() )
+        return false;
     }
   }
 #endif
@@ -2171,7 +2178,8 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
   for ( int i = 0; i < mPipe->size(); i++ )
   {
     QgsRasterInterface *interface = mPipe->at( i );
-    if ( !interface ) continue;
+    if ( !interface )
+      continue;
     interface->writeXml( document, pipeElement );
   }
 
@@ -2603,13 +2611,15 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
 
 int QgsRasterLayer::width() const
 {
-  if ( !mDataProvider ) return 0;
+  if ( !mDataProvider )
+    return 0;
   return mDataProvider->xSize();
 }
 
 int QgsRasterLayer::height() const
 {
-  if ( !mDataProvider ) return 0;
+  if ( !mDataProvider )
+    return 0;
   return mDataProvider->ySize();
 }
 

--- a/src/core/raster/qgsrasternuller.cpp
+++ b/src/core/raster/qgsrasternuller.cpp
@@ -55,13 +55,15 @@ void QgsRasterNuller::setNoData( int bandNo, const QgsRasterRangeList &noData )
 
 int QgsRasterNuller::bandCount() const
 {
-  if ( mInput ) return mInput->bandCount();
+  if ( mInput )
+    return mInput->bandCount();
   return 0;
 }
 
 Qgis::DataType QgsRasterNuller::dataType( int bandNo ) const
 {
-  if ( mInput ) return mInput->dataType( bandNo );
+  if ( mInput )
+    return mInput->dataType( bandNo );
   return Qgis::DataType::UnknownDataType;
 }
 

--- a/src/core/raster/qgsrasterpipe.cpp
+++ b/src/core/raster/qgsrasterpipe.cpp
@@ -113,10 +113,12 @@ bool QgsRasterPipe::insert( int idx, QgsRasterInterface *interface )
 
 bool QgsRasterPipe::replace( int idx, QgsRasterInterface *interface )
 {
-  if ( !interface ) return false;
+  if ( !interface )
+    return false;
 
   QgsDebugMsgLevel( QStringLiteral( "replace by %1 at %2" ).arg( typeid( *interface ).name() ).arg( idx ), 4 );
-  if ( !checkBounds( idx ) ) return false;
+  if ( !checkBounds( idx ) )
+    return false;
 
   // make a copy of pipe to test connection, we test the connections
   // of the whole pipe, because the types and band numbers may change
@@ -333,7 +335,8 @@ bool QgsRasterPipe::remove( int idx )
 
 bool QgsRasterPipe::remove( QgsRasterInterface *interface )
 {
-  if ( !interface ) return false;
+  if ( !interface )
+    return false;
 
   return remove( mInterfaces.indexOf( interface ) );
 }

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -50,14 +50,16 @@ QgsRasterProjector *QgsRasterProjector::clone() const
 
 int QgsRasterProjector::bandCount() const
 {
-  if ( mInput ) return mInput->bandCount();
+  if ( mInput )
+    return mInput->bandCount();
 
   return 0;
 }
 
 Qgis::DataType QgsRasterProjector::dataType( int bandNo ) const
 {
-  if ( mInput ) return mInput->dataType( bandNo );
+  if ( mInput )
+    return mInput->dataType( bandNo );
 
   return Qgis::DataType::UnknownDataType;
 }
@@ -546,10 +548,14 @@ bool ProjectorData::preciseSrcRowCol( int destRow, int destCol, int *srcRow, int
   // For now silently correct limits to avoid crashes
   // TODO: review
   // should not happen
-  if ( *srcRow >= mSrcRows ) return false;
-  if ( *srcRow < 0 ) return false;
-  if ( *srcCol >= mSrcCols ) return false;
-  if ( *srcCol < 0 ) return false;
+  if ( *srcRow >= mSrcRows )
+    return false;
+  if ( *srcRow < 0 )
+    return false;
+  if ( *srcCol >= mSrcCols )
+    return false;
+  if ( *srcCol < 0 )
+    return false;
 
   return true;
 }
@@ -603,10 +609,14 @@ bool ProjectorData::approximateSrcRowCol( int destRow, int destCol, int *srcRow,
   // For now silently correct limits to avoid crashes
   // TODO: review
   // should not happen
-  if ( *srcRow >= mSrcRows ) return false;
-  if ( *srcRow < 0 ) return false;
-  if ( *srcCol >= mSrcCols ) return false;
-  if ( *srcCol < 0 ) return false;
+  if ( *srcRow >= mSrcRows )
+    return false;
+  if ( *srcRow < 0 )
+    return false;
+  if ( *srcCol >= mSrcCols )
+    return false;
+  if ( *srcCol < 0 )
+    return false;
 
   return true;
 }
@@ -889,7 +899,8 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
     for ( int j = 0; j < width; ++j )
     {
       const bool inside = pd.srcRowCol( i, j, &srcRow, &srcCol );
-      if ( !inside ) continue; // we have everything set to no data
+      if ( !inside )
+        continue; // we have everything set to no data
 
       const qgssize srcIndex = static_cast< qgssize >( srcRow ) * pd.srcCols() + srcCol;
 

--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -43,9 +43,11 @@ QgsRasterRenderer::~QgsRasterRenderer()
 
 int QgsRasterRenderer::bandCount() const
 {
-  if ( mOn ) return 1;
+  if ( mOn )
+    return 1;
 
-  if ( mInput ) return mInput->bandCount();
+  if ( mInput )
+    return mInput->bandCount();
 
   return 0;
 }
@@ -54,9 +56,11 @@ Qgis::DataType QgsRasterRenderer::dataType( int bandNo ) const
 {
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
 
-  if ( mOn ) return Qgis::DataType::ARGB32_Premultiplied;
+  if ( mOn )
+    return Qgis::DataType::ARGB32_Premultiplied;
 
-  if ( mInput ) return mInput->dataType( bandNo );
+  if ( mInput )
+    return mInput->dataType( bandNo );
 
   return Qgis::DataType::UnknownDataType;
 }
@@ -64,7 +68,8 @@ Qgis::DataType QgsRasterRenderer::dataType( int bandNo ) const
 bool QgsRasterRenderer::setInput( QgsRasterInterface *input )
 {
   // Renderer can only work with numerical values in at least 1 band
-  if ( !input ) return false;
+  if ( !input )
+    return false;
 
   if ( !mOn )
   {

--- a/src/core/raster/qgsrasterresamplefilter.cpp
+++ b/src/core/raster/qgsrasterresamplefilter.cpp
@@ -55,18 +55,22 @@ QgsRasterResampleFilter *QgsRasterResampleFilter::clone() const
 
 int QgsRasterResampleFilter::bandCount() const
 {
-  if ( mOn ) return 1;
+  if ( mOn )
+    return 1;
 
-  if ( mInput ) return mInput->bandCount();
+  if ( mInput )
+    return mInput->bandCount();
 
   return 0;
 }
 
 Qgis::DataType QgsRasterResampleFilter::dataType( int bandNo ) const
 {
-  if ( mOn ) return Qgis::DataType::ARGB32_Premultiplied;
+  if ( mOn )
+    return Qgis::DataType::ARGB32_Premultiplied;
 
-  if ( mInput ) return mInput->dataType( bandNo );
+  if ( mInput )
+    return mInput->dataType( bandNo );
 
   return Qgis::DataType::UnknownDataType;
 }

--- a/src/core/raster/qgssinglebandcolordatarenderer.cpp
+++ b/src/core/raster/qgssinglebandcolordatarenderer.cpp
@@ -117,7 +117,8 @@ QList<int> QgsSingleBandColorDataRenderer::usesBands() const
 bool QgsSingleBandColorDataRenderer::setInput( QgsRasterInterface *input )
 {
   // Renderer can only work with numerical values in at least 1 band
-  if ( !input ) return false;
+  if ( !input )
+    return false;
 
   if ( !mOn )
   {

--- a/src/core/simplify/effectivearea.cpp
+++ b/src/core/simplify/effectivearea.cpp
@@ -106,12 +106,14 @@ static void down( MINHEAP *tree, areanode *arealist, int parent )
   if ( left < tree->usedSize )
   {
     leftarea = ( ( areanode * )treearray[left] )->area;
-    if ( parentarea > leftarea ) swap = left;
+    if ( parentarea > leftarea )
+      swap = left;
   }
   if ( right < tree->usedSize )
   {
     rightarea = ( ( areanode * )treearray[right] )->area;
-    if ( rightarea < parentarea && rightarea < leftarea ) swap = right;
+    if ( rightarea < parentarea && rightarea < leftarea )
+      swap = right;
   }
   if ( swap > parent )
   {
@@ -123,7 +125,8 @@ static void down( MINHEAP *tree, areanode *arealist, int parent )
     treearray[swap] = tmp;
     // Update reference
     ( ( areanode * )treearray[swap] )->treeindex = swap;
-    if ( swap < tree->usedSize ) down( tree, arealist, swap );
+    if ( swap < tree->usedSize )
+      down( tree, arealist, swap );
   }
 }
 

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -104,7 +104,8 @@ void QgsRendererCategory::setValue( const QVariant &value )
 
 void QgsRendererCategory::setSymbol( QgsSymbol *s )
 {
-  if ( mSymbol.get() != s ) mSymbol.reset( s );
+  if ( mSymbol.get() != s )
+    mSymbol.reset( s );
 }
 
 void QgsRendererCategory::setLabel( const QString &label )
@@ -370,7 +371,8 @@ void QgsCategorizedSymbolRenderer::deleteAllCategories()
 
 void QgsCategorizedSymbolRenderer::moveCategory( int from, int to )
 {
-  if ( from < 0 || from >= mCategories.size() || to < 0 || to >= mCategories.size() ) return;
+  if ( from < 0 || from >= mCategories.size() || to < 0 || to >= mCategories.size() )
+    return;
   mCategories.move( from, to );
 }
 
@@ -976,8 +978,10 @@ QString QgsCategorizedSymbolRenderer::displayString( const QVariant &v, int prec
           }
           else
           {
-            if ( dotPosition < 0 ) precision = 0;
-            else precision = s.length() - dotPosition - 1;
+            if ( dotPosition < 0 )
+              precision = 0;
+            else
+              precision = s.length() - dotPosition - 1;
 
             if ( -1 < v.toDouble() && v.toDouble() < 1 )
             {

--- a/src/core/symbology/qgscptcityarchive.cpp
+++ b/src/core/symbology/qgscptcityarchive.cpp
@@ -1691,7 +1691,8 @@ QMimeData *QgsCptCityBrowserModel::mimeData( const QModelIndexList &indexes ) co
     if ( index.isValid() )
     {
       QgsCptCityDataItem *ptr = ( QgsCptCityDataItem * ) index.internalPointer();
-      if ( ptr->type() != QgsCptCityDataItem::Layer ) continue;
+      if ( ptr->type() != QgsCptCityDataItem::Layer )
+        continue;
       QgsLayerItem *layer = ( QgsLayerItem * ) ptr;
       lst.append( QgsMimeDataUtils::Uri( ayer ) );
     }

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -421,7 +421,8 @@ QgsSymbolList QgsFeatureRenderer::symbolsForFeature( const QgsFeature &feature, 
 {
   QgsSymbolList lst;
   QgsSymbol *s = symbolForFeature( feature, context );
-  if ( s ) lst.append( s );
+  if ( s )
+    lst.append( s );
   return lst;
 }
 
@@ -435,7 +436,8 @@ QgsSymbolList QgsFeatureRenderer::originalSymbolsForFeature( const QgsFeature &f
 {
   QgsSymbolList lst;
   QgsSymbol *s = originalSymbolForFeature( feature, context );
-  if ( s ) lst.append( s );
+  if ( s )
+    lst.append( s );
   return lst;
 }
 

--- a/src/core/symbology/qgsrendererrange.cpp
+++ b/src/core/symbology/qgsrendererrange.cpp
@@ -93,7 +93,8 @@ QString QgsRendererRange::label() const
 
 void QgsRendererRange::setSymbol( QgsSymbol *s )
 {
-  if ( mSymbol.get() != s ) mSymbol.reset( s );
+  if ( mSymbol.get() != s )
+    mSymbol.reset( s );
 }
 
 void QgsRendererRange::setLabel( const QString &label )

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -133,7 +133,8 @@ void QgsSingleSymbolRenderer::toSld( QDomDocument &doc, QDomElement &element, co
 
   QgsSymbolLayerUtils::applyScaleDependency( doc, ruleElem, newProps );
 
-  if ( mSymbol ) mSymbol->toSld( doc, ruleElem, newProps );
+  if ( mSymbol )
+    mSymbol->toSld( doc, ruleElem, newProps );
 }
 
 QgsSymbolList QgsSingleSymbolRenderer::symbols( QgsRenderContext &context ) const

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -242,8 +242,8 @@ Qt::PenJoinStyle QgsSymbolLayerUtils::decodeSldLineJoinStyle( const QString &str
 {
   if ( str == QLatin1String( "bevel" ) )
     return Qt::BevelJoin;
-  if ( str == QLatin1String( "mitre" ) )
-    return Qt::MiterJoin;  //#spellok
+  if ( str == QLatin1String( "mitre" ) )  //#spellok
+    return Qt::MiterJoin;
   if ( str == QLatin1String( "round" ) )
     return Qt::RoundJoin;
   return Qt::BevelJoin;

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -117,21 +117,28 @@ QString QgsSymbolLayerUtils::encodeSldFontStyle( QFont::Style style )
 
 QFont::Style QgsSymbolLayerUtils::decodeSldFontStyle( const QString &str )
 {
-  if ( str == QLatin1String( "normal" ) ) return QFont::StyleNormal;
-  if ( str == QLatin1String( "italic" ) ) return QFont::StyleItalic;
-  if ( str == QLatin1String( "oblique" ) ) return QFont::StyleOblique;
+  if ( str == QLatin1String( "normal" ) )
+    return QFont::StyleNormal;
+  if ( str == QLatin1String( "italic" ) )
+    return QFont::StyleItalic;
+  if ( str == QLatin1String( "oblique" ) )
+    return QFont::StyleOblique;
   return QFont::StyleNormal;
 }
 
 QString QgsSymbolLayerUtils::encodeSldFontWeight( int weight )
 {
-  if ( weight == 50 ) return QStringLiteral( "normal" );
-  if ( weight == 75 ) return QStringLiteral( "bold" );
+  if ( weight == 50 )
+    return QStringLiteral( "normal" );
+  if ( weight == 75 )
+    return QStringLiteral( "bold" );
 
   // QFont::Weight is between 0 and 99
   // CSS font-weight is between 100 and 900
-  if ( weight < 0 ) return QStringLiteral( "100" );
-  if ( weight > 99 ) return QStringLiteral( "900" );
+  if ( weight < 0 )
+    return QStringLiteral( "100" );
+  if ( weight > 99 )
+    return QStringLiteral( "900" );
   return QString::number( weight * 800 / 99 + 100 );
 }
 
@@ -144,8 +151,10 @@ int QgsSymbolLayerUtils::decodeSldFontWeight( const QString &str )
 
   // CSS font-weight is between 100 and 900
   // QFont::Weight is between 0 and 99
-  if ( weight > 900 ) return 99;
-  if ( weight < 100 ) return 0;
+  if ( weight > 900 )
+    return 99;
+  if ( weight < 100 )
+    return 0;
   return ( weight - 100 ) * 99 / 800;
 }
 
@@ -172,12 +181,18 @@ QString QgsSymbolLayerUtils::encodePenStyle( Qt::PenStyle style )
 
 Qt::PenStyle QgsSymbolLayerUtils::decodePenStyle( const QString &str )
 {
-  if ( str == QLatin1String( "no" ) ) return Qt::NoPen;
-  if ( str == QLatin1String( "solid" ) ) return Qt::SolidLine;
-  if ( str == QLatin1String( "dash" ) ) return Qt::DashLine;
-  if ( str == QLatin1String( "dot" ) ) return Qt::DotLine;
-  if ( str == QLatin1String( "dash dot" ) ) return Qt::DashDotLine;
-  if ( str == QLatin1String( "dash dot dot" ) ) return Qt::DashDotDotLine;
+  if ( str == QLatin1String( "no" ) )
+    return Qt::NoPen;
+  if ( str == QLatin1String( "solid" ) )
+    return Qt::SolidLine;
+  if ( str == QLatin1String( "dash" ) )
+    return Qt::DashLine;
+  if ( str == QLatin1String( "dot" ) )
+    return Qt::DotLine;
+  if ( str == QLatin1String( "dash dot" ) )
+    return Qt::DashDotLine;
+  if ( str == QLatin1String( "dash dot dot" ) )
+    return Qt::DashDotDotLine;
   return Qt::SolidLine;
 }
 
@@ -225,9 +240,12 @@ QString QgsSymbolLayerUtils::encodeSldLineJoinStyle( Qt::PenJoinStyle style )
 
 Qt::PenJoinStyle QgsSymbolLayerUtils::decodeSldLineJoinStyle( const QString &str )
 {
-  if ( str == QLatin1String( "bevel" ) ) return Qt::BevelJoin;
-  if ( str == QLatin1String( "mitre" ) ) return Qt::MiterJoin;  //#spellok
-  if ( str == QLatin1String( "round" ) ) return Qt::RoundJoin;
+  if ( str == QLatin1String( "bevel" ) )
+    return Qt::BevelJoin;
+  if ( str == QLatin1String( "mitre" ) )
+    return Qt::MiterJoin;  //#spellok
+  if ( str == QLatin1String( "round" ) )
+    return Qt::RoundJoin;
   return Qt::BevelJoin;
 }
 
@@ -248,9 +266,12 @@ QString QgsSymbolLayerUtils::encodePenCapStyle( Qt::PenCapStyle style )
 
 Qt::PenCapStyle QgsSymbolLayerUtils::decodePenCapStyle( const QString &str )
 {
-  if ( str == QLatin1String( "square" ) ) return Qt::SquareCap;
-  if ( str == QLatin1String( "flat" ) ) return Qt::FlatCap;
-  if ( str == QLatin1String( "round" ) ) return Qt::RoundCap;
+  if ( str == QLatin1String( "square" ) )
+    return Qt::SquareCap;
+  if ( str == QLatin1String( "flat" ) )
+    return Qt::FlatCap;
+  if ( str == QLatin1String( "round" ) )
+    return Qt::RoundCap;
   return Qt::SquareCap;
 }
 
@@ -271,9 +292,12 @@ QString QgsSymbolLayerUtils::encodeSldLineCapStyle( Qt::PenCapStyle style )
 
 Qt::PenCapStyle QgsSymbolLayerUtils::decodeSldLineCapStyle( const QString &str )
 {
-  if ( str == QLatin1String( "square" ) ) return Qt::SquareCap;
-  if ( str == QLatin1String( "butt" ) ) return Qt::FlatCap;
-  if ( str == QLatin1String( "round" ) ) return Qt::RoundCap;
+  if ( str == QLatin1String( "square" ) )
+    return Qt::SquareCap;
+  if ( str == QLatin1String( "butt" ) )
+    return Qt::FlatCap;
+  if ( str == QLatin1String( "round" ) )
+    return Qt::RoundCap;
   return Qt::SquareCap;
 }
 
@@ -318,21 +342,36 @@ QString QgsSymbolLayerUtils::encodeBrushStyle( Qt::BrushStyle style )
 
 Qt::BrushStyle QgsSymbolLayerUtils::decodeBrushStyle( const QString &str )
 {
-  if ( str == QLatin1String( "solid" ) ) return Qt::SolidPattern;
-  if ( str == QLatin1String( "horizontal" ) ) return Qt::HorPattern;
-  if ( str == QLatin1String( "vertical" ) ) return Qt::VerPattern;
-  if ( str == QLatin1String( "cross" ) ) return Qt::CrossPattern;
-  if ( str == QLatin1String( "b_diagonal" ) ) return Qt::BDiagPattern;
-  if ( str == QLatin1String( "f_diagonal" ) ) return Qt::FDiagPattern;
-  if ( str == QLatin1String( "diagonal_x" ) ) return Qt::DiagCrossPattern;
-  if ( str == QLatin1String( "dense1" ) ) return Qt::Dense1Pattern;
-  if ( str == QLatin1String( "dense2" ) ) return Qt::Dense2Pattern;
-  if ( str == QLatin1String( "dense3" ) ) return Qt::Dense3Pattern;
-  if ( str == QLatin1String( "dense4" ) ) return Qt::Dense4Pattern;
-  if ( str == QLatin1String( "dense5" ) ) return Qt::Dense5Pattern;
-  if ( str == QLatin1String( "dense6" ) ) return Qt::Dense6Pattern;
-  if ( str == QLatin1String( "dense7" ) ) return Qt::Dense7Pattern;
-  if ( str == QLatin1String( "no" ) ) return Qt::NoBrush;
+  if ( str == QLatin1String( "solid" ) )
+    return Qt::SolidPattern;
+  if ( str == QLatin1String( "horizontal" ) )
+    return Qt::HorPattern;
+  if ( str == QLatin1String( "vertical" ) )
+    return Qt::VerPattern;
+  if ( str == QLatin1String( "cross" ) )
+    return Qt::CrossPattern;
+  if ( str == QLatin1String( "b_diagonal" ) )
+    return Qt::BDiagPattern;
+  if ( str == QLatin1String( "f_diagonal" ) )
+    return Qt::FDiagPattern;
+  if ( str == QLatin1String( "diagonal_x" ) )
+    return Qt::DiagCrossPattern;
+  if ( str == QLatin1String( "dense1" ) )
+    return Qt::Dense1Pattern;
+  if ( str == QLatin1String( "dense2" ) )
+    return Qt::Dense2Pattern;
+  if ( str == QLatin1String( "dense3" ) )
+    return Qt::Dense3Pattern;
+  if ( str == QLatin1String( "dense4" ) )
+    return Qt::Dense4Pattern;
+  if ( str == QLatin1String( "dense5" ) )
+    return Qt::Dense5Pattern;
+  if ( str == QLatin1String( "dense6" ) )
+    return Qt::Dense6Pattern;
+  if ( str == QLatin1String( "dense7" ) )
+    return Qt::Dense7Pattern;
+  if ( str == QLatin1String( "no" ) )
+    return Qt::NoBrush;
   return Qt::SolidPattern;
 }
 
@@ -375,12 +414,18 @@ QString QgsSymbolLayerUtils::encodeSldBrushStyle( Qt::BrushStyle style )
 
 Qt::BrushStyle QgsSymbolLayerUtils::decodeSldBrushStyle( const QString &str )
 {
-  if ( str == QLatin1String( "horline" ) ) return Qt::HorPattern;
-  if ( str == QLatin1String( "line" ) ) return Qt::VerPattern;
-  if ( str == QLatin1String( "cross" ) ) return Qt::CrossPattern;
-  if ( str == QLatin1String( "slash" ) ) return Qt::BDiagPattern;
-  if ( str == QLatin1String( "backshash" ) ) return Qt::FDiagPattern;
-  if ( str == QLatin1String( "x" ) ) return Qt::DiagCrossPattern;
+  if ( str == QLatin1String( "horline" ) )
+    return Qt::HorPattern;
+  if ( str == QLatin1String( "line" ) )
+    return Qt::VerPattern;
+  if ( str == QLatin1String( "cross" ) )
+    return Qt::CrossPattern;
+  if ( str == QLatin1String( "slash" ) )
+    return Qt::BDiagPattern;
+  if ( str == QLatin1String( "backshash" ) )
+    return Qt::FDiagPattern;
+  if ( str == QLatin1String( "x" ) )
+    return Qt::DiagCrossPattern;
 
   if ( str.startsWith( QLatin1String( "brush://" ) ) )
     return decodeBrushStyle( str.mid( 8 ) );
@@ -851,18 +896,30 @@ Qgis::ScaleMethod QgsSymbolLayerUtils::decodeScaleMethod( const QString &str )
 
 QPainter::CompositionMode QgsSymbolLayerUtils::decodeBlendMode( const QString &s )
 {
-  if ( s.compare( QLatin1String( "Lighten" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Lighten;
-  if ( s.compare( QLatin1String( "Screen" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Screen;
-  if ( s.compare( QLatin1String( "Dodge" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_ColorDodge;
-  if ( s.compare( QLatin1String( "Addition" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Plus;
-  if ( s.compare( QLatin1String( "Darken" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Darken;
-  if ( s.compare( QLatin1String( "Multiply" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Multiply;
-  if ( s.compare( QLatin1String( "Burn" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_ColorBurn;
-  if ( s.compare( QLatin1String( "Overlay" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Overlay;
-  if ( s.compare( QLatin1String( "SoftLight" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_SoftLight;
-  if ( s.compare( QLatin1String( "HardLight" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_HardLight;
-  if ( s.compare( QLatin1String( "Difference" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Difference;
-  if ( s.compare( QLatin1String( "Subtract" ), Qt::CaseInsensitive ) == 0 ) return QPainter::CompositionMode_Exclusion;
+  if ( s.compare( QLatin1String( "Lighten" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Lighten;
+  if ( s.compare( QLatin1String( "Screen" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Screen;
+  if ( s.compare( QLatin1String( "Dodge" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_ColorDodge;
+  if ( s.compare( QLatin1String( "Addition" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Plus;
+  if ( s.compare( QLatin1String( "Darken" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Darken;
+  if ( s.compare( QLatin1String( "Multiply" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Multiply;
+  if ( s.compare( QLatin1String( "Burn" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_ColorBurn;
+  if ( s.compare( QLatin1String( "Overlay" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Overlay;
+  if ( s.compare( QLatin1String( "SoftLight" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_SoftLight;
+  if ( s.compare( QLatin1String( "HardLight" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_HardLight;
+  if ( s.compare( QLatin1String( "Difference" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Difference;
+  if ( s.compare( QLatin1String( "Subtract" ), Qt::CaseInsensitive ) == 0 )
+    return QPainter::CompositionMode_Exclusion;
   return QPainter::CompositionMode_SourceOver; // "Normal"
 }
 
@@ -4367,7 +4424,8 @@ QPointF QgsSymbolLayerUtils::polygonPointOnSurface( const QPolygonF &points, con
   {
     unsigned int i, pointCount = points.count();
     QgsPolylineXY polyline( pointCount );
-    for ( i = 0; i < pointCount; ++i ) polyline[i] = QgsPointXY( points[i].x(), points[i].y() );
+    for ( i = 0; i < pointCount; ++i )
+      polyline[i] = QgsPointXY( points[i].x(), points[i].y() );
     QgsGeometry geom = QgsGeometry::fromPolygonXY( QgsPolygonXY() << polyline );
     if ( !geom.isNull() )
     {
@@ -4377,7 +4435,8 @@ QPointF QgsSymbolLayerUtils::polygonPointOnSurface( const QPolygonF &points, con
         {
           pointCount = ( *ringIt ).count();
           QgsPolylineXY polyline( pointCount );
-          for ( i = 0; i < pointCount; ++i ) polyline[i] = QgsPointXY( ( *ringIt )[i].x(), ( *ringIt )[i].y() );
+          for ( i = 0; i < pointCount; ++i )
+            polyline[i] = QgsPointXY( ( *ringIt )[i].x(), ( *ringIt )[i].y() );
           geom.addRing( polyline );
         }
       }

--- a/src/gui/attributetable/qgsfieldconditionalformatwidget.cpp
+++ b/src/gui/attributetable/qgsfieldconditionalformatwidget.cpp
@@ -105,7 +105,8 @@ void QgsFieldConditionalFormatWidget::editStyle( int editIndex, const QgsConditi
     }
     if ( rowRadio->isChecked() )
     {
-      mLayer->conditionalStyles()->setRowStyles( styles );
+      mLayer->conditionalStyles()
+      ->setRowStyles( styles );
     }
     reloadStyles();
     emit rulesUpdated( fieldName );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -281,8 +281,10 @@ QString QgsEditorWidgetWrapper::constraintFailureReason() const
 
 bool QgsEditorWidgetWrapper::isInTable( const QWidget *parent )
 {
-  if ( !parent ) return false;
-  if ( qobject_cast<const QTableView *>( parent ) ) return true;
+  if ( !parent )
+    return false;
+  if ( qobject_cast<const QTableView *>( parent ) )
+    return true;
   return isInTable( parent->parentWidget() );
 }
 

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -24,7 +24,8 @@ QgsKeyValueWidgetWrapper::QgsKeyValueWidgetWrapper( QgsVectorLayer *layer, int f
 
 QVariant QgsKeyValueWidgetWrapper::value() const
 {
-  if ( !mWidget ) return QVariant( QVariant::Map );
+  if ( !mWidget )
+    return QVariant( QVariant::Map );
   return mWidget->map();
 }
 

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -69,7 +69,8 @@ void QgsListWidgetWrapper::updateValues( const QVariant &value, const QVariantLi
 QVariant QgsListWidgetWrapper::value() const
 {
   const QVariant::Type type = field().type();
-  if ( !mWidget ) return QVariant( type );
+  if ( !mWidget )
+    return QVariant( type );
   const QVariantList list = mWidget->list();
   if ( list.size() == 0 && config( QStringLiteral( "EmptyIsNull" ) ).toBool() )
   {

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -37,9 +37,12 @@ QgsEditorConfigWidget *QgsRangeWidgetFactory::configWidget( QgsVectorLayer *vl, 
 unsigned int QgsRangeWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
   const QgsField field = vl->fields().at( fieldIdx );
-  if ( field.type() == QVariant::Int ) return 20;
-  if ( field.type() == QVariant::Double ) return 5; // low priority because the fixed number of decimal places may alter the original data
-  if ( field.isNumeric() ) return 5; // widgets used support only signed 32bits (int) and double
+  if ( field.type() == QVariant::Int )
+    return 20;
+  if ( field.type() == QVariant::Double )
+    return 5; // low priority because the fixed number of decimal places may alter the original data
+  if ( field.isNumeric() )
+    return 5; // widgets used support only signed 32bits (int) and double
   return 0;
 }
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -960,7 +960,8 @@ void QgsModelDesignerDialog::validate()
       QString longMessage = tr( "<p>This model is not valid:</p>" ) + QStringLiteral( "<ul>" );
       for ( const QString &issue : issues )
       {
-        longMessage += QStringLiteral( "<li>%1</li>" ).arg( issue );
+        longMessage += QStringLiteral( "<li>%1</li>" )
+        .arg( issue );
       }
       longMessage += QLatin1String( "</ul>" );
 

--- a/src/gui/processing/qgsprocessinghelpeditorwidget.cpp
+++ b/src/gui/processing/qgsprocessinghelpeditorwidget.cpp
@@ -60,7 +60,8 @@ QgsProcessingHelpEditorWidget::QgsProcessingHelpEditorWidget( QWidget *parent )
   {
     if ( !mCurrentName.isEmpty() )
     {
-      mHelpContent[ mCurrentName] = mTextEdit->toPlainText();
+      mHelpContent[ mCurrentName]
+      = mTextEdit->toPlainText();
       updateHtmlView();
     }
   } );

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -212,7 +212,8 @@ QVariant QgsProcessingModelerParameterWidget::value() const
         const QVariantList vList = v.toList();
         if ( std::all_of( vList.begin(), vList.end(), []( const QVariant & val )
       {
-        return val.canConvert< QgsProcessingModelChildParameterSource >();
+        return val.canConvert< QgsProcessingModelChildParameterSource >
+               ();
         } ) )
         {
           return v;

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -405,7 +405,8 @@ void QgsExpressionBuilderWidget::updateFunctionFileList( const QString &path )
   for ( const QString &name : constFiles )
   {
     QFileInfo info( mFunctionsPath + QDir::separator() + name );
-    if ( info.baseName() == QLatin1String( "__init__" ) ) continue;
+    if ( info.baseName() == QLatin1String( "__init__" ) )
+      continue;
     QListWidgetItem *item = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "console/iconTabEditorConsole.svg" ) ), info.baseName() );
     cmbFileNames->addItem( item );
   }

--- a/src/gui/qgslistwidget.cpp
+++ b/src/gui/qgslistwidget.cpp
@@ -61,7 +61,8 @@ bool QgsListModel::valid() const
   for ( QVariantList::const_iterator it = mLines.constBegin(); it != mLines.constEnd(); ++it )
   {
     QVariant cur = *it;
-    if ( !cur.convert( mSubType ) ) return false;
+    if ( !cur.convert( mSubType ) )
+      return false;
   }
   return true;
 }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1045,7 +1045,8 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
     selector.setCrs( QgsCoordinateReferenceSystem( customCrsString ) );
     if ( selector.exec() )
     {
-      QgsSettings().setValue( QStringLiteral( "qgis/custom_coordinate_crs" ), selector.crs().authid().isEmpty() ? selector.crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) : selector.crs().authid() );
+      QgsSettings()
+      .setValue( QStringLiteral( "qgis/custom_coordinate_crs" ), selector.crs().authid().isEmpty() ? selector.crs().toWkt( QgsCoordinateReferenceSystem::WKT_PREFERRED ) : selector.crs().authid() );
     }
   } );
   copyCoordinateMenu->addAction( setCustomCrsAction );
@@ -1984,7 +1985,8 @@ void QgsMapCanvas::keyReleaseEvent( QKeyEvent *e )
       {
         mMapTool->keyReleaseEvent( e );
       }
-      else e->ignore();
+      else
+        e->ignore();
 
       QgsDebugMsgLevel( "Ignoring key release: " + QString::number( e->key() ), 2 );
   }

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -83,7 +83,8 @@ void QgsMapOverviewCanvas::paintEvent( QPaintEvent *pe )
 
 void QgsMapOverviewCanvas::drawExtentRect()
 {
-  if ( !mMapCanvas ) return;
+  if ( !mMapCanvas )
+    return;
 
   const QgsRectangle &extent = mMapCanvas->extent();
 
@@ -336,7 +337,8 @@ QgsPanningWidget::QgsPanningWidget( QWidget *parent )
 
 void QgsPanningWidget::setPolygon( const QPolygon &p )
 {
-  if ( p == mPoly ) return;
+  if ( p == mPoly )
+    return;
   mPoly = p;
 
   //ensure polygon is closed

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -987,11 +987,16 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
   // check if the format is really supported otherwise use first supported format
   if ( !( QgsRasterDataProvider::identifyFormatToCapability( format ) & capabilities ) )
   {
-    if ( capabilities & QgsRasterInterface::IdentifyFeature ) format = QgsRaster::IdentifyFormatFeature;
-    else if ( capabilities & QgsRasterInterface::IdentifyValue ) format = QgsRaster::IdentifyFormatValue;
-    else if ( capabilities & QgsRasterInterface::IdentifyHtml ) format = QgsRaster::IdentifyFormatHtml;
-    else if ( capabilities & QgsRasterInterface::IdentifyText ) format = QgsRaster::IdentifyFormatText;
-    else return false;
+    if ( capabilities & QgsRasterInterface::IdentifyFeature )
+      format = QgsRaster::IdentifyFormatFeature;
+    else if ( capabilities & QgsRasterInterface::IdentifyValue )
+      format = QgsRaster::IdentifyFormatValue;
+    else if ( capabilities & QgsRasterInterface::IdentifyHtml )
+      format = QgsRaster::IdentifyFormatHtml;
+    else if ( capabilities & QgsRasterInterface::IdentifyText )
+      format = QgsRaster::IdentifyFormatText;
+    else
+      return false;
   }
 
   QgsRasterIdentifyResult identifyResult;

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -864,7 +864,8 @@ QModelIndex QgsOptionsProxyModel::pageNumberToSourceIndex( int page ) const
         if ( pagesRemaining == 0 )
           return currentIndex;
 
-        else pagesRemaining--;
+        else
+          pagesRemaining--;
       }
 
       const QModelIndex res = traversePages( currentIndex );

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -473,7 +473,10 @@ void QgsConnectionsApiFetcher::fetchTokens()
         const QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables = mConnection->tables( schema );
         for ( const QgsAbstractDatabaseProviderConnection::TableProperty &table : std::as_const( tables ) )
         {
-          if ( mStopFetching ) { return; }
+          if ( mStopFetching )
+          {
+            return;
+          }
           tableNames.push_back( table.tableName() );
         }
         emit tokensReady( tableNames );
@@ -496,11 +499,17 @@ void QgsConnectionsApiFetcher::fetchTokens()
         try
         {
           const QgsFields fields( mConnection->fields( schema, table ) );
-          if ( mStopFetching ) { return; }
+          if ( mStopFetching )
+          {
+            return;
+          }
           for ( const auto &field : std::as_const( fields ) )
           {
             fieldNames.push_back( field.name() );
-            if ( mStopFetching ) { return; }
+            if ( mStopFetching )
+            {
+              return;
+            }
           }
           emit tokensReady( fieldNames );
         }

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -657,7 +657,8 @@ QgsCoordinateReferenceSystem QgsRasterLayerSaveAsDialog::outputCrs()
 
 QgsRasterLayerSaveAsDialog::Mode QgsRasterLayerSaveAsDialog::mode() const
 {
-  if ( mRenderedModeRadioButton->isChecked() ) return RenderedImageMode;
+  if ( mRenderedModeRadioButton->isChecked() )
+    return RenderedImageMode;
   return RawDataMode;
 }
 
@@ -673,9 +674,11 @@ void QgsRasterLayerSaveAsDialog::mAddNoDataManuallyToolButton_clicked()
 
 void QgsRasterLayerSaveAsDialog::mLoadTransparentNoDataToolButton_clicked()
 {
-  if ( !mRasterLayer->renderer() ) return;
+  if ( !mRasterLayer->renderer() )
+    return;
   const QgsRasterTransparency *rasterTransparency = mRasterLayer->renderer()->rasterTransparency();
-  if ( !rasterTransparency ) return;
+  if ( !rasterTransparency )
+    return;
 
   const auto constTransparentSingleValuePixelList = rasterTransparency->transparentSingleValuePixelList();
   for ( const QgsRasterTransparency::TransparentSingleValuePixel &transparencyPixel : constTransparentSingleValuePixelList )
@@ -748,7 +751,8 @@ void QgsRasterLayerSaveAsDialog::noDataCellTextEdited( const QString &text )
   Q_UNUSED( text )
 
   QLineEdit *lineEdit = qobject_cast<QLineEdit *>( sender() );
-  if ( !lineEdit ) return;
+  if ( !lineEdit )
+    return;
   int row = -1;
   int column = -1;
   for ( int r = 0; r < mNoDataTableWidget->rowCount(); r++ )
@@ -762,14 +766,16 @@ void QgsRasterLayerSaveAsDialog::noDataCellTextEdited( const QString &text )
         break;
       }
     }
-    if ( row != -1 ) break;
+    if ( row != -1 )
+      break;
   }
   QgsDebugMsg( QStringLiteral( "row = %1 column =%2" ).arg( row ).arg( column ) );
 
   if ( column == 0 )
   {
     QLineEdit *toLineEdit = dynamic_cast<QLineEdit *>( mNoDataTableWidget->cellWidget( row, 1 ) );
-    if ( !toLineEdit ) return;
+    if ( !toLineEdit )
+      return;
     bool toChanged = mNoDataToEdited.value( row );
     QgsDebugMsg( QStringLiteral( "toChanged = %1" ).arg( toChanged ) );
     if ( !toChanged )
@@ -873,7 +879,8 @@ double QgsRasterLayerSaveAsDialog::noDataCellValue( int row, int column ) const
 void QgsRasterLayerSaveAsDialog::adjustNoDataCellWidth( int row, int column )
 {
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( mNoDataTableWidget->cellWidget( row, column ) );
-  if ( !lineEdit ) return;
+  if ( !lineEdit )
+    return;
 
   int width = std::max( lineEdit->fontMetrics().boundingRect( lineEdit->text() ).width() + 10, 100 );
   width = std::max( width, mNoDataTableWidget->columnWidth( column ) );

--- a/src/gui/qgssqlcomposerdialog.cpp
+++ b/src/gui/qgssqlcomposerdialog.cpp
@@ -469,8 +469,10 @@ void QgsSQLComposerDialog::getFunctionList( const QList<Function> &list,
     {
       for ( int i = 0; i < f.argumentList.size(); i++ )
       {
-        if ( f.minArgs >= 0 && i >= f.minArgs ) entryText += QLatin1Char( '[' );
-        if ( i > 0 ) entryText += QLatin1String( ", " );
+        if ( f.minArgs >= 0 && i >= f.minArgs )
+          entryText += QLatin1Char( '[' );
+        if ( i > 0 )
+          entryText += QLatin1String( ", " );
         if ( f.argumentList[i].name == QLatin1String( "number" ) && !f.argumentList[i].type.isEmpty() )
         {
           entryText += sanitizeType( f.argumentList[i].type );
@@ -486,7 +488,8 @@ void QgsSQLComposerDialog::getFunctionList( const QList<Function> &list,
             entryText += sanitizedType;
           }
         }
-        if ( f.minArgs >= 0 && i >= f.minArgs ) entryText += QLatin1Char( ']' );
+        if ( f.minArgs >= 0 && i >= f.minArgs )
+          entryText += QLatin1Char( ']' );
       }
       if ( entryText.size() > 60 )
       {

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -788,7 +788,8 @@ QMimeData *QgsPalettedRendererModel::mimeData( const QModelIndexList &indexes ) 
 bool QgsPalettedRendererModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex & )
 {
   Q_UNUSED( column )
-  if ( action != Qt::MoveAction ) return true;
+  if ( action != Qt::MoveAction )
+    return true;
 
   if ( !data->hasFormat( QStringLiteral( "application/x-qgspalettedrenderermodel" ) ) )
     return false;

--- a/src/gui/raster/qgsrasterbandcombobox.cpp
+++ b/src/gui/raster/qgsrasterbandcombobox.cpp
@@ -25,7 +25,8 @@ QgsRasterBandComboBox::QgsRasterBandComboBox( QWidget *parent )
   {
     if ( mLayer && mLayer->isValid() )
     {
-      const int newBand = currentIndex() >= 0 ? currentData().toInt() : -1 ;
+      const int newBand = currentIndex()
+      >= 0 ? currentData().toInt() : -1 ;
       if ( newBand != mPrevBand )
       {
         emit bandChanged( currentIndex() >= 0 ? currentData().toInt() : -1 );

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -307,8 +307,10 @@ static int getBinCount( QgsRasterInterface *rasterInterface,
   {
     const double srcXRes = extent.width() / rasterInterface->xSize();
     const double srcYRes = extent.height() / rasterInterface->ySize();
-    if ( xRes < srcXRes ) xRes = srcXRes;
-    if ( yRes < srcYRes ) yRes = srcYRes;
+    if ( xRes < srcXRes )
+      xRes = srcXRes;
+    if ( yRes < srcYRes )
+      yRes = srcYRes;
   }
 
   const int histogramWidth = static_cast <int>( extent.width() / xRes );
@@ -1037,7 +1039,8 @@ void QgsRasterHistogramWidget::btnHistoMax_toggled()
 // this is sensitive and may not always be correct, needs more testing
 QString findClosestTickVal( double target, const QwtScaleDiv *scale, int div = 100 )
 {
-  if ( !scale ) return QString();
+  if ( !scale )
+    return QString();
 
   QList< double > minorTicks = scale->ticks( QwtScaleDiv::MinorTick );
   QList< double > majorTicks = scale->ticks( QwtScaleDiv::MajorTick );

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1197,10 +1197,12 @@ void QgsRasterLayerProperties::setTransparencyCell( int row, int column, double 
 {
   QgsDebugMsgLevel( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ), 3 );
   QgsRasterDataProvider *provider = mRasterLayer->dataProvider();
-  if ( !provider ) return;
+  if ( !provider )
+    return;
 
   QgsRasterRenderer *renderer = mRendererWidget->renderer();
-  if ( !renderer ) return;
+  if ( !renderer )
+    return;
   int nBands = renderer->usesBands().size();
 
   QLineEdit *lineEdit = new QLineEdit();
@@ -1253,7 +1255,8 @@ void QgsRasterLayerProperties::setTransparencyCell( int row, int column, double 
 void QgsRasterLayerProperties::setTransparencyCellValue( int row, int column, double value )
 {
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( mRasterTransparencyWidget->tableTransparency->cellWidget( row, column ) );
-  if ( !lineEdit ) return;
+  if ( !lineEdit )
+    return;
   double v = QgsRasterBlock::printValue( value ).toDouble();
   lineEdit->setText( QLocale().toString( v, 'g' ) );
   lineEdit->adjustSize();
@@ -1274,7 +1277,8 @@ double QgsRasterLayerProperties::transparencyCellValue( int row, int column )
 void QgsRasterLayerProperties::adjustTransparencyCellWidth( int row, int column )
 {
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( mRasterTransparencyWidget->tableTransparency->cellWidget( row, column ) );
-  if ( !lineEdit ) return;
+  if ( !lineEdit )
+    return;
 
   int width = std::max( lineEdit->fontMetrics().boundingRect( lineEdit->text() ).width() + 10, 100 );
   width = std::max( width, mRasterTransparencyWidget->tableTransparency->columnWidth( column ) );
@@ -1295,7 +1299,8 @@ void QgsRasterLayerProperties::transparencyCellTextEdited( const QString &text )
   if ( nBands == 1 )
   {
     QLineEdit *lineEdit = qobject_cast<QLineEdit *>( sender() );
-    if ( !lineEdit ) return;
+    if ( !lineEdit )
+      return;
     int row = -1;
     int column = -1;
     for ( int r = 0; r < mRasterTransparencyWidget->tableTransparency->rowCount(); r++ )
@@ -1309,14 +1314,16 @@ void QgsRasterLayerProperties::transparencyCellTextEdited( const QString &text )
           break;
         }
       }
-      if ( row != -1 ) break;
+      if ( row != -1 )
+        break;
     }
     QgsDebugMsgLevel( QStringLiteral( "row = %1 column =%2" ).arg( row ).arg( column ), 3 );
 
     if ( column == 0 )
     {
       QLineEdit *toLineEdit = dynamic_cast<QLineEdit *>( mRasterTransparencyWidget->tableTransparency->cellWidget( row, 1 ) );
-      if ( !toLineEdit ) return;
+      if ( !toLineEdit )
+        return;
       bool toChanged = mTransparencyToEdited.value( row );
       QgsDebugMsgLevel( QStringLiteral( "toChanged = %1" ).arg( toChanged ), 3 );
       if ( !toChanged )

--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -191,7 +191,8 @@ void QgsRasterTransparencyWidget::transparencyCellTextEdited( const QString &tex
   if ( nBands == 1 )
   {
     QLineEdit *lineEdit = qobject_cast<QLineEdit *>( sender() );
-    if ( !lineEdit ) return;
+    if ( !lineEdit )
+      return;
     int row = -1;
     int column = -1;
     for ( int r = 0; r < tableTransparency->rowCount(); r++ )
@@ -205,14 +206,16 @@ void QgsRasterTransparencyWidget::transparencyCellTextEdited( const QString &tex
           break;
         }
       }
-      if ( row != -1 ) break;
+      if ( row != -1 )
+        break;
     }
     QgsDebugMsg( QStringLiteral( "row = %1 column =%2" ).arg( row ).arg( column ) );
 
     if ( column == 0 )
     {
       QLineEdit *toLineEdit = dynamic_cast<QLineEdit *>( tableTransparency->cellWidget( row, 1 ) );
-      if ( !toLineEdit ) return;
+      if ( !toLineEdit )
+        return;
       const bool toChanged = mTransparencyToEdited.value( row );
       QgsDebugMsg( QStringLiteral( "toChanged = %1" ).arg( toChanged ) );
       if ( !toChanged )
@@ -247,7 +250,8 @@ void QgsRasterTransparencyWidget::pbnAddValuesManually_clicked()
   tableTransparency->insertRow( tableTransparency->rowCount() );
 
   int n = renderer->usesBands().size();
-  if ( n == 1 ) n++;
+  if ( n == 1 )
+    n++;
 
   for ( int i = 0; i < n; i++ )
   {
@@ -705,10 +709,12 @@ void QgsRasterTransparencyWidget::setTransparencyCell( int row, int column, doub
 {
   QgsDebugMsg( QStringLiteral( "value = %1" ).arg( value, 0, 'g', 17 ) );
   QgsRasterDataProvider *provider = mRasterLayer->dataProvider();
-  if ( !provider ) return;
+  if ( !provider )
+    return;
 
   QgsRasterRenderer *renderer = mRasterLayer->renderer();
-  if ( !renderer ) return;
+  if ( !renderer )
+    return;
   const int nBands = renderer->usesBands().size();
 
   QLineEdit *lineEdit = new QLineEdit();
@@ -763,7 +769,8 @@ void QgsRasterTransparencyWidget::setTransparencyCell( int row, int column, doub
 void QgsRasterTransparencyWidget::adjustTransparencyCellWidth( int row, int column )
 {
   QLineEdit *lineEdit = dynamic_cast<QLineEdit *>( tableTransparency->cellWidget( row, column ) );
-  if ( !lineEdit ) return;
+  if ( !lineEdit )
+    return;
 
   int width = std::max( lineEdit->fontMetrics().boundingRect( lineEdit->text() ).width() + 10, 100 );
   width = std::max( width, tableTransparency->columnWidth( column ) );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -80,7 +80,8 @@ void QgsCategorizedSymbolRendererModel::setRenderer( QgsCategorizedSymbolRendere
 
 void QgsCategorizedSymbolRendererModel::addCategory( const QgsRendererCategory &cat )
 {
-  if ( !mRenderer ) return;
+  if ( !mRenderer )
+    return;
   const int idx = mRenderer->categories().size();
   beginInsertRows( QModelIndex(), idx, idx );
   mRenderer->addCategory( cat );
@@ -398,9 +399,11 @@ bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt:
 {
   Q_UNUSED( row )
   Q_UNUSED( column )
-  if ( action != Qt::MoveAction ) return true;
+  if ( action != Qt::MoveAction )
+    return true;
 
-  if ( !data->hasFormat( mMimeFormat ) ) return false;
+  if ( !data->hasFormat( mMimeFormat ) )
+    return false;
 
   QByteArray encodedData = data->data( mMimeFormat );
   QDataStream stream( &encodedData, QIODevice::ReadOnly );
@@ -416,21 +419,25 @@ bool QgsCategorizedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt:
   int to = parent.row();
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position
-  if ( to == -1 ) to = mRenderer->categories().size(); // out of rang ok, will be decreased
+  if ( to == -1 )
+    to = mRenderer->categories().size(); // out of rang ok, will be decreased
   for ( int i = rows.size() - 1; i >= 0; i-- )
   {
     QgsDebugMsg( QStringLiteral( "move %1 to %2" ).arg( rows[i] ).arg( to ) );
     int t = to;
     // moveCategory first removes and then inserts
-    if ( rows[i] < t ) t--;
+    if ( rows[i] < t )
+      t--;
     mRenderer->moveCategory( rows[i], t );
     // current moved under another, shift its index up
     for ( int j = 0; j < i; j++ )
     {
-      if ( to < rows[j] && rows[i] > rows[j] ) rows[j] += 1;
+      if ( to < rows[j] && rows[i] > rows[j] )
+        rows[j] += 1;
     }
     // removed under 'to' so the target shifted down
-    if ( rows[i] < to ) to--;
+    if ( rows[i] < to )
+      to--;
   }
   emit dataChanged( createIndex( 0, 0 ), createIndex( mRenderer->categories().size(), 0 ) );
   emit rowsMoved();
@@ -490,7 +497,8 @@ void QgsCategorizedSymbolRendererViewStyle::drawPrimitive( PrimitiveElement elem
     opt.rect.setLeft( 0 );
     // draw always as line above, because we move item to that index
     opt.rect.setHeight( 0 );
-    if ( widget ) opt.rect.setRight( widget->width() );
+    if ( widget )
+      opt.rect.setRight( widget->width() );
     QProxyStyle::drawPrimitive( element, &opt, painter, widget );
     return;
   }
@@ -1099,7 +1107,8 @@ void QgsCategorizedSymbolRendererWidget::deleteAllCategories()
 
 void QgsCategorizedSymbolRendererWidget::addCategory()
 {
-  if ( !mModel ) return;
+  if ( !mModel )
+    return;
   QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
   const QgsRendererCategory cat( QString(), symbol, QString(), true );
   mModel->addCategory( cat );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -97,7 +97,8 @@ void QgsGraduatedSymbolRendererModel::setRenderer( QgsGraduatedSymbolRenderer *r
 
 void QgsGraduatedSymbolRendererModel::addClass( QgsSymbol *symbol )
 {
-  if ( !mRenderer ) return;
+  if ( !mRenderer )
+    return;
   int idx = mRenderer->ranges().size();
   beginInsertRows( QModelIndex(), idx, idx );
   mRenderer->addClass( symbol );
@@ -150,7 +151,8 @@ Qt::DropActions QgsGraduatedSymbolRendererModel::supportedDropActions() const
 
 QVariant QgsGraduatedSymbolRendererModel::data( const QModelIndex &index, int role ) const
 {
-  if ( !index.isValid() || !mRenderer ) return QVariant();
+  if ( !index.isValid() || !mRenderer )
+    return QVariant();
 
   const QgsRendererRange range = mRenderer->ranges().value( index.row() );
 
@@ -165,7 +167,8 @@ QVariant QgsGraduatedSymbolRendererModel::data( const QModelIndex &index, int ro
       case 1:
       {
         int decimalPlaces = mRenderer->classificationMethod()->labelPrecision() + 2;
-        if ( decimalPlaces < 0 ) decimalPlaces = 0;
+        if ( decimalPlaces < 0 )
+          decimalPlaces = 0;
         return QString( QLocale().toString( range.lowerValue(), 'f', decimalPlaces ) + " - " + QLocale().toString( range.upperValue(), 'f', decimalPlaces ) );
       }
       case 2:
@@ -300,9 +303,11 @@ bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::D
 {
   Q_UNUSED( row )
   Q_UNUSED( column )
-  if ( action != Qt::MoveAction ) return true;
+  if ( action != Qt::MoveAction )
+    return true;
 
-  if ( !data->hasFormat( mMimeFormat ) ) return false;
+  if ( !data->hasFormat( mMimeFormat ) )
+    return false;
 
   QByteArray encodedData = data->data( mMimeFormat );
   QDataStream stream( &encodedData, QIODevice::ReadOnly );
@@ -318,21 +323,25 @@ bool QgsGraduatedSymbolRendererModel::dropMimeData( const QMimeData *data, Qt::D
   int to = parent.row();
   // to is -1 if dragged outside items, i.e. below any item,
   // then move to the last position
-  if ( to == -1 ) to = mRenderer->ranges().size(); // out of rang ok, will be decreased
+  if ( to == -1 )
+    to = mRenderer->ranges().size(); // out of rang ok, will be decreased
   for ( int i = rows.size() - 1; i >= 0; i-- )
   {
     QgsDebugMsg( QStringLiteral( "move %1 to %2" ).arg( rows[i] ).arg( to ) );
     int t = to;
     // moveCategory first removes and then inserts
-    if ( rows[i] < t ) t--;
+    if ( rows[i] < t )
+      t--;
     mRenderer->moveClass( rows[i], t );
     // current moved under another, shift its index up
     for ( int j = 0; j < i; j++ )
     {
-      if ( to < rows[j] && rows[i] > rows[j] ) rows[j] += 1;
+      if ( to < rows[j] && rows[i] > rows[j] )
+        rows[j] += 1;
     }
     // removed under 'to' so the target shifted down
-    if ( rows[i] < to ) to--;
+    if ( rows[i] < to )
+      to--;
   }
   emit dataChanged( createIndex( 0, 0 ), createIndex( mRenderer->ranges().size(), 0 ) );
   emit rowsMoved();
@@ -397,7 +406,8 @@ void QgsGraduatedSymbolRendererViewStyle::drawPrimitive( PrimitiveElement elemen
     opt.rect.setLeft( 0 );
     // draw always as line above, because we move item to that index
     opt.rect.setHeight( 0 );
-    if ( widget ) opt.rect.setRight( widget->width() );
+    if ( widget )
+      opt.rect.setRight( widget->width() );
     QProxyStyle::drawPrimitive( element, &opt, painter, widget );
     return;
   }
@@ -1206,7 +1216,8 @@ void QgsGraduatedSymbolRendererWidget::changeRange( int rangeIdx )
   // Add arbitrary 2 to number of decimal places to retain a bit extra.
   // Ensures users can see if legend is not completely honest!
   int decimalPlaces = mRenderer->classificationMethod()->labelPrecision() + 2;
-  if ( decimalPlaces < 0 ) decimalPlaces = 0;
+  if ( decimalPlaces < 0 )
+    decimalPlaces = 0;
   dialog.setLowerValue( QLocale().toString( range.lowerValue(), 'f', decimalPlaces ) );
   dialog.setUpperValue( QLocale().toString( range.upperValue(), 'f', decimalPlaces ) );
 

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -671,7 +671,8 @@ void QgsRuleBasedRendererWidget::countFeatures()
       const auto constFeatureRuleList = featureRuleList;
       for ( QgsRuleBasedRenderer::Rule *duplicateRule : constFeatureRuleList )
       {
-        if ( duplicateRule == rule ) continue;
+        if ( duplicateRule == rule )
+          continue;
         countMap[rule].duplicateCountMap[duplicateRule] += 1;
       }
     }

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -164,7 +164,8 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
     switch ( mLayer->fields().fieldOrigin( idx ) )
     {
       case QgsFields::OriginExpression:
-        if ( i == 7 ) continue;
+        if ( i == 7 )
+          continue;
         mFieldsList->item( row, i )->setBackground( expressionColor );
         break;
 

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -833,7 +833,8 @@ void QgsVectorLayerProperties::apply()
   if ( mSimplifyDrawingGroupBox->isChecked() )
   {
     simplifyHints |= QgsVectorSimplifyMethod::GeometrySimplification;
-    if ( mSimplifyDrawingSpinBox->value() > 1 ) simplifyHints |= QgsVectorSimplifyMethod::AntialiasingSimplification;
+    if ( mSimplifyDrawingSpinBox->value() > 1 )
+      simplifyHints |= QgsVectorSimplifyMethod::AntialiasingSimplification;
   }
   QgsVectorSimplifyMethod simplifyMethod = mLayer->simplifyMethod();
   simplifyMethod.setSimplifyHints( simplifyHints );

--- a/src/plugins/grass/qgsgrassmoduleoptions.cpp
+++ b/src/plugins/grass/qgsgrassmoduleoptions.cpp
@@ -798,7 +798,8 @@ bool QgsGrassModuleStandardOptions::requestsRegion()
 {
   QgsDebugMsgLevel( "called.", 4 );
 
-  if ( mDirect ) return true;
+  if ( mDirect )
+    return true;
 
   for ( int i = 0; i < mParams.size(); i++ )
   {

--- a/src/plugins/grass/qgsgrassmoduleparam.cpp
+++ b/src/plugins/grass/qgsgrassmoduleparam.cpp
@@ -870,7 +870,8 @@ void QgsGrassModuleGdalInput::updateQgisLayers()
 
   for ( QgsMapLayer *layer : QgsProject::instance()->mapLayers().values() )
   {
-    if ( !layer ) continue;
+    if ( !layer )
+      continue;
 
     if ( mType == Ogr && layer->type() == QgsMapLayerType::VectorLayer )
     {

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -52,7 +52,8 @@ QVariant DockModel::headerData( int section, Qt::Orientation orientation, int ro
       return mHeader[section];
     }
   }
-  else return QVariant();
+  else
+    return QVariant();
 }
 
 QVariant DockModel::data( const QModelIndex &index, int role ) const

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -39,7 +39,8 @@ QgsDelimitedTextFile::QgsDelimitedTextFile( const QString &url )
   mDefaultFieldRegexp.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
   // The default type is CSV
   setTypeCSV();
-  if ( ! url.isNull() ) setFromUrl( url );
+  if ( ! url.isNull() )
+    setFromUrl( url );
 
   // For tests
   const QString bufferSizeStr( getenv( "QGIS_DELIMITED_TEXT_FILE_BUFFER_SIZE" ) );
@@ -269,9 +270,12 @@ QUrl QgsDelimitedTextFile::url()
   }
   if ( mType == DelimTypeCSV )
   {
-    if ( mDelimChars != QLatin1String( "," ) ) query.addQueryItem( QStringLiteral( "delimiter" ), encodeChars( mDelimChars ) );
-    if ( mQuoteChar != QLatin1String( "\"" ) ) query.addQueryItem( QStringLiteral( "quote" ), encodeChars( mQuoteChar ) );
-    if ( mEscapeChar != QLatin1String( "\"" ) ) query.addQueryItem( QStringLiteral( "escape" ), encodeChars( mEscapeChar ) );
+    if ( mDelimChars != QLatin1String( "," ) )
+      query.addQueryItem( QStringLiteral( "delimiter" ), encodeChars( mDelimChars ) );
+    if ( mQuoteChar != QLatin1String( "\"" ) )
+      query.addQueryItem( QStringLiteral( "quote" ), encodeChars( mQuoteChar ) );
+    if ( mEscapeChar != QLatin1String( "\"" ) )
+      query.addQueryItem( QStringLiteral( "escape" ), encodeChars( mEscapeChar ) );
   }
   if ( mSkipLines > 0 )
   {
@@ -317,9 +321,12 @@ void QgsDelimitedTextFile::setUseWatcher( bool useWatcher )
 
 QString QgsDelimitedTextFile::type()
 {
-  if ( mType == DelimTypeWhitespace ) return QStringLiteral( "whitespace" );
-  if ( mType == DelimTypeCSV ) return QStringLiteral( "csv" );
-  if ( mType == DelimTypeRegexp ) return QStringLiteral( "regexp" );
+  if ( mType == DelimTypeWhitespace )
+    return QStringLiteral( "whitespace" );
+  if ( mType == DelimTypeCSV )
+    return QStringLiteral( "csv" );
+  if ( mType == DelimTypeRegexp )
+    return QStringLiteral( "regexp" );
   return QStringLiteral( "csv" );
 }
 
@@ -416,7 +423,8 @@ void QgsDelimitedTextFile::setFieldNames( const QStringList &names )
     bool nameOk = true;
     const int fieldNo = mFieldNames.size() + 1;
     name = name.trimmed();
-    if ( name.length() > mMaxNameLength ) name = name.mid( 0, mMaxNameLength );
+    if ( name.length() > mMaxNameLength )
+      name = name.mid( 0, mMaxNameLength );
 
     // If the name is empty then reset it to default name
     if ( name.length() == 0 )
@@ -446,9 +454,11 @@ void QgsDelimitedTextFile::setFieldNames( const QStringList &names )
         suffix++;
         name = basename.arg( suffix );
         // Not OK if it is already in the name list
-        if ( mFieldNames.contains( name, Qt::CaseInsensitive ) ) continue;
+        if ( mFieldNames.contains( name, Qt::CaseInsensitive ) )
+          continue;
         // Not OK if it is already in proposed names
-        if ( names.contains( name, Qt::CaseInsensitive ) ) continue;
+        if ( names.contains( name, Qt::CaseInsensitive ) )
+          continue;
         break;
       }
     }
@@ -461,7 +471,8 @@ QStringList &QgsDelimitedTextFile::fieldNames()
 {
   // If not yet opened then reset file to read column headers
   //
-  if ( mUseHeader && ! mFile ) reset();
+  if ( mUseHeader && ! mFile )
+    reset();
   // If have read more fields than field names, then append field names
   // to match the field count (will only happen if parsed some records)
   if ( mMaxFieldCount > mFieldNames.size() )
@@ -478,7 +489,8 @@ int QgsDelimitedTextFile::fieldIndex( const QString &name )
 {
   // If not yet opened then reset file to read column headers
   //
-  if ( mUseHeader && ! mFile ) reset();
+  if ( mUseHeader && ! mFile )
+    reset();
   // Try to determine the field based on a default field name, includes
   // Field_### and simple integer fields.
   if ( const QRegularExpressionMatch match = mDefaultFieldRegexp.match( name ); match.capturedStart() == 0 )
@@ -487,7 +499,8 @@ int QgsDelimitedTextFile::fieldIndex( const QString &name )
   }
   for ( int i = 0; i < mFieldNames.size(); i++ )
   {
-    if ( mFieldNames[i].compare( name, Qt::CaseInsensitive ) == 0 ) return i;
+    if ( mFieldNames[i].compare( name, Qt::CaseInsensitive ) == 0 )
+      return i;
   }
   return -1;
 
@@ -495,10 +508,12 @@ int QgsDelimitedTextFile::fieldIndex( const QString &name )
 
 bool QgsDelimitedTextFile::setNextRecordId( long nextRecordId )
 {
-  if ( ! mFile ) reset();
+  if ( ! mFile )
+    reset();
 
   mHoldCurrentRecord = nextRecordId == mRecordLineNumber;
-  if ( mHoldCurrentRecord ) return true;
+  if ( mHoldCurrentRecord )
+    return true;
   return setNextLineNumber( nextRecordId );
 }
 
@@ -520,14 +535,16 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::nextRecord( QStringList &reco
     // Find the first non-blank line to read
     QString buffer;
     status = nextLine( buffer, true );
-    if ( status != RecordOk ) return RecordEOF;
+    if ( status != RecordOk )
+      return RecordEOF;
 
     mCurrentRecord.clear();
     mRecordLineNumber = mLineNumber;
     if ( mRecordNumber >= 0 )
     {
       mRecordNumber++;
-      if ( mRecordNumber > mMaxRecordNumber ) mMaxRecordNumber = mRecordNumber;
+      if ( mRecordNumber > mMaxRecordNumber )
+        mMaxRecordNumber = mRecordNumber;
     }
     status = ( this->*mParser )( buffer, mCurrentRecord );
   }
@@ -541,7 +558,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::nextRecord( QStringList &reco
 QgsDelimitedTextFile::Status  QgsDelimitedTextFile::reset()
 {
   // Make sure the file is valid open
-  if ( ! isValid() || ! open() ) return InvalidDefinition;
+  if ( ! isValid() || ! open() )
+    return InvalidDefinition;
 
   // Reset the file pointer
   mFile->seek( 0 );
@@ -555,7 +573,8 @@ QgsDelimitedTextFile::Status  QgsDelimitedTextFile::reset()
   for ( int i = mSkipLines; i-- > 0; )
   {
     QString ignoredContent;
-    if ( nextLine( ignoredContent ) == RecordEOF ) return RecordEOF;
+    if ( nextLine( ignoredContent ) == RecordEOF )
+      return RecordEOF;
   }
   // Read the column names
   Status result = RecordOk;
@@ -565,7 +584,8 @@ QgsDelimitedTextFile::Status  QgsDelimitedTextFile::reset()
     result = nextRecord( names );
     setFieldNames( names );
   }
-  if ( result == RecordOk ) mRecordNumber = 0;
+  if ( result == RecordOk )
+    mRecordNumber = 0;
   return result;
 }
 
@@ -574,7 +594,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::nextLine( QString &buffer, bo
   if ( ! mFile )
   {
     const Status status = reset();
-    if ( status != RecordOk ) return status;
+    if ( status != RecordOk )
+      return status;
   }
   if ( mLineNumber == 0 )
   {
@@ -665,7 +686,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::nextLine( QString &buffer, bo
       }
     }
     mLineNumber++;
-    if ( skipBlank && buffer.isEmpty() ) continue;
+    if ( skipBlank && buffer.isEmpty() )
+      continue;
     return RecordOk;
   }
 
@@ -675,7 +697,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::nextLine( QString &buffer, bo
 
 bool QgsDelimitedTextFile::setNextLineNumber( long nextLineNumber )
 {
-  if ( ! mFile ) return false;
+  if ( ! mFile )
+    return false;
   if ( mLineNumber > nextLineNumber - 1 )
   {
     mRecordNumber = -1;
@@ -685,7 +708,8 @@ bool QgsDelimitedTextFile::setNextLineNumber( long nextLineNumber )
   QString buffer;
   while ( mLineNumber < nextLineNumber - 1 )
   {
-    if ( nextLine( buffer, false ) != RecordOk ) return false;
+    if ( nextLine( buffer, false ) != RecordOk )
+      return false;
   }
   return true;
 
@@ -693,15 +717,18 @@ bool QgsDelimitedTextFile::setNextLineNumber( long nextLineNumber )
 
 void QgsDelimitedTextFile::appendField( QStringList &record, QString field, bool quoted )
 {
-  if ( mMaxFields > 0 && record.size() >= mMaxFields ) return;
+  if ( mMaxFields > 0 && record.size() >= mMaxFields )
+    return;
   if ( quoted )
   {
     record.append( field );
   }
   else
   {
-    if ( mTrimFields ) field = field.trimmed();
-    if ( !( mDiscardEmptyFields && field.isEmpty() ) ) record.append( field );
+    if ( mTrimFields )
+      field = field.trimmed();
+    if ( !( mDiscardEmptyFields && field.isEmpty() ) )
+      record.append( field );
   }
   // Keep track of maximum number of non-empty fields in a record
   if ( record.size() > mMaxFieldCount && ! field.isEmpty() )
@@ -767,7 +794,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::parseRegexp( QString &buffer,
     pos = matchPos + matchLen;
 
     // Quit loop if we have enough fields.
-    if ( mMaxFields > 0 && fields.size() >= mMaxFields ) break;
+    if ( mMaxFields > 0 && fields.size() >= mMaxFields )
+      break;
   }
   return RecordOk;
 }
@@ -833,7 +861,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::parseQuoted( QString &buffer,
       const bool isQuoteChar = mQuoteChar.contains( c );
       isQuote = quoted ? c == quoteChar : isQuoteChar;
       isEscape = mEscapeChar.contains( c );
-      if ( isQuoteChar && isEscape ) isEscape = isQuote;
+      if ( isQuoteChar && isEscape )
+        isEscape = isQuote;
     }
 
     // Start or end of quote ...
@@ -895,7 +924,8 @@ QgsDelimitedTextFile::Status QgsDelimitedTextFile::parseQuoted( QString &buffer,
     // after the end..
     else if ( c.isSpace() )
     {
-      if ( ! ended ) field.append( c );
+      if ( ! ended )
+        field.append( c );
     }
     // Other chars permitted if not after quoted field
     else

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -91,10 +91,14 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
   if ( query.hasQueryItem( QStringLiteral( "geomType" ) ) )
   {
     const QString gtype = query.queryItemValue( QStringLiteral( "geomType" ) ).toLower();
-    if ( gtype == QLatin1String( "point" ) ) mGeometryType = QgsWkbTypes::PointGeometry;
-    else if ( gtype == QLatin1String( "line" ) ) mGeometryType = QgsWkbTypes::LineGeometry;
-    else if ( gtype == QLatin1String( "polygon" ) ) mGeometryType = QgsWkbTypes::PolygonGeometry;
-    else if ( gtype == QLatin1String( "none " ) ) mGeometryType = QgsWkbTypes::NullGeometry;
+    if ( gtype == QLatin1String( "point" ) )
+      mGeometryType = QgsWkbTypes::PointGeometry;
+    else if ( gtype == QLatin1String( "line" ) )
+      mGeometryType = QgsWkbTypes::LineGeometry;
+    else if ( gtype == QLatin1String( "polygon" ) )
+      mGeometryType = QgsWkbTypes::PolygonGeometry;
+    else if ( gtype == QLatin1String( "none " ) )
+      mGeometryType = QgsWkbTypes::NullGeometry;
   }
 
   if ( mGeometryType != QgsWkbTypes::NullGeometry )
@@ -158,7 +162,8 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
     QgsDebugMsgLevel( "subset is: " + subset, 2 );
   }
 
-  if ( query.hasQueryItem( QStringLiteral( "quiet" ) ) ) mShowInvalidLines = false;
+  if ( query.hasQueryItem( QStringLiteral( "quiet" ) ) )
+    mShowInvalidLines = false;
 
   // Parse and store user-defined field types and boolean literals
   const QList<QPair<QString, QString> > queryItems { query.queryItems( QUrl::ComponentFormattingOption::FullyDecoded ) };
@@ -211,10 +216,13 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   // Look for a file with the same name as the data file, but an extra 't' or 'T' at the end
   QStringList types;
   QFileInfo csvtInfo( filename + 't' );
-  if ( ! csvtInfo.exists() ) csvtInfo.setFile( filename + 'T' );
-  if ( ! csvtInfo.exists() ) return types;
+  if ( ! csvtInfo.exists() )
+    csvtInfo.setFile( filename + 'T' );
+  if ( ! csvtInfo.exists() )
+    return types;
   QFile csvtFile( csvtInfo.filePath() );
-  if ( ! csvtFile.open( QIODevice::ReadOnly ) ) return types;
+  if ( ! csvtFile.open( QIODevice::ReadOnly ) )
+    return types;
 
 
   // If anything goes wrong here, just ignore it, as the file
@@ -228,11 +236,13 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   {
     QTextStream csvtStream( &csvtFile );
     strTypeList = csvtStream.readLine();
-    if ( strTypeList.isEmpty() ) return types;
+    if ( strTypeList.isEmpty() )
+      return types;
     QString extra = csvtStream.readLine();
     while ( ! extra.isNull() )
     {
-      if ( ! extra.isEmpty() ) return types;
+      if ( ! extra.isEmpty() )
+        return types;
       extra = csvtStream.readLine();
     }
   }
@@ -253,7 +263,10 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString &filenam
   if ( !match.hasMatch() )
   {
     // Looks like this was supposed to be a CSVT file, so report bad formatted string
-    if ( message ) { *message = tr( "File type string in %1 is not correctly formatted" ).arg( csvtInfo.fileName() ); }
+    if ( message )
+    {
+      *message = tr( "File type string in %1 is not correctly formatted" ).arg( csvtInfo.fileName() );
+    }
     return types;
   }
 

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -214,7 +214,8 @@ void QgsDelimitedTextSourceSelect::loadSettings( const QString &subkey, bool loa
   // at startup, fetch the last used delimiter and directory from
   // settings
   QString key = mSettingsKey;
-  if ( ! subkey.isEmpty() ) key.append( '/' ).append( subkey );
+  if ( ! subkey.isEmpty() )
+    key.append( '/' ).append( subkey );
 
   // and how to use the delimiter
   const QString delimiterType = settings.value( key + "/delimiterType", "" ).toString();
@@ -233,15 +234,18 @@ void QgsDelimitedTextSourceSelect::loadSettings( const QString &subkey, bool loa
   swFileFormat->setCurrentIndex( bgFileFormat->checkedId() );
 
   const QString encoding = settings.value( key + "/encoding", "" ).toString();
-  if ( ! encoding.isEmpty() ) cmbEncoding->setCurrentIndex( cmbEncoding->findText( encoding ) );
+  if ( ! encoding.isEmpty() )
+    cmbEncoding->setCurrentIndex( cmbEncoding->findText( encoding ) );
   const QString delimiters = settings.value( key + "/delimiters", "" ).toString();
-  if ( ! delimiters.isEmpty() ) setSelectedChars( delimiters );
+  if ( ! delimiters.isEmpty() )
+    setSelectedChars( delimiters );
 
   txtQuoteChars->setText( settings.value( key + "/quoteChars", "\"" ).toString() );
   txtEscapeChars->setText( settings.value( key + "/escapeChars", "\"" ).toString() );
 
   const QString regexp = settings.value( key + "/delimiterRegexp", "" ).toString();
-  if ( ! regexp.isEmpty() ) txtDelimiterRegexp->setText( regexp );
+  if ( ! regexp.isEmpty() )
+    txtDelimiterRegexp->setText( regexp );
 
   rowCounter->setValue( settings.value( key + "/startFrom", 0 ).toInt() );
   cbxUseHeader->setChecked( settings.value( key + "/useHeader", "true" ) != "false" );
@@ -258,9 +262,12 @@ void QgsDelimitedTextSourceSelect::loadSettings( const QString &subkey, bool loa
   if ( loadGeomSettings )
   {
     const QString geomColumnType = settings.value( key + "/geomColumnType", "xy" ).toString();
-    if ( geomColumnType == QLatin1String( "xy" ) ) geomTypeXY->setChecked( true );
-    else if ( geomColumnType == QLatin1String( "wkt" ) ) geomTypeWKT->setChecked( true );
-    else geomTypeNone->setChecked( true );
+    if ( geomColumnType == QLatin1String( "xy" ) )
+      geomTypeXY->setChecked( true );
+    else if ( geomColumnType == QLatin1String( "wkt" ) )
+      geomTypeWKT->setChecked( true );
+    else
+      geomTypeNone->setChecked( true );
     cbxXyDms->setChecked( settings.value( key + "/xyDms", "false" ) == "true" );
     swGeomType->setCurrentIndex( bgGeomType->checkedId() );
     const QString authid = settings.value( key + "/crs", "" ).toString();
@@ -277,7 +284,8 @@ void QgsDelimitedTextSourceSelect::saveSettings( const QString &subkey, bool sav
 {
   QgsSettings settings;
   QString key = mSettingsKey;
-  if ( ! subkey.isEmpty() ) key.append( '/' ).append( subkey );
+  if ( ! subkey.isEmpty() )
+    key.append( '/' ).append( subkey );
   settings.setValue( key + "/encoding", cmbEncoding->currentText() );
   settings.setValue( key + "/geometry", saveGeometry() );
 
@@ -305,8 +313,10 @@ void QgsDelimitedTextSourceSelect::saveSettings( const QString &subkey, bool sav
   if ( saveGeomSettings )
   {
     QString geomColumnType = QStringLiteral( "none" );
-    if ( geomTypeXY->isChecked() ) geomColumnType = QStringLiteral( "xy" );
-    if ( geomTypeWKT->isChecked() ) geomColumnType = QStringLiteral( "wkt" );
+    if ( geomTypeXY->isChecked() )
+      geomColumnType = QStringLiteral( "xy" );
+    if ( geomTypeWKT->isChecked() )
+      geomColumnType = QStringLiteral( "wkt" );
     settings.setValue( key + "/geomColumnType", geomColumnType );
     settings.setValue( key + "/xyDms", cbxXyDms->isChecked() ? "true" : "false" );
     if ( crsGeometry->crs().isValid() )
@@ -319,17 +329,20 @@ void QgsDelimitedTextSourceSelect::saveSettings( const QString &subkey, bool sav
 
 void QgsDelimitedTextSourceSelect::loadSettingsForFile( const QString &filename )
 {
-  if ( filename.isEmpty() ) return;
+  if ( filename.isEmpty() )
+    return;
   const QFileInfo fi( filename );
   const QString filetype = fi.suffix();
   // Don't expect to change settings if not changing file type
-  if ( filetype != mLastFileType ) loadSettings( fi.suffix(), true );
+  if ( filetype != mLastFileType )
+    loadSettings( fi.suffix(), true );
   mLastFileType = filetype;
 }
 
 void QgsDelimitedTextSourceSelect::saveSettingsForFile( const QString &filename )
 {
-  if ( filename.isEmpty() ) return;
+  if ( filename.isEmpty() )
+    return;
   const QFileInfo fi( filename );
   saveSettings( fi.suffix(), true );
 }
@@ -408,15 +421,21 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
   while ( counter < mExampleRowCount )
   {
     const QgsDelimitedTextFile::Status status = mFile->nextRecord( values );
-    if ( status == QgsDelimitedTextFile::RecordEOF ) break;
-    if ( status != QgsDelimitedTextFile::RecordOk ) { mBadRowCount++; continue; }
+    if ( status == QgsDelimitedTextFile::RecordEOF )
+      break;
+    if ( status != QgsDelimitedTextFile::RecordOk )
+    {
+      mBadRowCount++;
+      continue;
+    }
     counter++;
 
 
     // Look at count of non-blank fields
 
     int nv = values.size();
-    while ( nv > 0 && values[nv - 1].isEmpty() ) nv--;
+    while ( nv > 0 && values[nv - 1].isEmpty() )
+      nv--;
 
     if ( isEmpty.size() < nv )
     {
@@ -569,7 +588,8 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
   {
     const QString field = fieldList[i];
     // skip empty field names
-    if ( field.isEmpty() ) continue;
+    if ( field.isEmpty() )
+      continue;
     cmbXField->addItem( field );
     cmbYField->addItem( field );
     cmbZField->addItem( field );
@@ -601,7 +621,8 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
   {
     for ( int i = 0; i < fieldList.size(); i++ )
     {
-      if ( ! isValidWkt[i] ) continue;
+      if ( ! isValidWkt[i] )
+        continue;
       const int index = cmbWktField->findText( fieldList[i] );
       if ( index >= 0 )
       {
@@ -638,7 +659,8 @@ void QgsDelimitedTextSourceSelect::updateFieldLists()
 bool QgsDelimitedTextSourceSelect::trySetXYField( QStringList &fields, QList<bool> &isValidNumber, const QString &xname, const QString &yname )
 {
   // If fields already set, then nothing to do
-  if ( cmbXField->currentIndex() >= 0 && cmbYField->currentIndex() >= 0 ) return true;
+  if ( cmbXField->currentIndex() >= 0 && cmbYField->currentIndex() >= 0 )
+    return true;
 
   // Try and find a valid field name matching the x field
   int indexX = -1;
@@ -648,10 +670,13 @@ bool QgsDelimitedTextSourceSelect::trySetXYField( QStringList &fields, QList<boo
   {
     // Only interested in number fields containing the xname string
     // that are in the X combo box
-    if ( ! isValidNumber[i] ) continue;
-    if ( ! fields[i].contains( xname, Qt::CaseInsensitive ) ) continue;
+    if ( ! isValidNumber[i] )
+      continue;
+    if ( ! fields[i].contains( xname, Qt::CaseInsensitive ) )
+      continue;
     indexX = cmbXField->findText( fields[i] );
-    if ( indexX < 0 ) continue;
+    if ( indexX < 0 )
+      continue;
 
     // Now look for potential y fields, like xname with x replaced with y
     const QString xfield( fields[i] );
@@ -659,23 +684,29 @@ bool QgsDelimitedTextSourceSelect::trySetXYField( QStringList &fields, QList<boo
     while ( true )
     {
       const int pos = xfield.indexOf( xname, from, Qt::CaseInsensitive );
-      if ( pos < 0 ) break;
+      if ( pos < 0 )
+        break;
       from = pos + 1;
       const QString yfield = xfield.mid( 0, pos ) + yname + xfield.mid( pos + xname.size() );
-      if ( ! fields.contains( yfield, Qt::CaseInsensitive ) ) continue;
+      if ( ! fields.contains( yfield, Qt::CaseInsensitive ) )
+        continue;
       for ( int iy = 0; iy < fields.size(); iy++ )
       {
-        if ( ! isValidNumber[iy] ) continue;
-        if ( iy == i ) continue;
+        if ( ! isValidNumber[iy] )
+          continue;
+        if ( iy == i )
+          continue;
         if ( fields[iy].compare( yfield, Qt::CaseInsensitive ) == 0 )
         {
           indexY = cmbYField->findText( fields[iy] );
           break;
         }
       }
-      if ( indexY >= 0 ) break;
+      if ( indexY >= 0 )
+        break;
     }
-    if ( indexY >= 0 ) break;
+    if ( indexY >= 0 )
+      break;
   }
   if ( indexY >= 0 )
   {

--- a/src/providers/grass/qgis.g.info.c
+++ b/src/providers/grass/qgis.g.info.c
@@ -320,8 +320,10 @@ int main( int argc, char **argv )
           }
           if ( ! Rast_is_null_value( ptr, rast_type ) )
           {
-            if ( val < min ) min = val;
-            if ( val > max ) max = val;
+            if ( val < min )
+              min = val;
+            if ( val > max )
+              max = val;
             sum += val;
             count++;
             squares_sum += val * val;

--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -541,7 +541,8 @@ bool QgsGrassFeatureIterator::fetchFeature( QgsFeature &feature )
       {
         int line = Vect_get_node_line( mSource->map(), lid, i );
         QgsDebugMsg( "cancel" );
-        if ( i > 0 ) lines += QLatin1Char( ',' );
+        if ( i > 0 )
+          lines += QLatin1Char( ',' );
         lines += QString::number( line );
       }
       feature.setAttribute( 1, lines );

--- a/src/providers/grass/qgsgrassgislib.cpp
+++ b/src/providers/grass/qgsgrassgislib.cpp
@@ -457,7 +457,8 @@ QgsGrassGisLib::Raster QgsGrassGisLib::raster( QString name )
 
   for ( Raster raster : mRasters )
   {
-    if ( raster.name == name ) return raster;
+    if ( raster.name == name )
+      return raster;
   }
 
   QString providerKey;
@@ -596,7 +597,8 @@ int QgsGrassGisLib::G_open_raster_new( const char *name, RASTER_MAP_TYPE wr_type
   raster.provider = QgsRasterDataProvider::create( providerKey, dataSource, outputFormat, nBands, type, mColumns, mRows, geoTransform, mCrs );
   if ( !raster.provider || !raster.provider->isValid() )
   {
-    if ( raster.provider ) delete raster.provider;
+    if ( raster.provider )
+      delete raster.provider;
     fatal( "Cannot create output data source: " + dataSource );
   }
 
@@ -653,7 +655,8 @@ RASTER_MAP_TYPE GRASS_LIB_EXPORT G_get_raster_map_type( int fd )
 int GRASS_LIB_EXPORT G_raster_map_is_fp( const char *name, const char *mapset )
 {
   RASTER_MAP_TYPE type = QgsGrassGisLib::instance()->G_raster_map_type( name, mapset );
-  if ( type == FCELL_TYPE || type == DCELL_TYPE ) return 1;
+  if ( type == FCELL_TYPE || type == DCELL_TYPE )
+    return 1;
   return 0;
 }
 
@@ -766,7 +769,8 @@ int QgsGrassGisLib::readRasterRow( int fd, void *buf, int row, RASTER_MAP_TYPE d
   // TODO: use cached block with more rows
   Raster raster = mRasters.value( fd );
   //if ( !raster.provider ) return -1;
-  if ( !raster.input ) return -1;
+  if ( !raster.input )
+    return -1;
 
   // Create extent for current row
   QgsRectangle blockRect = mExtent;
@@ -779,7 +783,8 @@ int QgsGrassGisLib::readRasterRow( int fd, void *buf, int row, RASTER_MAP_TYPE d
   blockRect.setYMinimum( yMax - yRes );
 
   QgsRasterBlock *block = raster.input->block( raster.band, blockRect, mColumns, 1 );
-  if ( !block ) return -1;
+  if ( !block )
+    return -1;
 
   Qgis::DataType requestedType = qgisRasterType( data_type );
 
@@ -1103,8 +1108,10 @@ double GRASS_LIB_EXPORT G_database_units_to_meters_factor( void )
 
 int QgsGrassGisLib::beginCalculations( void )
 {
-  if ( !mCrs.isValid() ) return 0;
-  if ( !mCrs.isGeographic() ) return 1; // planimetric
+  if ( !mCrs.isValid() )
+    return 0;
+  if ( !mCrs.isGeographic() )
+    return 1; // planimetric
   return 2; // non-planimetric
 }
 

--- a/src/providers/grass/qgsgrassoptions.cpp
+++ b/src/providers/grass/qgsgrassoptions.cpp
@@ -98,7 +98,8 @@ void QgsGrassOptions::mGisbaseBrowseButton_clicked()
   gisbase = QFileDialog::getExistingDirectory(
               nullptr, QObject::tr( "Choose GRASS installation path (GISBASE)" ), gisbase,
               QFileDialog::DontUseNativeDialog );
-  if ( !gisbase.isEmpty() )gisbaseChanged();
+  if ( !gisbase.isEmpty() )
+    gisbaseChanged();
   {
     mGisbaseLineEdit->setText( gisbase );
   }

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -684,7 +684,8 @@ double QgsGrassRasterValue::value( double x, double y, bool *ok )
   QStringList list = str.trimmed().split( ':' );
   if ( list.size() == 2 )
   {
-    if ( list[1] == QLatin1String( "error" ) ) return value;
+    if ( list[1] == QLatin1String( "error" ) )
+      return value;
     value = list[1].toDouble( ok );
   }
   return value;

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -614,8 +614,10 @@ void QgsMdalProvider::fileMeshFilters( QString &fileMeshFiltersString, QString &
   fileMeshDatasetFiltersString.prepend( QObject::tr( "All files" ) + " (*);;" );
 
   // cleanup
-  if ( fileMeshFiltersString.endsWith( QLatin1String( ";;" ) ) ) fileMeshFiltersString.chop( 2 );
-  if ( fileMeshDatasetFiltersString.endsWith( QLatin1String( ";;" ) ) ) fileMeshDatasetFiltersString.chop( 2 );
+  if ( fileMeshFiltersString.endsWith( QLatin1String( ";;" ) ) )
+    fileMeshFiltersString.chop( 2 );
+  if ( fileMeshDatasetFiltersString.endsWith( QLatin1String( ";;" ) ) )
+    fileMeshDatasetFiltersString.chop( 2 );
 
   QgsDebugMsgLevel( "Mesh filter list built: " + fileMeshFiltersString, 2 );
   QgsDebugMsgLevel( "Mesh dataset filter list built: " + fileMeshDatasetFiltersString, 2 );

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -3097,7 +3097,8 @@ QString QgsMssqlProvider::whereClauseFid( QgsFeatureId featureId )
 /* static */
 QStringList QgsMssqlProvider::parseUriKey( const QString &key )
 {
-  if ( key.isEmpty() ) return QStringList();
+  if ( key.isEmpty() )
+    return QStringList();
 
   QStringList cols;
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -94,7 +94,8 @@ struct QgsPostgresLayerProperty
   QString defaultName() const
   {
     QString n = tableName;
-    if ( nSpCols > 1 ) n += '.' + geometryColName;
+    if ( nSpCols > 1 )
+      n += '.' + geometryColName;
     return n;
   }
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -516,7 +516,8 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
   QString whereClause;
 
   QString aliased;
-  if ( alias ) aliased = QStringLiteral( "%1." ).arg( alias );
+  if ( alias )
+    aliased = QStringLiteral( "%1." ).arg( alias );
 
   switch ( mPrimaryKeyType )
   {
@@ -1416,7 +1417,8 @@ void QgsPostgresProvider::setEditorWidgets()
   QgsPostgresResult result( connectionRO()->PQexec( sql ) );
   for ( int i = 0; i < result.PQntuples(); ++i )
   {
-    if ( result.PQgetisnull( i, 2 ) ) continue; // config can be null and it's OK
+    if ( result.PQgetisnull( i, 2 ) )
+      continue; // config can be null and it's OK
 
     const QString &configTxt = result.PQgetvalue( i, 2 );
     const QString &type = result.PQgetvalue( i, 1 );
@@ -1814,7 +1816,8 @@ bool QgsPostgresProvider::determinePrimaryKey()
 /* static */
 QStringList QgsPostgresProvider::parseUriKey( const QString &key )
 {
-  if ( key.isEmpty() ) return QStringList();
+  if ( key.isEmpty() )
+    return QStringList();
 
   QStringList cols;
 
@@ -4081,7 +4084,8 @@ bool QgsPostgresProvider::getGeometryDetails()
         detectedType += QLatin1String( "ZM" );
 
       QString ds = result.PQgetvalue( 0, 1 );
-      if ( ds != QLatin1String( "0" ) ) detectedSrid = ds;
+      if ( ds != QLatin1String( "0" ) )
+        detectedSrid = ds;
       mSpatialColType = SctGeometry;
     }
     else
@@ -4104,9 +4108,11 @@ bool QgsPostgresProvider::getGeometryDetails()
       if ( result.PQntuples() == 1 )
       {
         QString dt = result.PQgetvalue( 0, 0 );
-        if ( dt != "GEOMETRY" ) detectedType = dt;
+        if ( dt != "GEOMETRY" )
+          detectedType = dt;
         QString ds = result.PQgetvalue( 0, 1 );
-        if ( ds != "0" ) detectedSrid = ds;
+        if ( ds != "0" )
+          detectedSrid = ds;
         mSpatialColType = SctGeography;
       }
       else
@@ -4386,7 +4392,8 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
     case QVariant::List:
     {
       QgsField sub( QString(), field.subType(), QString(), fieldSize, fieldPrec );
-      if ( !convertField( sub, nullptr ) ) return false;
+      if ( !convertField( sub, nullptr ) )
+        return false;
       fieldType = "_" + sub.typeName();
       fieldPrec = 0;
       break;
@@ -4567,7 +4574,8 @@ Qgis::VectorExportResult QgsPostgresProvider::createEmptyLayer( const QString &u
           }
         }
       }
-      if ( type.isEmpty() ) type = QStringLiteral( "serial" );
+      if ( type.isEmpty() )
+        type = QStringLiteral( "serial" );
       else
       {
         // if the pk field's type is one of the postgres integer types,
@@ -4981,8 +4989,10 @@ QVariant QgsPostgresProvider::parseMultidimensionalArray( const QString &txt )
     {
       ++i;
 
-      if ( text.at( i ) == '}' && !escaped ) openedBrackets--;
-      else if ( text.at( i ) == '{' && !escaped ) openedBrackets++;
+      if ( text.at( i ) == '}' && !escaped )
+        openedBrackets--;
+      else if ( text.at( i ) == '{' && !escaped )
+        openedBrackets++;
 
       escaped = !escaped ? text.at( i ) == '\\' : false;
     }

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -1892,7 +1892,8 @@ bool QgsPostgresRasterProvider::loadFields()
 /* static */
 QStringList QgsPostgresRasterProvider::parseUriKey( const QString &key )
 {
-  if ( key.isEmpty() ) return QStringList();
+  if ( key.isEmpty() )
+    return QStringList();
 
   QStringList cols;
 

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -106,7 +106,8 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
       QgsField subField = field;
       subField.setType( field.subType() );
       subField.setSubType( QVariant::Invalid );
-      if ( !convertField( subField ) ) return false;
+      if ( !convertField( subField ) )
+        return false;
       fieldType = QgsSpatiaLiteConnection::SPATIALITE_ARRAY_PREFIX + subField.typeName() + QgsSpatiaLiteConnection::SPATIALITE_ARRAY_SUFFIX;
       fieldSize = subField.length();
       fieldPrec = subField.precision();

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -326,7 +326,8 @@ bool QgsWcsCapabilities::describeCoverage( QString const &identifier, bool force
     return false;
   }
 
-  if ( coverage->described && ! forceRefresh ) return true;
+  if ( coverage->described && ! forceRefresh )
+    return true;
 
   QString url = getDescribeCoverageUrl( coverage->identifier );
 
@@ -472,7 +473,8 @@ bool QgsWcsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWcsCapa
   }
 #endif
 
-  if ( ! convertToDom( xml ) ) return false;
+  if ( ! convertToDom( xml ) )
+    return false;
 
   QDomElement documentElement = mCapabilitiesDom.documentElement();
 
@@ -587,7 +589,8 @@ QList<QDomElement> QgsWcsCapabilities::domElements( const QDomElement &element, 
   QList<QDomElement> list;
 
   QStringList names = path.split( '.' );
-  if ( names.isEmpty() ) return list;
+  if ( names.isEmpty() )
+    return list;
   QString name = names.value( 0 );
   names.removeFirst();
 
@@ -632,7 +635,8 @@ QStringList QgsWcsCapabilities::domElementsTexts( const QDomElement &element, co
 QDomElement QgsWcsCapabilities::domElement( const QDomElement &element, const QString &path )
 {
   QStringList names = path.split( '.' );
-  if ( names.isEmpty() ) return QDomElement();
+  if ( names.isEmpty() )
+    return QDomElement();
 
   QDomElement firstChildElement = firstChild( element, names.value( 0 ) );
   if ( names.size() == 1 || firstChildElement.isNull() )
@@ -819,7 +823,8 @@ bool QgsWcsCapabilities::convertToDom( QByteArray const &xml )
 bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsWcsCoverageSummary *coverage )
 {
   QgsDebugMsg( "coverage->identifier = " + coverage->identifier );
-  if ( ! convertToDom( xml ) ) return false;
+  if ( ! convertToDom( xml ) )
+    return false;
 
   QDomElement documentElement = mCapabilitiesDom.documentElement();
 
@@ -842,7 +847,8 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsW
 
   QDomElement coverageOfferingElement = firstChild( documentElement, QStringLiteral( "CoverageOffering" ) );
 
-  if ( coverageOfferingElement.isNull() ) return false;
+  if ( coverageOfferingElement.isNull() )
+    return false;
   QDomElement supportedCRSsElement = firstChild( coverageOfferingElement, QStringLiteral( "supportedCRSs" ) );
 
   // requestResponseCRSs and requestCRSs + responseCRSs are alternatives
@@ -999,7 +1005,8 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsW
 bool QgsWcsCapabilities::parseDescribeCoverageDom11( QByteArray const &xml, QgsWcsCoverageSummary *coverage )
 {
   QgsDebugMsg( "coverage->identifier = " + coverage->identifier );
-  if ( ! convertToDom( xml ) ) return false;
+  if ( ! convertToDom( xml ) )
+    return false;
 
   QDomElement documentElement = mCapabilitiesDom.documentElement();
 
@@ -1035,7 +1042,8 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom11( QByteArray const &xml, QgsW
     QList<double> low = parseDoubles( domElementText( el, QStringLiteral( "LowerCorner" ) ) );
     QList<double> high = parseDoubles( domElementText( el, QStringLiteral( "UpperCorner" ) ) );
 
-    if ( low.size() != 2 && high.size() != 2 ) continue;
+    if ( low.size() != 2 && high.size() != 2 )
+      continue;
 
     if ( el.attribute( QStringLiteral( "crs" ) ) == QLatin1String( "urn:ogc:def:crs:OGC::imageCRS" ) )
     {
@@ -1293,7 +1301,8 @@ void QgsWcsCapabilities::showMessageBox( const QString &title, const QString &te
 QgsWcsCoverageSummary QgsWcsCapabilities::coverage( QString const &identifier )
 {
   QgsWcsCoverageSummary *coverageSummaryPointer = coverageSummary( identifier );
-  if ( coverageSummaryPointer ) return *coverageSummaryPointer;
+  if ( coverageSummaryPointer )
+    return *coverageSummaryPointer;
 
   QgsWcsCoverageSummary coverageSummary;
   initCoverageSummary( coverageSummary );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -71,7 +71,8 @@ QgsWcsProvider::QgsWcsProvider( const QString &uri, const ProviderOptions &optio
   mValid = false;
   mCachedMemFilename = QStringLiteral( "/vsimem/qgis/wcs/%0.dat" ).arg( reinterpret_cast<std::uintptr_t>( this ) );
 
-  if ( !parseUri( uri ) ) return;
+  if ( !parseUri( uri ) )
+    return;
 
   // GetCapabilities and DescribeCoverage
   // TODO(?): do only DescribeCoverage to avoid one request
@@ -116,7 +117,8 @@ QgsWcsProvider::QgsWcsProvider( const QString &uri, const ProviderOptions &optio
   }
 
   // We cannot continue without format, it is required
-  if ( mFormat.isEmpty() ) return;
+  if ( mFormat.isEmpty() )
+    return;
 
   // It could happen (usually not with current QgsWCSSourceSelect if at least
   // one CRS is available) that crs is not set in uri, in that case we
@@ -341,11 +343,15 @@ QgsWcsProvider::QgsWcsProvider( const QString &uri, const ProviderOptions &optio
   if ( mHasSize )
   {
     // This is taken from GDAL, how they come to these numbers?
-    if ( mWidth > 1800 ) mXBlockSize = 1024;
-    else mXBlockSize = mWidth;
+    if ( mWidth > 1800 )
+      mXBlockSize = 1024;
+    else
+      mXBlockSize = mWidth;
 
-    if ( mHeight > 900 ) mYBlockSize = 512;
-    else mYBlockSize = mHeight;
+    if ( mHeight > 900 )
+      mYBlockSize = 512;
+    else
+      mYBlockSize = mHeight;
   }
 
   mValid = true;
@@ -684,7 +690,8 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const &viewExtent, int 
     }
   }
 
-  if ( mInvertAxisOrientation ) changeXY = !changeXY;
+  if ( mInvertAxisOrientation )
+    changeXY = !changeXY;
 
   const double xRes = viewExtent.width() / pixelWidth;
   const double yRes = viewExtent.height() / pixelHeight;
@@ -1369,7 +1376,8 @@ QString QgsWcsProvider::htmlMetadata()
   {
     metadata += coverageMetadata( c );
     count++;
-    if ( count >= 100 ) break;
+    if ( count >= 100 )
+      break;
   }
   metadata += QLatin1String( "</table>" );
   if ( count < mCapabilities.coverages().size() )
@@ -1650,7 +1658,8 @@ QMap<QString, QString> QgsWcsProvider::supportedMimes()
 
     const QString mimeType = GDALGetMetadataItem( driver, "DMD_MIMETYPE", "" );
 
-    if ( mimeType.isEmpty() ) continue;
+    if ( mimeType.isEmpty() )
+      continue;
 
     desc = desc.isEmpty() ? mimeType : desc;
 

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -104,7 +104,8 @@ void QgsWCSSourceSelect::populateLayerList()
 QString QgsWCSSourceSelect::selectedIdentifier()
 {
   const QList<QTreeWidgetItem *> selectionList = mLayersTreeWidget->selectedItems();
-  if ( selectionList.size() < 1 ) return QString(); // should not happen
+  if ( selectionList.size() < 1 )
+    return QString(); // should not happen
   QString identifier = selectionList.value( 0 )->data( 0, Qt::UserRole + 0 ).toString();
   QgsDebugMsg( " identifier = " + identifier );
   return identifier;
@@ -115,7 +116,10 @@ void QgsWCSSourceSelect::addButtonClicked()
   QgsDataSourceUri uri = mUri;
 
   const QString identifier = selectedIdentifier();
-  if ( identifier.isEmpty() ) { return; }
+  if ( identifier.isEmpty() )
+  {
+    return;
+  }
 
   uri.setParam( QStringLiteral( "identifier" ), identifier );
 
@@ -154,7 +158,10 @@ void QgsWCSSourceSelect::mLayersTreeWidget_itemSelectionChanged()
 {
 
   const QString identifier = selectedIdentifier();
-  if ( identifier.isEmpty() ) { return; }
+  if ( identifier.isEmpty() )
+  {
+    return;
+  }
 
   mCapabilities.describeCoverage( identifier );
 
@@ -214,10 +221,16 @@ QStringList QgsWCSSourceSelect::selectedLayersFormats()
 {
 
   const QString identifier = selectedIdentifier();
-  if ( identifier.isEmpty() ) { return QStringList(); }
+  if ( identifier.isEmpty() )
+  {
+    return QStringList();
+  }
 
   const QgsWcsCoverageSummary c = mCapabilities.coverage( identifier );
-  if ( !c.valid ) { return QStringList(); }
+  if ( !c.valid )
+  {
+    return QStringList();
+  }
 
   QgsDebugMsg( "supportedFormat = " + c.supportedFormat.join( "," ) );
   return c.supportedFormat;
@@ -226,10 +239,16 @@ QStringList QgsWCSSourceSelect::selectedLayersFormats()
 QStringList QgsWCSSourceSelect::selectedLayersCrses()
 {
   const QString identifier = selectedIdentifier();
-  if ( identifier.isEmpty() ) { return QStringList(); }
+  if ( identifier.isEmpty() )
+  {
+    return QStringList();
+  }
 
   const QgsWcsCoverageSummary c = mCapabilities.coverage( identifier );
-  if ( !c.valid ) { return QStringList(); }
+  if ( !c.valid )
+  {
+    return QStringList();
+  }
 
   return c.supportedCrs;
 }
@@ -238,10 +257,16 @@ QStringList QgsWCSSourceSelect::selectedLayersTimes()
 {
 
   const QString identifier = selectedIdentifier();
-  if ( identifier.isEmpty() ) { return QStringList(); }
+  if ( identifier.isEmpty() )
+  {
+    return QStringList();
+  }
 
   const QgsWcsCoverageSummary c = mCapabilities.coverage( identifier );
-  if ( !c.valid ) { return QStringList(); }
+  if ( !c.valid )
+  {
+    return QStringList();
+  }
 
   QgsDebugMsg( "times = " + c.times.join( "," ) );
   return c.times;

--- a/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
@@ -282,7 +282,8 @@ bool QgsBackgroundCachedSharedData::createCache()
     if ( rc != SQLITE_OK )
     {
       QgsDebugMsg( QStringLiteral( "%1 failed" ).arg( sql ) );
-      if ( failedSql.isEmpty() ) failedSql = sql;
+      if ( failedSql.isEmpty() )
+        failedSql = sql;
       ret = false;
     }
 
@@ -291,7 +292,8 @@ bool QgsBackgroundCachedSharedData::createCache()
     if ( rc != SQLITE_OK )
     {
       QgsDebugMsg( QStringLiteral( "%1 failed" ).arg( sql ) );
-      if ( failedSql.isEmpty() ) failedSql = sql;
+      if ( failedSql.isEmpty() )
+        failedSql = sql;
       ret = false;
     }
 
@@ -300,7 +302,8 @@ bool QgsBackgroundCachedSharedData::createCache()
     if ( rc != SQLITE_OK )
     {
       QgsDebugMsg( QStringLiteral( "%1 failed" ).arg( sql ) );
-      if ( failedSql.isEmpty() ) failedSql = sql;
+      if ( failedSql.isEmpty() )
+        failedSql = sql;
       ret = false;
     }
 
@@ -312,7 +315,8 @@ bool QgsBackgroundCachedSharedData::createCache()
     if ( rc != SQLITE_OK )
     {
       QgsDebugMsg( QStringLiteral( "%1 failed" ).arg( sql ) );
-      if ( failedSql.isEmpty() ) failedSql = sql;
+      if ( failedSql.isEmpty() )
+        failedSql = sql;
       ret = false;
     }
 
@@ -323,7 +327,8 @@ bool QgsBackgroundCachedSharedData::createCache()
       if ( rc != SQLITE_OK )
       {
         QgsDebugMsg( QStringLiteral( "%1 failed" ).arg( sql ) );
-        if ( failedSql.isEmpty() ) failedSql = sql;
+        if ( failedSql.isEmpty() )
+          failedSql = sql;
         ret = false;
       }
     }

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -128,7 +128,8 @@ class CPLXMLTreeUniquePointer
     //! Destructor
     ~CPLXMLTreeUniquePointer()
     {
-      if ( the_data_ ) CPLDestroyXMLNode( the_data_ );
+      if ( the_data_ )
+        CPLDestroyXMLNode( the_data_ );
     }
 
     /**

--- a/tests/bench/main.cpp
+++ b/tests/bench/main.cpp
@@ -504,11 +504,15 @@ int main( int argc, char *argv[] )
     const QStringList list = myQuality.split( ',' );
     for ( const QString &q : list )
     {
-      if ( q == QLatin1String( "Antialiasing" ) ) hints |= QPainter::Antialiasing;
-      else if ( q == QLatin1String( "TextAntialiasing" ) ) hints |= QPainter::TextAntialiasing;
-      else if ( q == QLatin1String( "SmoothPixmapTransform" ) ) hints |= QPainter::SmoothPixmapTransform;
+      if ( q == QLatin1String( "Antialiasing" ) )
+        hints |= QPainter::Antialiasing;
+      else if ( q == QLatin1String( "TextAntialiasing" ) )
+        hints |= QPainter::TextAntialiasing;
+      else if ( q == QLatin1String( "SmoothPixmapTransform" ) )
+        hints |= QPainter::SmoothPixmapTransform;
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-      else if ( q == QLatin1String( "NonCosmeticDefaultPen" ) ) hints |= QPainter::NonCosmeticDefaultPen;
+      else if ( q == QLatin1String( "NonCosmeticDefaultPen" ) )
+        hints |= QPainter::NonCosmeticDefaultPen;
 #endif
       else
       {

--- a/tests/bench/qgsbench.cpp
+++ b/tests/bench/qgsbench.cpp
@@ -225,8 +225,10 @@ void QgsBench::render()
     {
       avg[t] += mTimes.at( i )[t];
 
-      if ( i == 0 || mTimes.at( i )[t] < min[t] ) min[t] = mTimes.at( i )[t];
-      if ( i == 0 || mTimes.at( i )[t] > max[t] ) max[t] = mTimes.at( i )[t];
+      if ( i == 0 || mTimes.at( i )[t] < min[t] )
+        min[t] = mTimes.at( i )[t];
+      if ( i == 0 || mTimes.at( i )[t] > max[t] )
+        max[t] = mTimes.at( i )[t];
     }
     avg[t] /= mTimes.size();
   }
@@ -240,7 +242,8 @@ void QgsBench::render()
       {
         const double d = std::fabs( avg[t] - mTimes.at( i )[t] );
         stdev[t] += std::pow( d, 2 );
-        if ( i == 0 || d > maxdev[t] ) maxdev[t] = d;
+        if ( i == 0 || d > maxdev[t] )
+          maxdev[t] = d;
       }
 
       stdev[t] = std::sqrt( stdev[t] / mTimes.size() );

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -49,13 +49,25 @@ struct TriangleCoords
 #define FLOAT3_TO_VECTOR(x)  QVector3D( data[0], -data[2], data[1] )
 
     pts[0] = FLOAT3_TO_VECTOR( data ); data += 3;
-    if ( withNormal ) { normals[0] = FLOAT3_TO_VECTOR( data ); data += 3; }
+    if ( withNormal )
+    {
+      normals[0] = FLOAT3_TO_VECTOR( data );
+      data += 3;
+    }
 
     pts[1] = FLOAT3_TO_VECTOR( data ); data += 3;
-    if ( withNormal ) { normals[1] = FLOAT3_TO_VECTOR( data ); data += 3; }
+    if ( withNormal )
+    {
+      normals[1] = FLOAT3_TO_VECTOR( data );
+      data += 3;
+    }
 
     pts[2] = FLOAT3_TO_VECTOR( data ); data += 3;
-    if ( withNormal ) { normals[2] = FLOAT3_TO_VECTOR( data ); data += 3; }
+    if ( withNormal )
+    {
+      normals[2] = FLOAT3_TO_VECTOR( data );
+      data += 3;
+    }
   }
 
   //! Compares two triangles

--- a/tests/src/core/testqgslayoutitemgroup.cpp
+++ b/tests/src/core/testqgslayoutitemgroup.cpp
@@ -61,7 +61,8 @@ class TestQgsLayoutItemGroup : public QObject
 // private
 void TestQgsLayoutItemGroup::dumpUndoStack( const QUndoStack &us, QString prefix ) const
 {
-  if ( ! prefix.isEmpty() ) prefix += QLatin1String( ": " );
+  if ( ! prefix.isEmpty() )
+    prefix += QLatin1String( ": " );
   for ( int i = 0; i < us.count(); ++i )
   {
     QgsDebugMsg( QStringLiteral( "%4US %1: %2%3" )

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -43,7 +43,8 @@ class BackgroundRequest : public QThread
         switch ( op )
         {
           case QNetworkAccessManager::GetOperation:
-            mReply = QgsNetworkAccessManager::instance()->get( mRequest );
+            mReply = QgsNetworkAccessManager::instance()
+            ->get( mRequest );
             break;
 
           case QNetworkAccessManager::PostOperation:

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -102,7 +102,8 @@ void TestQgsRasterFileWriter::writeTest()
   for ( const QString &rasterName : rasterNames )
   {
     const bool ok = writeTest( "raster/" + rasterName );
-    if ( !ok ) allOK = false;
+    if ( !ok )
+      allOK = false;
   }
 
   QVERIFY( allOK );
@@ -120,7 +121,8 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
       myRasterFileInfo.completeBaseName() ) );
   qDebug() << rasterName <<  " metadata: " << mpRasterLayer->dataProvider()->htmlMetadata();
 
-  if ( !mpRasterLayer->isValid() ) return false;
+  if ( !mpRasterLayer->isValid() )
+    return false;
 
   // Open provider only (avoid layer)?
   QgsRasterDataProvider *provider = mpRasterLayer->dataProvider();

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -79,7 +79,8 @@ class TestStyle : public QObject
 
     static bool compareItemLists( QList<QgsColorRampShader::ColorRampItem> &itemsList1, QList<QgsColorRampShader::ColorRampItem> &itemsList2 )
     {
-      if ( itemsList1.size() != itemsList2.size() ) return false;
+      if ( itemsList1.size() != itemsList2.size() )
+        return false;
       for ( int i = 0; i < itemsList1.size(); ++i )
       {
         if ( itemsList1[i].value != itemsList2[i].value )

--- a/tests/src/gui/testqgsexternalstoragefilewidget.cpp
+++ b/tests/src/gui/testqgsexternalstoragefilewidget.cpp
@@ -288,7 +288,8 @@ void TestQgsExternalStorageFileWidget::testStoring()
   {
     QVERIFY( useLink == w.mLinkLabel->isVisible() );
     QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-    if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+    if ( useLink )
+      QCOMPARE( w.mLinkEditButton->icon(), editIcon );
     QVERIFY( useLink != w.mLineEdit->isVisible() );
     QVERIFY( w.mFileWidgetButton->isVisible() );
     QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -325,7 +326,8 @@ void TestQgsExternalStorageFileWidget::testStoring()
 
     QVERIFY( useLink == w.mLinkLabel->isVisible() );
     QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-    if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+    if ( useLink )
+      QCOMPARE( w.mLinkEditButton->icon(), editIcon );
     QVERIFY( useLink != w.mLineEdit->isVisible() );
     QVERIFY( w.mFileWidgetButton->isVisible() );
     QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -369,7 +371,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFiles()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -418,7 +421,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFiles()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -466,7 +470,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFilesError()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -516,7 +521,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFilesError()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -564,7 +570,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFilesCancel()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -613,7 +620,8 @@ void TestQgsExternalStorageFileWidget::testStoringSeveralFilesCancel()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -703,7 +711,8 @@ void TestQgsExternalStorageFileWidget::testStoringBadExpression()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -717,7 +726,8 @@ void TestQgsExternalStorageFileWidget::testStoringBadExpression()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -758,7 +768,8 @@ void TestQgsExternalStorageFileWidget::testStoringDirectory()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );
@@ -783,7 +794,8 @@ void TestQgsExternalStorageFileWidget::testStoringDirectory()
 
   QVERIFY( useLink == w.mLinkLabel->isVisible() );
   QVERIFY( useLink == w.mLinkEditButton->isVisible() );
-  if ( useLink ) QCOMPARE( w.mLinkEditButton->icon(), editIcon );
+  if ( useLink )
+    QCOMPARE( w.mLinkEditButton->icon(), editIcon );
   QVERIFY( useLink != w.mLineEdit->isVisible() );
   QVERIFY( w.mFileWidgetButton->isVisible() );
   QVERIFY( w.mFileWidgetButton->isEnabled() );

--- a/tests/src/providers/testqgspostgresconn.cpp
+++ b/tests/src/providers/testqgspostgresconn.cpp
@@ -63,7 +63,8 @@ class TestQgsPostgresConn: public QObject
       if ( ! _connection )
       {
         const char *connstring = getenv( "QGIS_PGTEST_DB" );
-        if ( NULL == connstring ) connstring = "service=qgis_test";
+        if ( NULL == connstring )
+          connstring = "service=qgis_test";
         _connection = QgsPostgresConn::connectDb( connstring, true );
         assert( _connection );
       }
@@ -77,7 +78,8 @@ class TestQgsPostgresConn: public QObject
     }
     void cleanupTestCase() // will be called after the last testfunction was executed.
     {
-      if ( this->_connection ) this->_connection->unref();
+      if ( this->_connection )
+        this->_connection->unref();
     }
 
     void quotedValueHstore()

--- a/tests/src/providers/testqgswcspublicservers.cpp
+++ b/tests/src/providers/testqgswcspublicservers.cpp
@@ -184,7 +184,8 @@ TestQgsWcsPublicServers::Server TestQgsWcsPublicServers::getServer( const QStrin
 {
   for ( const Server &server : std::as_const( mServers ) )
   {
-    if ( server.url == url ) return server;
+    if ( server.url == url )
+      return server;
   }
   return Server();
 }
@@ -347,7 +348,8 @@ void TestQgsWcsPublicServers::test()
       for ( QgsWcsCoverageSummary myCoverage : myCoverages )
       {
         QgsDebugMsg( "coverage: " + myCoverage.identifier );
-        if ( !mCoverage.isEmpty() && myCoverage.identifier != mCoverage ) continue;
+        if ( !mCoverage.isEmpty() && myCoverage.identifier != mCoverage )
+          continue;
         myCoverageFound = true;
 
         // Go in steps to get more success/errors
@@ -362,7 +364,8 @@ void TestQgsWcsPublicServers::test()
         }
 
         myCoverageCount++;
-        if ( myCoverageCount > mMaxCoverages ) break;
+        if ( myCoverageCount > mMaxCoverages )
+          break;
 
 
         QString myPath = myVersionDirPath + '/' + myCoverage.identifier;
@@ -480,7 +483,8 @@ void TestQgsWcsPublicServers::test()
                 {
                   double value = myBlock->value( row, col );
                   QString valueStr = QString::number( value );
-                  if ( !myValues.contains( valueStr ) ) myValues.insert( valueStr );
+                  if ( !myValues.contains( valueStr ) )
+                    myValues.insert( valueStr );
                 }
               }
               delete myBlock;
@@ -495,7 +499,8 @@ void TestQgsWcsPublicServers::test()
               for ( int col = 0; col < myWidth; col++ )
               {
                 QRgb color = myImage.pixel( col, row );
-                if ( !myColors.contains( color ) ) myColors.insert( color );
+                if ( !myColors.contains( color ) )
+                  myColors.insert( color );
               }
             }
             QgsDebugMsg( QStringLiteral( "%1 colors" ).arg( myColors.size() ) );
@@ -624,7 +629,8 @@ void TestQgsWcsPublicServers::report()
         myVersionDir.setNameFilters( filters );
         for ( const QString &myLogFileName : myVersionDir.entryList( QDir::Files ) )
         {
-          if ( myLogFileName == QLatin1String( "version.log" ) ) continue;
+          if ( myLogFileName == QLatin1String( "version.log" ) )
+            continue;
           myVersionCoverageCount++;
           myCoverageCount++;
 
@@ -741,12 +747,16 @@ void TestQgsWcsPublicServers::report()
                                  QStringLiteral( "<b>Warnings: %1</b><br><br>" ).arg( myVersionWarnCount ) );
         myServerReport += myVersionReport;
       }
-      if ( myVersionErrCount > 0 ) myServerErr = true;
-      if ( myVersionWarnCount > 0 ) myServerWarn = true;
+      if ( myVersionErrCount > 0 )
+        myServerErr = true;
+      if ( myVersionWarnCount > 0 )
+        myServerWarn = true;
     } // versions
     myReport += myServerReport;
-    if ( myServerErr ) myServerErrCount++;
-    if ( myServerWarn ) myServerWarnCount++;
+    if ( myServerErr )
+      myServerErrCount++;
+    if ( myServerWarn )
+      myServerWarnCount++;
   } // servers
 
   QString mySettings = QgsApplication::showSettings();


### PR DESCRIPTION
## Description

I'd like to propose to force braces around statements (aka clang's [readability-braces-around-statements](https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html)

For astyle, it's [add-braces](http://astyle.sourceforge.net/astyle.html#_add-braces) option. I propose to also add `break-one-line-headers`

Some examples:

```
if( foo() )
  bar();
```

or

```
if( foo() )  bar();
```

Are converted to:

```
if( foo() )
{
  bar();
}
```
