### PR TITLE
Let widgets use more space in tabs if they can take advantage of it

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2264,6 +2264,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
       int row = 0;
       int column = 0;
+      bool addSpacer = true;
 
       const QList<QgsAttributeEditorElement *> children = container->children();
 
@@ -2338,11 +2339,25 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
           column = 0;
           row += 1;
         }
+
+        if ( widgetInfo.widget
+             && widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Fixed
+             && widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Maximum
+             && widgetInfo.widget->sizePolicy().verticalPolicy() != QSizePolicy::Preferred )
+          addSpacer = false;
+
+        // we consider all relation editors should be expanding
+        if ( qobject_cast<QgsAttributeFormRelationEditorWidget *>( widgetInfo.widget ) )
+          addSpacer = false;
       }
-      QWidget *spacer = new QWidget();
-      spacer->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Preferred );
-      gbLayout->addWidget( spacer, ++row, 0 );
-      gbLayout->setRowStretch( row, 1 );
+
+      if ( addSpacer )
+      {
+        QWidget *spacer = new QWidget();
+        spacer->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Preferred );
+        gbLayout->addWidget( spacer, ++row, 0 );
+        gbLayout->setRowStretch( row, 1 );
+      }
 
       newWidgetInfo.labelText = QString();
       newWidgetInfo.labelOnTop = true;


### PR DESCRIPTION
Widgets which can use more vertical space (like RelationEditorWidget) where not expanding when put into tabs.

Before this pr:
![image](https://user-images.githubusercontent.com/9881900/160855046-f6327566-4dcf-48f7-a618-d81dd2ce23c5.png)

After:
![image](https://user-images.githubusercontent.com/9881900/160855546-4fa07080-2a66-40dc-8425-fee953052de9.png)

