### PR TITLE
Add support for date/time/datetime expressions in HANA

### DIFF
--- a/src/providers/hana/qgshanaexpressioncompiler.h
+++ b/src/providers/hana/qgshanaexpressioncompiler.h
@@ -30,6 +30,7 @@ class QgsHanaExpressionCompiler : public QgsSqlExpressionCompiler
     QString quotedIdentifier( const QString &identifier ) override;
     QString quotedValue( const QVariant &value, bool &ok ) override;
     QString sqlFunctionFromFunctionName( const QString &fnName ) const override;
+    QStringList sqlArgumentsFromFunctionName( const QString &fnName, const QStringList &fnArgs ) const override;
     QString castToReal( const QString &value ) const override;
     QString castToInt( const QString &value ) const override;
     QString castToText( const QString &value ) const override;

--- a/tests/src/python/test_provider_hana.py
+++ b/tests/src/python/test_provider_hana.py
@@ -180,16 +180,9 @@ class TestPyQgsHanaProvider(unittest.TestCase, ProviderTestCase):
             'overlaps(buffer($geometry,1),geom_from_wkt( \'Polygon ((-75.1 76.1, -75.1 81.6, -68.8 81.6, -68.8 76.1, -75.1 76.1))\'))',
             'intersects(centroid($geometry),geom_from_wkt( \'Polygon ((-74.4 78.2, -74.4 79.1, -66.8 79.1, -66.8 78.2, -74.4 78.2))\'))',
             'intersects(point_on_surface($geometry),geom_from_wkt( \'Polygon ((-74.4 78.2, -74.4 79.1, -66.8 79.1, -66.8 78.2, -74.4 78.2))\'))',
-            '"dt" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-            '"dt" < make_date(2020, 5, 4)',
             '"dt" = to_datetime(\'000www14ww13ww12www4ww5ww2020\',\'zzzwwwsswwmmwwhhwwwdwwMwwyyyy\')',
-            '"date" <= make_datetime(2020, 5, 4, 12, 13, 14)',
-            '"date" >= make_date(2020, 5, 4)',
             '"date" = to_date(\'www4ww5ww2020\',\'wwwdwwMwwyyyy\')',
-            '"time" >= make_time(12, 14, 14)',
             '"time" = to_time(\'000www14ww13ww12www\',\'zzzwwwsswwmmwwhhwww\')',
-            'dt BETWEEN make_datetime(2020, 5, 3, 12, 13, 14) AND make_datetime(2020, 5, 4, 12, 14, 14)',
-            'dt NOT BETWEEN make_datetime(2020, 5, 3, 12, 13, 14) AND make_datetime(2020, 5, 4, 12, 14, 14)',
         ])
         return filters
 


### PR DESCRIPTION
This change converts make_date, make_time and make_datetime expressions to HANA specific functions.
