### PR TITLE
[MetaSearch] fix CSW search when user/passwords are empty (Fix #48201)

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -863,8 +863,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
                 cat = get_catalog_service(self.catalog_url,  # spellok
                                           catalog_type=self.catalog_type,
                                           timeout=self.timeout,
-                                          username=self.catalog_username,
-                                          password=self.catalog_password,
+                                          username=self.catalog_username or None,
+                                          password=self.catalog_password or None,
                                           auth=auth)
                 record = cat.get_record(identifier)
                 if cat.type == 'OGC API - Records':
@@ -957,8 +957,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             try:
                 self.catalog = get_catalog_service(
                     self.catalog_url, catalog_type=self.catalog_type,
-                    timeout=self.timeout, username=self.catalog_username,
-                    password=self.catalog_password, auth=auth)
+                    timeout=self.timeout, username=self.catalog_username or None,
+                    password=self.catalog_password or None, auth=auth)
                 return True
             except Exception as err:
                 msg = self.tr('Error connecting to service: {0}').format(err)

--- a/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
+++ b/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
@@ -94,8 +94,14 @@ class NewConnectionDialog(QDialog, BASE_CLASS):
             self.settings.setValue(keyurl, conn_url)
             self.settings.setValue('/MetaSearch/selected', conn_name)
 
-            self.settings.setValue('%s/username' % key, conn_username)
-            self.settings.setValue('%s/password' % key, conn_password)
+            if conn_username != '':
+                self.settings.setValue('%s/username' % key, conn_username)
+            else:
+                self.settings.remove('%s/username' % key)
+            if conn_password != '':
+                self.settings.setValue('%s/password' % key, conn_password)
+            else:
+                self.settings.remove('%s/password' % key)
 
             self.settings.setValue('%s/catalog-type' % key, conn_catalog_type)
 


### PR DESCRIPTION
## Description

Avoids to store username and password values for CSW catalog services if they are empty. Otherwise the search request (through oswlib via requests) will contain an "Authorization" header with empty username and password that will make the request to be rejected by some servers (an unintended adverse side effect of https://github.com/qgis/QGIS/pull/42780).

Fixes #48201

I think this should be backported to 3.22 and 3.24 branches (although it is possible that the automatic backports will fail).

What do you think @tomkralidis?
Could it be better to put the changes of the commit "[[MetaSearch] avoid to send username/passwords if empty](https://github.com/qgis/QGIS/pull/48288/commits/394dd83f000ee82ee00042cf6adaca287f3b967f)" directly in `get_catalog_service`?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
