### PR TITLE
Keep map tips out of the way

### DIFF
--- a/python/gui/auto_generated/qgsmaptip.sip.in
+++ b/python/gui/auto_generated/qgsmaptip.sip.in
@@ -56,11 +56,12 @@ Show a maptip at a given point on the map canvas
 :param mpMapCanvas: a map canvas on which the tip is drawn
 %End
 
-    void clear( QgsMapCanvas *mpMapCanvas = 0 );
+    void clear( QgsMapCanvas *mpMapCanvas = 0, int msDelay = 0 );
 %Docstring
 Clear the current maptip if it exists
 
 :param mpMapCanvas: the canvas from which the tip should be cleared.
+:param msDelay: optional time in ms to defer clearing the maptip (since QGIS 3.26)
 %End
 
     void applyFontSettings();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12140,7 +12140,8 @@ void QgisApp::saveLastMousePosition( const QgsPointXY &p )
     if ( mMapCanvas->underMouse() )
     {
       // Clear the maptip (this is done conditionally)
-      mpMaptip->clear( mMapCanvas );
+      int interval = std::min( 300, mpMapTipsTimer->interval() );
+      mpMaptip->clear( mMapCanvas, interval );
       // don't start the timer if the mouse is not over the map canvas
       mpMapTipsTimer->start();
     }

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -25,6 +25,7 @@ class QgsWebView;
 
 #include <QWidget>
 #include <QUrl>
+#include <QTimer>
 #include "qgsfeature.h"
 #include "qgis_gui.h"
 
@@ -76,8 +77,9 @@ class GUI_EXPORT QgsMapTip : public QWidget
     /**
      * Clear the current maptip if it exists
      * \param mpMapCanvas the canvas from which the tip should be cleared.
+     * \param msDelay optional time in ms to defer clearing the maptip (since QGIS 3.26)
      */
-    void clear( QgsMapCanvas *mpMapCanvas = nullptr );
+    void clear( QgsMapCanvas *mpMapCanvas = nullptr, int msDelay = 0 );
 
     /**
      * Apply font family and size to match user settings
@@ -108,5 +110,7 @@ class GUI_EXPORT QgsMapTip : public QWidget
     int mFontSize = 8;
 
     const int MARGIN_VALUE = 5;
+
+    QTimer mDelayedClearTimer;
 };
 #endif // QGSMAPTIP_H


### PR DESCRIPTION
## Description
This is a different take on #30976:
- Offset the map tips on the X direction so that they do not steal mouse events.
- Use a timer to defer clearing map tips so that the user can hover and interact with them


Fix #48312
Fix #33981
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
