### PR TITLE
Expose elevation profile tolerance setting to users 

### DIFF
--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -121,6 +121,28 @@ The CRS associated with the curve is retrieved via :py:func:`~QgsElevationProfil
 .. seealso:: :py:func:`setProfileCurve`
 %End
 
+    void setTolerance( double tolerance );
+%Docstring
+Sets the profile tolerance (in :py:func:`~QgsElevationProfileCanvas.crs` units).
+
+This value determines how far from the :py:func:`~QgsElevationProfileCanvas.profileCurve` is appropriate for inclusion of results. For instance,
+when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+actual profile curve a point can reside within to be included in the results.
+
+.. seealso:: :py:func:`tolerance`
+%End
+
+    double tolerance() const;
+%Docstring
+Returns the tolerance of the profile (in :py:func:`~QgsElevationProfileCanvas.crs` units).
+
+This value determines how far from the :py:func:`~QgsElevationProfileCanvas.profileCurve` is appropriate for inclusion of results. For instance,
+when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+actual profile curve a point can reside within to be included in the results.
+
+.. seealso:: :py:func:`setTolerance`
+%End
+
     void setVisiblePlotRange( double minimumDistance, double maximumDistance, double minimumElevation, double maximumElevation );
 %Docstring
 Sets the visible area of the plot.

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -38,6 +38,8 @@
 #include "qgslinesymbollayer.h"
 #include "qgsfillsymbol.h"
 #include "qgsfillsymbollayer.h"
+#include "qgsmarkersymbol.h"
+#include "qgsmarkersymbollayer.h"
 
 #include <QToolBar>
 #include <QProgressBar>
@@ -500,6 +502,24 @@ void QgsElevationProfileWidget::createOrUpdateRubberBands( )
     bottomLayer->setColor( QColor( 40, 40, 40, 100 ) );
     bottomLayer->setPenCapStyle( Qt::PenCapStyle::FlatCap );
     layers.append( bottomLayer.release() );
+
+    std::unique_ptr< QgsMarkerLineSymbolLayer > arrowLayer = std::make_unique< QgsMarkerLineSymbolLayer >();
+    arrowLayer->setPlacements( Qgis::MarkerLinePlacement::CentralPoint );
+
+    QgsSymbolLayerList markerLayers;
+    std::unique_ptr< QgsSimpleMarkerSymbolLayer > arrowSymbolLayer = std::make_unique< QgsSimpleMarkerSymbolLayer >( Qgis::MarkerShape::EquilateralTriangle );
+    arrowSymbolLayer->setSize( 4 );
+    arrowSymbolLayer->setAngle( 90 );
+    arrowSymbolLayer->setSizeUnit( QgsUnitTypes::RenderMillimeters );
+    arrowSymbolLayer->setColor( QColor( 40, 40, 40, 100 ) );
+    arrowSymbolLayer->setStrokeColor( QColor( 255, 255, 255, 255 ) );
+    arrowSymbolLayer->setStrokeWidth( 0.2 );
+    markerLayers.append( arrowSymbolLayer.release() );
+
+    std::unique_ptr< QgsMarkerSymbol > markerSymbol = std::make_unique< QgsMarkerSymbol >( markerLayers );
+    arrowLayer->setSubSymbol( markerSymbol.release() );
+
+    layers.append( arrowLayer.release() );
 
     std::unique_ptr< QgsSimpleLineSymbolLayer > topLayer = std::make_unique< QgsSimpleLineSymbolLayer >();
     topLayer->setWidth( 0.4 );

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -22,6 +22,9 @@
 #include "qgis_app.h"
 #include "qgsgeometry.h"
 #include "qobjectuniqueptr.h"
+#include "qgssettingsentryimpl.h"
+
+#include <QWidgetAction>
 
 class QgsDockableWidgetHelper;
 class QgsMapCanvas;
@@ -35,11 +38,16 @@ class QgsRubberBand;
 class QgsPlotToolPan;
 class QgsPlotToolZoom;
 class QgsPlotToolXAxisZoom;
+class QgsDoubleSpinBox;
+class QgsElevationProfileWidgetSettingsAction;
 
 class QgsElevationProfileWidget : public QWidget
 {
     Q_OBJECT
   public:
+
+    static const inline QgsSettingsEntryDouble settingTolerance = QgsSettingsEntryDouble( QStringLiteral( "tolerance" ), QgsSettings::Prefix::ELEVATION_PROFILE, 10, QStringLiteral( "Tolerance distance for elevation profile plots" ), Qgis::SettingsOptions(), 0 );
+
     QgsElevationProfileWidget( const QString &name );
     ~QgsElevationProfileWidget();
 
@@ -95,6 +103,23 @@ class QgsElevationProfileWidget : public QWidget
     QgsPlotToolPan *mPanTool = nullptr;
     QgsPlotToolXAxisZoom *mXAxisZoomTool = nullptr;
     QgsPlotToolZoom *mZoomTool = nullptr;
+
+    QgsElevationProfileWidgetSettingsAction *mSettingsAction = nullptr;
+};
+
+
+class QgsElevationProfileWidgetSettingsAction: public QWidgetAction
+{
+    Q_OBJECT
+
+  public:
+
+    QgsElevationProfileWidgetSettingsAction( QWidget *parent = nullptr );
+
+    QgsDoubleSpinBox *toleranceSpinBox() { return mToleranceWidget; }
+
+  private:
+    QgsDoubleSpinBox *mToleranceWidget = nullptr;
 };
 
 #endif // QGSELEVATIONPROFILEWIDGET_H

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -46,7 +46,7 @@ class QgsElevationProfileWidget : public QWidget
     Q_OBJECT
   public:
 
-    static const inline QgsSettingsEntryDouble settingTolerance = QgsSettingsEntryDouble( QStringLiteral( "tolerance" ), QgsSettings::Prefix::ELEVATION_PROFILE, 10, QStringLiteral( "Tolerance distance for elevation profile plots" ), Qgis::SettingsOptions(), 0 );
+    static const inline QgsSettingsEntryDouble settingTolerance = QgsSettingsEntryDouble( QStringLiteral( "tolerance" ), QgsSettings::Prefix::ELEVATION_PROFILE, 0.1, QStringLiteral( "Tolerance distance for elevation profile plots" ), Qgis::SettingsOptions(), 0 );
 
     QgsElevationProfileWidget( const QString &name );
     ~QgsElevationProfileWidget();
@@ -95,10 +95,11 @@ class QgsElevationProfileWidget : public QWidget
 
     QObjectUniquePtr<QgsRubberBand> mMapPointRubberBand;
     QObjectUniquePtr<QgsRubberBand> mRubberBand;
+    QObjectUniquePtr<QgsRubberBand> mToleranceRubberBand;
 
     QTimer *mSetCurveTimer = nullptr;
     bool mUpdateScheduled = false;
-    QgsRubberBand *createRubberBand();
+    void createOrUpdateRubberBands();
 
     QgsPlotToolPan *mPanTool = nullptr;
     QgsPlotToolXAxisZoom *mXAxisZoomTool = nullptr;

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -23,6 +23,7 @@
 #include "georeferencer/qgsgeorefmainwindow.h"
 #include "georeferencer/qgstransformsettingsdialog.h"
 #include "vertextool/qgsvertexeditor.h"
+#include "elevation/qgselevationprofilewidget.h"
 
 QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   : QgsSettingsRegistry()
@@ -44,6 +45,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   addSettingsEntry( &QgsTransformSettingsDialog::settingLastPdfFolder );
 
   addSettingsEntry( &QgsVertexEditor::settingAutoPopupVertexEditorDock );
+
+  addSettingsEntry( &QgsElevationProfileWidget::settingTolerance );
 
   QgsApplication::settingsRegistryCore()->addSubRegistry( this );
 }

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -103,6 +103,7 @@ class CORE_EXPORT QgsSettings : public QObject
         static const inline char *QGIS_DIGITIZING_SHAPEMAPTOOLS = "qgis/digitizing/shape-map-tools";
         static const inline char *QGIS_NETWORKANDPROXY = "qgis/networkAndProxy";
         static const inline char *SVG = "svg";
+        static const inline char *ELEVATION_PROFILE = "elevation-profile";
         static const inline char *CORE_LAYERTREE = "core/layer-tree";
     };
 

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -512,6 +512,7 @@ void QgsElevationProfileCanvas::refresh()
 
   QgsProfileRequest request( profileCurve()->clone() );
   request.setCrs( mCrs );
+  request.setTolerance( mTolerance );
   request.setTransformContext( mProject->transformContext() );
   request.setTerrainProvider( mProject->elevationProperties()->terrainProvider() ? mProject->elevationProperties()->terrainProvider()->clone() : nullptr );
   QgsExpressionContext context;
@@ -577,6 +578,11 @@ void QgsElevationProfileCanvas::setProfileCurve( QgsCurve *curve )
 QgsCurve *QgsElevationProfileCanvas::profileCurve() const
 {
   return mProfileCurve.get();
+}
+
+void QgsElevationProfileCanvas::setTolerance( double tolerance )
+{
+  mTolerance = tolerance;
 }
 
 QgsCoordinateReferenceSystem QgsElevationProfileCanvas::crs() const

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -134,6 +134,28 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsCurve *profileCurve() const;
 
     /**
+     * Sets the profile tolerance (in crs() units).
+     *
+     * This value determines how far from the profileCurve() is appropriate for inclusion of results. For instance,
+     * when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+     * actual profile curve a point can reside within to be included in the results.
+     *
+     * \see tolerance()
+     */
+    void setTolerance( double tolerance );
+
+    /**
+     * Returns the tolerance of the profile (in crs() units).
+     *
+     * This value determines how far from the profileCurve() is appropriate for inclusion of results. For instance,
+     * when a profile is generated for a point vector layer this tolerance distance will dictate how far from the
+     * actual profile curve a point can reside within to be included in the results.
+     *
+     * \see setTolerance()
+     */
+    double tolerance() const { return mTolerance; }
+
+    /**
      * Sets the visible area of the plot.
      */
     void setVisiblePlotRange( double minimumDistance, double maximumDistance, double minimumElevation, double maximumElevation );
@@ -208,6 +230,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsProfilePlotRenderer *mCurrentJob = nullptr;
 
     std::unique_ptr< QgsCurve > mProfileCurve;
+    double mTolerance = 0;
 
     bool mFirstDrawOccurred = false;
 


### PR DESCRIPTION
Allows users to control the tolerance distance for points (and point cloud features) to be included on an elevation profile plot.

![Peek 2022-04-20 06-50](https://user-images.githubusercontent.com/1829991/164093493-ad7ee6f4-9d65-47b4-81ec-755d01e2ef3a.gif)

