### PR TITLE
set Qt::AA_ShareOpenGLContexts on all platforms

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -920,7 +920,7 @@ int main( int argc, char *argv[] )
   // As suggested by Qt documentation at:
   //   - https://doc.qt.io/qt-5/qtwebengine.html
   //   - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
-#if defined(QT_OS_WIN) && !defined(QT_NO_OPENGL)
+#if !defined(QT_NO_OPENGL)
   QCoreApplication::setAttribute( Qt::AA_ShareOpenGLContexts, true );
 #endif
 


### PR DESCRIPTION
## Description

Qt::AA_ShareOpenGLContexts needs to set in order to be able to use of QWebEngine in plugins (see QT doc in comments for detailed explanation).

Currently, it is always set to false due to a typo in the IF statement (it should be Q_OS_WIN and not QT_OS_WIN).

I don't see any reason why this should only be set on windows, so I suggest to remove this faulty check entirely in order to make it available on other platforms as well. 

This is only a partial fix, two other things have to be addressed:
- an issue with Pyqt binding which needs to be addressed upstream 
- python3-pyqt5-sip dependency has to be upgraded to API v12.9

