### PR TITLE
Disable backface culling on terrain

### DIFF
--- a/src/3d/terrain/qgsterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsterraintileloader_p.cpp
@@ -25,6 +25,8 @@
 #include "qgscoordinatetransform.h"
 
 #include <Qt3DRender/QTexture>
+#include <Qt3DRender/QTechnique>
+#include <Qt3DRender/QCullFace>
 
 #include <Qt3DExtras/QTextureMaterial>
 #include <Qt3DExtras/QDiffuseSpecularMaterial>
@@ -95,6 +97,19 @@ void QgsTerrainTileLoader::createTextureComponent( QgsTerrainTileEntity *entity,
     phongMaterial->setSpecular( shadingMaterial.specular() );
     phongMaterial->setShininess( shadingMaterial.shininess() );
     material = phongMaterial;
+  }
+
+  // no backface culling on terrain, to allow terrain to be viewed from underground
+  const QVector<Qt3DRender::QTechnique *> techniques = material->effect()->techniques();
+  for ( Qt3DRender::QTechnique *techique : techniques )
+  {
+    const QVector<Qt3DRender::QRenderPass *> passes = techique->renderPasses();
+    for ( Qt3DRender::QRenderPass *pass : passes )
+    {
+      Qt3DRender::QCullFace *cullFace = new Qt3DRender::QCullFace;
+      cullFace->setMode( Qt3DRender::QCullFace::NoCulling );
+      pass->addRenderState( cullFace );
+    }
   }
 
   entity->addComponent( material ); // takes ownership if the component has no parent


### PR DESCRIPTION
This allows the terrain to be visible from below (underground), which
is handy when visualising boreholes or other underground features
