### PR TITLE
Make HANA connection string compatible accross different OS

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1899,6 +1899,11 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     // required so that source differs between memory layers
     mDataSource = mDataSource + QStringLiteral( "&uid=%1" ).arg( QUuid::createUuid().toString() );
   }
+  else if ( provider == QLatin1String( "hana" ) )
+  {
+    // update datasource from data provider computed one
+    mDataSource = mDataProvider->dataSourceUri( false );
+  }
 
   connect( mDataProvider, &QgsVectorDataProvider::dataChanged, this, &QgsVectorLayer::emitDataChanged );
   connect( mDataProvider, &QgsVectorDataProvider::dataChanged, this, &QgsVectorLayer::removeSelection );

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -37,6 +37,8 @@
 #include "qgsmessagelog.h"
 #include "qgsrectangle.h"
 
+#include <QtGlobal>
+
 #include "odbc/PreparedStatement.h"
 #include "odbc/ResultSet.h"
 #include "odbc/ResultSetMetaDataUnicode.h"
@@ -1784,6 +1786,26 @@ void QgsHanaProviderMetadata::cleanupProvider()
 QgsHanaProvider *QgsHanaProviderMetadata::createProvider(
   const QString &uri, const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags )
 {
+  QgsDataSourceUri dsUri { uri };
+  QgsHanaDriver *drv = QgsHanaDriver::instance();
+
+  auto isDriverValid = [&drv]( const QString & driver )
+  {
+#ifdef Q_OS_WIN
+    return drv->isInstalled( driver );
+#else
+    return drv->isInstalled( driver ) || QgsHanaDriver::isValidPath( driver );
+#endif
+  };
+
+  // The following block is intended to resolve an issue when a data source was created under
+  // another operating system. In this case, the driver parameter may differ.
+  if ( !drv->driver().isEmpty() && drv->driver() != dsUri.driver() &&
+       !isDriverValid( dsUri.driver() ) && isDriverValid( drv->driver() ) )
+  {
+    dsUri.setDriver( drv->driver() );
+    return new QgsHanaProvider( dsUri.uri(), options, flags );
+  }
   return new QgsHanaProvider( uri, options, flags );
 }
 


### PR DESCRIPTION
This PR fixes an interoperability issue caused by the driver parameter in HANA connection strings.
