### PR TITLE
2D to 3D sync map canvas not updated fix

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -571,12 +571,12 @@ void Qgs3DMapCanvasWidget::onViewed2DExtentFrom3DChanged( QVector<QgsPointXY> ex
       if ( mCanvas->map()->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync3DTo2D ) )
       {
         whileBlocking( mMainCanvas )->setExtent( extentRect );
-        mMainCanvas->refresh();
       }
       else
       {
         mMainCanvas->setExtent( extentRect );
       }
+      mMainCanvas->refresh();
     }
   }
 


### PR DESCRIPTION
## Description
Fixes the refreshing of the 2D map canvas when the 2D canvas is following the 3D view.