### PR TITLE
Tweak logic for warning on project/qgis version mismatches

### DIFF
--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -1575,9 +1575,27 @@ additional information to the layer.
 Emitted when the project file has been written and closed.
 %End
 
-    void oldProjectVersionWarning( const QString & );
+ void oldProjectVersionWarning( const QString & ) /Deprecated/;
 %Docstring
 Emitted when an old project file is read.
+
+.. deprecated::
+   use :py:func:`~QgsProject.readVersionMismatchOccurred` instead.
+%End
+
+    void readVersionMismatchOccurred( const QString &fileVersion );
+%Docstring
+Emitted when a project is read and the version of QGIS used to save
+the project differs from the current QGIS version.
+
+The ``fileVersion`` argument indicates the version of QGIS used to save
+the project.
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.26
 %End
 
     void layerLoaded( int i, int n );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4313,8 +4313,8 @@ void QgisApp::setupConnections()
            this, &QgisApp::fileOpenAfterLaunch );
 
   // Connect warning dialog from project reading
-  connect( QgsProject::instance(), &QgsProject::oldProjectVersionWarning,
-           this, &QgisApp::oldProjectVersionWarning );
+  connect( QgsProject::instance(), &QgsProject::readVersionMismatchOccurred,
+           this, &QgisApp::projectVersionMismatchOccurred );
   connect( QgsProject::instance(), &QgsProject::layerLoaded,
            this, [this]( int i, int n )
   {
@@ -16416,23 +16416,29 @@ void QgisApp::takeAppScreenShots( const QString &saveDirectory, const int catego
   ass.takePicturesOf( QgsAppScreenShots::Categories( categories ) );
 }
 
-// Slot that gets called when the project file was saved with an older
-// version of QGIS
-
-void QgisApp::oldProjectVersionWarning( const QString &oldVersion )
+void QgisApp::projectVersionMismatchOccurred( const QString &projectVersion )
 {
-  Q_UNUSED( oldVersion )
-  QgsSettings settings;
+  const QgsProjectVersion fileVersion( projectVersion );
+  const QgsProjectVersion thisVersion( Qgis::version() );
 
-  if ( settings.value( QStringLiteral( "qgis/warnOldProjectVersion" ), QVariant( true ) ).toBool() )
+  if ( thisVersion > fileVersion )
   {
-    QString smalltext = tr( "This project file was saved by QGIS version %1."
-                            " When saving this project file, QGIS will update it to version %2, "
-                            "possibly rendering it useless for older versions of QGIS." ).arg( oldVersion, Qgis::version() );
+    QgsSettings settings;
 
-    QString title = tr( "Project file is older" );
+    if ( settings.value( QStringLiteral( "qgis/warnOldProjectVersion" ), QVariant( true ) ).toBool() )
+    {
+      QString smalltext = tr( "This project file was saved by QGIS version %1."
+                              " When saving this project file, QGIS will update it to version %2, "
+                              "possibly rendering it useless for older versions of QGIS." ).arg( projectVersion, Qgis::version() );
 
-    visibleMessageBar()->pushMessage( title, smalltext );
+      QString title = tr( "Project file is older" );
+
+      visibleMessageBar()->pushMessage( title, smalltext );
+    }
+  }
+  else
+  {
+    visibleMessageBar()->pushWarning( QString(), tr( "This project file was created by a newer version of QGIS (%1) and could not be completely loaded." ).arg( projectVersion ) );
   }
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1885,8 +1885,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! add Python cnosole at start up
     void initPythonConsoleOptions();
 
-    //! Shows a warning when an old project file is read.
-    void oldProjectVersionWarning( const QString & );
+    //! Shows a warning when an older/newer project file is read.
+    void projectVersionMismatchOccurred( const QString &projectVersion );
 
     //! Toggle map tips on/off
     void toggleMapTips( bool enabled );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1428,10 +1428,15 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   profile.switchTask( tr( "Updating project file" ) );
   if ( thisVersion > fileVersion )
   {
-    QgsLogger::warning( "Loading a file that was saved with an older "
-                        "version of qgis (saved in " + fileVersion.text() +
-                        ", loaded in " + Qgis::version() +
-                        "). Problems may occur." );
+    const bool isOlderMajorVersion = fileVersion.majorVersion() < thisVersion.majorVersion();
+
+    if ( isOlderMajorVersion )
+    {
+      QgsLogger::warning( "Loading a file that was saved with an older "
+                          "version of qgis (saved in " + fileVersion.text() +
+                          ", loaded in " + Qgis::version() +
+                          "). Problems may occur." );
+    }
 
     QgsProjectFileTransform projectFile( *doc, fileVersion );
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1441,9 +1441,21 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
     QgsProjectFileTransform projectFile( *doc, fileVersion );
 
     // Shows a warning when an old project file is read.
+    Q_NOWARN_DEPRECATED_PUSH
     emit oldProjectVersionWarning( fileVersion.text() );
+    Q_NOWARN_DEPRECATED_POP
+    emit readVersionMismatchOccurred( fileVersion.text() );
 
     projectFile.updateRevision( thisVersion );
+  }
+  else if ( fileVersion > thisVersion )
+  {
+    QgsLogger::warning( "Loading a file that was saved with a newer "
+                        "version of qgis (saved in " + fileVersion.text() +
+                        ", loaded in " + Qgis::version() +
+                        "). Problems may occur." );
+
+    emit readVersionMismatchOccurred( fileVersion.text() );
   }
 
   // start new project, just keep the file name and auxiliary storage

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -1611,8 +1611,22 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     /**
      * Emitted when an old project file is read.
+     *
+     * \deprecated use readVersionMismatchOccurred() instead.
      */
-    void oldProjectVersionWarning( const QString & );
+    Q_DECL_DEPRECATED void oldProjectVersionWarning( const QString & ) SIP_DEPRECATED;
+
+    /**
+     * Emitted when a project is read and the version of QGIS used to save
+     * the project differs from the current QGIS version.
+     *
+     * The \a fileVersion argument indicates the version of QGIS used to save
+     * the project.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+     */
+    void readVersionMismatchOccurred( const QString &fileVersion );
 
     /**
      * Emitted when a layer from a projects was read.


### PR DESCRIPTION
- Don't show a warning in message log when opening a project saved in an older QGIS version, UNLESS it was saved in QGIS 2.x. (The message is misleading -- we don't expected any problems to occur if you open a project created in QGIS 3.x. If there is, then it's a serious bug which needs fixing.)
- Show a message bar warning when a user opens a project created in a NEWER qgis version, warning them that the project may not be fully loaded