### PR TITLE
[processing] Add a raise message algorithm to the model tools

### DIFF
--- a/src/analysis/processing/qgsalgorithmraiseexception.cpp
+++ b/src/analysis/processing/qgsalgorithmraiseexception.cpp
@@ -177,4 +177,84 @@ QVariantMap QgsRaiseWarningAlgorithm::processAlgorithm( const QVariantMap &param
   return QVariantMap();
 }
 
+
+//
+// QgsRaiseMessageAlgorithm
+//
+
+QString QgsRaiseMessageAlgorithm::name() const
+{
+  return QStringLiteral( "raisemessage" );
+}
+
+QgsProcessingAlgorithm::Flags QgsRaiseMessageAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagHideFromToolbox | FlagSkipGenericModelLogging;
+}
+
+QString QgsRaiseMessageAlgorithm::displayName() const
+{
+  return QObject::tr( "Raise message" );
+}
+
+QStringList QgsRaiseMessageAlgorithm::tags() const
+{
+  return QObject::tr( "information" ).split( ',' );
+}
+
+QString QgsRaiseMessageAlgorithm::group() const
+{
+  return QObject::tr( "Modeler tools" );
+}
+
+QString QgsRaiseMessageAlgorithm::groupId() const
+{
+  return QStringLiteral( "modelertools" );
+}
+
+QString QgsRaiseMessageAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm raises an information message in the log.\n\n"
+                      "The message can be customized, and optionally an expression based condition "
+                      "can be specified. If an expression condition is used, then the message will only "
+                      "be logged if the expression result is true. A false result indicates that no message "
+                      "will be logged." );
+}
+
+QString QgsRaiseMessageAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Raises an information message." );
+}
+
+QgsRaiseMessageAlgorithm *QgsRaiseMessageAlgorithm::createInstance() const
+{
+  return new QgsRaiseMessageAlgorithm();
+}
+
+void QgsRaiseMessageAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "MESSAGE" ), QObject::tr( "Information message" ) ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "CONDITION" ), QObject::tr( "Condition" ), QVariant(), QString(), true ) );
+}
+
+QVariantMap QgsRaiseMessageAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  const QString expression = parameterAsExpression( parameters, QStringLiteral( "CONDITION" ), context );
+  if ( !expression.isEmpty() )
+  {
+    const QgsExpressionContext expContext = createExpressionContext( parameters, context );
+    QgsExpression exp( expression );
+    if ( exp.hasParserError() )
+    {
+      throw QgsProcessingException( QObject::tr( "Error parsing condition expression: %1" ).arg( exp.parserErrorString() ) );
+    }
+    if ( !exp.evaluate( &expContext ).toBool() )
+      return QVariantMap();
+  }
+
+  const QString info = parameterAsString( parameters, QStringLiteral( "MESSAGE" ), context );
+  feedback->pushInfo( info );
+  return QVariantMap();
+}
+
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmraiseexception.h
+++ b/src/analysis/processing/qgsalgorithmraiseexception.h
@@ -76,6 +76,30 @@ class QgsRaiseWarningAlgorithm : public QgsProcessingAlgorithm
 
 };
 
+/**
+ * Native raise message algorithm.
+ */
+class QgsRaiseMessageAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsRaiseMessageAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsRaiseMessageAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+};
 
 ///@endcond PRIVATE
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -405,6 +405,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsPromoteToMultipartAlgorithm() );
   addAlgorithm( new QgsRaiseExceptionAlgorithm() );
   addAlgorithm( new QgsRaiseWarningAlgorithm() );
+  addAlgorithm( new QgsRaiseMessageAlgorithm() );
   addAlgorithm( new QgsRandomBinomialRasterAlgorithm() );
   addAlgorithm( new QgsRandomExponentialRasterAlgorithm() );
   addAlgorithm( new QgsRandomExtractAlgorithm() );


### PR DESCRIPTION
## Description

This can come in handy when users want to output more information in their models' logs. Avoids abuses of the raise error/warning algorithms.

