### PR TITLE
Use shorter "Offset" label for terrain in 3D Map settings

### DIFF
--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -379,6 +379,8 @@ void Qgs3DMapConfigWidget::onTerrainTypeChanged()
 
   labelTerrainResolution->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   spinTerrainResolution->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
+  labelTerrainScale->setVisible( !( genType == QgsTerrainGenerator::Flat ) );
+  spinTerrainScale->setVisible( !( genType == QgsTerrainGenerator::Flat ) );
   labelTerrainSkirtHeight->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   spinTerrainSkirtHeight->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   labelTerrainLayer->setVisible( genType == QgsTerrainGenerator::Dem || genType == QgsTerrainGenerator::Mesh );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -379,8 +379,8 @@ void Qgs3DMapConfigWidget::onTerrainTypeChanged()
 
   labelTerrainResolution->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   spinTerrainResolution->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
-  labelTerrainScale->setVisible( !( genType == QgsTerrainGenerator::Flat ) );
-  spinTerrainScale->setVisible( !( genType == QgsTerrainGenerator::Flat ) );
+  labelTerrainScale->setVisible( genType != QgsTerrainGenerator::Flat );
+  spinTerrainScale->setVisible( genType != QgsTerrainGenerator::Flat );
   labelTerrainSkirtHeight->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   spinTerrainSkirtHeight->setVisible( !( genType == QgsTerrainGenerator::Flat || genType == QgsTerrainGenerator::Mesh ) );
   labelTerrainLayer->setVisible( genType == QgsTerrainGenerator::Dem || genType == QgsTerrainGenerator::Mesh );

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -328,9 +328,9 @@
                    </widget>
                   </item>
                   <item row="5" column="0">
-                   <widget class="QLabel" name="label_12">
+                   <widget class="QLabel" name="labelterrainElevationOffset">
                     <property name="text">
-                     <string>Terrain elevation offset</string>
+                     <string>Offset</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
same as in project properties
Also for flat terrain, we have "Terrain height" in project properties ~~vs "vertical scale" + "terrain elevation offset" in 3D Map setting.  ~~Not sure of the scale use here,~~ (Hidden, now) and are the two others the same?