### PR TITLE
UI: Make sure users cannot enter values that are lower than the minimum in 'points displacement' alg

### DIFF
--- a/python/plugins/processing/algs/qgis/PointsDisplacement.py
+++ b/python/plugins/processing/algs/qgis/PointsDisplacement.py
@@ -55,12 +55,18 @@ class PointsDisplacement(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
-        self.addParameter(QgsProcessingParameterDistance(self.PROXIMITY,
-                                                         self.tr('Minimum distance to other points'), parentParameterName='INPUT',
-                                                         minValue=0.00001, defaultValue=1.0))
-        self.addParameter(QgsProcessingParameterDistance(self.DISTANCE,
-                                                         self.tr('Displacement distance'), parentParameterName='INPUT',
-                                                         minValue=0.00001, defaultValue=1.0))
+        param = QgsProcessingParameterDistance(self.PROXIMITY,
+                                               self.tr('Minimum distance to other points'), parentParameterName='INPUT',
+                                               minValue=0.00001, defaultValue=1.0)
+        param.setMetadata({'widget_wrapper': {'decimals': 5}})
+        self.addParameter(param)
+
+        param = QgsProcessingParameterDistance(self.DISTANCE,
+                                               self.tr('Displacement distance'), parentParameterName='INPUT',
+                                               minValue=0.00001, defaultValue=1.0)
+        param.setMetadata({'widget_wrapper': {'decimals': 5}})
+        self.addParameter(param)
+
         self.addParameter(QgsProcessingParameterBoolean(self.HORIZONTAL,
                                                         self.tr('Horizontal distribution for two point case')))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Displaced'), QgsProcessing.TypeVectorPoint))


### PR DESCRIPTION
Minimum allowed: 1e-5
UI currently accepts until: 1e-6


Followup #47972