### PR TITLE
Add an optional "Silent" flag for QgsTask, which hides the operating system level success/fail notifications for that task

### DIFF
--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -49,6 +49,7 @@ clean up and terminate at the earliest possible convenience.
       CanCancel,
       CancelWithoutPrompt,
       Hidden,
+      Silent,
       AllFlags,
     };
     typedef QFlags<QgsTask::Flag> Flags;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16417,7 +16417,11 @@ void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
   {
     long long minTime = QgsSettings().value( QStringLiteral( "minTaskLengthForSystemNotification" ), 5, QgsSettings::App ).toLongLong() * 1000;
     QgsTask *task = QgsApplication::taskManager()->task( taskId );
-    if ( task && !( task->flags() & QgsTask::Flag::Hidden ) && task->elapsedTime() >= minTime )
+    if ( task
+         && !(
+           ( task->flags() & QgsTask::Hidden )
+           || ( task->flags() & QgsTask::Silent ) )
+         && task->elapsedTime() >= minTime )
     {
       if ( status == QgsTask::Complete )
         showSystemNotification( tr( "Task complete" ), task->description() );

--- a/src/core/network/qgsnewsfeedparser.cpp
+++ b/src/core/network/qgsnewsfeedparser.cpp
@@ -143,7 +143,7 @@ void QgsNewsFeedParser::fetch()
   mFetchStartTime = QDateTime::currentDateTimeUtc().toSecsSinceEpoch();
 
   // allow canceling the news fetching without prompts -- it's not crucial if this gets finished or not
-  QgsNetworkContentFetcherTask *task = new QgsNetworkContentFetcherTask( req, mAuthCfg, QgsTask::CanCancel | QgsTask::CancelWithoutPrompt );
+  QgsNetworkContentFetcherTask *task = new QgsNetworkContentFetcherTask( req, mAuthCfg, QgsTask::CanCancel | QgsTask::CancelWithoutPrompt | QgsTask::Silent );
   task->setDescription( tr( "Fetching News Feed" ) );
   connect( task, &QgsNetworkContentFetcherTask::fetched, this, [this, task]
   {

--- a/src/core/providers/qgsprovidersublayertask.cpp
+++ b/src/core/providers/qgsprovidersublayertask.cpp
@@ -22,7 +22,7 @@
 #include "qgsreadwritelocker.h"
 
 QgsProviderSublayerTask::QgsProviderSublayerTask( const QString &uri, bool includeSystemTables )
-  : QgsTask( tr( "Retrieving layers" ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt )
+  : QgsTask( tr( "Retrieving layers" ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt | QgsTask::Silent )
   , mUri( uri )
   , mIncludeSystemTables( includeSystemTables )
 {

--- a/src/core/qgspointlocatorinittask.cpp
+++ b/src/core/qgspointlocatorinittask.cpp
@@ -20,7 +20,7 @@
 /// @cond PRIVATE
 
 QgsPointLocatorInitTask::QgsPointLocatorInitTask( QgsPointLocator *loc )
-  : QgsTask( tr( "Indexing %1" ).arg( loc->layer()->id() ), QgsTask::Flags() )
+  : QgsTask( tr( "Indexing %1" ).arg( loc->layer()->id() ), QgsTask::Silent )
   , mLoc( loc )
 {}
 

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -74,6 +74,7 @@ class CORE_EXPORT QgsTask : public QObject
       CanCancel = 1 << 1, //!< Task can be canceled
       CancelWithoutPrompt = 1 << 2, //!< Task can be canceled without any users prompts, e.g. when closing a project or QGIS.
       Hidden = 1 << 3, //!< Hide task from GUI (since QGIS 3.26)
+      Silent = 1 << 4, //!< Don't show task updates (such as completion/failure messages) as operating-system level notifications (since QGIS 3.26)
       AllFlags = CanCancel, //!< Task supports all flags
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/vector/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/vector/qgsvectorlayerfeaturecounter.cpp
@@ -20,7 +20,7 @@
 #include "qgsrendercontext.h"
 
 QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context, bool storeSymbolFids )
-  : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt )
+  : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel | QgsTask::CancelWithoutPrompt | QgsTask::Silent )
   , mSource( new QgsVectorLayerFeatureSource( layer ) )
   , mRenderer( layer->renderer()->clone() )
   , mExpressionContext( context )


### PR DESCRIPTION
And don't show these notifications for some non-important tasks, like the news feed fetching