### PR TITLE
expose QgsMeshVerticesElevationDatasetGroup

### DIFF
--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -797,7 +797,7 @@ class QgsMeshVerticesElevationDataset: public QgsMeshDataset
  *
  * \since QGIS 3.22
  */
-class QgsMeshVerticesElevationDatasetGroup : public QgsMeshDatasetGroup
+class CORE_EXPORT QgsMeshVerticesElevationDatasetGroup : public QgsMeshDatasetGroup
 {
   public:
     //! Constructor with a \a name and linked to \a mesh


### PR DESCRIPTION
Just exposed this `QgsMeshVerticesElevationDatasetGroup` in the core API. That allow to add this virtual dataset group  representing the Z value of vertices to the mesh from the API.