### PR TITLE
fix path for sipify tests

### DIFF
--- a/tests/code_layout/CMakeLists.txt
+++ b/tests/code_layout/CMakeLists.txt
@@ -9,9 +9,9 @@ add_test(qgis_defwindowtitle ${CMAKE_SOURCE_DIR}/tests/code_layout/test_defwindo
 add_test(qgis_qvariant_no_brace_init ${CMAKE_SOURCE_DIR}/tests/code_layout/test_qvariant_no_brace_init.sh)
 
 add_test(qgis_shellcheck ${CMAKE_SOURCE_DIR}/tests/code_layout/test_shellcheck.sh)
-add_test(qgis_sipify ${CMAKE_SOURCE_DIR}/tests/code_layout/test_sipify.sh)
-add_test(qgis_sip_include ${CMAKE_SOURCE_DIR}/tests/code_layout/test_sip_include.sh)
-add_test(qgis_sip_uptodate ${CMAKE_SOURCE_DIR}/tests/code_layout/test_sipfiles.sh)  # spellok
+add_test(qgis_sipify ${CMAKE_SOURCE_DIR}/tests/code_layout/sipify/test_sipify.sh)
+add_test(qgis_sip_include ${CMAKE_SOURCE_DIR}/tests/code_layout/sipify/test_sip_include.sh)
+add_test(qgis_sip_uptodate ${CMAKE_SOURCE_DIR}/tests/code_layout/sipify/test_sipfiles.sh)  # spellok
 
 add_test(qgis_doxygen_order ${CMAKE_SOURCE_DIR}/tests/code_layout/test_doxygen_layout.sh)
 


### PR DESCRIPTION
consistently with 1c3554971af57e845b220584d58b7976eb7948bd move sip* tests to subfolder