### PR TITLE
Remove "geographic" from "Point Input" model input description

### DIFF
--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -480,7 +480,7 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
 
     QString description() const override
     {
-      return QCoreApplication::translate( "Processing", "A point parameter." );
+      return QCoreApplication::translate( "Processing", "A point geometry parameter." );
     }
 
     QString name() const override

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -480,7 +480,7 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
 
     QString description() const override
     {
-      return QCoreApplication::translate( "Processing", "A geographic point parameter." );
+      return QCoreApplication::translate( "Processing", "A point parameter." );
     }
 
     QString name() const override


### PR DESCRIPTION
## Description
The "`Point Input`" Model input says in its mouse-over description that it is "A geographic point parameter."
This implies that the coordinates of the resulting point would be in longitude and latitude.

![image](https://user-images.githubusercontent.com/7661092/162400968-3f30d1d3-1e79-433d-888c-682d8aa0f1f1.png)

In reality the point's coordinates are taken from the clicked canvas, in the CRS of that canvas, and the result includes the information which CRS was used, e.g. "`460268.370659,5515249.399492 [EPSG:25832]`"
![image](https://user-images.githubusercontent.com/7661092/162401094-9d2b8476-f1e1-4b15-ba74-9fb1c5e5ca8e.png)


This PR simply drops the "geographic" from the text.


I admit that I did not compile and test this. The change seems trivial enough to skip that. :D
