### PR TITLE
Force legend node pixmap as icon to be correctly displayed

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1530,6 +1530,9 @@ QVariant QgsLayerTreeModel::legendNodeData( QgsLayerTreeModelLegendNode *node, i
 {
   if ( role == Qt::CheckStateRole && !testFlag( AllowLegendChangeState ) )
     return QVariant();
+  else if ( role == Qt::DecorationRole )
+    return QIcon( qvariant_cast<QPixmap>( node->data( Qt::DecorationRole ) ) );
+
   return node->data( role );
 }
 


### PR DESCRIPTION
Fixes #38606

This is identical to what is done in [QgsLayerTreeModel::legendIconEmbeddedInParent](https://github.com/qgis/QGIS/blob/master/src/core/layertree/qgslayertreemodel.cpp#L1562)

| Before fix | After fix |
| --- | --- |
| ![w_bug](https://user-images.githubusercontent.com/14358135/164236137-3f8fe267-a94f-4175-bdaa-a0b7bf2c6e9a.png) | ![wo_bug](https://user-images.githubusercontent.com/14358135/164236140-f7b15c69-9b0c-47e5-89b4-2b4136ee117a.png) |

**Funded by** Metropole Européenne de Lille 
