### PR TITLE
[GUI] Open vector layer dialog: do not expose GPKG 'NOLOCK' open option

### DIFF
--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -691,6 +691,11 @@ void QgsOgrSourceSelect::fillOpenOptions()
          !EQUAL( pszOptionName, "PRELUDE_STATEMENTS" ) )
       continue;
 
+    // The NOLOCK option is automatically set by the OGR provider. Do not
+    // expose it
+    if ( bIsGPKG && EQUAL( pszOptionName, "NOLOCK" ) )
+      continue;
+
     // Do not list database options already asked in the database dialog
     if ( radioSrcDatabase->isChecked() &&
          ( EQUAL( pszOptionName, "USER" ) ||


### PR DESCRIPTION
This option is automatically set by the OGR provider. No need for the
user to mess with it.

Refs https://github.com/qgis/QGIS/pull/47098#issuecomment-1080274084
