### PR TITLE
Display correct shortcut for profiles-path in command line

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -170,7 +170,7 @@ void usage( const QString &appName )
       << QStringLiteral( "\t[--take-screenshots output_path]\ttake screen shots for the user documentation\n" )
       << QStringLiteral( "\t[--screenshots-categories categories]\tspecify the categories of screenshot to be used (see QgsAppScreenShots::Categories).\n" )
       << QStringLiteral( "\t[--profile name]\tload a named profile from the users profiles folder.\n" )
-      << QStringLiteral( "\t[-s, --profiles-path path]\tpath to store user profile folders. Will create profiles inside a {path}\\profiles folder \n" )
+      << QStringLiteral( "\t[-S, --profiles-path path]\tpath to store user profile folders. Will create profiles inside a {path}\\profiles folder \n" )
       << QStringLiteral( "\t[--version-migration]\tforce the settings migration from older version if found\n" )
 #ifdef HAVE_OPENCL
       << QStringLiteral( "\t[--openclprogramfolder]\t\tpath to the folder containing the sources for OpenCL programs.\n" )


### PR DESCRIPTION
and avoid collision with snapshot refs 
https://github.com/qgis/QGIS/pull/46548/files#diff-214bd4636579818fc26242a65aee285dbdca02666343ff789ba776caae1ddc9aR681