### PR TITLE
Have to use g prefix for gnu tools also on *BSD

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -16,7 +16,7 @@
 
 # sort by version option
 SV=V
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
 	SV=n
 fi
 

--- a/scripts/customwidget_create.sh
+++ b/scripts/customwidget_create.sh
@@ -9,9 +9,9 @@
 
 set -e
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/prepare_commit.sh
+++ b/scripts/prepare_commit.sh
@@ -24,9 +24,9 @@ fi
 
 cd "$TOPLEVEL"
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/qstringfixup.sh
+++ b/scripts/qstringfixup.sh
@@ -30,9 +30,9 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 
 cd "$TOPLEVEL" || exit
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/rename_cpp.sh
+++ b/scripts/rename_cpp.sh
@@ -7,9 +7,9 @@
 
 set -e
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/sip_include.sh
+++ b/scripts/sip_include.sh
@@ -25,9 +25,9 @@ DIR=$(git rev-parse --show-toplevel)
 
 pushd ${DIR} > /dev/null
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/sipify_all.sh
+++ b/scripts/sipify_all.sh
@@ -27,9 +27,9 @@ set -e
 
 DIR=$(git rev-parse --show-toplevel)
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/spell_check/check_spelling.sh
+++ b/scripts/spell_check/check_spelling.sh
@@ -32,9 +32,9 @@ DIR=$(git rev-parse --show-toplevel)/scripts/spell_check
 
 AGIGNORE=${DIR}/.agignore
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/scripts/spell_check/test.sh
+++ b/scripts/spell_check/test.sh
@@ -16,9 +16,9 @@
 
 # Testing the spell test :)
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/tests/code_layout/sipify/test_sipfiles.sh
+++ b/tests/code_layout/sipify/test_sipfiles.sh
@@ -6,9 +6,9 @@ srcdir=$(dirname $0)/../../
 
 DIR=$(git -C ${srcdir} rev-parse --show-toplevel)
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 

--- a/tests/code_layout/test_settings_registry.sh
+++ b/tests/code_layout/test_settings_registry.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-# GNU prefix command for mac os support (gsed, gsplit)
+# GNU prefix command for bsd/mac os support (gsed, gsplit)
 GP=
-if [[ "$OSTYPE" =~ darwin* ]]; then
+if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 


### PR DESCRIPTION
## Description

Error discovered while using spell_check script.
I never encountered an error during pre commit or astyle, but I might as well use the gnu version as macos since it's installed anyway...