### PR TITLE
Add a "filter rules" search box to vector tile renderer and labeling widgets

### DIFF
--- a/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasiclabelingwidget.h
@@ -111,6 +111,9 @@ class QgsVectorTileBasicLabelingListModel : public QAbstractListModel
     {
       MinZoom = Qt::UserRole + 1,
       MaxZoom,
+      Label,
+      Layer,
+      Filter
     };
 
     QgsVectorTileBasicLabelingListModel( QgsVectorTileBasicLabeling *r, QObject *parent = nullptr );
@@ -144,12 +147,14 @@ class QgsVectorTileBasicLabelingProxyModel : public QSortFilterProxyModel
 
     void setCurrentZoom( int zoom );
     void setFilterVisible( bool enabled );
+    void setFilterString( const QString &string );
 
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
 
     bool mFilterVisible = false;
+    QString mFilterString;
     int mCurrentZoom = -1;
 };
 

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -117,6 +117,15 @@ QVariant QgsVectorTileBasicRendererListModel::data( const QModelIndex &index, in
     case MaxZoom:
       return style.maxZoomLevel();
 
+    case Label:
+      return style.styleName();
+
+    case Layer:
+      return style.layerName();
+
+    case Filter:
+      return style.filterExpression();
+
   }
   return QVariant();
 }
@@ -312,6 +321,10 @@ QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTil
   setupUi( this );
   layout()->setContentsMargins( 0, 0, 0, 0 );
 
+  mFilterLineEdit->setShowClearButton( true );
+  mFilterLineEdit->setShowSearchIcon( true );
+  mFilterLineEdit->setPlaceholderText( tr( "Filter rules" ) );
+
   QMenu *menuAddRule = new QMenu( btnAddRule );
   menuAddRule->addAction( tr( "Marker" ), this, [this] { addStyle( QgsWkbTypes::PointGeometry ); } );
   menuAddRule->addAction( tr( "Line" ), this, [this] { addStyle( QgsWkbTypes::LineGeometry ); } );
@@ -338,6 +351,11 @@ QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTil
   connect( mCheckVisibleOnly, &QCheckBox::toggled, this, [ = ]( bool filter )
   {
     mProxyModel->setFilterVisible( filter );
+  } );
+
+  connect( mFilterLineEdit, &QgsFilterLineEdit::textChanged, this, [ = ]( const QString & text )
+  {
+    mProxyModel->setFilterString( text );
   } );
 
   setLayer( layer );
@@ -528,19 +546,38 @@ void QgsVectorTileBasicRendererProxyModel::setFilterVisible( bool enabled )
   invalidateFilter();
 }
 
+void QgsVectorTileBasicRendererProxyModel::setFilterString( const QString &string )
+{
+  mFilterString = string;
+  invalidateFilter();
+}
+
 bool QgsVectorTileBasicRendererProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
-  if ( mCurrentZoom < 0 || !mFilterVisible )
-    return true;
+  if ( mCurrentZoom >= 0 && mFilterVisible )
+  {
+    const int rowMinZoom = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::MinZoom ).toInt();
+    const int rowMaxZoom = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::MaxZoom ).toInt();
 
-  const int rowMinZoom = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::MinZoom ).toInt();
-  const int rowMaxZoom = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::MaxZoom ).toInt();
+    if ( rowMinZoom >= 0 && rowMinZoom > mCurrentZoom )
+      return false;
 
-  if ( rowMinZoom >= 0 && rowMinZoom > mCurrentZoom )
-    return false;
+    if ( rowMaxZoom >= 0 && rowMaxZoom < mCurrentZoom )
+      return false;
+  }
 
-  if ( rowMaxZoom >= 0 && rowMaxZoom < mCurrentZoom )
-    return false;
+  if ( !mFilterString.isEmpty() )
+  {
+    const QString name = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::Label ).toString();
+    const QString layer = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::Layer ).toString();
+    const QString filter = sourceModel()->data( sourceModel()->index( source_row, 0, source_parent ), QgsVectorTileBasicRendererListModel::Filter ).toString();
+    if ( !name.contains( mFilterString, Qt::CaseInsensitive )
+         && !layer.contains( mFilterString, Qt::CaseInsensitive )
+         && !filter.contains( mFilterString, Qt::CaseInsensitive ) )
+    {
+      return false;
+    }
+  }
 
   return true;
 }

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -85,6 +85,9 @@ class QgsVectorTileBasicRendererListModel : public QAbstractListModel
     {
       MinZoom = Qt::UserRole + 1,
       MaxZoom,
+      Label,
+      Layer,
+      Filter
     };
 
     QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent = nullptr );
@@ -118,12 +121,14 @@ class QgsVectorTileBasicRendererProxyModel : public QSortFilterProxyModel
 
     void setCurrentZoom( int zoom );
     void setFilterVisible( bool enabled );
+    void setFilterString( const QString &string );
 
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
   private:
 
     bool mFilterVisible = false;
+    QString mFilterString;
     int mCurrentZoom = -1;
 };
 

--- a/src/ui/qgsvectortilebasiclabelingwidget.ui
+++ b/src/ui/qgsvectortilebasiclabelingwidget.ui
@@ -12,6 +12,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsFilterLineEdit" name="mFilterLineEdit"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mCheckVisibleOnly">
+       <property name="toolTip">
+        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
+       </property>
+       <property name="text">
+        <string>Visible rules only</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTreeView" name="viewStyles">
      <property name="acceptDrops">
       <bool>true</bool>
@@ -100,21 +120,27 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QCheckBox" name="mCheckVisibleOnly">
-       <property name="toolTip">
-        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
-       </property>
-       <property name="text">
-        <string>Visible rules only</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mFilterLineEdit</tabstop>
+  <tabstop>mCheckVisibleOnly</tabstop>
+  <tabstop>viewStyles</tabstop>
+  <tabstop>btnAddRule</tabstop>
+  <tabstop>btnRemoveRule</tabstop>
+  <tabstop>btnEditRule</tabstop>
+ </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -12,6 +12,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsFilterLineEdit" name="mFilterLineEdit"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mCheckVisibleOnly">
+       <property name="toolTip">
+        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
+       </property>
+       <property name="text">
+        <string>Visible rules only</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTreeView" name="viewStyles">
      <property name="acceptDrops">
       <bool>true</bool>
@@ -100,21 +120,27 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QCheckBox" name="mCheckVisibleOnly">
-       <property name="toolTip">
-        <string>Hides any rules which are invisible because they fall outside the current map canvas zoom level</string>
-       </property>
-       <property name="text">
-        <string>Visible rules only</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mFilterLineEdit</tabstop>
+  <tabstop>mCheckVisibleOnly</tabstop>
+  <tabstop>viewStyles</tabstop>
+  <tabstop>btnAddRule</tabstop>
+  <tabstop>btnRemoveRule</tabstop>
+  <tabstop>btnEditRule</tabstop>
+ </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Allows users to filter the visible rules by a portion of their label/layer or filter strings. This can greatly help with finding rules in a complex vector tile style!

![Peek 2022-03-15 10-16](https://user-images.githubusercontent.com/1829991/158281565-6a14ff12-a82b-4209-a05f-cb1d33dcc312.gif)
