### PR TITLE
Bug fixed, QGIS now works with Geos 3.7 or lower

### DIFF
--- a/src/core/geometry/qgsgeometrymakevalid.cpp
+++ b/src/core/geometry/qgsgeometrymakevalid.cpp
@@ -18,8 +18,6 @@
 //
 // Ideally one day the implementation will go to GEOS library...
 
-#if ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR<8 )
-
 #include "qgsgeometry.h"
 #include "qgsgeos.h"
 #include "qgslogger.h"
@@ -32,6 +30,7 @@
 
 #include <memory>
 
+#if ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR<8 )
 
 // ------------ BuildArea stuff ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

While trying to build QGIS on RockyLinux 8.5, an error was found:

-----------------------------------------------------------------------------------------------------

[ 64%] Linking CXX shared library ../../output/lib/libqgis_core.so
CMakeFiles/qgis_core.dir/geometry/qgsgeometry.cpp.o: In function `QgsGeometry::makeValid() const':
qgsgeometry.cpp:(.text+0xd80c): undefined reference to `_qgis_lwgeom_make_valid(QgsAbstractGeometry const*, QString&)'
collect2: error: ld returned 1 exit status
make[2]: *** [src/core/CMakeFiles/qgis_core.dir/build.make:14046: output/lib/libqgis_core.so.3.22.4] Error 1
make[1]: *** [CMakeFiles/Makefile2:1152: src/core/CMakeFiles/qgis_core.dir/all] Error 2
make: *** [Makefile:156: all] Error 2

-----------------------------------------------------------------------------------------------------

Trying to figure out what happened I found that the latest Geos version available in the RockyLinux repositories is 3.7.2 (its lower than 3.8).

In the file qgsgeometrymakevalid.cpp:line 21 there is an #if instruction that should be moved to line 34 (after the includes) so the macros GEOS_VERSION_MAJOR and GEOS_VERSION_MINOR have the right values and the file gets compiled when the geos version is lower than 3.8.



