### PR TITLE
Add method to prepare animated images in advance, by extracting all frames from the animation to a temporary directory

### DIFF
--- a/python/core/auto_generated/qgsimagecache.sip.in
+++ b/python/core/auto_generated/qgsimagecache.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsImageCache : QgsAbstractContentCacheBase
 {
 %Docstring(signature="appended")
@@ -34,6 +35,8 @@ reuse without incurring the cost of resampling on every render.
 %Docstring
 Constructor for QgsImageCache, with the specified ``parent`` object.
 %End
+
+    ~QgsImageCache();
 
     long maximumSize() const;
 %Docstring
@@ -122,6 +125,13 @@ be ``True`` from GUI based applications (like the main QGIS application) or cras
 use in external scripts or QGIS server.
 
 If the image could not be read or is not an animated format then -1 is returned.
+
+.. versionadded:: 3.26
+%End
+
+    void prepareAnimation( const QString &path );
+%Docstring
+Prepares for optimized retrieval of frames for the animation at the given ``path``.
 
 .. versionadded:: 3.26
 %End

--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -1193,6 +1193,9 @@ Returns the marker frame rate in frame per second.
 .. seealso:: :py:func:`setFrameRate`
 %End
 
+    virtual void startRender( QgsSymbolRenderContext &context );
+
+
   protected:
 
 };

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -41,7 +41,7 @@
 #include <QImageReader>
 #include <QSvgRenderer>
 #include <QTemporaryDir>
-#include <QUUid>
+#include <QUuid>
 
 ///@cond PRIVATE
 

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -41,6 +41,7 @@
 #include <QImageReader>
 #include <QSvgRenderer>
 #include <QTemporaryDir>
+#include <QUUid>
 
 ///@cond PRIVATE
 

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -40,6 +40,7 @@
 #include <QBuffer>
 #include <QImageReader>
 #include <QSvgRenderer>
+#include <QTemporaryDir>
 
 ///@cond PRIVATE
 
@@ -89,6 +90,8 @@ void QgsImageCacheEntry::dump() const
 QgsImageCache::QgsImageCache( QObject *parent )
   : QgsAbstractContentCache< QgsImageCacheEntry >( parent, QObject::tr( "Image" ) )
 {
+  mTemporaryDir.reset( new QTemporaryDir() );
+
   const int bytes = QgsSettings().value( QStringLiteral( "/qgis/maxImageCacheSize" ), 0 ).toInt();
   if ( bytes > 0 )
   {
@@ -128,6 +131,8 @@ QgsImageCache::QgsImageCache( QObject *parent )
   connect( this, &QgsAbstractContentCacheBase::remoteContentFetched, this, &QgsImageCache::remoteImageFetched );
 }
 
+QgsImageCache::~QgsImageCache() = default;
+
 QImage QgsImageCache::pathAsImage( const QString &f, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache, bool blocking, double targetDpi, int frameNumber, bool *isMissing )
 {
   int totalFrameCount = -1;
@@ -137,7 +142,7 @@ QImage QgsImageCache::pathAsImage( const QString &f, const QSize size, const boo
 
 QImage QgsImageCache::pathAsImagePrivate( const QString &f, const QSize size, const bool keepAspectRatio, const double opacity, bool &fitsInCache, bool blocking, double targetDpi, int frameNumber, bool *isMissing, int &totalFrameCount, int &nextFrameDelayMs )
 {
-  const QString file = f.trimmed();
+  QString file = f.trimmed();
   if ( isMissing )
     *isMissing = true;
 
@@ -145,6 +150,13 @@ QImage QgsImageCache::pathAsImagePrivate( const QString &f, const QSize size, co
     return QImage();
 
   const QMutexLocker locker( &mMutex );
+
+  const auto extractedAnimationIt = mExtractedAnimationPaths.constFind( file );
+  if ( extractedAnimationIt != mExtractedAnimationPaths.constEnd() )
+  {
+    file = QDir( extractedAnimationIt.value() ).filePath( QStringLiteral( "frame_%1.png" ).arg( frameNumber ) );
+    frameNumber = -1;
+  }
 
   fitsInCache = true;
 
@@ -237,6 +249,10 @@ int QgsImageCache::totalFrameCount( const QString &path, bool blocking )
 
   const QMutexLocker locker( &mMutex );
 
+  auto it = mTotalFrameCounts.find( path );
+  if ( it != mTotalFrameCounts.end() )
+    return it.value(); // already prepared
+
   int res = -1;
   int nextFrameDelayMs = 0;
   bool fitsInCache = false;
@@ -255,6 +271,10 @@ int QgsImageCache::nextFrameDelay( const QString &path, int currentFrame, bool b
 
   const QMutexLocker locker( &mMutex );
 
+  auto it = mImageDelays.find( path );
+  if ( it != mImageDelays.end() )
+    return it.value().value( currentFrame ); // already prepared
+
   int frameCount = -1;
   int nextFrameDelayMs = 0;
   bool fitsInCache = false;
@@ -262,6 +282,69 @@ int QgsImageCache::nextFrameDelay( const QString &path, int currentFrame, bool b
   const QImage res = pathAsImagePrivate( file, QSize(), true, 1.0, fitsInCache, blocking, 96, currentFrame, &isMissing, frameCount, nextFrameDelayMs );
 
   return nextFrameDelayMs <= 0 || res.isNull() ? -1 : nextFrameDelayMs;
+}
+
+void QgsImageCache::prepareAnimation( const QString &path )
+{
+  const QMutexLocker locker( &mMutex );
+
+  auto it = mExtractedAnimationPaths.find( path );
+  if ( it != mExtractedAnimationPaths.end() )
+    return; // already prepared
+
+  QString filePath;
+  std::unique_ptr< QImageReader > reader;
+  std::unique_ptr< QBuffer > buffer;
+
+  if ( !path.startsWith( QLatin1String( "base64:" ) ) && QFile::exists( path ) )
+  {
+    const QString basePart = QFileInfo( path ).baseName();
+    int id = 1;
+    filePath = mTemporaryDir->filePath( QStringLiteral( "%1_%2" ).arg( basePart ).arg( id ) );
+    while ( QFile::exists( filePath ) )
+      filePath = mTemporaryDir->filePath( QStringLiteral( "%1_%2" ).arg( basePart ).arg( ++id ) );
+
+    reader = std::make_unique< QImageReader >( path );
+  }
+  else
+  {
+    QByteArray ba = getContent( path, QByteArray( "broken" ), QByteArray( "fetching" ), false );
+    if ( ba == "broken" || ba == "fetching" )
+    {
+      return;
+    }
+    else
+    {
+      const QString path = QUuid::createUuid().toString( QUuid::WithoutBraces );
+      filePath = mTemporaryDir->filePath( path );
+
+      buffer = std::make_unique< QBuffer >( &ba );
+      buffer->open( QIODevice::ReadOnly );
+      reader = std::make_unique< QImageReader> ( buffer.get() );
+    }
+  }
+
+  QDir().mkpath( filePath );
+  mExtractedAnimationPaths.insert( path, filePath );
+
+  const QDir frameDirectory( filePath );
+  // extract all the frames to separate images
+
+  reader->setAutoTransform( true );
+  int frameNumber = 0;
+  while ( true )
+  {
+    const QImage frame = reader->read();
+    if ( frame.isNull() )
+      break;
+
+    mImageDelays[ path ].append( reader->nextImageDelay() );
+
+    const QString framePath = frameDirectory.filePath( QStringLiteral( "frame_%1.png" ).arg( frameNumber++ ) );
+    frame.save( framePath, "PNG" );
+  }
+
+  mTotalFrameCounts.insert( path, frameNumber );
 }
 
 QImage QgsImageCache::renderImage( const QString &path, QSize size, const bool keepAspectRatio, const double opacity, double targetDpi, int frameNumber, bool &isBroken, int &totalFrameCount, int &nextFrameDelayMs, bool blocking ) const

--- a/src/core/qgsimagecache.h
+++ b/src/core/qgsimagecache.h
@@ -26,6 +26,8 @@
 #include <QSize>
 #include <QImage>
 
+class QTemporaryDir;
+
 #ifndef SIP_RUN
 
 ///@cond PRIVATE
@@ -138,6 +140,8 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
      */
     QgsImageCache( QObject *parent SIP_TRANSFERTHIS = nullptr );
 
+    ~QgsImageCache() override;
+
     /**
      * Returns the maximum size of the cache, in bytes.
      *
@@ -230,6 +234,13 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
      */
     int nextFrameDelay( const QString &path, int currentFrame = 0, bool blocking = false );
 
+    /**
+     * Prepares for optimized retrieval of frames for the animation at the given \a path.
+     *
+     * \since QGIS 3.26
+     */
+    void prepareAnimation( const QString &path );
+
   signals:
 
     /**
@@ -249,6 +260,11 @@ class CORE_EXPORT QgsImageCache : public QgsAbstractContentCache< QgsImageCacheE
     QByteArray mMissingSvg;
 
     QByteArray mFetchingSvg;
+
+    QMap< QString, QString > mExtractedAnimationPaths;
+    std::unique_ptr< QTemporaryDir > mTemporaryDir;
+    QMap< QString, int > mTotalFrameCounts;
+    QMap< QString, QVector< int > > mImageDelays;
 
     friend class TestQgsImageCache;
 };

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -1126,11 +1126,15 @@ class CORE_EXPORT QgsAnimatedMarkerSymbolLayer : public QgsRasterMarkerSymbolLay
      */
     double frameRate() const { return mFrameRateFps; }
 
+    void startRender( QgsSymbolRenderContext &context ) override;
+
   protected:
     QImage fetchImage( QgsRenderContext &context, const QString &path, QSize size, bool preserveAspectRatio, double opacity ) const override SIP_SKIP;
 
   private:
     double mFrameRateFps = 10;
+    bool mStaticPath = false;
+    mutable QSet< QString > mPreparedPaths;
 
 };
 

--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -60,6 +60,7 @@ class TestQgsImageCache : public QObject
     void frameCount();
     void nextFrameDelay();
     void imageFrames();
+    void preseedAnimation();
 };
 
 
@@ -382,6 +383,55 @@ void TestQgsImageCache::imageFrames()
 
   // call twice to test caching
   img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 0 );
+  QVERIFY( !img.isNull() );
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 0 );
+  QVERIFY( !img.isNull() );
+  QVERIFY( imageCheck( QStringLiteral( "imagecache_animation_0" ), img, 0 ) );
+
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 1 );
+  QVERIFY( !img.isNull() );
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 1 );
+  QVERIFY( !img.isNull() );
+  QVERIFY( imageCheck( QStringLiteral( "imagecache_animation_1" ), img, 0 ) );
+
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 2 );
+  QVERIFY( !img.isNull() );
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 2 );
+  QVERIFY( !img.isNull() );
+  QVERIFY( imageCheck( QStringLiteral( "imagecache_animation_2" ), img, 0 ) );
+
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 3 );
+  QVERIFY( !img.isNull() );
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 3 );
+  QVERIFY( !img.isNull() );
+  QVERIFY( imageCheck( QStringLiteral( "imagecache_animation_3" ), img, 0 ) );
+
+  // invalid frame
+  img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 4 );
+  QVERIFY( img.isNull() );
+}
+
+void TestQgsImageCache::preseedAnimation()
+{
+  QgsImageCache cache;
+  const QString originalImage = TEST_DATA_DIR + QStringLiteral( "/qgis_logo_animated.gif" );
+
+  const QString tempDir = cache.mTemporaryDir->path();
+  QVERIFY( QFile::exists( tempDir ) );
+
+  QStringList entries = QDir( tempDir ).entryList( QDir::Dirs | QDir::Filter::NoDotAndDotDot );
+  QVERIFY( entries.isEmpty() );
+
+  cache.prepareAnimation( originalImage );
+
+  entries = QDir( tempDir ).entryList( QDir::Dirs | QDir::Filter::NoDotAndDotDot );
+  QCOMPARE( entries.size(), 1 );
+  QStringList files = QDir( QDir( tempDir ).filePath( entries.at( 0 ) ) ).entryList( QDir::Files | QDir::Filter::NoDotAndDotDot );
+  QCOMPARE( files.size(), 4 );
+
+  // call twice to test caching
+  bool inCache = false;
+  QImage img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 0 );
   QVERIFY( !img.isNull() );
   img = cache.pathAsImage( originalImage, QSize(), true, 1.0, inCache, false, 96, 0 );
   QVERIFY( !img.isNull() );


### PR DESCRIPTION
This avoids lengthy delays when trying to render a specific frame
from the animation, as most animation formats require us to
iterate through all preceding frames in order to retrieve a specific
frame. By iterating once in advance and saving the results out we
gain instant access to any individual frame from the animation.
