### PR TITLE
Show error message for unsupported wkbType by layer creation in HANA

### DIFF
--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -1624,6 +1624,14 @@ Qgis::VectorExportResult QgsHanaProvider::createEmptyLayer(
     return Qgis::VectorExportResult::ErrorCreatingLayer;
   }
 
+  if ( wkbType != QgsWkbTypes::Unknown && wkbType != QgsWkbTypes::NoGeometry &&
+       !QgsHanaUtils::isGeometryTypeSupported( wkbType ) )
+  {
+    if ( errorMessage )
+      *errorMessage = QObject::tr( "Geometry type '%1' is not supported" ).arg( QgsWkbTypes::displayString( wkbType ) );
+    return Qgis::VectorExportResult::ErrorCreatingLayer;
+  }
+
   QString geometryColumn = dsUri.geometryColumn();
   QString schemaTableName = QgsHanaUtils::quotedIdentifier( schemaName ) + '.' +
                             QgsHanaUtils::quotedIdentifier( tableName );

--- a/src/providers/hana/qgshanautils.cpp
+++ b/src/providers/hana/qgshanautils.cpp
@@ -339,6 +339,24 @@ const char16_t *QgsHanaUtils::toUtf16( const QString &sql )
   return reinterpret_cast<const char16_t *>( sql.utf16() );
 }
 
+bool QgsHanaUtils::isGeometryTypeSupported( QgsWkbTypes::Type wkbType )
+{
+  switch ( QgsWkbTypes::flatType( wkbType ) )
+  {
+    case QgsWkbTypes::Point:
+    case QgsWkbTypes::LineString:
+    case QgsWkbTypes::Polygon:
+    case QgsWkbTypes::MultiPoint:
+    case QgsWkbTypes::MultiLineString:
+    case QgsWkbTypes::MultiPolygon:
+    case QgsWkbTypes::CircularString:
+    case QgsWkbTypes::GeometryCollection:
+      return true;
+    default:
+      return false;
+  }
+}
+
 QgsWkbTypes::Type QgsHanaUtils::toWkbType( const String &type, const Int &hasZ, const Int &hasM )
 {
   if ( type.isNull() )

--- a/src/providers/hana/qgshanautils.h
+++ b/src/providers/hana/qgshanautils.h
@@ -65,6 +65,7 @@ class QgsHanaUtils
     static QVariant toVariant( const NS_ODBC::Binary &value );
 
     static const char16_t *toUtf16( const QString &sql );
+    static bool isGeometryTypeSupported( QgsWkbTypes::Type wkbType );
     static QgsWkbTypes::Type toWkbType( const NS_ODBC::String &type, const NS_ODBC::Int &hasZ, const NS_ODBC::Int &hasM );
     static QVersionNumber toHANAVersion( const QString &dbVersion );
     static int toPlanarSRID( int srid );


### PR DESCRIPTION
This PR improves the error messaging in QgsHanaProvider::createEmptyLayer for geometry types that are not supported in HANA.