### PR TITLE
add methods to allow interacting with drag&drop edit forms from Python

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorcontainer.sip.in
@@ -31,11 +31,45 @@ Creates a new attribute editor container
 
     ~QgsAttributeEditorContainer();
 
-    virtual void addChildElement( QgsAttributeEditorElement *element /Transfer/ );
+    void addChildElement( QgsAttributeEditorElement *element /Transfer/ );
 %Docstring
 Add a child element to this container. This may be another container, a field or a relation.
 
 :param element: The element to add as child
+%End
+
+    void insertChildElement( int index, QgsAttributeEditorElement *widget /Transfer/ );
+%Docstring
+Insert a child element into this container. This may be another container, a field or a relation.
+Note that the element must first be taken out of its original container.
+
+:param index: The location to insert the child
+:param widget: The element to add as child
+
+.. versionadded:: 3.26
+%End
+
+    QgsAttributeEditorElement *takeChildElement( int index ) /TransferBack/;
+%Docstring
+Take a child element from a container, so that it can be inserted into another container.
+
+:param index: The index of the child element
+
+:return: widget The element to add as child
+
+.. versionadded:: 3.26
+%End
+
+    virtual bool removeChildElement( QgsAttributeEditorElement *element );
+%Docstring
+Remove a child element from this container. The supplied child element is deleted.
+
+:param element: The child element to remove.
+
+:return: ``False`` if the element is not a direct child of this container, in which case it is not removed.
+         ``True`` if the child element is found and deleted.
+
+.. versionadded:: 3.26
 %End
 
     virtual void setIsGroupBox( bool isGroupBox );

--- a/src/core/editform/qgsattributeeditorcontainer.cpp
+++ b/src/core/editform/qgsattributeeditorcontainer.cpp
@@ -27,6 +27,26 @@ void QgsAttributeEditorContainer::addChildElement( QgsAttributeEditorElement *wi
   mChildren.append( widget );
 }
 
+void QgsAttributeEditorContainer::insertChildElement( int index, QgsAttributeEditorElement *widget )
+{
+  mChildren.insert( index, widget );
+}
+
+QgsAttributeEditorElement* QgsAttributeEditorContainer::takeChildElement( int index )
+{
+  return mChildren.takeAt( index );
+}
+
+bool QgsAttributeEditorContainer::removeChildElement( QgsAttributeEditorElement *widget)
+{
+  int removed = mChildren.removeAll( widget );
+  if ( 0 == removed )
+    return false;
+
+  delete widget;
+  return true;
+}
+
 void QgsAttributeEditorContainer::setName( const QString &name )
 {
   mName = name;

--- a/src/core/editform/qgsattributeeditorcontainer.h
+++ b/src/core/editform/qgsattributeeditorcontainer.h
@@ -50,7 +50,36 @@ class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
      *
      * \param element The element to add as child
      */
-    virtual void addChildElement( QgsAttributeEditorElement *element SIP_TRANSFER );
+    void addChildElement( QgsAttributeEditorElement *element SIP_TRANSFER );
+
+    /**
+     * Insert a child element into this container. This may be another container, a field or a relation.
+     * Note that the element must first be taken out of its original container.
+     *
+     * \param index The location to insert the child
+     * \param widget The element to add as child
+     * \since QGIS 3.26
+     */
+    void insertChildElement( int index, QgsAttributeEditorElement *widget SIP_TRANSFER );
+
+    /**
+     * Take a child element from a container, so that it can be inserted into another container.
+     *
+     * \param index The index of the child element
+     * \returns widget The element to add as child
+     * \since QGIS 3.26
+     */
+    QgsAttributeEditorElement *takeChildElement( int index ) SIP_TRANSFERBACK;
+
+    /**
+     * Remove a child element from this container. The supplied child element is deleted.
+     *
+     * \param element The child element to remove.
+     * \returns FALSE if the element is not a direct child of this container, in which case it is not removed.
+     * TRUE if the child element is found and deleted.
+     * \since QGIS 3.26
+     */
+    virtual bool removeChildElement( QgsAttributeEditorElement *element );
 
     /**
      * Determines if this container is rendered as collapsible group box or tab in a tabwidget


### PR DESCRIPTION
## Description

Hello folks,

This is my first commit to QGIS and I'm also not too familiar with github so please feel free to let me know if I have done anything incorrectly.
This is just a small patch to expose some more of the inner workings of drag & drop editor forms to Python. It would be quite convenient for me if it was possible to change these via pyqgis. My usecase is I have created a form for data collection according to a certain standard and saved it as a layer style in a qml file. Later, that layer style is applied to different data sources, but sometimes there are optional parts of the form which need to be shuffled around or removed.
I've obviously built and tested the code but I'd appreciate if you could tell me whether I've used the SIP tags correctly here.

Warm regards, Sem