### PR TITLE
[backport release-3_24][wmst/xyz] Use the tile download manager to fetch tiles

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -306,6 +306,9 @@ void QgsApplication::init( QString profileFolder )
     qRegisterMetaType<QPainter::CompositionMode>( "QPainter::CompositionMode" );
     qRegisterMetaType<QgsDateTimeRange>( "QgsDateTimeRange" );
     qRegisterMetaType<QList<QgsMapLayer *>>( "QList<QgsMapLayer*>" );
+    qRegisterMetaType<QMap<QNetworkRequest::Attribute, QVariant>>( "QMap<QNetworkRequest::Attribute,QVariant>" );
+    qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );
+    qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
   } );
 
   ( void ) resolvePkgPath();

--- a/src/core/qgstiledownloadmanager.h
+++ b/src/core/qgstiledownloadmanager.h
@@ -53,11 +53,18 @@ class CORE_EXPORT QgsTileDownloadManagerReply : public QObject
     bool hasFinished() const { return mHasFinished; }
     //! Returns binary data returned in the reply (only valid when already finished)
     QByteArray data() const { return mData; }
+    //! Returns the reply URL
+    QUrl url() const { return mUrl; }
+    //! Returns the attribute associated with the \a code
+    QVariant attribute( QNetworkRequest::Attribute code );
+    //! Returns the value of the known header \a header.
+    QVariant header( QNetworkRequest::KnownHeaders header );
+    //! Returns a list of raw header pairs
+    const QList<QNetworkReply::RawHeaderPair> rawHeaderPairs() const { return mRawHeaderPairs; }
     //! Returns error code (only valid when already finished)
     QNetworkReply::NetworkError error() const { return mError; }
     //! Returns error string (only valid when already finished)
     QString errorString() const { return mErrorString; }
-
     //! Returns the original request for this reply object
     QNetworkRequest request() const { return mRequest; }
 
@@ -66,7 +73,7 @@ class CORE_EXPORT QgsTileDownloadManagerReply : public QObject
     void finished();
 
   private slots:
-    void requestFinished( QByteArray data, QNetworkReply::NetworkError error, const QString &errorString );
+    void requestFinished( QByteArray data, QUrl url, const QMap<QNetworkRequest::Attribute, QVariant> &attributes, const QMap<QNetworkRequest::KnownHeaders, QVariant> &headers, const QList<QNetworkReply::RawHeaderPair> rawHeaderPairs, QNetworkReply::NetworkError error, const QString &errorString );
 
   private:
     QgsTileDownloadManagerReply( QgsTileDownloadManager *manager, const QNetworkRequest &request );
@@ -81,6 +88,10 @@ class CORE_EXPORT QgsTileDownloadManagerReply : public QObject
     QByteArray mData;
     QNetworkReply::NetworkError mError = QNetworkReply::NoError;
     QString mErrorString;
+    QUrl mUrl;
+    QMap<QNetworkRequest::Attribute, QVariant> mAttributes;
+    QMap<QNetworkRequest::KnownHeaders, QVariant> mHeaders;
+    QList<QNetworkReply::RawHeaderPair> mRawHeaderPairs;
 };
 
 
@@ -102,7 +113,7 @@ class QgsTileDownloadManagerReplyWorkerObject : public QObject
     void replyFinished();
 
   signals:
-    void finished( QByteArray data, QNetworkReply::NetworkError error, const QString &errorString );
+    void finished( QByteArray data, QUrl url, const QMap<QNetworkRequest::Attribute, QVariant> &attributes, const QMap<QNetworkRequest::KnownHeaders, QVariant> &headers, const QList<QNetworkReply::RawHeaderPair> rawHeaderPairs, QNetworkReply::NetworkError error, const QString &errorString );
 
   private:
     //! "parent" download manager of this worker object

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -51,6 +51,7 @@
 #include "qgsogrutils.h"
 #include "qgsproviderregistry.h"
 #include "qgsruntimeprofiler.h"
+#include "qgstiledownloadmanager.h"
 
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -4315,11 +4316,8 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString 
     request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRect ), r.rect );
     request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), 0 );
 
-    QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( request );
-    connect( reply, &QNetworkReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
-
-    QString reqString = r.url.url();
-
+    QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
+    connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
     mReplies << reply;
   }
 }
@@ -4342,7 +4340,7 @@ void QgsWmsTiledImageDownloadHandler::downloadBlocking()
 
 void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 {
-  QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
+  QgsTileDownloadManagerReply *reply = qobject_cast<QgsTileDownloadManagerReply *>( sender() );
 
 #if defined(QGISDEBUG)
   bool fromCache = reply->attribute( QNetworkRequest::SourceIsFromCacheAttribute ).toBool();
@@ -4421,10 +4419,10 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       reply->deleteLater();
 
       QgsDebugMsgLevel( QStringLiteral( "redirected gettile: %1" ).arg( redirect.toString() ), 2 );
-      reply = QgsNetworkAccessManager::instance()->get( request );
-      mReplies << reply;
 
-      connect( reply, &QNetworkReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
+      QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
+      connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
+      mReplies << reply;
 
       return;
     }
@@ -4449,7 +4447,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     if ( !contentType.isEmpty() && !contentType.startsWith( QLatin1String( "image/" ), Qt::CaseInsensitive ) &&
          contentType.compare( QLatin1String( "application/octet-stream" ), Qt::CaseInsensitive ) != 0 )
     {
-      QByteArray text = reply->readAll();
+      QByteArray text = reply->data();
       QString errorTitle, errorText;
       if ( contentType.compare( QLatin1String( "text/xml" ), Qt::CaseInsensitive ) == 0 && QgsWmsProvider::parseServiceExceptionReportDom( text, errorTitle, errorText ) )
       {
@@ -4493,9 +4491,9 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
                   r.width() / cr,
                   r.height() / cr );
 
-      QgsDebugMsgLevel( QStringLiteral( "tile reply: length %1" ).arg( reply->bytesAvailable() ), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "tile reply: length %1" ).arg( reply->data().size() ), 2 );
 
-      QImage myLocalImage = QImage::fromData( reply->readAll() );
+      QImage myLocalImage = QImage::fromData( reply->data() );
 
       if ( !myLocalImage.isNull() )
       {
@@ -4557,7 +4555,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 
           QString errorMessage;
           if ( contentType.startsWith( QLatin1String( "text/plain" ) ) )
-            errorMessage = reply->readAll();
+            errorMessage = reply->data();
           else
             errorMessage = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString();
 
@@ -4587,12 +4585,9 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 void QgsWmsTiledImageDownloadHandler::canceled()
 {
   QgsDebugMsgLevel( QStringLiteral( "Caught canceled() signal" ), 3 );
-  const auto constMReplies = mReplies;
-  for ( QNetworkReply *reply : constMReplies )
-  {
-    QgsDebugMsgLevel( QStringLiteral( "Aborting tiled network request" ), 3 );
-    reply->abort();
-  }
+  qDeleteAll( mReplies );
+  mReplies.clear();
+  finish();
 }
 
 
@@ -4635,9 +4630,9 @@ void QgsWmsTiledImageDownloadHandler::repeatTileRequest( QNetworkRequest const &
   QgsDebugMsgLevel( QStringLiteral( "repeat tileRequest %1 %2(retry %3) for url: %4" ).arg( tileReqNo ).arg( tileNo ).arg( retry ).arg( url ), 2 );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), retry );
 
-  QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( request );
+  QgsTileDownloadManagerReply *reply = QgsApplication::tileDownloadManager()->get( request );
+  connect( reply, &QgsTileDownloadManagerReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
   mReplies << reply;
-  connect( reply, &QNetworkReply::finished, this, &QgsWmsTiledImageDownloadHandler::tileReplyFinished );
 }
 
 QString QgsWmsTiledImageDownloadHandler::error() const

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -37,6 +37,7 @@
 class QgsCoordinateTransform;
 class QgsNetworkAccessManager;
 class QgsWmsCapabilities;
+class QgsTileDownloadManagerReply;
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -666,7 +667,7 @@ class QgsWmsTiledImageDownloadHandler : public QObject
     bool mSmoothPixmapTransform;
 
     //! Running tile requests
-    QList<QNetworkReply *> mReplies;
+    QList<QgsTileDownloadManagerReply *> mReplies;
 
     QgsRasterBlockFeedback *mFeedback = nullptr;
 


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/48129.

Considering how this makes QGIS a much, much better citizen when it comes to its requests to XYZ servers, we should probably backport this to 3.22 in a couple of point releases from now.