### PR TITLE
Enable LZM compression when saving map as tiff image

### DIFF
--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -28,6 +28,7 @@
 #include "qgsvectorlayer.h"
 
 #include <QFile>
+#include <QImageWriter>
 #include <QTextStream>
 #include <QTimeZone>
 #ifndef QT_NO_PRINTER
@@ -383,7 +384,13 @@ bool QgsMapRendererTask::run()
     }
     else if ( mFileFormat != QLatin1String( "PDF" ) )
     {
-      const bool success = mImage.save( mFileName, mFileFormat.toLocal8Bit().data() );
+      QImageWriter writer( mFileName, mFileFormat.toLocal8Bit().data() );
+      if ( mFileFormat == QLatin1String( "TIF" ) || mFileFormat == QLatin1String( "TIFF" ) )
+      {
+        // Enable LZW compression
+        writer.setCompression( 1 );
+      }
+      const bool success = writer.write( mImage );
       if ( !success )
       {
         mError = ImageSaveFail;


### PR DESCRIPTION
## Description

This PR enables LZM compression when saving the map [canvas] as a tiff image. 36.2mb without compression vs 5.1mb with LZM compression, I pick the latter :)



