### PR TITLE
fix incorrect attribute form for default values with geometry

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2815,6 +2815,10 @@ void QgsAttributeForm::updateFieldDependencies()
 void QgsAttributeForm::updateFieldDependenciesDefaultValue( QgsEditorWidgetWrapper *eww )
 {
   QgsExpression exp( eww->field().defaultValueDefinition().expression() );
+
+  if ( exp.needsGeometry() )
+    mNeedsGeometry = true;
+
   const QSet<QString> referencedColumns = exp.referencedColumns();
   for ( const QString &referencedColumn : referencedColumns )
   {
@@ -2841,6 +2845,10 @@ void QgsAttributeForm::updateFieldDependenciesVirtualFields( QgsEditorWidgetWrap
     return;
 
   QgsExpression exp( expressionField );
+
+  if ( exp.needsGeometry() )
+    mNeedsGeometry = true;
+
   const QSet<QString> referencedColumns = exp.referencedColumns();
   for ( const QString &referencedColumn : referencedColumns )
   {


### PR DESCRIPTION
If the attribute form is embedded in the attribute table the feature geometry is not passed to it by default.

If a default value expression or a virtual field needs geometry `mNeedsGeometry` needs to be set.