### PR TITLE
Show raster scale and offset in raster properties (fix #47673)

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -559,7 +559,10 @@ QString QgsGdalProvider::htmlMetadata()
     }
     QStringList scaleOffset;
     scaleOffset << QStringLiteral( "Scale: %1, Offset: %2" ).arg( bandScale( i ) ).arg( bandOffset( i ) );
-    myMetadata += QgsHtmlUtils::buildBulletList( scaleOffset );
+    myMetadata += QgsHtmlUtils::buildBulletList( QStringList{ {
+           QObject::tr("Scale: %1").arg( bandScale( i ) ),
+           QObject::tr("Offset: %1").arg( bandOffset( i ) ),
+    }) );
     myMetadata += QLatin1String( "</td></tr>" );
   }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -557,12 +557,11 @@ QString QgsGdalProvider::htmlMetadata()
       QStringList categories = QgsOgrUtils::cStringListToQStringList( GDALcategories );
       myMetadata += QgsHtmlUtils::buildBulletList( categories );
     }
-    QStringList scaleOffset;
-    scaleOffset << QStringLiteral( "Scale: %1, Offset: %2" ).arg( bandScale( i ) ).arg( bandOffset( i ) );
-    myMetadata += QgsHtmlUtils::buildBulletList( QStringList{ {
-           QObject::tr("Scale: %1").arg( bandScale( i ) ),
-           QObject::tr("Offset: %1").arg( bandOffset( i ) ),
-    }) );
+    myMetadata += QgsHtmlUtils::buildBulletList( QStringList(
+    {
+      QObject::tr( "Scale: %1" ).arg( bandScale( i ) ),
+      QObject::tr( "Offset: %1" ).arg( bandOffset( i ) ),
+    } ) );
     myMetadata += QLatin1String( "</td></tr>" );
   }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -557,6 +557,9 @@ QString QgsGdalProvider::htmlMetadata()
       QStringList categories = QgsOgrUtils::cStringListToQStringList( GDALcategories );
       myMetadata += QgsHtmlUtils::buildBulletList( categories );
     }
+    QStringList scaleOffset;
+    scaleOffset << QStringLiteral( "Scale: %1, Offset: %2" ).arg( bandScale( i ) ).arg( bandOffset( i ) );
+    myMetadata += QgsHtmlUtils::buildBulletList( scaleOffset );
     myMetadata += QLatin1String( "</td></tr>" );
   }
 


### PR DESCRIPTION
## Description
While raster scale and offset are taken into account while reading raster data, these values are not reported in the "Information" tab of the layer properties dialog.

Fixes #47673.