### PR TITLE
Add "Keep disjoint features separate" option for dissolve algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/overlapping_polys.geojson
+++ b/python/plugins/processing/tests/testdata/custom/overlapping_polys.geojson
@@ -1,0 +1,13 @@
+{
+"type": "FeatureCollection",
+"name": "overlapping_polys",
+"features": [
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 0.0, -3.0 ], [ 0.0, -6.0 ], [ 3.0, -6.0 ], [ 3.0, -3.0 ], [ 0.0, -3.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.1", "class": "a" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 2.0, -2.0 ], [ 2.0, -5.0 ], [ 5.0, -5.0 ], [ 5.0, -2.0 ], [ 2.0, -2.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.2", "class": "a" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 8.0, -4.0 ], [ 8.0, -6.0 ], [ 11.0, -6.0 ], [ 11.0, -4.0 ], [ 8.0, -4.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.3", "class": "a" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 9.0, -5.0 ], [ 7.0, -5.0 ], [ 7.0, -7.0 ], [ 9.0, -7.0 ], [ 9.0, -5.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.4", "class": "a" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 7.0, -9.0 ], [ 9.0, -9.0 ], [ 9.0, -10.0 ], [ 7.0, -10.0 ], [ 7.0, -9.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.5", "class": "b" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 6.0, -6.0 ], [ 8.0, -6.0 ], [ 8.0, -11.0 ], [ 6.0, -11.0 ], [ 6.0, -6.0 ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.6", "class": "b" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 0.0, -8.0 ], [ 3.0, -8.0 ], [ 3.0, -10.0 ], [ 0.0, -10.0 ], [ 0.0, -8.0 ] ] ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/expected/dissolve_disjoint.geojson
+++ b/python/plugins/processing/tests/testdata/expected/dissolve_disjoint.geojson
@@ -1,0 +1,10 @@
+{
+"type": "FeatureCollection",
+"name": "dissolve_disjoint",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 9.0, -10.0 ], [ 8.0, -10.0 ], [ 8.0, -11.0 ], [ 6.0, -11.0 ], [ 6.0, -6.0 ], [ 7.0, -6.0 ], [ 7.0, -5.0 ], [ 8.0, -5.0 ], [ 8.0, -4.0 ], [ 11.0, -4.0 ], [ 11.0, -6.0 ], [ 9.0, -6.0 ], [ 9.0, -7.0 ], [ 8.0, -7.0 ], [ 8.0, -9.0 ], [ 9.0, -9.0 ], [ 9.0, -10.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 0.0, -10.0 ], [ 0.0, -8.0 ], [ 3.0, -8.0 ], [ 3.0, -10.0 ], [ 0.0, -10.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 0.0, -3.0 ], [ 2.0, -3.0 ], [ 2.0, -2.0 ], [ 5.0, -2.0 ], [ 5.0, -5.0 ], [ 3.0, -5.0 ], [ 3.0, -6.0 ], [ 0.0, -6.0 ], [ 0.0, -3.0 ] ] ] ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/expected/dissolve_disjoint_by_class.geojson
+++ b/python/plugins/processing/tests/testdata/expected/dissolve_disjoint_by_class.geojson
@@ -1,0 +1,12 @@
+{
+"type": "FeatureCollection",
+"name": "dissolve_disjoint_by_class",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 9.0, -10.0 ], [ 7.0, -10.0 ], [ 7.0, -9.0 ], [ 9.0, -9.0 ], [ 9.0, -10.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 11.0, -6.0 ], [ 9.0, -6.0 ], [ 9.0, -7.0 ], [ 7.0, -7.0 ], [ 7.0, -5.0 ], [ 8.0, -5.0 ], [ 8.0, -4.0 ], [ 11.0, -4.0 ], [ 11.0, -6.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.0", "class": "a" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 0.0, -3.0 ], [ 2.0, -3.0 ], [ 2.0, -2.0 ], [ 5.0, -2.0 ], [ 5.0, -5.0 ], [ 3.0, -5.0 ], [ 3.0, -6.0 ], [ 0.0, -6.0 ], [ 0.0, -3.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.5", "class": "b" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 3.0, -8.0 ], [ 3.0, -10.0 ], [ 0.0, -10.0 ], [ 0.0, -8.0 ], [ 3.0, -8.0 ] ] ] ] } },
+{ "type": "Feature", "properties": { "fid": "overlapping_polys.5", "class": "b" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 8.0, -6.0 ], [ 8.0, -11.0 ], [ 6.0, -11.0 ], [ 6.0, -6.0 ], [ 8.0, -6.0 ] ] ] ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
@@ -78,6 +78,7 @@ tests:
         compare:
           geometry:
             ignore_part_order: True
+            normalize: True
 
   - name: Aggregate using field
     algorithm: qgis:aggregate
@@ -127,6 +128,7 @@ tests:
         compare:
           geometry:
             ignore_part_order: True
+            normalize: True
 
   - algorithm: qgis:aggregate
     name: Aggregate using two fields
@@ -176,6 +178,7 @@ tests:
         compare:
           geometry:
             ignore_part_order: True
+            normalize: True
 
   - name: Aggregate points
     algorithm: qgis:aggregate
@@ -331,6 +334,9 @@ tests:
       OUTPUT:
         name: expected/clip_lines_by_multipolygon.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:clip
     name: Clip polygons by multipolygons
@@ -345,6 +351,9 @@ tests:
       OUTPUT:
         name: expected/clip_polys_by_multipolygon.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:clip
     name: Clip multipolygons by polygons
@@ -359,6 +368,9 @@ tests:
       OUTPUT:
         name: expected/clip_multipolygons_by_polygons.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:clip
     name: Clip points by polygons
@@ -406,6 +418,9 @@ tests:
       OUTPUT:
         name: expected/intersection_collection_fallback.shp
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - name: Densify geometries
     algorithm: native:densifygeometries
@@ -699,6 +714,7 @@ tests:
           geometry:
             precision: 4
             ignore_part_order: True
+            normalize: True
 
   - algorithm: native:dissolve
     name: Dissolve using two fields
@@ -715,6 +731,7 @@ tests:
           geometry:
             precision: 4
             ignore_part_order: True
+            normalize: True
 
   - name: Dissolve with geometries reported as valid but as invalid with isGeosValid
     algorithm: native:dissolve
@@ -729,6 +746,7 @@ tests:
         compare:
           geometry:
             precision: 0
+            normalize: True
 
   - name: Dissolve with NULL geometries
     algorithm: native:dissolve
@@ -743,6 +761,7 @@ tests:
         compare:
           geometry:
             precision: 7
+            normalize: True
 
   - name: Dissolve with invalid geometries
     algorithm: native:dissolve
@@ -758,6 +777,7 @@ tests:
         compare:
           geometry:
             precision: 7
+            normalize: True
 
   - algorithm: native:dissolve
     name: Dissolve separate disjoint
@@ -770,6 +790,9 @@ tests:
       OUTPUT:
         name: expected/dissolve_disjoint.geojson
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:dissolve
     name: Dissolve separate disjoint with classes
@@ -784,6 +807,10 @@ tests:
       OUTPUT:
         name: expected/dissolve_disjoint_by_class.geojson
         type: vector
+        compare:
+          unordered: True
+          geometry:
+            normalize: True
 
   - algorithm: native:buffer
     name: Basic polygon buffer
@@ -818,6 +845,7 @@ tests:
         compare:
           geometry:
             precision: 7
+            normalize: True
           fields:
             fid: skip
             name: skip

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
@@ -759,6 +759,32 @@ tests:
           geometry:
             precision: 7
 
+  - algorithm: native:dissolve
+    name: Dissolve separate disjoint
+    params:
+      INPUT:
+        name: custom/overlapping_polys.geojson
+        type: vector
+      SEPARATE_DISJOINT: true
+    results:
+      OUTPUT:
+        name: expected/dissolve_disjoint.geojson
+        type: vector
+
+  - algorithm: native:dissolve
+    name: Dissolve separate disjoint with classes
+    params:
+      FIELD:
+      - class
+      INPUT:
+        name: custom/overlapping_polys.geojson
+        type: vector
+      SEPARATE_DISJOINT: true
+    results:
+      OUTPUT:
+        name: expected/dissolve_disjoint_by_class.geojson
+        type: vector
+
   - algorithm: native:buffer
     name: Basic polygon buffer
     params:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests2.yaml
@@ -1395,6 +1395,7 @@ tests:
         compare:
           geometry:
             precision: 5
+            normalize: True
           fields:
             id: skip
             id2: skip

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -172,6 +172,9 @@ tests:
       OUTPUT:
         name: expected/valid.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: qgis:checkvalidity
     name: Check validity polygon ring self intersection
@@ -1977,6 +1980,9 @@ tests:
       OUTPUT:
         name: expected/extract_by_extent_clip.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:assignprojection
     name: Assign projection

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -91,6 +91,9 @@ tests:
       OUTPUT:
         name: expected/multiring_buffer.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:multiringconstantbuffer
     name: Multi-ring negative buffer with polygons
@@ -104,6 +107,9 @@ tests:
       OUTPUT:
         name: expected/multiring_negative_buffer.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: native:segmentizebymaxangle
     name: Segmentize by angle
@@ -193,6 +199,9 @@ tests:
       OUTPUT:
         name: expected/concave_hull_points_03.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: qgis:concavehull
     name: Concave Hull - Points (0.7)
@@ -207,6 +216,9 @@ tests:
       OUTPUT:
         name: expected/concave_hull_points_07.gml
         type: vector
+        compare:
+          geometry:
+            normalize: True
 
   - algorithm: qgis:knearestconcavehull
     name: K-nearest Neighbor Concave Hull - Points (k=7)
@@ -324,6 +336,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:intersection
     name: Test Intersection (geom types)
@@ -342,6 +356,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:intersection
     name: Test Intersection (custom prefix)
@@ -361,6 +377,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:wedgebuffers
     name: Wedge buffers
@@ -394,6 +412,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:difference
     name: Test Difference B - A (basic)
@@ -412,6 +432,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:symmetricaldifference
     name: Test Symmetrical Difference A - B (basic)
@@ -430,6 +452,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:symmetricaldifference
     name: Test Symmetrical Difference B - A (basic)
@@ -448,6 +472,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:symmetricaldifference
     name: Test Symmetrical Difference B - A (custom prefix)
@@ -467,6 +493,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:union
     name: Test Union of single layer
@@ -482,6 +510,8 @@ tests:
           unordered: true
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:union
     name: Test Union (basic)
@@ -500,6 +530,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:union
     name: Test Union (custom prefix)
@@ -519,6 +551,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:union
     name: Test Union (geom types)
@@ -537,6 +571,8 @@ tests:
         compare:
           fields:
             fid: skip
+          geometry:
+            normalize: True
 
   - algorithm: native:taperedbuffer
     name: Tapered buffers (lines)
@@ -573,7 +609,7 @@ tests:
         compare:
           geometry:
             topo_equal_check: True
-
+            normalize: True
 
   - algorithm: native:bufferbym
     name: Variable width buffer by m

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -125,6 +125,11 @@ class TestCase(_TestCase):
             ignore_part_order = False
 
         try:
+            normalize = compare['geometry']['normalize']
+        except KeyError:
+            normalize = False
+
+        try:
             unordered = compare['unordered']
         except KeyError:
             unordered = False
@@ -136,7 +141,7 @@ class TestCase(_TestCase):
                 for feat_expected in features_expected:
                     if self.checkGeometriesEqual(feat.geometry(), feat_expected.geometry(),
                                                  feat.id(), feat_expected.id(),
-                                                 False, precision, topo_equal_check, ignore_part_order) and \
+                                                 False, precision, topo_equal_check, ignore_part_order, normalize=normalize) and \
                        self.checkAttributesEqual(feat, feat_expected, layer_expected.fields(), False, compare):
                         feat_expected_equal = feat_expected
                         break
@@ -189,7 +194,7 @@ class TestCase(_TestCase):
                                            feats[1].geometry(),
                                            feats[0].id(),
                                            feats[1].id(),
-                                           use_asserts, precision, topo_equal_check, ignore_part_order)
+                                           use_asserts, precision, topo_equal_check, ignore_part_order, normalize=normalize)
             if not eq and not use_asserts:
                 return False
 
@@ -263,16 +268,20 @@ class TestCase(_TestCase):
             if p.is_dir():
                 self.assertDirectoriesEqual(str(p), path_result / p.stem)
 
-    def assertGeometriesEqual(self, geom0, geom1, geom0_id='geometry 1', geom1_id='geometry 2', precision=14, topo_equal_check=False, ignore_part_order=False):
-        self.checkGeometriesEqual(geom0, geom1, geom0_id, geom1_id, use_asserts=True, precision=precision, topo_equal_check=topo_equal_check, ignore_part_order=ignore_part_order)
+    def assertGeometriesEqual(self, geom0, geom1, geom0_id='geometry 1', geom1_id='geometry 2', precision=14, topo_equal_check=False, ignore_part_order=False, normalize=False):
+        self.checkGeometriesEqual(geom0, geom1, geom0_id, geom1_id, use_asserts=True, precision=precision, topo_equal_check=topo_equal_check, ignore_part_order=ignore_part_order, normalize=normalize)
 
-    def checkGeometriesEqual(self, geom0, geom1, geom0_id, geom1_id, use_asserts=False, precision=14, topo_equal_check=False, ignore_part_order=False):
+    def checkGeometriesEqual(self, geom0, geom1, geom0_id, geom1_id, use_asserts=False, precision=14, topo_equal_check=False, ignore_part_order=False, normalize=False):
         """ Checks whether two geometries are the same - using either a strict check of coordinates (up to given precision)
         or by using topological equality (where e.g. a polygon with clockwise is equal to a polygon with counter-clockwise
         order of vertices)
         .. versionadded:: 3.2
         """
         if not geom0.isNull() and not geom1.isNull():
+            if normalize:
+                geom0.normalize()
+                geom1.normalize()
+
             equal = geom0.constGet().asWkt(precision) == geom1.constGet().asWkt(precision)
             if not equal and topo_equal_check:
                 equal = geom0.isGeosEqual(geom1)

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -24,7 +24,7 @@
 //
 
 QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
-    const std::function<QgsGeometry( const QVector< QgsGeometry >& )> &collector, int maxQueueLength, QgsProcessingFeatureSource::Flags sourceFlags )
+    const std::function<QgsGeometry( const QVector< QgsGeometry >& )> &collector, int maxQueueLength, QgsProcessingFeatureSource::Flags sourceFlags, bool separateDisjoint )
 {
   std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
   if ( !source )
@@ -83,15 +83,30 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
       current++;
     }
 
-    outputFeature.setGeometry( collector( geomQueue ) );
-    if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
-      throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    if ( !separateDisjoint )
+    {
+      outputFeature.setGeometry( collector( geomQueue ) );
+      if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
+        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+    }
+    else
+    {
+      const QgsGeometry combinedGeometry = collector( geomQueue );
+      for ( auto it = combinedGeometry.const_parts_begin(); it != combinedGeometry.const_parts_end(); ++it )
+      {
+        QgsGeometry partGeom( ( ( *it )->clone() ) );
+        partGeom.convertToMultiType();
+        outputFeature.setGeometry( partGeom );
+        if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
+          throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
+    }
   }
   else
   {
     QList< int > fieldIndexes;
-    const auto constFields = fields;
-    for ( const QString &field : constFields )
+    fieldIndexes.reserve( fields.size() );
+    for ( const QString &field : fields )
     {
       const int index = source->fields().lookupField( field );
       if ( index >= 0 )
@@ -109,8 +124,8 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
       }
 
       QVariantList indexAttributes;
-      const auto constFieldIndexes = fieldIndexes;
-      for ( const int index : constFieldIndexes )
+      indexAttributes.reserve( fieldIndexes.size() );
+      for ( const int index : std::as_const( fieldIndexes ) )
       {
         indexAttributes << f.attribute( index );
       }
@@ -137,18 +152,38 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
       }
 
       QgsFeature outputFeature;
-      if ( geometryHash.contains( attrIt.key() ) )
+      outputFeature.setAttributes( attrIt.value() );
+      auto geometryHashIt = geometryHash.find( attrIt.key() );
+      if ( geometryHashIt != geometryHash.end() )
       {
-        QgsGeometry geom = collector( geometryHash.value( attrIt.key() ) );
+        QgsGeometry geom = collector( geometryHashIt.value() );
         if ( !geom.isMultipart() )
         {
           geom.convertToMultiType();
         }
-        outputFeature.setGeometry( geom );
+        if ( !separateDisjoint )
+        {
+          outputFeature.setGeometry( geom );
+          if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
+            throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+        }
+        else
+        {
+          for ( auto it = geom.const_parts_begin(); it != geom.const_parts_end(); ++it )
+          {
+            QgsGeometry partGeom( ( ( *it )->clone() ) );
+            partGeom.convertToMultiType();
+            outputFeature.setGeometry( partGeom );
+            if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
+              throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+          }
+        }
       }
-      outputFeature.setAttributes( attrIt.value() );
-      if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
-        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      else
+      {
+        if ( !sink->addFeature( outputFeature, QgsFeatureSink::FastInsert ) )
+          throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
+      }
 
       feedback->setProgress( current * 100.0 / numberFeatures );
       current++;
@@ -197,6 +232,11 @@ void QgsDissolveAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Dissolve field(s)" ), QVariant(),
                 QStringLiteral( "INPUT" ), QgsProcessingParameterField::Any, true, true ) );
 
+  std::unique_ptr< QgsProcessingParameterBoolean > disjointParam = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "SEPARATE_DISJOINT" ),
+      QObject::tr( "Keep disjoint features separate" ), false );
+  disjointParam->setFlags( disjointParam->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  addParameter( disjointParam.release() );
+
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Dissolved" ) ) );
 }
 
@@ -206,7 +246,9 @@ QString QgsDissolveAlgorithm::shortHelpString() const
                       "be specified to dissolve features belonging to the same class (having the same value for the specified attributes), alternatively "
                       "all features can be dissolved in a single one.\n\n"
                       "All output geometries will be converted to multi geometries. "
-                      "In case the input is a polygon layer, common boundaries of adjacent polygons being dissolved will get erased." );
+                      "In case the input is a polygon layer, common boundaries of adjacent polygons being dissolved will get erased.\n\n"
+                      "If enabled, the optional \"Keep disjoing features separate\" setting will cause disjoint features and parts to be exported "
+                      "as separate features (instead of parts of a single multipart feature)." );
 }
 
 QgsDissolveAlgorithm *QgsDissolveAlgorithm::createInstance() const
@@ -216,6 +258,8 @@ QgsDissolveAlgorithm *QgsDissolveAlgorithm::createInstance() const
 
 QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  const bool separateDisjoint = parameterAsBool( parameters, QStringLiteral( "SEPARATE_DISJOINT" ), context );
+
   return processCollection( parameters, context, feedback, [ & ]( const QVector< QgsGeometry > &parts )->QgsGeometry
   {
     QgsGeometry result( QgsGeometry::unaryUnion( parts ) );
@@ -246,7 +290,7 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
         throw QgsProcessingException( QObject::tr( "The algorithm returned no output." ) );
     }
     return result;
-  }, 10000 );
+  }, 10000, QgsProcessingFeatureSource::Flags(), separateDisjoint );
 }
 
 //

--- a/src/analysis/processing/qgsalgorithmdissolve.h
+++ b/src/analysis/processing/qgsalgorithmdissolve.h
@@ -34,7 +34,8 @@ class QgsCollectorAlgorithm : public QgsProcessingAlgorithm
   protected:
 
     QVariantMap processCollection( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback,
-                                   const std::function<QgsGeometry( const QVector<QgsGeometry>& )> &collector, int maxQueueLength = 0, QgsProcessingFeatureSource::Flags sourceFlags = QgsProcessingFeatureSource::Flags() );
+                                   const std::function<QgsGeometry( const QVector<QgsGeometry>& )> &collector, int maxQueueLength = 0, QgsProcessingFeatureSource::Flags sourceFlags = QgsProcessingFeatureSource::Flags(),
+                                   bool separateDisjoint = false );
 };
 
 /**


### PR DESCRIPTION
If enabled, this option will cause disjoint features and parts to be exported as separate features (instead of as parts of a
single multipart feature).

Sponsored by City of Canning

To illustrate, given this set of input features:

![image](https://user-images.githubusercontent.com/1829991/158746626-929230b4-d8de-415c-bc84-b63ba4c87994.png)

by default the dissolve algorithm will export a single multipolygon feature:

![image](https://user-images.githubusercontent.com/1829991/158746680-d9925edf-1c90-45b2-8018-7b236aa6dc41.png)

With the new "keep disjoint features separate" option enabled we get 3 different output features instead:

![image](https://user-images.githubusercontent.com/1829991/158746776-a61f1e68-b14f-4542-9cfb-23307abec322.png)


When dissolving by class, the default behaviour gives 2 multi-part polygon features:

![image](https://user-images.githubusercontent.com/1829991/158746894-e70d0296-1f5f-44ae-8ee1-6d252ab2547f.png)

With the "keep disjoint features separate" option enabled we get 5 output features:

![image](https://user-images.githubusercontent.com/1829991/158747007-f381d985-eafe-4d5c-944b-8374f89dee27.png)

