### PR TITLE
Fix serious crasher which occurs when manipulating layer tree with styling panel open

### DIFF
--- a/src/gui/qgsproxystyle.cpp
+++ b/src/gui/qgsproxystyle.cpp
@@ -75,7 +75,7 @@ QPixmap QgsAppStyle::generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &p
         QgsImageOperation::multiplyOpacity( im, 0.3 );
         return QPixmap::fromImage( im );
       }
-      break;
+      return pixmap;
     }
 
     case QIcon::Normal:
@@ -83,7 +83,7 @@ QPixmap QgsAppStyle::generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &p
     case QIcon::Selected:
       return pixmap;
   }
-  BUILTIN_UNREACHABLE
+
   return QProxyStyle::generatedIconPixmap( iconMode, pixmap, opt );
 }
 


### PR DESCRIPTION
I finally managed to narrow down a QGIS crasher that's been randomly haunting me (and I assume quite a few people). 

It manifested quite often when modifying the layer tree (via the layers panel) when the styling panel is open. Turns out the problem was within our proxy QgsAppStyle styling of disabled icon and, in this instance, the QgsColorButton, which when being destroyed would send a null QPixmap as its icon.

The fix is to simply return the null pixmap here.

One assumes this might have created additional obscure issues with other parts of our UI. Happy day! :)