### PR TITLE
Fix qgis server settings cache size tests

### DIFF
--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -21,6 +21,8 @@ from utilities import unitTestDataPath
 from qgis.testing import unittest
 from qgis.server import QgsServerSettings, QgsServerSettingsEnv
 
+DEFAULT_CACHE_SIZE = 256 * 1024 * 1024
+
 
 class TestQgsServerSettings(unittest.TestCase):
 
@@ -104,7 +106,7 @@ class TestQgsServerSettings(unittest.TestCase):
     def test_env_cache_size(self):
         env = "QGIS_SERVER_CACHE_SIZE"
 
-        self.assertEqual(self.settings.cacheSize(), 50 * 1024 * 1024)
+        self.assertEqual(self.settings.cacheSize(), DEFAULT_CACHE_SIZE)
 
         os.environ[env] = "1024"
         self.settings.load()


### PR DESCRIPTION
## Description

The danger of having a false-positive 100% failing test: it obscures regressions :) But ultimately, my bad. This PR fixes a regression following the change of default cache size earlier today.

Thanks to @3nids for pointing this out.