### PR TITLE
Fix technique handling with non-core tools

### DIFF
--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
@@ -67,11 +67,16 @@ class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
   private slots:
     void setCaptureTechnique( Qgis::CaptureTechnique technique, bool alsoSetShapeTool = true );
     void setShapeTool( const QString &shapeToolId );
+    void mapToolSet( QgsMapTool *newTool, QgsMapTool * );
 
   private:
+    void setupTool( QgsMapToolCapture *tool );
+
     QMap<Qgis::CaptureTechnique, QAction *> mTechniqueActions;
     QHash<QString, QAction *> mShapeActions;
     QMap<QgsMapToolShapeAbstract::ShapeCategory, QToolButton *> mShapeCategoryButtons;
+
+    QSet< QgsMapTool * > mInitializedTools;
 
     QToolButton *mDigitizeModeToolButton = nullptr;
     QgsStreamDigitizingSettingsAction *mStreamDigitizingSettingsAction = nullptr;


### PR DESCRIPTION
@3nids this fixes the technique handling with tools which aren't part of the QgisApp map tools, where regardless of the techniques supported by the tool the corresponding actions are never enabled.

