### PR TITLE
[Offline editing] Unbreak TestQgsOfflineEditing with GDAL >= 3.4.2

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3434,6 +3434,10 @@ void QgsOgrProvider::open( OpenMode mode )
 
   const bool bIsGpkg = QFileInfo( mFilePath ).suffix().compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0;
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,2)
+  bool forceWAL = false;
+#endif
+
   // first try to open in update mode (unless specified otherwise)
   QString errCause;
   if ( !openReadOnly )
@@ -3445,7 +3449,12 @@ void QgsOgrProvider::open( OpenMode mode )
     }
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,2)
-    if ( bIsGpkg && mode == OpenModeInitial )
+    if ( bIsGpkg && options.contains( "QGIS_FORCE_WAL=ON" ) )
+    {
+      // Hack use for qgsofflineediting / https://github.com/qgis/QGIS/issues/48012
+      forceWAL = true;
+    }
+    if ( bIsGpkg && mode == OpenModeInitial && !forceWAL )
     {
       // A hint to QgsOgrProviderUtils::GDALOpenWrapper() to not force WAL
       // as in OpenModeInitial we are not going to do anything besides getting capabilities
@@ -3574,7 +3583,7 @@ void QgsOgrProvider::open( OpenMode mode )
        ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) ||
          mGDALDriverName == QLatin1String( "MapInfo File" )
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,2)
-         || mGDALDriverName == QLatin1String( "GPKG" )
+         || ( !forceWAL && mGDALDriverName == QLatin1String( "GPKG" ) )
 #endif
        ) )
   {

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3454,7 +3454,7 @@ void QgsOgrProvider::open( OpenMode mode )
       // Hack use for qgsofflineediting / https://github.com/qgis/QGIS/issues/48012
       forceWAL = true;
     }
-    if ( bIsGpkg && mode == OpenModeInitial && !forceWAL )
+    if ( bIsGpkg && mode == OpenModeInitial && !forceWAL && QgsOgrProviderUtils::IsLocalFile( mFilePath ) )
     {
       // A hint to QgsOgrProviderUtils::GDALOpenWrapper() to not force WAL
       // as in OpenModeInitial we are not going to do anything besides getting capabilities
@@ -3583,7 +3583,7 @@ void QgsOgrProvider::open( OpenMode mode )
        ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) ||
          mGDALDriverName == QLatin1String( "MapInfo File" )
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,2)
-         || ( !forceWAL && mGDALDriverName == QLatin1String( "GPKG" ) )
+         || ( !forceWAL && mGDALDriverName == QLatin1String( "GPKG" ) && QgsOgrProviderUtils::IsLocalFile( mFilePath ) )
 #endif
        ) )
   {

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -1000,6 +1000,12 @@ GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUp
   bool bIsGpkg = QFileInfo( filePath ).suffix().compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0;
   bool bIsLocalGpkg = false;
 
+  if ( bIsGpkg )
+  {
+    // Hack use for qgsofflineediting / https://github.com/qgis/QGIS/issues/48012
+    papszOpenOptions = CSLSetNameValue( papszOpenOptions, "QGIS_FORCE_WAL", nullptr );
+  }
+
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,2)
   if ( bIsGpkg && !bUpdate )
   {

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -47,8 +47,6 @@ email                : nyall dot dawson at gmail dot com
 
 ///@cond PRIVATE
 
-static bool IsLocalFile( const QString &path );
-
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 Q_GLOBAL_STATIC_WITH_ARGS( QMutex, sGlobalMutex, ( QMutex::Recursive ) )
 #else
@@ -1124,7 +1122,7 @@ GDALDatasetH QgsOgrProviderUtils::GDALOpenWrapper( const char *pszPath, bool bUp
   return hDS;
 }
 
-static bool IsLocalFile( const QString &path )
+bool QgsOgrProviderUtils::IsLocalFile( const QString &path )
 {
   QString dirName( QFileInfo( path ).absolutePath() );
   // Start with the OS specific methods since the QT >= 5.4 method just

--- a/src/core/providers/ogr/qgsogrproviderutils.h
+++ b/src/core/providers/ogr/qgsogrproviderutils.h
@@ -134,6 +134,9 @@ class CORE_EXPORT QgsOgrProviderUtils
     static QStringList directoryExtensions();
     static QStringList wildcards();
 
+    //! Whether the file is a local file.
+    static bool IsLocalFile( const QString &path );
+
     /**
      * Creates an empty data source
      * \param uri location to store the file(s)

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -779,7 +779,7 @@ void QgsOfflineEditing::convertToOfflineLayer( QgsVectorLayer *layer, sqlite3 *d
       }
       hDS.reset();
 
-      const QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
+      const QString uri = QStringLiteral( "%1|layername=%2|option:QGIS_FORCE_WAL=ON" ).arg( offlineDbPath,  tableName );
       const QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
       newLayer = std::make_unique<QgsVectorLayer>( uri, layer->name() + layerNameSuffix, QStringLiteral( "ogr" ), layerOptions );
       break;


### PR DESCRIPTION
Fixes #48012

Basically, for offline editing, we ask QgsOgrProvider to adopt the
behaviour it had before https://github.com/qgis/QGIS/pull/47098, that is
use SQLite3 journal_mode = WAL even in read-only mode.

Sorry, this "fix" is horrible, but I couldn't get with something better after
many hours of investigation. The root cause seems to be that QgsOfflineEditing
creates layers using direct OGR API or sqlite3 API, and also uses
QgsOgrProvider which has a GDAL dataset reuse mechanism. And all that does
not place nicely at all. Maybe the root root cause is that the OGR GPKG driver
establishes the list of layers at its opening, and if creates a new one behind its
back, which is prone to happen with the dataset caching metchanism, the
GDALDataset::GetLayerByName() method doesn't see the newly created layer.

With that in mind, I tried to add calls to
QgsOgrProviderUtils::invalidateCachedDatasets() but to no avail.
Also QgsOgrProviderUtils::invalidateCachedLastModifiedDate() which is
used by QgsOgrProvider::createEmptyLayer(), but to no avail.

So basically I don't understand why offline editing worked before with a
GPKG backend. I'd say it is pure luck.

Note: I also saw that qgsofflineediting.cpp at line 315 calls
offlineLayer->dataProvider()->invalidateConnections() but that method is
only implemented in the Spatialite provider. I tried to implement it in
the OGR one, but to no avail too.

This should probably be backported, despite being horrible...