### PR TITLE
fix wrong shading when 2-class color

### DIFF
--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -428,7 +428,7 @@ bool QgsColorRampShader::shade( double value, int *returnRedValue, int *returnGr
 
   // find index of the first ColorRampItem that is equal or higher to theValue
   const int lutIndex = ( value - mLUTOffset ) * mLUTFactor;
-  if ( value < mLUTOffset )
+  if ( value <= mLUTOffset )
   {
     idx = 0;
   }

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -46,6 +46,15 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
         self.assertEqual(shaderRamp.color2(), gradientRamp.color2())
         self.assertEqual(shaderRamp.stops(), gradientRamp.stops())
 
+    def testTwoClassesDiscrete(self):
+        shader = QgsColorRampShader(0, 100, None, QgsColorRampShader.Discrete)
+        item1 = QgsColorRampShader.ColorRampItem(50, QColor(0, 0, 0))
+        item2 = QgsColorRampShader.ColorRampItem(float("inf"), QColor(255, 255, 255))
+        shader.setColorRampItemList([item1, item2, item3])
+        shaderRamp = shader.createColorRamp()
+
+        color = shader.shade(50)
+        print(color)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -47,14 +47,19 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
         self.assertEqual(shaderRamp.stops(), gradientRamp.stops())
 
     def testTwoClassesDiscrete(self):
-        shader = QgsColorRampShader(0, 100, None, QgsColorRampShader.Discrete)
+        # test for #47759
+        shader = QgsColorRampShader(0, 50, None, QgsColorRampShader.Discrete)
+        
         item1 = QgsColorRampShader.ColorRampItem(50, QColor(0, 0, 0))
         item2 = QgsColorRampShader.ColorRampItem(float("inf"), QColor(255, 255, 255))
-        shader.setColorRampItemList([item1, item2, item3])
+        shader.setColorRampItemList([item1, item2])
         shaderRamp = shader.createColorRamp()
 
-        color = shader.shade(50)
-        print(color)
+        color1 = shader.shade(50)
+        self.assertEqual(color1[1:4], (0, 0, 0))
+
+        color2 = shader.shade(50.00000000001)
+        self.assertEqual(color2[1:4], (255, 255, 255))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -53,7 +53,6 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
         item1 = QgsColorRampShader.ColorRampItem(50, QColor(0, 0, 0))
         item2 = QgsColorRampShader.ColorRampItem(float("inf"), QColor(255, 255, 255))
         shader.setColorRampItemList([item1, item2])
-        shaderRamp = shader.createColorRamp()
 
         color1 = shader.shade(50)
         self.assertEqual(color1[1:4], (0, 0, 0))

--- a/tests/src/python/test_qgsrastercolorrampshader.py
+++ b/tests/src/python/test_qgsrastercolorrampshader.py
@@ -49,7 +49,7 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
     def testTwoClassesDiscrete(self):
         # test for #47759
         shader = QgsColorRampShader(0, 50, None, QgsColorRampShader.Discrete)
-        
+
         item1 = QgsColorRampShader.ColorRampItem(50, QColor(0, 0, 0))
         item2 = QgsColorRampShader.ColorRampItem(float("inf"), QColor(255, 255, 255))
         shader.setColorRampItemList([item1, item2])
@@ -60,6 +60,7 @@ class TestQgsRasterColorRampShader(unittest.TestCase):
 
         color2 = shader.shade(50.00000000001)
         self.assertEqual(color2[1:4], (255, 255, 255))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

close #45861

I've fixed wrong shading when 2-class. This is caused by boolean `value < mLUTOffset`.
`mLUTOffset` is defined as following
```c++
mLUTOffset = minimumValue + DOUBLE_DIFF_THRESHOLD;`
```

In 2-class colored shading, the `value` is same to `minimumValue` and `value < mLUTOffset` is always `false` because `DOUBLE_DIFF_THRESHOLD` is zero.
I think this may be unexpected behavior because `DOUBLE_DIFF_THRESHOLD` looks rewrote as following.
https://github.com/qgis/QGIS/blob/102bc431d755d4a214fcd73ee847232acd6f01d0/src/core/raster/qgscolorrampshader.cpp#L23

So I rewrote `value < mLUTOffset` to `value <= mLUTOffset`, what do you think?

## Reproduce

- In #45861, I posted QGIS-project reproduce that issue. By using this and this branch you can test the issue don't occur.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
