### PR TITLE
Increase max allowed GPU memory for a chunked entity

### DIFF
--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -207,7 +207,7 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     bool mIsValid = true;
 
     int mPrimitivesBudget = std::numeric_limits<int>::max();
-    double mGpuMemoryLimit = 100.0; // in megabytes
+    double mGpuMemoryLimit = 500.0; // in megabytes
 };
 
 /// @endcond


### PR DESCRIPTION
It turns out that 100mb is often not enough to show a point cloud
scene of a larger area, and one could easily end up in a situation
where tiles get constantly unloaded and then loaded again.
