### PR TITLE
Ignore symbol layer types which do not have colors (raster fill, marker, etc) when calculating overall symbol colors

### DIFF
--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -965,6 +965,8 @@ Used internally when reading/writing symbols.
 
     virtual bool usesMapUnits() const;
 
+    virtual QColor color() const;
+
 
     virtual QgsSymbol *subSymbol();
     virtual bool setSubSymbol( QgsSymbol *symbol /Transfer/ );

--- a/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -331,6 +331,8 @@ Creates the symbol layer
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );
 
+    virtual QColor color() const;
+
 
     virtual void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
 

--- a/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -1378,6 +1378,8 @@ Set the line opacity.
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
 
+    virtual QColor color() const;
+
 
   protected:
 
@@ -1438,6 +1440,8 @@ serialized in the ``properties`` map (corresponding to the output from
     virtual QgsMapUnitScale mapUnitScale() const;
 
     virtual double estimateMaxBleed( const QgsRenderContext &context ) const;
+
+    virtual QColor color() const;
 
 
     Qgis::GradientColorSource gradientColorType() const;

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -790,13 +790,13 @@ Used internally when reading/writing symbols.
 
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 
-
     virtual QVariantMap properties() const;
-
 
     virtual QgsRasterMarkerSymbolLayer *clone() const /Factory/;
 
     virtual bool usesMapUnits() const;
+
+    virtual QColor color() const;
 
 
     double calculateAspectRatio( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedAspectRatio ) const;

--- a/python/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
@@ -64,6 +64,8 @@ Create a new QgsMaskMarkerSymbolLayer
 
     virtual bool usesMapUnits() const;
 
+    virtual QColor color() const;
+
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size );
 

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -206,38 +206,95 @@ when desired.
 
     virtual QColor color() const;
 %Docstring
-The fill color.
+Returns the "representative" color of the symbol layer.
+
+Depending on the symbol layer type, this will have different meaning. For instance, a line
+symbol layer will generally return the stroke color of the layer, while a fill symbol layer
+will return the "fill" color instead of stroke.
+
+Some symbol layer types will return an invalid QColor if they have no representative
+color associated (e.g. raster image based symbol layers).
+
+.. seealso:: :py:func:`setColor`
+
+.. seealso:: :py:func:`strokeColor`
+
+.. seealso:: :py:func:`fillColor`
 %End
 
     virtual void setColor( const QColor &color );
 %Docstring
-The fill color.
+Sets the "representative" color for the symbol layer.
+
+Depending on the symbol layer type, this will have different meaning. For instance, a line
+symbol layer will generally set the stroke color of the layer, while a fill symbol layer
+will set the "fill" color instead of stroke.
+
+.. seealso:: :py:func:`color`
+
+.. seealso:: :py:func:`setStrokeColor`
+
+.. seealso:: :py:func:`setFillColor`
 %End
 
     virtual void setStrokeColor( const QColor &color );
 %Docstring
-Set stroke color. Supported by marker and fill layers.
+Sets the stroke ``color`` for the symbol layer.
+
+This property is not supported by all symbol layer types, only those with a stroke component.
+
+.. seealso:: :py:func:`strokeColor`
+
+.. seealso:: :py:func:`setColor`
+
+.. seealso:: :py:func:`setFillColor`
 
 .. versionadded:: 2.1
 %End
 
     virtual QColor strokeColor() const;
 %Docstring
-Gets stroke color. Supported by marker and fill layers.
+Returns the stroke color for the symbol layer.
+
+This property is not supported by all symbol layer types, only those with a stroke component. Symbol
+layers without a stroke component will return an invalid QColor.
+
+.. seealso:: :py:func:`setStrokeColor`
+
+.. seealso:: :py:func:`color`
+
+.. seealso:: :py:func:`fillColor`
 
 .. versionadded:: 2.1
 %End
 
     virtual void setFillColor( const QColor &color );
 %Docstring
-Set fill color. Supported by marker and fill layers.
+Sets the fill ``color`` for the symbol layer.
+
+This property is not supported by all symbol layer types, only those with a fill component.
+
+.. seealso:: :py:func:`fillColor`
+
+.. seealso:: :py:func:`setColor`
+
+.. seealso:: :py:func:`setStrokeColor`
 
 .. versionadded:: 2.1
 %End
 
     virtual QColor fillColor() const;
 %Docstring
-Gets fill color. Supported by marker and fill layers.
+Returns the fill color for the symbol layer.
+
+This property is not supported by all symbol layer types, only those with a fill component. Symbol
+layers without a fill component will return an invalid QColor.
+
+.. seealso:: :py:func:`setFillColor`
+
+.. seealso:: :py:func:`color`
+
+.. seealso:: :py:func:`strokeColor`
 
 .. versionadded:: 2.1
 %End

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -4859,6 +4859,11 @@ bool QgsRasterFillSymbolLayer::usesMapUnits() const
          || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
+QColor QgsRasterFillSymbolLayer::color() const
+{
+  return QColor();
+}
+
 void QgsRasterFillSymbolLayer::setImageFilePath( const QString &imagePath )
 {
   mImageFilePath = imagePath;

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -909,6 +909,7 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
     QgsRasterFillSymbolLayer *clone() const override SIP_FACTORY;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
     bool usesMapUnits() const override;
+    QColor color() const override;
 
     //override QgsImageFillSymbolLayer's support for sub symbols
     QgsSymbol *subSymbol() override { return nullptr; }

--- a/src/core/symbology/qgsinterpolatedlinerenderer.cpp
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.cpp
@@ -925,6 +925,18 @@ void QgsInterpolatedLineSymbolLayer::drawPreviewIcon( QgsSymbolRenderContext &co
 
 }
 
+QColor QgsInterpolatedLineSymbolLayer::color() const
+{
+  switch ( mLineRender.interpolatedColor().coloringMethod() )
+  {
+    case QgsInterpolatedLineColor::SingleColor:
+      return mLineRender.interpolatedColor().singleColor();
+    case QgsInterpolatedLineColor::ColorRamp:
+      return QColor();
+  }
+  BUILTIN_UNREACHABLE
+}
+
 
 void QgsInterpolatedLineSymbolLayer::setExpressionsStringForWidth( const QString &start, const QString &end )
 {

--- a/src/core/symbology/qgsinterpolatedlinerenderer.h
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.h
@@ -299,6 +299,7 @@ class CORE_EXPORT QgsInterpolatedLineSymbolLayer : public QgsLineSymbolLayer
     QgsInterpolatedLineSymbolLayer *clone() const override SIP_FACTORY;
     QVariantMap properties() const override;
     void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size ) override;
+    QColor color() const override;
 
     void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
     void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -3525,6 +3525,11 @@ double QgsRasterLineSymbolLayer::estimateMaxBleed( const QgsRenderContext & ) co
   return ( mWidth / 2.0 ) + mOffset;
 }
 
+QColor QgsRasterLineSymbolLayer::color() const
+{
+  return QColor();
+}
+
 
 //
 // QgsLineburstSymbolLayer
@@ -3760,6 +3765,11 @@ QgsMapUnitScale QgsLineburstSymbolLayer::mapUnitScale() const
 double QgsLineburstSymbolLayer::estimateMaxBleed( const QgsRenderContext & ) const
 {
   return ( mWidth / 2.0 ) + mOffset;
+}
+
+QColor QgsLineburstSymbolLayer::color() const
+{
+  return QColor();
 }
 
 QgsColorRamp *QgsLineburstSymbolLayer::colorRamp()

--- a/src/core/symbology/qgslinesymbollayer.h
+++ b/src/core/symbology/qgslinesymbollayer.h
@@ -1258,6 +1258,7 @@ class CORE_EXPORT QgsRasterLineSymbolLayer : public QgsAbstractBrushedLineSymbol
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
+    QColor color() const override;
 
   protected:
     QString mPath;
@@ -1308,6 +1309,7 @@ class CORE_EXPORT QgsLineburstSymbolLayer : public QgsAbstractBrushedLineSymbolL
     void setMapUnitScale( const QgsMapUnitScale &scale ) override;
     QgsMapUnitScale mapUnitScale() const override;
     double estimateMaxBleed( const QgsRenderContext &context ) const override;
+    QColor color() const override;
 
     /**
      * Returns the gradient color mode, which controls how gradient color stops are created.

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3131,6 +3131,11 @@ bool QgsRasterMarkerSymbolLayer::usesMapUnits() const
          || mOffsetUnit == QgsUnitTypes::RenderMapUnits || mOffsetUnit == QgsUnitTypes::RenderMetersInMapUnits;
 }
 
+QColor QgsRasterMarkerSymbolLayer::color() const
+{
+  return QColor();
+}
+
 void QgsRasterMarkerSymbolLayer::setMapUnitScale( const QgsMapUnitScale &scale )
 {
   QgsMarkerSymbolLayer::setMapUnitScale( scale );

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -714,11 +714,10 @@ class CORE_EXPORT QgsRasterMarkerSymbolLayer : public QgsMarkerSymbolLayer
     QString layerType() const override;
 
     void renderPoint( QPointF point, QgsSymbolRenderContext &context ) override;
-
     QVariantMap properties() const override;
-
     QgsRasterMarkerSymbolLayer *clone() const override SIP_FACTORY;
     bool usesMapUnits() const override;
+    QColor color() const override;
 
     /**
      * Calculates the marker aspect ratio between width and height.

--- a/src/core/symbology/qgsmasksymbollayer.cpp
+++ b/src/core/symbology/qgsmasksymbollayer.cpp
@@ -150,6 +150,11 @@ bool QgsMaskMarkerSymbolLayer::usesMapUnits() const
          || ( mSymbol && mSymbol->usesMapUnits() );
 }
 
+QColor QgsMaskMarkerSymbolLayer::color() const
+{
+  return QColor();
+}
+
 void QgsMaskMarkerSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &context )
 {
   if ( !context.renderContext().painter() )

--- a/src/core/symbology/qgsmasksymbollayer.h
+++ b/src/core/symbology/qgsmasksymbollayer.h
@@ -62,6 +62,7 @@ class CORE_EXPORT QgsMaskMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void renderPoint( QPointF point, QgsSymbolRenderContext &context ) override;
     QRectF bounds( QPointF point, QgsSymbolRenderContext &context ) override;
     bool usesMapUnits() const override;
+    QColor color() const override;
 
     virtual void drawPreviewIcon( QgsSymbolRenderContext &context, QSize size ) override;
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -550,11 +550,15 @@ void QgsSymbol::setColor( const QColor &color )
 
 QColor QgsSymbol::color() const
 {
-  for ( QgsSymbolLayerList::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  for ( const QgsSymbolLayer *layer : mLayers )
   {
     // return color of the first unlocked layer
-    if ( !( *it )->isLocked() )
-      return ( *it )->color();
+    if ( !layer->isLocked() )
+    {
+      const QColor layerColor = layer->color();
+      if ( layerColor.isValid() )
+        return layerColor;
+    }
   }
   return QColor( 0, 0, 0 );
 }

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -233,6 +233,35 @@ Qgis::SymbolLayerFlags QgsSymbolLayer::flags() const
   return Qgis::SymbolLayerFlags();
 }
 
+QColor QgsSymbolLayer::color() const
+{
+  return mColor;
+}
+
+void QgsSymbolLayer::setColor( const QColor &color )
+{
+  mColor = color;
+}
+
+void QgsSymbolLayer::setStrokeColor( const QColor & )
+{
+
+}
+
+QColor QgsSymbolLayer::strokeColor() const
+{
+  return QColor();
+}
+
+void QgsSymbolLayer::setFillColor( const QColor & )
+{
+}
+
+QColor QgsSymbolLayer::fillColor() const
+{
+  return QColor();
+}
+
 void QgsSymbolLayer::prepareExpressions( const QgsSymbolRenderContext &context )
 {
   mDataDefinedProperties.prepare( context.renderContext().expressionContext() );

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -248,38 +248,87 @@ class CORE_EXPORT QgsSymbolLayer
     void setEnabled( bool enabled ) { mEnabled = enabled; }
 
     /**
-     * The fill color.
+     * Returns the "representative" color of the symbol layer.
+     *
+     * Depending on the symbol layer type, this will have different meaning. For instance, a line
+     * symbol layer will generally return the stroke color of the layer, while a fill symbol layer
+     * will return the "fill" color instead of stroke.
+     *
+     * Some symbol layer types will return an invalid QColor if they have no representative
+     * color associated (e.g. raster image based symbol layers).
+     *
+     * \see setColor()
+     * \see strokeColor()
+     * \see fillColor()
      */
-    virtual QColor color() const { return mColor; }
+    virtual QColor color() const;
 
     /**
-     * The fill color.
+     * Sets the "representative" color for the symbol layer.
+     *
+     * Depending on the symbol layer type, this will have different meaning. For instance, a line
+     * symbol layer will generally set the stroke color of the layer, while a fill symbol layer
+     * will set the "fill" color instead of stroke.
+     *
+     * \see color()
+     * \see setStrokeColor()
+     * \see setFillColor()
      */
-    virtual void setColor( const QColor &color ) { mColor = color; }
+    virtual void setColor( const QColor &color );
 
     /**
-     * Set stroke color. Supported by marker and fill layers.
+     * Sets the stroke \a color for the symbol layer.
+     *
+     * This property is not supported by all symbol layer types, only those with a stroke component.
+     *
+     * \see strokeColor()
+     * \see setColor()
+     * \see setFillColor()
+     *
      * \since QGIS 2.1
     */
-    virtual void setStrokeColor( const QColor &color ) { Q_UNUSED( color ) }
+    virtual void setStrokeColor( const QColor &color );
 
     /**
-     * Gets stroke color. Supported by marker and fill layers.
+     * Returns the stroke color for the symbol layer.
+     *
+     * This property is not supported by all symbol layer types, only those with a stroke component. Symbol
+     * layers without a stroke component will return an invalid QColor.
+     *
+     * \see setStrokeColor()
+     * \see color()
+     * \see fillColor()
+     *
      * \since QGIS 2.1
     */
-    virtual QColor strokeColor() const { return QColor(); }
+    virtual QColor strokeColor() const;
 
     /**
-     * Set fill color. Supported by marker and fill layers.
+     * Sets the fill \a color for the symbol layer.
+     *
+     * This property is not supported by all symbol layer types, only those with a fill component.
+     *
+     * \see fillColor()
+     * \see setColor()
+     * \see setStrokeColor()
+     *
      * \since QGIS 2.1
     */
-    virtual void setFillColor( const QColor &color ) { Q_UNUSED( color ) }
+    virtual void setFillColor( const QColor &color );
 
     /**
-     * Gets fill color. Supported by marker and fill layers.
+     * Returns the fill color for the symbol layer.
+     *
+     * This property is not supported by all symbol layer types, only those with a fill component. Symbol
+     * layers without a fill component will return an invalid QColor.
+     *
+     * \see setFillColor()
+     * \see color()
+     * \see strokeColor()
+     *
      * \since QGIS 2.1
     */
-    virtual QColor fillColor() const { return QColor(); }
+    virtual QColor fillColor() const;
 
     /**
      * Returns a string that represents this layer type. Used for serialization.


### PR DESCRIPTION
Fixes #47723
