### PR TITLE
[mssql] Fix regression with identity column types

### DIFF
--- a/tests/testdata/provider/testdata_mssql.sql
+++ b/tests/testdata/provider/testdata_mssql.sql
@@ -42,6 +42,18 @@ GO
 DROP TABLE IF EXISTS qgis_test.[constraints];
 GO
 
+DROP TABLE IF EXISTS qgis_test.[edit_data];
+GO
+
+DROP TABLE IF EXISTS qgis_test.[layer_extent_in_geometry_table];
+GO
+
+DROP TABLE IF EXISTS qgis_test.[test_complex_pk_name];
+GO
+
+DROP TABLE IF EXISTS qgis_test.[test_identity];
+GO
+
 DROP SCHEMA qgis_test;
 GO
 


### PR DESCRIPTION
Fix identity column types have a forced not null constraint but not a complimentary defaultValueClause, introduced by https://github.com/qgis/QGIS/pull/43682.

(identity columns return false for NULLABLE but an empty  COLUMN_DEF in exec sp_columns)

This causes issues with any table using a identity column, as a user is forced to populate these columns themselves in order to create features, yet the value will be discarded when the feature is saved to the database.

Instead correctly set the constraints, read only and a default value clause for these column types.
