### PR TITLE
add GRASS8 to build tests

### DIFF
--- a/.docker/docker-qgis-build.sh
+++ b/.docker/docker-qgis-build.sh
@@ -52,6 +52,12 @@ if [[ ${PATCH_QT_3D} == "true" ]]; then
   )
 fi
 
+if [[ ${WITH_GRASS7} == "ON" || ${WITH_GRASS8} == "ON" ]]; then
+  CMAKE_EXTRA_ARGS+=(
+    "-DGRASS_PREFIX$( grass --config version | cut -b 1 )=$( grass --config path )"
+  )
+fi
+
 cmake \
  -GNinja \
  -DUSE_CCACHE=OFF \
@@ -62,7 +68,8 @@ cmake \
  -DWITH_QUICK=${WITH_QUICK} \
  -DWITH_3D=${WITH_3D} \
  -DWITH_STAGED_PLUGINS=ON \
- -DWITH_GRASS=OFF \
+ -DWITH_GRASS7=${WITH_GRASS7} \
+ -DWITH_GRASS8=${WITH_GRASS8} \
  -DSUPPRESS_QT_WARNINGS=ON \
  -DENABLE_TESTS=ON \
  -DENABLE_MODELTEST=${WITH_QT5} \
@@ -82,7 +89,7 @@ cmake \
  -DWITH_SERVER=${WITH_QT5} \
  -DWITH_SERVER_LANDINGPAGE_WEBAPP=${WITH_QT5} \
  -DWITH_ORACLE=${WITH_QT5} \
- -DWITH_PDAL=${WITH_QT5} \
+ -DWITH_PDAL=ON \
  -DWITH_QT5SERIALPORT=${WITH_QT5} \
  -DWITH_QTWEBKIT=${WITH_QT5} \
  -DWITH_OAUTH2_PLUGIN=${WITH_QT5} \

--- a/.docker/qgis3-qt6-build-deps.dockerfile
+++ b/.docker/qgis3-qt6-build-deps.dockerfile
@@ -1,4 +1,6 @@
-FROM fedora:34 as single
+ARG DISTRO_VERSION=36
+
+FROM fedora:${DISTRO_VERSION} as single
 MAINTAINER Matthias Kuhn <matthias@opengis.ch>
 
 RUN dnf -y install \
@@ -13,12 +15,18 @@ RUN dnf -y install \
     git \
     gdal-devel \
     geos-devel \
+    grass \
+    grass-devel \
     gsl-devel \
     libpq-devel \
     libspatialite-devel \
+    libxml2-devel \
     libzip-devel \
     libzstd-devel \
+    netcdf-devel \
     ninja-build \
+    ocl-icd-devel \
+    PDAL-devel \
     proj-devel \
     protobuf-devel \
     protobuf-lite-devel \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,10 +31,10 @@ jobs:
       RUN_FLAKY_TESTS: ${{ contains( github.event.pull_request.labels.*.name, 'run flaky tests') }}
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
-        # tests run on 20.04 (Qt 5.12), compile test on 20.10 (Qt 5.14) and 21.04 (Qt 5.15)
         include:
           - distro-version: '20.04'
             qt-version: 5
@@ -45,7 +45,10 @@ jobs:
             with-3d: ON
             with-quick: ON
             patch-qt-3d: true
+            with-grass7: OFF
+            with-grass8: OFF
             LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
+            experimental: false
 
           - distro-version: '21.10'
             qt-version: 5
@@ -56,9 +59,12 @@ jobs:
             with-3d: OFF
             with-quick: ON
             patch-qt-3d: false
+            with-grass7: OFF
+            with-grass8: OFF
             LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
+            experimental: false
 
-          - distro-version: '34'
+          - distro-version: '36'
             qt-version: 6
             run-tests: true
             docker-tag-suffix: ''
@@ -67,7 +73,10 @@ jobs:
             with-3d: OFF
             with-quick: OFF
             patch-qt-3d: false
+            with-grass7: OFF
+            with-grass8: ON
             LD_PRELOAD: ''
+            experimental: false
 
 
       fail-fast: false
@@ -166,6 +175,8 @@ jobs:
                      --env WITH_QUICK=${{ matrix.with-quick }} \
                      --env WITH_3D=${{ matrix.with-3d }} \
                      --env PATCH_QT_3D=${{ matrix.patch-qt-3d }} \
+                     --env WITH_GRASS7=${{ matrix.with-grass7 }} \
+                     --env WITH_GRASS8=${{ matrix.with-grass8 }} \
                      --env LD_PRELOAD=${{ matrix.LD_PRELOAD }} \
                      qgis3-build-deps \
                      /root/QGIS/.docker/docker-qgis-build.sh
@@ -300,7 +311,7 @@ jobs:
             test-batch: ORACLE
             docker-target: binary-for-oracle
 
-          - distro-version: '34'
+          - distro-version: '36'
             qt-version: 6
             test-batch: ALL_BUT_PROVIDERS
             docker-target: single


### PR DESCRIPTION
## add GRASS8 to build tests

this PR adds GRASS8 to build tests 
- it serves to systematically detect compatibility issues between qgis and grass 
  - i.e. build errors like https://github.com/OSGeo/grass/issues/2268 or https://github.com/qgis/QGIS/pull/47850 could be auto detected with such a test. 