### PR TITLE
Rename 'Processing' menu as 'Analysis'

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -239,6 +239,13 @@ Returns a reference to the main window "Database" menu.
 Returns a reference to the main window "Vector" menu.
 %End
 
+    virtual QMenu *analysisMenu() = 0;
+%Docstring
+Returns a reference to the main window "Analysis" menu.
+
+.. versionadded:: 3.26
+%End
+
     virtual QMenu *webMenu() = 0;
 %Docstring
 Returns a reference to the main window "Web" menu.

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -662,6 +662,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMenu *rasterMenu() { return mRasterMenu; }
     QMenu *vectorMenu() { return mVectorMenu; }
     QMenu *meshMenu() { return mMeshMenu; }
+    QMenu *analysisMenu() { return mAnalysisMenu; }
     QMenu *webMenu() { return mWebMenu; }
 #ifdef Q_OS_MAC
     QMenu *firstRightStandardMenu() { return mWindowMenu; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -650,6 +650,7 @@ QMenu *QgisAppInterface::pluginHelpMenu() { return qgis->pluginHelpMenu(); }
 QMenu *QgisAppInterface::rasterMenu() { return qgis->rasterMenu(); }
 QMenu *QgisAppInterface::vectorMenu() { return qgis->vectorMenu(); }
 QMenu *QgisAppInterface::databaseMenu() { return qgis->databaseMenu(); }
+QMenu *QgisAppInterface::analysisMenu() { return qgis->analysisMenu(); }
 QMenu *QgisAppInterface::webMenu() { return qgis->webMenu(); }
 QMenu *QgisAppInterface::firstRightStandardMenu() { return qgis->firstRightStandardMenu(); }
 QMenu *QgisAppInterface::windowMenu() { return qgis->windowMenu(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -175,6 +175,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QMenu *rasterMenu() override;
     QMenu *vectorMenu() override;
     QMenu *databaseMenu() override;
+    QMenu *analysisMenu() override;
     QMenu *webMenu() override;
     QMenu *firstRightStandardMenu() override;
     QMenu *windowMenu() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -276,6 +276,13 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual QMenu *vectorMenu() = 0;
 
     /**
+     * Returns a reference to the main window "Analysis" menu.
+     *
+     * \since QGIS 3.26
+     */
+    virtual QMenu *analysisMenu() = 0;
+
+    /**
      * Returns a reference to the main window "Web" menu.
      */
     virtual QMenu *webMenu() = 0;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -396,6 +396,11 @@
     </property>
     <addaction name="mActionShowMeshCalculator"/>
    </widget>
+   <widget class="QMenu" name="mAnalysisMenu">
+    <property name="title">
+     <string>&amp;Analysis</string>
+    </property>
+   </widget>
    <addaction name="mProjectMenu"/>
    <addaction name="mEditMenu"/>
    <addaction name="mViewMenu"/>
@@ -405,6 +410,7 @@
    <addaction name="mVectorMenu"/>
    <addaction name="mRasterMenu"/>
    <addaction name="mMeshMenu"/>
+   <addaction name="mAnalysisMenu"/>
    <addaction name="mHelpMenu"/>
   </widget>
   <widget class="QStatusBar" name="statusbar">


### PR DESCRIPTION
This is a moderately intrusive change for users, but the motivation here is that we currently **don't** any logical place to put analytical tools which aren't related to the Processing framework.

For instance, the upcoming Elevation Profile tool is a generic analysis tool which operates on all kinds of data, so it doesn't fit into the existing Vector/Raster/Mesh menus at all. It's also **not** a Processing tool (by design, not by omission -- it's a fully interactive tool, closer in concept to a map canvas then a setup-and-run once processing tool), so putting it into the "Processing" menu just seems wrong. 

Accordingly, I'm proposing that we rename the Processing menu to "Analysis" in order to give us a generic place to locate tools like this.

(Arguably it's more user-friendly for first-time QGIS users too, who wouldn't have any idea what "Processing" actually is.)


![image](https://user-images.githubusercontent.com/1829991/160719157-4c6f5fab-7464-4ecd-947e-894eab2d87f1.png)
 