### PR TITLE
Insert processing results at the top of the optional results group

### DIFF
--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -101,8 +101,8 @@ def handleAlgorithmResults(alg, context, feedback=None, showResults=True, parame
                     if not group:
                         group = details.project.layerTreeRoot().insertGroup(0, group_name)
 
-                    details.project.addMapLayer(mapLayer, False)
-                    group.addLayer(mapLayer)
+                    details.project.addMapLayer(mapLayer, False)  # Add to registry
+                    group.insertLayer(0, mapLayer)
                 else:
                     details.project.addMapLayer(mapLayer)
 


### PR DESCRIPTION
That is, load new results at the top, which is what users would expect.

Note this only works for the optional processing results group.

Followup #37595