### PR TITLE
Merge features into an existing one instead of a new one

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10462,16 +10462,18 @@ void QgisApp::mergeSelectedFeatures()
 
   vl->beginEditCommand( tr( "Merged features" ) );
 
-  //create new feature
-  QgsFeature newFeature = QgsVectorLayerUtils::createFeature( vl, unionGeom, newAttributes );
-
+  // Delete other features
+  QgsFeatureId mainFeature = d.mainFeatureId();
+  featureIdsAfter.remove( mainFeature );
   QgsFeatureIds::const_iterator feature_it = featureIdsAfter.constBegin();
   for ( ; feature_it != featureIdsAfter.constEnd(); ++feature_it )
   {
     vl->deleteFeature( *feature_it );
   }
 
-  vl->addFeature( newFeature );
+  // Modify merge feature
+  vl->changeGeometry( mainFeature, unionGeom );
+  vl->changeAttributeValues( mainFeature, newAttributes );
 
   vl->endEditCommand();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10442,12 +10442,19 @@ void QgisApp::mergeSelectedFeatures()
   QgsAttributes attrs = d.mergedAttributes();
   QgsAttributeMap newAttributes;
   QString errorMessage;
+  QgsFeatureId mergeFeatureId = FID_NULL;
   for ( int i = 0; i < attrs.count(); ++i )
   {
     QVariant val = attrs.at( i );
     bool isDefaultValue = vl->fields().fieldOrigin( i ) == QgsFields::OriginProvider &&
                           vl->dataProvider() &&
                           vl->dataProvider()->defaultValueClause( vl->fields().fieldOriginIndex( i ) ) == val;
+    bool isPrimaryKey =  vl->fields().fieldOrigin( i ) == QgsFields::OriginProvider &&
+                         vl->dataProvider() &&
+                         vl->dataProvider()->pkAttributeIndexes().contains( vl->fields().fieldOriginIndex( i ) );
+
+    if ( isPrimaryKey && !isDefaultValue )
+      mergeFeatureId = val.toLongLong();
 
     // convert to destination data type
     if ( !isDefaultValue && !vl->fields().at( i ).convertCompatible( val, &errorMessage ) )
@@ -10462,18 +10469,37 @@ void QgisApp::mergeSelectedFeatures()
 
   vl->beginEditCommand( tr( "Merged features" ) );
 
+  QgsFeature mergeFeature;
+  if ( mergeFeatureId == FID_NULL )
+  {
+    // Create new feature
+    mergeFeature = QgsVectorLayerUtils::createFeature( vl, unionGeom, newAttributes );
+  }
+  else
+  {
+    // Merge into existing feature
+    featureIdsAfter.remove( mergeFeatureId );
+  }
+
   // Delete other features
-  QgsFeatureId mainFeature = d.mainFeatureId();
-  featureIdsAfter.remove( mainFeature );
   QgsFeatureIds::const_iterator feature_it = featureIdsAfter.constBegin();
   for ( ; feature_it != featureIdsAfter.constEnd(); ++feature_it )
   {
     vl->deleteFeature( *feature_it );
   }
 
-  // Modify merge feature
-  vl->changeGeometry( mainFeature, unionGeom );
-  vl->changeAttributeValues( mainFeature, newAttributes );
+
+  if ( mergeFeatureId == FID_NULL )
+  {
+    // Add the new feature
+    vl->addFeature( mergeFeature );
+  }
+  else
+  {
+    // Modify merge feature
+    vl->changeGeometry( mergeFeatureId, unionGeom );
+    vl->changeAttributeValues( mergeFeatureId, newAttributes );
+  }
 
   vl->endEditCommand();
 

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -108,11 +108,6 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &featur
       break;
   }
 
-  if ( !mFeatureList.isEmpty() )
-    mMainFeatureId = mFeatureList.first().id();
-  else
-    mMainFeatureId = FID_NULL;
-
   connect( mSkipAllButton, &QAbstractButton::clicked, this, &QgsMergeAttributesDialog::setAllToSkip );
   connect( mTableWidget, &QTableWidget::cellChanged, this, &QgsMergeAttributesDialog::tableWidgetCellChanged );
 
@@ -131,11 +126,6 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog()
 QgsMergeAttributesDialog::~QgsMergeAttributesDialog()
 {
   delete mSelectionRubberBand;
-}
-
-QgsFeatureId QgsMergeAttributesDialog::mainFeatureId() const
-{
-  return mMainFeatureId;
 }
 
 void QgsMergeAttributesDialog::setAttributeTableConfig( const QgsAttributeTableConfig &config )
@@ -190,7 +180,8 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
     mFieldToColumnMap[ mFields.at( idx ).name() ] = col;
 
     QComboBox *cb = createMergeComboBox( mFields.at( idx ).type() );
-    if ( mFields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+    if ( ! mVectorLayer->dataProvider()->pkAttributeIndexes().contains( mFields.fieldOriginIndex( idx ) ) &&
+         mFields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
     {
       cb->setCurrentIndex( cb->findData( "skip" ) );
     }
@@ -464,7 +455,8 @@ void QgsMergeAttributesDialog::setAllAttributesFromFeature( QgsFeatureId feature
     if ( !currentComboBox )
       continue;
 
-    if ( mVectorLayer->fields().at( i ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
+    if ( ! mVectorLayer->dataProvider()->pkAttributeIndexes().contains( mVectorLayer->fields().fieldOriginIndex( i ) ) &&
+         mVectorLayer->fields().at( i ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique )
     {
       currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "skip" ) ) );
     }
@@ -473,8 +465,6 @@ void QgsMergeAttributesDialog::setAllAttributesFromFeature( QgsFeatureId feature
       currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "f%1" ).arg( FID_TO_STRING( featureId ) ) ) );
     }
   }
-
-  mMainFeatureId = featureId;
 }
 
 QVariant QgsMergeAttributesDialog::calcStatistic( int col, QgsStatisticalSummary::Statistic stat )

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -108,6 +108,11 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog( const QgsFeatureList &featur
       break;
   }
 
+  if ( !mFeatureList.isEmpty() )
+    mMainFeatureId = mFeatureList.first().id();
+  else
+    mMainFeatureId = FID_NULL;
+
   connect( mSkipAllButton, &QAbstractButton::clicked, this, &QgsMergeAttributesDialog::setAllToSkip );
   connect( mTableWidget, &QTableWidget::cellChanged, this, &QgsMergeAttributesDialog::tableWidgetCellChanged );
 
@@ -126,6 +131,11 @@ QgsMergeAttributesDialog::QgsMergeAttributesDialog()
 QgsMergeAttributesDialog::~QgsMergeAttributesDialog()
 {
   delete mSelectionRubberBand;
+}
+
+QgsFeatureId QgsMergeAttributesDialog::mainFeatureId() const
+{
+  return mMainFeatureId;
 }
 
 void QgsMergeAttributesDialog::setAttributeTableConfig( const QgsAttributeTableConfig &config )
@@ -463,6 +473,8 @@ void QgsMergeAttributesDialog::setAllAttributesFromFeature( QgsFeatureId feature
       currentComboBox->setCurrentIndex( currentComboBox->findData( QStringLiteral( "f%1" ).arg( FID_TO_STRING( featureId ) ) ) );
     }
   }
+
+  mMainFeatureId = featureId;
 }
 
 QVariant QgsMergeAttributesDialog::calcStatistic( int col, QgsStatisticalSummary::Statistic stat )

--- a/src/app/qgsmergeattributesdialog.h
+++ b/src/app/qgsmergeattributesdialog.h
@@ -47,6 +47,8 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
     QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsMergeAttributesDialog() override;
 
+    QgsFeatureId mainFeatureId() const;
+
     QgsAttributes mergedAttributes() const;
 
     /**
@@ -102,6 +104,7 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
     void createRubberBandForFeature( QgsFeatureId featureId );
 
     QgsFeatureList mFeatureList;
+    QgsFeatureId mMainFeatureId = FID_NULL;
     QgsVectorLayer *mVectorLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     //! Item that highlights the selected feature in the merge table

--- a/src/app/qgsmergeattributesdialog.h
+++ b/src/app/qgsmergeattributesdialog.h
@@ -47,8 +47,6 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
     QgsMergeAttributesDialog( const QgsFeatureList &features, QgsVectorLayer *vl, QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsMergeAttributesDialog() override;
 
-    QgsFeatureId mainFeatureId() const;
-
     QgsAttributes mergedAttributes() const;
 
     /**
@@ -104,7 +102,6 @@ class APP_EXPORT QgsMergeAttributesDialog: public QDialog, private Ui::QgsMergeA
     void createRubberBandForFeature( QgsFeatureId featureId );
 
     QgsFeatureList mFeatureList;
-    QgsFeatureId mMainFeatureId = FID_NULL;
     QgsVectorLayer *mVectorLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     //! Item that highlights the selected feature in the merge table


### PR DESCRIPTION
This aims to fix #47629.

- Per default the first selected feature will be preserved (other features are merged in)
- When pressing "Take attributes from selected feature" selected feature will be preserved
- When pressing "Take attributes from feature with the largest area/longest line" that feature will be preserved