### PR TITLE
Fetch plugins list by the full QGIS version including the patch number

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -207,8 +207,8 @@ class Repositories(QObject):
 
     def urlParams(self) -> str:
         """ return GET parameters to be added to every request """
-        # Strip down the point release segment from the version string
-        return "?qgis={}".format(re.sub(r'\.\d*$', '', pyQgisVersion()))
+        # Add full version string as value for the qgis key
+        return "?qgis={}".format(pyQgisVersion())
 
     def setRepositoryData(self, reposName: str, key: str, value):
         """ write data to the mRepositories dict """


### PR DESCRIPTION
Fixes #46283 (the QGIS part of the issue)

From https://github.com/qgis/QGIS/issues/46283#issuecomment-1074879930:

> Because of this issue, some versions are not shown in plugin manager despite they are valid for the specific QGIS version.
> 
> Example:
> For QGIS 3.16.16 and a plugin with minimum version 3.16.14 :
> 
> QGIS sends only https://plugins.qgis.org/plugins/plugins.xml?qgis=3.16 and the plugin with minimum version 3.16.14 ist not shown in plugin manager.



**Please do not merge before this is also fixed and deployed for the plugin repo (currently a request with the full version number results in a 404) -> https://github.com/qgis/QGIS-Plugins-Website/issues/53**