### PR TITLE
Always use the same method to launder names

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -583,6 +583,15 @@ Given a child algorithm ID and output name, attempts to match it to a parameter 
 .. versionadded:: 3.26
 %End
 
+    static QString safeName( const QString &name, bool capitalize = false );
+%Docstring
+Makes a name "safe", by replacing any non-alphanumeric characters with underscores.
+
+If ``capitalize`` is ``True`` then the string will be converted to a camel case string.
+
+.. versionadded:: 3.26
+%End
+
 
   protected:
 

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -42,6 +42,7 @@ from qgis.core import (Qgis,
                        QgsProcessing,
                        QgsProject,
                        QgsProcessingModelParameter,
+                       QgsProcessingModelAlgorithm,
                        QgsSettings,
                        QgsProcessingContext,
                        QgsFileUtils
@@ -272,9 +273,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         Automatically generates and sets a new parameter's name, based on the parameter's
         description and ensuring that it is unique for the model.
         """
-        validChars = \
-            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-        safeName = ''.join(c for c in parameter.description() if c in validChars)
+        safeName = QgsProcessingModelAlgorithm.safeName(parameter.description())
         name = safeName.lower()
         i = 2
         while self.model().parameterDefinition(name):

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -25,6 +25,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 
 from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProcessingModelOutput,
+                       QgsProcessingModelAlgorithm,
                        QgsProject,
                        Qgis)
 from qgis.gui import (
@@ -119,9 +120,7 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
                 comment = dlg.comments()
                 comment_color = dlg.commentColor()
 
-                validChars = \
-                    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-                safeName = ''.join(c for c in new_param.description() if c in validChars)
+                safeName = QgsProcessingModelAlgorithm.safeName(new_param.description())
                 new_param.setName(safeName.lower())
 
         if new_param is not None:

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -51,7 +51,8 @@ from qgis.core import (QgsApplication,
                        QgsProcessingParameterFileDestination,
                        QgsProcessingParameterFolderDestination,
                        QgsProcessingParameterRasterDestination,
-                       QgsProcessingParameterVectorDestination)
+                       QgsProcessingParameterVectorDestination,
+                       QgsProcessingModelAlgorithm)
 
 from processing.core import parameters
 from processing.modeler.exceptions import UndefinedParameterException
@@ -198,9 +199,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                                 self.tr('Invalid parameter name'))
             return
 
-        validChars = \
-            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-        safeName = ''.join(c for c in description if c in validChars)
+        safeName = QgsProcessingModelAlgorithm.safeName(description)
         name = safeName.lower()
 
         # Destination parameter

--- a/python/plugins/processing/tools/system.py
+++ b/python/plugins/processing/tools/system.py
@@ -70,23 +70,6 @@ def getTempFilename(ext=None):
     return filename
 
 
-def getTempDirInTempFolder():
-    """Returns a temporary directory, putting it into a temp folder.
-    """
-
-    path = QgsProcessingUtils.tempFolder()
-    path = os.path.join(path, uuid.uuid4().hex)
-    mkdir(path)
-    return path
-
-
-def removeInvalidChars(string):
-    validChars = \
-        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:.'
-    string = ''.join(c for c in string if c in validChars)
-    return string
-
-
 def getNumExportedLayers():
     global numExported
     numExported += 1

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -531,6 +531,15 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
      */
     const QgsProcessingParameterDefinition *modelParameterFromChildIdAndOutputName( const QString &childId, const QString &childOutputName ) const;
 
+    /**
+     * Makes a name "safe", by replacing any non-alphanumeric characters with underscores.
+     *
+     * If \a capitalize is TRUE then the string will be converted to a camel case string.
+     *
+     * \since QGIS 3.26
+     */
+    static QString safeName( const QString &name, bool capitalize = false );
+
 #ifndef SIP_RUN
 
     //! Internal model versions
@@ -576,8 +585,6 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QMap< QString, QgsProcessingModelGroupBox > mGroupBoxes;
 
     QStringList mParameterOrder;
-
-    static QString safeName( const QString &name, bool capitalize );
 
     void dependsOnChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;
     void dependentChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends, const QString &branch ) const;


### PR DESCRIPTION
Ultimately avoids forced removal of _ characters in model parameter names