### PR TITLE
Add setting to show feature counts by default for newly added layers

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -772,6 +772,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   // but the checkbox is true to use QPixmap
   chkAddedVisibility->setChecked( mSettings->value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool() );
   cbxLegendClassifiers->setChecked( mSettings->value( QStringLiteral( "/qgis/showLegendClassifiers" ), false ).toBool() );
+  mShowFeatureCountByDefaultCheckBox->setChecked( QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers.value() );
   cbxHideSplash->setChecked( mSettings->value( QStringLiteral( "/qgis/hideSplash" ), false ).toBool() );
   cbxShowNews->setChecked( !mSettings->value( QStringLiteral( "%1/disabled" ).arg( QgsNewsFeedParser::keyForFeed( QgsWelcomePage::newsFeedUrl() ) ), false, QgsSettings::Core ).toBool() );
   mDataSourceManagerNonModal->setChecked( mSettings->value( QStringLiteral( "/qgis/dataSourceManagerNonModal" ), false ).toBool() );
@@ -1667,6 +1668,7 @@ void QgsOptions::saveOptions()
 
   bool showLegendClassifiers = mSettings->value( QStringLiteral( "/qgis/showLegendClassifiers" ), false ).toBool();
   mSettings->setValue( QStringLiteral( "/qgis/showLegendClassifiers" ), cbxLegendClassifiers->isChecked() );
+  QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers.setValue( mShowFeatureCountByDefaultCheckBox->isChecked() );
   mSettings->setValue( QStringLiteral( "/qgis/hideSplash" ), cbxHideSplash->isChecked() );
   mSettings->setValue( QStringLiteral( "%1/disabled" ).arg( QgsNewsFeedParser::keyForFeed( QgsWelcomePage::newsFeedUrl() ) ), !cbxShowNews->isChecked(), QgsSettings::Core );
 

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -36,6 +36,7 @@
 #include "qgslayerdefinition.h"
 #include "qgsiconutils.h"
 #include "qgsmimedatautils.h"
+#include "qgssettingsregistrycore.h"
 
 #include <QPalette>
 
@@ -879,11 +880,17 @@ void QgsLayerTreeModel::connectToLayer( QgsLayerTreeLayer *nodeLayer )
   {
     addLegendToLayer( nodeLayer );
 
-    // automatic collapse of legend nodes - useful if a layer has many legend nodes
+    // if we aren't loading a layer from a project, setup some nice default settings
     if ( !mRootNode->customProperty( QStringLiteral( "loading" ) ).toBool() )
     {
+      // automatic collapse of legend nodes - useful if a layer has many legend nodes
       if ( mAutoCollapseLegendNodesCount != -1 && rowCount( node2index( nodeLayer ) )  >= mAutoCollapseLegendNodesCount )
         nodeLayer->setExpanded( false );
+
+      if ( nodeLayer->layer()->type() == QgsMapLayerType::VectorLayer && QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers.value() )
+      {
+        nodeLayer->setCustomProperty( QStringLiteral( "showFeatureCount" ), true );
+      }
     }
   }
 

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -103,7 +103,7 @@ class CORE_EXPORT QgsSettings : public QObject
         static const inline char *QGIS_DIGITIZING_SHAPEMAPTOOLS = "qgis/digitizing/shape-map-tools";
         static const inline char *QGIS_NETWORKANDPROXY = "qgis/networkAndProxy";
         static const inline char *SVG = "svg";
-        static const inline char *LAYER_TREE = "core/layer_tree";
+        static const inline char *CORE_LAYERTREE = "core/layer-tree";
     };
 
     /**

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -103,6 +103,7 @@ class CORE_EXPORT QgsSettings : public QObject
         static const inline char *QGIS_DIGITIZING_SHAPEMAPTOOLS = "qgis/digitizing/shape-map-tools";
         static const inline char *QGIS_NETWORKANDPROXY = "qgis/networkAndProxy";
         static const inline char *SVG = "svg";
+        static const inline char *LAYER_TREE = "core/layer_tree";
     };
 
     /**

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -99,6 +99,7 @@ QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   addSettingsEntry( &settingsDigitizingOffsetShowAdvanced );
   addSettingsEntry( &settingsDigitizingTracingMaxFeatureCount );
   addSettingsEntry( &settingsGpsBabelPath );
+  addSettingsEntry( &settingsLayerTreeShowFeatureCountForNewLayers );
 }
 
 QgsSettingsRegistryCore::~QgsSettingsRegistryCore()

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -172,7 +172,7 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     static const inline QgsSettingsEntryString settingsGpsBabelPath = QgsSettingsEntryString( QStringLiteral( "gpsbabelPath" ), QgsSettings::Prefix::GPS, QStringLiteral( "gpsbabel" ) );
 
     //! Settings entry show feature counts for newly added layers by default
-    static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::LAYER_TREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
+    static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::CORE_LAYERTREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
 #endif
 
 };

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -170,6 +170,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
 
     //! Settings entry path to GPSBabel executable.
     static const inline QgsSettingsEntryString settingsGpsBabelPath = QgsSettingsEntryString( QStringLiteral( "gpsbabelPath" ), QgsSettings::Prefix::GPS, QStringLiteral( "gpsbabel" ) );
+
+    //! Settings entry show feature counts for newly added layers by default
+    static const inline QgsSettingsEntryBool settingsLayerTreeShowFeatureCountForNewLayers = QgsSettingsEntryBool( QStringLiteral( "show_feature_count_for_new_layers" ), QgsSettings::Prefix::LAYER_TREE, false, QStringLiteral( "If true, feature counts will be shown in the layer tree for all newly added layers." ) );
 #endif
 
 };

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3412,6 +3412,13 @@
                    </layout>
                   </item>
                   <item>
+                   <widget class="QCheckBox" name="mShowFeatureCountByDefaultCheckBox">
+                    <property name="text">
+                     <string>Show feature count for newly added layers</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QCheckBox" name="cbxLegendClassifiers">
                     <property name="text">
                      <string>Display classification attribute in layer titles</string>
@@ -6229,6 +6236,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>
   <tabstop>cmbLegendDoubleClickAction</tabstop>
+  <tabstop>mShowFeatureCountByDefaultCheckBox</tabstop>
   <tabstop>cbxLegendClassifiers</tabstop>
   <tabstop>mLegendGraphicResolutionSpinBox</tabstop>
   <tabstop>mLegendSymbolMinimumSizeSpinBox</tabstop>


### PR DESCRIPTION
If enabled (the default remains disabled), this option will cause the feature count to be enabled for any newly added/created map
layers.

Sponsored by SevenCs GmbH

![image](https://user-images.githubusercontent.com/1829991/161675842-508ca22c-2081-48ba-b2fc-7d5b84aa77b6.png)