### PR TITLE
UI: Make sure users can enter the minimum tolerance value in 'snap geometries to layer'

### DIFF
--- a/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
@@ -85,8 +85,18 @@ void QgsSnapGeometriesAlgorithm::initAlgorithm( const QVariantMap & )
                 QList< int >() << QgsProcessing::TypeVectorPoint << QgsProcessing::TypeVectorLine << QgsProcessing::TypeVectorPolygon ) );
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "REFERENCE_LAYER" ), QObject::tr( "Reference layer" ),
                 QList< int >() << QgsProcessing::TypeVectorPoint << QgsProcessing::TypeVectorLine << QgsProcessing::TypeVectorPolygon ) );
-  addParameter( new QgsProcessingParameterDistance( QStringLiteral( "TOLERANCE" ), QObject::tr( "Tolerance" ),
-                10.0, QStringLiteral( "INPUT" ), false, 0.00000001 ) );
+
+  std::unique_ptr< QgsProcessingParameterDistance > tolParam = std::make_unique< QgsProcessingParameterDistance >( QStringLiteral( "TOLERANCE" ), QObject::tr( "Tolerance" ), 10.0, QStringLiteral( "INPUT" ), false, 0.00000001 );
+  tolParam->setMetadata(
+  {
+    QVariantMap( {{
+        QStringLiteral( "widget_wrapper" ),
+        QVariantMap( {{
+            QStringLiteral( "decimals" ), 8
+          }} )
+      }} )
+  } );
+  addParameter( tolParam.release() );
 
   const QStringList options = QStringList()
                               << QObject::tr( "Prefer aligning nodes, insert extra vertices where required" )


### PR DESCRIPTION
Followup #44766

Now that the algorithm behaves well using tiny tolerance values, let's allow users to enter the minimum value we are currently offering them (i.e., 1e-8).

The widget is currently allowing them to enter up to 6 decimal places, which is confusing since it doesn't match the minimum value (1e-8).

Note that since a 0 tolerance is not allowed for this algorithm, users can enter such low values as a way to approach the 0 value.

Before:
![before](https://user-images.githubusercontent.com/652785/160220404-522082d9-9bc0-4785-9421-1b3dee4b76c5.gif)

After:
![after](https://user-images.githubusercontent.com/652785/160220412-1adc6ba2-4f13-41c5-ac3c-2669680436d7.gif)

------------------------------

_Note: We could also shorten the minimum value allowed to 1e-6, but I guess that might break things for plugins relying on the current value._
