### PR TITLE
Fix compiler warning: use boolean operands

### DIFF
--- a/external/lazperf/detail/field_rgb10.cpp
+++ b/external/lazperf/detail/field_rgb10.cpp
@@ -47,9 +47,9 @@ unsigned int color_diff_bits(const las::rgb& this_val, const las::rgb& last)
                     (__flag_diff(a.g, b.g, 0xFF00) << 3) |
                     (__flag_diff(a.b, b.b, 0x00FF) << 4) |
                     (__flag_diff(a.b, b.b, 0xFF00) << 5) |
-                    (__flag_diff(b.r, b.g, 0x00FF) |
-                     __flag_diff(b.r, b.b, 0x00FF) |
-                     __flag_diff(b.r, b.g, 0xFF00) |
+                    (__flag_diff(b.r, b.g, 0x00FF) ||
+                     __flag_diff(b.r, b.b, 0x00FF) ||
+                     __flag_diff(b.r, b.g, 0xFF00) ||
                      __flag_diff(b.r, b.b, 0xFF00)) << 6;
 #undef __flag_diff
 

--- a/external/lazperf/detail/field_rgb14.cpp
+++ b/external/lazperf/detail/field_rgb14.cpp
@@ -55,9 +55,9 @@ unsigned int color_diff_bits_1_4(const las::rgb14& color, const las::rgb14& last
         (flag_diff(a.g, b.g, 0xFF00) << 3) |
         (flag_diff(a.b, b.b, 0x00FF) << 4) |
         (flag_diff(a.b, b.b, 0xFF00) << 5) |
-        ((flag_diff(b.r, b.g, 0x00FF) |
-          flag_diff(b.r, b.b, 0x00FF) |
-          flag_diff(b.r, b.g, 0xFF00) |
+        ((flag_diff(b.r, b.g, 0x00FF) ||
+          flag_diff(b.r, b.b, 0x00FF) ||
+          flag_diff(b.r, b.g, 0xFF00) ||
           flag_diff(b.r, b.b, 0xFF00)) << 6);
     return r;
 }

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -199,7 +199,7 @@ struct QgsWmsDimensionProperty
       QDateTime start = QDateTime::fromString( extentContent.at( 0 ), Qt::ISODateWithMs );
       QDateTime end = QDateTime::fromString( extentContent.at( extentSize - 2 ), Qt::ISODateWithMs );
 
-      if ( start.isValid() & end.isValid() )
+      if ( start.isValid() && end.isValid() )
         return QgsDateTimeRange( start, end );
     }
 


### PR DESCRIPTION
fix compiler warning on bitwise operator with boolean operands 
upstream fix: https://github.com/hobu/laz-perf/pull/132