### PR TITLE
[MetaSearch] Fix error navigating the search results (Fix #48290)

### DIFF
--- a/python/plugins/MetaSearch/search_backend.py
+++ b/python/plugins/MetaSearch/search_backend.py
@@ -96,6 +96,8 @@ class CSW202Search(SearchBase):
 
     def query_records(self, bbox=[], keywords=None, limit=10, offset=1):
 
+        self.constraints = []
+
         # only apply spatial filter if bbox is not global
         # even for a global bbox, if a spatial filter is applied, then
         # the CSW server will skip records without a bbox


### PR DESCRIPTION
## Description

Fixes the "Search error: list object has no attribute 'toXML'" error that occurs navigating the search results after the second time the navigation buttons are pressed.

Fixes https://github.com/qgis/QGIS/issues/48290

I think this PR needs to be backported to the 3.24 branch (the 3.22 branch is not affected by the issue).

Current incorrect behaviour QGIS 3.24.2 - QGIS 3.25.0-Master (https://github.com/qgis/QGIS/commit/6ea5ffb270515b6ed968a355fe57809ecbf85f69)

https://user-images.githubusercontent.com/16253859/164258229-16d3c9c0-81f3-421d-aa1e-540d3553a7a0.mp4

New correct behaviour 

https://user-images.githubusercontent.com/16253859/164385859-8d984348-5c89-44da-8c76-1dbc295c28e1.mp4


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
