### PR TITLE
Use a more sensible default order for layers in profile charts

### DIFF
--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -56,6 +56,16 @@ uses a data provider which does not specify paths in a layer URI.
 .. versionadded:: 3.22
 %End
 
+    static QList< QgsMapLayer * > sortLayersByType( const QList< QgsMapLayer * > &layers, const QList< QgsMapLayerType > &order );
+%Docstring
+Sorts a list of map ``layers`` by their layer type, respecting the ``order`` of types specified.
+
+Layer types which appear earlier in the ``order`` list will result in matching layers appearing earlier in the
+result list.
+
+.. versionadded:: 3.26
+%End
+
 
 };
 

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -22,6 +22,108 @@ which are not wrapped by PyQt:
 - NULL QVariant which is missing in PyQt5 with sip.enableautoconversion
 */
 
+// adapted from the qpymultimedia_qlist.sip file from the PyQt6 sources
+%MappedType QList<QgsMapLayerType>
+        /TypeHintIn="Iterable[QgsMapLayerType]",
+        TypeHintOut="List[QgsMapLayerType]", TypeHintValue="[]"/
+{
+%TypeHeaderCode
+#include "qgis.h"
+%End
+
+%ConvertFromTypeCode
+    PyObject *l = PyList_New(sipCpp->size());
+
+    if (!l)
+        return 0;
+
+    for (int i = 0; i < sipCpp->size(); ++i)
+    {
+        PyObject *eobj = sipConvertFromEnum(static_cast<int>(sipCpp->at(i)),
+                sipType_QgsMapLayerType);
+
+        if (!eobj)
+        {
+            Py_DECREF(l);
+
+            return 0;
+        }
+
+        PyList_SetItem(l, i, eobj);
+    }
+
+    return l;
+%End
+
+%ConvertToTypeCode
+    PyObject *iter = PyObject_GetIter(sipPy);
+
+    if (!sipIsErr)
+    {
+        PyErr_Clear();
+        Py_XDECREF(iter);
+
+        return (iter && !PyBytes_Check(sipPy) && !PyUnicode_Check(sipPy));
+    }
+
+    if (!iter)
+    {
+        *sipIsErr = 1;
+
+        return 0;
+    }
+
+    QList<QgsMapLayerType> *ql = new QList<QgsMapLayerType>;
+
+    for (Py_ssize_t i = 0; ; ++i)
+    {
+        PyErr_Clear();
+        PyObject *itm = PyIter_Next(iter);
+
+        if (!itm)
+        {
+            if (PyErr_Occurred())
+            {
+                delete ql;
+                Py_DECREF(iter);
+                *sipIsErr = 1;
+
+                return 0;
+            }
+
+            break;
+        }
+
+        int v = sipConvertToEnum(itm, sipType_QgsMapLayerType);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Format(PyExc_TypeError,
+                    "index %zd has type '%s' but 'QgsMapLayerType' is expected",
+                    i, sipPyTypeName(Py_TYPE(itm)));
+
+            Py_DECREF(itm);
+            delete ql;
+            Py_DECREF(iter);
+            *sipIsErr = 1;
+
+            return 0;
+        }
+
+        ql->append(static_cast<QgsMapLayerType>(v));
+
+        Py_DECREF(itm);
+    }
+
+    Py_DECREF(iter);
+
+    *sipCppPtr = ql;
+
+    return sipGetState(sipTransferObj);
+%End
+};
+
+
 
 template <TYPE>
 %MappedType QVector< QVector<TYPE> >

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -31,6 +31,7 @@
 #include "qgsfileutils.h"
 #include "qgsmessagebar.h"
 #include "qgsplot.h"
+#include "qgsmaplayerutils.h"
 
 #include <QToolBar>
 #include <QProgressBar>
@@ -233,7 +234,21 @@ void QgsElevationProfileWidget::cancelJobs()
 void QgsElevationProfileWidget::onMainCanvasLayersChanged()
 {
   // possibly not right -- do we always want to sync the profile layers to canvas layers?
-  mCanvas->setLayers( mMainCanvas->layers( true ) );
+
+  QList< QgsMapLayer * > layers = mMainCanvas->layers( true );
+
+  // sort layers so that types which are more likely to obscure others are rendered below
+  // e.g. vector features should be drawn above raster DEMS, or the DEM line may completely obscure
+  // the vector feature
+  layers = QgsMapLayerUtils::sortLayersByType( layers,
+  {
+    QgsMapLayerType::RasterLayer,
+    QgsMapLayerType::MeshLayer,
+    QgsMapLayerType::VectorLayer,
+    QgsMapLayerType::PointCloudLayer
+  } );
+
+  mCanvas->setLayers( layers );
   scheduleUpdate();
 }
 

--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -137,3 +137,20 @@ bool QgsMapLayerUtils::updateLayerSourcePath( QgsMapLayer *layer, const QString 
   layer->setDataSource( newUri, layer->name(), layer->providerType() );
   return true;
 }
+
+QList<QgsMapLayer *> QgsMapLayerUtils::sortLayersByType( const QList<QgsMapLayer *> &layers, const QList<QgsMapLayerType> &order )
+{
+  QList< QgsMapLayer * > res = layers;
+  std::sort( res.begin(), res.end(), [&order]( const QgsMapLayer * a, const QgsMapLayer * b ) -> bool
+  {
+    for ( QgsMapLayerType type : order )
+    {
+      if ( a->type() == type && b->type() != type )
+        return true;
+      else if ( b->type() == type )
+        return false;
+    }
+    return false;
+  } );
+  return res;
+}

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -70,6 +70,16 @@ class CORE_EXPORT QgsMapLayerUtils
      */
     static bool updateLayerSourcePath( QgsMapLayer *layer, const QString &newPath );
 
+    /**
+     * Sorts a list of map \a layers by their layer type, respecting the \a order of types specified.
+     *
+     * Layer types which appear earlier in the \a order list will result in matching layers appearing earlier in the
+     * result list.
+     *
+     * \since QGIS 3.26
+     */
+    static QList< QgsMapLayer * > sortLayersByType( const QList< QgsMapLayer * > &layers, const QList< QgsMapLayerType > &order );
+
 
 };
 


### PR DESCRIPTION
Eg. Don't draw raster layer profiles over vector layer ones, since they are likely to obscure the vector results