### PR TITLE
Update parse.c

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -390,7 +390,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
     return 0;
   }
 
-  if (type != 'P' && type != 'N' && type != 'L' && type != 'A' && type != 'B' && type != 'Q')
+  if ( type != 'P' && type != 'N' && type != 'L' && type != 'A' && type != 'B' && type != 'Q' )
   {
     nmea_error( "G?GSV invalid type " );
     return 0;

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -390,7 +390,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
     return 0;
   }
 
-  if ( type != 'P' && type != 'N' )
+  if (type != 'P' && type != 'N' && type != 'L' && type != 'A' && type != 'B' && type != 'Q')
   {
     nmea_error( "G?GSV invalid type " );
     return 0;


### PR DESCRIPTION
Qfield uses the standard QGIS libraries for NMEA message.
There is currently a problem with the **@position_number_of_used_satellites** variable
the **returned value is never greater than 12**, it seems to refer only to GPS/SBAS satellites and does not take into account GLONASS, GALILEO, BEIDOU, QZS.

In this Trimble link:
[https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_GSV.html](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_GSV.html)
the further NMEA messages related xxGSV are indicated:
**GLGSV for GLONASS satellites;
GAGSV for the GALILEO satellites;
GBGSV for the BEIDOU satellites;
GQGSV for the Quasi-Zenith satellites;**

This should fix the problem I have with QField

