### PR TITLE
CMAKE: Add an option to explicitly use internal lazperf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,7 @@ if(WITH_CORE)
     message(STATUS "Qt WebKit support DISABLED.")
   endif()
 
-  set (WITH_INTERNAL_LAZPERF FALSE CACHE BOOL "Determines whether LazPerf should be built from internal copy")
+  set (WITH_INTERNAL_LAZPERF TRUE CACHE BOOL "Determines whether LazPerf should be built from internal copy")
   if (WITH_EPT OR WITH_COPC)
     if (NOT WITH_INTERNAL_LAZPERF)
       find_package(LazPerf) # for decompression of point clouds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,8 +411,11 @@ if(WITH_CORE)
     message(STATUS "Qt WebKit support DISABLED.")
   endif()
 
+  set (WITH_INTERNAL_LAZPERF FALSE CACHE BOOL "Determines whether LazPerf should be built from internal copy")
   if (WITH_EPT OR WITH_COPC)
-    find_package(LazPerf) # for decompression of point clouds
+    if (NOT WITH_INTERNAL_LAZPERF)
+      find_package(LazPerf) # for decompression of point clouds
+    endif()
     if (NOT LazPerf_FOUND)
       message(STATUS "Using embedded laz-perf")
     endif()


### PR DESCRIPTION
## Description

Sometimes, one could have lazperf on the system, but prefer the internal one.

cc @rhurlin