### PR TITLE
Be more tolerant when deciding when to render preview jobs for vector tile layers

### DIFF
--- a/src/app/devtools/networklogger/qgsnetworklogger.cpp
+++ b/src/app/devtools/networklogger/qgsnetworklogger.cpp
@@ -316,6 +316,12 @@ void QgsNetworkLoggerProxyModel::setShowTimeouts( bool show )
   invalidateFilter();
 }
 
+void QgsNetworkLoggerProxyModel::setShowCached( bool show )
+{
+  mShowCached = show;
+  invalidateFilter();
+}
+
 bool QgsNetworkLoggerProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   QgsNetworkLoggerNode *node = mLogger->index2node( mLogger->index( source_row, 0, source_parent ) );
@@ -325,6 +331,8 @@ bool QgsNetworkLoggerProxyModel::filterAcceptsRow( int source_row, const QModelI
          & !mShowSuccessful )
       return false;
     else if ( request->status() == QgsNetworkLoggerRequestGroup::Status::TimeOut && !mShowTimeouts )
+      return false;
+    else if ( request->replyFromCache() && !mShowCached )
       return false;
     return mFilterString.isEmpty() || request->url().url().contains( mFilterString, Qt::CaseInsensitive );
   }

--- a/src/app/devtools/networklogger/qgsnetworklogger.h
+++ b/src/app/devtools/networklogger/qgsnetworklogger.h
@@ -153,6 +153,11 @@ class QgsNetworkLoggerProxyModel : public QSortFilterProxyModel
      */
     void setShowTimeouts( bool show );
 
+    /**
+     * Sets whether requests served directly from cache are shown
+     */
+    void setShowCached( bool show );
+
   protected:
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
@@ -163,6 +168,7 @@ class QgsNetworkLoggerProxyModel : public QSortFilterProxyModel
     QString mFilterString;
     bool mShowSuccessful = true;
     bool mShowTimeouts = true;
+    bool mShowCached = true;
 };
 
 #endif // QGSNETWORKLOGGER_H

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
@@ -265,7 +265,12 @@ QVariant QgsNetworkLoggerRequestGroup::data( int role ) const
         case QgsNetworkLoggerRequestGroup::Status::TimeOut:
           return QBrush( QColor( 235, 10, 10 ) );
         case QgsNetworkLoggerRequestGroup::Status::Complete:
+        {
+          if ( mReplyFromCache )
+            return QBrush( QColor( 10, 40, 85, 150 ) );
+
           break;
+        }
       }
       break;
     }
@@ -381,6 +386,7 @@ void QgsNetworkLoggerRequestGroup::setReply( const QgsNetworkReplyContent &reply
   mTotalTime = mTimer.elapsed();
   mHttpStatus = reply.attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
   mContentType = reply.rawHeader( "Content - Type" );
+  mReplyFromCache = reply.attribute( QNetworkRequest::SourceIsFromCacheAttribute ).toBool();
 
   std::unique_ptr< QgsNetworkLoggerReplyGroup > replyGroup = std::make_unique< QgsNetworkLoggerReplyGroup >( reply ) ;
   mReplyGroup = replyGroup.get();

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -265,6 +265,11 @@ class QgsNetworkLoggerRequestGroup final : public QgsNetworkLoggerGroup
     QUrl url() const { return mUrl; }
 
     /**
+     * Returns TRUE if the request was served directly from local cache.
+     */
+    bool replyFromCache() const { return mReplyFromCache; }
+
+    /**
      * Called to set the \a reply associated with the request.
      *
      * Will automatically create children encapsulating the reply details.

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -316,6 +316,7 @@ class QgsNetworkLoggerRequestGroup final : public QgsNetworkLoggerGroup
     QByteArray mData;
     Status mStatus = Status::Pending;
     bool mHasSslErrors = false;
+    bool mReplyFromCache = false;
     QList< QPair< QString, QString > > mHeaders;
     QgsNetworkLoggerRequestDetailsGroup *mDetailsGroup = nullptr;
     QgsNetworkLoggerReplyGroup *mReplyGroup = nullptr;

--- a/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.cpp
@@ -104,6 +104,11 @@ void QgsNetworkLoggerTreeView::setShowTimeouts( bool show )
   mProxyModel->setShowTimeouts( show );
 }
 
+void QgsNetworkLoggerTreeView::setShowCached( bool show )
+{
+  mProxyModel->setShowCached( show );
+}
+
 void QgsNetworkLoggerTreeView::itemExpanded( const QModelIndex &index )
 {
   // if the item is a QgsNetworkLoggerRequestGroup item, open all children (show ALL info of it)
@@ -171,11 +176,13 @@ QgsNetworkLoggerPanelWidget::QgsNetworkLoggerPanelWidget( QgsNetworkLogger *logg
 
   mActionShowTimeouts->setChecked( true );
   mActionShowSuccessful->setChecked( true );
+  mActionShowCached->setChecked( true );
   mActionRecord->setChecked( mLogger->isLogging() );
 
   connect( mFilterLineEdit, &QgsFilterLineEdit::textChanged, mTreeView, &QgsNetworkLoggerTreeView::setFilterString );
   connect( mActionShowTimeouts, &QAction::toggled, mTreeView, &QgsNetworkLoggerTreeView::setShowTimeouts );
   connect( mActionShowSuccessful, &QAction::toggled, mTreeView, &QgsNetworkLoggerTreeView::setShowSuccessful );
+  connect( mActionShowCached, &QAction::toggled, mTreeView, &QgsNetworkLoggerTreeView::setShowCached );
   connect( mActionClear, &QAction::triggered, mLogger, &QgsNetworkLogger::clear );
   connect( mActionRecord, &QAction::toggled, this, [ = ]( bool enabled )
   {
@@ -219,6 +226,7 @@ QgsNetworkLoggerPanelWidget::QgsNetworkLoggerPanelWidget( QgsNetworkLogger *logg
 
   settingsMenu->addAction( mActionShowSuccessful );
   settingsMenu->addAction( mActionShowTimeouts );
+  settingsMenu->addAction( mActionShowCached );
 
   mToolbar->addSeparator();
   QCheckBox *disableCacheCheck = new QCheckBox( tr( "Disable cache" ) );

--- a/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggerpanelwidget.h
@@ -56,6 +56,11 @@ class QgsNetworkLoggerTreeView: public QTreeView
      */
     void setShowTimeouts( bool show );
 
+    /**
+     * Sets whether requests served directly from cache are shown
+     */
+    void setShowCached( bool show );
+
   private slots:
     void itemExpanded( const QModelIndex &index );
     void contextMenu( QPoint point );

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -818,4 +818,13 @@ bool QgsVectorTileDataProvider::isValid() const
 {
   return true;
 }
+
+bool QgsVectorTileDataProvider::renderInPreview( const PreviewContext &context )
+{
+  // Vector tiles by design are very CPU light to render, so we are much more permissive here compared
+  // with other layer types. (Generally if a vector tile layer has taken more than a few milliseconds to render it's
+  // a result of network requests, and the tile manager class handles these gracefully for us)
+  return context.lastRenderingTimeMs <= 1000;
+}
+
 ///@endcond

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -254,6 +254,7 @@ class QgsVectorTileDataProvider : public QgsDataProvider
     QString description() const override;
     QgsRectangle extent() const override;
     bool isValid() const override;
+    bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
 
 };
 ///@endcond

--- a/src/ui/qgsnetworkloggerpanelbase.ui
+++ b/src/ui/qgsnetworkloggerpanelbase.ui
@@ -112,6 +112,17 @@
     <string>Save Log…</string>
    </property>
   </action>
+  <action name="mActionShowCached">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Replies Served from Cache</string>
+   </property>
+   <property name="toolTip">
+    <string>Show replies served directly from local cached data</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -127,6 +138,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Be more tolerant when deciding when to render preview jobs for vector tile layers, since vector tile layers by design are extremely CPU light to render. If a vector tile layer has taken more than a few milliseconds to render then it's a result of network request latency, and the tile manager class will handle that gracefully for us anyway.

Also adds an option to the network logger panel to hide replies served directly from local cache, which is handy to see exactly how many requests we are sending to a server. Refs #47768 