### PR TITLE
"Add group" on a selected group should add a group inside it, not put it inside a new group

### DIFF
--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -240,7 +240,8 @@ void QgsLayerTreeViewDefaultActions::checkAndAllParents()
 
 void QgsLayerTreeViewDefaultActions::addGroup()
 {
-  if ( !mView->selectedNodes( true ).empty() )
+  int nodeCount = mView->selectedNodes( true ).count();
+  if ( nodeCount > 1 || ( nodeCount == 1 && mView->currentLayer() ) )
   {
     groupSelected();
     return;


### PR DESCRIPTION
Make `addGroup()` only call `groupSelected()` if there is a multiple selection or, if being a single selection, the selected node is a layer.

Fix #47657

--------------
@alexbruy: Could you please check it? It's related to https://github.com/qgis/QGIS/pull/46704