### PR TITLE
Feature - Scalebar Data Defined Overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ python/plugins/processing/tests/testdata/custom/*.aux.xml
 python/plugins/processing/tests/testdata/*.aux.xml
 Thumb.db
 Testing/*
+.cache/
+compile_commands.json

--- a/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -136,6 +136,41 @@ Sets the number of scalebar ``units`` per segment.
 .. seealso:: :py:func:`unitsPerSegment`
 %End
 
+    void refreshUnitsPerSegment( const QgsExpressionContext *context = 0 );
+%Docstring
+Recalculates the number of scalebar units per segment
+
+:param context: for evaluating data defined units per segment
+%End
+
+    void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = 0 );
+%Docstring
+Recalculates the number of segments to the left of 0.
+
+:param context: for evaluating data defined number of segments to the left.
+%End
+
+    void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = 0 );
+%Docstring
+Recalculates the number of segments to the right of 0.
+
+:param context: for evaluating data defined number of segments to the left.
+%End
+
+    void refreshMinimumBarWidth( const QgsExpressionContext *context = 0 );
+%Docstring
+Recalculates the minimum size of a bar segment in mm.
+
+:param context: for evaluating data defined minimum width of a segment.
+%End
+
+    void refreshMaximumBarWidth( const QgsExpressionContext *context = 0 );
+%Docstring
+Recalculates the maximum size of a bar segment in mm.
+
+:param context: for evaluating data defined maximum width of a segment.
+%End
+
     QgsScaleBarSettings::SegmentSizeMode segmentSizeMode() const;
 %Docstring
 Returns the size mode for the scale bar segments.

--- a/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -136,41 +136,6 @@ Sets the number of scalebar ``units`` per segment.
 .. seealso:: :py:func:`unitsPerSegment`
 %End
 
-    void refreshUnitsPerSegment( const QgsExpressionContext *context = 0 );
-%Docstring
-Recalculates the number of scalebar units per segment
-
-:param context: for evaluating data defined units per segment
-%End
-
-    void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = 0 );
-%Docstring
-Recalculates the number of segments to the left of 0.
-
-:param context: for evaluating data defined number of segments to the left.
-%End
-
-    void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = 0 );
-%Docstring
-Recalculates the number of segments to the right of 0.
-
-:param context: for evaluating data defined number of segments to the left.
-%End
-
-    void refreshMinimumBarWidth( const QgsExpressionContext *context = 0 );
-%Docstring
-Recalculates the minimum size of a bar segment in mm.
-
-:param context: for evaluating data defined minimum width of a segment.
-%End
-
-    void refreshMaximumBarWidth( const QgsExpressionContext *context = 0 );
-%Docstring
-Recalculates the maximum size of a bar segment in mm.
-
-:param context: for evaluating data defined maximum width of a segment.
-%End
-
     QgsScaleBarSettings::SegmentSizeMode segmentSizeMode() const;
 %Docstring
 Returns the size mode for the scale bar segments.

--- a/python/core/auto_generated/layout/qgslayoutobject.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutobject.sip.in
@@ -165,6 +165,11 @@ A base class for objects which belong to a layout.
       LegendTitle,
       LegendColumnCount,
       //scalebar item
+      ScalebarLeftSegments,
+      ScalebarRightSegments,
+      ScalebarSegmentWidth,
+      ScalebarMinWidth,
+      ScalebarMaxWidth,
       ScalebarFillColor,
       ScalebarFillColor2,
       ScalebarLineColor,

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -372,7 +372,6 @@ void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *
       QgsMessageLog::logMessage( tr( "Scalebar maximum segment width expression eval error" ) );
     }
   }
-
   setMaximumBarWidth( maximumBarWidth );
 }
 
@@ -492,6 +491,7 @@ void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::D
   {
     refreshItemSize();
     update();
+    emit changed();
   }
 
   QgsLayoutItem::refreshDataDefinedProperty( property );

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -301,10 +301,10 @@ void QgsLayoutItemScaleBar::refreshUnitsPerSegment( const QgsExpressionContext *
 
   mHasExpressionError = false;
 
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarSegmentWidth ) )
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarSegmentWidth ) )
   {
     bool ok = false;
-    unitsPerSegment = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarSegmentWidth, *evalContext, unitsPerSegment, &ok);
+    unitsPerSegment = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarSegmentWidth, *evalContext, unitsPerSegment, &ok );
 
     if ( !ok )
     {
@@ -315,7 +315,7 @@ void QgsLayoutItemScaleBar::refreshUnitsPerSegment( const QgsExpressionContext *
     }
   }
 
-  setUnitsPerSegment(unitsPerSegment);
+  setUnitsPerSegment( unitsPerSegment );
 }
 
 void QgsLayoutItemScaleBar::refreshMinimumBarWidth( const QgsExpressionContext *context )
@@ -325,15 +325,15 @@ void QgsLayoutItemScaleBar::refreshMinimumBarWidth( const QgsExpressionContext *
 
   mDataDefinedProperties.prepare( *evalContext );
 
-    //mSettings.setMinimumBarWidth( minWidth );
+  //mSettings.setMinimumBarWidth( minWidth );
   double minimumBarWidth = mSettings.minimumBarWidth();
 
   mHasExpressionError = false;
 
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMinWidth ) )
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarMinWidth ) )
   {
     bool ok = false;
-    minimumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMinWidth, *evalContext, minimumBarWidth, &ok);
+    minimumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMinWidth, *evalContext, minimumBarWidth, &ok );
 
     if ( !ok )
     {
@@ -354,15 +354,15 @@ void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *
 
   mDataDefinedProperties.prepare( *evalContext );
 
-    //mSettings.setMinimumBarWidth( minWidth );
+  //mSettings.setMinimumBarWidth( minWidth );
   double maximumBarWidth = mSettings.maximumBarWidth();
 
   mHasExpressionError = false;
 
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMaxWidth ) )
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarMaxWidth ) )
   {
     bool ok = false;
-    maximumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMaxWidth, *evalContext, maximumBarWidth, &ok);
+    maximumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMaxWidth, *evalContext, maximumBarWidth, &ok );
 
     if ( !ok )
     {
@@ -375,7 +375,7 @@ void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *
   setMaximumBarWidth( maximumBarWidth );
 }
 
-void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft(const QgsExpressionContext *context)
+void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft( const QgsExpressionContext *context )
 {
   const QgsExpressionContext scopedContext = createExpressionContext();
   const QgsExpressionContext *evalContext = context ? context : &scopedContext;
@@ -386,10 +386,10 @@ void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft(const QgsExpressionConte
 
   mHasExpressionError = false;
 
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarLeftSegments ) )
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarLeftSegments ) )
   {
     bool ok = false;
-    leftSegments = mDataDefinedProperties.valueAsInt(QgsLayoutObject::ScalebarLeftSegments, *evalContext, leftSegments, &ok);
+    leftSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarLeftSegments, *evalContext, leftSegments, &ok );
 
     if ( !ok )
     {
@@ -400,10 +400,10 @@ void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft(const QgsExpressionConte
     }
   }
 
-  setNumberOfSegmentsLeft(leftSegments);
+  setNumberOfSegmentsLeft( leftSegments );
 }
 
-void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight(const QgsExpressionContext *context)
+void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight( const QgsExpressionContext *context )
 {
   const QgsExpressionContext scopedContext = createExpressionContext();
   const QgsExpressionContext *evalContext = context ? context : &scopedContext;
@@ -414,10 +414,10 @@ void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight(const QgsExpressionCont
 
   mHasExpressionError = false;
 
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarRightSegments ) )
+  if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarRightSegments ) )
   {
     bool ok = false;
-    rightSegments = mDataDefinedProperties.valueAsInt(QgsLayoutObject::ScalebarRightSegments, *evalContext, rightSegments, &ok);
+    rightSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarRightSegments, *evalContext, rightSegments, &ok );
 
     if ( !ok )
     {
@@ -428,7 +428,7 @@ void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight(const QgsExpressionCont
     }
   }
 
-  setNumberOfSegments(rightSegments);
+  setNumberOfSegments( rightSegments );
 }
 
 void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property )
@@ -437,31 +437,31 @@ void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::D
 
   bool forceUpdate = false;
 
-  if (property == QgsLayoutObject::ScalebarLeftSegments || property == QgsLayoutObject::AllProperties)
+  if ( property == QgsLayoutObject::ScalebarLeftSegments || property == QgsLayoutObject::AllProperties )
   {
     refreshNumberOfSegmentsLeft( &context );
     forceUpdate = true;
   }
 
-  if (property == QgsLayoutObject::ScalebarRightSegments || property == QgsLayoutObject::AllProperties)
+  if ( property == QgsLayoutObject::ScalebarRightSegments || property == QgsLayoutObject::AllProperties )
   {
     refreshNumberOfSegmentsRight( &context );
     forceUpdate = true;
   }
 
-  if (property == QgsLayoutObject::ScalebarSegmentWidth || property == QgsLayoutObject::AllProperties)
+  if ( property == QgsLayoutObject::ScalebarSegmentWidth || property == QgsLayoutObject::AllProperties )
   {
     refreshUnitsPerSegment( &context );
     forceUpdate = true;
   }
 
-  if (property == QgsLayoutObject::ScalebarMinWidth || property == QgsLayoutObject::AllProperties)
+  if ( property == QgsLayoutObject::ScalebarMinWidth || property == QgsLayoutObject::AllProperties )
   {
     refreshMinimumBarWidth( &context );
     forceUpdate = true;
   }
 
-  if (property == QgsLayoutObject::ScalebarMaxWidth || property == QgsLayoutObject::AllProperties)
+  if ( property == QgsLayoutObject::ScalebarMaxWidth || property == QgsLayoutObject::AllProperties )
   {
     refreshMaximumBarWidth( &context );
     forceUpdate = true;

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -139,91 +139,6 @@ void QgsLayoutItemScaleBar::setUnitsPerSegment( double units )
   resizeToMinimumWidth();
 }
 
-void QgsLayoutItemScaleBar::refreshUnitsPerSegment( const QgsExpressionContext *context )
-{
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  double unitsPerSegment = mSettings.unitsPerSegment();
-
-  mHasExpressionError = false;
-
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarSegmentWidth ) )
-  {
-    bool ok = false;
-    unitsPerSegment = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarSegmentWidth, *evalContext, unitsPerSegment, &ok);
-
-    if ( !ok )
-    {
-      mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      unitsPerSegment = 100.0;
-      QgsMessageLog::logMessage( tr( "Scalebar units per segment expression eval error" ) );
-    }
-  }
-
-  setUnitsPerSegment(unitsPerSegment);
-}
-
-void QgsLayoutItemScaleBar::refreshMinimumBarWidth( const QgsExpressionContext *context )
-{
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-    //mSettings.setMinimumBarWidth( minWidth );
-  double minimumBarWidth = mSettings.minimumBarWidth();
-
-  mHasExpressionError = false;
-
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMinWidth ) )
-  {
-    bool ok = false;
-    minimumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMinWidth, *evalContext, minimumBarWidth, &ok);
-
-    if ( !ok )
-    {
-      mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      minimumBarWidth = 50.0;
-      QgsMessageLog::logMessage( tr( "Scalebar minimum segment width expression eval error" ) );
-    }
-  }
-
-  setMinimumBarWidth( minimumBarWidth );
-}
-
-void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *context )
-{
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-    //mSettings.setMinimumBarWidth( minWidth );
-  double maximumBarWidth = mSettings.maximumBarWidth();
-
-  mHasExpressionError = false;
-
-  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMaxWidth ) )
-  {
-    bool ok = false;
-    maximumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMaxWidth, *evalContext, maximumBarWidth, &ok);
-
-    if ( !ok )
-    {
-      mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      maximumBarWidth = 150.0;
-      QgsMessageLog::logMessage( tr( "Scalebar maximum segment width expression eval error" ) );
-    }
-  }
-
-  setMaximumBarWidth( maximumBarWidth );
-}
 
 void QgsLayoutItemScaleBar::setSegmentSizeMode( QgsScaleBarSettings::SegmentSizeMode mode )
 {
@@ -373,6 +288,148 @@ void QgsLayoutItemScaleBar::disconnectCurrentMap()
   disconnect( mMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemScaleBar::updateScale );
   disconnect( mMap, &QObject::destroyed, this, &QgsLayoutItemScaleBar::disconnectCurrentMap );
   mMap = nullptr;
+}
+
+void QgsLayoutItemScaleBar::refreshUnitsPerSegment( const QgsExpressionContext *context )
+{
+  const QgsExpressionContext scopedContext = createExpressionContext();
+  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
+
+  mDataDefinedProperties.prepare( *evalContext );
+
+  double unitsPerSegment = mSettings.unitsPerSegment();
+
+  mHasExpressionError = false;
+
+  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarSegmentWidth ) )
+  {
+    bool ok = false;
+    unitsPerSegment = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarSegmentWidth, *evalContext, unitsPerSegment, &ok);
+
+    if ( !ok )
+    {
+      mHasExpressionError = true;
+      // TODO: find out how to get actual default value
+      unitsPerSegment = 100.0;
+      QgsMessageLog::logMessage( tr( "Scalebar units per segment expression eval error" ) );
+    }
+  }
+
+  setUnitsPerSegment(unitsPerSegment);
+}
+
+void QgsLayoutItemScaleBar::refreshMinimumBarWidth( const QgsExpressionContext *context )
+{
+  const QgsExpressionContext scopedContext = createExpressionContext();
+  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
+
+  mDataDefinedProperties.prepare( *evalContext );
+
+    //mSettings.setMinimumBarWidth( minWidth );
+  double minimumBarWidth = mSettings.minimumBarWidth();
+
+  mHasExpressionError = false;
+
+  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMinWidth ) )
+  {
+    bool ok = false;
+    minimumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMinWidth, *evalContext, minimumBarWidth, &ok);
+
+    if ( !ok )
+    {
+      mHasExpressionError = true;
+      // TODO: find out how to get actual default value
+      minimumBarWidth = 50.0;
+      QgsMessageLog::logMessage( tr( "Scalebar minimum segment width expression eval error" ) );
+    }
+  }
+
+  setMinimumBarWidth( minimumBarWidth );
+}
+
+void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *context )
+{
+  const QgsExpressionContext scopedContext = createExpressionContext();
+  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
+
+  mDataDefinedProperties.prepare( *evalContext );
+
+    //mSettings.setMinimumBarWidth( minWidth );
+  double maximumBarWidth = mSettings.maximumBarWidth();
+
+  mHasExpressionError = false;
+
+  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarMaxWidth ) )
+  {
+    bool ok = false;
+    maximumBarWidth = mDataDefinedProperties.valueAsDouble(QgsLayoutObject::ScalebarMaxWidth, *evalContext, maximumBarWidth, &ok);
+
+    if ( !ok )
+    {
+      mHasExpressionError = true;
+      // TODO: find out how to get actual default value
+      maximumBarWidth = 150.0;
+      QgsMessageLog::logMessage( tr( "Scalebar maximum segment width expression eval error" ) );
+    }
+  }
+
+  setMaximumBarWidth( maximumBarWidth );
+}
+
+void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft(const QgsExpressionContext *context)
+{
+  const QgsExpressionContext scopedContext = createExpressionContext();
+  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
+
+  mDataDefinedProperties.prepare( *evalContext );
+
+  int leftSegments = mSettings.numberOfSegmentsLeft();
+
+  mHasExpressionError = false;
+
+  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarLeftSegments ) )
+  {
+    bool ok = false;
+    leftSegments = mDataDefinedProperties.valueAsInt(QgsLayoutObject::ScalebarLeftSegments, *evalContext, leftSegments, &ok);
+
+    if ( !ok )
+    {
+      mHasExpressionError = true;
+      // TODO: find out how to get actual default value
+      leftSegments = 0;
+      QgsMessageLog::logMessage( tr( "Scalebar left segment count expression eval error" ) );
+    }
+  }
+
+  setNumberOfSegmentsLeft(leftSegments);
+}
+
+void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight(const QgsExpressionContext *context)
+{
+  const QgsExpressionContext scopedContext = createExpressionContext();
+  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
+
+  mDataDefinedProperties.prepare( *evalContext );
+
+  int rightSegments = mSettings.numberOfSegments();
+
+  mHasExpressionError = false;
+
+  if ( mDataDefinedProperties.isActive(QgsLayoutObject::ScalebarRightSegments ) )
+  {
+    bool ok = false;
+    rightSegments = mDataDefinedProperties.valueAsInt(QgsLayoutObject::ScalebarRightSegments, *evalContext, rightSegments, &ok);
+
+    if ( !ok )
+    {
+      mHasExpressionError = true;
+      // TODO: find out how to get actual default value
+      rightSegments = 2;
+      QgsMessageLog::logMessage( tr( "Scalebar left segment count expression eval error" ) );
+    }
+  }
+
+  setNumberOfSegments(rightSegments);
 }
 
 void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property )
@@ -991,6 +1048,7 @@ bool QgsLayoutItemScaleBar::writePropertiesToElement( QDomElement &composerScale
 
   return true;
 }
+
 
 bool QgsLayoutItemScaleBar::readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &, const QgsReadWriteContext &context )
 {

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -292,143 +292,112 @@ void QgsLayoutItemScaleBar::disconnectCurrentMap()
 
 void QgsLayoutItemScaleBar::refreshUnitsPerSegment( const QgsExpressionContext *context )
 {
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  double unitsPerSegment = mSettings.unitsPerSegment();
-
-  mHasExpressionError = false;
-
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarSegmentWidth ) )
   {
+    mDataDefinedProperties.prepare( *context );
+
+    double unitsPerSegment = mSettings.unitsPerSegment();
+
+    mHasExpressionError = false;
+
     bool ok = false;
-    unitsPerSegment = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarSegmentWidth, *evalContext, unitsPerSegment, &ok );
+    unitsPerSegment = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarSegmentWidth, *context, unitsPerSegment, &ok );
 
     if ( !ok )
     {
       mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      unitsPerSegment = 100.0;
       QgsMessageLog::logMessage( tr( "Scalebar units per segment expression eval error" ) );
     }
+    setUnitsPerSegment( unitsPerSegment );
   }
-
-  setUnitsPerSegment( unitsPerSegment );
 }
 
 void QgsLayoutItemScaleBar::refreshMinimumBarWidth( const QgsExpressionContext *context )
 {
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  //mSettings.setMinimumBarWidth( minWidth );
-  double minimumBarWidth = mSettings.minimumBarWidth();
-
-  mHasExpressionError = false;
-
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarMinWidth ) )
   {
+    mDataDefinedProperties.prepare( *context );
+
+    double minimumBarWidth = mSettings.minimumBarWidth();
+
+    mHasExpressionError = false;
+
     bool ok = false;
-    minimumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMinWidth, *evalContext, minimumBarWidth, &ok );
+    minimumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMinWidth, *context, minimumBarWidth, &ok );
 
     if ( !ok )
     {
       mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      minimumBarWidth = 50.0;
       QgsMessageLog::logMessage( tr( "Scalebar minimum segment width expression eval error" ) );
     }
+    setMinimumBarWidth( minimumBarWidth );
   }
-
-  setMinimumBarWidth( minimumBarWidth );
 }
 
 void QgsLayoutItemScaleBar::refreshMaximumBarWidth( const QgsExpressionContext *context )
 {
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  //mSettings.setMinimumBarWidth( minWidth );
-  double maximumBarWidth = mSettings.maximumBarWidth();
-
-  mHasExpressionError = false;
-
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarMaxWidth ) )
   {
+    mDataDefinedProperties.prepare( *context );
+
+    double maximumBarWidth = mSettings.maximumBarWidth();
+
+    mHasExpressionError = false;
+
     bool ok = false;
-    maximumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMaxWidth, *evalContext, maximumBarWidth, &ok );
+    maximumBarWidth = mDataDefinedProperties.valueAsDouble( QgsLayoutObject::ScalebarMaxWidth, *context, maximumBarWidth, &ok );
 
     if ( !ok )
     {
       mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      maximumBarWidth = 150.0;
       QgsMessageLog::logMessage( tr( "Scalebar maximum segment width expression eval error" ) );
     }
+    setMaximumBarWidth( maximumBarWidth );
   }
-  setMaximumBarWidth( maximumBarWidth );
 }
 
 void QgsLayoutItemScaleBar::refreshNumberOfSegmentsLeft( const QgsExpressionContext *context )
 {
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  int leftSegments = mSettings.numberOfSegmentsLeft();
-
-  mHasExpressionError = false;
-
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarLeftSegments ) )
   {
+    mDataDefinedProperties.prepare( *context );
+
+    int leftSegments = mSettings.numberOfSegmentsLeft();
+
+    mHasExpressionError = false;
+
     bool ok = false;
-    leftSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarLeftSegments, *evalContext, leftSegments, &ok );
+    leftSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarLeftSegments, *context, leftSegments, &ok );
 
     if ( !ok )
     {
       mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      leftSegments = 0;
       QgsMessageLog::logMessage( tr( "Scalebar left segment count expression eval error" ) );
     }
+    setNumberOfSegmentsLeft( leftSegments );
   }
-
-  setNumberOfSegmentsLeft( leftSegments );
 }
 
 void QgsLayoutItemScaleBar::refreshNumberOfSegmentsRight( const QgsExpressionContext *context )
 {
-  const QgsExpressionContext scopedContext = createExpressionContext();
-  const QgsExpressionContext *evalContext = context ? context : &scopedContext;
-
-  mDataDefinedProperties.prepare( *evalContext );
-
-  int rightSegments = mSettings.numberOfSegments();
-
-  mHasExpressionError = false;
-
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::ScalebarRightSegments ) )
   {
+    mDataDefinedProperties.prepare( *context );
+
+    int rightSegments = mSettings.numberOfSegments();
+
+    mHasExpressionError = false;
+
     bool ok = false;
-    rightSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarRightSegments, *evalContext, rightSegments, &ok );
+    rightSegments = mDataDefinedProperties.valueAsInt( QgsLayoutObject::ScalebarRightSegments, *context, rightSegments, &ok );
 
     if ( !ok )
     {
       mHasExpressionError = true;
-      // TODO: find out how to get actual default value
-      rightSegments = 2;
       QgsMessageLog::logMessage( tr( "Scalebar left segment count expression eval error" ) );
     }
+    setNumberOfSegments( rightSegments );
   }
-
-  setNumberOfSegments( rightSegments );
 }
 
 void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property )
@@ -491,7 +460,8 @@ void QgsLayoutItemScaleBar::refreshDataDefinedProperty( const QgsLayoutObject::D
   {
     refreshItemSize();
     update();
-    emit changed();
+    //FIXME: @nyall said this is not necessary
+    //emit changed();
   }
 
   QgsLayoutItem::refreshDataDefinedProperty( property );

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -132,7 +132,6 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
 
     /**
      * Recalculates the number of scalebar units per segment
-     * (if using an expression for the value)
      * \param expression context for evaluating data defined units per segment
      */
     void refreshUnitsPerSegment( const QgsExpressionContext *context = nullptr );
@@ -725,7 +724,6 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     QgsScaleBarRenderer::ScaleBarContext createScaleContext() const;
 
     friend class QgsCompositionConverter;
-
 };
 
 #endif //QGSLAYOUTITEMSCALEBAR_H

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -140,25 +140,25 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
      * Recalculates the number of segments to the left of 0.
      * \param expression context for evaluating data defined number of segments to the left.
      */
-    void refreshNumberOfSegmentsLeft ( const QgsExpressionContext *context = nullptr );
+    void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the number of segments to the right of 0.
      * \param expression context for evaluating data defined number of segments to the left.
      */
-    void refreshNumberOfSegmentsRight ( const QgsExpressionContext *context = nullptr );
+    void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the minimum size of a bar segment in mm.
      * \param expression context for evaluating data defined minimum width of a segment.
      */
-    void refreshMinimumBarWidth ( const QgsExpressionContext *context = nullptr );
+    void refreshMinimumBarWidth( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the maximum size of a bar segment in mm.
      * \param expression context for evaluating data defined maximum width of a segment.
      */
-    void refreshMaximumBarWidth ( const QgsExpressionContext *context = nullptr );
+    void refreshMaximumBarWidth( const QgsExpressionContext *context = nullptr );
 
     /**
      * Returns the size mode for the scale bar segments.

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -132,31 +132,31 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
 
     /**
      * Recalculates the number of scalebar units per segment
-     * \param expression context for evaluating data defined units per segment
+     * \param context for evaluating data defined units per segment
      */
     void refreshUnitsPerSegment( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the number of segments to the left of 0.
-     * \param expression context for evaluating data defined number of segments to the left.
+     * \param context for evaluating data defined number of segments to the left.
      */
     void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the number of segments to the right of 0.
-     * \param expression context for evaluating data defined number of segments to the left.
+     * \param context for evaluating data defined number of segments to the left.
      */
     void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the minimum size of a bar segment in mm.
-     * \param expression context for evaluating data defined minimum width of a segment.
+     * \param context for evaluating data defined minimum width of a segment.
      */
     void refreshMinimumBarWidth( const QgsExpressionContext *context = nullptr );
 
     /**
      * Recalculates the maximum size of a bar segment in mm.
-     * \param expression context for evaluating data defined maximum width of a segment.
+     * \param context for evaluating data defined maximum width of a segment.
      */
     void refreshMaximumBarWidth( const QgsExpressionContext *context = nullptr );
 

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -131,6 +131,37 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     void setUnitsPerSegment( double units );
 
     /**
+     * Recalculates the number of scalebar units per segment
+     * (if using an expression for the value)
+     * \param expression context for evaluating data defined units per segment
+     */
+    void refreshUnitsPerSegment( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the number of segments to the left of 0.
+     * \param expression context for evaluating data defined number of segments to the left.
+     */
+    void refreshNumberOfSegmentsLeft ( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the number of segments to the right of 0.
+     * \param expression context for evaluating data defined number of segments to the left.
+     */
+    void refreshNumberOfSegmentsRight ( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the minimum size of a bar segment in mm.
+     * \param expression context for evaluating data defined minimum width of a segment.
+     */
+    void refreshMinimumBarWidth ( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the maximum size of a bar segment in mm.
+     * \param expression context for evaluating data defined maximum width of a segment.
+     */
+    void refreshMaximumBarWidth ( const QgsExpressionContext *context = nullptr );
+
+    /**
      * Returns the size mode for the scale bar segments.
      * \see setSegmentSizeMode()
      * \see minimumBarWidth()
@@ -674,6 +705,8 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     //! Linked map
     QgsLayoutItemMap *mMap = nullptr;
     QString mMapUuid;
+
+    bool mHasExpressionError;
 
     QgsScaleBarSettings mSettings;
 

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -131,36 +131,6 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     void setUnitsPerSegment( double units );
 
     /**
-     * Recalculates the number of scalebar units per segment
-     * \param context for evaluating data defined units per segment
-     */
-    void refreshUnitsPerSegment( const QgsExpressionContext *context = nullptr );
-
-    /**
-     * Recalculates the number of segments to the left of 0.
-     * \param context for evaluating data defined number of segments to the left.
-     */
-    void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = nullptr );
-
-    /**
-     * Recalculates the number of segments to the right of 0.
-     * \param context for evaluating data defined number of segments to the left.
-     */
-    void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = nullptr );
-
-    /**
-     * Recalculates the minimum size of a bar segment in mm.
-     * \param context for evaluating data defined minimum width of a segment.
-     */
-    void refreshMinimumBarWidth( const QgsExpressionContext *context = nullptr );
-
-    /**
-     * Recalculates the maximum size of a bar segment in mm.
-     * \param context for evaluating data defined maximum width of a segment.
-     */
-    void refreshMaximumBarWidth( const QgsExpressionContext *context = nullptr );
-
-    /**
      * Returns the size mode for the scale bar segments.
      * \see setSegmentSizeMode()
      * \see minimumBarWidth()
@@ -724,6 +694,36 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
     QgsScaleBarRenderer::ScaleBarContext createScaleContext() const;
 
     friend class QgsCompositionConverter;
+
+    /**
+     * Recalculates the number of scalebar units per segment
+     * \param context for evaluating data defined units per segment
+     */
+    void refreshUnitsPerSegment( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the number of segments to the left of 0.
+     * \param context for evaluating data defined number of segments to the left.
+     */
+    void refreshNumberOfSegmentsLeft( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the number of segments to the right of 0.
+     * \param context for evaluating data defined number of segments to the left.
+     */
+    void refreshNumberOfSegmentsRight( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the minimum size of a bar segment in mm.
+     * \param context for evaluating data defined minimum width of a segment.
+     */
+    void refreshMinimumBarWidth( const QgsExpressionContext *context = nullptr );
+
+    /**
+     * Recalculates the maximum size of a bar segment in mm.
+     * \param context for evaluating data defined maximum width of a segment.
+     */
+    void refreshMaximumBarWidth( const QgsExpressionContext *context = nullptr );
 };
 
 #endif //QGSLAYOUTITEMSCALEBAR_H

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -101,9 +101,9 @@ void QgsLayoutObject::initPropertyDefinitions()
     { QgsLayoutObject::MapCrs, QgsPropertyDefinition( "dataDefinedCrs", QgsPropertyDefinition::DataTypeString, QObject::tr( "Map CRS" ), QObject::tr( "string representing a CRS, either an authority/id pair (e.g. \"EPSG:4326\"), a proj string prefixes by \"PROJ:\" (e.g. \"PROJ: +proj=...\") or a WKT string prefixed by \"WKT:\" (e.g. \"WKT:GEOGCS[\"WGS 84\"...)" ) ) },
     { QgsLayoutObject::StartDateTime, QgsPropertyDefinition( "dataDefinedStartDateTime", QObject::tr( "Temporal range start date / time" ), QgsPropertyDefinition::DateTime ) },
     { QgsLayoutObject::EndDateTime, QgsPropertyDefinition( "dataDefinedEndDateTime", QObject::tr( "Temporal range end date / time" ), QgsPropertyDefinition::DateTime ) },
-    { QgsLayoutObject::ScalebarLeftSegments, QgsPropertyDefinition ( "dataDefinedScaleBarLeftSegments", QObject::tr( "Segments to the left of 0" ), QgsPropertyDefinition::IntegerPositive )},
+    { QgsLayoutObject::ScalebarLeftSegments, QgsPropertyDefinition( "dataDefinedScaleBarLeftSegments", QObject::tr( "Segments to the left of 0" ), QgsPropertyDefinition::IntegerPositive )},
     { QgsLayoutObject::ScalebarRightSegments, QgsPropertyDefinition( "dataDefinedScaleBarRightSegments", QObject::tr( "Segments to the right of 0" ), QgsPropertyDefinition::IntegerPositive ) },
-    { QgsLayoutObject::ScalebarSegmentWidth, QgsPropertyDefinition( "dataDefinedScalebarSegmentWidth", QObject::tr( "Length of a segment in map units" ), QgsPropertyDefinition::DoublePositive) },
+    { QgsLayoutObject::ScalebarSegmentWidth, QgsPropertyDefinition( "dataDefinedScalebarSegmentWidth", QObject::tr( "Length of a segment in map units" ), QgsPropertyDefinition::DoublePositive ) },
     { QgsLayoutObject::ScalebarMinWidth, QgsPropertyDefinition( "dataDefinedScalebarMinWidth", QObject::tr( "Minimum length of a segment in mm" ), QgsPropertyDefinition::DoublePositive ) },
     { QgsLayoutObject::ScalebarMaxWidth, QgsPropertyDefinition( "dataDefinedScalebarMaxWidth", QObject::tr( "Maximum length of a segment in mm" ), QgsPropertyDefinition::DoublePositive ) },
   };

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -101,6 +101,11 @@ void QgsLayoutObject::initPropertyDefinitions()
     { QgsLayoutObject::MapCrs, QgsPropertyDefinition( "dataDefinedCrs", QgsPropertyDefinition::DataTypeString, QObject::tr( "Map CRS" ), QObject::tr( "string representing a CRS, either an authority/id pair (e.g. \"EPSG:4326\"), a proj string prefixes by \"PROJ:\" (e.g. \"PROJ: +proj=...\") or a WKT string prefixed by \"WKT:\" (e.g. \"WKT:GEOGCS[\"WGS 84\"...)" ) ) },
     { QgsLayoutObject::StartDateTime, QgsPropertyDefinition( "dataDefinedStartDateTime", QObject::tr( "Temporal range start date / time" ), QgsPropertyDefinition::DateTime ) },
     { QgsLayoutObject::EndDateTime, QgsPropertyDefinition( "dataDefinedEndDateTime", QObject::tr( "Temporal range end date / time" ), QgsPropertyDefinition::DateTime ) },
+    { QgsLayoutObject::ScalebarLeftSegments, QgsPropertyDefinition ( "dataDefinedScaleBarLeftSegments", QObject::tr( "Segments to the left of 0" ), QgsPropertyDefinition::IntegerPositive )},
+    { QgsLayoutObject::ScalebarRightSegments, QgsPropertyDefinition( "dataDefinedScaleBarRightSegments", QObject::tr( "Segments to the right of 0" ), QgsPropertyDefinition::IntegerPositive ) },
+    { QgsLayoutObject::ScalebarSegmentWidth, QgsPropertyDefinition( "dataDefinedScalebarSegmentWidth", QObject::tr( "Length of a segment in map units" ), QgsPropertyDefinition::DoublePositive) },
+    { QgsLayoutObject::ScalebarMinWidth, QgsPropertyDefinition( "dataDefinedScalebarMinWidth", QObject::tr( "Minimum length of a segment in mm" ), QgsPropertyDefinition::DoublePositive ) },
+    { QgsLayoutObject::ScalebarMaxWidth, QgsPropertyDefinition( "dataDefinedScalebarMaxWidth", QObject::tr( "Maximum length of a segment in mm" ), QgsPropertyDefinition::DoublePositive ) },
   };
 }
 
@@ -176,6 +181,11 @@ bool QgsLayoutObject::propertyAssociatesWithParentMultiframe( QgsLayoutObject::D
     case QgsLayoutObject::ScalebarFillColor2:
     case QgsLayoutObject::ScalebarLineColor:
     case QgsLayoutObject::ScalebarLineWidth:
+    case QgsLayoutObject::ScalebarLeftSegments:
+    case QgsLayoutObject::ScalebarRightSegments:
+    case QgsLayoutObject::ScalebarSegmentWidth:
+    case QgsLayoutObject::ScalebarMinWidth:
+    case QgsLayoutObject::ScalebarMaxWidth:
     case QgsLayoutObject::MapCrs:
     case QgsLayoutObject::StartDateTime:
     case QgsLayoutObject::EndDateTime:

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -193,6 +193,11 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
       LegendTitle, //!< Legend title
       LegendColumnCount, //!< Legend column count
       //scalebar item
+      ScalebarLeftSegments, //!< Number of segments on the left of 0
+      ScalebarRightSegments, //!< Number of segments on the right of 0
+      ScalebarSegmentWidth, //!< Scalebar width in map units of a single segment
+      ScalebarMinWidth, //!< Scalebar segment minimum width
+      ScalebarMaxWidth, //!< Scalebar segment maximum width
       ScalebarFillColor, //!< Scalebar fill color (deprecated, use data defined properties on scalebar fill symbol 1 instead)
       ScalebarFillColor2, //!< Scalebar secondary fill color (deprecated, use data defined properties on scalebar fill symbol 2 instead)
       ScalebarLineColor, //!< Scalebar line color (deprecated, use data defined properties on scalebar line symbol instead)

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -193,11 +193,11 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
       LegendTitle, //!< Legend title
       LegendColumnCount, //!< Legend column count
       //scalebar item
-      ScalebarLeftSegments, //!< Number of segments on the left of 0
-      ScalebarRightSegments, //!< Number of segments on the right of 0
-      ScalebarSegmentWidth, //!< Scalebar width in map units of a single segment
-      ScalebarMinWidth, //!< Scalebar segment minimum width
-      ScalebarMaxWidth, //!< Scalebar segment maximum width
+      ScalebarLeftSegments, //!< Number of segments on the left of 0 (since QGIS 3.26)
+      ScalebarRightSegments, //!< Number of segments on the right of 0 (since QGIS 3.26)
+      ScalebarSegmentWidth, //!< Scalebar width in map units of a single segment (since QGIS 3.26)
+      ScalebarMinWidth, //!< Scalebar segment minimum width (since QGIS 3.26)
+      ScalebarMaxWidth, //!< Scalebar segment maximum width (since QGIS 3.26)
       ScalebarFillColor, //!< Scalebar fill color (deprecated, use data defined properties on scalebar fill symbol 1 instead)
       ScalebarFillColor2, //!< Scalebar secondary fill color (deprecated, use data defined properties on scalebar fill symbol 2 instead)
       ScalebarLineColor, //!< Scalebar line color (deprecated, use data defined properties on scalebar line symbol instead)

--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -59,13 +59,13 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
 
   connect( mSegmentsLeftDDBtn, &QgsPropertyOverrideButton::activated, mSegmentsLeftSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsLeftDDBtn, QgsLayoutObject::ScalebarLeftSegments );
-  connect(mSegmentsRightDDBtn, &QgsPropertyOverrideButton::activated, mNumberOfSegmentsSpinBox, &QSpinBox::setDisabled );
+  connect( mSegmentsRightDDBtn, &QgsPropertyOverrideButton::activated, mNumberOfSegmentsSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsRightDDBtn, QgsLayoutObject::ScalebarRightSegments );
-  connect(mSegmentSizeDDBtn, &QgsPropertyOverrideButton::activated, mSegmentSizeSpinBox, &QDoubleSpinBox::setDisabled );
+  connect( mSegmentSizeDDBtn, &QgsPropertyOverrideButton::activated, mSegmentSizeSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentSizeDDBtn, QgsLayoutObject::ScalebarSegmentWidth );
-  connect(mMinWidthDDBtn, &QgsPropertyOverrideButton::activated, mMinWidthSpinBox, &QDoubleSpinBox::setDisabled );
+  connect( mMinWidthDDBtn, &QgsPropertyOverrideButton::activated, mMinWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMinWidthDDBtn, QgsLayoutObject::ScalebarMinWidth );
-  connect(mMaxWidthDDBtn, &QgsPropertyOverrideButton::activated, mMaxWidthSpinBox, &QDoubleSpinBox::setDisabled );
+  connect( mMaxWidthDDBtn, &QgsPropertyOverrideButton::activated, mMaxWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMaxWidthDDBtn, QgsLayoutObject::ScalebarMaxWidth );
 
   /*

--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -56,6 +56,13 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
   connect( mMinWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutScaleBarWidget::mMinWidthSpinBox_valueChanged );
   connect( mMaxWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutScaleBarWidget::mMaxWidthSpinBox_valueChanged );
   connect( mNumberFormatPushButton, &QPushButton::clicked, this, &QgsLayoutScaleBarWidget::changeNumberFormat );
+
+  registerDataDefinedButton( mSegmentsLeftDDBtn, QgsLayoutObject::ScalebarLeftSegments );
+  registerDataDefinedButton( mSegmentsRightDDBtn, QgsLayoutObject::ScalebarRightSegments );
+  registerDataDefinedButton( mSegmentSizeDDBtn, QgsLayoutObject::ScalebarSegmentWidth );
+  registerDataDefinedButton( mMinWidthDDBtn, QgsLayoutObject::ScalebarMinWidth );
+  registerDataDefinedButton( mMaxWidthDDBtn, QgsLayoutObject::ScalebarMaxWidth );
+
   setPanelTitle( tr( "Scalebar Properties" ) );
 
   mFontButton->registerExpressionContextGenerator( this );
@@ -780,4 +787,13 @@ void QgsLayoutScaleBarWidget::mMaxWidthSpinBox_valueChanged( double )
   mScalebar->update();
   connectUpdateSignal();
   mScalebar->endCommand();
+}
+
+void QgsLayoutScaleBarWidget::populateDataDefinedButtons()
+{
+  updateDataDefinedButton( mSegmentsLeftDDBtn );
+  updateDataDefinedButton( mSegmentsRightDDBtn );
+  updateDataDefinedButton( mSegmentSizeDDBtn );
+  updateDataDefinedButton( mMinWidthDDBtn );
+  updateDataDefinedButton( mMaxWidthDDBtn );
 }

--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -57,11 +57,24 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
   connect( mMaxWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutScaleBarWidget::mMaxWidthSpinBox_valueChanged );
   connect( mNumberFormatPushButton, &QPushButton::clicked, this, &QgsLayoutScaleBarWidget::changeNumberFormat );
 
+  connect( mSegmentsLeftDDBtn, &QgsPropertyOverrideButton::activated, mSegmentsLeftSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsLeftDDBtn, QgsLayoutObject::ScalebarLeftSegments );
+  connect(mSegmentsRightDDBtn, &QgsPropertyOverrideButton::activated, mNumberOfSegmentsSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsRightDDBtn, QgsLayoutObject::ScalebarRightSegments );
+  connect(mSegmentSizeDDBtn, &QgsPropertyOverrideButton::activated, mSegmentSizeSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentSizeDDBtn, QgsLayoutObject::ScalebarSegmentWidth );
+  connect(mMinWidthDDBtn, &QgsPropertyOverrideButton::activated, mMinWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMinWidthDDBtn, QgsLayoutObject::ScalebarMinWidth );
+  connect(mMaxWidthDDBtn, &QgsPropertyOverrideButton::activated, mMaxWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMaxWidthDDBtn, QgsLayoutObject::ScalebarMaxWidth );
+
+  /*
+  mSegmentsLeftDDBtn->registerLinkedWidget( mSegmentsLeftSpinBox );
+  mSegmentsRightDDBtn->registerLinkedWidget( mNumberOfSegmentsSpinBox );
+  mSegmentSizeDDBtn->registerLinkedWidget( mSegmentSizeSpinBox );
+  mMinWidthDDBtn->registerLinkedWidget( mMinWidthSpinBox );
+  mMaxWidthDDBtn->registerLinkedWidget( mMaxWidthSpinBox );
+  */
 
   setPanelTitle( tr( "Scalebar Properties" ) );
 
@@ -796,4 +809,10 @@ void QgsLayoutScaleBarWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mSegmentSizeDDBtn );
   updateDataDefinedButton( mMinWidthDDBtn );
   updateDataDefinedButton( mMaxWidthDDBtn );
+
+  mSegmentsLeftSpinBox->setEnabled( !mSegmentsLeftDDBtn->isActive() );
+  mNumberOfSegmentsSpinBox->setEnabled( !mSegmentsRightDDBtn->isActive() );
+  mSegmentSizeSpinBox->setEnabled( !mSegmentSizeDDBtn->isActive() );
+  mMinWidthSpinBox->setEnabled( !mMinWidthDDBtn->isActive() );
+  mMaxWidthSpinBox->setEnabled( !mMaxWidthDDBtn->isActive() );
 }

--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -57,24 +57,17 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
   connect( mMaxWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutScaleBarWidget::mMaxWidthSpinBox_valueChanged );
   connect( mNumberFormatPushButton, &QPushButton::clicked, this, &QgsLayoutScaleBarWidget::changeNumberFormat );
 
-  connect( mSegmentsLeftDDBtn, &QgsPropertyOverrideButton::activated, mSegmentsLeftSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsLeftDDBtn, QgsLayoutObject::ScalebarLeftSegments );
-  connect( mSegmentsRightDDBtn, &QgsPropertyOverrideButton::activated, mNumberOfSegmentsSpinBox, &QSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentsRightDDBtn, QgsLayoutObject::ScalebarRightSegments );
-  connect( mSegmentSizeDDBtn, &QgsPropertyOverrideButton::activated, mSegmentSizeSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mSegmentSizeDDBtn, QgsLayoutObject::ScalebarSegmentWidth );
-  connect( mMinWidthDDBtn, &QgsPropertyOverrideButton::activated, mMinWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMinWidthDDBtn, QgsLayoutObject::ScalebarMinWidth );
-  connect( mMaxWidthDDBtn, &QgsPropertyOverrideButton::activated, mMaxWidthSpinBox, &QDoubleSpinBox::setDisabled );
   registerDataDefinedButton( mMaxWidthDDBtn, QgsLayoutObject::ScalebarMaxWidth );
 
-  /*
   mSegmentsLeftDDBtn->registerLinkedWidget( mSegmentsLeftSpinBox );
   mSegmentsRightDDBtn->registerLinkedWidget( mNumberOfSegmentsSpinBox );
   mSegmentSizeDDBtn->registerLinkedWidget( mSegmentSizeSpinBox );
   mMinWidthDDBtn->registerLinkedWidget( mMinWidthSpinBox );
   mMaxWidthDDBtn->registerLinkedWidget( mMaxWidthSpinBox );
-  */
 
   setPanelTitle( tr( "Scalebar Properties" ) );
 

--- a/src/gui/layout/qgslayoutscalebarwidget.h
+++ b/src/gui/layout/qgslayoutscalebarwidget.h
@@ -80,6 +80,10 @@ class GUI_EXPORT QgsLayoutScaleBarWidget: public QgsLayoutItemBaseWidget, public
     void textFormatChanged();
     void changeNumberFormat();
 
+  protected slots:
+    //! Initializes data defined buttons to current atlas coverage layer
+    void populateDataDefinedButtons();
+
   private:
     QPointer< QgsLayoutItemScaleBar > mScalebar;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;

--- a/src/ui/layout/qgslayoutscalebarwidgetbase.ui
+++ b/src/ui/layout/qgslayoutscalebarwidgetbase.ui
@@ -242,25 +242,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QgsDoubleSpinBox" name="mSegmentSizeSpinBox">
-            <property name="toolTip">
-             <string>Number of scalebar units per scalebar segment</string>
-            </property>
-            <property name="suffix">
-             <string> units</string>
-            </property>
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="maximum">
-             <double>9999999999999.000000000000000</double>
-            </property>
-            <property name="showClearButton" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="0" colspan="2">
            <widget class="QLabel" name="label">
             <property name="text">
@@ -268,28 +249,50 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QgsSpinBox" name="mNumberOfSegmentsSpinBox">
-            <property name="suffix">
-             <string/>
-            </property>
-            <property name="prefix">
-             <string>right </string>
-            </property>
-            <property name="value">
-             <number>0</number>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="2">
-           <widget class="QgsSpinBox" name="mSegmentsLeftSpinBox">
-            <property name="suffix">
-             <string/>
-            </property>
-            <property name="prefix">
-             <string>left </string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout1">
+            <item>
+             <widget class="QgsSpinBox" name="mSegmentsLeftSpinBox">
+              <property name="suffix">
+               <string/>
+              </property>
+              <property name="prefix">
+               <string>left </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mSegmentsLeftDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout2">
+            <item>
+             <widget class="QgsSpinBox" name="mNumberOfSegmentsSpinBox">
+              <property name="suffix">
+               <string/>
+              </property>
+              <property name="prefix">
+               <string>right </string>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mSegmentsRightDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="2" column="0" colspan="2">
            <widget class="QRadioButton" name="mFixedSizeRadio">
@@ -301,6 +304,36 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout3">
+            <item>
+             <widget class="QgsDoubleSpinBox" name="mSegmentSizeSpinBox">
+              <property name="toolTip">
+               <string>Number of scalebar units per scalebar segment</string>
+              </property>
+              <property name="suffix">
+               <string> units</string>
+              </property>
+              <property name="decimals">
+               <number>6</number>
+              </property>
+              <property name="maximum">
+               <double>9999999999999.000000000000000</double>
+              </property>
+              <property name="showClearButton" stdset="0">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mSegmentSizeDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item row="3" column="0" colspan="2">
            <widget class="QRadioButton" name="mFitWidthRadio">
             <property name="text">
@@ -308,34 +341,56 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
-           <widget class="QgsDoubleSpinBox" name="mHeightSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="maximum">
-             <double>999.990000000000009</double>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="2">
-           <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="maximum">
-             <double>999.990000000000009</double>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout4">
+            <item>
+             <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string> mm</string>
+              </property>
+              <property name="maximum">
+               <double>999.990000000000009</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mMinWidthDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="4" column="2">
-           <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
+           <layout class="QHBoxLayout" name="horizontalLayout5">
+            <item>
+             <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string> mm</string>
+              </property>
+              <property name="maximum">
+               <double>999.990000000000009</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mMaxWidthDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="5" column="2">
+           <widget class="QgsDoubleSpinBox" name="mHeightSpinBox">
             <property name="suffix">
              <string> mm</string>
             </property>
@@ -595,6 +650,11 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -649,12 +709,17 @@
   <tabstop>mNumberFormatPushButton</tabstop>
   <tabstop>mGroupBoxSegments</tabstop>
   <tabstop>mSegmentsLeftSpinBox</tabstop>
+  <tabstop>mSegmentsLeftDDBtn</tabstop>
   <tabstop>mNumberOfSegmentsSpinBox</tabstop>
+  <tabstop>mSegmentsRightDDBtn</tabstop>
   <tabstop>mFixedSizeRadio</tabstop>
   <tabstop>mSegmentSizeSpinBox</tabstop>
+  <tabstop>mSegmentSizeDDBtn</tabstop>
   <tabstop>mFitWidthRadio</tabstop>
   <tabstop>mMinWidthSpinBox</tabstop>
+  <tabstop>mMinWidthDDBtn</tabstop>
   <tabstop>mMaxWidthSpinBox</tabstop>
+  <tabstop>mMaxWidthDDBtn</tabstop>
   <tabstop>mHeightSpinBox</tabstop>
   <tabstop>mNumberOfSubdivisionsSpinBox</tabstop>
   <tabstop>mSubdivisionsHeightSpinBox</tabstop>

--- a/tests/src/core/testqgslayoutscalebar.cpp
+++ b/tests/src/core/testqgslayoutscalebar.cpp
@@ -643,6 +643,14 @@ void TestQgsLayoutScaleBar::dataDefined()
   scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarFillColor2, QgsProperty::fromExpression( QStringLiteral( "'blue'" ) ) );
   scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarLineColor, QgsProperty::fromExpression( QStringLiteral( "'yellow'" ) ) );
   scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarLineWidth, QgsProperty::fromExpression( QStringLiteral( "1.2*3" ) ) );
+
+  // New Data Defined Properties (as of QGIS 3.26)
+  // The values should equal the manually set values previous
+  scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarLeftSegments, QgsProperty::fromExpression( QStringLiteral( "0" )));               // hard-coded value -> 0
+  scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarRightSegments, QgsProperty::fromExpression( QStringLiteral( "length('Hi')" )));   // basic expression -> 2
+  scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarSegmentWidth, QgsProperty::fromExpression( QStringLiteral( "1000.0 * 2.0" )));    // basic math expression -> 2
+  scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarMinWidth, QgsProperty::fromExpression( QStringLiteral( "to_real('50.0')" )));     // basic conversion expression -> 50
+  scalebar->dataDefinedProperties().setProperty( QgsLayoutObject::ScalebarMaxWidth, QgsProperty::fromExpression( QStringLiteral( "to_real('50.0') * 3" ))); // basic conversion with math expression -> 150
   scalebar->refreshDataDefinedProperty();
 
   QgsLayoutChecker checker2( QStringLiteral( "layoutscalebar_datadefined" ), &l );


### PR DESCRIPTION
## Description

Adds data defined overrides to the Scalebar layout item. This feature is useful when generating an atlas with the atlas feature containing the scale as a field. The map can be driven by this value, but the scalebar cannot. This implements #48084, which allows the scalebar properties to be data driven by the atlas feature.

Screenshot showing the newly added buttons:
![Scalebar_Data_Override_Buttons_Screenshot](https://user-images.githubusercontent.com/61027950/164756261-4c0f4f87-c005-48f6-9db9-8dadd3a188de.png)

As per testing & documentation, I don't know what to do there, so please advise.

Here's a screencast of it in use (for this particular demo, this feature is not really necessary, but it demonstrates the capabilities.)

https://user-images.githubusercontent.com/61027950/164756024-c0807022-773e-4049-8f26-757e26e03f68.mp4

Fix #48084 

* Edit: Added screenshot & screencast of new feature
* Edit: Added linked Issue