### PR TITLE
Fix round trip of html content edit in the model designer help dialog

### DIFF
--- a/python/gui/auto_generated/qgsrichtexteditor.sip.in
+++ b/python/gui/auto_generated/qgsrichtexteditor.sip.in
@@ -79,6 +79,15 @@ The ``text`` can either be a plain text string or a HTML document.
 Clears the current text from the widget.
 %End
 
+  signals:
+
+    void textChanged();
+%Docstring
+Emitted when the text contents are changed.
+
+.. versionadded:: 3.26
+%End
+
   protected:
     virtual void focusInEvent( QFocusEvent *event );
 

--- a/src/gui/processing/qgsprocessinghelpeditorwidget.h
+++ b/src/gui/processing/qgsprocessinghelpeditorwidget.h
@@ -67,7 +67,8 @@ class GUI_EXPORT QgsProcessingHelpEditorWidget : public QWidget, public Ui::QgsP
   private:
 
     QString formattedHelp() const;
-    QString helpComponent( const QString &name ) const;
+
+    void storeCurrentValue();
 
     QVariantMap mHelpContent;
 

--- a/src/gui/qgsrichtexteditor.cpp
+++ b/src/gui/qgsrichtexteditor.cpp
@@ -214,6 +214,9 @@ QgsRichTextEditor::QgsRichTextEditor( QWidget *parent )
 #endif
 
   fontChanged( mTextEdit->font() );
+
+  connect( mTextEdit, &QTextEdit::textChanged, this, &QgsRichTextEditor::textChanged );
+  connect( mSourceEdit, &QgsCodeEditorHTML::textChanged, this, &QgsRichTextEditor::textChanged );
 }
 
 QString QgsRichTextEditor::toPlainText() const

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -112,6 +112,15 @@ class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEd
      */
     void clearSource();
 
+  signals:
+
+    /**
+     * Emitted when the text contents are changed.
+     *
+     * \since QGIS 3.26
+     */
+    void textChanged();
+
   protected:
     void focusInEvent( QFocusEvent *event ) override;
 

--- a/src/ui/processing/qgsprocessinghelpeditorwidgetbase.ui
+++ b/src/ui/processing/qgsprocessinghelpeditorwidgetbase.ui
@@ -89,13 +89,55 @@
          </widget>
         </item>
         <item>
-         <widget class="QTextEdit" name="mTextEdit">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>200</height>
-           </size>
+         <widget class="QStackedWidget" name="mEditStackedWidget">
+          <property name="currentIndex">
+           <number>0</number>
           </property>
+          <widget class="QWidget" name="mPagePlainText">
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QTextEdit" name="mTextEdit">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>200</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="mPageRichEdit">
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QgsRichTextEditor" name="mRichTextEdit" native="true"/>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
        </layout>
@@ -105,6 +147,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsRichTextEditor</class>
+   <extends>QWidget</extends>
+   <header>qgsrichtexteditor.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
And use QgsRichTextEditor widget to give a nice editing experience for the help components which support html content.
