### PR TITLE
Add map frame rate and current frame numbers to QgsMapSettings/QgsRenderContext

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -934,7 +934,52 @@ Sets the rendering usage
 .. versionadded:: 3.24
 %End
 
+    double frameRate() const;
+%Docstring
+Returns the frame rate of the map (in frames per second), for maps which are part of an animation.
+
+Returns -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`setFrameRate`
+
+.. versionadded:: 3.26
+%End
+
+    void setFrameRate( double rate );
+%Docstring
+Sets the frame ``rate`` of the map (in frames per second), for maps which are part of an animation.
+
+Defaults to -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`frameRate`
+
+.. versionadded:: 3.26
+%End
+
+    long long currentFrame() const;
+%Docstring
+Returns the current frame number of the map, for maps which are part of an animation.
+
+Returns -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`setCurrentFrame`
+
+.. versionadded:: 3.26
+%End
+
+    void setCurrentFrame( long long frame );
+%Docstring
+Sets the current ``frame`` of the map, for maps which are part of an animation.
+
+Defaults to -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`currentFrame`
+
+.. versionadded:: 3.26
+%End
+
   protected:
+
 
 
 

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -1053,6 +1053,50 @@ Sets the renderer usage
 .. versionadded:: 3.24
 %End
 
+    double frameRate() const;
+%Docstring
+Returns the frame rate of the map, for maps which are part of an animation.
+
+Returns -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`setFrameRate`
+
+.. versionadded:: 3.26
+%End
+
+    void setFrameRate( double rate );
+%Docstring
+Sets the frame ``rate`` of the map (in frames per second), for maps which are part of an animation.
+
+Defaults to -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`frameRate`
+
+.. versionadded:: 3.26
+%End
+
+    long long currentFrame() const;
+%Docstring
+Returns the current frame number of the map (in frames per second), for maps which are part of an animation.
+
+Returns -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`setCurrentFrame`
+
+.. versionadded:: 3.26
+%End
+
+    void setCurrentFrame( long long frame );
+%Docstring
+Sets the current ``frame`` of the map, for maps which are part of an animation.
+
+Defaults to -1 if the map is not associated with an animation.
+
+.. seealso:: :py:func:`currentFrame`
+
+.. versionadded:: 3.26
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgstemporalutils.sip.in
+++ b/python/core/auto_generated/qgstemporalutils.sip.in
@@ -58,6 +58,8 @@ The returned list may be non-contiguous and have gaps in the ranges. The ranges 
 
       QList<QgsMapDecoration *> decorations;
 
+      double frameRate;
+
     };
 
     static bool exportAnimation( const QgsMapSettings &mapSettings, const AnimationExportSettings &settings, QString &error /Out/, QgsFeedback *feedback = 0 );

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -503,6 +503,11 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )
 
+  if ( mapSettings.frameRate() >= 0 )
+    scope->setVariable( QStringLiteral( "frame_rate" ), mapSettings.frameRate(), true );
+  if ( mapSettings.currentFrame() >= 0 )
+    scope->setVariable( QStringLiteral( "frame_number" ), mapSettings.currentFrame(), true );
+
   return scope;
 }
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1726,6 +1726,13 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_end_time" ), isTemporal() ? temporalRange().end() : QVariant(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_interval" ), isTemporal() ? ( temporalRange().end() - temporalRange().begin() ) : QVariant(), true ) );
 
+#if 0 // not relevant here! (but left so as to respect all the dangerous warnings in QgsExpressionContextUtils::mapSettingsScope)
+  if ( mapSettings.frameRate() >= 0 )
+    scope->setVariable( QStringLiteral( "frame_rate" ), mapSettings.frameRate(), true );
+  if ( mapSettings.currentFrame() >= 0 )
+    scope->setVariable( QStringLiteral( "frame_number" ), mapSettings.currentFrame(), true );
+#endif
+
   return context;
 }
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -864,3 +864,23 @@ void QgsMapSettings::setRendererUsage( Qgis::RendererUsage rendererUsage )
 {
   mRendererUsage = rendererUsage;
 }
+
+double QgsMapSettings::frameRate() const
+{
+  return mFrameRate;
+}
+
+void QgsMapSettings::setFrameRate( double rate )
+{
+  mFrameRate = rate;
+}
+
+long long QgsMapSettings::currentFrame() const
+{
+  return mCurrentFrame;
+}
+
+void QgsMapSettings::setCurrentFrame( long long frame )
+{
+  mCurrentFrame = frame;
+}

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -824,6 +824,46 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      */
     void setRendererUsage( Qgis::RendererUsage rendererUsage );
 
+    /**
+     * Returns the frame rate of the map (in frames per second), for maps which are part of an animation.
+     *
+     * Returns -1 if the map is not associated with an animation.
+     *
+     * \see setFrameRate()
+     * \since QGIS 3.26
+     */
+    double frameRate() const;
+
+    /**
+     * Sets the frame \a rate of the map (in frames per second), for maps which are part of an animation.
+     *
+     * Defaults to -1 if the map is not associated with an animation.
+     *
+     * \see frameRate()
+     * \since QGIS 3.26
+     */
+    void setFrameRate( double rate );
+
+    /**
+     * Returns the current frame number of the map, for maps which are part of an animation.
+     *
+     * Returns -1 if the map is not associated with an animation.
+     *
+     * \see setCurrentFrame()
+     * \since QGIS 3.26
+     */
+    long long currentFrame() const;
+
+    /**
+     * Sets the current \a frame of the map, for maps which are part of an animation.
+     *
+     * Defaults to -1 if the map is not associated with an animation.
+     *
+     * \see currentFrame()
+     * \since QGIS 3.26
+     */
+    void setCurrentFrame( long long frame );
+
   protected:
 
     double mDpi = 96.0;
@@ -884,6 +924,9 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     QgsVectorSimplifyMethod mSimplifyMethod;
 
     Qgis::RendererUsage mRendererUsage = Qgis::RendererUsage::Unknown;
+
+    double mFrameRate = -1;
+    long long mCurrentFrame = -1;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -79,6 +79,8 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mDevicePixelRatio( rh.mDevicePixelRatio )
   , mImageFormat( rh.mImageFormat )
   , mRendererUsage( rh.mRendererUsage )
+  , mFrameRate( rh.mFrameRate )
+  , mCurrentFrame( rh.mCurrentFrame )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -125,6 +127,8 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mImageFormat = rh.mImageFormat;
   setIsTemporal( rh.isTemporal() );
   mRendererUsage = rh.mRendererUsage;
+  mFrameRate = rh.mFrameRate;
+  mCurrentFrame = rh.mCurrentFrame;
   if ( isTemporal() )
     setTemporalRange( rh.temporalRange() );
 #ifdef QGISDEBUG
@@ -280,6 +284,8 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.mClippingRegions = mapSettings.clippingRegions();
 
   ctx.mRendererUsage = mapSettings.rendererUsage();
+  ctx.mFrameRate = mapSettings.frameRate();
+  ctx.mCurrentFrame = mapSettings.currentFrame();
 
   return ctx;
 }
@@ -674,4 +680,23 @@ QSize QgsRenderContext::deviceOutputSize() const
   return outputSize() * mDevicePixelRatio;
 }
 
+double QgsRenderContext::frameRate() const
+{
+  return mFrameRate;
+}
+
+void QgsRenderContext::setFrameRate( double rate )
+{
+  mFrameRate = rate;
+}
+
+long long QgsRenderContext::currentFrame() const
+{
+  return mCurrentFrame;
+}
+
+void QgsRenderContext::setCurrentFrame( long long frame )
+{
+  mCurrentFrame = frame;
+}
 

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -993,6 +993,46 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     */
     void setRendererUsage( Qgis::RendererUsage usage ) {mRendererUsage = usage;}
 
+    /**
+     * Returns the frame rate of the map, for maps which are part of an animation.
+     *
+     * Returns -1 if the map is not associated with an animation.
+     *
+     * \see setFrameRate()
+     * \since QGIS 3.26
+     */
+    double frameRate() const;
+
+    /**
+     * Sets the frame \a rate of the map (in frames per second), for maps which are part of an animation.
+     *
+     * Defaults to -1 if the map is not associated with an animation.
+     *
+     * \see frameRate()
+     * \since QGIS 3.26
+     */
+    void setFrameRate( double rate );
+
+    /**
+     * Returns the current frame number of the map (in frames per second), for maps which are part of an animation.
+     *
+     * Returns -1 if the map is not associated with an animation.
+     *
+     * \see setCurrentFrame()
+     * \since QGIS 3.26
+     */
+    long long currentFrame() const;
+
+    /**
+     * Sets the current \a frame of the map, for maps which are part of an animation.
+     *
+     * Defaults to -1 if the map is not associated with an animation.
+     *
+     * \see currentFrame()
+     * \since QGIS 3.26
+     */
+    void setCurrentFrame( long long frame );
+
   private:
 
     Qgis::RenderContextFlags mFlags;
@@ -1107,6 +1147,9 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     QImage::Format mImageFormat = QImage::Format_ARGB32_Premultiplied;
 
     Qgis::RendererUsage mRendererUsage = Qgis::RendererUsage::Unknown;
+
+    double mFrameRate = -1;
+    long long mCurrentFrame = -1;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgstemporalutils.cpp
+++ b/src/core/qgstemporalutils.cpp
@@ -101,6 +101,7 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
   navigator.setFrameDuration( settings.frameDuration );
   QgsMapSettings ms = mapSettings;
   const QgsExpressionContext context = ms.expressionContext();
+  ms.setFrameRate( settings.frameRate );
 
   const long long totalFrames = navigator.totalFrameCount();
   long long currentFrame = 0;
@@ -121,6 +122,7 @@ bool QgsTemporalUtils::exportAnimation( const QgsMapSettings &mapSettings, const
 
     ms.setIsTemporal( true );
     ms.setTemporalRange( navigator.dateTimeRangeForFrameNumber( currentFrame ) );
+    ms.setCurrentFrame( currentFrame );
 
     QgsExpressionContext frameContext = context;
     frameContext.appendScope( navigator.createExpressionContextScope() );

--- a/src/core/qgstemporalutils.h
+++ b/src/core/qgstemporalutils.h
@@ -167,6 +167,13 @@ class CORE_EXPORT QgsTemporalUtils
       //! List of decorations to draw onto exported frames.
       QList<QgsMapDecoration *> decorations;
 
+      /**
+       * Target animation frame rate in frames per second.
+       *
+       * \since QGIS 3.26
+       */
+      double frameRate = 30;
+
     };
 
     /**

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1255,6 +1255,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
     void startPreviewJob( int number );
 
+    void temporalControllerModeChanged();
+
   private:
 
     // Restore scale RAII

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -594,6 +594,9 @@ void TestQgsMapSettings::testExpressionContext()
   r = e.evaluate( &c );
   QVERIFY( !r.isValid() );
 
+  QVERIFY( !c.variable( QStringLiteral( "frame_rate" ) ).isValid() );
+  QVERIFY( !c.variable( QStringLiteral( "frame_number" ) ).isValid() );
+
   ms.setTemporalRange( QgsDateTimeRange( QDateTime( QDate( 2002, 3, 4 ), QTime( 0, 0, 0 ) ), QDateTime( QDate( 2010, 6, 7 ), QTime( 0, 0, 0 ) ) ) );
   c = QgsExpressionContext();
   c << QgsExpressionContextUtils::mapSettingsScope( ms );
@@ -606,6 +609,22 @@ void TestQgsMapSettings::testExpressionContext()
   e = QgsExpression( QStringLiteral( "@map_interval" ) );
   r = e.evaluate( &c );
   QCOMPARE( r.value< QgsInterval >(), QgsInterval( QDateTime( QDate( 2010, 6, 7 ), QTime( 0, 0, 0 ) ) - QDateTime( QDate( 2002, 3, 4 ), QTime( 0, 0, 0 ) ) ) );
+
+  QVERIFY( !c.variable( QStringLiteral( "frame_rate" ) ).isValid() );
+  QVERIFY( !c.variable( QStringLiteral( "frame_number" ) ).isValid() );
+
+  ms.setFrameRate( 30 );
+  ms.setCurrentFrame( 5 );
+  c = QgsExpressionContext();
+  c << QgsExpressionContextUtils::mapSettingsScope( ms );
+  QVERIFY( c.variable( QStringLiteral( "frame_rate" ) ).isValid() );
+  QVERIFY( c.variable( QStringLiteral( "frame_number" ) ).isValid() );
+  e = QgsExpression( QStringLiteral( "@frame_rate" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toDouble(), 30.0 );
+  e = QgsExpression( QStringLiteral( "@frame_number" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toLongLong(), 5LL );
 }
 
 void TestQgsMapSettings::testRenderedFeatureHandlers()

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -127,6 +127,14 @@ void TestQgsMapSettings::testGettersSetters()
   QVERIFY( ms.zRange().isInfinite() );
   ms.setZRange( QgsDoubleRange( 1, 10 ) );
   QCOMPARE( ms.zRange(), QgsDoubleRange( 1, 10 ) );
+
+  QCOMPARE( ms.frameRate(), -1.0 );
+  ms.setFrameRate( 30.0 );
+  QCOMPARE( ms.frameRate(), 30.0 );
+
+  QCOMPARE( ms.currentFrame(), -1 );
+  ms.setCurrentFrame( 6 );
+  QCOMPARE( ms.currentFrame(), 6LL );
 }
 
 void TestQgsMapSettings::testLabelingEngineSettings()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -83,6 +83,14 @@ class TestQgsRenderContext(unittest.TestCase):
         # should have an invalid mapToPixel by default
         self.assertFalse(c.mapToPixel().isValid())
 
+        self.assertEqual(c.frameRate(), -1)
+        c.setFrameRate(30)
+        self.assertEqual(c.frameRate(), 30)
+
+        self.assertEqual(c.currentFrame(), -1)
+        c.setCurrentFrame(6)
+        self.assertEqual(c.currentFrame(), 6)
+
     def testCopyConstructor(self):
         """
         Test the copy constructor
@@ -96,6 +104,8 @@ class TestQgsRenderContext(unittest.TestCase):
         c1.setOutputSize(QSize(100, 200))
         c1.setImageFormat(QImage.Format_Alpha8)
         c1.setDevicePixelRatio(2)
+        c1.setFrameRate(30)
+        c1.setCurrentFrame(6)
 
         c2 = QgsRenderContext(c1)
         self.assertEqual(c2.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
@@ -106,6 +116,8 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertEqual(c2.imageFormat(), QImage.Format_Alpha8)
         self.assertEqual(c2.devicePixelRatio(), 2)
         self.assertEqual(c2.deviceOutputSize(), QSize(200, 400))
+        self.assertEqual(c2.frameRate(), 30)
+        self.assertEqual(c2.currentFrame(), 6)
 
         c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         c2 = QgsRenderContext(c1)
@@ -172,6 +184,8 @@ class TestQgsRenderContext(unittest.TestCase):
         ms.setOutputSize(QSize(100, 100))
         ms.setDevicePixelRatio(2)
         ms.setOutputImageFormat(QImage.Format_Alpha8)
+        ms.setFrameRate(30)
+        ms.setCurrentFrame(6)
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
         rc = QgsRenderContext.fromMapSettings(ms)
@@ -185,6 +199,8 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertEqual(rc.devicePixelRatio(), 2)
         self.assertEqual(rc.deviceOutputSize(), QSize(200, 200))
         self.assertEqual(rc.imageFormat(), QImage.Format_Alpha8)
+        self.assertEqual(rc.frameRate(), 30)
+        self.assertEqual(rc.currentFrame(), 6)
 
         # should have an valid mapToPixel
         self.assertTrue(rc.mapToPixel().isValid())


### PR DESCRIPTION
Makes this information available for symbol rendering logic when a map is being rendered as part of an animation

Useful for either temporal controller set to animation mode, or 3rd party animation creation plugins