### PR TITLE
add method to clear rendering cache

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -451,3 +451,9 @@ void QgsQuickMapCanvasMap::refresh()
   if ( !mFreeze )
     mRefreshTimer.start( 1 );
 }
+
+void QgsQuickMapCanvasMap::clearCache()
+{
+  if ( mCache )
+    mCache->clear();
+}

--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -166,6 +166,11 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
      */
     void refresh();
 
+    /**
+     * Clears rendering cache
+     */
+    void clearCache();
+
   private slots:
     void refreshMap( bool silent = false );
     void renderJobUpdated();


### PR DESCRIPTION
## Description

Add method to clear canvas rendering cache. In some cases it is necessary to clear cache before refreshing canvas otherwise refresh will just redraw cached image.