### PR TITLE
[nmea] Convert RMC mode indicator to its equivalent signal variant to provide accurate quality description

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -617,6 +617,20 @@ Qgis.ContentStatus.__doc__ = 'Status for fetched or stored content\n\n.. version
 # --
 Qgis.ContentStatus.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.GpsQualityIndicator.Unknown.__doc__ = "Unknown"
+Qgis.GpsQualityIndicator.Invalid.__doc__ = "Invalid"
+Qgis.GpsQualityIndicator.GPS.__doc__ = "Standalone"
+Qgis.GpsQualityIndicator.DGPS.__doc__ = "Differential GPS"
+Qgis.GpsQualityIndicator.PPS.__doc__ = "PPS"
+Qgis.GpsQualityIndicator.RTK.__doc__ = "Real-time-kynematic"
+Qgis.GpsQualityIndicator.FloatRTK.__doc__ = "Float real-time-kynematic"
+Qgis.GpsQualityIndicator.Estimated.__doc__ = "Estimated"
+Qgis.GpsQualityIndicator.Manual.__doc__ = "Manual input mode"
+Qgis.GpsQualityIndicator.Simulation.__doc__ = "Simulation mode"
+Qgis.GpsQualityIndicator.__doc__ = 'GPS signal quality indicator\n\n.. versionadded:: 3.22.6\n\n' + '* ``Unknown``: ' + Qgis.GpsQualityIndicator.Unknown.__doc__ + '\n' + '* ``Invalid``: ' + Qgis.GpsQualityIndicator.Invalid.__doc__ + '\n' + '* ``GPS``: ' + Qgis.GpsQualityIndicator.GPS.__doc__ + '\n' + '* ``DGPS``: ' + Qgis.GpsQualityIndicator.DGPS.__doc__ + '\n' + '* ``PPS``: ' + Qgis.GpsQualityIndicator.PPS.__doc__ + '\n' + '* ``RTK``: ' + Qgis.GpsQualityIndicator.RTK.__doc__ + '\n' + '* ``FloatRTK``: ' + Qgis.GpsQualityIndicator.FloatRTK.__doc__ + '\n' + '* ``Estimated``: ' + Qgis.GpsQualityIndicator.Estimated.__doc__ + '\n' + '* ``Manual``: ' + Qgis.GpsQualityIndicator.Manual.__doc__ + '\n' + '* ``Simulation``: ' + Qgis.GpsQualityIndicator.Simulation.__doc__
+# --
+Qgis.GpsQualityIndicator.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.BabelFormatCapability.Import.__doc__ = "Format supports importing"
 Qgis.BabelFormatCapability.Export.__doc__ = "Format supports exporting"
 Qgis.BabelFormatCapability.Waypoints.__doc__ = "Format supports waypoints"

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -94,6 +94,8 @@ Encapsulates information relating to a GPS position fix.
 
     int quality;
 
+    Qgis::GpsQualityIndicator qualityIndicator;
+
     int satellitesUsed;
 
     QChar status;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -438,6 +438,20 @@ The development version
       Canceled,
     };
 
+    enum class GpsQualityIndicator
+    {
+      Unknown,
+      Invalid,
+      GPS,
+      DGPS,
+      PPS,
+      RTK,
+      FloatRTK,
+      Estimated,
+      Manual,
+      Simulation,
+    };
+
     enum class BabelFormatCapability
     {
       Import,

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -752,7 +752,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
   FixStatus fixStatus = NoData;
 
   // no fix if any of the three report bad; default values are invalid values and won't be changed if the corresponding NMEA msg is not received
-  if ( info.status == 'V' || info.fixType == NMEA_FIX_BAD || info.quality == 0 ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( info.status == 'V' || info.fixType == NMEA_FIX_BAD || info.qualityIndicator == Qgis::GpsQualityIndicator::Invalid || info.qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     fixStatus = NoFix;
   }
@@ -761,7 +761,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     fixStatus = Fix2D;
     validFlag = true;
   }
-  else if ( info.status == 'A' || info.fixType == NMEA_FIX_3D || info.quality > 0 ) // good
+  else if ( info.status == 'A' || info.fixType == NMEA_FIX_3D || ( info.qualityIndicator != Qgis::GpsQualityIndicator::Invalid && info.qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
   {
     fixStatus = Fix3D;
     validFlag = true;

--- a/src/core/gps/qgsgpsconnection.cpp
+++ b/src/core/gps/qgsgpsconnection.cpp
@@ -31,7 +31,7 @@
 bool QgsGpsInformation::isValid() const
 {
   bool valid = false;
-  if ( status == 'V' || fixType == NMEA_FIX_BAD || quality == 0 ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid || qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     valid = false;
   }
@@ -39,7 +39,7 @@ bool QgsGpsInformation::isValid() const
   {
     valid = true;
   }
-  else if ( status == 'A' || fixType == NMEA_FIX_3D || quality > 0 ) // good
+  else if ( status == 'A' || fixType == NMEA_FIX_3D || ( qualityIndicator != Qgis::GpsQualityIndicator::Invalid && qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
   {
     valid = true;
   }
@@ -52,7 +52,7 @@ QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
   FixStatus fixStatus = NoData;
 
   // no fix if any of the three report bad; default values are invalid values and won't be changed if the corresponding NMEA msg is not received
-  if ( status == 'V' || fixType == NMEA_FIX_BAD || quality == 0 ) // some sources say that 'V' indicates position fix, but is below acceptable quality
+  if ( status == 'V' || fixType == NMEA_FIX_BAD || qualityIndicator == Qgis::GpsQualityIndicator::Invalid || qualityIndicator == Qgis::GpsQualityIndicator::Unknown ) // some sources say that 'V' indicates position fix, but is below acceptable quality
   {
     fixStatus = NoFix;
   }
@@ -60,7 +60,7 @@ QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
   {
     fixStatus = Fix2D;
   }
-  else if ( status == 'A' || fixType == NMEA_FIX_3D || quality > 0 ) // good
+  else if ( status == 'A' || fixType == NMEA_FIX_3D || ( qualityIndicator != Qgis::GpsQualityIndicator::Invalid && qualityIndicator != Qgis::GpsQualityIndicator::Unknown ) ) // good
   {
     fixStatus = Fix3D;
   }
@@ -69,35 +69,36 @@ QgsGpsInformation::FixStatus QgsGpsInformation::fixStatus() const
 
 QString QgsGpsInformation::qualityDescription() const
 {
-  switch ( quality )
+  switch ( qualityIndicator )
   {
-    case 8:
+    case Qgis::GpsQualityIndicator::Simulation:
       return QCoreApplication::translate( "QgsGpsInformation", "Simulation mode" );
 
-    case 7:
+    case Qgis::GpsQualityIndicator::Manual:
       return QCoreApplication::translate( "QgsGpsInformation", "Manual input mode" );
 
-    case 6:
+    case Qgis::GpsQualityIndicator::Estimated:
       return QCoreApplication::translate( "QgsGpsInformation", "Estimated" );
 
-    case 5:
+    case Qgis::GpsQualityIndicator::FloatRTK:
       return QCoreApplication::translate( "QgsGpsInformation", "Float RTK" );
 
-    case 4:
+    case Qgis::GpsQualityIndicator::RTK:
       return QCoreApplication::translate( "QgsGpsInformation", "Fixed RTK" );
 
-    case 3:
+    case Qgis::GpsQualityIndicator::PPS:
       return QCoreApplication::translate( "QgsGpsInformation", "PPS" );
 
-    case 2:
+    case Qgis::GpsQualityIndicator::DGPS:
       return QCoreApplication::translate( "QgsGpsInformation", "DGPS" );
 
-    case 1:
+    case Qgis::GpsQualityIndicator::GPS:
       return QCoreApplication::translate( "QgsGpsInformation", "Autonomous" );
 
-    case 0:
+    case Qgis::GpsQualityIndicator::Invalid:
       return QCoreApplication::translate( "QgsGpsInformation", "Invalid" );
 
+    case Qgis::GpsQualityIndicator::Unknown:
     default:
       return QCoreApplication::translate( "QgsGpsInformation", "Unknown (%1)" ).arg( QString::number( quality ) );
   }

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -215,9 +215,16 @@ class CORE_EXPORT QgsGpsInformation
     int fixType = 0;
 
     /**
-     * GPS quality indicator (0 = Invalid; 1 = Fix; 2 = Differential, 3 = Sensitive)
+     * GPS quality indicator (0 = Invalid; 1 = Fix; 2 = Differential, 3 = Sensitive, etc.)
+     * \deprecated use qualityIndicator instead
      */
     int quality = -1;
+
+    /**
+     * Returns the signal quality indicator
+     * \since QGIS 3.22.6
+     */
+    Qgis::GpsQualityIndicator qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
 
     /**
      * Count of satellites used in obtaining the fix.

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -189,7 +189,17 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
     mLastGPSInformation.latitude = nmea_ndeg2degree( latitude );
     mLastGPSInformation.elevation = result.elv;
     mLastGPSInformation.elevation_diff = result.diff;
+
     mLastGPSInformation.quality = result.sig;
+    if ( result.sig >= 0 && result.sig <= 8 )
+    {
+      mLastGPSInformation.qualityIndicator = static_cast<Qgis::GpsQualityIndicator>( result.sig );
+    }
+    else
+    {
+      mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
+    }
+
     mLastGPSInformation.satellitesUsed = result.satinuse;
   }
 }
@@ -278,6 +288,62 @@ void QgsNmeaConnection::processRmcSentence( const char *data, int len )
       QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toString(), 2 );
       QgsDebugMsgLevel( QStringLiteral( "local time:" ), 2 );
       QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toLocalTime().toString(), 2 );
+    }
+
+    // convert mode to signal (aka quality) indicator
+    // (see https://gitlab.com/fhuberts/nmealib/-/blob/master/src/info.c#L27)
+    if ( result.status == 'A' )
+    {
+      if ( result.mode == 'A' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::GPS );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::GPS;
+      }
+      else if ( result.mode == 'D' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::DGPS );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::DGPS;
+      }
+      else if ( result.mode == 'P' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::PPS );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::PPS;
+      }
+      else if ( result.mode == 'R' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::RTK );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::RTK;
+      }
+      else if ( result.mode == 'F' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::FloatRTK );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::FloatRTK;
+      }
+      else if ( result.mode == 'E' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Estimated );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Estimated;
+      }
+      else if ( result.mode == 'M' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Manual );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Manual;
+      }
+      else if ( result.mode == 'S' )
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Simulation );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Simulation;
+      }
+      else
+      {
+        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Unknown );
+        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
+      }
+    }
+    else
+    {
+      mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Invalid );
+      mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Invalid;
     }
   }
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -690,6 +690,26 @@ class CORE_EXPORT Qgis
     Q_ENUM( ContentStatus )
 
     /**
+     * GPS signal quality indicator
+     *
+     * \since QGIS 3.22.6
+     */
+    enum class GpsQualityIndicator
+    {
+      Unknown = -1, //!< Unknown
+      Invalid, //!< Invalid
+      GPS, //!< Standalone
+      DGPS, //!< Differential GPS
+      PPS, //!< PPS
+      RTK, //!< Real-time-kynematic
+      FloatRTK, //!< Float real-time-kynematic
+      Estimated, //!< Estimated
+      Manual, //!< Manual input mode
+      Simulation, //!< Simulation mode
+    };
+    Q_ENUM( GpsQualityIndicator )
+
+    /**
      * Babel GPS format capabilities.
      *
      * \since QGIS 3.22


### PR DESCRIPTION
## Description

Issue detailed here (https://github.com/opengisch/QField/issues/2623). While this is essentially a "blind" fix on my part due to not having the GNSS device, the rational was taken from nmealib (as indicated in code comment). I'm very certain translating the NMEA RMC sentence's mode indicator to quality indicator is the correct behavior to insure our quality description matches what's being sent. 

The only uncertainty I have is whether the device sends both a RMC as well as a GGA sentence, and if so, which one should take priority over the other. In any case, this fix is required.

@nyalldawson , as discussed.