### PR TITLE
Fix installation of grid shift files (Fix #48193)

### DIFF
--- a/src/gui/qgsinstallgridshiftdialog.cpp
+++ b/src/gui/qgsinstallgridshiftdialog.cpp
@@ -62,19 +62,21 @@ void QgsInstallGridShiftFileDialog::installFromFile()
   settings.setValue( QStringLiteral( "lastTransformGridFolder" ), fi.absolutePath(), QgsSettings::App );
 
   const QString baseGridPath = QgsApplication::qgisSettingsDirPath() + QStringLiteral( "proj" );
-  if ( !QDir( baseGridPath ).exists() )
-    QDir().mkdir( baseGridPath );
 
-  const QString destPath = baseGridPath + '/' + fi.fileName();
+  const QString destFilePath = baseGridPath + '/' + mGridName;
+  const QString destPath = QFileInfo( destFilePath ).absolutePath();
 
-  if ( QFile::copy( gridFilePath, destPath ) )
+  if ( !QDir( destPath ).exists() )
+    QDir().mkdir( destPath );
+
+  if ( QFile::copy( gridFilePath, destFilePath ) )
   {
     QMessageBox::information( this, tr( "Install Grid File" ), tr( "The %1 grid shift file has been successfully installed. Please restart QGIS for this change to take effect." ).arg( mGridName ) );
     accept();
   }
   else
   {
-    QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and retry." ).arg( mGridName, destPath ) );
+    QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and retry." ).arg( mGridName, destFilePath ) );
   }
 }
 

--- a/src/gui/qgsinstallgridshiftdialog.cpp
+++ b/src/gui/qgsinstallgridshiftdialog.cpp
@@ -67,7 +67,7 @@ void QgsInstallGridShiftFileDialog::installFromFile()
   const QString destPath = QFileInfo( destFilePath ).absolutePath();
 
   if ( !QDir( destPath ).exists() )
-    QDir().mkdir( destPath );
+    QDir().mkpath( destPath );
 
   if ( QFile::copy( gridFilePath, destFilePath ) )
   {


### PR DESCRIPTION
## Description

Fixes the logic of the installation of grid shift files.

When a missing grid shift file is needed, e.g. `nehpgn.gsb` or `uk/osgb36_xrail84`, then the user is asked to select such grid shift file to be copied in the `proj` folder.

The user could select any file that contains the shifts, e.g. `us_noaa_nehpgn.tif` or `osgb36_xrail84.gsb`.

The current (incorrect) behaviour is to copy the selected file with the very same name (e.g. `us_noaa_nehpgn.tif` or `osgb36_xrail84.gsb`) instead of the expected file name (e.g. `nehpgn.gsb` or `osgb36_xrail84` in the `uk` subfolder) to the proj folder: because of this, the PROJ library cannot find the grid shift file.

The proposed new behaviour is to copy the selected file to the correct expected subfolder of the `proj` dir (and create it if it does not exists) and with the correct expected file name: i.e. it will copy the user selected grid shift file, e.g. `us_noaa_nehpgn.tif` or `osgb36_xrail84.gsb` , the former as `nehpgn.gsb` into the `proj` dir and the latter as `osgb36_xrail84` into the `uk` subfolder of the `proj` dir.

See also https://github.com/qgis/QGIS/issues/45470#issuecomment-939765428.

Fixes https://github.com/qgis/QGIS/issues/48193

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
