### PR TITLE
[wms] Re-allow prefetching/preview of XYZ layers

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2241,12 +2241,9 @@ int QgsWmsProvider::capabilities() const
   }
 
   // Prevent prefetch of XYZ openstreetmap images, see: https://github.com/qgis/QGIS/issues/34813
-  // But also prevent prefetching if service is a true WMS (mSettings.mTiled = True)
-  // See https://github.com/qgis/QGIS/issues/34813
-  if ( mSettings.mTiled && !( mSettings.mXyz && dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) ) )
+  if ( mSettings.mXyz && !dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) )
   {
-    // March 2021: *never* prefetch tile based layers, see: https://github.com/qgis/QGIS/pull/41953
-    // capability |= Capability::Prefetch;
+    capability |= Capability::Prefetch;
   }
 
   if ( mSettings.mTiled || mSettings.mXyz )


### PR DESCRIPTION
## Description

Now that we use the tile download manager within the wms provider, we can re-allow prefetching/preview of XYZ layers as the download manager prevents us from spamming requests (and abruptly interrupting only to re-request the same tile).