### PR TITLE
fix downcasting with recent SIP versions

### DIFF
--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -138,9 +138,9 @@ Abstract base class for connection to a GPS device
 #include <qgsnmeaconnection.h>
 %End
 %ConvertToSubClassCode
-    if ( sipCpp->inherits( "QgsGpsdConnection" ) )
+    if ( qobject_cast<QgsGpsdConnection *>( sipCpp ) )
       sipType = sipType_QgsGpsdConnection;
-    else if ( sipCpp->inherits( "QgsNmeaConnection" ) )
+    else if ( qobject_cast<QgsNmeaConnection *>( sipCpp ) )
       sipType = sipType_QgsNmeaConnection;
     else
       sipType = NULL;

--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -12,7 +12,8 @@
 
 
 %ModuleHeaderCode
-#include "qgsgpsconnection.h"
+#include <qgsgpsdconnection.h>
+#include <qgsnmeaconnection.h>
 %End
 
 class QgsSatelliteInfo
@@ -126,6 +127,7 @@ Returns a descriptive string for the signal quality.
 %End
 };
 
+
 class QgsGpsConnection : QObject
 {
 %Docstring(signature="appended")
@@ -134,8 +136,6 @@ Abstract base class for connection to a GPS device
 
 %TypeHeaderCode
 #include "qgsgpsconnection.h"
-#include <qgsgpsdconnection.h>
-#include <qgsnmeaconnection.h>
 %End
 %ConvertToSubClassCode
     if ( qobject_cast<QgsGpsdConnection *>( sipCpp ) )

--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -33,7 +33,7 @@ whether to allow changes to the layer tree.
 #include "qgslayertreemodel.h"
 %End
 %ConvertToSubClassCode
-    if ( sipCpp->inherits( "QgsLayerTreeModel" ) )
+    if ( qobject_cast<QgsLayerTreeModel *>( sipCpp ) )
       sipType = sipType_QgsLayerTreeModel;
     else
       sipType = 0;

--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -62,7 +62,7 @@ Custom properties that have already been used within QGIS:
 #include "qgslayertreenode.h"
 %End
 %ConvertToSubClassCode
-    if ( sipCpp->inherits( "QgsLayerTreeNode" ) )
+    if ( qobject_cast<QgsLayerTreeNode *>( sipCpp ) )
     {
       sipType = sipType_QgsLayerTreeNode;
       QgsLayerTreeNode *node = qobject_cast<QgsLayerTreeNode *>( sipCpp );

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -77,7 +77,7 @@ with a set of default actions that can be used when building context menu.
 #include "qgslayertreeview.h"
 %End
 %ConvertToSubClassCode
-    if ( sipCpp->inherits( "QgsLayerTreeView" ) )
+    if ( qobject_cast<QgsLayerTreeView *>( sipCpp ) )
       sipType = sipType_QgsLayerTreeView;
     else
       sipType = 0;

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -26,7 +26,7 @@ Abstract base class for nodes contained within a :py:class:`QgsProcessingToolbox
 #include "qgsprocessingtoolboxmodel.h"
 %End
 %ConvertToSubClassCode
-    if ( sipCpp->inherits( "QgsProcessingToolboxModelNode" ) )
+    if ( qobject_cast<QgsProcessingToolboxModelNode *>( sipCpp ) )
     {
       sipType = sipType_QgsProcessingToolboxModelNode;
       QgsProcessingToolboxModelNode *node = qobject_cast<QgsProcessingToolboxModelNode *>( sipCpp );

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -280,9 +280,9 @@ class CORE_EXPORT QgsGpsConnection : public QObject
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->inherits( "QgsGpsdConnection" ) )
+    if ( qobject_cast<QgsGpsdConnection *>( sipCpp ) )
       sipType = sipType_QgsGpsdConnection;
-    else if ( sipCpp->inherits( "QgsNmeaConnection" ) )
+    else if ( qobject_cast<QgsNmeaConnection *>( sipCpp ) )
       sipType = sipType_QgsNmeaConnection;
     else
       sipType = NULL;

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -29,7 +29,8 @@ class QIODevice;
 
 #ifdef SIP_RUN
 % ModuleHeaderCode
-#include "qgsgpsconnection.h"
+#include <qgsgpsdconnection.h>
+#include <qgsnmeaconnection.h>
 % End
 #endif
 
@@ -266,17 +267,13 @@ class CORE_EXPORT QgsGpsInformation
     QString qualityDescription() const;
 };
 
+
 /**
  * \ingroup core
  * \brief Abstract base class for connection to a GPS device
 */
 class CORE_EXPORT QgsGpsConnection : public QObject
 {
-#ifdef SIP_RUN
-#include <qgsgpsdconnection.h>
-#include <qgsnmeaconnection.h>
-#endif
-
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->inherits( "QgsLayerTreeModel" ) )
+    if ( qobject_cast<QgsLayerTreeModel *>( sipCpp ) )
       sipType = sipType_QgsLayerTreeModel;
     else
       sipType = 0;

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->inherits( "QgsLayerTreeNode" ) )
+    if ( qobject_cast<QgsLayerTreeNode *>( sipCpp ) )
     {
       sipType = sipType_QgsLayerTreeNode;
       QgsLayerTreeNode *node = qobject_cast<QgsLayerTreeNode *>( sipCpp );

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -105,7 +105,7 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->inherits( "QgsLayerTreeView" ) )
+    if ( qobject_cast<QgsLayerTreeView *>( sipCpp ) )
       sipType = sipType_QgsLayerTreeView;
     else
       sipType = 0;

--- a/src/gui/processing/qgsprocessingtoolboxmodel.h
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.h
@@ -43,7 +43,7 @@ class GUI_EXPORT QgsProcessingToolboxModelNode : public QObject
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->inherits( "QgsProcessingToolboxModelNode" ) )
+    if ( qobject_cast<QgsProcessingToolboxModelNode *>( sipCpp ) )
     {
       sipType = sipType_QgsProcessingToolboxModelNode;
       QgsProcessingToolboxModelNode *node = qobject_cast<QgsProcessingToolboxModelNode *>( sipCpp );


### PR DESCRIPTION
for instance in 3.22:

```
root = iface.layerTreeView().model().rootGroup()
AttributeError: 'QSortFilterProxyModel' object has no attribute 'rootGroup'
```

while it's working in 3.16 (windows).