### PR TITLE
🐛 Fix for reports section not remembering last used field

### DIFF
--- a/src/app/layout/qgsreportfieldgroupsectionwidget.cpp
+++ b/src/app/layout/qgsreportfieldgroupsectionwidget.cpp
@@ -35,6 +35,7 @@ QgsReportSectionFieldGroupWidget::QgsReportSectionFieldGroupWidget( QgsReportOrg
   connect( mButtonEditFooter, &QPushButton::clicked, this, &QgsReportSectionFieldGroupWidget::editFooter );
 
   mLayerComboBox->setLayer( section->layer() );
+  mFieldComboBox->setLayer( section->layer() );
   mFieldComboBox->setField( section->field() );
   mSortAscendingCheckBox->setChecked( section->sortAscending() );
 


### PR DESCRIPTION
## Description

When you create a report with a field group section, the report forgets your last used field when the section is dispatched and restored. Thanks to @nyalldawson for this code-by-proxy fix...