### PR TITLE
MetaSearch: update startindex to items

### DIFF
--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -190,12 +190,12 @@ class OARecSearch(SearchBase):
 
         self.response = self.conn.response
 
-    def query_records(self, bbox=[], keywords=None, limit=10, offset=1):
+    def query_records(self, bbox=[], keywords=None, limit=10, offset=0):
 
         params = {
             'collection_id': self.record_collection,
             'limit': limit,
-            'startindex': offset,
+            'offset': offset
         }
 
         if keywords:

--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -190,12 +190,15 @@ class OARecSearch(SearchBase):
 
         self.response = self.conn.response
 
-    def query_records(self, bbox=[], keywords=None, limit=10, offset=0):
+    def query_records(self, bbox=[], keywords=None, limit=10, offset=1):
+        # set zero-based offset (default MetaSearch behaviour is CSW-based
+        # offset of 1
+        offset2 = offset - 1
 
         params = {
             'collection_id': self.record_collection,
             'limit': limit,
-            'offset': offset
+            'offset': offset2
         }
 
         if keywords:

--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -191,7 +191,7 @@ class OARecSearch(SearchBase):
         self.response = self.conn.response
 
     def query_records(self, bbox=[], keywords=None, limit=10, offset=1):
-        # set zero-based offset (default MetaSearch behaviour is CSW-based
+        # set zero-based offset (default MetaSearch behavior is CSW-based
         # offset of 1
         offset2 = offset - 1
 


### PR DESCRIPTION
## Description

OGC API - Features provides a convention/examples to use `offset` for items paging workflow.  OGC API - Records uses OGC API - Features as a building block.  We have used `startindex` in the MetaSearch client thus far (was used in WFS 2, for example).  Server implementations like [QGIS Server](https://github.com/qgis/QGIS/blob/master/src/server/services/wfs3/qgswfs3handlers.cpp#L788) have been using `offset`.  pygeoapi has [updated](https://github.com/geopython/pygeoapi/pull/864) their codebase to align with `offset` as well as [OWSLib](https://github.com/geopython/OWSLib/commit/16ba31af36d155d1a89007ead2792218dcbb4fa7) (which MetaSearch uses as a client).

Having said this, even though this is an OAFeat convention and `next`/`prev` link relations are opaque, it makes sense to update for convenience.

cc @rouault