### PR TITLE
Expose task flags control for QgsMapRendererTask

### DIFF
--- a/python/core/auto_generated/maprenderer/qgsmaprenderertask.sip.in
+++ b/python/core/auto_generated/maprenderer/qgsmaprenderertask.sip.in
@@ -32,15 +32,16 @@ task. This can be used to draw maps without blocking the QGIS interface.
       ImageUnsupportedFormat
     };
 
+
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
-                        bool forceRaster = false );
+                        bool forceRaster = false,
+                        QgsTask::Flags flags = QgsTask::CanCancel );
 %Docstring
 Constructor for QgsMapRendererTask to render a map to an image file.
 
-If the output ``fileFormat`` is set to PDF, the ``geoPdf`` argument controls whether a GeoPDF file is created.
-See :py:func:`QgsAbstractGeoPdfExporter.geoPDFCreationAvailable()` for conditions on GeoPDF creation availability.
+Since QGIS 3.26 the optional ``flags`` argument can be used to control the task flags.
 %End
 
     QgsMapRendererTask( const QgsMapSettings &ms,

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -541,7 +541,7 @@ void QgsMapSaveDialog::onAccepted()
 
           geoPdfExportDetails.includeFeatures = mExportGeoPdfFeaturesCheckBox->isChecked();
         }
-        QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), mGeoPDFGroupBox->isChecked(), geoPdfExportDetails );
+        QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), QgsTask::CanCancel, mGeoPDFGroupBox->isChecked(), geoPdfExportDetails );
 
         if ( drawAnnotations() )
         {

--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -117,9 +117,9 @@ class QgsMapRendererTaskRenderedFeatureHandler : public QgsRenderedFeatureHandle
 
 ///@endcond
 
-QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster,
+QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster, Flags flags,
                                         const bool geoPDF, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails )
-  : QgsTask( fileFormat == QLatin1String( "PDF" ) ? tr( "Saving as PDF" ) : tr( "Saving as image" ) )
+  : QgsTask( fileFormat == QLatin1String( "PDF" ) ? tr( "Saving as PDF" ) : tr( "Saving as image" ), flags )
   , mMapSettings( ms )
   , mFileName( fileName )
   , mFileFormat( fileFormat )

--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -117,7 +117,7 @@ class QgsMapRendererTaskRenderedFeatureHandler : public QgsRenderedFeatureHandle
 
 ///@endcond
 
-QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster, Flags flags,
+QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster, QgsTask::Flags flags,
                                         const bool geoPDF, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails )
   : QgsTask( fileFormat == QLatin1String( "PDF" ) ? tr( "Saving as PDF" ) : tr( "Saving as image" ), flags )
   , mMapSettings( ms )

--- a/src/core/maprenderer/qgsmaprenderertask.h
+++ b/src/core/maprenderer/qgsmaprenderertask.h
@@ -57,23 +57,34 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
       ImageUnsupportedFormat //!< Format is unsupported on the platform \since QGIS 3.4
     };
 
+#ifndef SIP_RUN
+
     /**
      * Constructor for QgsMapRendererTask to render a map to an image file.
      *
      * If the output \a fileFormat is set to PDF, the \a geoPdf argument controls whether a GeoPDF file is created.
      * See QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() for conditions on GeoPDF creation availability.
+     *
+     * Since QGIS 3.26 the optional \a flags argument can be used to control the task flags.
      */
-#ifndef SIP_RUN
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
                         bool forceRaster = false,
-                        bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails() );
+                        QgsTask::Flags flags = QgsTask::CanCancel, bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails()
+                      );
 #else
+
+    /**
+     * Constructor for QgsMapRendererTask to render a map to an image file.
+     *
+     * Since QGIS 3.26 the optional \a flags argument can be used to control the task flags.
+     */
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
-                        bool forceRaster = false );
+                        bool forceRaster = false,
+                        QgsTask::Flags flags = QgsTask::CanCancel );
 #endif
 
     /**


### PR DESCRIPTION
Allows plugins to create hidden/uncancelable render tasks
