### PR TITLE
When running a model with detailed logging in a background thread show a warning when a step is about to be run in the main thread 

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -432,6 +432,9 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
             context.pushToThread( modelThread );
           };
 
+          if ( feedback && !skipGenericLogging && modelThread != qApp->thread() )
+            feedback->pushWarning( QObject::tr( "Algorithm “%1” cannot be run in a background thread, switching to main thread for this step" ).arg( childAlg->displayName() ) );
+
           context.pushToThread( qApp->thread() );
           QMetaObject::invokeMethod( qApp, runOnMainThread, Qt::BlockingQueuedConnection );
         }


### PR DESCRIPTION
... warning the user that that child algorithm cannot be run in the background

Follow up https://github.com/qgis/QGIS/pull/47735