### PR TITLE
Do not split expression functions tags list into single words for translation

### DIFF
--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -117,11 +117,9 @@ for f in sorted(glob.glob('resources/function_help/json/*')):
         else:
             cpp.write(",\n            QString()")
 
+        cpp.write(",\n            QStringList()")
         if 'tags' in v:
-            cpp.write(",\n            QStringList()")
-
-            for t in v['tags']:
-                cpp.write("\n              << QStringLiteral( \"{0}\" ) << tr( \"{0}\" )".format(t))
+            cpp.write("\n              << tr( \"{0}\" )".format(",".join(v['tags'])))
 
         cpp.write("\n         )")
 


### PR DESCRIPTION
Fixes #47486
I've tested locally (no tags, existing or new ones) and it seems to work. I just couldn't figure out how to generate the translation file (.ts?) sent to transifex to preview in Linguist but...

Previous generated string for translation (in the generated qgsexpression_texts.cpp)
![image](https://user-images.githubusercontent.com/7983394/163798678-09761c5a-d4d3-4122-89f2-49d8c60a241b.png)

New formatting after PR
![image](https://user-images.githubusercontent.com/7983394/163799203-919c25bb-dd88-497f-b968-720752f51d10.png)
