### PR TITLE
fix: testqgsgeoreferencer if HAVE_GEOREFERENCER

### DIFF
--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -18,7 +18,6 @@ set(TESTS
   testqgsapplocatorfilters.cpp
   testqgsdecorationscalebar.cpp
   testqgsfieldcalculator.cpp
-  testqgsgeoreferencer.cpp
   testqgsmaptooleditannotation.cpp
   testqgsmaptoolidentifyaction.cpp
   testqgsmaptoollabel.cpp
@@ -47,6 +46,11 @@ set(TESTS
   testqgsgpsinformationwidget.cpp
   testqgslabelpropertydialog.cpp
 )
+
+if (HAVE_GEOREFERENCER)
+  set(TESTS ${TESTS} testqgsgeoreferencer.cpp)
+endif()
+
 if (WITH_BINDINGS)
   set(TESTS ${TESTS} testqgisapppython.cpp)
 endif()


### PR DESCRIPTION
build testqgsgeoreferencer only if GEOREFERENCER is set

## Description

currently build WITH_ANALYSIS and WITH_GSL enables HAVE_GEOREFERENCER.
https://github.com/qgis/QGIS/blob/98637ac0ae837b2586e6fd5cd10f27caeb2ff302/CMakeLists.txt#L694-L698

currently if building with WITH_ANALYSIS and WITH_GSL (implies HAVE_GEOREFERENCER) and without ENABLE_TESTS fails with linking error.
```
FAILED: output/bin/test_app_georeferencer 
: && /usr/bin/x86_64-pc-linux-gnu-g++ -march=native -O2 -pipe -Wl,-O1 -Wl,--as-needed -Wl,--no-undefined tests/src/app/CMakeFiles/test_app_georeferencer.dir/test_app_georeferencer_autogen/mocs_compilation.cpp.o tests/src/app/CMakeFiles/test_app_georeferencer.dir/testqgsgeoreferencer.cpp.o -o output/bin/test_app_georeferencer -L/var/tmp/portage/sci-geosciences/qgis-3.24.1/work/qgis-3.24.1_build/src/core   -L/var/tmp/portage/sci-geosciences/qgis-3.24.1/work/qgis-3.24.1_build/src/gui -Wl,-rpath,/var/tmp/portage/sci-geosciences/qgis-3.24.1/work/qgis-3.24.1_build/src/core:/var/tmp/portage/sci-geosciences/qgis-3.24.1/work/qgis-3.24.1_build/src/gui:/var/tmp/portage/sci-geosciences/qgis-3.24.1/work/qgis-3.24.1_build/output/lib64  output/lib64/libqgis_app.so.3.24.1  /usr/lib64/libQt5Test.so.5.15.2  output/lib64/libqgis_gui.so.3.24.1  /usr/lib64/libqwt6-qt5.so  /usr/lib64/libQt5UiTools.a  /usr/lib64//libQt5Widgets.so  /usr/lib64//libQt5Gui.so  /usr/lib64//libQt5Core.so  /usr/lib64//libQt5Widgets.so  /usr/lib64//libQt5Gui.so  /usr/lib64//libQt5Core.so  /usr/lib64/libGL.so  /usr/lib64/libqscintilla2_qt5.so  /usr/lib64/libQt5QuickWidgets.so.5.15.2  /usr/lib64/libQt5Quick.so.5.15.2  /usr/lib64/libQt5QmlModels.so.5.15.2  /usr/lib64/libQt5Qml.so.5.15.2  output/lib64/libqgis_analysis.so.3.24.1  output/lib64/libqgis_native.so.3.24.1  /usr/lib64/libQt5DBus.so.5.15.2  src/app/dwg/libdxfrw/liblibdxfrw.a  output/lib64/libqgispython.so.3.24.1  /usr/lib64/libpython3.10.so  output/lib64/libqgis_3d.so.3.24.1  output/lib64/libqgis_core.so.3.24.1  /usr/lib64/libQt5Sql.so.5.15.2  /usr/lib64/libOpenCL.so  /usr/lib64/libQt5Xml.so.5.15.2  /usr/lib64/libQt5Svg.so.5.15.2  /usr/lib64/libQt5Concurrent.so.5.15.2  /usr/lib64/libqca-qt5.so  /usr/lib64/libqt5keychain.so  /usr/lib64/libproj.so  /usr/lib64/libgeos_c.so  /usr/lib64/libgdal.so  /usr/lib64/libspatialindex.so  /usr/lib64/libexpat.so  /usr/lib64/libsqlite3.so  /usr/lib64/libzip.so  /usr/lib64/libprotobuf-lite.so  -lz  /usr/lib64/libexiv2.so  /usr/lib64/libQt5PrintSupport.so.5.15.2  /usr/lib64/libQt5Widgets.so.5.15.2  /usr/lib64/libspatialite.so  /usr/lib64/libzstd.so  /usr/lib64/libQt5Positioning.so.5.15.2  /usr/lib64/libQt53DExtras.so.5.15.2  /usr/lib64/libQt53DRender.so.5.15.2  /usr/lib64/libQt53DInput.so.5.15.2  /usr/lib64/libQt53DLogic.so.5.15.2  /usr/lib64/libQt53DCore.so.5.15.2  /usr/lib64/libQt5Gui.so.5.15.2  /usr/lib64/libQt5Network.so.5.15.2  /usr/lib64/libpq.so  -lpdalcpp  /usr/lib64/libpdal_util.so  /usr/lib64/libQt5Core.so.5.15.2 && :
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: tests/src/app/CMakeFiles/test_app_georeferencer.dir/testqgsgeoreferencer.cpp.o: in function `TestQgsGeoreferencer::testRasterChangeCoords()':
testqgsgeoreferencer.cpp:(.text+0x1478): undefined reference to `QgsRasterChangeCoords::loadRaster(QString const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x1534): undefined reference to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x15c8): undefined reference to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x160d): undefined reference to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x1666): undefined reference to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x16ea): undefined reference to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: tests/src/app/CMakeFiles/test_app_georeferencer.dir/testqgsgeoreferencer.cpp.o:testqgsgeoreferencer.cpp:(.text+0x174e): more undefined references to `QgsRasterChangeCoords::toXY(QgsPointXY const&) const' follow
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: tests/src/app/CMakeFiles/test_app_georeferencer.dir/testqgsgeoreferencer.cpp.o: in function `TestQgsGeoreferencer::testRasterChangeCoords()':
testqgsgeoreferencer.cpp:(.text+0x1ed5): undefined reference to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x1f67): undefined reference to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x1fae): undefined reference to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x2005): undefined reference to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: testqgsgeoreferencer.cpp:(.text+0x2087): undefined reference to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: tests/src/app/CMakeFiles/test_app_georeferencer.dir/testqgsgeoreferencer.cpp.o:testqgsgeoreferencer.cpp:(.text+0x2113): more undefined references to `QgsRasterChangeCoords::toColumnLine(QgsPointXY const&) const' follow
...
```

this PR solves the issue in building testqgsgeoreferencer.cpp only if HAVE_GEOREFERENCER

tested locally WITH_ANALYSIS=ON WITH_GSL=[ON|OFF] and ENABLE_TESTS=ON.