### PR TITLE
[raster] Fix crash when calling setDataProvider against a pre-existing raster layer

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -611,7 +611,8 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   setValid( false ); // assume the layer is invalid until we determine otherwise
 
-  mPipe->remove( mDataProvider ); // deletes if exists
+  // deletes pipe elements (including data provider)
+  mPipe = std::make_unique< QgsRasterPipe >();
   mDataProvider = nullptr;
 
   // XXX should I check for and possibly delete any pre-existing providers?

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -1638,6 +1638,21 @@ class TestQgsRasterLayerTransformContext(unittest.TestCase):
 
         self.assertTrue(checker.runTest("raster_data_defined_opacity"))
 
+    def test_read_xml_crash(self):
+        """Check if converting a raster from 1.8 to 2 works."""
+        path = os.path.join(unitTestDataPath('raster'),
+                            'raster-palette-crash2.tif')
+        layer = QgsRasterLayer(path, QFileInfo(path).baseName())
+        context = QgsReadWriteContext()
+        document = QDomDocument("style")
+        map_layers_element = document.createElement("maplayers")
+        map_layer_element = document.createElement("maplayer")
+        layer.writeLayerXml(map_layer_element, document, context)
+
+        num = 10
+        for _ in range(num):
+            layer.readLayerXml(map_layer_element, context)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Stumbled on a bad raster layer crash while debugging qfieldsync plugin: calling QgsRasterLayer::setDataProvider(...) against a pre-existing raster layer will quickly lead to QGIS crashing. 

With a WMS provider raster layer, the crash happens instantly, while with gdal provider raster layer, the crash will happen after calling setDataProvider 4 times here.

Disclosure time: I don't fully understand what was wrong here, something deep into the bowel of Qt / C++. The crash reliably happened when accessing mDataProvider _after_ calling the setRenderer(...) function which in turn replaced the renderer in the QgsRasterPipe member. 

The fix I've tested is to do a _full_ raster pipe reset (instead of only removing the old data provider) when calling setDataProvider(...). This looks to me like the right thing to do in any case.

A test case was added to insure we don't regress again.

For people interested in replicating the crash, executing the following script through the python console with an active raster layer 4-5 times will see QGIS die:
```
def test(layer):
    context = QgsReadWriteContext()
    document = QDomDocument("style")
    map_layers_element = document.createElement("maplayers")
    map_layer_element = document.createElement("maplayer")
    layer.writeLayerXml(map_layer_element, document, context)
    layer.readLayerXml(map_layer_element, context)
    layer.reload()
 
test(iface.activeLayer())
```