### PR TITLE
[qgsquick] Better handling of deferred painting, always rely on timer triggered refreshMap()

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -172,7 +172,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     void clearCache();
 
   private slots:
-    void refreshMap( bool silent = false );
+    void refreshMap();
     void renderJobUpdated();
     void renderJobFinished();
     void layerRepaintRequested( bool deferred );
@@ -205,6 +205,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QList<QMetaObject::Connection> mLayerConnections;
     QTimer mMapUpdateTimer;
     bool mIncrementalRendering = false;
+    bool mSilentRefresh = false;
     bool mDeferredRefreshPending = false;
 
     QQuickWindow *mWindow = nullptr;


### PR DESCRIPTION
## Description

Follow up on recent addition of proper laye repaint requests handling. Long story short, one never calls refreshMap() directly as it screws up signal queues and what not. In practice, it meant that layer repaint requests triggered by feature addition wouldn't show the added feature(s) on refresh until another refresh (manual or otherwise) would occur.

Somewhat counter-intuitively, calling the QTimer-based refresh() also had animations run even smoother now. It can easily handle 30fps now. Yay.