### PR TITLE
Make sure CRS axis ordering is respected for map canvas' copy coordinates and goto locator

### DIFF
--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemutils.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemutils.sip.in
@@ -31,6 +31,11 @@ Returns the default coordinate order to use for the specified ``crs``.
    This is quite a "coarse" method, in that many possible CRS axis don't map well to a simply X/Y or Y/X order.
    Accordingly this method will default to returning Qgis.CoordinateOrder.XY unless we are reasonably certain of a Y/X order.
 %End
+
+    static QString axisDirectionToAbbreviatedString( Qgis::CrsAxisDirection axis );
+%Docstring
+Returns a translated abbreviation representing an ``axis`` direction.
+%End
 };
 
 /************************************************************************

--- a/src/app/locator/qgsgotolocatorfilter.cpp
+++ b/src/app/locator/qgsgotolocatorfilter.cpp
@@ -20,6 +20,7 @@
 #include "qgisapp.h"
 #include "qgsmapcanvas.h"
 #include "qgscoordinateutils.h"
+#include "qgscoordinatereferencesystemutils.h"
 
 #include <QUrl>
 
@@ -38,13 +39,10 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   if ( feedback->isCanceled() )
     return;
 
-  const QgsCoordinateReferenceSystem currentCrs = QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs();
-  const QgsCoordinateReferenceSystem wgs84Crs( QStringLiteral( "EPSG:4326" ) );
-
-  bool okX = false;
-  bool okY = false;
-  double posX = 0.0;
-  double posY = 0.0;
+  bool firstOk = false;
+  bool secondOk = false;
+  double firstNumber = 0.0;
+  double secondNumber = 0.0;
   bool posIsWgs84 = false;
   const QLocale locale;
 
@@ -55,19 +53,19 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   QRegularExpressionMatch match = separatorRx.match( string.trimmed() );
   if ( match.hasMatch() )
   {
-    posX = locale.toDouble( match.captured( 1 ), &okX );
-    posY = locale.toDouble( match.captured( 2 ), &okY );
+    firstNumber = locale.toDouble( match.captured( 1 ), &firstOk );
+    secondNumber = locale.toDouble( match.captured( 2 ), &secondOk );
   }
 
-  if ( !match.hasMatch() || !okX || !okY )
+  if ( !match.hasMatch() || !firstOk || !secondOk )
   {
     // Digit detection using user locale failed, use default C decimal separators
     separatorRx = QRegularExpression( QStringLiteral( "^([0-9\\-\\.]*)[\\s\\,]*([0-9\\-\\.]*)$" ) );
     match = separatorRx.match( string.trimmed() );
     if ( match.hasMatch() )
     {
-      posX = match.captured( 1 ).toDouble( &okX );
-      posY = match.captured( 2 ).toDouble( &okY );
+      firstNumber = match.captured( 1 ).toDouble( &firstOk );
+      secondNumber = match.captured( 2 ).toDouble( &secondOk );
     }
   }
 
@@ -80,10 +78,11 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
     {
       posIsWgs84 = true;
       bool isEasting = false;
-      posX = QgsCoordinateUtils::degreeToDecimal( match.captured( 1 ), &okX, &isEasting );
-      posY = QgsCoordinateUtils::degreeToDecimal( match.captured( 2 ), &okY );
-      if ( !isEasting )
-        std::swap( posX, posY );
+      firstNumber = QgsCoordinateUtils::degreeToDecimal( match.captured( 1 ), &firstOk, &isEasting );
+      secondNumber = QgsCoordinateUtils::degreeToDecimal( match.captured( 2 ), &secondOk );
+      // normalize to northing (i.e. Y) first
+      if ( isEasting )
+        std::swap( firstNumber, secondNumber );
     }
   }
 
@@ -96,25 +95,43 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
     {
       posIsWgs84 = true;
       bool isEasting = false;
-      posX = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &okX, &isEasting );
-      posY = QgsCoordinateUtils::dmsToDecimal( match.captured( 3 ), &okY );
-      if ( !isEasting )
-        std::swap( posX, posY );
+      firstNumber = QgsCoordinateUtils::dmsToDecimal( match.captured( 1 ), &firstOk, &isEasting );
+      secondNumber = QgsCoordinateUtils::dmsToDecimal( match.captured( 3 ), &secondOk );
+      // normalize to northing (i.e. Y) first
+      if ( isEasting )
+        std::swap( firstNumber, secondNumber );
     }
   }
 
-  if ( okX && okY )
+  const QgsCoordinateReferenceSystem currentCrs = QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs();
+  const QgsCoordinateReferenceSystem wgs84Crs( QStringLiteral( "EPSG:4326" ) );
+
+  if ( firstOk && secondOk )
   {
     QVariantMap data;
-    const QgsPointXY point( posX, posY );
-    data.insert( QStringLiteral( "point" ), point );
+    const bool currentCrsIsXY = QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( currentCrs ) == Qgis::CoordinateOrder::XY;
+    const bool withinWgs84 = wgs84Crs.bounds().contains( secondNumber, firstNumber );
 
-    const bool withinWgs84 = wgs84Crs.bounds().contains( point );
     if ( !posIsWgs84 && currentCrs != wgs84Crs )
     {
+      const QgsPointXY point( currentCrsIsXY ? firstNumber : secondNumber,
+                              currentCrsIsXY ? secondNumber : firstNumber );
+      data.insert( QStringLiteral( "point" ), point );
+
+      const QList< Qgis::CrsAxisDirection > axisList = currentCrs.axisOrdering();
+      QString firstSuffix;
+      QString secondSuffix;
+      if ( axisList.size() >= 2 )
+      {
+        firstSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 0 ) );
+        secondSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 1 ) );
+      }
+
       QgsLocatorResult result;
       result.filter = this;
-      result.displayString = tr( "Go to %1 %2 (Map CRS, %3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), currentCrs.userFriendlyIdentifier() );
+      result.displayString = tr( "Go to %1%2 %3%4 (Map CRS, %5)" ).arg( locale.toString( firstNumber, 'g', 10 ), firstSuffix,
+                             locale.toString( secondNumber, 'g', 10 ), secondSuffix,
+                             currentCrs.userFriendlyIdentifier() );
       result.userData = data;
       result.score = 0.9;
       emit resultFetched( result );
@@ -122,6 +139,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
 
     if ( withinWgs84 )
     {
+      const QgsPointXY point( secondNumber, firstNumber );
       if ( currentCrs != wgs84Crs )
       {
         const QgsCoordinateTransform transform( wgs84Crs, currentCrs, QgsProject::instance()->transformContext() );
@@ -140,7 +158,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
 
       QgsLocatorResult result;
       result.filter = this;
-      result.displayString = tr( "Go to %1° %2° (%3)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
+      result.displayString = tr( "Go to %1°N %2°E (%3)" ).arg( locale.toString( point.y(), 'g', 10 ), locale.toString( point.x(), 'g', 10 ), wgs84Crs.userFriendlyIdentifier() );
       result.userData = data;
       result.score = 1.0;
       emit resultFetched( result );
@@ -177,10 +195,10 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
   {
     double scale = 0.0;
     int meters = 0;
-    okX = false;
-    okY = false;
-    posX = 0.0;
-    posY = 0.0;
+    bool okX = false;
+    bool okY = false;
+    double posX = 0.0;
+    double posY = 0.0;
     if ( url.hasFragment() )
     {
       // Check for OSM/Leaflet/OpenLayers pattern (e.g. http://www.openstreetmap.org/#map=6/46.423/4.746)

--- a/src/app/locator/qgsgotolocatorfilter.cpp
+++ b/src/app/locator/qgsgotolocatorfilter.cpp
@@ -296,7 +296,7 @@ void QgsGotoLocatorFilter::fetchResults( const QString &string, const QgsLocator
 
       QgsLocatorResult result;
       result.filter = this;
-      result.displayString = tr( "Go to %1° %2° %3(%4)" ).arg( locale.toString( point.x(), 'g', 10 ), locale.toString( point.y(), 'g', 10 ),
+      result.displayString = tr( "Go to %1°N %2°E %3(%4)" ).arg( locale.toString( point.y(), 'g', 10 ), locale.toString( point.x(), 'g', 10 ),
                              scale > 0.0 ? tr( "at scale 1:%1 " ).arg( scale ) : QString(),
                              wgs84Crs.userFriendlyIdentifier() );
       result.userData = data;

--- a/src/core/proj/qgscoordinatereferencesystemutils.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemutils.cpp
@@ -78,3 +78,92 @@ Qgis::CoordinateOrder QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderF
 
   return Qgis::CoordinateOrder::XY;
 }
+
+QString QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( Qgis::CrsAxisDirection axis )
+{
+  switch ( axis )
+  {
+    case Qgis::CrsAxisDirection::North:
+      return QStringLiteral( "N" );
+    case Qgis::CrsAxisDirection::NorthNorthEast:
+      return QStringLiteral( "NNE" );
+    case Qgis::CrsAxisDirection::SouthSouthEast:
+      return QStringLiteral( "SSE" );
+    case Qgis::CrsAxisDirection::South:
+      return QStringLiteral( "S" );
+    case Qgis::CrsAxisDirection::SouthSouthWest:
+      return QStringLiteral( "SSW" );
+    case Qgis::CrsAxisDirection::NorthNorthWest:
+      return QStringLiteral( "NNW" );
+    case Qgis::CrsAxisDirection::GeocentricY:
+      return QStringLiteral( "Y" );
+    case Qgis::CrsAxisDirection::DisplayUp:
+      return QStringLiteral( "Up" );
+    case Qgis::CrsAxisDirection::DisplayDown:
+      return QStringLiteral( "Down" );
+    case Qgis::CrsAxisDirection::NorthEast:
+      return QStringLiteral( "NE" );
+    case Qgis::CrsAxisDirection::EastNorthEast:
+      return QStringLiteral( "ENE" );
+    case Qgis::CrsAxisDirection::East:
+      return QStringLiteral( "E" );
+    case Qgis::CrsAxisDirection::EastSouthEast:
+      return QStringLiteral( "ESE" );
+    case Qgis::CrsAxisDirection::SouthEast:
+      return QStringLiteral( "SE" );
+    case Qgis::CrsAxisDirection::SouthWest:
+      return QStringLiteral( "SW" );
+    case Qgis::CrsAxisDirection::WestSouthWest:
+      return QStringLiteral( "WSW" );
+    case Qgis::CrsAxisDirection::West:
+      return QStringLiteral( "W" );
+    case Qgis::CrsAxisDirection::WestNorthWest:
+      return QStringLiteral( "WNW" );
+    case Qgis::CrsAxisDirection::NorthWest:
+      return QStringLiteral( "NW" );
+    case Qgis::CrsAxisDirection::GeocentricX:
+      return QStringLiteral( "X" );
+    case Qgis::CrsAxisDirection::DisplayRight:
+      return QStringLiteral( "Disp. R" );
+    case Qgis::CrsAxisDirection::DisplayLeft:
+      return QStringLiteral( "Disp. L" );
+    case Qgis::CrsAxisDirection::GeocentricZ:
+      return QStringLiteral( "Z" );
+    case Qgis::CrsAxisDirection::Up:
+      return QStringLiteral( "U" );
+    case Qgis::CrsAxisDirection::Down:
+      return QStringLiteral( "D" );
+    case Qgis::CrsAxisDirection::Forward:
+      return QStringLiteral( "F" );
+    case Qgis::CrsAxisDirection::Aft:
+      return QStringLiteral( "A" );
+    case Qgis::CrsAxisDirection::Port:
+      return QStringLiteral( "P" );
+    case Qgis::CrsAxisDirection::Starboard:
+      return QStringLiteral( "STBD" );
+    case Qgis::CrsAxisDirection::Clockwise:
+      return QStringLiteral( "CW" );
+    case Qgis::CrsAxisDirection::CounterClockwise:
+      return QStringLiteral( "CCW" );
+    case Qgis::CrsAxisDirection::ColumnPositive:
+      return QStringLiteral( "C+" );
+    case Qgis::CrsAxisDirection::ColumnNegative:
+      return QStringLiteral( "C-" );
+    case Qgis::CrsAxisDirection::RowPositive:
+      return QStringLiteral( "R+" );
+    case Qgis::CrsAxisDirection::RowNegative:
+      return QStringLiteral( "R-" );
+    case Qgis::CrsAxisDirection::Future:
+      return QStringLiteral( "F" );
+    case Qgis::CrsAxisDirection::Past:
+      return QStringLiteral( "P" );
+    case Qgis::CrsAxisDirection::Towards:
+      return QStringLiteral( "T" );
+    case Qgis::CrsAxisDirection::AwayFrom:
+      return QStringLiteral( "AF" );
+    case Qgis::CrsAxisDirection::Unspecified:
+      break;
+  }
+
+  return QString();
+}

--- a/src/core/proj/qgscoordinatereferencesystemutils.cpp
+++ b/src/core/proj/qgscoordinatereferencesystemutils.cpp
@@ -84,83 +84,83 @@ QString QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( Qgi
   switch ( axis )
   {
     case Qgis::CrsAxisDirection::North:
-      return QStringLiteral( "N" );
+      return QObject::tr( "N", "axis" );
     case Qgis::CrsAxisDirection::NorthNorthEast:
-      return QStringLiteral( "NNE" );
+      return QObject::tr( "NNE", "axis" );
     case Qgis::CrsAxisDirection::SouthSouthEast:
-      return QStringLiteral( "SSE" );
+      return QObject::tr( "SSE", "axis" );
     case Qgis::CrsAxisDirection::South:
-      return QStringLiteral( "S" );
+      return QObject::tr( "S", "axis" );
     case Qgis::CrsAxisDirection::SouthSouthWest:
-      return QStringLiteral( "SSW" );
+      return QObject::tr( "SSW", "axis" );
     case Qgis::CrsAxisDirection::NorthNorthWest:
-      return QStringLiteral( "NNW" );
+      return QObject::tr( "NNW", "axis" );
     case Qgis::CrsAxisDirection::GeocentricY:
-      return QStringLiteral( "Y" );
+      return QObject::tr( "Y", "axis" );
     case Qgis::CrsAxisDirection::DisplayUp:
-      return QStringLiteral( "Up" );
+      return QObject::tr( "Up", "axis" );
     case Qgis::CrsAxisDirection::DisplayDown:
-      return QStringLiteral( "Down" );
+      return QObject::tr( "Down", "axis" );
     case Qgis::CrsAxisDirection::NorthEast:
-      return QStringLiteral( "NE" );
+      return QObject::tr( "NE", "axis" );
     case Qgis::CrsAxisDirection::EastNorthEast:
-      return QStringLiteral( "ENE" );
+      return QObject::tr( "ENE", "axis" );
     case Qgis::CrsAxisDirection::East:
-      return QStringLiteral( "E" );
+      return QObject::tr( "E", "axis" );
     case Qgis::CrsAxisDirection::EastSouthEast:
-      return QStringLiteral( "ESE" );
+      return QObject::tr( "ESE", "axis" );
     case Qgis::CrsAxisDirection::SouthEast:
-      return QStringLiteral( "SE" );
+      return QObject::tr( "SE", "axis" );
     case Qgis::CrsAxisDirection::SouthWest:
-      return QStringLiteral( "SW" );
+      return QObject::tr( "SW", "axis" );
     case Qgis::CrsAxisDirection::WestSouthWest:
-      return QStringLiteral( "WSW" );
+      return QObject::tr( "WSW", "axis" );
     case Qgis::CrsAxisDirection::West:
-      return QStringLiteral( "W" );
+      return QObject::tr( "W", "axis" );
     case Qgis::CrsAxisDirection::WestNorthWest:
-      return QStringLiteral( "WNW" );
+      return QObject::tr( "WNW", "axis" );
     case Qgis::CrsAxisDirection::NorthWest:
-      return QStringLiteral( "NW" );
+      return QObject::tr( "NW", "axis" );
     case Qgis::CrsAxisDirection::GeocentricX:
-      return QStringLiteral( "X" );
+      return QObject::tr( "X", "axis" );
     case Qgis::CrsAxisDirection::DisplayRight:
-      return QStringLiteral( "Disp. R" );
+      return QObject::tr( "Disp. R", "axis" );
     case Qgis::CrsAxisDirection::DisplayLeft:
-      return QStringLiteral( "Disp. L" );
+      return QObject::tr( "Disp. L", "axis" );
     case Qgis::CrsAxisDirection::GeocentricZ:
-      return QStringLiteral( "Z" );
+      return QObject::tr( "Z", "axis" );
     case Qgis::CrsAxisDirection::Up:
-      return QStringLiteral( "U" );
+      return QObject::tr( "U", "axis" );
     case Qgis::CrsAxisDirection::Down:
-      return QStringLiteral( "D" );
+      return QObject::tr( "D", "axis" );
     case Qgis::CrsAxisDirection::Forward:
-      return QStringLiteral( "F" );
+      return QObject::tr( "F", "axis" );
     case Qgis::CrsAxisDirection::Aft:
-      return QStringLiteral( "A" );
+      return QObject::tr( "A", "axis" );
     case Qgis::CrsAxisDirection::Port:
-      return QStringLiteral( "P" );
+      return QObject::tr( "P", "axis" );
     case Qgis::CrsAxisDirection::Starboard:
-      return QStringLiteral( "STBD" );
+      return QObject::tr( "STBD", "axis" );
     case Qgis::CrsAxisDirection::Clockwise:
-      return QStringLiteral( "CW" );
+      return QObject::tr( "CW", "axis" );
     case Qgis::CrsAxisDirection::CounterClockwise:
-      return QStringLiteral( "CCW" );
+      return QObject::tr( "CCW", "axis" );
     case Qgis::CrsAxisDirection::ColumnPositive:
-      return QStringLiteral( "C+" );
+      return QObject::tr( "C+", "axis" );
     case Qgis::CrsAxisDirection::ColumnNegative:
-      return QStringLiteral( "C-" );
+      return QObject::tr( "C-", "axis" );
     case Qgis::CrsAxisDirection::RowPositive:
-      return QStringLiteral( "R+" );
+      return QObject::tr( "R+", "axis" );
     case Qgis::CrsAxisDirection::RowNegative:
-      return QStringLiteral( "R-" );
+      return QObject::tr( "R-", "axis" );
     case Qgis::CrsAxisDirection::Future:
-      return QStringLiteral( "F" );
+      return QObject::tr( "F", "axis" );
     case Qgis::CrsAxisDirection::Past:
-      return QStringLiteral( "P" );
+      return QObject::tr( "P", "axis" );
     case Qgis::CrsAxisDirection::Towards:
-      return QStringLiteral( "T" );
+      return QObject::tr( "T", "axis" );
     case Qgis::CrsAxisDirection::AwayFrom:
-      return QStringLiteral( "AF" );
+      return QObject::tr( "AF", "axis" );
     case Qgis::CrsAxisDirection::Unspecified:
       break;
   }

--- a/src/core/proj/qgscoordinatereferencesystemutils.h
+++ b/src/core/proj/qgscoordinatereferencesystemutils.h
@@ -40,6 +40,11 @@ class CORE_EXPORT QgsCoordinateReferenceSystemUtils
      * Accordingly this method will default to returning Qgis::CoordinateOrder::XY unless we are reasonably certain of a Y/X order.
      */
     static Qgis::CoordinateOrder defaultCoordinateOrderForCrs( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Returns a translated abbreviation representing an \a axis direction.
+     */
+    static QString axisDirectionToAbbreviatedString( Qgis::CrsAxisDirection axis );
 };
 
 #endif // QGSCOORDINATEREFERENCESYSTEMUTILS_H

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1091,7 +1091,7 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
       QAction *copyCoordinateAction = new QAction( QStringLiteral( "%5 (%1%2, %3%4)" ).arg(
             firstNumber, firstSuffix, secondNumber, secondSuffix, identifier ), &menu );
 
-      connect( copyCoordinateAction, &QAction::triggered, this, [displayPrecision, transformedPoint, firstNumber, secondNumber]
+      connect( copyCoordinateAction, &QAction::triggered, this, [firstNumber, secondNumber, transformedPoint]
       {
         QClipboard *clipboard = QApplication::clipboard();
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -73,6 +73,7 @@ email                : sherman at mrcc.com
 #include "qgsvectorlayer.h"
 #include "qgsmapthemecollection.h"
 #include "qgscoordinatetransformcontext.h"
+#include "qgscoordinatereferencesystemutils.h"
 #include "qgssvgcache.h"
 #include "qgsimagecache.h"
 #include "qgsexpressioncontextutils.h"
@@ -1065,16 +1066,36 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
         displayPrecision = crs.mapUnits() == QgsUnitTypes::DistanceDegrees ? 5 : 3;
       }
 
-      QAction *copyCoordinateAction = new QAction( QStringLiteral( "%3 (%1, %2)" ).arg(
-            QString::number( transformedPoint.x(), 'f', displayPrecision ),
-            QString::number( transformedPoint.y(), 'f', displayPrecision ),
-            identifier ), &menu );
+      const QList< Qgis::CrsAxisDirection > axisList = crs.axisOrdering();
+      QString firstSuffix;
+      QString secondSuffix;
+      if ( axisList.size() >= 2 )
+      {
+        firstSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 0 ) );
+        secondSuffix = QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisList.at( 1 ) );
+      }
 
-      connect( copyCoordinateAction, &QAction::triggered, this, [displayPrecision, transformedPoint]
+      QString firstNumber;
+      QString secondNumber;
+      if ( QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::YX )
+      {
+        firstNumber = QString::number( transformedPoint.y(), 'f', displayPrecision );
+        secondNumber = QString::number( transformedPoint.x(), 'f', displayPrecision );
+      }
+      else
+      {
+        firstNumber = QString::number( transformedPoint.x(), 'f', displayPrecision );
+        secondNumber = QString::number( transformedPoint.y(), 'f', displayPrecision );
+      }
+
+      QAction *copyCoordinateAction = new QAction( QStringLiteral( "%5 (%1%2, %3%4)" ).arg(
+            firstNumber, firstSuffix, secondNumber, secondSuffix, identifier ), &menu );
+
+      connect( copyCoordinateAction, &QAction::triggered, this, [displayPrecision, transformedPoint, firstNumber, secondNumber]
       {
         QClipboard *clipboard = QApplication::clipboard();
 
-        const QString coordinates = QString::number( transformedPoint.x(), 'f', displayPrecision ) + ',' + QString::number( transformedPoint.y(), 'f', displayPrecision );
+        const QString coordinates = firstNumber + ',' + secondNumber;
 
         //if we are on x11 system put text into selection ready for middle button pasting
         if ( clipboard->supportsSelection() )

--- a/tests/src/app/testqgsapplocatorfilters.cpp
+++ b/tests/src/app/testqgsapplocatorfilters.cpp
@@ -365,8 +365,8 @@ void TestQgsAppLocatorFilters::testGoto()
   QCOMPARE( results.count(), 2 );
   QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 4 5 (Map CRS, )" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
-  QCOMPARE( results.at( 1 ).displayString, QObject::tr( "Go to 4° 5° (EPSG:4326 - WGS 84)" ) );
-  QCOMPARE( results.at( 1 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 4, 5 ) );
+  QCOMPARE( results.at( 1 ).displayString, QObject::tr( "Go to 4°N 5°E (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 1 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 5, 4 ) );
 
   // locale-specific goto
   results = gatherResults( &filter, QStringLiteral( "1,234.56 789.012" ), QgsLocatorContext() );
@@ -377,44 +377,44 @@ void TestQgsAppLocatorFilters::testGoto()
   // decimal degree with suffixes
   results = gatherResults( &filter, QStringLiteral( "12.345N, 67.890W" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to -67.89° 12.345° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 12.345°N -67.89°E (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( -67.890, 12.345 ) );
 
   results = gatherResults( &filter, QStringLiteral( "12.345 e, 67.890 s" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 12.345° -67.89° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to -67.89°N 12.345°E (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 12.345, -67.890 ) );
 
   // degree/minuste/second coordinates goto
   // easting northing
   results = gatherResults( &filter, QStringLiteral( "40deg 1' 0\" E 11deg  55' 0\" S" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 40.01666667° -11.91666667° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to -11.91666667°N 40.01666667°E (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 40.0166666667, -11.9166666667 ) );
 
   // northing easting
   results = gatherResults( &filter, QStringLiteral( "14°49′48″N 01°48′45″E" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 14.83°N 1.8125°E (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
   // northing, esting (comma separated)
   results = gatherResults( &filter, QStringLiteral( "14°49′48″N, 01°48′45″E" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 1.8125° 14.83° (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 14.83°N 1.8125°E (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 1.8125, 14.83 ) );
 
   // OSM/Leaflet/OpenLayers
   results = gatherResults( &filter, QStringLiteral( "https://www.openstreetmap.org/#map=15/44.5546/6.4936" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 6.4936° 44.5546° at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 44.5546°N 6.4936°E at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
 
   // Google Maps
   results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@44.5546,6.4936,15.25z" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 6.4936° 44.5546° at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 44.5546°N 6.4936°E at scale 1:22569 (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 6.4936, 44.5546 ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 22569.0 );
 
@@ -424,7 +424,7 @@ void TestQgsAppLocatorFilters::testGoto()
 
   results = gatherResults( &filter, QStringLiteral( "https://www.google.com/maps/@27.7132,85.3288,3a,75y,278.89h,90t/data=!3m8!1e1!3m6!1sAF1QipMrXuXozGc9x9bxx5uPl_3ys4H-rNVqMLr6EYLA!2e10!3e11!6shttps:%2F%2Flh5.googleusercontent.com%2Fp%2FAF1QipMrXuXozGc9x9bxx5uPl_3ys4H-rNVqMLr6EYLA%3Dw203-h100-k-no-pi2.869903-ya293.58762-ro-1.9255565-fo100!7i3840!8i1920" ), QgsLocatorContext() );
   QCOMPARE( results.count(), 1 );
-  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 85.3288° 27.7132° at scale 1:282 (EPSG:4326 - WGS 84)" ) );
+  QCOMPARE( results.at( 0 ).displayString, QObject::tr( "Go to 27.7132°N 85.3288°E at scale 1:282 (EPSG:4326 - WGS 84)" ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "point" )].value<QgsPointXY>(), QgsPointXY( 85.3288, 27.7132 ) );
   QCOMPARE( results.at( 0 ).userData.toMap()[QStringLiteral( "scale" )].toDouble(), 282.0 );
 }

--- a/tests/src/python/test_qgscoordinatereferencesystemutils.py
+++ b/tests/src/python/test_qgscoordinatereferencesystemutils.py
@@ -30,6 +30,14 @@ class TestQgsCoordinateReferenceSystemUtils(unittest.TestCase):
         self.assertEqual(QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(QgsCoordinateReferenceSystem('EPSG:3111')), Qgis.CoordinateOrder.XY)
         self.assertEqual(QgsCoordinateReferenceSystemUtils.defaultCoordinateOrderForCrs(QgsCoordinateReferenceSystem('EPSG:4326')), Qgis.CoordinateOrder.YX)
 
+    def test_axis_direction_to_abbreviation(self):
+        """
+        Test QgsCoordinateReferenceSystem.axisDirectionToAbbreviatedString()
+        """
+        self.assertEqual(QgsCoordinateReferenceSystemUtils.axisDirectionToAbbreviatedString(Qgis.CrsAxisDirection.North), 'N')
+        self.assertEqual(QgsCoordinateReferenceSystemUtils.axisDirectionToAbbreviatedString(Qgis.CrsAxisDirection.East), 'E')
+        self.assertEqual(QgsCoordinateReferenceSystemUtils.axisDirectionToAbbreviatedString(Qgis.CrsAxisDirection.CounterClockwise), 'CCW')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

This PR upgrades the logic behind the map canvas' copy coordinates menu as well as the goto locator filter to have CRSes' axis ordering taken into account.

This *finally* allows us to copy WGS84 coordinates in the proper longitude,latitude ordering, making for frictionless use of those copied coordinates in different softwares/web platforms (e.g. sentinel-hub's eo browser, nasa's worldview, google maps, openstreetmap, etc.).

Since we're now axis ordering aware, we can also avoid forcing a wgs84 coordinate to be typed as latitude,longitude in the goto locator filter :partying_face: 

To insure that people are aware of the ordering, an axis direction suffix has been added to the copy coordinate menu as well as goto locator filter:
![image](https://user-images.githubusercontent.com/1728657/161910148-189e98a5-742d-4395-8bdb-e15d81505868.png)

![image](https://user-images.githubusercontent.com/1728657/161910212-a80d5628-582c-45d4-a19d-b0053bd43c23.png)

