### PR TITLE
Allow label customization in D&D forms

### DIFF
--- a/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
@@ -124,6 +124,84 @@ Controls if this element should be labeled with a title (field, relation or grou
 .. versionadded:: 2.18
 %End
 
+    const QFont &labelFont() const;
+%Docstring
+Returns the custom label font, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
+
+.. seealso:: :py:func:`setLabelFont`
+
+.. seealso:: :py:func:`overrideLabelStyle`
+
+.. seealso:: :py:func:`setOverrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
+    void setLabelFont( const QFont &labelFont );
+%Docstring
+Sets the custom ``labelFont``, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
+
+.. seealso:: :py:func:`setLabelFont`
+
+.. seealso:: :py:func:`overrideLabelStyle`
+
+.. seealso:: :py:func:`setOverrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
+    const QColor &labelColor() const;
+%Docstring
+Returns the custom label color, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
+
+.. seealso:: :py:func:`setLabelColor`
+
+.. seealso:: :py:func:`overrideLabelStyle`
+
+.. seealso:: :py:func:`setOverrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
+    void setLabelColor( const QColor &labelColor );
+%Docstring
+Sets the custom ``labelColor``, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
+
+.. seealso:: :py:func:`setLabelColor`
+
+.. seealso:: :py:func:`overrideLabelStyle`
+
+.. seealso:: :py:func:`setOverrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
+    bool overrideLabelStyle() const;
+%Docstring
+Returns ``True`` if the label style (font and color) is overridden.
+
+.. seealso:: :py:func:`labelColor`
+
+.. seealso:: :py:func:`labelFont`
+
+.. seealso:: :py:func:`setOverrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
+    void setOverrideLabelStyle( bool overrideLabelStyle );
+%Docstring
+Sets ``overrideLabelStyle`` flag which determines if label style (font and color) is overridden.
+
+.. seealso:: :py:func:`labelColor`
+
+.. seealso:: :py:func:`labelFont`
+
+.. seealso:: :py:func:`overrideLabelStyle`
+
+.. versionadded:: 3.26
+%End
+
   protected:
 
 };

--- a/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/editform/qgsattributeeditorelement.sip.in
@@ -124,7 +124,7 @@ Controls if this element should be labeled with a title (field, relation or grou
 .. versionadded:: 2.18
 %End
 
-    const QFont &labelFont() const;
+    const QFont labelFont() const;
 %Docstring
 Returns the custom label font, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
 
@@ -150,7 +150,7 @@ Sets the custom ``labelFont``, this is only effective if :py:func:`~QgsAttribute
 .. versionadded:: 3.26
 %End
 
-    const QColor &labelColor() const;
+    const QColor labelColor() const;
 %Docstring
 Returns the custom label color, this is only effective if :py:func:`~QgsAttributeEditorElement.overrideStyleLabel` is also set.
 

--- a/python/gui/auto_generated/qgsfontbutton.sip.in
+++ b/python/gui/auto_generated/qgsfontbutton.sip.in
@@ -36,6 +36,7 @@ used only in a QFont object.
     {
       ModeTextRenderer,
       ModeQFont,
+      ModeQFontColor,
     };
 
 
@@ -127,9 +128,19 @@ This is only used when :py:func:`~QgsFontButton.mode` is ModeTextRenderer.
     QFont currentFont() const;
 %Docstring
 Returns the current QFont set by the widget.
-This is only used when :py:func:`~QgsFontButton.mode` is ModeQFont.
+This is only used when :py:func:`~QgsFontButton.mode` is ModeQFont or ModeQFontColor.
 
 .. seealso:: :py:func:`setCurrentFont`
+%End
+
+    QColor currentColor() const;
+%Docstring
+Returns the current QColor set by the widget.
+This is only used when :py:func:`~QgsFontButton.mode` is ModeQFontColor.
+
+.. seealso:: :py:func:`setColor`
+
+.. versionadded:: 3.26
 %End
 
     QgsVectorLayer *layer() const;
@@ -236,7 +247,7 @@ This is only used when :py:func:`~QgsFontButton.mode` is ModeQFont.
 %Docstring
 Sets the current ``color`` for the text. Will emit a changed signal if the color is different
 to the previous text color.
-This is only used when :py:func:`~QgsFontButton.mode` is ModeTextRenderer.
+This is only used when :py:func:`~QgsFontButton.mode` is ModeTextRenderer or ModeQFontColor.
 %End
 
     void copyFormat();

--- a/python/gui/auto_generated/qgstabwidget.sip.in
+++ b/python/gui/auto_generated/qgstabwidget.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsTabWidget : QTabWidget
 {
 %Docstring(signature="appended")

--- a/python/gui/auto_generated/qgstabwidget.sip.in
+++ b/python/gui/auto_generated/qgstabwidget.sip.in
@@ -7,6 +7,9 @@
  ************************************************************************/
 
 
+
+
+
 class QgsTabWidget : QTabWidget
 {
 %Docstring(signature="appended")
@@ -76,6 +79,13 @@ Is called internally whenever a tab has been removed.
 Is used to keep track of currently available and visible tabs.
 
 .. versionadded:: 3.0
+%End
+
+    void setTabFont( int tabIndex, const QFont &font );
+%Docstring
+Sets the optional custom ``font`` for the tab idenfied by ``tabIndex``.
+
+.. versionadded:: 3.26
 %End
 
 };

--- a/src/core/editform/qgsattributeeditorcontainer.cpp
+++ b/src/core/editform/qgsattributeeditorcontainer.cpp
@@ -122,6 +122,9 @@ QgsAttributeEditorElement *QgsAttributeEditorContainer::clone( QgsAttributeEdito
   element->mVisibilityExpression = mVisibilityExpression;
   element->mCollapsed = mCollapsed;
   element->mCollapsedExpression = mCollapsedExpression;
+  element->mOverrideLabelStyle = mOverrideLabelStyle;
+  element->mLabelColor = mLabelColor;
+  element->mLabelFont = mLabelFont;
 
   return element;
 }

--- a/src/core/editform/qgsattributeeditorelement.cpp
+++ b/src/core/editform/qgsattributeeditorelement.cpp
@@ -23,6 +23,7 @@
 #include "qgsattributeeditorqmlelement.h"
 #include "qgsattributeeditorrelation.h"
 #include "qgssymbollayerutils.h"
+#include "qgsfontutils.h"
 
 
 QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
@@ -31,7 +32,7 @@ QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
   elem.setAttribute( QStringLiteral( "name" ), mName );
   elem.setAttribute( QStringLiteral( "showLabel" ), mShowLabel );
   elem.setAttribute( QStringLiteral( "labelColor" ), QgsSymbolLayerUtils::encodeColor( mLabelColor ) );
-  elem.setAttribute( QStringLiteral( "labelFont" ), mLabelFont.toString() );
+  elem.appendChild( QgsFontUtils::toXmlElement( mLabelFont, doc, QStringLiteral( "labelFont" ) ) );
   elem.setAttribute( QStringLiteral( "overrideLabelStyle" ), mOverrideLabelStyle );
   saveConfiguration( elem, doc );
   return elem;
@@ -47,7 +48,7 @@ void QgsAttributeEditorElement::setShowLabel( bool showLabel )
   mShowLabel = showLabel;
 }
 
-const QFont &QgsAttributeEditorElement::labelFont() const
+const QFont QgsAttributeEditorElement::labelFont() const
 {
   return mLabelFont;
 }
@@ -57,7 +58,7 @@ void QgsAttributeEditorElement::setLabelFont( const QFont &labelFont )
   mLabelFont = labelFont;
 }
 
-const QColor &QgsAttributeEditorElement::labelColor() const
+const QColor QgsAttributeEditorElement::labelColor() const
 {
   return mLabelColor;
 }
@@ -125,12 +126,9 @@ QgsAttributeEditorElement *QgsAttributeEditorElement::create( const QDomElement 
       newElement->setLabelColor( QgsSymbolLayerUtils::decodeColor( element.attribute( QStringLiteral( "labelColor" ) ) ) );
     }
 
-    if ( element.hasAttribute( QStringLiteral( "labelFont" ) ) )
-    {
-      QFont font;
-      font.fromString( element.attribute( QStringLiteral( "labelFont" ) ) );
-      newElement->setLabelFont( font );
-    }
+    QFont font;
+    QgsFontUtils::setFromXmlChildNode( font, element, QStringLiteral( "labelFont" ) );
+    newElement->setLabelFont( font );
 
     if ( element.hasAttribute( QStringLiteral( "overrideLabelStyle" ) ) )
     {

--- a/src/core/editform/qgsattributeeditorelement.cpp
+++ b/src/core/editform/qgsattributeeditorelement.cpp
@@ -22,7 +22,7 @@
 #include "qgsattributeeditorhtmlelement.h"
 #include "qgsattributeeditorqmlelement.h"
 #include "qgsattributeeditorrelation.h"
-
+#include "qgssymbollayerutils.h"
 
 
 QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
@@ -30,6 +30,9 @@ QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
   QDomElement elem = doc.createElement( typeIdentifier() );
   elem.setAttribute( QStringLiteral( "name" ), mName );
   elem.setAttribute( QStringLiteral( "showLabel" ), mShowLabel );
+  elem.setAttribute( QStringLiteral( "labelColor" ), QgsSymbolLayerUtils::encodeColor( mLabelColor ) );
+  elem.setAttribute( QStringLiteral( "labelFont" ), mLabelFont.toString() );
+  elem.setAttribute( QStringLiteral( "overrideLabelStyle" ), mOverrideLabelStyle );
   saveConfiguration( elem, doc );
   return elem;
 }
@@ -42,6 +45,36 @@ bool QgsAttributeEditorElement::showLabel() const
 void QgsAttributeEditorElement::setShowLabel( bool showLabel )
 {
   mShowLabel = showLabel;
+}
+
+const QFont &QgsAttributeEditorElement::labelFont() const
+{
+  return mLabelFont;
+}
+
+void QgsAttributeEditorElement::setLabelFont( const QFont &labelFont )
+{
+  mLabelFont = labelFont;
+}
+
+const QColor &QgsAttributeEditorElement::labelColor() const
+{
+  return mLabelColor;
+}
+
+void QgsAttributeEditorElement::setLabelColor( const QColor &labelColor )
+{
+  mLabelColor = labelColor;
+}
+
+bool QgsAttributeEditorElement::overrideLabelStyle() const
+{
+  return mOverrideLabelStyle;
+}
+
+void QgsAttributeEditorElement::setOverrideLabelStyle( bool overrideLabelStyle )
+{
+  mOverrideLabelStyle = overrideLabelStyle;
 }
 
 QgsAttributeEditorElement *QgsAttributeEditorElement::create( const QDomElement &element, const QString &layerId, const QgsFields &fields, const QgsReadWriteContext &context, QgsAttributeEditorElement *parent )
@@ -85,6 +118,24 @@ QgsAttributeEditorElement *QgsAttributeEditorElement::create( const QDomElement 
       newElement->setShowLabel( element.attribute( QStringLiteral( "showLabel" ) ).toInt() );
     else
       newElement->setShowLabel( true );
+
+    // Label font and color
+    if ( element.hasAttribute( QStringLiteral( "labelColor" ) ) )
+    {
+      newElement->setLabelColor( QgsSymbolLayerUtils::decodeColor( element.attribute( QStringLiteral( "labelColor" ) ) ) );
+    }
+
+    if ( element.hasAttribute( QStringLiteral( "labelFont" ) ) )
+    {
+      QFont font;
+      font.fromString( element.attribute( QStringLiteral( "labelFont" ) ) );
+      newElement->setLabelFont( font );
+    }
+
+    if ( element.hasAttribute( QStringLiteral( "overrideLabelStyle" ) ) )
+    {
+      newElement->setOverrideLabelStyle( element.attribute( QStringLiteral( "overrideLabelStyle" ) ) == QChar( '1' ) );
+    }
 
     newElement->loadConfiguration( element, layerId, context, fields );
   }

--- a/src/core/editform/qgsattributeeditorelement.h
+++ b/src/core/editform/qgsattributeeditorelement.h
@@ -21,6 +21,7 @@
 #include "qgsoptionalexpression.h"
 #include "qgspropertycollection.h"
 #include <QColor>
+#include <QFont>
 
 /**
  * \ingroup core
@@ -143,12 +144,69 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      */
     void setShowLabel( bool showLabel );
 
+    /**
+     * Returns the custom label font, this is only effective if overrideStyleLabel() is also set.
+     * \see setLabelFont()
+     * \see overrideLabelStyle()
+     * \see setOverrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    const QFont &labelFont() const;
+
+    /**
+     * Sets the custom \a labelFont, this is only effective if overrideStyleLabel() is also set.
+     * \see setLabelFont()
+     * \see overrideLabelStyle()
+     * \see setOverrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    void setLabelFont( const QFont &labelFont );
+
+    /**
+     * Returns the custom label color, this is only effective if overrideStyleLabel() is also set.
+     * \see setLabelColor()
+     * \see overrideLabelStyle()
+     * \see setOverrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    const QColor &labelColor() const;
+
+    /**
+     * Sets the custom \a labelColor, this is only effective if overrideStyleLabel() is also set.
+     * \see setLabelColor()
+     * \see overrideLabelStyle()
+     * \see setOverrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    void setLabelColor( const QColor &labelColor );
+
+    /**
+     * Returns TRUE if the label style (font and color) is overridden.
+     * \see labelColor()
+     * \see labelFont()
+     * \see setOverrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    bool overrideLabelStyle() const;
+
+    /**
+     * Sets \a overrideLabelStyle flag which determines if label style (font and color) is overridden.
+     * \see labelColor()
+     * \see labelFont()
+     * \see overrideLabelStyle()
+     * \since QGIS 3.26
+     */
+    void setOverrideLabelStyle( bool overrideLabelStyle );
+
   protected:
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
+    QFont mLabelFont;
+    QColor mLabelColor;
+    bool mOverrideLabelStyle = false;
 #endif
 
   private:

--- a/src/core/editform/qgsattributeeditorelement.h
+++ b/src/core/editform/qgsattributeeditorelement.h
@@ -151,7 +151,7 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      * \see setOverrideLabelStyle()
      * \since QGIS 3.26
      */
-    const QFont &labelFont() const;
+    const QFont labelFont() const;
 
     /**
      * Sets the custom \a labelFont, this is only effective if overrideStyleLabel() is also set.
@@ -169,7 +169,7 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      * \see setOverrideLabelStyle()
      * \since QGIS 3.26
      */
-    const QColor &labelColor() const;
+    const QColor labelColor() const;
 
     /**
      * Sets the custom \a labelColor, this is only effective if overrideStyleLabel() is also set.

--- a/src/core/editform/qgsattributeeditorfield.cpp
+++ b/src/core/editform/qgsattributeeditorfield.cpp
@@ -18,6 +18,9 @@
 QgsAttributeEditorElement *QgsAttributeEditorField::clone( QgsAttributeEditorElement *parent ) const
 {
   QgsAttributeEditorField *element = new QgsAttributeEditorField( name(), mIdx, parent );
+  element->mOverrideLabelStyle = mOverrideLabelStyle;
+  element->mLabelColor = mLabelColor;
+  element->mLabelFont = mLabelFont;
   return element;
 }
 

--- a/src/core/editform/qgsattributeeditorrelation.cpp
+++ b/src/core/editform/qgsattributeeditorrelation.cpp
@@ -33,6 +33,9 @@ QgsAttributeEditorElement *QgsAttributeEditorRelation::clone( QgsAttributeEditor
   element->mLabel = mLabel;
   element->mRelationEditorConfig = mRelationEditorConfig;
   element->mRelationWidgetTypeId = mRelationWidgetTypeId;
+  element->mOverrideLabelStyle = mOverrideLabelStyle;
+  element->mLabelColor = mLabelColor;
+  element->mLabelFont = mLabelFont;
 
   return element;
 }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -630,6 +630,7 @@ set(QGIS_GUI_SRCS
   qgsstatusbar.cpp
   qgssymbolbutton.cpp
   qgssymbollayerselectionwidget.cpp
+  qgstabbarproxystyle.cpp
   qgstableview.cpp
   qgstablewidgetbase.cpp
   qgstabwidget.cpp
@@ -893,6 +894,7 @@ set(QGIS_GUI_HDRS
   qgssymbolbutton.h
   qgssymbollayerselectionwidget.h
   qgstableview.h
+  qgstabbarproxystyle.h
   qgstablewidgetbase.h
   qgstablewidgetitem.h
   qgstabwidget.h

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -35,7 +35,27 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
     mShowAsGroupBox->setEnabled( false );
   }
 
+  connect( mTitleLineEdit, &QLineEdit::textChanged, [ = ]( const QString & title )
+  {
+    mFontButton->setText( title.isEmpty() ? tr( "Title" ) :  title );
+  } );
+
+  connect( mOverrideLabelStyle, &QCheckBox::stateChanged, [ = ]( bool checked )
+  {
+    mFontButton->setEnabled( checked );
+  } );
+
+  mOverrideLabelStyle->setChecked( itemData.overrideLabelStyle() );
+  mFontButton->setEnabled( itemData.overrideLabelStyle() );
+
   mTitleLineEdit->setText( itemData.name() );
+
+  mFontButton->setMode( QgsFontButton::Mode::ModeQFontColor );
+  mFontButton->setColor( itemData.labelColor() );
+  mFontButton->setCurrentFont( itemData.labelFont() );
+
+  connect( mShowLabelCheckBox, &QCheckBox::stateChanged, [ = ]( bool checked ) { mFontButton->setEnabled( checked ); } );
+
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
   mShowLabelCheckBox->setEnabled( itemData.showAsGroupBox() ); // show label makes sense for group box, not for tabs
   mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
@@ -72,6 +92,9 @@ void QgsAttributeFormContainerEdit::updateItemData()
   itemData.setName( mTitleLineEdit->text() );
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setBackgroundColor( mBackgroundColorButton->color() );
+  itemData.setLabelColor( mFontButton->currentColor() );
+  itemData.setLabelFont( mFontButton->currentFont() );
+  itemData.setOverrideLabelStyle( mOverrideLabelStyle->isChecked() );
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -28,6 +28,20 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
   const QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
 
   // common configs
+  mFontButton->setMode( QgsFontButton::Mode::ModeQFontColor );
+  mFontButton->setColor( itemData.labelColor( ) );
+  mFontButton->setCurrentFont( itemData.labelFont( ) );
+  mFontButton->setText( itemData.name() );
+
+  connect( mShowLabelCheckBox, &QCheckBox::stateChanged, [ = ]( bool checked ) { mFontButton->setEnabled( checked ); } );
+  connect( mOverrideLabelStyle, &QCheckBox::stateChanged, [ = ]( bool checked )
+  {
+    mFontButton->setEnabled( checked );
+  } );
+
+  mOverrideLabelStyle->setChecked( itemData.overrideLabelStyle( ) );
+  mFontButton->setEnabled( itemData.overrideLabelStyle() );
+
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
 
   switch ( itemData.type() )
@@ -62,6 +76,9 @@ void QgsAttributeWidgetEdit::updateItemData()
 
   // common configs
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
+  itemData.setLabelColor( mFontButton->currentColor() );
+  itemData.setLabelFont( mFontButton->currentFont() );
+  itemData.setOverrideLabelStyle( mOverrideLabelStyle->isChecked() );
 
   // specific configs
   switch ( itemData.type() )

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -401,6 +401,9 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
       bool labelOnTop = false;
       bool labelAlignRight = false;
       bool showLabel = true;
+      QFont labelFont;
+      QColor labelColor;
+      bool overrideLabelStyle = false;
     };
 
     WidgetInfo createWidgetFromDef( const QgsAttributeEditorElement *widgetDef, QWidget *parent, QgsVectorLayer *vl, QgsAttributeEditorContext &context );

--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -345,16 +345,25 @@ void QgsFontButton::dragEnterEvent( QDragEnterEvent *e )
     e->acceptProposedAction();
     updatePreview( QColor(), nullptr, &font );
   }
-  else if ( mMode == ModeQFontColor && fontFromMimeData( e->mimeData(), font ) )
+  else if ( mMode == ModeQFontColor )
   {
-    e->acceptProposedAction();
-    if ( colorFromMimeData( e->mimeData(), mimeColor, hasAlpha ) )
+    const bool hasFont { fontFromMimeData( e->mimeData(), font ) };
+    const bool hasColor { colorFromMimeData( e->mimeData(), mimeColor, hasAlpha ) };
+    if ( hasColor || hasFont )
     {
-      updatePreview( mimeColor, nullptr, &font );
-    }
-    else
-    {
-      updatePreview( QColor(), nullptr, &font );
+      e->acceptProposedAction();
+      if ( hasColor && hasFont )
+      {
+        updatePreview( mimeColor, nullptr, &font );
+      }
+      else if ( hasFont )
+      {
+        updatePreview( QColor(), nullptr, &font );
+      }
+      else
+      {
+        updatePreview( mimeColor, nullptr, nullptr );
+      }
     }
   }
   else if ( mMode == ModeTextRenderer && colorFromMimeData( e->mimeData(), mimeColor, hasAlpha ) )
@@ -1093,7 +1102,24 @@ void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, Q
 void QgsFontButton::copyColor()
 {
   //copy color
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( currentColor() ) );
+  switch ( mMode )
+  {
+
+    case ModeQFontColor:
+    {
+      QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( currentColor() ) );
+      break;
+    }
+
+    case ModeTextRenderer:
+    {
+      QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mFormat.color() ) );
+      break;
+    }
+
+    case ModeQFont:
+      break;
+  }
 }
 
 void QgsFontButton::pasteColor()

--- a/src/gui/qgsfontbutton.h
+++ b/src/gui/qgsfontbutton.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsFontButton : public QToolButton
     {
       ModeTextRenderer,  //!< Configure font settings for use with QgsTextRenderer
       ModeQFont, //!< Configure font settings for use with QFont objects
-      ModeQFontColor, //!< Configure font settings for use with QFont objects and allows to set the foreground color
+      ModeQFontColor, //!< Configure font settings for use with QFont objects and the foreground QColor.
     };
 
     Q_ENUM( Mode )

--- a/src/gui/qgsfontbutton.h
+++ b/src/gui/qgsfontbutton.h
@@ -60,6 +60,7 @@ class GUI_EXPORT QgsFontButton : public QToolButton
     {
       ModeTextRenderer,  //!< Configure font settings for use with QgsTextRenderer
       ModeQFont, //!< Configure font settings for use with QFont objects
+      ModeQFontColor, //!< Configure font settings for use with QFont objects and allows to set the foreground color
     };
 
     Q_ENUM( Mode )
@@ -138,10 +139,18 @@ class GUI_EXPORT QgsFontButton : public QToolButton
 
     /**
      * Returns the current QFont set by the widget.
-     * This is only used when mode() is ModeQFont.
+     * This is only used when mode() is ModeQFont or ModeQFontColor.
      * \see setCurrentFont()
      */
     QFont currentFont() const;
+
+    /**
+     * Returns the current QColor set by the widget.
+     * This is only used when mode() is ModeQFontColor.
+     * \see setColor()
+     * \since QGIS 3.26
+     */
+    QColor currentColor() const;
 
     /**
      * Returns the layer associated with the widget.
@@ -233,7 +242,7 @@ class GUI_EXPORT QgsFontButton : public QToolButton
     /**
      * Sets the current \a color for the text. Will emit a changed signal if the color is different
      * to the previous text color.
-     * This is only used when mode() is ModeTextRenderer.
+     * This is only used when mode() is ModeTextRenderer or ModeQFontColor.
      */
     void setColor( const QColor &color );
 
@@ -315,6 +324,7 @@ class GUI_EXPORT QgsFontButton : public QToolButton
     QString mDialogTitle;
     QgsTextFormat mFormat;
     QFont mFont;
+    QColor mColor;
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;

--- a/src/gui/qgstabbarproxystyle.cpp
+++ b/src/gui/qgstabbarproxystyle.cpp
@@ -1,0 +1,87 @@
+/***************************************************************************
+  qgstabbarproxystyle.cpp - QgsTabBarProxyStyle
+
+ ---------------------
+ begin                : 25.3.2022
+ copyright            : (C) 2022 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstabbarproxystyle.h"
+#include <QPainter>
+#include <QStyleOption>
+#include <QDebug>
+
+
+///@cond PRIVATE
+
+QgsTabBarProxyStyle::QgsTabBarProxyStyle( QTabBar *tabBar )
+  : QProxyStyle()
+  , mTabBar( tabBar )
+{
+}
+
+void QgsTabBarProxyStyle::drawControl( ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget ) const
+{
+  if ( element == CE_TabBarTab && mTabStyles.contains( mTabBar->tabAt( option->rect.center() ) ) )
+  {
+    painter->save(); // save the painter to restore later
+    const TabStyle &style { mTabStyles.value( mTabBar->tabAt( option->rect.center() ) ) };
+    painter->setFont( style.font ); // change the defaul font of painter
+    QProxyStyle::drawControl( element, option, painter, widget ); // paint the TabBarTab using the default drawControl
+    painter->restore(); // restore to default painter
+  }
+  else
+  {
+    QProxyStyle::drawControl( element, option, painter, widget ); // use default drawControl to paint all other components without changes.
+  }
+}
+
+void QgsTabBarProxyStyle::addStyle( int tabIndex, const TabStyle &style )
+{
+  mTabStyles.insert( tabIndex, style );
+}
+
+const QMap<int, QgsTabBarProxyStyle::TabStyle> &QgsTabBarProxyStyle::tabStyles() const
+{
+  return mTabStyles;
+}
+
+
+QgsTabBar::QgsTabBar( QWidget *parent )
+  : QTabBar( parent )
+{
+}
+
+void QgsTabBar::setTabBarStyle( QgsTabBarProxyStyle *tabStyle )
+{
+  mTabBarStyle = tabStyle;
+}
+
+QSize QgsTabBar::tabSizeHint( int index ) const
+{
+  if ( mTabBarStyle->tabStyles().contains( index ) )
+  {
+    const QSize s = QTabBar::tabSizeHint( index );
+    const QFontMetrics fm( font() );
+    const int w = fm.horizontalAdvance( tabText( index ) );
+    const QFont f = mTabBarStyle->tabStyles().value( index ).font;
+    const QFontMetrics bfm( f );
+    const int bw = bfm.horizontalAdvance( tabText( index ) );
+    return QSize( s.width() - w + bw, s.height() );
+  }
+  else
+  {
+    return QTabBar::tabSizeHint( index );
+  }
+}
+
+
+
+///@endcond

--- a/src/gui/qgstabbarproxystyle.h
+++ b/src/gui/qgstabbarproxystyle.h
@@ -1,0 +1,92 @@
+/***************************************************************************
+  qgstabbarproxystyle.h - QgsTabBarProxyStyle
+
+ ---------------------
+ begin                : 25.3.2022
+ copyright            : (C) 2022 by Alessandro Pasotti
+ email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSTABBARPROXYSTYLE_H
+#define QGSTABBARPROXYSTYLE_H
+
+#include <QProxyStyle>
+#include <QFont>
+#include <QColor>
+#include <QMap>
+#include <QTabBar>
+
+#define SIP_NO_FILE
+
+#include "qgis_gui.h"
+
+///@cond PRIVATE
+
+/**
+ * The QgsTabBarProxyStyle class provides a proxy style to set font for a tab bar.
+ * This class is an implementation detail and it is not exposed to public API.
+ */
+class QgsTabBarProxyStyle : public QProxyStyle
+{
+  public:
+
+    struct TabStyle
+    {
+      QFont font;
+    };
+
+    QgsTabBarProxyStyle( QTabBar *tabBar );
+
+    void drawControl( ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget ) const override;
+
+    void addStyle( int tabIndex, const TabStyle &style );
+
+    const QMap<int, TabStyle> &tabStyles() const;
+
+  private:
+
+    QMap<int, TabStyle> mTabStyles;
+    QTabBar *mTabBar;
+
+};
+
+
+
+/**
+ * The QgsTabBar class supports custom fonts for tab's titles and provides the tab bar for QgsTabWidget.
+ * This class is an implementation detail and it is not exposed to public API.
+ */
+class QgsTabBar: public QTabBar
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Create a new QgsTabBar with the optionally provided parent.
+     */
+    QgsTabBar( QWidget *parent );
+
+    /**
+     * Set the \a tabStyle.
+     */
+    void setTabBarStyle( QgsTabBarProxyStyle *tabStyle );
+
+  protected:
+
+    QSize tabSizeHint( int index ) const;
+
+  private:
+    QgsTabBarProxyStyle *mTabBarStyle = nullptr;
+
+};
+
+/// @endcond
+
+#endif // QGSTABBARPROXYSTYLE_H

--- a/src/gui/qgstabwidget.cpp
+++ b/src/gui/qgstabwidget.cpp
@@ -16,15 +16,21 @@
 #include "qgstabwidget.h"
 
 #include "qgslogger.h"
+#include "qgstabbarproxystyle.h"
 
 QgsTabWidget::QgsTabWidget( QWidget *parent )
   : QTabWidget( parent )
 {
+  QgsTabBar *qgsTabBar = new QgsTabBar( this );
+  setTabBar( qgsTabBar );
+  mTabBarStyle = std::make_unique<QgsTabBarProxyStyle>( tabBar() );
+  qgsTabBar->setTabBarStyle( mTabBarStyle.get() );
+  setStyle( mTabBarStyle.get() );
 }
 
 void QgsTabWidget::hideTab( QWidget *tab )
 {
-  QgsDebugMsg( QStringLiteral( "Hide" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Hide" ), 3 );
   TabInformation &info = mTabs[ realTabIndex( tab )];
   if ( info.visible )
   {
@@ -37,7 +43,7 @@ void QgsTabWidget::hideTab( QWidget *tab )
 
 void QgsTabWidget::showTab( QWidget *tab )
 {
-  QgsDebugMsg( QStringLiteral( "Show" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Show" ), 3 );
   TabInformation &info = mTabs[ realTabIndex( tab )];
   if ( ! info.visible )
   {
@@ -123,9 +129,14 @@ void QgsTabWidget::tabRemoved( int index )
   synchronizeIndexes();
 }
 
+void QgsTabWidget::setTabFont( int tabIndex, const QFont &customFont )
+{
+  mTabBarStyle->addStyle( tabIndex, QgsTabBarProxyStyle::TabStyle{ customFont } );
+}
+
 void QgsTabWidget::synchronizeIndexes()
 {
-  QgsDebugMsg( QStringLiteral( "---------" ) );
+  QgsDebugMsgLevel( QStringLiteral( "---------" ), 4 );
   int i = -1;
   QWidget *nextWidget = widget( 0 );
 
@@ -139,7 +150,7 @@ void QgsTabWidget::synchronizeIndexes()
       nextWidget = widget( i + 1 );
     }
     it->sourceIndex = i;
-    QgsDebugMsg( QStringLiteral( "Tab %1 (%2): %3" ).arg( it->sourceIndex ).arg( it->label ).arg( i ) );
+    QgsDebugMsgLevel( QStringLiteral( "Tab %1 (%2): %3" ).arg( it->sourceIndex ).arg( it->label ).arg( i ), 4 );
   }
 }
 

--- a/src/gui/qgstabwidget.h
+++ b/src/gui/qgstabwidget.h
@@ -17,7 +17,12 @@
 #define QGSTABWIDGET_H
 
 #include <QTabWidget>
+
+#include "qgis_sip.h"
 #include "qgis_gui.h"
+
+#include "qgstabbarproxystyle.h"
+
 
 /**
  * \ingroup gui
@@ -87,6 +92,12 @@ class GUI_EXPORT QgsTabWidget : public QTabWidget
      */
     void tabRemoved( int index ) override;
 
+    /**
+     * Sets the optional custom \a font for the tab idenfied by \a tabIndex.
+     * \since QGIS 3.26
+     */
+    void setTabFont( int tabIndex, const QFont &font );
+
   private:
     void synchronizeIndexes();
 
@@ -113,6 +124,7 @@ class GUI_EXPORT QgsTabWidget : public QTabWidget
 
     QList<TabInformation> mTabs;
     bool mSetTabVisibleFlag = false;
+    std::unique_ptr<QgsTabBarProxyStyle> mTabBarStyle;
 };
 
 #endif // QGSTABWIDGET_H

--- a/src/gui/qgstabwidget.h
+++ b/src/gui/qgstabwidget.h
@@ -16,6 +16,8 @@
 #ifndef QGSTABWIDGET_H
 #define QGSTABWIDGET_H
 
+#include <memory>
+
 #include <QTabWidget>
 
 #include "qgis_sip.h"

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1620,7 +1620,7 @@ void QgsAttributesFormProperties::DnDTreeItemData::setBackgroundColor( const QCo
   mBackgroundColor = backgroundColor;
 }
 
-const QFont &QgsAttributesFormProperties::DnDTreeItemData::labelFont() const
+const QFont QgsAttributesFormProperties::DnDTreeItemData::labelFont() const
 {
   return mLabelFont;
 }
@@ -1640,7 +1640,7 @@ void QgsAttributesFormProperties::DnDTreeItemData::setOverrideLabelStyle( bool o
   mOverrideLabelStyle = overrideLabelStyle;
 }
 
-const QColor &QgsAttributesFormProperties::DnDTreeItemData::labelColor() const
+const QColor QgsAttributesFormProperties::DnDTreeItemData::labelColor() const
 {
   return mLabelColor;
 }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -427,6 +427,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelColor( widgetDef->labelColor() );
+      itemData.setLabelFont( widgetDef->labelFont() );
+      itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -439,6 +442,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       {
         DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Action, action.id().toString(), action.shortTitle().isEmpty() ? action.name() : action.shortTitle() );
         itemData.setShowLabel( widgetDef->showLabel() );
+        itemData.setLabelColor( widgetDef->labelColor() );
+        itemData.setLabelFont( widgetDef->labelFont() );
+        itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
         newWidget = tree->addItem( parent, itemData );
       }
       else
@@ -453,6 +459,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelColor( widgetDef->labelColor() );
+      itemData.setLabelFont( widgetDef->labelFont() );
+      itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
 
       RelationEditorConfiguration relEdConfig;
 //      relEdConfig.buttons = relationEditor->visibleButtons();
@@ -470,6 +479,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       DnDTreeItemData itemData( DnDTreeItemData::Container, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelColor( widgetDef->labelColor() );
+      itemData.setLabelFont( widgetDef->labelFont() );
+      itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
 
       const QgsAttributeEditorContainer *container = static_cast<const QgsAttributeEditorContainer *>( widgetDef );
       if ( !container )
@@ -499,6 +511,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       QmlElementEditorConfiguration qmlEdConfig;
       qmlEdConfig.qmlCode = qmlElementEditor->qmlCode();
       itemData.setQmlElementEditorConfiguration( qmlEdConfig );
+      itemData.setLabelColor( widgetDef->labelColor() );
+      itemData.setLabelFont( widgetDef->labelFont() );
+      itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -511,6 +526,9 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       HtmlElementEditorConfiguration htmlEdConfig;
       htmlEdConfig.htmlCode = htmlElementEditor->htmlCode();
       itemData.setHtmlElementEditorConfiguration( htmlEdConfig );
+      itemData.setLabelColor( widgetDef->labelColor() );
+      itemData.setLabelFont( widgetDef->labelFont() );
+      itemData.setOverrideLabelStyle( widgetDef->overrideLabelStyle() );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -773,7 +791,12 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
   }
 
   if ( widgetDef )
+  {
     widgetDef->setShowLabel( itemData.showLabel() );
+    widgetDef->setLabelColor( itemData.labelColor() );
+    widgetDef->setLabelFont( itemData.labelFont() );
+    widgetDef->setOverrideLabelStyle( itemData.overrideLabelStyle() );
+  }
 
   return widgetDef;
 }
@@ -1595,4 +1618,34 @@ QColor QgsAttributesFormProperties::DnDTreeItemData::backgroundColor() const
 void QgsAttributesFormProperties::DnDTreeItemData::setBackgroundColor( const QColor &backgroundColor )
 {
   mBackgroundColor = backgroundColor;
+}
+
+const QFont &QgsAttributesFormProperties::DnDTreeItemData::labelFont() const
+{
+  return mLabelFont;
+}
+
+void QgsAttributesFormProperties::DnDTreeItemData::setLabelFont( const QFont &newLabelFont )
+{
+  mLabelFont = newLabelFont;
+}
+
+bool QgsAttributesFormProperties::DnDTreeItemData::overrideLabelStyle() const
+{
+  return mOverrideLabelStyle;
+}
+
+void QgsAttributesFormProperties::DnDTreeItemData::setOverrideLabelStyle( bool overrideLabelStyle )
+{
+  mOverrideLabelStyle = overrideLabelStyle;
+}
+
+const QColor &QgsAttributesFormProperties::DnDTreeItemData::labelColor() const
+{
+  return mLabelColor;
+}
+
+void QgsAttributesFormProperties::DnDTreeItemData::setLabelColor( const QColor &newLabelColor )
+{
+  mLabelColor = newLabelColor;
 }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -201,13 +201,58 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         QColor backgroundColor() const;
         void setBackgroundColor( const QColor &backgroundColor );
 
-        const QColor &labelColor() const;
-        void setLabelColor( const QColor &newLabelColor );
-
+        /**
+         * Returns the custom label font, this is only effective if overrideStyleLabel() is also set.
+         * \see setLabelFont()
+         * \see overrideLabelStyle()
+         * \see setOverrideLabelStyle()
+         * \since QGIS 3.26
+         */
         const QFont &labelFont() const;
-        void setLabelFont( const QFont &newLabelFont );
 
+        /**
+         * Sets the custom \a labelFont, this is only effective if overrideStyleLabel() is also set.
+         * \see setLabelFont()
+         * \see overrideLabelStyle()
+         * \see setOverrideLabelStyle()
+         * \since QGIS 3.26
+         */
+        void setLabelFont( const QFont &labelFont );
+
+        /**
+         * Returns the custom label color, this is only effective if overrideStyleLabel() is also set.
+         * \see setLabelColor()
+         * \see overrideLabelStyle()
+         * \see setOverrideLabelStyle()
+         * \since QGIS 3.26
+         */
+        const QColor &labelColor() const;
+
+        /**
+         * Sets the custom \a labelColor, this is only effective if overrideStyleLabel() is also set.
+         * \see setLabelColor()
+         * \see overrideLabelStyle()
+         * \see setOverrideLabelStyle()
+         * \since QGIS 3.26
+         */
+        void setLabelColor( const QColor &labelColor );
+
+        /**
+         * Returns TRUE if the label style (font and color) is overridden.
+         * \see labelColor()
+         * \see labelFont()
+         * \see setOverrideLabelStyle()
+         * \since QGIS 3.26
+         */
         bool overrideLabelStyle() const;
+
+        /**
+         * Sets \a overrideLabelStyle flag which determines if label style (font and color) is overridden.
+         * \see labelColor()
+         * \see labelFont()
+         * \see overrideLabelStyle()
+         * \since QGIS 3.26
+         */
         void setOverrideLabelStyle( bool overrideLabelStyle );
 
       private:

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -208,7 +208,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
          * \see setOverrideLabelStyle()
          * \since QGIS 3.26
          */
-        const QFont &labelFont() const;
+        const QFont labelFont() const;
 
         /**
          * Sets the custom \a labelFont, this is only effective if overrideStyleLabel() is also set.
@@ -226,7 +226,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
          * \see setOverrideLabelStyle()
          * \since QGIS 3.26
          */
-        const QColor &labelColor() const;
+        const QColor labelColor() const;
 
         /**
          * Sets the custom \a labelColor, this is only effective if overrideStyleLabel() is also set.

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -201,6 +201,15 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         QColor backgroundColor() const;
         void setBackgroundColor( const QColor &backgroundColor );
 
+        const QColor &labelColor() const;
+        void setLabelColor( const QColor &newLabelColor );
+
+        const QFont &labelFont() const;
+        void setLabelFont( const QFont &newLabelFont );
+
+        bool overrideLabelStyle() const;
+        void setOverrideLabelStyle( bool overrideLabelStyle );
+
       private:
         Type mType = Field;
         QString mName;
@@ -215,6 +224,9 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
         QColor mBackgroundColor;
         bool mCollapsed = false;
         QgsOptionalExpression mCollapsedExpression;
+        QColor mLabelColor;
+        QFont mLabelFont;
+        bool mOverrideLabelStyle = false;
     };
 
 

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>401</width>
-    <height>320</height>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,6 +35,13 @@
       <string>Style</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="2" column="1">
+       <widget class="QgsFontButton" name="mFontButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
@@ -44,6 +51,16 @@
       </item>
       <item row="1" column="1">
        <widget class="QgsColorButton" name="mBackgroundColorButton"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="mOverrideLabelStyle">
+        <property name="statusTip">
+         <string>Override title default font and color</string>
+        </property>
+        <property name="text">
+         <string>Title font and color</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -149,6 +166,11 @@
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>283</width>
-    <height>278</height>
+    <width>242</width>
+    <height>121</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,17 +17,50 @@
    <string>Widget Display</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="mShowLabelCheckBox">
-     <property name="text">
-      <string>Show label</string>
-     </property>
-    </widget>
+   <item row="5" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+     <item>
+      <widget class="QCheckBox" name="mOverrideLabelStyle">
+       <property name="toolTip">
+        <string>Override default label font and color</string>
+       </property>
+       <property name="text">
+        <string>Label font and color</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsFontButton" name="mFontButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="3" column="0">
+   <item row="10" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mWidgetSpecificConfigGroupBox">
      <property name="title">
       <string>GroupBox</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="mShowLabelCheckBox">
+     <property name="text">
+      <string>Show label</string>
      </property>
     </widget>
    </item>
@@ -39,6 +72,11 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/tests/src/python/test_qgsfontbutton.py
+++ b/tests/src/python/test_qgsfontbutton.py
@@ -12,10 +12,11 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import qgis  # NOQA
 
-from qgis.core import QgsTextFormat
+from qgis.core import QgsTextFormat, QgsFontUtils
 from qgis.gui import QgsFontButton, QgsMapCanvas
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtGui import QColor, QFont
+from qgis.PyQt.QtWidgets import QDialog, QVBoxLayout
 from qgis.PyQt.QtTest import QSignalSpy
 from utilities import getTestFont
 
@@ -117,6 +118,27 @@ class TestQgsFontButton(unittest.TestCase):
         self.assertFalse(button.textFormat().isValid())
         button.setTextFormat(s)
         self.assertTrue(button.textFormat().isValid())
+
+    def testFontColorMode(self):
+
+        button = QgsFontButton()
+        button.setMode(QgsFontButton.ModeQFontColor)
+        button.setColor(QColor(255, 0, 0))
+        self.assertEqual(button.currentColor(), QColor(255, 0, 0))
+
+        font = QFont()
+        font.fromString("QGIS Vera Sans,16,-1,5,50,0,0,0,0,0")
+        button.setCurrentFont(font)
+        self.assertEqual(button.currentColor(), QColor(255, 0, 0))
+        self.assertEqual(button.currentFont().toString(), font.toString())
+
+        # Change to True for local interactive testing
+        if False:
+            d = QDialog()
+            l = QVBoxLayout(d)
+            l.addWidget(button)
+            d.setLayout(l)
+            d.exec_()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Color and font can be set for labels, tabs and group.

Funded by: ARPA Piemonte

![form_label_color_3](https://user-images.githubusercontent.com/142164/160396274-8749bda3-a628-49cb-af4a-75252eb8ffd8.png)
![form_label_color_2](https://user-images.githubusercontent.com/142164/160396277-6357f005-1a8f-4178-8789-3d2298848350.png)
![form_label_color_1](https://user-images.githubusercontent.com/142164/160396280-76590fc9-b368-4946-b7b9-df6099424cdb.png)
