### PR TITLE
[ui] Fix broken img within HTML labels when referring to qrc images

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -166,7 +166,7 @@ class QgsPluginInstaller(QObject):
                 tabIndex = 3  # PLUGMAN_TAB_UPGRADEABLE
         # finally set the notify label
         if status:
-            self.statusLabel.setText(u'<a href="%d"><img src="qrc:/images/themes/default/%s"></a>' % (tabIndex, icon))
+            self.statusLabel.setText(u'<a href="%d"><img src=":/images/themes/default/%s"></a>' % (tabIndex, icon))
             self.statusLabel.setToolTip(status)
         else:
             iface.mainWindow().statusBar().removeWidget(self.statusLabel)

--- a/src/app/qgsprojectlistitemdelegate.cpp
+++ b/src/app/qgsprojectlistitemdelegate.cpp
@@ -78,7 +78,7 @@ void QgsProjectListItemDelegate::paint( QPainter *painter, const QStyleOptionVie
 
   doc.setHtml( QStringLiteral( "<div style='font-size:%1px'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( QString::number( titleSize ),
                index.data( QgsProjectListItemDelegate::TitleRole ).toString(),
-               index.data( QgsProjectListItemDelegate::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
+               index.data( QgsProjectListItemDelegate::PinRole ).toBool() ? QStringLiteral( "<img src=\":/images/themes/default/pin.svg\">" ) : QString(),
                mShowPath ? index.data( QgsProjectListItemDelegate::NativePathRole ).toString() : QString(),
                index.data( QgsProjectListItemDelegate::CrsRole ).toString() ) );
   doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );


### PR DESCRIPTION
## Description

On latest Qt 5.15.3, HTML images with a source referring to an image declared in the .qrc are broken. As per the doc (https://doc.qt.io/qt-5/resources.html), we can either refer to the images as `:/image.png` or a URL with a qrc scheme. 

~~I'm not sure how our previous src strings worked since I assume a qrc scheme would have meant `qrc:///image.png`. (ignore me, qrc:/image.png was perfectly fine :)~~ Somehow, the qrc scheme format turns out not to be working on 5.15.3 either.

The other supported form, `:/image.png`, works flawlessly, so let's jump to that.

This is the bug in full display:
![image](https://user-images.githubusercontent.com/1728657/163781081-e68c6a97-c1ff-4b08-908a-0542aea36683.png)

That sheet icon is actually a broken state indicator, it should look like this:
![image](https://user-images.githubusercontent.com/1728657/163781174-a5975571-955d-44e2-8855-5495026c2682.png)
