### PR TITLE
Add a checkbox to disable vertex tool dock auto-opening behavior

### DIFF
--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -3527,7 +3527,7 @@ housr:hours
 hovewer:however
 how log:how long
 howerver:however
-howver:however
+howver:however:*
 hsitorians:historians
 hstory:history
 hte:the

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -113,6 +113,7 @@ class QgsAbstractMapToolHandler;
 class QgsAppMapTools;
 class QgsMapToolIdentifyAction;
 class Qgs3DMapCanvasWidget;
+class QgsVertexEditor;
 
 class QDomDocument;
 class QNetworkReply;
@@ -893,6 +894,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * is automatically registered within the QgsApplication::gpsConnectionRegistry().
      */
     void setGpsPanelConnection( QgsGpsConnection *connection );
+
+    //! Returns the application vertex editor
+    QgsVertexEditor *vertexEditor() { return mVertexEditorDock; }
 
   public slots:
     //! save current vector layer
@@ -2477,6 +2481,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsDockWidget *mOverviewDock = nullptr;
     QgsDockWidget *mpGpsDock = nullptr;
     QgsDockWidget *mLogDock = nullptr;
+    QgsVertexEditor *mVertexEditorDock = nullptr;
 
 #ifdef Q_OS_MAC
     //! Window menu action to select this window

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -22,6 +22,7 @@
 #include "qgsmaptoolsdigitizingtechniquemanager.h"
 #include "georeferencer/qgsgeorefmainwindow.h"
 #include "georeferencer/qgstransformsettingsdialog.h"
+#include "vertextool/qgsvertexeditor.h"
 
 QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   : QgsSettingsRegistry()
@@ -41,6 +42,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
 
   addSettingsEntry( &QgsTransformSettingsDialog::settingLastDestinationFolder );
   addSettingsEntry( &QgsTransformSettingsDialog::settingLastPdfFolder );
+
+  addSettingsEntry( &QgsVertexEditor::settingAutoPopupVertexEditorDock );
 
   QgsApplication::settingsRegistryCore()->addSubRegistry( this );
 }

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -28,6 +28,8 @@
 #include "qgspoint.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvertexid.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettings.h"
 
 class QLabel;
 class QTableView;
@@ -35,7 +37,8 @@ class QTableView;
 class QgsMapCanvas;
 class QgsLockedFeature;
 class QgsVectorLayer;
-
+class QCheckBox;
+class QStackedWidget;
 
 class APP_EXPORT QgsVertexEntry
 {
@@ -100,6 +103,9 @@ class APP_EXPORT QgsVertexEditor : public QgsDockWidget
 {
     Q_OBJECT
   public:
+
+    static const inline QgsSettingsEntryBool settingAutoPopupVertexEditorDock = QgsSettingsEntryBool( QStringLiteral( "auto_popup_vertex_editor_dock" ), QgsSettings::Prefix::QGIS_DIGITIZING, true, QStringLiteral( "Whether the auto-popup behavior of the vertex editor dock should be enabled" ) );
+
     QgsVertexEditor( QgsMapCanvas *canvas );
 
     void updateEditor( QgsLockedFeature *lockedFeature );
@@ -123,6 +129,10 @@ class APP_EXPORT QgsVertexEditor : public QgsDockWidget
   private:
 
     QLabel *mHintLabel = nullptr;
+    QCheckBox *mAutoPopupDockCheckBox = nullptr;
+    QStackedWidget *mStackedWidget = nullptr;
+    QWidget *mPageHint = nullptr;
+    QWidget *mPageTable = nullptr;
 
     bool mUpdatingTableSelection = false;
     bool mUpdatingVertexSelection = false;

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -30,6 +30,7 @@
 #include "qgsvertexid.h"
 #include "qgssettingsentryimpl.h"
 #include "qgssettings.h"
+#include "qgspanelwidget.h"
 
 class QLabel;
 class QTableView;
@@ -99,6 +100,45 @@ class APP_EXPORT QgsVertexEditorModel : public QAbstractTableModel
 
 };
 
+class APP_EXPORT QgsVertexEditorWidget : public QgsPanelWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsVertexEditorWidget( QgsMapCanvas *canvas );
+
+    void updateEditor( QgsLockedFeature *lockedFeature );
+    QgsLockedFeature *mLockedFeature = nullptr;
+    QgsMapCanvas *mCanvas = nullptr;
+    QTableView *mTableView = nullptr;
+    QgsVertexEditorModel *mVertexModel = nullptr;
+
+    QMenu *menuButtonMenu() override;
+    QString menuButtonTooltip() const override;
+
+  signals:
+    void deleteSelectedRequested();
+
+  protected:
+    void keyPressEvent( QKeyEvent *event ) override;
+
+  private slots:
+    void updateTableSelection();
+    void updateVertexSelection( const QItemSelection &, const QItemSelection &deselected );
+
+  private:
+
+    QLabel *mHintLabel = nullptr;
+    QStackedWidget *mStackedWidget = nullptr;
+    QWidget *mPageHint = nullptr;
+    QWidget *mPageTable = nullptr;
+
+    QMenu *mWidgetMenu = nullptr;
+
+    bool mUpdatingTableSelection = false;
+    bool mUpdatingVertexSelection = false;
+};
+
 class APP_EXPORT QgsVertexEditor : public QgsDockWidget
 {
     Q_OBJECT
@@ -109,33 +149,18 @@ class APP_EXPORT QgsVertexEditor : public QgsDockWidget
     QgsVertexEditor( QgsMapCanvas *canvas );
 
     void updateEditor( QgsLockedFeature *lockedFeature );
-    QgsLockedFeature *mLockedFeature = nullptr;
-    QgsMapCanvas *mCanvas = nullptr;
-    QTableView *mTableView = nullptr;
-    QgsVertexEditorModel *mVertexModel = nullptr;
 
   signals:
     void deleteSelectedRequested();
     void editorClosed();
 
   protected:
-    void keyPressEvent( QKeyEvent *event ) override;
     void closeEvent( QCloseEvent *event ) override;
-
-  private slots:
-    void updateTableSelection();
-    void updateVertexSelection( const QItemSelection &, const QItemSelection &deselected );
 
   private:
 
-    QLabel *mHintLabel = nullptr;
-    QCheckBox *mAutoPopupDockCheckBox = nullptr;
-    QStackedWidget *mStackedWidget = nullptr;
-    QWidget *mPageHint = nullptr;
-    QWidget *mPageTable = nullptr;
+    QgsVertexEditorWidget *mWidget = nullptr;
 
-    bool mUpdatingTableSelection = false;
-    bool mUpdatingVertexSelection = false;
 };
 
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -330,7 +330,7 @@ void QgsVertexTool::activate()
     showVertexEditor();  //#spellok
   }
 
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
   {
     connect( editor, &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
     connect( editor, &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
@@ -346,7 +346,7 @@ void QgsVertexTool::deactivate()
   setHighlightedVertices( QList<Vertex>() );
   removeTemporaryRubberBands();
   cleanupVertexEditor();
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
   {
     disconnect( editor, &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
     disconnect( editor, &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
@@ -1479,7 +1479,7 @@ void QgsVertexTool::onCachedGeometryChanged( QgsFeatureId fid, const QgsGeometry
   if ( mLockedFeature && mLockedFeature->featureId() == fid && mLockedFeature->layer() == layer )
   {
     mLockedFeature->geometryChanged( fid, geom );
-    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+    if ( QgsVertexEditor *editor = vertexEditor() )
       editor->updateEditor( mLockedFeature.get() );
     updateLockedFeatureVertices();
   }
@@ -1532,7 +1532,7 @@ void QgsVertexTool::updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid 
   if ( QgsVertexEditor::settingAutoPopupVertexEditorDock.value() )
     showVertexEditor();  //#spellok
 
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
   {
     editor->updateEditor( mLockedFeature.get() );
   }
@@ -1542,7 +1542,7 @@ void QgsVertexTool::updateLockedFeatureVertices()
 {
   qDeleteAll( mLockedFeatureVerticesMarkers );
   mLockedFeatureVerticesMarkers.clear();
-  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  QgsVertexEditor *editor = vertexEditor();
   if ( editor && mLockedFeature )
   {
     const QList<QgsVertexEntry *> &vertexMap = mLockedFeature->vertexMap();
@@ -1562,14 +1562,20 @@ void QgsVertexTool::updateLockedFeatureVertices()
   }
 }
 
+QgsVertexEditor *QgsVertexTool::vertexEditor()
+{
+  return QgisApp::instance() ? QgisApp::instance()->vertexEditor() : nullptr;
+}
+
 void QgsVertexTool::showVertexEditor()  //#spellok
 {
-  QgisApp::instance()->vertexEditor()->setUserVisible( true );
+  if ( QgsVertexEditor *editor = vertexEditor() )
+    editor->setUserVisible( true );
 }
 
 void QgsVertexTool::cleanupVertexEditor()
 {
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
   {
     cleanupLockedFeature();
     if ( QgsVertexEditor::settingAutoPopupVertexEditorDock.value() )
@@ -1582,7 +1588,7 @@ void QgsVertexTool::cleanupVertexEditor()
 void QgsVertexTool::cleanupLockedFeature()
 {
   mLockedFeature.reset();
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
   {
     editor->updateEditor( nullptr );
   }
@@ -2259,7 +2265,7 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
   }
 
   updateLockedFeatureVertices();
-  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  if ( QgsVertexEditor *editor = vertexEditor() )
     editor->updateEditor( mLockedFeature.get() );
 
   setHighlightedVertices( mSelectedVertices );  // update positions of existing highlighted vertices
@@ -2366,7 +2372,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
       edits[layer][it2.key()] = featGeom;
     }
 
-    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+    if ( QgsVertexEditor *editor = vertexEditor() )
       editor->updateEditor( mLockedFeature.get() );
   }
 
@@ -2419,7 +2425,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     layer->endEditCommand();
     layer->triggerRepaint();
 
-    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+    if ( QgsVertexEditor *editor = vertexEditor() )
       editor->updateEditor( mLockedFeature.get() );
   }
 
@@ -2594,7 +2600,7 @@ void QgsVertexTool::deleteVertex()
     }
   }
 
-  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  QgsVertexEditor *editor = vertexEditor();
   if ( editor && mLockedFeature )
     editor->updateEditor( mLockedFeature.get() );
 }
@@ -2667,7 +2673,7 @@ void QgsVertexTool::toggleVertexCurve()
       Qgis::Warning );
   }
 
-  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  QgsVertexEditor *editor = vertexEditor();
   if ( editor && mLockedFeature )
     editor->updateEditor( mLockedFeature.get() );
 }

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -321,15 +321,21 @@ QgsVertexTool::~QgsVertexTool()
   delete mVertexBand;
   delete mEdgeBand;
   delete mEndpointMarker;
-  delete mVertexEditor;
 }
 
 void QgsVertexTool::activate()
 {
-  if ( QgisApp::instance() )
+  if ( QgisApp::instance() && QgsVertexEditor::settingAutoPopupVertexEditorDock.value() )
   {
     showVertexEditor();  //#spellok
   }
+
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  {
+    connect( editor, &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
+    connect( editor, &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
+  }
+
   connect( mCanvas, &QgsMapCanvas::currentLayerChanged, this, &QgsVertexTool::currentLayerChanged );
 
   QgsMapToolAdvancedDigitizing::activate();
@@ -340,6 +346,11 @@ void QgsVertexTool::deactivate()
   setHighlightedVertices( QList<Vertex>() );
   removeTemporaryRubberBands();
   cleanupVertexEditor();
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  {
+    disconnect( editor, &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
+    disconnect( editor, &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
+  }
 
   mSnapIndicator->setMatch( QgsPointLocator::Match() );
 
@@ -1468,8 +1479,8 @@ void QgsVertexTool::onCachedGeometryChanged( QgsFeatureId fid, const QgsGeometry
   if ( mLockedFeature && mLockedFeature->featureId() == fid && mLockedFeature->layer() == layer )
   {
     mLockedFeature->geometryChanged( fid, geom );
-    if ( mVertexEditor )
-      mVertexEditor->updateEditor( mLockedFeature.get() );
+    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+      editor->updateEditor( mLockedFeature.get() );
     updateLockedFeatureVertices();
   }
 }
@@ -1518,16 +1529,21 @@ void QgsVertexTool::updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid 
   updateLockedFeatureVertices();
 
   // make sure the vertex editor is alive and visible
-  showVertexEditor();  //#spellok
+  if ( QgsVertexEditor::settingAutoPopupVertexEditorDock.value() )
+    showVertexEditor();  //#spellok
 
-  mVertexEditor->updateEditor( mLockedFeature.get() );
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+  {
+    editor->updateEditor( mLockedFeature.get() );
+  }
 }
 
 void QgsVertexTool::updateLockedFeatureVertices()
 {
   qDeleteAll( mLockedFeatureVerticesMarkers );
   mLockedFeatureVerticesMarkers.clear();
-  if ( mVertexEditor && mLockedFeature )
+  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  if ( editor && mLockedFeature )
   {
     const QList<QgsVertexEntry *> &vertexMap = mLockedFeature->vertexMap();
     for ( const QgsVertexEntry *vertex : vertexMap )
@@ -1546,45 +1562,29 @@ void QgsVertexTool::updateLockedFeatureVertices()
   }
 }
 
-
 void QgsVertexTool::showVertexEditor()  //#spellok
 {
-  if ( !mVertexEditor )
-  {
-    mVertexEditor = new QgsVertexEditor( mCanvas );
-    if ( !QgisApp::instance()->restoreDockWidget( mVertexEditor ) )
-      QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor );
-
-    connect( mVertexEditor, &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
-    connect( mVertexEditor, &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
-
-    // timer required as showing/raising the vertex editor in the same function following restoreDockWidget fails
-    QTimer::singleShot( 200, this, [ = ] { if ( mVertexEditor ) { mVertexEditor->show(); mVertexEditor->raise(); } } );
-  }
-  else
-  {
-    mVertexEditor->show();
-    mVertexEditor->raise();
-  }
+  QgisApp::instance()->vertexEditor()->setUserVisible( true );
 }
 
 void QgsVertexTool::cleanupVertexEditor()
 {
-  if ( mVertexEditor )
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
   {
     cleanupLockedFeature();
-    // do not delete immediately because vertex editor
-    // can be still used in the qt event loop
-    mVertexEditor->deleteLater();
+    if ( QgsVertexEditor::settingAutoPopupVertexEditorDock.value() )
+    {
+      editor->setUserVisible( false );
+    }
   }
 }
 
 void QgsVertexTool::cleanupLockedFeature()
 {
   mLockedFeature.reset();
-  if ( mVertexEditor )
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
   {
-    mVertexEditor->updateEditor( nullptr );
+    editor->updateEditor( nullptr );
   }
   updateLockedFeatureVertices();
 }
@@ -2259,8 +2259,8 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
   }
 
   updateLockedFeatureVertices();
-  if ( mVertexEditor )
-    mVertexEditor->updateEditor( mLockedFeature.get() );
+  if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+    editor->updateEditor( mLockedFeature.get() );
 
   setHighlightedVertices( mSelectedVertices );  // update positions of existing highlighted vertices
   setHighlightedVerticesVisible( true );  // time to show highlighted vertices again
@@ -2366,8 +2366,8 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
       edits[layer][it2.key()] = featGeom;
     }
 
-    if ( mVertexEditor )
-      mVertexEditor->updateEditor( mLockedFeature.get() );
+    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+      editor->updateEditor( mLockedFeature.get() );
   }
 
 
@@ -2419,8 +2419,8 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     layer->endEditCommand();
     layer->triggerRepaint();
 
-    if ( mVertexEditor )
-      mVertexEditor->updateEditor( mLockedFeature.get() );
+    if ( QgsVertexEditor *editor = QgisApp::instance()->vertexEditor() )
+      editor->updateEditor( mLockedFeature.get() );
   }
 
 }
@@ -2594,8 +2594,9 @@ void QgsVertexTool::deleteVertex()
     }
   }
 
-  if ( mVertexEditor && mLockedFeature )
-    mVertexEditor->updateEditor( mLockedFeature.get() );
+  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  if ( editor && mLockedFeature )
+    editor->updateEditor( mLockedFeature.get() );
 }
 
 
@@ -2666,8 +2667,9 @@ void QgsVertexTool::toggleVertexCurve()
       Qgis::Warning );
   }
 
-  if ( mVertexEditor && mLockedFeature )
-    mVertexEditor->updateEditor( mLockedFeature.get() );
+  QgsVertexEditor *editor = QgisApp::instance()->vertexEditor();
+  if ( editor && mLockedFeature )
+    editor->updateEditor( mLockedFeature.get() );
 }
 
 void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, HighlightMode mode )

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -303,6 +303,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
   private:
 
+    QgsVertexEditor *vertexEditor();
+
     // members used for temporary highlight of stuff
 
     //! marker of a snap match (if any) when dragging a vertex

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -448,8 +448,6 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     //! Locked feature for the vertex editor
     QObjectUniquePtr<QgsLockedFeature> mLockedFeature;
-    //! Dock widget which allows editing vertices
-    QPointer<QgsVertexEditor> mVertexEditor;
 
     /**
      * Data structure that stores alternative features to the currently selected (locked) feature.

--- a/src/gui/qgspanelwidgetstack.cpp
+++ b/src/gui/qgspanelwidgetstack.cpp
@@ -43,6 +43,7 @@ void QgsPanelWidgetStack::setMainPanel( QgsPanelWidget *panel )
            Qt::UniqueConnection );
   mStackedWidget->insertWidget( 0, panel );
   mStackedWidget->setCurrentIndex( 0 );
+  updateMenuButton();
 }
 
 QgsPanelWidget *QgsPanelWidgetStack::mainPanel()

--- a/src/ui/styledock/qgsrenderercontainerbase.ui
+++ b/src/ui/styledock/qgsrenderercontainerbase.ui
@@ -14,48 +14,81 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
      <item>
-      <widget class="QToolButton" name="mBackButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QWidget" name="widget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>55</width>
+         <height>0</height>
+        </size>
        </property>
-       <property name="toolTip">
-        <string>Go back</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionArrowLeft.svg</normaloff>:/images/themes/default/mActionArrowLeft.svg</iconset>
-       </property>
-       <property name="autoRepeat">
-        <bool>false</bool>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="mTitleText">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QToolButton" name="mBackButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Go back</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionArrowLeft.svg</normaloff>:/images/themes/default/mActionArrowLeft.svg</iconset>
+          </property>
+          <property name="autoRepeat">
+           <bool>false</bool>
+          </property>
+          <property name="popupMode">
+           <enum>QToolButton::InstantPopup</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="mTitleText">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item>
@@ -73,7 +106,7 @@
         <string/>
        </property>
        <property name="icon">
-        <iconset>
+        <iconset resource="../../../images/images.qrc">
          <normaloff>:/images/themes/default/mIconHamburgerMenu.svg</normaloff>:/images/themes/default/mIconHamburgerMenu.svg</iconset>
        </property>
        <property name="autoRepeat">
@@ -100,11 +133,20 @@
         <x>0</x>
         <y>0</y>
         <width>375</width>
-        <height>596</height>
+        <height>597</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -125,6 +167,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
The vertex tool dock now has a new checkbox for "Auto-open table", (which is checked by default, i.e. the existing behavior). If a user opts to uncheck this then the vertex editor dock auto open/close behavior will be disabled, leaving the dock as just a plain old normal QGIS dock which behaves the same as any other dock.

This is desirable in situations like:

- The user is editing in a full screen session with docks hidden, and doesn't want the vertex editor dock to keep opening itself
- The user has a heavily customised setup of stacked/tabbed/rearranged docks, and doesn't want the vertex editor dock to keep appearing and disappearing and causing other docks to be rearranged

If a user has opted out of the auto-open table behavior, then the dock can be closed and won't show immediately when switching to the vertex tool. The dock can then be re-opened either through the standard Views - Panels menu (or by right clicking a toolbar), OR through a new "Show Vertex Editor" action which has been added to the dropdown menu for the vertex editor toolbar button.

Sponsored by SevenCs GmbH


Code notes:

To facilitate this change I've also reworked the vertex editor dock handling so that only a single vertex dock is created once by QgisApp, instead of having multiple dock widgets created for the two different vertex editor map tools