### PR TITLE
Optimise refreshes and updates of elevation profile charts

### DIFF
--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -190,6 +190,9 @@ The scenario will be:
     virtual QString sourceId() const = 0;
 %Docstring
 Returns a unique identifier representing the source of the profile.
+
+For generators associated with a map layer the source ID will match the layer's :py:func:`QgsMapLayer.id()`. Other (non-map-layer) sources
+will have a different unique ID with its own custom interpretation.
 %End
 
     virtual bool generateProfile() = 0;

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -141,6 +141,16 @@ Returns the range of the retrieved elevation values
 %Docstring
 Snaps a ``point`` to the generated elevation profile.
 %End
+
+    virtual void updateFromGenerator( const QgsAbstractProfileGenerator *generator );
+%Docstring
+Updates the results to match the properties from the specified ``generator``.
+
+For instance, this method can be used to replace any stored properties relating to rendering
+the gathered results to reflect the ``generator``'s current properties.
+
+The base class method does nothing.
+%End
 };
 
 class QgsAbstractProfileGenerator

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -142,11 +142,11 @@ Returns the range of the retrieved elevation values
 Snaps a ``point`` to the generated elevation profile.
 %End
 
-    virtual void updateFromGenerator( const QgsAbstractProfileGenerator *generator );
+    virtual void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator );
 %Docstring
-Updates the results to match the properties from the specified ``generator``.
+Copies properties from specified ``generator`` to the results object.
 
-For instance, this method can be used to replace any stored properties relating to rendering
+For instance, this method can be used to copy any properties relating to rendering
 the gathered results to reflect the ``generator``'s current properties.
 
 The base class method does nothing.
@@ -192,7 +192,7 @@ The scenario will be:
 Returns a unique identifier representing the source of the profile.
 
 For generators associated with a map layer the source ID will match the layer's :py:func:`QgsMapLayer.id()`. Other (non-map-layer) sources
-will have a different unique ID with its own custom interpretation.
+will have a different unique ID with its own custom interpretation.gen
 %End
 
     virtual bool generateProfile() = 0;

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -177,6 +177,11 @@ The scenario will be:
 
     virtual ~QgsAbstractProfileGenerator();
 
+    virtual QString sourceId() const = 0;
+%Docstring
+Returns a unique identifier representing the source of the profile.
+%End
+
     virtual bool generateProfile() = 0;
 %Docstring
 Generate the profile (based on data stored in the class).

--- a/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -95,12 +95,12 @@ The matching stored source will be deleted and replaced with ``source``.
 
 Returns ``True`` if results were previously stored for the matching source and have been invalidated.
 
-.. seealso:: :py:func:`updateInvalidatedResults`
+.. seealso:: :py:func:`regenerateInvalidatedResults`
 %End
 
-    void updateInvalidatedResults();
+    void regenerateInvalidatedResults();
 %Docstring
-Starts a background update of any invalidate results and immediately returns.
+Starts a background regeneration of any invalidated results and immediately returns.
 
 Does nothing if the generation is already in progress.
 

--- a/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -46,6 +46,11 @@ results.
 
     ~QgsProfilePlotRenderer();
 
+    QStringList sourceIds() const;
+%Docstring
+Returns the ordered list of source IDs for the sources used by the renderer.
+%End
+
     void startGeneration();
 %Docstring
 Start the generation job and immediately return.
@@ -75,6 +80,13 @@ Block until the current job has finished.
 Returns ``True`` if the generation job is currently running in background.
 %End
 
+    void replaceSource( QgsAbstractProfileSource *source );
+%Docstring
+Replaces the existing source with matching ID.
+
+The matching stored source will be deleted and replaced with ``source``.
+%End
+
     bool invalidateResults( QgsAbstractProfileSource *source );
 %Docstring
 Invalidates the profile results from the source with matching ID.
@@ -100,14 +112,18 @@ Does nothing if the generation is already in progress.
 Returns the limits of the retrieved elevation values.
 %End
 
-    QImage renderToImage( int width, int height, double distanceMin, double distanceMax, double zMin, double zMax );
+    QImage renderToImage( int width, int height, double distanceMin, double distanceMax, double zMin, double zMax, const QString &sourceId = QString() );
 %Docstring
 Renders a portion of the profile to an image with the given ``width`` and ``height``.
+
+If ``sourceId`` is empty then all sources will be rendered, otherwise only the matching source will be rendered.
 %End
 
-    void render( QgsRenderContext &context, double width, double height, double distanceMin, double distanceMax, double zMin, double zMax );
+    void render( QgsRenderContext &context, double width, double height, double distanceMin, double distanceMax, double zMin, double zMax, const QString &sourceId = QString() );
 %Docstring
 Renders a portion of the profile using the specified render ``context``.
+
+If ``sourceId`` is empty then all sources will be rendered, otherwise only the matching source will be rendered.
 %End
 
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context );

--- a/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -75,6 +75,26 @@ Block until the current job has finished.
 Returns ``True`` if the generation job is currently running in background.
 %End
 
+    bool invalidateResults( QgsAbstractProfileSource *source );
+%Docstring
+Invalidates the profile results from the source with matching ID.
+
+The matching stored source will be deleted and replaced with ``source``.
+
+Returns ``True`` if results were previously stored for the matching source and have been invalidated.
+
+.. seealso:: :py:func:`updateInvalidatedResults`
+%End
+
+    void updateInvalidatedResults();
+%Docstring
+Starts a background update of any invalidate results and immediately returns.
+
+Does nothing if the generation is already in progress.
+
+.. seealso:: :py:func:`invalidateResults`
+%End
+
     QgsDoubleRange zRange() const;
 %Docstring
 Returns the limits of the retrieved elevation values.

--- a/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
@@ -228,7 +228,33 @@ Returns the definitions for data defined properties available for use in elevati
 
     void changed();
 %Docstring
-Emitted when the elevation properties have changed.
+Emitted when any of the elevation properties have changed.
+
+See :py:func:`~QgsMapLayerElevationProperties.renderingPropertyChanged` and :py:func:`~QgsMapLayerElevationProperties.profileGenerationPropertyChanged` for more fine-grained signals.
+%End
+
+    void renderingPropertyChanged();
+%Docstring
+Emitted when any of the elevation properties which relate solely to presentation of elevation
+results have changed.
+
+.. seealso:: :py:func:`changed`
+
+.. seealso:: :py:func:`profileGenerationPropertyChanged`
+
+.. versionadded:: 3.26
+%End
+
+    void profileGenerationPropertyChanged();
+%Docstring
+Emitted when any of the elevation properties which relate solely to generation of elevation
+profiles have changed.
+
+.. seealso:: :py:func:`changed`
+
+.. seealso:: :py:func:`renderingPropertyChanged`
+
+.. versionadded:: 3.26
 %End
 
   protected:

--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -53,7 +53,7 @@ Constructor for QgsElevationProfileCanvas, with the specified ``parent`` widget.
 Scales the plot axis by the given factors.
 %End
 
-    virtual void zoomToRect( const QRectF rect );
+    virtual void zoomToRect( const QRectF &rect );
 
     virtual void wheelZoom( QWheelEvent *event );
 

--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -68,7 +68,7 @@ Returns the interior rectangle representing the surface of the plot, in canvas c
     virtual void refresh();
 
 %Docstring
-Triggers an update of the profile, causing the profile extraction to perform in the
+Triggers a complete regeneration of the profile, causing the profile extraction to perform in the
 background.
 %End
 

--- a/python/gui/auto_generated/plot/qgsplotcanvas.sip.in
+++ b/python/gui/auto_generated/plot/qgsplotcanvas.sip.in
@@ -109,7 +109,7 @@ Scales the plot by a specified ``scale`` factor.
 The default implementation does nothing.
 %End
 
-    virtual void zoomToRect( const QRectF rect );
+    virtual void zoomToRect( const QRectF &rect );
 %Docstring
 Zooms the plot to the specified ``rect`` in canvas units.
 

--- a/src/core/elevation/qgsabstractprofilegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilegenerator.cpp
@@ -63,3 +63,8 @@ QgsProfileSnapResult QgsAbstractProfileResults::snapPoint( const QgsProfilePoint
 {
   return QgsProfileSnapResult();
 }
+
+void QgsAbstractProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator * )
+{
+
+}

--- a/src/core/elevation/qgsabstractprofilegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilegenerator.cpp
@@ -64,7 +64,7 @@ QgsProfileSnapResult QgsAbstractProfileResults::snapPoint( const QgsProfilePoint
   return QgsProfileSnapResult();
 }
 
-void QgsAbstractProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator * )
+void QgsAbstractProfileResults::copyPropertiesFromGenerator( const QgsAbstractProfileGenerator * )
 {
 
 }

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -211,6 +211,9 @@ class CORE_EXPORT QgsAbstractProfileGenerator
 
     /**
      * Returns a unique identifier representing the source of the profile.
+     *
+     * For generators associated with a map layer the source ID will match the layer's QgsMapLayer::id(). Other (non-map-layer) sources
+     * will have a different unique ID with its own custom interpretation.
      */
     virtual QString sourceId() const = 0;
 

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -199,6 +199,11 @@ class CORE_EXPORT QgsAbstractProfileGenerator
     virtual ~QgsAbstractProfileGenerator();
 
     /**
+     * Returns a unique identifier representing the source of the profile.
+     */
+    virtual QString sourceId() const = 0;
+
+    /**
      * Generate the profile (based on data stored in the class).
      *
      * Returns TRUE if the profile was generated successfully (i.e. the generation

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -167,14 +167,14 @@ class CORE_EXPORT QgsAbstractProfileResults
     virtual QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context );
 
     /**
-     * Updates the results to match the properties from the specified \a generator.
+     * Copies properties from specified \a generator to the results object.
      *
-     * For instance, this method can be used to replace any stored properties relating to rendering
+     * For instance, this method can be used to copy any properties relating to rendering
      * the gathered results to reflect the \a generator's current properties.
      *
      * The base class method does nothing.
      */
-    virtual void updateFromGenerator( const QgsAbstractProfileGenerator *generator );
+    virtual void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator );
 };
 
 /**
@@ -213,7 +213,7 @@ class CORE_EXPORT QgsAbstractProfileGenerator
      * Returns a unique identifier representing the source of the profile.
      *
      * For generators associated with a map layer the source ID will match the layer's QgsMapLayer::id(). Other (non-map-layer) sources
-     * will have a different unique ID with its own custom interpretation.
+     * will have a different unique ID with its own custom interpretation.gen
      */
     virtual QString sourceId() const = 0;
 

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -116,6 +116,7 @@ class CORE_EXPORT QgsProfileRenderContext
 
 };
 
+class QgsAbstractProfileGenerator;
 
 /**
  * \brief Abstract base class for storage of elevation profiles.
@@ -164,6 +165,16 @@ class CORE_EXPORT QgsAbstractProfileResults
      * Snaps a \a point to the generated elevation profile.
      */
     virtual QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context );
+
+    /**
+     * Updates the results to match the properties from the specified \a generator.
+     *
+     * For instance, this method can be used to replace any stored properties relating to rendering
+     * the gathered results to reflect the \a generator's current properties.
+     *
+     * The base class method does nothing.
+     */
+    virtual void updateFromGenerator( const QgsAbstractProfileGenerator *generator );
 };
 
 /**

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -169,7 +169,7 @@ bool QgsProfilePlotRenderer::replaceSourceInternal( QgsAbstractProfileSource *so
       }
       else if ( job.results )
       {
-        job.results->updateFromGenerator( generator.get() );
+        job.results->copyPropertiesFromGenerator( generator.get() );
       }
       job.generator = generator.get();
       for ( auto it = mGenerators.begin(); it != mGenerators.end(); )

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -185,7 +185,7 @@ bool QgsProfilePlotRenderer::replaceSourceInternal( QgsAbstractProfileSource *so
   return res;
 }
 
-void QgsProfilePlotRenderer::updateInvalidatedResults()
+void QgsProfilePlotRenderer::regenerateInvalidatedResults()
 {
   if ( isActive() )
     return;

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -96,6 +96,26 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
     bool isActive() const;
 
     /**
+     * Invalidates the profile results from the source with matching ID.
+     *
+     * The matching stored source will be deleted and replaced with \a source.
+     *
+     * Returns TRUE if results were previously stored for the matching source and have been invalidated.
+     *
+     * \see updateInvalidatedResults()
+     */
+    bool invalidateResults( QgsAbstractProfileSource *source );
+
+    /**
+     * Starts a background update of any invalidate results and immediately returns.
+     *
+     * Does nothing if the generation is already in progress.
+     *
+     * \see invalidateResults()
+     */
+    void updateInvalidatedResults();
+
+    /**
      * Returns the limits of the retrieved elevation values.
      */
     QgsDoubleRange zRange() const;

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -71,6 +71,11 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
     ~QgsProfilePlotRenderer() override;
 
     /**
+     * Returns the ordered list of source IDs for the sources used by the renderer.
+     */
+    QStringList sourceIds() const;
+
+    /**
      * Start the generation job and immediately return.
      * Does nothing if the generation is already in progress.
      */
@@ -94,6 +99,13 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
 
     //! Returns TRUE if the generation job is currently running in background.
     bool isActive() const;
+
+    /**
+     * Replaces the existing source with matching ID.
+     *
+     * The matching stored source will be deleted and replaced with \a source.
+     */
+    void replaceSource( QgsAbstractProfileSource *source );
 
     /**
      * Invalidates the profile results from the source with matching ID.
@@ -122,13 +134,17 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
 
     /**
      * Renders a portion of the profile to an image with the given \a width and \a height.
+     *
+     * If \a sourceId is empty then all sources will be rendered, otherwise only the matching source will be rendered.
      */
-    QImage renderToImage( int width, int height, double distanceMin, double distanceMax, double zMin, double zMax );
+    QImage renderToImage( int width, int height, double distanceMin, double distanceMax, double zMin, double zMax, const QString &sourceId = QString() );
 
     /**
      * Renders a portion of the profile using the specified render \a context.
+     *
+     * If \a sourceId is empty then all sources will be rendered, otherwise only the matching source will be rendered.
      */
-    void render( QgsRenderContext &context, double width, double height, double distanceMin, double distanceMax, double zMin, double zMax );
+    void render( QgsRenderContext &context, double width, double height, double distanceMin, double distanceMax, double zMin, double zMax, const QString &sourceId = QString() );
 
     /**
      * Snap a \a point to the results.
@@ -154,6 +170,7 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
     };
 
     static void generateProfileStatic( ProfileJob &job );
+    bool replaceSourceInternal( QgsAbstractProfileSource *source, bool clearPreviousResults );
 
     std::vector< std::unique_ptr< QgsAbstractProfileGenerator > > mGenerators;
     QgsProfileRequest mRequest;

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -114,18 +114,18 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
      *
      * Returns TRUE if results were previously stored for the matching source and have been invalidated.
      *
-     * \see updateInvalidatedResults()
+     * \see regenerateInvalidatedResults()
      */
     bool invalidateResults( QgsAbstractProfileSource *source );
 
     /**
-     * Starts a background update of any invalidate results and immediately returns.
+     * Starts a background regeneration of any invalidated results and immediately returns.
      *
      * Does nothing if the generation is already in progress.
      *
      * \see invalidateResults()
      */
-    void updateInvalidatedResults();
+    void regenerateInvalidatedResults();
 
     /**
      * Returns the limits of the retrieved elevation values.

--- a/src/core/mesh/qgsmeshlayerelevationproperties.cpp
+++ b/src/core/mesh/qgsmeshlayerelevationproperties.cpp
@@ -104,6 +104,8 @@ QgsLineSymbol *QgsMeshLayerElevationProperties::profileLineSymbol() const
 void QgsMeshLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *symbol )
 {
   mProfileLineSymbol.reset( symbol );
+  emit changed();
+  emit renderingPropertyChanged();
 }
 
 void QgsMeshLayerElevationProperties::setDefaultProfileLineSymbol()

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
@@ -135,6 +135,13 @@ QgsProfileSnapResult QgsMeshLayerProfileResults::snapPoint( const QgsProfilePoin
   return result;
 }
 
+void QgsMeshLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+{
+  const QgsMeshLayerProfileGenerator *mlGenerator = qgis::down_cast<  const QgsMeshLayerProfileGenerator * >( generator );
+
+  lineSymbol.reset( mlGenerator->mLineSymbol->clone() );
+}
+
 //
 // QgsMeshLayerProfileGenerator
 //

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
@@ -135,7 +135,7 @@ QgsProfileSnapResult QgsMeshLayerProfileResults::snapPoint( const QgsProfilePoin
   return result;
 }
 
-void QgsMeshLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+void QgsMeshLayerProfileResults::copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator )
 {
   const QgsMeshLayerProfileGenerator *mlGenerator = qgis::down_cast<  const QgsMeshLayerProfileGenerator * >( generator );
 
@@ -192,7 +192,7 @@ bool QgsMeshLayerProfileGenerator::generateProfile()
     return false;
 
   mResults = std::make_unique< QgsMeshLayerProfileResults >();
-  mResults->lineSymbol.reset( mLineSymbol->clone() );
+  mResults->copyPropertiesFromGenerator( this );
 
   // we don't currently have any method to determine line->mesh intersection points, so for now we just sample at about 100(?) points over the line
   const double curveLength = transformedCurve.length();

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.cpp
@@ -140,7 +140,8 @@ QgsProfileSnapResult QgsMeshLayerProfileResults::snapPoint( const QgsProfilePoin
 //
 
 QgsMeshLayerProfileGenerator::QgsMeshLayerProfileGenerator( QgsMeshLayer *layer, const QgsProfileRequest &request )
-  : mFeedback( std::make_unique< QgsFeedback >() )
+  : mId( layer->id() )
+  , mFeedback( std::make_unique< QgsFeedback >() )
   , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )
   , mLineSymbol( qgis::down_cast< QgsMeshLayerElevationProperties* >( layer->elevationProperties() )->profileLineSymbol()->clone() )
   , mSourceCrs( layer->crs() )
@@ -152,6 +153,11 @@ QgsMeshLayerProfileGenerator::QgsMeshLayerProfileGenerator( QgsMeshLayer *layer,
 {
   layer->updateTriangularMesh();
   mTriangularMesh = *layer->triangularMesh();
+}
+
+QString QgsMeshLayerProfileGenerator::sourceId() const
+{
+  return mId;
 }
 
 QgsMeshLayerProfileGenerator::~QgsMeshLayerProfileGenerator() = default;

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.h
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.h
@@ -63,6 +63,7 @@ class CORE_EXPORT QgsMeshLayerProfileResults : public QgsAbstractProfileResults
     QVector< QgsGeometry > asGeometries() const override;
     void renderResults( QgsProfileRenderContext &context ) override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
+    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 
@@ -115,6 +116,8 @@ class CORE_EXPORT QgsMeshLayerProfileGenerator : public QgsAbstractProfileGenera
     QgsCoordinateTransform mLayerToTargetTransform;
 
     std::unique_ptr< QgsMeshLayerProfileResults > mResults;
+
+    friend class QgsMeshLayerProfileResults;
 
 
 };

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.h
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.h
@@ -85,6 +85,7 @@ class CORE_EXPORT QgsMeshLayerProfileGenerator : public QgsAbstractProfileGenera
 
     ~QgsMeshLayerProfileGenerator() override;
 
+    QString sourceId() const override;
     bool generateProfile() override;
     QgsAbstractProfileResults *takeResults() override;
     QgsFeedback *feedback() const override;
@@ -93,6 +94,7 @@ class CORE_EXPORT QgsMeshLayerProfileGenerator : public QgsAbstractProfileGenera
 
     double heightAt( double x, double y );
 
+    QString mId;
     std::unique_ptr<QgsFeedback> mFeedback = nullptr;
 
     std::unique_ptr< QgsCurve > mProfileCurve;

--- a/src/core/mesh/qgsmeshlayerprofilegenerator.h
+++ b/src/core/mesh/qgsmeshlayerprofilegenerator.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsMeshLayerProfileResults : public QgsAbstractProfileResults
     QVector< QgsGeometry > asGeometries() const override;
     void renderResults( QgsProfileRenderContext &context ) override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
-    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
+    void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 

--- a/src/core/qgsmaplayerelevationproperties.cpp
+++ b/src/core/qgsmaplayerelevationproperties.cpp
@@ -83,6 +83,36 @@ bool QgsMapLayerElevationProperties::showByDefaultInElevationProfilePlots() cons
   return false;
 }
 
+void QgsMapLayerElevationProperties::setZOffset( double offset )
+{
+  if ( qgsDoubleNear( offset, mZOffset ) )
+    return;
+
+  mZOffset = offset;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsMapLayerElevationProperties::setZScale( double scale )
+{
+  if ( qgsDoubleNear( scale, mZScale ) )
+    return;
+
+  mZScale = scale;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsMapLayerElevationProperties::setDataDefinedProperties( const QgsPropertyCollection &collection )
+{
+  if ( mDataDefinedProperties == collection )
+    return;
+
+  mDataDefinedProperties = collection;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
 QgsPropertiesDefinition QgsMapLayerElevationProperties::propertyDefinitions()
 {
   static std::once_flag initialized;

--- a/src/core/qgsmaplayerelevationproperties.h
+++ b/src/core/qgsmaplayerelevationproperties.h
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
      *
      * \see zOffset()
      */
-    void setZOffset( double offset ) { mZOffset = offset; }
+    void setZOffset( double offset );
 
     /**
      * Returns the z scale, which is a scaling factor which should be applied to z values from
@@ -213,7 +213,7 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
      *
      * \see zScale()
      */
-    void setZScale( double scale ) { mZScale = scale; }
+    void setZScale( double scale );
 
     /**
      * Returns a reference to the object's property collection, used for data defined overrides.
@@ -240,7 +240,7 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
      * \see Property
      * \since QGIS 3.26
      */
-    void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mDataDefinedProperties = collection; }
+    void setDataDefinedProperties( const QgsPropertyCollection &collection );
 
     /**
      * Returns the definitions for data defined properties available for use in elevation properties.
@@ -252,9 +252,31 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
   signals:
 
     /**
-     * Emitted when the elevation properties have changed.
+     * Emitted when any of the elevation properties have changed.
+     *
+     * See renderingPropertyChanged() and profileGenerationPropertyChanged() for more fine-grained signals.
      */
     void changed();
+
+    /**
+     * Emitted when any of the elevation properties which relate solely to presentation of elevation
+     * results have changed.
+     *
+     * \see changed()
+     * \see profileGenerationPropertyChanged()
+     * \since QGIS 3.26
+     */
+    void renderingPropertyChanged();
+
+    /**
+     * Emitted when any of the elevation properties which relate solely to generation of elevation
+     * profiles have changed.
+     *
+     * \see changed()
+     * \see renderingPropertyChanged()
+     * \since QGIS 3.26
+     */
+    void profileGenerationPropertyChanged();
 
   protected:
     //! Z scale

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -104,6 +104,26 @@ bool QgsRasterLayerElevationProperties::showByDefaultInElevationProfilePlots() c
   return mEnabled;
 }
 
+void QgsRasterLayerElevationProperties::setEnabled( bool enabled )
+{
+  if ( enabled == mEnabled )
+    return;
+
+  mEnabled = enabled;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsRasterLayerElevationProperties::setBandNumber( int band )
+{
+  if ( mBandNumber == band )
+    return;
+
+  mBandNumber = band;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
 QgsLineSymbol *QgsRasterLayerElevationProperties::profileLineSymbol() const
 {
   return mProfileLineSymbol.get();
@@ -112,6 +132,8 @@ QgsLineSymbol *QgsRasterLayerElevationProperties::profileLineSymbol() const
 void QgsRasterLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *symbol )
 {
   mProfileLineSymbol.reset( symbol );
+  emit changed();
+  emit renderingPropertyChanged();
 }
 
 void QgsRasterLayerElevationProperties::setDefaultProfileLineSymbol()

--- a/src/core/raster/qgsrasterlayerelevationproperties.h
+++ b/src/core/raster/qgsrasterlayerelevationproperties.h
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsRasterLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see isEnabled()
      */
-    void setEnabled( bool enabled ) { mEnabled = enabled; }
+    void setEnabled( bool enabled );
 
     /**
      * Returns the band number from which the elevation should be taken.
@@ -79,7 +79,7 @@ class CORE_EXPORT QgsRasterLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see bandNumber()
      */
-    void setBandNumber( int band ) { mBandNumber = band; }
+    void setBandNumber( int band );
 
     /**
      * Returns the line symbol used to render the raster profile in elevation profile plots.

--- a/src/core/raster/qgsrasterlayerprofilegenerator.cpp
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.cpp
@@ -144,7 +144,8 @@ void QgsRasterLayerProfileResults::renderResults( QgsProfileRenderContext &conte
 //
 
 QgsRasterLayerProfileGenerator::QgsRasterLayerProfileGenerator( QgsRasterLayer *layer, const QgsProfileRequest &request )
-  : mFeedback( std::make_unique< QgsRasterBlockFeedback >() )
+  : mId( layer->id() )
+  , mFeedback( std::make_unique< QgsRasterBlockFeedback >() )
   , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )
   , mLineSymbol( qgis::down_cast< QgsRasterLayerElevationProperties * >( layer->elevationProperties() )->profileLineSymbol()->clone() )
   , mSourceCrs( layer->crs() )
@@ -158,6 +159,11 @@ QgsRasterLayerProfileGenerator::QgsRasterLayerProfileGenerator( QgsRasterLayer *
   , mStepDistance( request.stepDistance() )
 {
   mRasterProvider.reset( layer->dataProvider()->clone() );
+}
+
+QString QgsRasterLayerProfileGenerator::sourceId() const
+{
+  return mId;
 }
 
 QgsRasterLayerProfileGenerator::~QgsRasterLayerProfileGenerator() = default;

--- a/src/core/raster/qgsrasterlayerprofilegenerator.cpp
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.cpp
@@ -138,6 +138,13 @@ void QgsRasterLayerProfileResults::renderResults( QgsProfileRenderContext &conte
   lineSymbol->stopRender( context.renderContext() );
 }
 
+void QgsRasterLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+{
+  const QgsRasterLayerProfileGenerator *rlGenerator = qgis::down_cast<  const QgsRasterLayerProfileGenerator * >( generator );
+
+  lineSymbol.reset( rlGenerator->mLineSymbol->clone() );
+}
+
 
 //
 // QgsRasterLayerProfileGenerator

--- a/src/core/raster/qgsrasterlayerprofilegenerator.cpp
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.cpp
@@ -138,7 +138,7 @@ void QgsRasterLayerProfileResults::renderResults( QgsProfileRenderContext &conte
   lineSymbol->stopRender( context.renderContext() );
 }
 
-void QgsRasterLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+void QgsRasterLayerProfileResults::copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator )
 {
   const QgsRasterLayerProfileGenerator *rlGenerator = qgis::down_cast<  const QgsRasterLayerProfileGenerator * >( generator );
 
@@ -204,7 +204,7 @@ bool QgsRasterLayerProfileGenerator::generateProfile()
     return false;
 
   mResults = std::make_unique< QgsRasterLayerProfileResults >();
-  mResults->lineSymbol.reset( mLineSymbol->clone() );
+  mResults->copyPropertiesFromGenerator( this );
 
   std::unique_ptr< QgsGeometryEngine > curveEngine( QgsGeometry::createGeometryEngine( transformedCurve.get() ) );
   curveEngine->prepareGeometry();

--- a/src/core/raster/qgsrasterlayerprofilegenerator.h
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.h
@@ -62,6 +62,7 @@ class CORE_EXPORT QgsRasterLayerProfileResults : public QgsAbstractProfileResult
     QVector< QgsGeometry > asGeometries() const override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
     void renderResults( QgsProfileRenderContext &context ) override;
+    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 /**
@@ -112,6 +113,8 @@ class CORE_EXPORT QgsRasterLayerProfileGenerator : public QgsAbstractProfileGene
     double mRasterUnitsPerPixelY = 1;
 
     double mStepDistance = std::numeric_limits<double>::quiet_NaN();
+
+    friend class QgsRasterLayerProfileResults;
 
 };
 

--- a/src/core/raster/qgsrasterlayerprofilegenerator.h
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.h
@@ -83,12 +83,13 @@ class CORE_EXPORT QgsRasterLayerProfileGenerator : public QgsAbstractProfileGene
 
     ~QgsRasterLayerProfileGenerator() override;
 
+    QString sourceId() const override;
     bool generateProfile() override;
     QgsAbstractProfileResults *takeResults() override;
     QgsFeedback *feedback() const override;
 
   private:
-
+    QString mId;
     std::unique_ptr<QgsRasterBlockFeedback> mFeedback = nullptr;
 
     std::unique_ptr< QgsCurve > mProfileCurve;

--- a/src/core/raster/qgsrasterlayerprofilegenerator.h
+++ b/src/core/raster/qgsrasterlayerprofilegenerator.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsRasterLayerProfileResults : public QgsAbstractProfileResult
     QVector< QgsGeometry > asGeometries() const override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
     void renderResults( QgsProfileRenderContext &context ) override;
-    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
+    void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 /**

--- a/src/core/vector/qgsvectorlayerelevationproperties.cpp
+++ b/src/core/vector/qgsvectorlayerelevationproperties.cpp
@@ -237,6 +237,56 @@ bool QgsVectorLayerElevationProperties::showByDefaultInElevationProfilePlots() c
          || mClamping != Qgis::AltitudeClamping::Terrain;
 }
 
+void QgsVectorLayerElevationProperties::setClamping( Qgis::AltitudeClamping clamping )
+{
+  if ( mClamping == clamping )
+    return;
+
+  mClamping = clamping;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsVectorLayerElevationProperties::setBinding( Qgis::AltitudeBinding binding )
+{
+  if ( mBinding == binding )
+    return;
+
+  mBinding = binding;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsVectorLayerElevationProperties::setExtrusionEnabled( bool enabled )
+{
+  if ( mEnableExtrusion == enabled )
+    return;
+
+  mEnableExtrusion = enabled;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsVectorLayerElevationProperties::setExtrusionHeight( double height )
+{
+  if ( mExtrusionHeight == height )
+    return;
+
+  mExtrusionHeight = height;
+  emit changed();
+  emit profileGenerationPropertyChanged();
+}
+
+void QgsVectorLayerElevationProperties::setRespectLayerSymbology( bool enabled )
+{
+  if ( mRespectLayerSymbology == enabled )
+    return;
+
+  mRespectLayerSymbology = enabled;
+  emit changed();
+  emit renderingPropertyChanged();
+}
+
 QgsLineSymbol *QgsVectorLayerElevationProperties::profileLineSymbol() const
 {
   return mProfileLineSymbol.get();
@@ -245,6 +295,8 @@ QgsLineSymbol *QgsVectorLayerElevationProperties::profileLineSymbol() const
 void QgsVectorLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *symbol )
 {
   mProfileLineSymbol.reset( symbol );
+  emit changed();
+  emit renderingPropertyChanged();
 }
 
 QgsFillSymbol *QgsVectorLayerElevationProperties::profileFillSymbol() const
@@ -255,6 +307,8 @@ QgsFillSymbol *QgsVectorLayerElevationProperties::profileFillSymbol() const
 void QgsVectorLayerElevationProperties::setProfileFillSymbol( QgsFillSymbol *symbol )
 {
   mProfileFillSymbol.reset( symbol );
+  emit changed();
+  emit renderingPropertyChanged();
 }
 
 QgsMarkerSymbol *QgsVectorLayerElevationProperties::profileMarkerSymbol() const
@@ -265,6 +319,8 @@ QgsMarkerSymbol *QgsVectorLayerElevationProperties::profileMarkerSymbol() const
 void QgsVectorLayerElevationProperties::setProfileMarkerSymbol( QgsMarkerSymbol *symbol )
 {
   mProfileMarkerSymbol.reset( symbol );
+  emit changed();
+  emit renderingPropertyChanged();
 }
 
 void QgsVectorLayerElevationProperties::setDefaultProfileLineSymbol( const QColor &color )

--- a/src/core/vector/qgsvectorlayerelevationproperties.h
+++ b/src/core/vector/qgsvectorlayerelevationproperties.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsVectorLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see clamping()
      */
-    void setClamping( Qgis::AltitudeClamping clamping ) { mClamping = clamping; }
+    void setClamping( Qgis::AltitudeClamping clamping );
 
     /**
      * Returns the altitude binding method, which determines how altitude is bound to individual vertices in features.
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsVectorLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see binding()
      */
-    void setBinding( Qgis::AltitudeBinding binding ) { mBinding = binding; }
+    void setBinding( Qgis::AltitudeBinding binding );
 
     /**
      * Returns TRUE if extrusion is enabled.
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsVectorLayerElevationProperties : public QgsMapLayerElevatio
      * \see extrusionEnabled()
      * \see setExtrusionHeight()
      */
-    void setExtrusionEnabled( bool enabled ) { mEnableExtrusion = enabled; }
+    void setExtrusionEnabled( bool enabled );
 
     /**
      * Returns the feature extrusion height.
@@ -126,7 +126,7 @@ class CORE_EXPORT QgsVectorLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see extrusionHeight()
      */
-    void setExtrusionHeight( double height ) { mExtrusionHeight = height; }
+    void setExtrusionHeight( double height );
 
     /**
      * Returns TRUE if layer symbology should be respected when rendering elevation profile plots.
@@ -146,7 +146,7 @@ class CORE_EXPORT QgsVectorLayerElevationProperties : public QgsMapLayerElevatio
      *
      * \see respectLayerSymbology()
      */
-    void setRespectLayerSymbology( bool enabled ) { mRespectLayerSymbology = enabled; }
+    void setRespectLayerSymbology( bool enabled );
 
     /**
      * Returns the symbol used to render lines for the layer in elevation profile plots.

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -398,7 +398,7 @@ void QgsVectorLayerProfileResults::renderResults( QgsProfileRenderContext &conte
   }
 }
 
-void QgsVectorLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+void QgsVectorLayerProfileResults::copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator )
 {
   const QgsVectorLayerProfileGenerator *vlGenerator = qgis::down_cast<  const QgsVectorLayerProfileGenerator * >( generator );
 
@@ -480,11 +480,7 @@ bool QgsVectorLayerProfileGenerator::generateProfile()
 
   mResults = std::make_unique< QgsVectorLayerProfileResults >();
   mResults->mLayer = mLayer;
-
-  mResults->respectLayerSymbology = mRespectLayerSymbology;
-  mResults->profileLineSymbol.reset( mProfileLineSymbol->clone() );
-  mResults->profileFillSymbol.reset( mProfileFillSymbol->clone() );
-  mResults->profileMarkerSymbol.reset( mProfileMarkerSymbol->clone() );
+  mResults->copyPropertiesFromGenerator( this );
 
   mProfileCurveEngine.reset( new QgsGeos( mProfileCurve.get() ) );
   mProfileCurveEngine->prepareGeometry();

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -398,6 +398,16 @@ void QgsVectorLayerProfileResults::renderResults( QgsProfileRenderContext &conte
   }
 }
 
+void QgsVectorLayerProfileResults::updateFromGenerator( const QgsAbstractProfileGenerator *generator )
+{
+  const QgsVectorLayerProfileGenerator *vlGenerator = qgis::down_cast<  const QgsVectorLayerProfileGenerator * >( generator );
+
+  respectLayerSymbology = vlGenerator->mRespectLayerSymbology;
+  profileLineSymbol.reset( vlGenerator->mProfileLineSymbol->clone() );
+  profileFillSymbol.reset( vlGenerator->mProfileFillSymbol->clone() );
+  profileMarkerSymbol.reset( vlGenerator->mProfileMarkerSymbol->clone() );
+}
+
 //
 // QgsVectorLayerProfileGenerator
 //

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -403,7 +403,8 @@ void QgsVectorLayerProfileResults::renderResults( QgsProfileRenderContext &conte
 //
 
 QgsVectorLayerProfileGenerator::QgsVectorLayerProfileGenerator( QgsVectorLayer *layer, const QgsProfileRequest &request )
-  : mFeedback( std::make_unique< QgsFeedback >() )
+  : mId( layer->id() )
+  , mFeedback( std::make_unique< QgsFeedback >() )
   , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )
   , mTerrainProvider( request.terrainProvider() ? request.terrainProvider()->clone() : nullptr )
   , mTolerance( request.tolerance() )
@@ -430,6 +431,11 @@ QgsVectorLayerProfileGenerator::QgsVectorLayerProfileGenerator( QgsVectorLayer *
 {
   if ( mTerrainProvider )
     mTerrainProvider->prepare(); // must be done on main thread
+}
+
+QString QgsVectorLayerProfileGenerator::sourceId() const
+{
+  return mId;
 }
 
 QgsVectorLayerProfileGenerator::~QgsVectorLayerProfileGenerator() = default;

--- a/src/core/vector/qgsvectorlayerprofilegenerator.h
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.h
@@ -107,6 +107,7 @@ class CORE_EXPORT QgsVectorLayerProfileGenerator : public QgsAbstractProfileGene
 
     ~QgsVectorLayerProfileGenerator() override;
 
+    QString sourceId() const override;
     bool generateProfile() override;
     QgsAbstractProfileResults *takeResults() override;
     QgsFeedback *feedback() const override;
@@ -123,6 +124,7 @@ class CORE_EXPORT QgsVectorLayerProfileGenerator : public QgsAbstractProfileGene
     void clampAltitudes( QgsLineString *lineString, const QgsPoint &centroid, double offset );
     bool clampAltitudes( QgsPolygon *polygon, double offset );
 
+    QString mId;
     std::unique_ptr<QgsFeedback> mFeedback = nullptr;
 
     std::unique_ptr< QgsCurve > mProfileCurve;

--- a/src/core/vector/qgsvectorlayerprofilegenerator.h
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.h
@@ -85,6 +85,7 @@ class CORE_EXPORT QgsVectorLayerProfileResults : public QgsAbstractProfileResult
     QVector< QgsGeometry > asGeometries() const override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
     void renderResults( QgsProfileRenderContext &context ) override;
+    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 
@@ -167,6 +168,8 @@ class CORE_EXPORT QgsVectorLayerProfileGenerator : public QgsAbstractProfileGene
 
     // NOT for use in the background thread!
     QPointer< QgsVectorLayer > mLayer;
+
+    friend class QgsVectorLayerProfileResults;
 
 };
 

--- a/src/core/vector/qgsvectorlayerprofilegenerator.h
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.h
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsVectorLayerProfileResults : public QgsAbstractProfileResult
     QVector< QgsGeometry > asGeometries() const override;
     QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
     void renderResults( QgsProfileRenderContext &context ) override;
-    void updateFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
+    void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
 };
 
 

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -394,7 +394,7 @@ void QgsElevationProfileCanvas::scalePlot( double xFactor, double yFactor )
   mPlotItem->updatePlot();
 }
 
-void QgsElevationProfileCanvas::zoomToRect( const QRectF rect )
+void QgsElevationProfileCanvas::zoomToRect( const QRectF &rect )
 {
   const QRectF intersected = rect.intersected( mPlotItem->plotArea() );
 

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QRectF plotArea() const;
 
     /**
-     * Triggers an update of the profile, causing the profile extraction to perform in the
+     * Triggers a complete regeneration of the profile, causing the profile extraction to perform in the
      * background.
      */
     void refresh() override;
@@ -206,10 +206,10 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     void generationFinished();
     void onLayerProfileGenerationPropertyChanged();
     void onLayerProfileRendererPropertyChanged();
-    void updateResultsForLayer();
-    void scheduleDeferredUpdate();
+    void regenerateResultsForLayer();
+    void scheduleDeferredRegeneration();
     void scheduleDeferredRedraw();
-    void startDeferredUpdate();
+    void startDeferredRegeneration();
     void startDeferredRedraw();
 
   private:
@@ -237,8 +237,8 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsElevationProfileCrossHairsItem *mCrossHairsItem = nullptr;
 
     QgsProfilePlotRenderer *mCurrentJob = nullptr;
-    QTimer *mDeferredUpdateTimer = nullptr;
-    bool mDeferredUpdateScheduled = false;
+    QTimer *mDeferredRegenerationTimer = nullptr;
+    bool mDeferredRegenerationScheduled = false;
     QTimer *mDeferredRedrawTimer = nullptr;
     bool mDeferredRedrawScheduled = false;
 

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
      */
     void scalePlot( double xFactor, double yFactor );
 
-    void zoomToRect( const QRectF rect ) override;
+    void zoomToRect( const QRectF &rect ) override;
     void wheelZoom( QWheelEvent *event ) override;
     void mouseMoveEvent( QMouseEvent *e ) override;
 
@@ -210,7 +210,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     /**
      * Converts a canvas point to the equivalent plot point.
      */
-    QgsProfilePoint canvasPointToPlotPoint( const QPointF &point ) const;
+    QgsProfilePoint canvasPointToPlotPoint( QPointF point ) const;
 
     /**
      * Converts a plot point to the equivalent canvas point.

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -205,9 +205,12 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
 
     void generationFinished();
     void onLayerProfileGenerationPropertyChanged();
+    void onLayerProfileRendererPropertyChanged();
     void updateResultsForLayer();
     void scheduleDeferredUpdate();
+    void scheduleDeferredRedraw();
     void startDeferredUpdate();
+    void startDeferredRedraw();
 
   private:
 
@@ -236,6 +239,8 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsProfilePlotRenderer *mCurrentJob = nullptr;
     QTimer *mDeferredUpdateTimer = nullptr;
     bool mDeferredUpdateScheduled = false;
+    QTimer *mDeferredRedrawTimer = nullptr;
+    bool mDeferredRedrawScheduled = false;
 
     std::unique_ptr< QgsCurve > mProfileCurve;
     double mTolerance = 0;

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -204,6 +204,9 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
   private slots:
 
     void generationFinished();
+    void onLayerProfileGenerationPropertyChanged();
+    void scheduleDeferredUpdate();
+    void startDeferredUpdate();
 
   private:
 
@@ -228,6 +231,8 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsElevationProfileCrossHairsItem *mCrossHairsItem = nullptr;
 
     QgsProfilePlotRenderer *mCurrentJob = nullptr;
+    QTimer *mDeferredUpdateTimer = nullptr;
+    bool mDeferredUpdateScheduled = false;
 
     std::unique_ptr< QgsCurve > mProfileCurve;
     double mTolerance = 0;

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -205,6 +205,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
 
     void generationFinished();
     void onLayerProfileGenerationPropertyChanged();
+    void updateResultsForLayer();
     void scheduleDeferredUpdate();
     void startDeferredUpdate();
 
@@ -221,6 +222,8 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsPointXY plotPointToCanvasPoint( const QgsProfilePoint &point ) const;
 
     QgsProfileSnapContext snapContext() const;
+
+    void setupLayerConnections( QgsMapLayer *layer, bool isDisconnect );
 
     QgsCoordinateReferenceSystem mCrs;
     QgsProject *mProject = nullptr;

--- a/src/gui/plot/qgsplotcanvas.cpp
+++ b/src/gui/plot/qgsplotcanvas.cpp
@@ -287,7 +287,7 @@ void QgsPlotCanvas::scalePlot( double )
 
 }
 
-void QgsPlotCanvas::zoomToRect( const QRectF )
+void QgsPlotCanvas::zoomToRect( const QRectF & )
 {
 
 }

--- a/src/gui/plot/qgsplotcanvas.h
+++ b/src/gui/plot/qgsplotcanvas.h
@@ -148,7 +148,7 @@ class GUI_EXPORT QgsPlotCanvas : public QGraphicsView
      *
      * The default implementation does nothing.
      */
-    virtual void zoomToRect( const QRectF rect );
+    virtual void zoomToRect( const QRectF &rect );
 
     /**
      * Snap a canvas point to the plot


### PR DESCRIPTION
This PR improves the handling of updates for elevation profile charts, so that:

- we only redraw existing results if a chart presentation only setting is changed (e,g the line color), instead of refetching all the results for that layer
- we don't refetch results for ALL layers when a elevation property (such as layer extrusion) is changed, just the affected layer
- charts are automatically updated whenever things change, including automatic updates when vector features are modified

(This is also a step towards progressive "refinement" of profiles, where for raster/point cloud layers we'll refetch the results as the plot is zoomed in/out, using an appropriate level of detail for that chart zoom range.)