### PR TITLE
Add LazInfo class tests

### DIFF
--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -86,7 +86,15 @@ void QgsLazInfo::parseHeader( lazperf::header14 &header )
 
   mProjectId = QString( QByteArray( header.guid, 16 ).toHex() );
   mSystemId = QString::fromLocal8Bit( header.system_identifier, 32 );
-  mSoftwareId = QString::fromLocal8Bit( header.generating_software, 32 );
+  while ( !mSystemId.isEmpty() && mSystemId.back() == '\0' )
+  {
+    mSystemId.remove( mSystemId.size() - 1, 1 );
+  }
+  mSoftwareId = QString::fromLocal8Bit( header.generating_software, 32 ).trimmed();
+  while ( !mSoftwareId.isEmpty() && mSoftwareId.back() == '\0' )
+  {
+    mSoftwareId.remove( mSoftwareId.size() - 1, 1 );
+  }
 
   mMinCoords = QgsVector3D( header.minx, header.miny, header.minz );
   mMaxCoords = QgsVector3D( header.maxx, header.maxy, header.maxz );

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -38,6 +38,7 @@
 #include "qgsgeometry.h"
 #include "qgseptdecoder.h"
 #include "qgslazdecoder.h"
+#include "qgslazinfo.h"
 
 /**
  * \ingroup UnitTests
@@ -61,6 +62,7 @@ class TestQgsCopcProvider : public QObject
     void uriIsBlocklisted();
     void querySublayers();
     void brokenPath();
+    void testLazInfo();
     void validLayer();
     void validLayerWithCopcHierarchy();
     void attributes();
@@ -201,6 +203,33 @@ void TestQgsCopcProvider::brokenPath()
   QVERIFY( !layer->isValid() );
 }
 
+void TestQgsCopcProvider::testLazInfo()
+{
+  QString dataPath = mTestDataDir + QStringLiteral( "point_clouds/copc/lone-star.copc.laz" );
+  std::ifstream file( dataPath.toStdString(), std::ios::binary );
+  QgsLazInfo lazInfo = QgsLazInfo::fromFile( file );
+
+  QVERIFY( lazInfo.isValid() );
+  QCOMPARE( lazInfo.pointCount(), 518862 );
+  QCOMPARE( lazInfo.scale().toVector3D(), QVector3D( 0.0001, 0.0001, 0.0001 ) );
+  QCOMPARE( lazInfo.offset().toVector3D(), QVector3D( 515385, 4918361, 2330.5 ) );
+  QPair<uint16_t, uint16_t> creationYearDay = lazInfo.creationYearDay();
+  QCOMPARE( creationYearDay.first, 1 );
+  QCOMPARE( creationYearDay.second, 1 );
+  QPair<uint8_t, uint8_t> version = lazInfo.version();
+  QCOMPARE( version.first, 1 );
+  QCOMPARE( version.second, 4 );
+  QCOMPARE( lazInfo.pointFormat(), 6 );
+  QCOMPARE( lazInfo.systemId(), QString() );
+  QCOMPARE( lazInfo.softwareId(), QString() );
+  QCOMPARE( lazInfo.minCoords().toVector3D(), QVector3D( 515368.60224999999627471, 4918340.36400000005960464, 2322.89624999999978172 ) );
+  QCOMPARE( lazInfo.maxCoords().toVector3D(), QVector3D( 515401.04300000000512227, 4918381.12375000026077032, 2338.57549999999991996 ) );
+  QCOMPARE( lazInfo.firstPointRecordOffset(), 1628 );
+  QCOMPARE( lazInfo.firstVariableLengthRecord(), 375 );
+  QCOMPARE( lazInfo.pointRecordLength(), 34 );
+  QCOMPARE( lazInfo.extrabytesCount(), 4 );
+}
+
 void TestQgsCopcProvider::validLayer()
 {
   std::unique_ptr< QgsPointCloudLayer > layer = std::make_unique< QgsPointCloudLayer >( mTestDataDir + QStringLiteral( "point_clouds/copc/sunshine-coast.copc.laz" ), QStringLiteral( "layer" ), QStringLiteral( "copc" ) );
@@ -220,8 +249,6 @@ void TestQgsCopcProvider::validLayer()
   QVERIFY( layer->dataProvider()->index()->hasNode( IndexedPointCloudNode::fromString( "0-0-0-0" ) ) );
   QVERIFY( !layer->dataProvider()->index()->hasNode( IndexedPointCloudNode::fromString( "1-0-0-0" ) ) );
 }
-
-#include "qgscopcpointcloudindex.h"
 
 void TestQgsCopcProvider::validLayerWithCopcHierarchy()
 {

--- a/tests/src/providers/testqgseptprovider.cpp
+++ b/tests/src/providers/testqgseptprovider.cpp
@@ -61,6 +61,7 @@ class TestQgsEptProvider : public QObject
     void uriIsBlocklisted();
     void querySublayers();
     void brokenPath();
+    void testLazInfo();
     void validLayer();
     void validLayerWithEptHierarchy();
     void attributes();
@@ -200,6 +201,41 @@ void TestQgsEptProvider::brokenPath()
   std::unique_ptr< QgsPointCloudLayer > layer = std::make_unique< QgsPointCloudLayer >( QStringLiteral( "not valid" ), QStringLiteral( "layer" ), QStringLiteral( "ept" ) );
   QVERIFY( !layer->isValid() );
 }
+
+void TestQgsEptProvider::testLazInfo()
+{
+  {
+    QString dataPath = mTestDataDir + QStringLiteral( "point_clouds/ept/lone-star-laszip/ept.json" );
+    std::ifstream file( dataPath.toStdString(), std::ios::binary );
+    QgsLazInfo lazInfo = QgsLazInfo::fromFile( file );
+    QVERIFY( !lazInfo.isValid() );
+  }
+  {
+    QString dataPath = mTestDataDir + QStringLiteral( "point_clouds/ept/lone-star-laszip/ept-data/0-0-0-0.laz" );
+    std::ifstream file( dataPath.toStdString(), std::ios::binary );
+    QgsLazInfo lazInfo = QgsLazInfo::fromFile( file );
+    QVERIFY( lazInfo.isValid() );
+    QCOMPARE( lazInfo.pointCount(), 41998 );
+    QCOMPARE( lazInfo.scale().toVector3D(), QVector3D( 0.00025, 0.00025, 0.00025 ) );
+    QCOMPARE( lazInfo.offset().toVector3D(), QVector3D( 515385, 4918360, 2331 ) );
+    QPair<uint16_t, uint16_t> creationYearDay = lazInfo.creationYearDay();
+    QCOMPARE( creationYearDay.first, 2019 );
+    QCOMPARE( creationYearDay.second, 172 );
+    QPair<uint8_t, uint8_t> version = lazInfo.version();
+    QCOMPARE( version.first, 1 );
+    QCOMPARE( version.second, 2 );
+    QCOMPARE( lazInfo.pointFormat(), 1 );
+    QCOMPARE( lazInfo.systemId(), "PDAL" );
+    QCOMPARE( lazInfo.softwareId(), QStringLiteral( "Entwine" ) );
+    QCOMPARE( lazInfo.minCoords().toVector3D(), QVector3D( 515368.63225000002421439, 4918340.36400000005960464, 2322.90050000000019281 ) );
+    QCOMPARE( lazInfo.maxCoords().toVector3D(), QVector3D( 515401.03749999997671694, 4918381.10350000020116568, 2338.56550000000015643 ) );
+    QCOMPARE( lazInfo.firstPointRecordOffset(), 865 );
+    QCOMPARE( lazInfo.firstVariableLengthRecord(), 227 );
+    QCOMPARE( lazInfo.pointRecordLength(), 32 );
+    QCOMPARE( lazInfo.extrabytesCount(), 4 );
+  }
+}
+
 
 void TestQgsEptProvider::validLayer()
 {


### PR DESCRIPTION
## Description
This PR adds some tests to the newly added QgsLazInfo class responsible for parsing the header of LAZ files 