### PR TITLE
add new refresh() method to MapCanvasWrapper to clear render cache and repaint map

### DIFF
--- a/src/quickgui/plugin/qgsquickmapcanvas.qml
+++ b/src/quickgui/plugin/qgsquickmapcanvas.qml
@@ -98,6 +98,11 @@ Item {
     mapCanvasWrapper.zoom(point, 1.5)
   }
 
+  function refresh() {
+    mapCanvasWrapper.clearCache()
+    mapCanvasWrapper.refresh()
+  }
+
   QgsQuick.MapCanvasMap {
     id: mapCanvasWrapper
 


### PR DESCRIPTION
## Description
Add convenient method to clear cache and refresh canvas to QgsQuick canvas.

Follow-up #48176.