### PR TITLE
Support shift+wheel scrolling in attribute table to switch to a horizontal scrolling action instead of vertical

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsAttributeTableView : QTableView
+class QgsAttributeTableView : QgsTableView
 {
 %Docstring(signature="appended")
 Provides a table view of features of a :py:class:`QgsVectorLayer`.

--- a/python/gui/auto_generated/qgstableview.sip.in
+++ b/python/gui/auto_generated/qgstableview.sip.in
@@ -11,7 +11,7 @@
 class QgsTableView : QTableView
 {
 %Docstring(signature="appended")
-A QTableView subclass with QGIS specifc tweaks and improvements.
+A QTableView subclass with QGIS specific tweaks and improvements.
 
 :py:class:`QgsTableView` should be used instead of QTableView widgets.
 In most cases the use is identical, however :py:class:`QgsTableView`

--- a/python/gui/auto_generated/qgstableview.sip.in
+++ b/python/gui/auto_generated/qgstableview.sip.in
@@ -1,0 +1,44 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgstableview.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsTableView : QTableView
+{
+%Docstring(signature="appended")
+A QTableView subclass with QGIS specifc tweaks and improvements.
+
+:py:class:`QgsTableView` should be used instead of QTableView widgets.
+In most cases the use is identical, however :py:class:`QgsTableView`
+adds extra functionality and UI tweaks for improved user
+experience in QGIS.
+
+.. versionadded:: 3.26
+%End
+
+%TypeHeaderCode
+#include "qgstableview.h"
+%End
+  public:
+
+    explicit QgsTableView( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsTableView.
+%End
+
+    virtual void wheelEvent( QWheelEvent *event );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgstableview.h                                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -211,6 +211,7 @@
 %Include auto_generated/qgssublayersdialog.sip
 %Include auto_generated/qgssubstitutionlistwidget.sip
 %Include auto_generated/qgssymbolbutton.sip
+%Include auto_generated/qgstableview.sip
 %Include auto_generated/qgstablewidgetbase.sip
 %Include auto_generated/qgstablewidgetitem.sip
 %Include auto_generated/qgstabwidget.sip

--- a/src/app/georeferencer/qgsgcplistwidget.cpp
+++ b/src/app/georeferencer/qgsgcplistwidget.cpp
@@ -27,7 +27,7 @@
 #include "qgsgcplistmodel.h"
 
 QgsGCPListWidget::QgsGCPListWidget( QWidget *parent )
-  : QTableView( parent )
+  : QgsTableView( parent )
   , mGCPListModel( new QgsGCPListModel( this ) )
   , mDmsAndDdDelegate( new QgsDmsAndDdDelegate( this ) )
   , mCoordDelegate( new QgsCoordDelegate( this ) )

--- a/src/app/georeferencer/qgsgcplistwidget.h
+++ b/src/app/georeferencer/qgsgcplistwidget.h
@@ -15,7 +15,7 @@
 #ifndef QGS_GCP_LIST_WIDGET_H
 #define QGS_GCP_LIST_WIDGET_H
 
-#include <QTableView>
+#include "qgstableview.h"
 
 class QgsDoubleSpinBoxDelegate;
 class QgsDmsAndDdDelegate;
@@ -29,7 +29,7 @@ class QgsPointXY;
 class QgsCoordinateReferenceSystem;
 class QgsCoordinateTransformContext;
 
-class QgsGCPListWidget : public QTableView
+class QgsGCPListWidget : public QgsTableView
 {
     Q_OBJECT
   public:

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -628,6 +628,7 @@ set(QGIS_GUI_SRCS
   qgsstatusbar.cpp
   qgssymbolbutton.cpp
   qgssymbollayerselectionwidget.cpp
+  qgstableview.cpp
   qgstablewidgetbase.cpp
   qgstabwidget.cpp
   qgstablewidgetitem.cpp
@@ -888,6 +889,7 @@ set(QGIS_GUI_HDRS
   qgssubstitutionlistwidget.h
   qgssymbolbutton.h
   qgssymbollayerselectionwidget.h
+  qgstableview.h
   qgstablewidgetbase.h
   qgstablewidgetitem.h
   qgstabwidget.h

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -39,7 +39,7 @@
 #include "qgsgui.h"
 
 QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
-  : QTableView( parent )
+  : QgsTableView( parent )
 {
   const QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "BetterAttributeTable/geometry" ) ).toByteArray() );

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -16,9 +16,9 @@
 #ifndef QGSATTRIBUTETABLEVIEW_H
 #define QGSATTRIBUTETABLEVIEW_H
 
-#include <QTableView>
 #include <QAction>
 #include "qgsfeatureid.h"
+#include "qgstableview.h"
 
 #include "qgis_gui.h"
 #include "qgsattributetableconfig.h"
@@ -45,7 +45,7 @@ class QgsFeature;
  * Or this can be used within the QgsDualView stacked widget.
  */
 
-class GUI_EXPORT QgsAttributeTableView : public QTableView
+class GUI_EXPORT QgsAttributeTableView : public QgsTableView
 {
     Q_OBJECT
 

--- a/src/gui/qgstableview.cpp
+++ b/src/gui/qgstableview.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+    qgstableview.cpp
+    ---------------
+    begin                : March 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstableview.h"
+
+#include <QWheelEvent>
+
+QgsTableView::QgsTableView( QWidget *parent )
+  : QTableView( parent )
+{
+
+}
+
+void QgsTableView::wheelEvent( QWheelEvent *event )
+{
+  if ( event->modifiers() & Qt::ShiftModifier )
+  {
+    // a wheel event with the shift modifier switches a vertical scroll to a horizontal scroll (or vice versa)
+    const QPoint invertedPixelDelta = QPoint( event->pixelDelta().y(), event->pixelDelta().x() );
+    const QPoint invertedAngleDelta = QPoint( event->angleDelta().y(), event->angleDelta().x() );
+    QWheelEvent axisSwappedScrollEvent( event->posF(), event->globalPosF(),
+                                        invertedPixelDelta, invertedAngleDelta,
+                                        event->buttons(), event->modifiers() & ~Qt::ShiftModifier, event->phase(),
+                                        event->inverted(), event->source() );
+    QTableView::wheelEvent( &axisSwappedScrollEvent );
+  }
+  else
+  {
+    QTableView::wheelEvent( event );
+  }
+}

--- a/src/gui/qgstableview.h
+++ b/src/gui/qgstableview.h
@@ -23,7 +23,7 @@
 /**
  * \class QgsTableView
  * \ingroup gui
- * \brief A QTableView subclass with QGIS specifc tweaks and improvements.
+ * \brief A QTableView subclass with QGIS specific tweaks and improvements.
  *
  * QgsTableView should be used instead of QTableView widgets.
  * In most cases the use is identical, however QgsTableView

--- a/src/gui/qgstableview.h
+++ b/src/gui/qgstableview.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+    qgstableview.h
+    ---------------
+    begin                : March 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTABLEVIEW_H
+#define QGSTABLEVIEW_H
+
+#include <QTableView>
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+
+/**
+ * \class QgsTableView
+ * \ingroup gui
+ * \brief A QTableView subclass with QGIS specifc tweaks and improvements.
+ *
+ * QgsTableView should be used instead of QTableView widgets.
+ * In most cases the use is identical, however QgsTableView
+ * adds extra functionality and UI tweaks for improved user
+ * experience in QGIS.
+ *
+ * \since QGIS 3.26
+ */
+class GUI_EXPORT QgsTableView : public QTableView
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsTableView.
+     */
+    explicit QgsTableView( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    void wheelEvent( QWheelEvent *event ) override;
+};
+
+#endif // QGSTABLEVIEW_H


### PR DESCRIPTION
This matches the same behaviour exposed by LibreOffice, and provides a convenient way to quickly horizontally scroll tables when a mouse doesn't have a dedicated horizontal scroll wheel.

Sponsored by the City of Canning