### PR TITLE
[wmst] Re-enable prefetching for simple XYZ layers

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2203,13 +2203,11 @@ int QgsWmsProvider::capabilities() const
     }
   }
 
-  // Prevent prefetch of XYZ openstreetmap images, see: https://github.com/qgis/QGIS/issues/34813
-  // But also prevent prefetching if service is a true WMS (mSettings.mTiled = True)
+  // Prefetch of simple XYZ layers, disable for true wMS service
   // See https://github.com/qgis/QGIS/issues/34813
-  if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
+  if ( mSettings.mXyz )
   {
-    // March 2021: *never* prefetch tile based layers, see: https://github.com/qgis/QGIS/pull/41953
-    // capability |= Capability::Prefetch;
+    capability |= Capability::Prefetch;
   }
 
   if ( mSettings.mTiled || mSettings.mXyz )


### PR DESCRIPTION
## Description

This PR re-enables pre-fetching in the WMS provider for a narrow subset of layers (namely simple XYZ layers). Not having that in was a really bad regression when it comes to rendering of preview areas outside of the main canvas.

@rduivenvoorde , I've tested your 'opentopo' WMTS layer from the service URL you provided in the PR that disabled all prefetching (https://github.com/qgis/QGIS/pull/41953) and it did not regress your specific use.

I don't think there's any reason why we don't want to prefetch especially now that we have a tile download manager / caching in place.