### PR TITLE
[wms] Re-enable prefetch of openstreetmap.org XYZ layers

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2240,8 +2240,7 @@ int QgsWmsProvider::capabilities() const
     }
   }
 
-  // Prevent prefetch of XYZ openstreetmap images, see: https://github.com/qgis/QGIS/issues/34813
-  if ( mSettings.mXyz && !dataSourceUri().contains( QStringLiteral( "openstreetmap.org" ) ) )
+  if ( mSettings.mXyz )
   {
     capability |= Capability::Prefetch;
   }


### PR DESCRIPTION
Now that XYZ raster layer rely on the tile download manager, tile requests are handled gracefully and never aborted only to be re-requested within milliseconds. That makes us a good citizen enough to remove the openstreetmap.org exception.
