### PR TITLE
Apply more flexible approach to match zoom levels expected for ESRI tiles

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1270,6 +1270,12 @@ Qgis.TextRendererFlag.__doc__ = 'Flags which control the behavior of rendering t
 Qgis.TextRendererFlag.baseClass = Qgis
 Qgis.TextRendererFlags.baseClass = Qgis
 TextRendererFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.ScaleToTileZoomLevelMethod.MapBox.__doc__ = "Uses a scale doubling approach to account for hi-DPI tiles, and rounds to the nearest tile level for the map scale"
+Qgis.ScaleToTileZoomLevelMethod.Esri.__doc__ = "No scale doubling, always rounds down when matching to available tile levels"
+Qgis.ScaleToTileZoomLevelMethod.__doc__ = 'Available methods for converting map scales to tile zoom levels.\n\n.. versionadded:: 3.26\n\n' + '* ``MapBox``: ' + Qgis.ScaleToTileZoomLevelMethod.MapBox.__doc__ + '\n' + '* ``Esri``: ' + Qgis.ScaleToTileZoomLevelMethod.Esri.__doc__
+# --
+Qgis.ScaleToTileZoomLevelMethod.baseClass = Qgis
 QgsCurve.Orientation = Qgis.AngularDirection
 # monkey patching scoped based enum
 QgsCurve.Clockwise = Qgis.AngularDirection.Clockwise

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -808,6 +808,12 @@ The development version
     typedef QFlags<Qgis::TextRendererFlag> TextRendererFlags;
 
 
+    enum class ScaleToTileZoomLevelMethod
+    {
+      MapBox,
+      Esri,
+    };
+
     enum class AngularDirection
       {
       Clockwise,

--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -304,22 +304,18 @@ Reads the set from an XML ``element``.
 Writes the set to an XML element.
 %End
 
-    bool applyTileScaleDoublingHack() const;
+    Qgis::ScaleToTileZoomLevelMethod scaleToTileZoomMethod() const;
 %Docstring
-Returns ``True`` if the scale doubling hack used to match MapBox scale to tile zoom levels should be applied.
+Returns the scale to tile zoom method.
 
-The default is that this hack will be applied.
-
-.. seealso:: :py:func:`setApplyTileScaleDoublingHack`
+.. seealso:: :py:func:`setScaleToTileZoomMethod`
 %End
 
-    void setApplyTileScaleDoublingHack( bool apply );
+    void setScaleToTileZoomMethod( Qgis::ScaleToTileZoomLevelMethod method );
 %Docstring
-Sets whether the scale doubling hack used to match MapBox scale to tile zoom levels should be applied.
+Sets the scale to tile zoom method.
 
-The default is that this hack will be applied.
-
-.. seealso:: :py:func:`applyTileScaleDoublingHack`
+.. seealso:: :py:func:`scaleToTileZoomMethod`
 %End
 
 };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1315,6 +1315,18 @@ class CORE_EXPORT Qgis
     Q_FLAG( TextRendererFlags )
 
     /**
+     * Available methods for converting map scales to tile zoom levels.
+     *
+     * \since QGIS 3.26
+     */
+    enum class ScaleToTileZoomLevelMethod : int
+    {
+      MapBox, //!< Uses a scale doubling approach to account for hi-DPI tiles, and rounds to the nearest tile level for the map scale
+      Esri, //!< No scale doubling, always rounds down when matching to available tile levels
+    };
+    Q_ENUM( ScaleToTileZoomLevelMethod );
+
+    /**
      * Angular directions.
      *
      * \since QGIS 3.24

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 
+#include "qgis.h"
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsreadwritecontext.h"
@@ -219,6 +220,7 @@ class CORE_EXPORT QgsTileMatrix
  */
 class CORE_EXPORT QgsTileMatrixSet
 {
+
   public:
 
     virtual ~QgsTileMatrixSet() = default;
@@ -295,27 +297,23 @@ class CORE_EXPORT QgsTileMatrixSet
     virtual QDomElement writeXml( QDomDocument &document, const QgsReadWriteContext &context ) const;
 
     /**
-     * Returns TRUE if the scale doubling hack used to match MapBox scale to tile zoom levels should be applied.
+     * Returns the scale to tile zoom method.
      *
-     * The default is that this hack will be applied.
-     *
-     * \see setApplyTileScaleDoublingHack()
+     * \see setScaleToTileZoomMethod()
      */
-    bool applyTileScaleDoublingHack() const { return mApplyTileScaleDoubleHack; }
+    Qgis::ScaleToTileZoomLevelMethod scaleToTileZoomMethod() const { return mScaleToTileZoomMethod; }
 
     /**
-     * Sets whether the scale doubling hack used to match MapBox scale to tile zoom levels should be applied.
+     * Sets the scale to tile zoom method.
      *
-     * The default is that this hack will be applied.
-     *
-     * \see applyTileScaleDoublingHack()
+     * \see scaleToTileZoomMethod()
      */
-    void setApplyTileScaleDoublingHack( bool apply ) { mApplyTileScaleDoubleHack = apply; }
+    void setScaleToTileZoomMethod( Qgis::ScaleToTileZoomLevelMethod method ) { mScaleToTileZoomMethod = method; }
 
   private:
 
     QMap< int, QgsTileMatrix > mTileMatrices;
-    bool mApplyTileScaleDoubleHack = true;
+    Qgis::ScaleToTileZoomLevelMethod mScaleToTileZoomMethod = Qgis::ScaleToTileZoomLevelMethod::MapBox;
 };
 
 #endif // QGSTILES_H

--- a/src/core/vectortile/qgsvectortilematrixset.cpp
+++ b/src/core/vectortile/qgsvectortilematrixset.cpp
@@ -28,8 +28,7 @@ QgsVectorTileMatrixSet QgsVectorTileMatrixSet::fromWebMercator()
 
 bool QgsVectorTileMatrixSet::fromEsriJson( const QVariantMap &json )
 {
-  // doesn't apply to ESRI tile zoom levels
-  setApplyTileScaleDoublingHack( false );
+  setScaleToTileZoomMethod( Qgis::ScaleToTileZoomLevelMethod::Esri );
 
   const QVariantMap tileInfo = json.value( QStringLiteral( "tileInfo" ) ).toMap();
 

--- a/tests/src/python/test_qgstiles.py
+++ b/tests/src/python/test_qgstiles.py
@@ -20,7 +20,8 @@ from qgis.core import (
     QgsPointXY,
     QgsTileMatrixSet,
     QgsVectorTileMatrixSet,
-    QgsReadWriteContext
+    QgsReadWriteContext,
+    Qgis
 )
 from qgis.testing import start_app, unittest
 
@@ -65,7 +66,7 @@ class TestQgsTiles(unittest.TestCase):
         matrix_set = QgsTileMatrixSet()
 
         # should be applied by default in order to match MapBox rendering of tiles
-        self.assertTrue(matrix_set.applyTileScaleDoublingHack())
+        self.assertEqual(matrix_set.scaleToTileZoomMethod(), Qgis.ScaleToTileZoomLevelMethod.MapBox)
 
         self.assertEqual(matrix_set.minimumZoom(), -1)
         self.assertEqual(matrix_set.maximumZoom(), -1)
@@ -136,9 +137,9 @@ class TestQgsTiles(unittest.TestCase):
         self.assertEqual(matrix_set.scaleToZoomLevel(198251572), 2)
         self.assertEqual(matrix_set.scaleToZoomLevel(6503144), 3)
 
-        # disable scale doubling hack
-        matrix_set.setApplyTileScaleDoublingHack(False)
-        self.assertFalse(matrix_set.applyTileScaleDoublingHack())
+        # with ESRI scale to zoom handling
+        matrix_set.setScaleToTileZoomMethod(Qgis.ScaleToTileZoomLevelMethod.Esri)
+        self.assertEqual(matrix_set.scaleToTileZoomMethod(), Qgis.ScaleToTileZoomLevelMethod.Esri)
 
         self.assertAlmostEqual(matrix_set.scaleToZoom(776503144), 1, 5)
         self.assertEqual(matrix_set.scaleToZoom(1776503144), 1)
@@ -152,7 +153,7 @@ class TestQgsTiles(unittest.TestCase):
         self.assertEqual(matrix_set.scaleToZoomLevel(76503144), 3)
         self.assertEqual(matrix_set.scaleToZoomLevel(388251572), 2)
         self.assertEqual(matrix_set.scaleToZoomLevel(298251572), 2)
-        self.assertEqual(matrix_set.scaleToZoomLevel(198251572), 3)
+        self.assertEqual(matrix_set.scaleToZoomLevel(198251572), 2)
         self.assertEqual(matrix_set.scaleToZoomLevel(6503144), 3)
 
     def testTileMatrixSetGoogle(self):
@@ -358,7 +359,7 @@ class TestQgsTiles(unittest.TestCase):
 
         # we should NOT apply the tile scale doubling hack to ESRI tiles, otherwise our scales
         # are double what ESRI use for the same tile sets
-        self.assertFalse(vector_tile_set.applyTileScaleDoublingHack())
+        self.assertEqual(vector_tile_set.scaleToTileZoomMethod(), Qgis.ScaleToTileZoomLevelMethod.Esri)
 
         self.assertEqual(vector_tile_set.minimumZoom(), 0)
         self.assertEqual(vector_tile_set.maximumZoom(), 14)


### PR DESCRIPTION
Follow up https://github.com/qgis/QGIS/pull/47617 -- this gives a better match for the zoom level thresholds used by ESRI, so that when we load vector tiles from ESRI sources (e.g. Arcgis online) we get a better match for their intended appearance