### PR TITLE
Fix crash of endless loop when having a recursive many-to-many relations in relationeditor

### DIFF
--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -75,7 +75,7 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 
 void QgsRelationWidgetWrapper::aboutToSave()
 {
-  if ( !mRelation.isValid() || !widget() || !widget()->isVisible() || mRelation.referencingLayer() ==  mRelation.referencedLayer() )
+  if ( !mRelation.isValid() || !widget() || !widget()->isVisible() || mRelation.referencingLayer() ==  mRelation.referencedLayer() || ( mNmRelation.isValid() && mNmRelation.referencedLayer() ==  mRelation.referencedLayer() ) )
     return;
 
   // If the layer is already saved before, return


### PR DESCRIPTION
While we used to be aware of recursive relations with cardinality many-to-one since #7888 the return when having the same layer referenced in a many-to-many relation was not provided. This fixes a crash-bug that existed for long time, but many-to-many recursions were apparently a rare use case. Still a valid use case being able to link features to each other.