### PR TITLE
Add some low-level optimised methods for geos routines for point objects

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -475,6 +475,38 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
   return distance;
 }
 
+double QgsGeos::distance( double x, double y, QString *errorMsg ) const
+{
+  double distance = -1.0;
+  if ( !mGeos )
+  {
+    return distance;
+  }
+
+  geos::unique_ptr point = createGeosPointXY( x, y, false, 0, false, 0, 2, 0 );
+  if ( !point )
+    return distance;
+
+  try
+  {
+#if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=9 )
+    if ( mGeosPrepared )
+    {
+      GEOSPreparedDistance_r( geosinit()->ctxt, mGeosPrepared.get(), point.get(), &distance );
+    }
+    else
+    {
+      GEOSDistance_r( geosinit()->ctxt, mGeos.get(), point.get(), &distance );
+    }
+#else
+    GEOSDistance_r( geosinit()->ctxt, mGeos.get(), point.get(), &distance );
+#endif
+  }
+  CATCH_GEOS_WITH_ERRMSG( -1.0 )
+
+  return distance;
+}
+
 bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, QString *errorMsg ) const
 {
   if ( !mGeos )
@@ -520,6 +552,35 @@ bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, Q
   CATCH_GEOS_WITH_ERRMSG( false )
 
   return distance <= maxdist;
+}
+
+bool QgsGeos::contains( double x, double y, QString *errorMsg ) const
+{
+  geos::unique_ptr point = createGeosPointXY( x, y, false, 0, false, 0, 2, 0 );
+  if ( !point )
+    return false;
+
+  bool result = false;
+  try
+  {
+    if ( mGeosPrepared ) //use faster version with prepared geometry
+    {
+      return GEOSPreparedContains_r( geosinit()->ctxt, mGeosPrepared.get(), point.get() ) == 1;
+    }
+
+    result = ( GEOSContains_r( geosinit()->ctxt, mGeos.get(), point.get() ) == 1 );
+  }
+  catch ( GEOSException &e )
+  {
+    logError( QStringLiteral( "GEOS" ), e.what() );
+    if ( errorMsg )
+    {
+      *errorMsg = e.what();
+    }
+    return false;
+  }
+
+  return result;
 }
 
 double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
@@ -2686,6 +2747,35 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   try
   {
     distance = GEOSProject_r( geosinit()->ctxt, mGeos.get(), otherGeom.get() );
+  }
+  catch ( GEOSException &e )
+  {
+    logError( QStringLiteral( "GEOS" ), e.what() );
+    if ( errorMsg )
+    {
+      *errorMsg = e.what();
+    }
+    return -1;
+  }
+
+  return distance;
+}
+
+double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
+{
+  if ( !mGeos )
+  {
+    return -1;
+  }
+
+  geos::unique_ptr point = createGeosPointXY( x, y, false, 0, false, 0, 2, 0 );
+  if ( !point )
+    return false;
+
+  double distance = -1;
+  try
+  {
+    distance = GEOSProject_r( geosinit()->ctxt, mGeos.get(), point.get() );
   }
   catch ( GEOSException &e )
   {

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -183,6 +183,24 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = nullptr ) const override;
 
     /**
+     * Returns TRUE if the geometry contains the point at (\a x, \a y).
+     *
+     * This method is more efficient than creating a temporary QgsPoint object to test for containment.
+     *
+     * \since QGIS 3.26
+     */
+    bool contains( double x, double y, QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns the minimum distance from the geometry to the point at (\a x, \a y).
+     *
+     * This method is more efficient than creating a temporary QgsPoint object to test distance.
+     *
+     * \since QGIS 3.26
+     */
+    double distance( double x, double y, QString *errorMsg = nullptr ) const;
+
+    /**
      * Returns the Hausdorff distance between this geometry and \a geom. This is basically a measure of how similar or dissimilar 2 geometries are.
      *
      * This algorithm is an approximation to the standard Hausdorff distance. This approximation is exact or close enough for a large
@@ -479,6 +497,20 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * \note only valid for linestring geometries
      */
     double lineLocatePoint( const QgsPoint &point, QString *errorMsg = nullptr ) const;
+
+    /**
+     * Returns a distance representing the location along this linestring of the closest point
+     * on this linestring geometry to the point at (\a x, \a y). Ie, the returned value indicates
+     * how far along this linestring you need to traverse to get to the closest location
+     * where this linestring comes to the specified point.
+     *
+     * This method is more efficient than creating a temporary QgsPoint object to locate.
+     *
+     * \note only valid for linestring geometries
+     *
+     * \since QGIS 3.26
+     */
+    double lineLocatePoint( double x, double y, QString *errorMsg = nullptr ) const;
 
     /**
      * Creates a GeometryCollection geometry containing possible polygons formed from the constituent


### PR DESCRIPTION
Avoids the need to construct a temporary QgsPoint object to access this functionality

