### PR TITLE
More efficient 2d point cloud rendering for remote sources

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -348,6 +348,14 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
   // Wait for all point cloud nodes to finish loading
   loop.exec();
 
+  // Rendering may have got canceled and the event loop exited before finished()
+  // was called for all blocks, so let's clean up anything that is left
+  for ( QgsPointCloudBlockRequest *blockRequest : std::as_const( blockRequests ) )
+  {
+    delete blockRequest->block();
+    blockRequest->deleteLater();
+  }
+
   return nodesDrawn;
 }
 


### PR DESCRIPTION
We used to query data from remote point clouds in groups of four chunks.
This commit avoids doing that - we query all necessary chunks at once
like we do with raster/vector tiles. This has two advantages:
1. requests are fired sooner than later, minimizing network latency
2. we can do more rendering while waiting for remaining chunks to download

@NEDJIMAbelgacem 