### PR TITLE
[OGR provider] Remove OGR_ORGANIZE_POLYGONS=ONLY_CCW configuration option

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3391,7 +3391,6 @@ void QgsOgrProvider::open( OpenMode mode )
   QgsDebugMsgLevel( "mLayerIndex: " + QString::number( mLayerIndex ), 3 );
   QgsDebugMsgLevel( "mLayerName: " + mLayerName, 3 );
   QgsDebugMsgLevel( "mSubsetString: " + mSubsetString, 3 );
-  CPLSetConfigOption( "OGR_ORGANIZE_POLYGONS", "ONLY_CCW" );  // "SKIP" returns MULTIPOLYGONs for multiringed POLYGONs
   CPLSetConfigOption( "GPX_ELE_AS_25D", "YES" );  // use GPX elevation as z values
   CPLSetConfigOption( "LIBKML_RESOLVE_STYLE", "YES" );  // resolve kml style urls from style tables to feature style strings
   if ( !CPLGetConfigOption( "OSM_USE_CUSTOM_INDEXING", nullptr ) )


### PR DESCRIPTION
The OGR_ORGANIZE_POLYGONS configuration option is unconditionally set to ONLY_CCW in the OGR provider
I believe this is inappropriate (should honour the value the user might have defined itself),
and useless. The OGR shapefile driver uses the ONLY_CCW strategy by default.
And this setting prevent the fix for OSGeo/gdal#1369
for non-conformant multipolygons in FileGeodatabase to be effective from QGIS.

Fixes #29425
