### PR TITLE
Change uppercase final to lowercase in qgsmaptooldigitizefeature.h

### DIFF
--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * Called when the feature has been digitized.
      * \param geometry the digitized geometry
      */
-    void layerGeometryCaptured( const QgsGeometry &geometry ) override final;
+    void layerGeometryCaptured( const QgsGeometry &geometry ) FINAL;
 
     /**
      * Called when the feature has been digitized

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * Called when the feature has been digitized.
      * \param geometry the digitized geometry
      */
-    void layerGeometryCaptured( const QgsGeometry &geometry ) override FINAL;
+    void layerGeometryCaptured( const QgsGeometry &geometry ) override final;
 
     /**
      * Called when the feature has been digitized


### PR DESCRIPTION
The lowercase final must be used here, otherwise it will be replaced by the macro definition，If so, there will be two override keywords
