### PR TITLE
Fix regression when adding feature without geom #46687

### DIFF
--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -73,30 +73,34 @@ void QgsMapToolDigitizeFeature::layerGeometryCaptured( const QgsGeometry &geomet
   if ( !vlayer )
     return;
 
-  const QgsWkbTypes::Type layerWKBType = vlayer->wkbType();
-
-  QgsGeometry layerGeometry;
-
-  if ( mCheckGeometryType )
-  {
-    double defaultZ = QgsSettingsRegistryCore::settingsDigitizingDefaultZValue.value();
-    double defaultM = QgsSettingsRegistryCore::settingsDigitizingDefaultMValue.value();
-    QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM );
-    if ( layerGeometries.count() > 0 )
-      layerGeometry = layerGeometries.at( 0 );
-
-    if ( layerGeometry.wkbType() != layerWKBType && layerGeometry.wkbType() != QgsWkbTypes::linearType( layerWKBType ) )
-    {
-      emit messageEmitted( tr( "The digitized geometry type (%1) does not correspond to the layer geometry type (%2)." ).arg( QgsWkbTypes::displayString( layerGeometry.wkbType() ) ).arg( QgsWkbTypes::displayString( layerWKBType ) ), Qgis::MessageLevel::Warning );
-      return;
-    }
-  }
-  else
-  {
-    layerGeometry = geometry;
-  }
   QgsFeature f( vlayer->fields(), 0 );
-  f.setGeometry( layerGeometry );
+
+  if ( vlayer->isSpatial() )
+  {
+    const QgsWkbTypes::Type layerWKBType = vlayer->wkbType();
+
+    QgsGeometry layerGeometry;
+
+    if ( mCheckGeometryType )
+    {
+      double defaultZ = QgsSettingsRegistryCore::settingsDigitizingDefaultZValue.value();
+      double defaultM = QgsSettingsRegistryCore::settingsDigitizingDefaultMValue.value();
+      QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM );
+      if ( layerGeometries.count() > 0 )
+        layerGeometry = layerGeometries.at( 0 );
+
+      if ( layerGeometry.wkbType() != layerWKBType && layerGeometry.wkbType() != QgsWkbTypes::linearType( layerWKBType ) )
+      {
+        emit messageEmitted( tr( "The digitized geometry type (%1) does not correspond to the layer geometry type (%2)." ).arg( QgsWkbTypes::displayString( layerGeometry.wkbType() ), QgsWkbTypes::displayString( layerWKBType ) ), Qgis::MessageLevel::Warning );
+        return;
+      }
+    }
+    else
+    {
+      layerGeometry = geometry;
+    }
+    f.setGeometry( layerGeometry );
+  }
   f.setValid( true );
   emit digitizingCompleted( f );
   featureDigitized( f );


### PR DESCRIPTION
On master, it wasn't possible to add new feature on a geometry less table, from the toolbar.

@3nids It seems a regression from your PR #46687