### PR TITLE
 [qgsquick] Properly handle deferred layer repaint requests

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -167,9 +167,10 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     void refresh();
 
   private slots:
-    void refreshMap();
+    void refreshMap( bool silent = false );
     void renderJobUpdated();
     void renderJobFinished();
+    void layerRepaintRequested( bool deferred );
     void onWindowChanged( QQuickWindow *window );
     void onScreenChanged( QScreen *screen );
     void onExtentChanged();
@@ -199,6 +200,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QList<QMetaObject::Connection> mLayerConnections;
     QTimer mMapUpdateTimer;
     bool mIncrementalRendering = false;
+    bool mDeferredRefreshPending = false;
 
     QQuickWindow *mWindow = nullptr;
 };


### PR DESCRIPTION
## Description

This fixes/improves the way QgsQuickMapCanvas handles layer repaint requests by taking into account whether the repaint request is flagged as deferred or not. If the request is deferred, we do two things:
- we handle the canvas refresh as a "silent" one (i.e., no map refresh signal is emitted)
- if an ongoing rendering job (i.e. refresh) is taking place, we _do not_ abort the refresh, instead we defer a refresh until the ongoing rendering job is done

This better aligns the QgsQuickMapCanvas to QgsMapCanvas. Without this fix, layers that signals repaint requests a lot (e.g., animation markers in upcoming 3.26 but also layers set to auto refresh every X milliseconds) would freeze the map canvas.

Proof of coolness: 
![Peek 2022-04-04 09-49](https://user-images.githubusercontent.com/1728657/161465881-e84af372-d21e-488e-ac8c-0e880ed86bfb.gif)

