### PR TITLE
Add opt-in setting in project properties for "Remember editable layer status between sessions"

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1384,7 +1384,8 @@ Qgis.LineExtensionSide.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ = "If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed."
 Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__ = "If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider."
-Qgis.ProjectFlag.__doc__ = 'Flags which control the behavior of :py:class:`QgsProjects`.\n\n.. versionadded:: 3.26\n\n' + '* ``EvaluateDefaultValuesOnProviderSide``: ' + Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ + '\n' + '* ``TrustStoredLayerStatistics``: ' + Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__
+Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions.__doc__ = "If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored"
+Qgis.ProjectFlag.__doc__ = 'Flags which control the behavior of :py:class:`QgsProjects`.\n\n.. versionadded:: 3.26\n\n' + '* ``EvaluateDefaultValuesOnProviderSide``: ' + Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ + '\n' + '* ``TrustStoredLayerStatistics``: ' + Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__ + '\n' + '* ``RememberLayerEditStatusBetweenSessions``: ' + Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions.__doc__
 # --
 Qgis.ProjectFlag.baseClass = Qgis
 Qgis.ProjectFlags.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1371,13 +1371,21 @@ Qgis.BetweenLineConstraint.Perpendicular.__doc__ = "Perpendicular"
 Qgis.Parallel = Qgis.BetweenLineConstraint.Parallel
 Qgis.Parallel.is_monkey_patched = True
 Qgis.BetweenLineConstraint.Parallel.__doc__ = "Parallel"
-Qgis.BetweenLineConstraint.__doc__ = 'Between line constraints which can be enabled\n\n' + '* ``NoConstraint``: ' + Qgis.BetweenLineConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + Qgis.BetweenLineConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + Qgis.BetweenLineConstraint.Parallel.__doc__
+Qgis.BetweenLineConstraint.__doc__ = 'Between line constraints which can be enabled\n\n.. versionadded:: 3.26\n\n' + '* ``NoConstraint``: ' + Qgis.BetweenLineConstraint.NoConstraint.__doc__ + '\n' + '* ``Perpendicular``: ' + Qgis.BetweenLineConstraint.Perpendicular.__doc__ + '\n' + '* ``Parallel``: ' + Qgis.BetweenLineConstraint.Parallel.__doc__
 # --
 Qgis.BetweenLineConstraint.baseClass = Qgis
 # monkey patching scoped based enum
-Qgis.LineExtensionSide.BeforeVertex.__doc__ = ""
-Qgis.LineExtensionSide.AfterVertex.__doc__ = ""
-Qgis.LineExtensionSide.NoVertex.__doc__ = ""
+Qgis.LineExtensionSide.BeforeVertex.__doc__ = "Lock to previous vertex"
+Qgis.LineExtensionSide.AfterVertex.__doc__ = "Lock to next vertex"
+Qgis.LineExtensionSide.NoVertex.__doc__ = "Don't lock to vertex"
 Qgis.LineExtensionSide.__doc__ = 'Designates whether the line extension constraint is currently soft locked\nwith the previous or next vertex of the locked one.\n\n.. versionadded:: 3.26\n\n' + '* ``BeforeVertex``: ' + Qgis.LineExtensionSide.BeforeVertex.__doc__ + '\n' + '* ``AfterVertex``: ' + Qgis.LineExtensionSide.AfterVertex.__doc__ + '\n' + '* ``NoVertex``: ' + Qgis.LineExtensionSide.NoVertex.__doc__
 # --
 Qgis.LineExtensionSide.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ = "If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed."
+Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__ = "If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider."
+Qgis.ProjectFlag.__doc__ = 'Flags which control the behavior of :py:class:`QgsProjects`.\n\n.. versionadded:: 3.26\n\n' + '* ``EvaluateDefaultValuesOnProviderSide``: ' + Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide.__doc__ + '\n' + '* ``TrustStoredLayerStatistics``: ' + Qgis.ProjectFlag.TrustStoredLayerStatistics.__doc__
+# --
+Qgis.ProjectFlag.baseClass = Qgis
+Qgis.ProjectFlags.baseClass = Qgis
+ProjectFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -138,7 +138,7 @@ Returns the project's flags, which dictate the behavior of the project.
 
     void setFlags( Qgis::ProjectFlags flags );
 %Docstring
-Sets the project's ``flags``, which dictate the behavior of the project..
+Sets the project's ``flags``, which dictate the behavior of the project.
 
 .. seealso:: :py:func:`flags`
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -125,6 +125,39 @@ Returns the project's title.
    Since QGIS 3.2 this is just a shortcut to retrieving the title from the project's :py:func:`~QgsProject.metadata`.
 %End
 
+    Qgis::ProjectFlags flags() const;
+%Docstring
+Returns the project's flags, which dictate the behavior of the project..
+
+.. seealso:: :py:func:`setFlags`
+
+.. seealso:: :py:func:`setFlag`
+
+.. versionadded:: 3.26
+%End
+
+    void setFlags( Qgis::ProjectFlags flags );
+%Docstring
+Sets the project's ``flags``, which dictate the behavior of the project..
+
+.. seealso:: :py:func:`flags`
+
+.. seealso:: :py:func:`setFlag`
+
+.. versionadded:: 3.26
+%End
+
+    void setFlag( Qgis::ProjectFlag flag, bool enabled = true );
+%Docstring
+Sets whether a project ``flag`` is ``enabled``.
+
+.. seealso:: :py:func:`flags`
+
+.. seealso:: :py:func:`setFlags`
+
+.. versionadded:: 3.26
+%End
+
     QString saveUser() const;
 %Docstring
 Returns the user name that did the last save.
@@ -924,18 +957,20 @@ Returns the edit buffer group
 .. versionadded:: 3.26
 %End
 
-    bool evaluateDefaultValues() const;
+ bool evaluateDefaultValues() const /Deprecated/;
 %Docstring
 Should default values be evaluated on provider side when requested and not when committed.
 
-.. versionadded:: 2.16
+.. deprecated::
+   Test whether the :py:func:`~QgsProject.flags` method returns the Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide flag instead.
 %End
 
-    void setEvaluateDefaultValues( bool evaluateDefaultValues );
+ void setEvaluateDefaultValues( bool evaluateDefaultValues ) /Deprecated/;
 %Docstring
 Defines if default values should be evaluated on provider side when requested and not when committed.
 
-.. versionadded:: 2.16
+.. deprecated::
+   use setFlag( Qgis.ProjectFlag.EvaluateDefaultValuesOnProviderSide ) instead.
 %End
 
     virtual QgsExpressionContext createExpressionContext() const;
@@ -1288,7 +1323,7 @@ Returns the default CRS for new layers based on the settings and
 the current project CRS
 %End
 
-    void setTrustLayerMetadata( bool trust );
+ void setTrustLayerMetadata( bool trust ) /Deprecated/;
 %Docstring
 Sets the trust option allowing to indicate if the extent has to be
 read from the XML document when data source has no metadata or if the
@@ -1298,10 +1333,11 @@ materialized views with Postgres provider.
 
 :param trust: ``True`` to trust the project, ``False`` otherwise
 
-.. versionadded:: 3.0
+.. deprecated::
+   Use setFlag( Qgis.ProjectFlag.TrustStoredLayerStatistics ) instead.
 %End
 
-    bool trustLayerMetadata() const;
+ bool trustLayerMetadata() const /Deprecated/;
 %Docstring
 Returns ``True`` if the trust option is activated, ``False`` otherwise. This
 option allows indicateing if the extent has to be read from the XML
@@ -1310,7 +1346,8 @@ to determine it. Moreover, when this option is activated, primary key
 unicity is not checked for views and materialized views with Postgres
 provider.
 
-.. versionadded:: 3.0
+.. deprecated::
+   Test whether the :py:func:`~QgsProject.flags` method returns the Qgis.ProjectFlag.TrustStoredLayerStatistics flag instead.
 %End
 
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -127,7 +127,7 @@ Returns the project's title.
 
     Qgis::ProjectFlags flags() const;
 %Docstring
-Returns the project's flags, which dictate the behavior of the project..
+Returns the project's flags, which dictate the behavior of the project.
 
 .. seealso:: :py:func:`setFlags`
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -908,6 +908,7 @@ The development version
     {
       EvaluateDefaultValuesOnProviderSide,
       TrustStoredLayerStatistics,
+      RememberLayerEditStatusBetweenSessions,
     };
     typedef QFlags<Qgis::ProjectFlag> ProjectFlags;
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -901,8 +901,16 @@ The development version
     {
       BeforeVertex,
       AfterVertex,
-      NoVertex
+      NoVertex,
     };
+
+    enum class ProjectFlag
+    {
+      EvaluateDefaultValuesOnProviderSide,
+      TrustStoredLayerStatistics,
+    };
+    typedef QFlags<Qgis::ProjectFlag> ProjectFlags;
+
 
     static const double DEFAULT_SEARCH_RADIUS_MM;
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -982,8 +982,8 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mRelationManagerDlg->setLayers( vectorLayers );
 
   mTransactionModeComboBox->setCurrentIndex( mTransactionModeComboBox->findData( static_cast<int>( QgsProject::instance()->transactionMode() ) ) );
-  mEvaluateDefaultValues->setChecked( QgsProject::instance()->evaluateDefaultValues() );
-  mTrustProjectCheckBox->setChecked( QgsProject::instance()->trustLayerMetadata() );
+  mEvaluateDefaultValues->setChecked( QgsProject::instance()->flags() & Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide );
+  mTrustProjectCheckBox->setChecked( QgsProject::instance()->flags() & Qgis::ProjectFlag::TrustStoredLayerStatistics );
 
   // Variables editor
   mVariableEditor->context()->appendScope( QgsExpressionContextUtils::globalScope() );
@@ -1126,8 +1126,8 @@ void QgsProjectProperties::apply()
 
   // DB-related options
   QgsProject::instance()->setTransactionMode( mTransactionModeComboBox->currentData().value<Qgis::TransactionMode>() );
-  QgsProject::instance()->setEvaluateDefaultValues( mEvaluateDefaultValues->isChecked() );
-  QgsProject::instance()->setTrustLayerMetadata( mTrustProjectCheckBox->isChecked() );
+  QgsProject::instance()->setFlag( Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide, mEvaluateDefaultValues->isChecked() );
+  QgsProject::instance()->setFlag( Qgis::ProjectFlag::TrustStoredLayerStatistics, mTrustProjectCheckBox->isChecked() );
 
   // Time settings
   QDateTime start = mStartDateTimeEdit->dateTime();

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -986,6 +986,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mTransactionModeComboBox->setCurrentIndex( mTransactionModeComboBox->findData( static_cast<int>( QgsProject::instance()->transactionMode() ) ) );
   mEvaluateDefaultValues->setChecked( QgsProject::instance()->flags() & Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide );
   mTrustProjectCheckBox->setChecked( QgsProject::instance()->flags() & Qgis::ProjectFlag::TrustStoredLayerStatistics );
+  mCheckRememberEditStatus->setChecked( QgsProject::instance()->flags() & Qgis::ProjectFlag::RememberLayerEditStatusBetweenSessions );
 
   // Variables editor
   mVariableEditor->context()->appendScope( QgsExpressionContextUtils::globalScope() );
@@ -1130,6 +1131,8 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->setTransactionMode( mTransactionModeComboBox->currentData().value<Qgis::TransactionMode>() );
   QgsProject::instance()->setFlag( Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide, mEvaluateDefaultValues->isChecked() );
   QgsProject::instance()->setFlag( Qgis::ProjectFlag::TrustStoredLayerStatistics, mTrustProjectCheckBox->isChecked() );
+
+  QgsProject::instance()->setFlag( Qgis::ProjectFlag::RememberLayerEditStatusBetweenSessions, mCheckRememberEditStatus->isChecked() );
 
   // Time settings
   QDateTime start = mStartDateTimeEdit->dateTime();

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -215,6 +215,36 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString title() const;
 
     /**
+     * Returns the project's flags, which dictate the behavior of the project..
+     *
+     * \see setFlags()
+     * \see setFlag()
+     *
+     * \since QGIS 3.26
+     */
+    Qgis::ProjectFlags flags() const { return mFlags; }
+
+    /**
+     * Sets the project's \a flags, which dictate the behavior of the project..
+     *
+     * \see flags()
+     * \see setFlag()
+     *
+     * \since QGIS 3.26
+     */
+    void setFlags( Qgis::ProjectFlags flags );
+
+    /**
+     * Sets whether a project \a flag is \a enabled.
+     *
+     * \see flags()
+     * \see setFlags()
+     *
+     * \since QGIS 3.26
+     */
+    void setFlag( Qgis::ProjectFlag flag, bool enabled = true );
+
+    /**
     * Returns the user name that did the last save.
     *
     * \see saveUserFullName()
@@ -971,16 +1001,16 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Should default values be evaluated on provider side when requested and not when committed.
      *
-     * \since QGIS 2.16
+     * \deprecated Test whether the flags() method returns the Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide flag instead.
      */
-    bool evaluateDefaultValues() const;
+    Q_DECL_DEPRECATED bool evaluateDefaultValues() const SIP_DEPRECATED;
 
     /**
      * Defines if default values should be evaluated on provider side when requested and not when committed.
      *
-     * \since QGIS 2.16
+     * \deprecated use setFlag( Qgis::ProjectFlag::EvaluateDefaultValuesOnProviderSide ) instead.
      */
-    void setEvaluateDefaultValues( bool evaluateDefaultValues );
+    Q_DECL_DEPRECATED void setEvaluateDefaultValues( bool evaluateDefaultValues ) SIP_DEPRECATED;
 
     QgsExpressionContext createExpressionContext() const override;
     QgsExpressionContextScope *createExpressionContextScope() const override;
@@ -1368,9 +1398,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \param trust TRUE to trust the project, FALSE otherwise
      *
-     * \since QGIS 3.0
+     * \deprecated Use setFlag( Qgis::ProjectFlag::TrustStoredLayerStatistics ) instead.
      */
-    void setTrustLayerMetadata( bool trust );
+    Q_DECL_DEPRECATED void setTrustLayerMetadata( bool trust ) SIP_DEPRECATED;
 
     /**
      * Returns TRUE if the trust option is activated, FALSE otherwise. This
@@ -1380,9 +1410,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * unicity is not checked for views and materialized views with Postgres
      * provider.
      *
-     * \since QGIS 3.0
+     * \deprecated Test whether the flags() method returns the Qgis::ProjectFlag::TrustStoredLayerStatistics flag instead.
      */
-    bool trustLayerMetadata() const { return mTrustLayerMetadata; }
+    Q_DECL_DEPRECATED bool trustLayerMetadata() const SIP_DEPRECATED;
 
     /**
      * Returns the current const auxiliary storage.
@@ -2226,11 +2256,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     Qgis::TransactionMode mTransactionMode = Qgis::TransactionMode::Disabled; // transaction grouped editing
-    bool mEvaluateDefaultValues = false; // evaluate default values immediately
+
+    Qgis::ProjectFlags mFlags;
     QgsCoordinateReferenceSystem mCrs;
     bool mDirty = false;                 // project has been modified since it has been read or saved
     int mDirtyBlockCount = 0;
-    bool mTrustLayerMetadata = false;
 
     QgsPropertyCollection mDataDefinedServerProperties;
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -215,7 +215,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString title() const;
 
     /**
-     * Returns the project's flags, which dictate the behavior of the project..
+     * Returns the project's flags, which dictate the behavior of the project.
      *
      * \see setFlags()
      * \see setFlag()

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -225,7 +225,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Qgis::ProjectFlags flags() const { return mFlags; }
 
     /**
-     * Sets the project's \a flags, which dictate the behavior of the project..
+     * Sets the project's \a flags, which dictate the behavior of the project.
      *
      * \see flags()
      * \see setFlag()

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1517,6 +1517,7 @@ class CORE_EXPORT Qgis
     {
       EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
       TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
+      RememberLayerEditStatusBetweenSessions = 1 << 2, //!< If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored
     };
     Q_ENUM( ProjectFlag )
     Q_DECLARE_FLAGS( ProjectFlags, ProjectFlag )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1484,6 +1484,8 @@ class CORE_EXPORT Qgis
 
     /**
      * Between line constraints which can be enabled
+     *
+     * \since QGIS 3.26
      */
     enum class BetweenLineConstraint SIP_MONKEYPATCH_SCOPEENUM : int
     {
@@ -1500,11 +1502,25 @@ class CORE_EXPORT Qgis
      */
     enum class LineExtensionSide : int
     {
-      BeforeVertex,
-      AfterVertex,
-      NoVertex
+      BeforeVertex, //!< Lock to previous vertex
+      AfterVertex, //!< Lock to next vertex
+      NoVertex, //!< Don't lock to vertex
     };
     Q_ENUM( LineExtensionSide )
+
+    /**
+     * Flags which control the behavior of QgsProjects.
+     *
+     * \since QGIS 3.26
+     */
+    enum class ProjectFlag : int
+    {
+      EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
+      TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
+    };
+    Q_ENUM( ProjectFlag )
+    Q_DECLARE_FLAGS( ProjectFlags, ProjectFlag )
+    Q_FLAG( ProjectFlags )
 
     /**
      * Identify search radius in mm

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -189,7 +189,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     // checkPkUnicity has only effect on views and materialized views, so we can safely disable it
     if ( layerProperty.isView || layerProperty.isMaterializedView )
     {
-      checkPkUnicityItem->setCheckState( QgsProject::instance( )->trustLayerMetadata() ? Qt::CheckState::Unchecked : Qt::CheckState::Checked );
+      checkPkUnicityItem->setCheckState( ( QgsProject::instance( )->flags() & Qgis::ProjectFlag::TrustStoredLayerStatistics ) ? Qt::CheckState::Unchecked : Qt::CheckState::Checked );
       checkPkUnicityItem->setToolTip( headerData( Columns::DbtmCheckPkUnicity, Qt::Orientation::Horizontal, Qt::ToolTipRole ).toString() );
     }
     else

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -117,7 +117,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     QStandardItem *typeItem = nullptr;
     if ( layerProperty.isRaster )
     {
-      typeItem = new QStandardItem( QgsApplication::getThemeIcon( "/mIconRasterLayer.svg" ), tr( "Raster" ) );
+      typeItem = new QStandardItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconRasterLayer.svg" ) ), tr( "Raster" ) );
     }
     else
     {
@@ -351,7 +351,7 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
 
   if ( idx.column() == DbtmType || idx.column() == DbtmSrid || idx.column() == DbtmPkCol )
   {
-    const QgsWkbTypes::Type wkbType = ( QgsWkbTypes::Type ) idx.sibling( idx.row(), DbtmType ).data( Qt::UserRole + 2 ).toInt();
+    const QgsWkbTypes::Type wkbType = static_cast< QgsWkbTypes::Type >( idx.sibling( idx.row(), DbtmType ).data( Qt::UserRole + 2 ).toInt() );
 
     QString tip;
     if ( wkbType == QgsWkbTypes::Unknown )
@@ -482,8 +482,8 @@ QString QgsPgTableModel::layerURI( const QModelIndex &index, const QString &conn
   QgsDataSourceUri uri( connInfo );
 
   QStringList cols;
-  const auto constS1 = s1;
-  for ( const QString &col : constS1 )
+  cols.reserve( s1.size() );
+  for ( const QString &col : s1 )
   {
     cols << QgsPostgresConn::quotedIdentifier( col );
   }
@@ -495,7 +495,7 @@ QString QgsPgTableModel::layerURI( const QModelIndex &index, const QString &conn
   uri.setWkbType( wkbType );
   uri.setSrid( srid );
   uri.disableSelectAtId( !selectAtId );
-  uri.setParam( QStringLiteral( "checkPrimaryKeyUnicity" ), checkPrimaryKeyUnicity ? QLatin1String( "1" ) : QLatin1String( "0" ) );
+  uri.setParam( QStringLiteral( "checkPrimaryKeyUnicity" ), checkPrimaryKeyUnicity ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   QgsDebugMsg( QStringLiteral( "returning uri %1" ).arg( uri.uri( false ) ) );
   return uri.uri( false );

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -702,12 +702,12 @@ QgsSqliteHandle *QgsSqliteHandle::openDb( const QString &dbPath, bool shared )
 
   if ( shared && sHandles.contains( dbPath ) )
   {
-    QgsDebugMsg( QStringLiteral( "Using cached connection for %1" ).arg( dbPath ) );
+    QgsDebugMsgLevel( QStringLiteral( "Using cached connection for %1" ).arg( dbPath ), 2 );
     sHandles[dbPath]->ref++;
     return sHandles[dbPath];
   }
 
-  QgsDebugMsg( QStringLiteral( "New sqlite connection for " ) + dbPath );
+  QgsDebugMsgLevel( QStringLiteral( "New sqlite connection for " ) + dbPath, 2 );
   spatialite_database_unique_ptr database;
   if ( database.open_v2( dbPath, shared ? SQLITE_OPEN_READWRITE : SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr ) )
   {
@@ -732,7 +732,7 @@ QgsSqliteHandle *QgsSqliteHandle::openDb( const QString &dbPath, bool shared )
   // activating Foreign Key constraints
   ( void )sqlite3_exec( database.get(), "PRAGMA foreign_keys = 1", nullptr, nullptr, nullptr );
 
-  QgsDebugMsg( QStringLiteral( "Connection to the database was successful" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Connection to the database was successful" ), 2 );
 
   QgsSqliteHandle *handle = new QgsSqliteHandle( std::move( database ), dbPath, shared );
   if ( shared )

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1473,37 +1473,7 @@
          </widget>
          <widget class="QWidget" name="mTab_DataSources">
           <layout class="QGridLayout" name="mTab_DataSourcesGridLayout">
-           <item row="1" column="0" colspan="3">
-            <widget class="QCheckBox" name="mEvaluateDefaultValues">
-             <property name="toolTip">
-              <string>When enabled, default values will be evaluated as early as possible. This will fill default values in the add feature form already and not only create them on commit. Only supported for postgres, GPKG, spatialite and oracle.</string>
-             </property>
-             <property name="text">
-              <string>Evaluate default values on provider side</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="mTransactionModeLabel">
-             <property name="text">
-              <string>Transaction mode</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0" colspan="3">
-            <widget class="QCheckBox" name="mTrustProjectCheckBox">
-             <property name="toolTip">
-              <string>Speed up project loading by skipping data checks in PostgreSQL layers. Useful in QGIS server context or project with huge database views or materialized views.</string>
-             </property>
-             <property name="text">
-              <string>Trust project when data source has no metadata</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="mTransactionModeComboBox"/>
-           </item>
-           <item row="3" column="0" colspan="3">
+           <item row="1" column="0" colspan="2">
             <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1512,12 +1482,9 @@
               </sizepolicy>
              </property>
              <property name="title">
-              <string>Layers Capabilities</string>
+              <string>Layer Capabilities</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_19">
-              <property name="verticalSpacing">
-               <number>0</number>
-              </property>
               <item row="3" column="1">
                <spacer name="horizontalSpacer_5">
                 <property name="orientation">
@@ -1570,18 +1537,60 @@
              </layout>
             </widget>
            </item>
-           <item row="0" column="2">
-            <spacer name="horizontalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+           <item row="0" column="0" colspan="2">
+            <widget class="QGroupBox" name="groupBox_3">
+             <property name="title">
+              <string>Editing Behavior</string>
              </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
+             <layout class="QGridLayout" name="gridLayout_8">
+              <item row="0" column="1">
+               <widget class="QComboBox" name="mTransactionModeComboBox"/>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="mTransactionModeLabel">
+                <property name="text">
+                 <string>Transaction mode</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0" colspan="2">
+               <widget class="QCheckBox" name="mEvaluateDefaultValues">
+                <property name="toolTip">
+                 <string>When enabled, default values will be evaluated as early as possible. This will fill default values in the add feature form already and not only create them on commit. Only supported for postgres, GPKG, spatialite and oracle.</string>
+                </property>
+                <property name="text">
+                 <string>Evaluate default values on provider side</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="mCheckRememberEditStatus">
+                <property name="text">
+                 <string>Remember editable layer status between sessions</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QGroupBox" name="groupBox_8">
+             <property name="title">
+              <string>Advanced Settings</string>
              </property>
-            </spacer>
+             <layout class="QGridLayout" name="gridLayout_13">
+              <item row="0" column="0">
+               <widget class="QCheckBox" name="mTrustProjectCheckBox">
+                <property name="toolTip">
+                 <string>Speed up project loading by skipping data checks in PostgreSQL layers. Useful in QGIS server context or project with huge database views or materialized views.</string>
+                </property>
+                <property name="text">
+                 <string>Trust project when data source has no metadata</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -3361,12 +3370,14 @@
   <tabstop>mButtonPasteColors</tabstop>
   <tabstop>mButtonImportColors</tabstop>
   <tabstop>mButtonExportColors</tabstop>
+  <tabstop>mTransactionModeComboBox</tabstop>
   <tabstop>mEvaluateDefaultValues</tabstop>
-  <tabstop>mTrustProjectCheckBox</tabstop>
+  <tabstop>mCheckRememberEditStatus</tabstop>
   <tabstop>mLayerCapabilitiesTree</tabstop>
   <tabstop>mLayerCapabilitiesToggleSelectionButton</tabstop>
   <tabstop>mShowSpatialLayersCheckBox</tabstop>
   <tabstop>mLayerCapabilitiesTreeFilterLineEdit</tabstop>
+  <tabstop>mTrustProjectCheckBox</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>grpPythonMacros</tabstop>
   <tabstop>scrollArea_5</tabstop>

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1513,6 +1513,59 @@ class TestQgsProject(unittest.TestCase):
 
         project.removeAllMapLayers()
 
+    def test_remember_editable_status(self):
+        """
+        Test a project with remember editable layers flag set
+        """
+        project = QgsProject()
+        project.removeAllMapLayers()
+
+        layer_a = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
+        layer_b = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
+        layer_c = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')
+
+        project.addMapLayers([layer_a, layer_b, layer_c])
+
+        layer_a.startEditing()
+        layer_c.startEditing()
+
+        tmp_dir = QTemporaryDir()
+        tmp_project_file = "{}/project.qgs".format(tmp_dir.path())
+        self.assertTrue(project.write(tmp_project_file))
+
+        # project did NOT have remember editable layers flag set, so layers should NOT be editable
+        project2 = QgsProject()
+        self.assertTrue(project2.read(tmp_project_file))
+
+        self.assertFalse(project2.mapLayer(layer_a.id()).isEditable())
+        self.assertFalse(project2.mapLayer(layer_b.id()).isEditable())
+        self.assertFalse(project2.mapLayer(layer_c.id()).isEditable())
+
+        # set remember edits status flag
+        project.setFlag(Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions)
+        tmp_project_file2 = "{}/project2.qgs".format(tmp_dir.path())
+        self.assertTrue(project.write(tmp_project_file2))
+
+        project3 = QgsProject()
+        self.assertTrue(project3.read(tmp_project_file2))
+        self.assertTrue(project3.flags() & Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions)
+        # the layers should be made immediately editable
+        self.assertTrue(project3.mapLayer(layer_a.id()).isEditable())
+        self.assertFalse(project3.mapLayer(layer_b.id()).isEditable())
+        self.assertTrue(project3.mapLayer(layer_c.id()).isEditable())
+
+        # turn off flag and re-save project
+        project3.setFlag(Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions, False)
+        tmp_project_file3 = "{}/project2.qgs".format(tmp_dir.path())
+        self.assertTrue(project3.write(tmp_project_file3))
+
+        project4 = QgsProject()
+        self.assertTrue(project4.read(tmp_project_file3))
+        self.assertFalse(project4.flags() & Qgis.ProjectFlag.RememberLayerEditStatusBetweenSessions)
+        self.assertFalse(project4.mapLayer(layer_a.id()).isEditable())
+        self.assertFalse(project4.mapLayer(layer_b.id()).isEditable())
+        self.assertFalse(project4.mapLayer(layer_c.id()).isEditable())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If checked, then any layers which are editable will be remembered when saving that project and immediately made editable whenever the project is restored.

This is an opt-in, per-project setting. The intended use case is for users who are making complex, data-editing focused projects.

Sponsored by City of Canning

![image](https://user-images.githubusercontent.com/1829991/158914248-4fc759c7-7581-4246-b5fc-72fe74fd1d93.png)

Also includes a bunch of related code cleanups 