### PR TITLE
Avoid python error for depending plugin not found

### DIFF
--- a/python/pyplugin_installer/plugindependencies.py
+++ b/python/pyplugin_installer/plugindependencies.py
@@ -69,6 +69,7 @@ def find_dependencies(plugin_id, plugin_data=None, plugin_deps=None, installed_p
                 'version_installed': None,
                 'version_required': None,
                 'version_available': None,
+                'use_stable_version': None,
                 'action': None,
                 'error': 'missing_id'
             }})


### PR DESCRIPTION
Avoid showing the following error when a dependent plugin was not found. Can be tested trying installing the experimental Model Baker plugin now (version v7.1.0)

```
Fehler bei der Ausführung folgenden Codes:
pyplugin_installer.instance().installPlugin('QgisModelBaker', stable=False)


Traceback (most recent call last):
  File "", line 1, in 
  File "/usr/share/qgis/python/pyplugin_installer/installer.py", line 333, in installPlugin
    self.processDependencies(plugin["id"])
  File "/usr/share/qgis/python/pyplugin_installer/installer.py", line 682, in processDependencies
    dlg = QgsPluginDependenciesDialog(plugin_id, to_install, to_upgrade, not_found)
  File "/usr/share/qgis/python/pyplugin_installer/qgsplugindependenciesdialog.py", line 92, in __init__
    _make_row(data, i, name)
  File "/usr/share/qgis/python/pyplugin_installer/qgsplugindependenciesdialog.py", line 63, in _make_row
    widget.use_stable_version = data['use_stable_version']
KeyError: 'use_stable_version'
```