### PR TITLE
Point cloud support in profile plots

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1491,3 +1491,19 @@ Qgis.ProfileGeneratorFlag.__doc__ = 'Flags that control the way the :py:class:`Q
 Qgis.ProfileGeneratorFlag.baseClass = Qgis
 Qgis.ProfileGeneratorFlags.baseClass = Qgis
 ProfileGeneratorFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+QgsPointCloudRenderer.PointSymbol = Qgis.PointCloudSymbol
+Qgis.PointCloudSymbol.baseClass = Qgis
+QgsPointCloudRenderer.DrawOrder = Qgis.PointCloudDrawOrder
+# monkey patching scoped based enum
+QgsPointCloudRenderer.Default = Qgis.PointCloudDrawOrder.Default
+QgsPointCloudRenderer.Default.is_monkey_patched = True
+QgsPointCloudRenderer.Default.__doc__ = "Draw points in the order they are stored"
+QgsPointCloudRenderer.BottomToTop = Qgis.PointCloudDrawOrder.BottomToTop
+QgsPointCloudRenderer.BottomToTop.is_monkey_patched = True
+QgsPointCloudRenderer.BottomToTop.__doc__ = "Draw points with larger Z values last"
+QgsPointCloudRenderer.TopToBottom = Qgis.PointCloudDrawOrder.TopToBottom
+QgsPointCloudRenderer.TopToBottom.is_monkey_patched = True
+QgsPointCloudRenderer.TopToBottom.__doc__ = "Draw points with larger Z values first"
+Qgis.PointCloudDrawOrder.__doc__ = 'Pointcloud rendering order for 2d views\n\n/since QGIS 3.26\n\n' + '* ``Default``: ' + Qgis.PointCloudDrawOrder.Default.__doc__ + '\n' + '* ``BottomToTop``: ' + Qgis.PointCloudDrawOrder.BottomToTop.__doc__ + '\n' + '* ``TopToBottom``: ' + Qgis.PointCloudDrawOrder.TopToBottom.__doc__
+# --
+Qgis.PointCloudDrawOrder.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1492,6 +1492,15 @@ Qgis.ProfileGeneratorFlag.baseClass = Qgis
 Qgis.ProfileGeneratorFlags.baseClass = Qgis
 ProfileGeneratorFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 QgsPointCloudRenderer.PointSymbol = Qgis.PointCloudSymbol
+# monkey patching scoped based enum
+QgsPointCloudRenderer.Square = Qgis.PointCloudSymbol.Square
+QgsPointCloudRenderer.Square.is_monkey_patched = True
+QgsPointCloudRenderer.Square.__doc__ = "Renders points as squares"
+QgsPointCloudRenderer.Circle = Qgis.PointCloudSymbol.Circle
+QgsPointCloudRenderer.Circle.is_monkey_patched = True
+QgsPointCloudRenderer.Circle.__doc__ = "Renders points as circles"
+Qgis.PointCloudSymbol.__doc__ = 'Rendering symbols for point cloud points.\n\n.. versionadded:: 3.26\n\n' + '* ``Square``: ' + Qgis.PointCloudSymbol.Square.__doc__ + '\n' + '* ``Circle``: ' + Qgis.PointCloudSymbol.Circle.__doc__
+# --
 Qgis.PointCloudSymbol.baseClass = Qgis
 QgsPointCloudRenderer.DrawOrder = Qgis.PointCloudDrawOrder
 # monkey patching scoped based enum

--- a/python/core/auto_additions/qgspointcloudrenderer.py
+++ b/python/core/auto_additions/qgspointcloudrenderer.py
@@ -1,7 +1,0 @@
-# The following has been generated automatically from src/core/pointcloud/qgspointcloudrenderer.h
-# monkey patching scoped based enum
-QgsPointCloudRenderer.DrawOrder.Default.__doc__ = "Draw points in the order they are stored"
-QgsPointCloudRenderer.DrawOrder.BottomToTop.__doc__ = "Draw points with larger Z values last"
-QgsPointCloudRenderer.DrawOrder.TopToBottom.__doc__ = "Draw points with larger Z values first"
-QgsPointCloudRenderer.DrawOrder.__doc__ = 'Pointcloud rendering order for 2d views\n/since QGIS 3.24\n\n' + '* ``Default``: ' + QgsPointCloudRenderer.DrawOrder.Default.__doc__ + '\n' + '* ``BottomToTop``: ' + QgsPointCloudRenderer.DrawOrder.BottomToTop.__doc__ + '\n' + '* ``TopToBottom``: ' + QgsPointCloudRenderer.DrawOrder.TopToBottom.__doc__
-# --

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -186,6 +186,20 @@ Larger values will result in a faster profile to generate.
 .. seealso:: :py:func:`maximumErrorMapUnits`
 %End
 
+    double mapUnitsPerDistancePixel() const;
+%Docstring
+Returns the number of map units per pixel in the distance dimension.
+
+.. seealso:: :py:func:`setMapUnitsPerDistancePixel`
+%End
+
+    void setMapUnitsPerDistancePixel( double units );
+%Docstring
+Sets the number of map ``units`` per pixel in the distance dimension.
+
+.. seealso:: :py:func:`mapUnitsPerDistancePixel`
+%End
+
     QgsDoubleRange distanceRange() const;
 %Docstring
 Returns the range of distances to include in the generation.

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -236,6 +236,29 @@ Elevations outside this range may be excluded from the generation (if it results
 .. seealso:: :py:func:`elevationRange`
 %End
 
+    double scaleFactor() const;
+%Docstring
+Returns the scaling factor for converting pixels to physical sizes.
+
+This is usually equal to the number of pixels per millimeter.
+
+.. seealso:: :py:func:`setScaleFactor`
+%End
+
+    void setScaleFactor( double factor );
+%Docstring
+Sets the scaling factor for the render to convert pixels to physical sizes.
+
+This should usually be equal to the number of pixels per millimeter.
+
+.. seealso:: :py:func:`scaleFactor`
+%End
+
+    double convertDistanceToPixels( double size, QgsUnitTypes::RenderUnit unit ) const;
+%Docstring
+Converts a distance size from the specified units to pixels.
+%End
+
     bool operator==( const QgsProfileGenerationContext &other ) const;
     bool operator!=( const QgsProfileGenerationContext &other ) const;
 

--- a/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -236,22 +236,18 @@ Elevations outside this range may be excluded from the generation (if it results
 .. seealso:: :py:func:`elevationRange`
 %End
 
-    double scaleFactor() const;
+    void setDpi( double dpi );
 %Docstring
-Returns the scaling factor for converting pixels to physical sizes.
+Sets the ``dpi`` (dots per inch) for the profie, to be used in size conversions.
 
-This is usually equal to the number of pixels per millimeter.
-
-.. seealso:: :py:func:`setScaleFactor`
+.. seealso:: :py:func:`dpi`
 %End
 
-    void setScaleFactor( double factor );
+    double dpi() const;
 %Docstring
-Sets the scaling factor for the render to convert pixels to physical sizes.
+Returns the DPI (dots per inch) for the profie, to be used in size conversions.
 
-This should usually be equal to the number of pixels per millimeter.
-
-.. seealso:: :py:func:`scaleFactor`
+.. seealso:: :py:func:`setDpi`
 %End
 
     double convertDistanceToPixels( double size, QgsUnitTypes::RenderUnit unit ) const;

--- a/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -89,7 +89,7 @@ Depending on the sources present, this may trigger automatically a regeneration 
 
     void invalidateAllRefinableSources();
 %Docstring
-Invalidates previous resutls from all refinable sources.
+Invalidates previous results from all refinable sources.
 %End
 
     void replaceSource( QgsAbstractProfileSource *source );

--- a/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -87,6 +87,11 @@ Sets the ``context`` in which the profile generation will occur.
 Depending on the sources present, this may trigger automatically a regeneration of results.
 %End
 
+    void invalidateAllRefinableSources();
+%Docstring
+Invalidates previous resutls from all refinable sources.
+%End
+
     void replaceSource( QgsAbstractProfileSource *source );
 %Docstring
 Replaces the existing source with matching ID.

--- a/python/core/auto_generated/elevation/qgsprofilesnapping.sip.in
+++ b/python/core/auto_generated/elevation/qgsprofilesnapping.sip.in
@@ -21,9 +21,13 @@ Encapsulates the context of snapping a profile point.
 %End
   public:
 
-    double maximumDistanceDelta;
+    double maximumSurfaceDistanceDelta;
 
-    double maximumElevationDelta;
+    double maximumSurfaceElevationDelta;
+
+    double maximumPointDistanceDelta;
+
+    double maximumPointElevationDelta;
 
     double displayRatioElevationVsDistance;
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -12,7 +12,7 @@
 
 
 
-class QgsPointCloudLayer : QgsMapLayer
+class QgsPointCloudLayer : QgsMapLayer, QgsAbstractProfileSource
 {
 %Docstring(signature="appended")
 
@@ -73,6 +73,8 @@ QgsPointCloudLayer cannot be copied.
     virtual QgsRectangle extent() const;
 
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) /Factory/;
+
+    virtual QgsAbstractProfileGenerator *createProfileGenerator( const QgsProfileRequest &request ) /Factory/;
 
 
     virtual QgsPointCloudDataProvider *dataProvider();

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
@@ -45,6 +45,142 @@ Constructor for QgsPointCloudLayerElevationProperties, with the specified ``pare
     virtual bool showByDefaultInElevationProfilePlots() const;
 
 
+    double maximumScreenError() const;
+%Docstring
+Returns the maximum screen error allowed when generating elevation profiles for the point cloud.
+
+Larger values result in a faster generation with less points included.
+
+Units are retrieved via :py:func:`~QgsPointCloudLayerElevationProperties.maximumScreenErrorUnit`.
+
+.. seealso:: :py:func:`setMaximumScreenError`
+
+.. seealso:: :py:func:`maximumScreenErrorUnit`
+
+.. versionadded:: 3.26
+%End
+
+    void setMaximumScreenError( double error );
+%Docstring
+Sets the maximum screen ``error`` allowed when generating elevation profiles for the point cloud.
+
+Larger values result in a faster generation with less points included.
+
+Units are set via :py:func:`~QgsPointCloudLayerElevationProperties.setMaximumScreenErrorUnit`.
+
+.. seealso:: :py:func:`maximumScreenError`
+
+.. seealso:: :py:func:`setMaximumScreenErrorUnit`
+
+.. versionadded:: 3.26
+%End
+
+    QgsUnitTypes::RenderUnit maximumScreenErrorUnit() const;
+%Docstring
+Returns the unit for the maximum screen error allowed when generating elevation profiles for the point cloud.
+
+.. seealso:: :py:func:`maximumScreenError`
+
+.. seealso:: :py:func:`setMaximumScreenErrorUnit`
+
+.. versionadded:: 3.26
+%End
+
+    void setMaximumScreenErrorUnit( QgsUnitTypes::RenderUnit unit );
+%Docstring
+Sets the ``unit`` for the maximum screen error allowed when generating elevation profiles for the point cloud.
+
+.. seealso:: :py:func:`setMaximumScreenError`
+
+.. seealso:: :py:func:`maximumScreenErrorUnit`
+
+.. versionadded:: 3.26
+%End
+
+    Qgis::PointCloudSymbol pointSymbol() const;
+%Docstring
+Returns the symbol used drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`setPointSymbol`
+
+.. versionadded:: 3.26
+%End
+
+    void setPointSymbol( Qgis::PointCloudSymbol symbol );
+%Docstring
+Sets the ``symbol`` used drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`pointSymbol`
+
+.. versionadded:: 3.26
+%End
+
+    QColor pointColor() const;
+%Docstring
+Returns the color used drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`setPointColor`
+
+.. versionadded:: 3.26
+%End
+
+    void setPointColor( const QColor &color );
+%Docstring
+Sets the ``color`` used drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`pointColor`
+
+.. versionadded:: 3.26
+%End
+
+    void setPointSize( double size );
+%Docstring
+Sets the point ``size`` used for drawing points in elevation profile charts.
+
+Point size units are specified via :py:func:`~QgsPointCloudLayerElevationProperties.setPointSizeUnit`.
+
+.. seealso:: :py:func:`pointSize`
+
+.. seealso:: :py:func:`setPointSizeUnit`
+
+.. versionadded:: 3.26
+%End
+
+    double pointSize() const;
+%Docstring
+Returns the point size used for drawing points in elevation profile charts.
+
+The point size units are retrieved by calling :py:func:`~QgsPointCloudLayerElevationProperties.pointSizeUnit`.
+
+.. seealso:: :py:func:`setPointSize`
+
+.. seealso:: :py:func:`pointSizeUnit`
+
+.. versionadded:: 3.26
+%End
+
+    void setPointSizeUnit( const QgsUnitTypes::RenderUnit units );
+%Docstring
+Sets the ``units`` used for the point size used for drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`setPointSize`
+
+.. seealso:: :py:func:`pointSizeUnit`
+
+.. versionadded:: 3.26
+%End
+
+    QgsUnitTypes::RenderUnit pointSizeUnit() const;
+%Docstring
+Returns the units used for the point size used for drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`setPointSizeUnit`
+
+.. seealso:: :py:func:`pointSize`
+
+.. versionadded:: 3.26
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
@@ -133,6 +133,26 @@ Sets the ``color`` used drawing points in elevation profile charts.
 .. versionadded:: 3.26
 %End
 
+    bool applyOpacityByDistanceEffect() const;
+%Docstring
+Returns ``True`` if a reduced opacity by distance from profile curve effect should
+be applied when drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`setApplyOpacityByDistanceEffect`
+
+.. versionadded:: 3.26
+%End
+
+    void setApplyOpacityByDistanceEffect( bool apply );
+%Docstring
+Sets whether a reduced opacity by distance from profile curve effect should
+be applied when drawing points in elevation profile charts.
+
+.. seealso:: :py:func:`applyOpacityByDistanceEffect`
+
+.. versionadded:: 3.26
+%End
+
     void setPointSize( double size );
 %Docstring
 Sets the point ``size`` used for drawing points in elevation profile charts.

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -191,19 +191,6 @@ Abstract base class for 2d point cloud renderers.
 %End
   public:
 
-    enum PointSymbol
-    {
-      Square,
-      Circle,
-    };
-
-    enum class DrawOrder
-    {
-      Default,
-      BottomToTop,
-      TopToBottom,
-    };
-
     QgsPointCloudRenderer();
 %Docstring
 Constructor for QgsPointCloudRenderer.
@@ -373,7 +360,7 @@ Returns the map unit scale used for the point size.
 .. seealso:: :py:func:`pointSize`
 %End
 
-    DrawOrder drawOrder2d() const;
+    Qgis::PointCloudDrawOrder drawOrder2d() const;
 %Docstring
 Returns the drawing order used by the renderer for drawing points.
 
@@ -382,7 +369,7 @@ Returns the drawing order used by the renderer for drawing points.
 .. versionadded:: 3.24
 %End
 
-    void setDrawOrder2d( DrawOrder order );
+    void setDrawOrder2d( Qgis::PointCloudDrawOrder order );
 %Docstring
 Sets the drawing ``order`` used by the renderer for drawing points.
 
@@ -391,14 +378,14 @@ Sets the drawing ``order`` used by the renderer for drawing points.
 .. versionadded:: 3.24
 %End
 
-    PointSymbol pointSymbol() const;
+    Qgis::PointCloudSymbol pointSymbol() const;
 %Docstring
 Returns the symbol used by the renderer for drawing points.
 
 .. seealso:: :py:func:`setPointSymbol`
 %End
 
-    void setPointSymbol( PointSymbol symbol );
+    void setPointSymbol( Qgis::PointCloudSymbol symbol );
 %Docstring
 Sets the ``symbol`` used by the renderer for drawing points.
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1016,6 +1016,19 @@ The development version
     typedef QFlags<Qgis::ProfileGeneratorFlag> ProfileGeneratorFlags;
 
 
+    enum PointCloudSymbol
+    {
+      Square,
+      Circle,
+    };
+
+    enum class PointCloudDrawOrder
+      {
+      Default,
+      BottomToTop,
+      TopToBottom,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1016,8 +1016,8 @@ The development version
     typedef QFlags<Qgis::ProfileGeneratorFlag> ProfileGeneratorFlags;
 
 
-    enum PointCloudSymbol
-    {
+    enum class PointCloudSymbol
+      {
       Square,
       Circle,
     };

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
@@ -55,6 +55,7 @@ QgsPointCloudElevationPropertiesWidget::QgsPointCloudElevationPropertiesWidget( 
   connect( mMaxErrorUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mPointStyleComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mPointColorButton, &QgsColorButton::colorChanged, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
+  connect( mOpacityByDistanceCheckBox, &QCheckBox::toggled, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
 }
 
 void QgsPointCloudElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )
@@ -74,6 +75,7 @@ void QgsPointCloudElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )
   mMaxErrorSpinBox->setValue( properties->maximumScreenError() );
   mMaxErrorUnitWidget->setUnit( properties->maximumScreenErrorUnit() );
   mPointColorButton->setColor( properties->pointColor() );
+  mOpacityByDistanceCheckBox->setChecked( properties->applyOpacityByDistanceEffect() );
 
   mBlockUpdates = false;
 }
@@ -93,6 +95,7 @@ void QgsPointCloudElevationPropertiesWidget::apply()
   properties->setMaximumScreenError( mMaxErrorSpinBox->value() );
   properties->setMaximumScreenErrorUnit( mMaxErrorUnitWidget->unit() );
   properties->setPointColor( mPointColorButton->color() );
+  properties->setApplyOpacityByDistanceEffect( mOpacityByDistanceCheckBox->isChecked() );
 
   mLayer->trigger3DUpdate();
 }

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
@@ -30,8 +30,8 @@ QgsPointCloudElevationPropertiesWidget::QgsPointCloudElevationPropertiesWidget( 
   mOffsetZSpinBox->setClearValue( 0 );
   mScaleZSpinBox->setClearValue( 1 );
 
-  mPointStyleComboBox->addItem( tr( "Square" ), Qgis::PointCloudSymbol::Square );
-  mPointStyleComboBox->addItem( tr( "Circle" ), Qgis::PointCloudSymbol::Circle );
+  mPointStyleComboBox->addItem( tr( "Square" ), static_cast< int >( Qgis::PointCloudSymbol::Square ) );
+  mPointStyleComboBox->addItem( tr( "Circle" ), static_cast< int >( Qgis::PointCloudSymbol::Circle ) );
   mPointSizeUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                                   << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
 
@@ -71,7 +71,7 @@ void QgsPointCloudElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )
   mScaleZSpinBox->setValue( properties->zScale() );
   mPointSizeSpinBox->setValue( properties->pointSize() );
   mPointSizeUnitWidget->setUnit( properties->pointSizeUnit() );
-  mPointStyleComboBox->setCurrentIndex( mPointStyleComboBox->findData( properties->pointSymbol() ) );
+  mPointStyleComboBox->setCurrentIndex( mPointStyleComboBox->findData( static_cast< int >( properties->pointSymbol() ) ) );
   mMaxErrorSpinBox->setValue( properties->maximumScreenError() );
   mMaxErrorUnitWidget->setUnit( properties->maximumScreenErrorUnit() );
   mPointColorButton->setColor( properties->pointColor() );

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
@@ -30,7 +30,7 @@ class QgsPointCloudElevationPropertiesWidget : public QgsMapLayerConfigWidget, p
 
     QgsPointCloudElevationPropertiesWidget( QgsPointCloudLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
-    void syncToLayer( QgsMapLayer *layer ) override;
+    void syncToLayer( QgsMapLayer *layer ) final;
 
   public slots:
     void apply() override;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -740,6 +740,7 @@ set(QGIS_CORE_SRCS
   pointcloud/qgspointcloudblockrequest.cpp
   pointcloud/qgspointcloudlayer.cpp
   pointcloud/qgspointcloudlayerelevationproperties.cpp
+  pointcloud/qgspointcloudlayerprofilegenerator.cpp
   pointcloud/qgspointcloudlayerrenderer.cpp
   pointcloud/qgspointcloudindex.cpp
   pointcloud/qgspointclouddataprovider.cpp
@@ -1534,6 +1535,7 @@ set(QGIS_CORE_HDRS
   pointcloud/qgspointcloudblockrequest.h
   pointcloud/qgspointcloudlayer.h
   pointcloud/qgspointcloudlayerelevationproperties.h
+  pointcloud/qgspointcloudlayerprofilegenerator.h
   pointcloud/qgspointcloudlayerrenderer.h
   pointcloud/qgspointcloudindex.h
   pointcloud/qgspointclouddataprovider.h

--- a/src/core/elevation/qgsabstractprofilegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilegenerator.cpp
@@ -76,6 +76,7 @@ void QgsAbstractProfileResults::copyPropertiesFromGenerator( const QgsAbstractPr
 bool QgsProfileGenerationContext::operator==( const QgsProfileGenerationContext &other ) const
 {
   return qgsDoubleNear( mMaxErrorMapUnits, other.mMaxErrorMapUnits )
+         && qgsDoubleNear( mMapUnitsPerDistancePixel, other.mMapUnitsPerDistancePixel )
          && mDistanceRange == other.mDistanceRange
          && mElevationRange == other.mElevationRange;
 }

--- a/src/core/elevation/qgsabstractprofilegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilegenerator.cpp
@@ -73,10 +73,51 @@ void QgsAbstractProfileResults::copyPropertiesFromGenerator( const QgsAbstractPr
 // QgsProfileGenerationContext
 //
 
+#define POINTS_TO_MM 2.83464567
+#define INCH_TO_MM 25.4
+
+double QgsProfileGenerationContext::convertDistanceToPixels( double size, QgsUnitTypes::RenderUnit unit ) const
+{
+  double conversionFactor = 1.0;
+  switch ( unit )
+  {
+    case QgsUnitTypes::RenderMillimeters:
+      conversionFactor = mScaleFactor;
+      break;
+
+    case QgsUnitTypes::RenderPoints:
+      conversionFactor = mScaleFactor / POINTS_TO_MM;
+      break;
+
+    case QgsUnitTypes::RenderInches:
+      conversionFactor = mScaleFactor * INCH_TO_MM;
+      break;
+
+    case QgsUnitTypes::RenderMapUnits:
+    {
+      conversionFactor = 1.0 / mMapUnitsPerDistancePixel;
+      break;
+    }
+    case QgsUnitTypes::RenderPixels:
+      conversionFactor = 1.0;
+      break;
+
+    case QgsUnitTypes::RenderUnknownUnit:
+    case QgsUnitTypes::RenderPercentage:
+    case QgsUnitTypes::RenderMetersInMapUnits:
+      //not supported
+      conversionFactor = 1.0;
+      break;
+  }
+
+  return size * conversionFactor;
+}
+
 bool QgsProfileGenerationContext::operator==( const QgsProfileGenerationContext &other ) const
 {
   return qgsDoubleNear( mMaxErrorMapUnits, other.mMaxErrorMapUnits )
          && qgsDoubleNear( mMapUnitsPerDistancePixel, other.mMapUnitsPerDistancePixel )
+         && qgsDoubleNear( mScaleFactor, other.mScaleFactor )
          && mDistanceRange == other.mDistanceRange
          && mElevationRange == other.mElevationRange;
 }

--- a/src/core/elevation/qgsabstractprofilegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilegenerator.cpp
@@ -79,18 +79,19 @@ void QgsAbstractProfileResults::copyPropertiesFromGenerator( const QgsAbstractPr
 double QgsProfileGenerationContext::convertDistanceToPixels( double size, QgsUnitTypes::RenderUnit unit ) const
 {
   double conversionFactor = 1.0;
+  const double pixelsPerMillimeter = mDpi / 25.4;
   switch ( unit )
   {
     case QgsUnitTypes::RenderMillimeters:
-      conversionFactor = mScaleFactor;
+      conversionFactor = pixelsPerMillimeter;
       break;
 
     case QgsUnitTypes::RenderPoints:
-      conversionFactor = mScaleFactor / POINTS_TO_MM;
+      conversionFactor = pixelsPerMillimeter / POINTS_TO_MM;
       break;
 
     case QgsUnitTypes::RenderInches:
-      conversionFactor = mScaleFactor * INCH_TO_MM;
+      conversionFactor = pixelsPerMillimeter * INCH_TO_MM;
       break;
 
     case QgsUnitTypes::RenderMapUnits:
@@ -117,7 +118,7 @@ bool QgsProfileGenerationContext::operator==( const QgsProfileGenerationContext 
 {
   return qgsDoubleNear( mMaxErrorMapUnits, other.mMaxErrorMapUnits )
          && qgsDoubleNear( mMapUnitsPerDistancePixel, other.mMapUnitsPerDistancePixel )
-         && qgsDoubleNear( mScaleFactor, other.mScaleFactor )
+         && qgsDoubleNear( mDpi, other.mDpi )
          && mDistanceRange == other.mDistanceRange
          && mElevationRange == other.mElevationRange;
 }

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -208,6 +208,20 @@ class CORE_EXPORT QgsProfileGenerationContext
     void setMaximumErrorMapUnits( double error ) { mMaxErrorMapUnits = error; }
 
     /**
+     * Returns the number of map units per pixel in the distance dimension.
+     *
+     * \see setMapUnitsPerDistancePixel()
+     */
+    double mapUnitsPerDistancePixel() const { return mMapUnitsPerDistancePixel; }
+
+    /**
+     * Sets the number of map \a units per pixel in the distance dimension.
+     *
+     * \see mapUnitsPerDistancePixel()
+     */
+    void setMapUnitsPerDistancePixel( double units ) { mMapUnitsPerDistancePixel = units; }
+
+    /**
      * Returns the range of distances to include in the generation.
      *
      * Distances outside this range may be excluded from the generation (if it results in faster profile generation).
@@ -249,6 +263,7 @@ class CORE_EXPORT QgsProfileGenerationContext
   private:
 
     double mMaxErrorMapUnits = std::numeric_limits< double >::quiet_NaN();
+    double mMapUnitsPerDistancePixel = 1;
     QgsDoubleRange mDistanceRange;
     QgsDoubleRange mElevationRange;
 };

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -258,22 +258,18 @@ class CORE_EXPORT QgsProfileGenerationContext
     void setElevationRange( const QgsDoubleRange &range ) { mElevationRange = range; }
 
     /**
-     * Returns the scaling factor for converting pixels to physical sizes.
+     * Sets the \a dpi (dots per inch) for the profie, to be used in size conversions.
      *
-     * This is usually equal to the number of pixels per millimeter.
-     *
-     * \see setScaleFactor()
+     * \see dpi()
      */
-    double scaleFactor() const {return mScaleFactor;}
+    void setDpi( double dpi ) { mDpi = dpi; }
 
     /**
-     * Sets the scaling factor for the render to convert pixels to physical sizes.
+     * Returns the DPI (dots per inch) for the profie, to be used in size conversions.
      *
-     * This should usually be equal to the number of pixels per millimeter.
-     *
-     * \see scaleFactor()
+     * \see setDpi()
      */
-    void setScaleFactor( double factor ) {mScaleFactor = factor;}
+    double dpi() const { return mDpi; }
 
     /**
      * Converts a distance size from the specified units to pixels.
@@ -289,7 +285,7 @@ class CORE_EXPORT QgsProfileGenerationContext
     double mMapUnitsPerDistancePixel = 1;
     QgsDoubleRange mDistanceRange;
     QgsDoubleRange mElevationRange;
-    double mScaleFactor = 1;
+    double mDpi = 96;
 };
 
 /**

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -257,6 +257,29 @@ class CORE_EXPORT QgsProfileGenerationContext
      */
     void setElevationRange( const QgsDoubleRange &range ) { mElevationRange = range; }
 
+    /**
+     * Returns the scaling factor for converting pixels to physical sizes.
+     *
+     * This is usually equal to the number of pixels per millimeter.
+     *
+     * \see setScaleFactor()
+     */
+    double scaleFactor() const {return mScaleFactor;}
+
+    /**
+     * Sets the scaling factor for the render to convert pixels to physical sizes.
+     *
+     * This should usually be equal to the number of pixels per millimeter.
+     *
+     * \see scaleFactor()
+     */
+    void setScaleFactor( double factor ) {mScaleFactor = factor;}
+
+    /**
+     * Converts a distance size from the specified units to pixels.
+     */
+    double convertDistanceToPixels( double size, QgsUnitTypes::RenderUnit unit ) const;
+
     bool operator==( const QgsProfileGenerationContext &other ) const;
     bool operator!=( const QgsProfileGenerationContext &other ) const;
 
@@ -266,6 +289,7 @@ class CORE_EXPORT QgsProfileGenerationContext
     double mMapUnitsPerDistancePixel = 1;
     QgsDoubleRange mDistanceRange;
     QgsDoubleRange mElevationRange;
+    double mScaleFactor = 1;
 };
 
 /**

--- a/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
+++ b/src/core/elevation/qgsabstractprofilesurfacegenerator.cpp
@@ -68,7 +68,7 @@ QgsProfileSnapResult QgsAbstractProfileSurfaceResults::snapPoint( const QgsProfi
       const double dy = it.value() - prevElevation;
       const double snappedZ = ( dy / dx ) * ( point.distance() - prevDistance ) + prevElevation;
 
-      if ( std::fabs( point.elevation() - snappedZ ) > context.maximumElevationDelta )
+      if ( std::fabs( point.elevation() - snappedZ ) > context.maximumSurfaceElevationDelta )
         return QgsProfileSnapResult();
 
       result.snappedPoint = QgsProfilePoint( point.distance(), snappedZ );

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -337,7 +337,7 @@ QgsProfileSnapResult QgsProfilePlotRenderer::snapPoint( const QgsProfilePoint &p
       if ( jobSnapResult.isValid() )
       {
         const double snapDistance = std::pow( point.distance() - jobSnapResult.snappedPoint.distance(), 2 )
-                                    + std::pow( ( point.elevation() - jobSnapResult.snappedPoint.elevation() ) * context.displayRatioElevationVsDistance, 2 );
+                                    + std::pow( ( point.elevation() - jobSnapResult.snappedPoint.elevation() ) / context.displayRatioElevationVsDistance, 2 );
 
         if ( snapDistance < bestSnapDistance )
         {

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
     void setContext( const QgsProfileGenerationContext &context );
 
     /**
-     * Invalidates previous resutls from all refinable sources.
+     * Invalidates previous results from all refinable sources.
      */
     void invalidateAllRefinableSources();
 

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -109,6 +109,11 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
     void setContext( const QgsProfileGenerationContext &context );
 
     /**
+     * Invalidates previous resutls from all refinable sources.
+     */
+    void invalidateAllRefinableSources();
+
+    /**
      * Replaces the existing source with matching ID.
      *
      * The matching stored source will be deleted and replaced with \a source.

--- a/src/core/elevation/qgsprofilesnapping.h
+++ b/src/core/elevation/qgsprofilesnapping.h
@@ -31,11 +31,17 @@ class CORE_EXPORT QgsProfileSnapContext
 {
   public:
 
-    //! Maximum allowed snapping delta for the distance values
-    double maximumDistanceDelta = 0;
+    //! Maximum allowed snapping delta for the distance values when snapping to a continuous elevation surface
+    double maximumSurfaceDistanceDelta = 0;
 
-    //! Maximum allowed snapping delta for the elevation values
-    double maximumElevationDelta = 0;
+    //! Maximum allowed snapping delta for the elevation values when snapping to a continuous elevation surface
+    double maximumSurfaceElevationDelta = 0;
+
+    //! Maximum allowed snapping delta for the distance values when snapping to a point
+    double maximumPointDistanceDelta = 0;
+
+    //! Maximum allowed snapping delta for the elevation values when snapping to a point
+    double maximumPointElevationDelta = 0;
 
     //! Display ratio of elevation vs distance units
     double displayRatioElevationVsDistance = 1;

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -34,6 +34,7 @@
 #include "qgsmaplayerfactory.h"
 #include "qgsmaplayerutils.h"
 #include "qgsabstractpointcloud3drenderer.h"
+#include "qgspointcloudlayerprofilegenerator.h"
 
 #include <QUrl>
 
@@ -94,6 +95,11 @@ QgsRectangle QgsPointCloudLayer::extent() const
 QgsMapLayerRenderer *QgsPointCloudLayer::createMapRenderer( QgsRenderContext &rendererContext )
 {
   return new QgsPointCloudLayerRenderer( this, rendererContext );
+}
+
+QgsAbstractProfileGenerator *QgsPointCloudLayer::createProfileGenerator( const QgsProfileRequest &request )
+{
+  return new QgsPointCloudLayerProfileGenerator( this, request );
 }
 
 QgsPointCloudDataProvider *QgsPointCloudLayer::dataProvider()

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -23,6 +23,7 @@ class QgsPointCloudLayerRenderer;
 #include "qgspointclouddataprovider.h"
 #include "qgsmaplayer.h"
 #include "qgis_core.h"
+#include "qgsabstractprofilesource.h"
 
 #include <QString>
 #include <memory>
@@ -40,7 +41,7 @@ class QgsAbstractPointCloud3DRenderer;
  *
  * \since QGIS 3.18
  */
-class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer
+class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractProfileSource
 {
     Q_OBJECT
   public:
@@ -112,6 +113,7 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer
     QgsPointCloudLayer *clone() const override SIP_FACTORY;
     QgsRectangle extent() const override;
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
+    QgsAbstractProfileGenerator *createProfileGenerator( const QgsProfileRequest &request ) override SIP_FACTORY;
 
     QgsPointCloudDataProvider *dataProvider() override;
     const QgsPointCloudDataProvider *dataProvider() const override SIP_SKIP;

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
@@ -43,6 +43,7 @@ QDomElement QgsPointCloudLayerElevationProperties::writeXml( QDomElement &parent
   element.setAttribute( QStringLiteral( "point_size_unit" ), QgsUnitTypes::encodeUnit( mPointSizeUnit ) );
   element.setAttribute( QStringLiteral( "point_symbol" ), qgsEnumValueToKey( mPointSymbol ) );
   element.setAttribute( QStringLiteral( "point_color" ), QgsSymbolLayerUtils::encodeColor( mPointColor ) );
+  element.setAttribute( QStringLiteral( "opacity_by_distance" ), mApplyOpacityByDistanceEffect ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   parentElement.appendChild( element );
   return element;
@@ -72,6 +73,8 @@ bool QgsPointCloudLayerElevationProperties::readXml( const QDomElement &element,
   {
     mPointColor = QgsApplication::colorSchemeRegistry()->fetchRandomStyleColor();
   }
+  mApplyOpacityByDistanceEffect = elevationElement.attribute( QStringLiteral( "opacity_by_distance" ) ).toInt();
+
   return true;
 }
 
@@ -86,6 +89,7 @@ QgsPointCloudLayerElevationProperties *QgsPointCloudLayerElevationProperties::cl
   res->mPointSizeUnit = mPointSizeUnit;
   res->mPointSymbol = mPointSymbol;
   res->mPointColor = mPointColor;
+  res->mApplyOpacityByDistanceEffect = mApplyOpacityByDistanceEffect;
 
   return res.release();
 }
@@ -169,6 +173,16 @@ void QgsPointCloudLayerElevationProperties::setPointColor( const QColor &color )
     return;
 
   mPointColor = color;
+  emit changed();
+  emit renderingPropertyChanged();
+}
+
+void QgsPointCloudLayerElevationProperties::setApplyOpacityByDistanceEffect( bool apply )
+{
+  if ( apply == mApplyOpacityByDistanceEffect )
+    return;
+
+  mApplyOpacityByDistanceEffect = apply;
   emit changed();
   emit renderingPropertyChanged();
 }

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
@@ -132,6 +132,24 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
     void setPointColor( const QColor &color );
 
     /**
+     * Returns TRUE if a reduced opacity by distance from profile curve effect should
+     * be applied when drawing points in elevation profile charts.
+     *
+     * \see setApplyOpacityByDistanceEffect()
+     * \since QGIS 3.26
+     */
+    bool applyOpacityByDistanceEffect() const { return mApplyOpacityByDistanceEffect; }
+
+    /**
+     * Sets whether a reduced opacity by distance from profile curve effect should
+     * be applied when drawing points in elevation profile charts.
+     *
+     * \see applyOpacityByDistanceEffect()
+     * \since QGIS 3.26
+     */
+    void setApplyOpacityByDistanceEffect( bool apply );
+
+    /**
      * Sets the point \a size used for drawing points in elevation profile charts.
      *
      * Point size units are specified via setPointSizeUnit().
@@ -182,6 +200,7 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
     QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
     QColor mPointColor;
+    bool mApplyOpacityByDistanceEffect = false;
 };
 
 #endif // QGSPOINTCLOUDLAYERELEVATIONPROPERTIES_H

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
@@ -51,6 +51,137 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
     QgsDoubleRange calculateZRange( QgsMapLayer *layer ) const override;
     bool showByDefaultInElevationProfilePlots() const override;
 
+    /**
+     * Returns the maximum screen error allowed when generating elevation profiles for the point cloud.
+     *
+     * Larger values result in a faster generation with less points included.
+     *
+     * Units are retrieved via maximumScreenErrorUnit().
+     *
+     * \see setMaximumScreenError()
+     * \see maximumScreenErrorUnit()
+     *
+     * \since QGIS 3.26
+     */
+    double maximumScreenError() const { return mMaximumScreenError; }
+
+    /**
+     * Sets the maximum screen \a error allowed when generating elevation profiles for the point cloud.
+     *
+     * Larger values result in a faster generation with less points included.
+     *
+     * Units are set via setMaximumScreenErrorUnit().
+     *
+     * \see maximumScreenError()
+     * \see setMaximumScreenErrorUnit()
+     *
+     * \since QGIS 3.26
+     */
+    void setMaximumScreenError( double error );
+
+    /**
+     * Returns the unit for the maximum screen error allowed when generating elevation profiles for the point cloud.
+     *
+     * \see maximumScreenError()
+     * \see setMaximumScreenErrorUnit()
+     *
+     * \since QGIS 3.26
+     */
+    QgsUnitTypes::RenderUnit maximumScreenErrorUnit() const { return mMaximumScreenErrorUnit; }
+
+    /**
+     * Sets the \a unit for the maximum screen error allowed when generating elevation profiles for the point cloud.
+     *
+     * \see setMaximumScreenError()
+     * \see maximumScreenErrorUnit()
+     *
+     * \since QGIS 3.26
+     */
+    void setMaximumScreenErrorUnit( QgsUnitTypes::RenderUnit unit );
+
+    /**
+     * Returns the symbol used drawing points in elevation profile charts.
+     *
+     * \see setPointSymbol()
+     * \since QGIS 3.26
+     */
+    Qgis::PointCloudSymbol pointSymbol() const;
+
+    /**
+     * Sets the \a symbol used drawing points in elevation profile charts.
+     *
+     * \see pointSymbol()
+     * \since QGIS 3.26
+     */
+    void setPointSymbol( Qgis::PointCloudSymbol symbol );
+
+    /**
+     * Returns the color used drawing points in elevation profile charts.
+     *
+     * \see setPointColor()
+     * \since QGIS 3.26
+     */
+    QColor pointColor() const { return mPointColor; }
+
+    /**
+     * Sets the \a color used drawing points in elevation profile charts.
+     *
+     * \see pointColor()
+     * \since QGIS 3.26
+     */
+    void setPointColor( const QColor &color );
+
+    /**
+     * Sets the point \a size used for drawing points in elevation profile charts.
+     *
+     * Point size units are specified via setPointSizeUnit().
+     * \see pointSize()
+     * \see setPointSizeUnit()
+     *
+     * \since QGIS 3.26
+     */
+    void setPointSize( double size );
+
+    /**
+     * Returns the point size used for drawing points in elevation profile charts.
+     *
+     * The point size units are retrieved by calling pointSizeUnit().
+     *
+     * \see setPointSize()
+     * \see pointSizeUnit()
+     *
+     * \since QGIS 3.26
+     */
+    double pointSize() const { return mPointSize; }
+
+    /**
+     * Sets the \a units used for the point size used for drawing points in elevation profile charts.
+     *
+     * \see setPointSize()
+     * \see pointSizeUnit()
+     *
+     * \since QGIS 3.26
+     */
+    void setPointSizeUnit( const QgsUnitTypes::RenderUnit units );
+
+    /**
+     * Returns the units used for the point size used for drawing points in elevation profile charts.
+     * \see setPointSizeUnit()
+     * \see pointSize()
+     *
+     * \since QGIS 3.26
+     */
+    QgsUnitTypes::RenderUnit pointSizeUnit() const { return mPointSizeUnit; }
+
+  private:
+
+    double mMaximumScreenError = 0.3;
+    QgsUnitTypes::RenderUnit mMaximumScreenErrorUnit = QgsUnitTypes::RenderMillimeters;
+
+    double mPointSize = 1;
+    QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
+    Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
+    QColor mPointColor;
 };
 
 #endif // QGSPOINTCLOUDLAYERELEVATIONPROPERTIES_H

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -1,0 +1,551 @@
+/***************************************************************************
+                         qgspointcloudlayerprofilegenerator.cpp
+                         ---------------fun!
+    begin                : April 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgspointcloudlayerprofilegenerator.h"
+#include "qgsprofilerequest.h"
+#include "qgscurve.h"
+#include "qgspointcloudlayer.h"
+#include "qgscoordinatetransform.h"
+#include "qgsgeos.h"
+#include "qgsterrainprovider.h"
+#include "qgslinesymbol.h"
+#include "qgspointcloudlayerelevationproperties.h"
+#include "qgsprofilesnapping.h"
+#include "qgsprofilepoint.h"
+#include "qgspointcloudrenderer.h"
+#include "qgspointcloudrequest.h"
+#include "qgspointcloudblockrequest.h"
+#include "qgsmarkersymbol.h"
+
+//
+// QgsPointCloudLayerProfileGenerator
+//
+
+QString QgsPointCloudLayerProfileResults::type() const
+{
+  return QStringLiteral( "pointcloud" );
+}
+
+QMap<double, double> QgsPointCloudLayerProfileResults::distanceToHeightMap() const
+{
+  // TODO -- cache?
+  QMap< double, double > res;
+  for ( const PointResult &point : results )
+  {
+    res.insert( point.distance, point.z );
+  }
+  return res;
+}
+
+QgsPointSequence QgsPointCloudLayerProfileResults::sampledPoints() const
+{
+  // TODO -- cache?
+  QgsPointSequence res;
+  res.reserve( results.size() );
+  for ( const PointResult &point : results )
+  {
+    res.append( QgsPoint( point.x, point.y, point.z ) );
+  }
+  return res;
+}
+
+QVector<QgsGeometry> QgsPointCloudLayerProfileResults::asGeometries() const
+{
+  // TODO -- cache?
+  QVector< QgsGeometry > res;
+  res.reserve( results.size() );
+  for ( const PointResult &point : results )
+  {
+    res.append( QgsGeometry( new QgsPoint( point.x, point.y, point.z ) ) );
+  }
+  return res;
+}
+
+QgsDoubleRange QgsPointCloudLayerProfileResults::zRange() const
+{
+  return QgsDoubleRange( minZ, maxZ );
+}
+
+void QgsPointCloudLayerProfileResults::renderResults( QgsProfileRenderContext &context )
+{
+  QPainter *painter = context.renderContext().painter();
+  if ( !painter )
+    return;
+
+  const QgsScopedQPainterState painterState( painter );
+
+  painter->setBrush( Qt::NoBrush );
+  painter->setPen( Qt::NoPen );
+
+  switch ( pointSymbol )
+  {
+    case Qgis::PointCloudSymbol::Square:
+      // for square point we always disable antialiasing -- it's not critical here and we benefit from the performance boost disabling it gives
+      context.renderContext().painter()->setRenderHint( QPainter::Antialiasing, false );
+      break;
+
+    case Qgis::PointCloudSymbol::Circle:
+      break;
+  }
+
+  const double minDistance = context.distanceRange().lower();
+  const double maxDistance = context.distanceRange().upper();
+  const double minZ = context.elevationRange().lower();
+  const double maxZ = context.elevationRange().upper();
+
+  const QRectF visibleRegion( minDistance, minZ, maxDistance - minDistance, maxZ - minZ );
+  QPainterPath clipPath;
+  clipPath.addPolygon( context.worldTransform().map( visibleRegion ) );
+  painter->setClipPath( clipPath, Qt::ClipOperation::IntersectClip );
+
+  const double penWidth = context.renderContext().convertToPainterUnits( pointSize, pointSizeUnit );
+
+  for ( const PointResult &point : std::as_const( results ) )
+  {
+    QPointF p = context.worldTransform().map( QPointF( point.distance, point.z ) );
+    QColor color = pointColor;
+    //  color.setAlphaF( 1.0 - point.curveDistance / tolerance );
+
+    switch ( pointSymbol )
+    {
+      case Qgis::PointCloudSymbol::Square:
+        painter->fillRect( QRectF( p.x() - penWidth * 0.5,
+                                   p.y() - penWidth * 0.5,
+                                   penWidth, penWidth ), color );
+        break;
+
+      case Qgis::PointCloudSymbol::Circle:
+        painter->setBrush( QBrush( color ) );
+        painter->setPen( Qt::NoPen );
+        painter->drawEllipse( QRectF( p.x() - penWidth * 0.5,
+                                      p.y() - penWidth * 0.5,
+                                      penWidth, penWidth ) );
+        break;
+    }
+  }
+}
+
+QgsProfileSnapResult QgsPointCloudLayerProfileResults::snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context )
+{
+  QgsProfileSnapResult result;
+  Q_UNUSED( point )
+  Q_UNUSED( context )
+#if 0
+  // TODO -- index
+  double prevDistance = std::numeric_limits< double >::max();
+  double prevElevation = 0;
+  for ( const PointResult &point : results )
+  {
+    // find segment which corresponds to the given distance along curve
+    if ( it != results.constBegin() && prevDistance <= point.distance() && it.key() >= point.distance() )
+    {
+      const double dx = it.key() - prevDistance;
+      const double dy = it.value() - prevElevation;
+      const double snappedZ = ( dy / dx ) * ( point.distance() - prevDistance ) + prevElevation;
+
+      if ( std::fabs( point.elevation() - snappedZ ) > context.maximumElevationDelta )
+        return QgsProfileSnapResult();
+
+      result.snappedPoint = QgsProfilePoint( point.distance(), snappedZ );
+      break;
+    }
+
+    prevDistance = it.key();
+    prevElevation = it.value();
+  }
+#endif
+  return result;
+}
+
+void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator )
+{
+  const QgsPointCloudLayerProfileGenerator *pcGenerator = qgis::down_cast< const QgsPointCloudLayerProfileGenerator *>( generator );
+  tolerance = pcGenerator->mTolerance;
+  pointSize = pcGenerator->mPointSize;
+  pointSizeUnit = pcGenerator->mPointSizeUnit;
+  pointSymbol = pcGenerator->mPointSymbol;
+  pointColor = pcGenerator->mPointColor;
+}
+
+//
+// QgsPointCloudLayerProfileGenerator
+//
+
+QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPointCloudLayer *layer, const QgsProfileRequest &request )
+  : mLayer( layer )
+  , mRenderer( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr )
+  , mMaximumScreenError( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->maximumScreenError() )
+  , mMaximumScreenErrorUnit( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->maximumScreenErrorUnit() )
+  , mPointSize( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSize() )
+  , mPointSizeUnit( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSizeUnit() )
+  , mPointSymbol( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSymbol() )
+  , mPointColor( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointColor() )
+  , mId( layer->id() )
+  , mFeedback( std::make_unique< QgsFeedback >() )
+  , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )
+  , mTolerance( request.tolerance() )
+  , mSourceCrs( layer->crs() )
+  , mTargetCrs( request.crs() )
+  , mTransformContext( request.transformContext() )
+  , mZOffset( layer->elevationProperties()->zOffset() )
+  , mZScale( layer->elevationProperties()->zScale() )
+  , mStepDistance( request.stepDistance() )
+{
+  if ( mLayer->dataProvider()->index() )
+  {
+    mScale = mLayer->dataProvider()->index()->scale();
+    mOffset = mLayer->dataProvider()->index()->offset();
+  }
+}
+
+QString QgsPointCloudLayerProfileGenerator::sourceId() const
+{
+  return mId;
+}
+
+Qgis::ProfileGeneratorFlags QgsPointCloudLayerProfileGenerator::flags() const
+{
+  return Qgis::ProfileGeneratorFlag::RespectsDistanceRange | Qgis::ProfileGeneratorFlag::RespectsMaximumErrorMapUnit;
+}
+
+QgsPointCloudLayerProfileGenerator::~QgsPointCloudLayerProfileGenerator() = default;
+
+bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenerationContext &context )
+{
+  if ( !mLayer || !mProfileCurve || mFeedback->isCanceled() )
+    return false;
+
+  // this is not AT ALL thread safe, but it's what QgsPointCloudLayerRenderer does !
+  // TODO: fix when QgsPointCloudLayerRenderer is made thread safe to use same approach
+
+  QgsPointCloudIndex *pc = mLayer->dataProvider()->index();
+  if ( !pc || !pc->isValid() )
+  {
+    return false;
+  }
+
+  const double startDistanceOffset = std::max( !context.distanceRange().isInfinite() ? context.distanceRange().lower() : 0, 0.0 );
+  const double endDistance = context.distanceRange().upper();
+
+  std::unique_ptr< QgsCurve > trimmedCurve;
+  QgsCurve *sourceCurve = nullptr;
+  if ( startDistanceOffset > 0 || endDistance < mProfileCurve->length() )
+  {
+    trimmedCurve.reset( mProfileCurve->curveSubstring( startDistanceOffset, endDistance ) );
+    sourceCurve = trimmedCurve.get();
+  }
+  else
+  {
+    sourceCurve = mProfileCurve.get();
+  }
+
+  const QgsRectangle maxSearchExtentInCurveCrs = sourceCurve->boundingBox().buffered( mTolerance );
+
+  // we need to transform the profile curve and max search extent to the layer's CRS
+  QgsGeos originalCurveGeos( sourceCurve );
+  originalCurveGeos.prepareGeometry();
+  mSearchGeometryInLayerCrs.reset( originalCurveGeos.buffer( mTolerance, 8, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Round, 2 ) );
+  mLayerToTargetTransform = QgsCoordinateTransform( mSourceCrs, mTargetCrs, mTransformContext );
+
+  QgsRectangle maxSearchExtentInLayerCrs;
+  try
+  {
+    mSearchGeometryInLayerCrs->transform( mLayerToTargetTransform, Qgis::TransformDirection::Reverse );
+    QgsCoordinateTransform layerToTargetBallparkTransform( mLayerToTargetTransform );
+    layerToTargetBallparkTransform.setBallparkTransformsAreAppropriate( true );
+    maxSearchExtentInLayerCrs = layerToTargetBallparkTransform.transformBoundingBox( maxSearchExtentInCurveCrs, Qgis::TransformDirection::Reverse );
+  }
+  catch ( QgsCsException & )
+  {
+    QgsDebugMsg( QStringLiteral( "Error transforming profile line to layer CRS" ) );
+    return false;
+  }
+
+  if ( mFeedback->isCanceled() )
+    return false;
+
+  mSearchGeometryInLayerCrsGeometryEngine = std::make_unique< QgsGeos >( mSearchGeometryInLayerCrs.get() );
+  mSearchGeometryInLayerCrsGeometryEngine->prepareGeometry();
+  mMaxSearchExtentInLayerCrs = mSearchGeometryInLayerCrs->boundingBox();
+
+  const IndexedPointCloudNode root = pc->root();
+
+  const double maximumErrorPixels = context.convertDistanceToPixels( mMaximumScreenError, mMaximumScreenErrorUnit );
+
+  const QgsRectangle rootNodeExtentLayerCoords = pc->nodeMapExtent( root );
+  QgsRectangle rootNodeExtentInCurveCrs;
+  try
+  {
+    QgsCoordinateTransform extentTransform = mLayerToTargetTransform;
+    extentTransform.setBallparkTransformsAreAppropriate( true );
+    rootNodeExtentInCurveCrs = extentTransform.transformBoundingBox( rootNodeExtentLayerCoords );
+  }
+  catch ( QgsCsException & )
+  {
+    QgsDebugMsg( QStringLiteral( "Could not transform node extent to curve CRS" ) );
+    rootNodeExtentInCurveCrs = rootNodeExtentLayerCoords;
+  }
+
+  const double rootErrorInMapCoordinates = rootNodeExtentInCurveCrs.width() / pc->span(); // in curve coords
+
+  const double mapUnitsPerPixel = context.mapUnitsPerDistancePixel();
+  if ( ( rootErrorInMapCoordinates < 0.0 ) || ( mapUnitsPerPixel < 0.0 ) || ( maximumErrorPixels < 0.0 ) )
+  {
+    QgsDebugMsg( QStringLiteral( "invalid screen error" ) );
+    return false;
+  }
+  double rootErrorPixels = rootErrorInMapCoordinates / mapUnitsPerPixel; // in pixels
+  const QVector<IndexedPointCloudNode> nodes = traverseTree( pc, pc->root(), maximumErrorPixels, rootErrorPixels, context.elevationRange() );
+
+  mResults = std::make_unique< QgsPointCloudLayerProfileResults >();
+  mResults->copyPropertiesFromGenerator( this );
+
+  QgsPointCloudRequest request;
+  QgsPointCloudAttributeCollection attributes;
+  // TODO -- add renderer attributes
+  attributes.push_back( QgsPointCloudAttribute( QStringLiteral( "X" ), QgsPointCloudAttribute::Int32 ) );
+  attributes.push_back( QgsPointCloudAttribute( QStringLiteral( "Y" ), QgsPointCloudAttribute::Int32 ) );
+  attributes.push_back( QgsPointCloudAttribute( QStringLiteral( "Z" ), QgsPointCloudAttribute::Int32 ) );
+  request.setAttributes( attributes );
+
+  switch ( pc->accessType() )
+  {
+    case QgsPointCloudIndex::AccessType::Local:
+    {
+      visitNodesSync( nodes, pc, request );
+      break;
+    }
+    case QgsPointCloudIndex::AccessType::Remote:
+    {
+      visitNodesAsync( nodes, pc, request );
+      break;
+    }
+  }
+
+  if ( mFeedback->isCanceled() )
+    return false;
+
+  // convert x/y values back to distance/height values
+
+  QString lastError;
+  QgsPointCloudLayerProfileResults::PointResult *pointData = mResults->results.data();
+  const int size = mResults->results.size();
+  for ( int i = 0; i < size; ++i, ++pointData )
+  {
+    if ( mFeedback->isCanceled() )
+      return false;
+
+    pointData->distance = startDistanceOffset + originalCurveGeos.lineLocatePoint( pointData->x, pointData->y, &lastError );
+    pointData->curveDistance = originalCurveGeos.distance( pointData->x, pointData->y );
+
+    mResults->minZ = std::min( pointData->z, mResults->minZ );
+    mResults->maxZ = std::max( pointData->z, mResults->maxZ );
+  }
+
+  return true;
+}
+
+QgsAbstractProfileResults *QgsPointCloudLayerProfileGenerator::takeResults()
+{
+  return mResults.release();
+}
+
+QgsFeedback *QgsPointCloudLayerProfileGenerator::feedback() const
+{
+  return mFeedback.get();
+}
+
+QVector<IndexedPointCloudNode> QgsPointCloudLayerProfileGenerator::traverseTree( const QgsPointCloudIndex *pc, IndexedPointCloudNode n, double maxErrorPixels, double nodeErrorPixels, const QgsDoubleRange &zRange )
+{
+  QVector<IndexedPointCloudNode> nodes;
+
+  if ( mFeedback->isCanceled() )
+  {
+    return nodes;
+  }
+
+  const QgsDoubleRange nodeZRange = pc->nodeZRange( n );
+  const QgsDoubleRange adjustedNodeZRange = QgsDoubleRange( nodeZRange.lower() * mZScale + mZOffset, nodeZRange.upper() * mZScale + mZOffset );
+  if ( !zRange.isInfinite() && !zRange.overlaps( adjustedNodeZRange ) )
+    return nodes;
+
+  const QgsRectangle nodeMapExtent = pc->nodeMapExtent( n );
+  if ( !mMaxSearchExtentInLayerCrs.intersects( nodeMapExtent ) )
+    return nodes;
+
+  const QgsGeometry nodeMapGeometry = QgsGeometry::fromRect( nodeMapExtent );
+  if ( !mSearchGeometryInLayerCrsGeometryEngine->intersects( nodeMapGeometry.constGet() ) )
+    return nodes;
+
+  nodes.append( n );
+
+  double childrenErrorPixels = nodeErrorPixels / 2.0;
+  if ( childrenErrorPixels < maxErrorPixels )
+    return nodes;
+
+  const QList<IndexedPointCloudNode> children = pc->nodeChildren( n );
+  for ( const IndexedPointCloudNode &nn : children )
+  {
+    nodes += traverseTree( pc, nn, maxErrorPixels, childrenErrorPixels, zRange );
+  }
+
+  return nodes;
+}
+
+int QgsPointCloudLayerProfileGenerator::visitNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRequest &request )
+{
+  int nodesDrawn = 0;
+  for ( const IndexedPointCloudNode &n : nodes )
+  {
+    if ( mFeedback->isCanceled() )
+      break;
+
+    std::unique_ptr<QgsPointCloudBlock> block( pc->nodeData( n, request ) );
+
+    if ( !block )
+      continue;
+
+    visitBlock( block.get() );
+
+    ++nodesDrawn;
+  }
+  return nodesDrawn;
+}
+
+int QgsPointCloudLayerProfileGenerator::visitNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRequest &request )
+{
+  int nodesDrawn = 0;
+
+  // see notes about this logic in QgsPointCloudLayerRenderer::renderNodesAsync
+
+  const int groupSize = 4;
+  for ( int groupIndex = 0; groupIndex < nodes.size(); groupIndex += groupSize )
+  {
+    if ( mFeedback->isCanceled() )
+      break;
+    // Async loading of nodes
+    const int currentGroupSize = std::min< size_t >( std::max< size_t >( nodes.size() - groupIndex, 0 ), groupSize );
+    QVector<QgsPointCloudBlockRequest *> blockRequests( currentGroupSize, nullptr );
+    QVector<bool> finishedLoadingBlock( currentGroupSize, false );
+    QEventLoop loop;
+
+    QObject::connect( mFeedback.get(), &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+    // Note: All capture by reference warnings here shouldn't be an issue since we have an event loop, so locals won't be deallocated
+    for ( int i = 0; i < blockRequests.size(); ++i )
+    {
+      int nodeIndex = groupIndex + i;
+      const IndexedPointCloudNode &n = nodes[nodeIndex];
+      const QString nStr = n.toString();
+      QgsPointCloudBlockRequest *blockRequest = pc->asyncNodeData( n, request );
+      blockRequests[ i ] = blockRequest;
+      QObject::connect( blockRequest, &QgsPointCloudBlockRequest::finished, &loop, [ &, i, nStr, blockRequest ]()
+      {
+        if ( !blockRequest->block() )
+        {
+          QgsDebugMsg( QStringLiteral( "Unable to load node %1, error: %2" ).arg( nStr, blockRequest->errorStr() ) );
+        }
+        finishedLoadingBlock[ i ] = true;
+        // If all blocks are loaded, exit the event loop
+        if ( !finishedLoadingBlock.contains( false ) ) loop.exit();
+      } );
+    }
+    // Wait for all point cloud nodes to finish loading
+    loop.exec();
+
+    if ( !mFeedback->isCanceled() )
+    {
+      // Render all the point cloud blocks sequentially
+      for ( int i = 0; i < blockRequests.size(); ++i )
+      {
+        if ( mFeedback->isCanceled() )
+        {
+          break;
+        }
+
+        if ( !blockRequests[ i ]->block() )
+          continue;
+
+        visitBlock( blockRequests[ i ]->block() );
+
+        ++nodesDrawn;
+      }
+    }
+
+    for ( int i = 0; i < blockRequests.size(); ++i )
+    {
+      if ( blockRequests[ i ] )
+      {
+        if ( blockRequests[ i ]->block() )
+          delete blockRequests[ i ]->block();
+        blockRequests[ i ]->deleteLater();
+      }
+    }
+  }
+
+  return nodesDrawn;
+}
+
+void QgsPointCloudLayerProfileGenerator::visitBlock( const QgsPointCloudBlock *block )
+{
+  const char *ptr = block->data();
+  int count = block->pointCount();
+
+  const QgsPointCloudAttributeCollection request = block->attributes();
+
+  const std::size_t recordSize = request.pointRecordSize();
+
+  const QgsPointCloudAttributeCollection blockAttributes = block->attributes();
+  int xOffset = 0, yOffset = 0, zOffset = 0;
+  const QgsPointCloudAttribute::DataType xType = blockAttributes.find( QStringLiteral( "X" ), xOffset )->type();
+  const QgsPointCloudAttribute::DataType yType = blockAttributes.find( QStringLiteral( "Y" ), yOffset )->type();
+  const QgsPointCloudAttribute::DataType zType = blockAttributes.find( QStringLiteral( "Z" ), zOffset )->type();
+
+  const bool reproject = !mLayerToTargetTransform.isShortCircuited();
+  for ( int i = 0; i < count; ++i )
+  {
+    if ( mFeedback->isCanceled() )
+    {
+      break;
+    }
+
+    QgsPointCloudLayerProfileResults::PointResult res;
+    QgsPointCloudAttribute::getPointXYZ( ptr, i, recordSize, xOffset, xType, yOffset, yType, zOffset, zType, block->scale(), block->offset(), res.x, res.y, res.z );
+
+    res.z = res.z * mZScale + mZOffset;
+
+    if ( mSearchGeometryInLayerCrsGeometryEngine->contains( res.x, res.y ) )
+    {
+      if ( reproject )
+      {
+        try
+        {
+          mLayerToTargetTransform.transformInPlace( res.x, res.y, res.z );
+        }
+        catch ( QgsCsException & )
+        {
+          continue;
+        }
+      }
+
+      res.color = mPointColor.rgba();
+
+      // TODO we may hit the limit of QVector size?
+      mResults->results.append( res );
+    }
+  }
+}
+
+

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
                          qgspointcloudlayerprofilegenerator.cpp
-                         ---------------fun!
+                         ---------------
     begin                : April 2022
     copyright            : (C) 2022 by Nyall Dawson
     email                : nyall dot dawson at gmail dot com
@@ -544,8 +544,6 @@ void QgsPointCloudLayerProfileGenerator::visitBlock( const QgsPointCloudBlock *b
       }
 
       res.color = mPointColor.rgba();
-
-      // TODO we may hit the limit of QVector size?
       mResults->results.append( res );
     }
   }

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -45,7 +45,7 @@ QMap<double, double> QgsPointCloudLayerProfileResults::distanceToHeightMap() con
   QMap< double, double > res;
   for ( const PointResult &point : results )
   {
-    res.insert( point.distance, point.z );
+    res.insert( point.distanceAlongCurve, point.z );
   }
   return res;
 }
@@ -115,10 +115,10 @@ void QgsPointCloudLayerProfileResults::renderResults( QgsProfileRenderContext &c
 
   for ( const PointResult &point : std::as_const( results ) )
   {
-    QPointF p = context.worldTransform().map( QPointF( point.distance, point.z ) );
+    QPointF p = context.worldTransform().map( QPointF( point.distanceAlongCurve, point.z ) );
     QColor color = pointColor;
     if ( opacityByDistanceEffect )
-      color.setAlphaF( color.alphaF() * ( 1.0 - std::pow( point.curveDistance / tolerance, 0.5 ) ) );
+      color.setAlphaF( color.alphaF() * ( 1.0 - std::pow( point.distanceFromCurve / tolerance, 0.5 ) ) );
 
     switch ( pointSymbol )
     {
@@ -351,8 +351,9 @@ bool QgsPointCloudLayerProfileGenerator::generateProfile( const QgsProfileGenera
     if ( mFeedback->isCanceled() )
       return false;
 
-    pointData->distance = startDistanceOffset + originalCurveGeos.lineLocatePoint( pointData->x, pointData->y, &lastError );
-    pointData->curveDistance = originalCurveGeos.distance( pointData->x, pointData->y );
+    pointData->distanceAlongCurve = startDistanceOffset + originalCurveGeos.lineLocatePoint( pointData->x, pointData->y, &lastError );
+    if ( mOpacityByDistanceEffect ) // don't calculate this if we don't need it
+      pointData->distanceFromCurve = originalCurveGeos.distance( pointData->x, pointData->y );
 
     mResults->minZ = std::min( pointData->z, mResults->minZ );
     mResults->maxZ = std::max( pointData->z, mResults->maxZ );

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -117,7 +117,8 @@ void QgsPointCloudLayerProfileResults::renderResults( QgsProfileRenderContext &c
   {
     QPointF p = context.worldTransform().map( QPointF( point.distance, point.z ) );
     QColor color = pointColor;
-    //  color.setAlphaF( 1.0 - point.curveDistance / tolerance );
+    if ( opacityByDistanceEffect )
+      color.setAlphaF( color.alphaF() * ( 1.0 - std::pow( point.curveDistance / tolerance, 0.5 ) ) );
 
     switch ( pointSymbol )
     {
@@ -178,6 +179,7 @@ void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbs
   pointSizeUnit = pcGenerator->mPointSizeUnit;
   pointSymbol = pcGenerator->mPointSymbol;
   pointColor = pcGenerator->mPointColor;
+  opacityByDistanceEffect = pcGenerator->mOpacityByDistanceEffect;
 }
 
 //
@@ -193,6 +195,7 @@ QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPoint
   , mPointSizeUnit( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSizeUnit() )
   , mPointSymbol( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSymbol() )
   , mPointColor( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointColor() )
+  , mOpacityByDistanceEffect( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->applyOpacityByDistanceEffect() )
   , mId( layer->id() )
   , mFeedback( std::make_unique< QgsFeedback >() )
   , mProfileCurve( request.profileCurve() ? request.profileCurve()->clone() : nullptr )

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -60,8 +60,8 @@ class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileRe
       double x;
       double y;
       double z;
-      double distance;
-      double curveDistance;
+      double distanceAlongCurve;
+      double distanceFromCurve; // only used when the opacity by distance effect is enabled
       QRgb color;
     };
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileRe
     void finalize( QgsFeedback *feedback );
 
     std::vector< PointResult > results;
-    double tolerance;
+    double tolerance = 0;
 
     double minZ = std::numeric_limits< double >::max();
     double maxZ = std::numeric_limits< double >::lowest();

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -1,0 +1,161 @@
+/***************************************************************************
+                         qgspointcloudlayerprofilegenerator.h
+                         ---------------
+    begin                : April 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSPOINTCLOUDLAYERPROFILEGENERATOR_H
+#define QGSPOINTCLOUDLAYERPROFILEGENERATOR_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsabstractprofilegenerator.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
+#include "qgscoordinatetransform.h"
+#include "qgslinesymbol.h"
+#include "qgsvector3d.h"
+
+#include <memory>
+
+class QgsProfileRequest;
+class QgsCurve;
+class QgsPointCloudLayer;
+class QgsAbstractTerrainProvider;
+class QgsProfileSnapContext;
+class QgsPointCloudRenderer;
+class IndexedPointCloudNode;
+class QgsPointCloudIndex;
+class QgsPointCloudRequest;
+class QgsPointCloudBlock;
+class QgsGeos;
+
+#define SIP_NO_FILE
+
+
+/**
+ * \brief Implementation of QgsAbstractProfileResults for point cloud layers.
+ *
+ * \note Not available in Python bindings
+ * \ingroup core
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileResults
+{
+
+  public:
+
+    struct PointResult
+    {
+      double x;
+      double y;
+      double z;
+      double distance;
+      double curveDistance;
+      QRgb color;
+    };
+
+    QVector< PointResult > results;
+    double tolerance;
+
+    double minZ = std::numeric_limits< double >::max();
+    double maxZ = std::numeric_limits< double >::lowest();
+
+    double pointSize = 1;
+    QgsUnitTypes::RenderUnit pointSizeUnit = QgsUnitTypes::RenderMillimeters;
+    Qgis::PointCloudSymbol pointSymbol = Qgis::PointCloudSymbol::Square;
+    QColor pointColor;
+
+    QString type() const override;
+    QMap< double, double > distanceToHeightMap() const override;
+    QgsDoubleRange zRange() const override;
+    QgsPointSequence sampledPoints() const override;
+    QVector< QgsGeometry > asGeometries() const override;
+    void renderResults( QgsProfileRenderContext &context ) override;
+    QgsProfileSnapResult snapPoint( const QgsProfilePoint &point, const QgsProfileSnapContext &context ) override;
+    void copyPropertiesFromGenerator( const QgsAbstractProfileGenerator *generator ) override;
+};
+
+
+/**
+ * \brief Implementation of QgsAbstractProfileGenerator for point cloud layers.
+ *
+ * \note Not available in Python bindings
+ * \ingroup core
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfileGenerator
+{
+
+  public:
+
+    /**
+     * Constructor for QgsPointCloudLayerProfileGenerator.
+     */
+    QgsPointCloudLayerProfileGenerator( QgsPointCloudLayer *layer, const QgsProfileRequest &request );
+
+    ~QgsPointCloudLayerProfileGenerator() override;
+
+    QString sourceId() const override;
+    Qgis::ProfileGeneratorFlags flags() const override;
+    bool generateProfile( const QgsProfileGenerationContext &context = QgsProfileGenerationContext() ) override;
+    QgsAbstractProfileResults *takeResults() override;
+    QgsFeedback *feedback() const override;
+
+  private:
+    QVector<IndexedPointCloudNode> traverseTree( const QgsPointCloudIndex *pc, IndexedPointCloudNode n, double maxErrorPixels, double nodeErrorPixels, const QgsDoubleRange &zRange );
+    int visitNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRequest &request );
+    int visitNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc,  QgsPointCloudRequest &request );
+    void visitBlock( const QgsPointCloudBlock *block );
+
+    QPointer< QgsPointCloudLayer > mLayer;
+    std::unique_ptr< QgsPointCloudRenderer > mRenderer;
+    double mMaximumScreenError = 0.3;
+    QgsUnitTypes::RenderUnit mMaximumScreenErrorUnit = QgsUnitTypes::RenderMillimeters;
+
+    double mPointSize = 1;
+    QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
+    Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
+    QColor mPointColor;
+
+    QString mId;
+    std::unique_ptr<QgsFeedback> mFeedback = nullptr;
+
+    std::unique_ptr< QgsCurve > mProfileCurve;
+
+    double mTolerance = 0;
+
+    QgsCoordinateReferenceSystem mSourceCrs;
+    QgsCoordinateReferenceSystem mTargetCrs;
+    QgsCoordinateTransformContext mTransformContext;
+
+    QgsVector3D mScale;
+    QgsVector3D mOffset;
+    double mZOffset = 0;
+    double mZScale = 1.0;
+
+    double mStepDistance = std::numeric_limits<double>::quiet_NaN();
+
+    QgsCoordinateTransform mLayerToTargetTransform;
+
+    std::unique_ptr< QgsAbstractGeometry > mSearchGeometryInLayerCrs;
+    std::unique_ptr< QgsGeos > mSearchGeometryInLayerCrsGeometryEngine;
+    QgsRectangle mMaxSearchExtentInLayerCrs;
+
+    std::unique_ptr< QgsPointCloudLayerProfileResults > mResults;
+
+    friend class QgsPointCloudLayerProfileResults;
+
+};
+
+#endif // QGSPOINTCLOUDLAYERPROFILEGENERATOR_H

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileRe
     QgsUnitTypes::RenderUnit pointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol pointSymbol = Qgis::PointCloudSymbol::Square;
     QColor pointColor;
+    bool opacityByDistanceEffect = false;
 
     QString type() const override;
     QMap< double, double > distanceToHeightMap() const override;
@@ -127,6 +128,7 @@ class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfile
     QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
     QColor mPointColor;
+    bool mOpacityByDistanceEffect = false;
 
     QString mId;
     std::unique_ptr<QgsFeedback> mFeedback = nullptr;

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -62,11 +62,11 @@ class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileRe
 
     struct PointResult
     {
-      double x;
-      double y;
-      double z;
-      double distanceAlongCurve;
-      double distanceFromCurve; // only used when the opacity by distance effect is enabled
+      double x = 0;
+      double y = 0;
+      double z = 0;
+      double distanceAlongCurve = 0;
+      double distanceFromCurve = 0; // only used when the opacity by distance effect is enabled
       QRgb color;
     };
 
@@ -134,9 +134,9 @@ class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfile
 
   private:
     QVector<IndexedPointCloudNode> traverseTree( const QgsPointCloudIndex *pc, IndexedPointCloudNode n, double maxErrorPixels, double nodeErrorPixels, const QgsDoubleRange &zRange );
-    int visitNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRequest &request );
-    int visitNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc,  QgsPointCloudRequest &request );
-    void visitBlock( const QgsPointCloudBlock *block );
+    int visitNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRequest &request, const QgsDoubleRange &zRange );
+    int visitNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc,  QgsPointCloudRequest &request, const QgsDoubleRange &zRange );
+    void visitBlock( const QgsPointCloudBlock *block, const QgsDoubleRange &zRange );
 
     QPointer< QgsPointCloudLayer > mLayer;
     std::unique_ptr< QgsPointCloudRenderer > mRenderer;

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -117,8 +117,8 @@ bool QgsPointCloudLayerRenderer::render()
   mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "Y" ), QgsPointCloudAttribute::Int32 ) );
 
   if ( !context.renderContext().zRange().isInfinite() ||
-       mRenderer->drawOrder2d() == QgsPointCloudRenderer::DrawOrder::BottomToTop ||
-       mRenderer->drawOrder2d() == QgsPointCloudRenderer::DrawOrder::TopToBottom )
+       mRenderer->drawOrder2d() == Qgis::PointCloudDrawOrder::BottomToTop ||
+       mRenderer->drawOrder2d() == Qgis::PointCloudDrawOrder::TopToBottom )
     mAttributes.push_back( QgsPointCloudAttribute( QStringLiteral( "Z" ), QgsPointCloudAttribute::Int32 ) );
 
   // collect attributes required by renderer
@@ -193,13 +193,13 @@ bool QgsPointCloudLayerRenderer::render()
 
   switch ( mRenderer->drawOrder2d() )
   {
-    case QgsPointCloudRenderer::DrawOrder::BottomToTop:
-    case QgsPointCloudRenderer::DrawOrder::TopToBottom:
+    case Qgis::PointCloudDrawOrder::BottomToTop:
+    case Qgis::PointCloudDrawOrder::TopToBottom:
     {
       nodesDrawn += renderNodesSorted( nodes, pc, context, request, canceled, mRenderer->drawOrder2d() );
       break;
     }
-    case QgsPointCloudRenderer::DrawOrder::Default:
+    case Qgis::PointCloudDrawOrder::Default:
     {
       switch ( pc->accessType() )
       {
@@ -359,7 +359,7 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
   return nodesDrawn;
 }
 
-int QgsPointCloudLayerRenderer::renderNodesSorted( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled, QgsPointCloudRenderer::DrawOrder order )
+int QgsPointCloudLayerRenderer::renderNodesSorted( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled, Qgis::PointCloudDrawOrder order )
 {
   int blockCount = 0;
   int pointCount = 0;
@@ -448,13 +448,13 @@ int QgsPointCloudLayerRenderer::renderNodesSorted( const QVector<IndexedPointClo
 
   switch ( order )
   {
-    case QgsPointCloudRenderer::DrawOrder::BottomToTop:
+    case Qgis::PointCloudDrawOrder::BottomToTop:
       std::sort( allPairs.begin(), allPairs.end(), []( QPair<int, double> a, QPair<int, double> b ) { return a.second < b.second; } );
       break;
-    case QgsPointCloudRenderer::DrawOrder::TopToBottom:
+    case Qgis::PointCloudDrawOrder::TopToBottom:
       std::sort( allPairs.begin(), allPairs.end(), []( QPair<int, double> a, QPair<int, double> b ) { return a.second > b.second; } );
       break;
-    case QgsPointCloudRenderer::DrawOrder::Default:
+    case Qgis::PointCloudDrawOrder::Default:
       break;
   }
 

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -277,9 +277,6 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<IndexedPointClou
 {
   int nodesDrawn = 0;
 
-  QElapsedTimer downloadTimer;
-  downloadTimer.start();
-
   if ( context.feedback() && context.feedback()->isCanceled() )
     return 0;
 

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     QVector<IndexedPointCloudNode> traverseTree( const QgsPointCloudIndex *pc, const QgsRenderContext &context, IndexedPointCloudNode n, double maxErrorPixels, double nodeErrorPixels );
     int renderNodesSync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled );
     int renderNodesAsync( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled );
-    int renderNodesSorted( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled, QgsPointCloudRenderer::DrawOrder order );
+    int renderNodesSorted( const QVector<IndexedPointCloudNode> &nodes, QgsPointCloudIndex *pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled, Qgis::PointCloudDrawOrder order );
 
     QgsPointCloudLayer *mLayer = nullptr;
 

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -97,12 +97,12 @@ void QgsPointCloudRenderer::startRender( QgsPointCloudRenderContext &context )
 
   switch ( mPointSymbol )
   {
-    case Square:
+    case Qgis::PointCloudSymbol::Square:
       // for square point we always disable antialiasing -- it's not critical here and we benefit from the performance boost disabling it gives
       context.renderContext().painter()->setRenderHint( QPainter::Antialiasing, false );
       break;
 
-    case Circle:
+    case Qgis::PointCloudSymbol::Circle:
       break;
   }
 }
@@ -173,8 +173,8 @@ void QgsPointCloudRenderer::restoreCommonProperties( const QDomElement &element,
 
   mMaximumScreenError = element.attribute( QStringLiteral( "maximumScreenError" ), QStringLiteral( "0.3" ) ).toDouble();
   mMaximumScreenErrorUnit = QgsUnitTypes::decodeRenderUnit( element.attribute( QStringLiteral( "maximumScreenErrorUnit" ), QStringLiteral( "MM" ) ) );
-  mPointSymbol = static_cast< PointSymbol >( element.attribute( QStringLiteral( "pointSymbol" ), QStringLiteral( "0" ) ).toInt() );
-  mDrawOrder2d = static_cast< DrawOrder >( element.attribute( QStringLiteral( "drawOrder2d" ), QStringLiteral( "0" ) ).toInt() );
+  mPointSymbol = static_cast< Qgis::PointCloudSymbol >( element.attribute( QStringLiteral( "pointSymbol" ), QStringLiteral( "0" ) ).toInt() );
+  mDrawOrder2d = static_cast< Qgis::PointCloudDrawOrder >( element.attribute( QStringLiteral( "drawOrder2d" ), QStringLiteral( "0" ) ).toInt() );
 }
 
 void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const QgsReadWriteContext & ) const
@@ -189,22 +189,22 @@ void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const Qg
   element.setAttribute( QStringLiteral( "drawOrder2d" ), QString::number( static_cast< int >( mDrawOrder2d ) ) );
 }
 
-QgsPointCloudRenderer::PointSymbol QgsPointCloudRenderer::pointSymbol() const
+Qgis::PointCloudSymbol QgsPointCloudRenderer::pointSymbol() const
 {
   return mPointSymbol;
 }
 
-void QgsPointCloudRenderer::setPointSymbol( PointSymbol symbol )
+void QgsPointCloudRenderer::setPointSymbol( Qgis::PointCloudSymbol symbol )
 {
   mPointSymbol = symbol;
 }
 
-QgsPointCloudRenderer::DrawOrder QgsPointCloudRenderer::drawOrder2d() const
+Qgis::PointCloudDrawOrder QgsPointCloudRenderer::drawOrder2d() const
 {
   return mDrawOrder2d;
 }
 
-void QgsPointCloudRenderer::setDrawOrder2d( DrawOrder order )
+void QgsPointCloudRenderer::setDrawOrder2d( Qgis::PointCloudDrawOrder order )
 {
   mDrawOrder2d = order;
 }
@@ -261,7 +261,7 @@ QVector<QVariantMap> QgsPointCloudRenderer::identify( QgsPointCloudLayer *layer,
     const double pointSizePixels = renderContext.convertToPainterUnits( mPointSize, mPointSizeUnit, mPointSizeMapUnitScale );
     switch ( pointSymbol() )
     {
-      case QgsPointCloudRenderer::PointSymbol::Square:
+      case Qgis::PointCloudSymbol::Square:
       {
         const QgsPointXY deviceCoords = renderContext.mapToPixel().transform( QgsPointXY( x, y ) );
         const QgsPointXY point1( deviceCoords.x() - std::max( toleranceInPixels, pointSizePixels / 2.0 ), deviceCoords.y() - std::max( toleranceInPixels, pointSizePixels / 2.0 ) );
@@ -272,7 +272,7 @@ QVector<QVariantMap> QgsPointCloudRenderer::identify( QgsPointCloudLayer *layer,
         selectionGeometry = QgsGeometry::fromRect( pointRect );
         break;
       }
-      case QgsPointCloudRenderer::PointSymbol::Circle:
+      case Qgis::PointCloudSymbol::Circle:
       {
         const QgsPoint centerMapCoords( x, y );
         const QgsPointXY deviceCoords = renderContext.mapToPixel().transform( centerMapCoords );

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -185,7 +185,7 @@ void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const Qg
 
   element.setAttribute( QStringLiteral( "maximumScreenError" ), qgsDoubleToString( mMaximumScreenError ) );
   element.setAttribute( QStringLiteral( "maximumScreenErrorUnit" ), QgsUnitTypes::encodeUnit( mMaximumScreenErrorUnit ) );
-  element.setAttribute( QStringLiteral( "pointSymbol" ), QString::number( mPointSymbol ) );
+  element.setAttribute( QStringLiteral( "pointSymbol" ), QString::number( static_cast< int >( mPointSymbol ) ) );
   element.setAttribute( QStringLiteral( "drawOrder2d" ), QString::number( static_cast< int >( mDrawOrder2d ) ) );
 }
 

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -275,26 +275,6 @@ class CORE_EXPORT QgsPointCloudRenderer
   public:
 
     /**
-     * Rendering symbols for points.
-     */
-    enum PointSymbol
-    {
-      Square, //!< Renders points as squares
-      Circle, //!< Renders points as circles
-    };
-
-    /**
-     * Pointcloud rendering order for 2d views
-     * /since QGIS 3.24
-     */
-    enum class DrawOrder : int
-    {
-      Default, //!< Draw points in the order they are stored
-      BottomToTop, //!< Draw points with larger Z values last
-      TopToBottom, //!< Draw points with larger Z values first
-    };
-
-    /**
      * Constructor for QgsPointCloudRenderer.
      */
     QgsPointCloudRenderer() = default;
@@ -464,7 +444,7 @@ class CORE_EXPORT QgsPointCloudRenderer
      * \see setDrawOrder2d()
      * \since QGIS 3.24
      */
-    DrawOrder drawOrder2d() const;
+    Qgis::PointCloudDrawOrder drawOrder2d() const;
 
     /**
      * Sets the drawing \a order used by the renderer for drawing points.
@@ -472,21 +452,21 @@ class CORE_EXPORT QgsPointCloudRenderer
      * \see drawOrder2d()
      * \since QGIS 3.24
      */
-    void setDrawOrder2d( DrawOrder order );
+    void setDrawOrder2d( Qgis::PointCloudDrawOrder order );
 
     /**
      * Returns the symbol used by the renderer for drawing points.
      *
      * \see setPointSymbol()
      */
-    PointSymbol pointSymbol() const;
+    Qgis::PointCloudSymbol pointSymbol() const;
 
     /**
      * Sets the \a symbol used by the renderer for drawing points.
      *
      * \see pointSymbol()
      */
-    void setPointSymbol( PointSymbol symbol );
+    void setPointSymbol( Qgis::PointCloudSymbol symbol );
 
     /**
      * Returns the maximum screen error allowed when rendering the point cloud.
@@ -574,13 +554,13 @@ class CORE_EXPORT QgsPointCloudRenderer
       QPainter *painter = context.renderContext().painter();
       switch ( mPointSymbol )
       {
-        case Square:
+        case Qgis::PointCloudSymbol::Square:
           painter->fillRect( QRectF( x - mPainterPenWidth * 0.5,
                                      y - mPainterPenWidth * 0.5,
                                      mPainterPenWidth, mPainterPenWidth ), color );
           break;
 
-        case Circle:
+        case Qgis::PointCloudSymbol::Circle:
           painter->setBrush( QBrush( color ) );
           painter->setPen( Qt::NoPen );
           painter->drawEllipse( QRectF( x - mPainterPenWidth * 0.5,
@@ -628,9 +608,9 @@ class CORE_EXPORT QgsPointCloudRenderer
     QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
     QgsMapUnitScale mPointSizeMapUnitScale;
 
-    PointSymbol mPointSymbol = Square;
+    Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
     int mPainterPenWidth = 1;
-    DrawOrder mDrawOrder2d = DrawOrder::Default;
+    Qgis::PointCloudDrawOrder mDrawOrder2d = Qgis::PointCloudDrawOrder::Default;
 };
 
 #endif // QGSPOINTCLOUDRENDERER_H

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1676,6 +1676,31 @@ class CORE_EXPORT Qgis
     Q_FLAG( ProfileGeneratorFlags )
 
     /**
+     * Rendering symbols for point cloud points.
+     *
+     * \since QGIS 3.26
+     */
+    enum PointCloudSymbol SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, PointSymbol ) : int
+    {
+      Square, //!< Renders points as squares
+      Circle, //!< Renders points as circles
+    };
+    Q_ENUM( PointCloudSymbol )
+
+    /**
+     * Pointcloud rendering order for 2d views
+     *
+     * /since QGIS 3.26
+     */
+    enum class PointCloudDrawOrder SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, DrawOrder ) : int
+      {
+      Default, //!< Draw points in the order they are stored
+      BottomToTop, //!< Draw points with larger Z values last
+      TopToBottom, //!< Draw points with larger Z values first
+    };
+    Q_ENUM( PointCloudDrawOrder )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1680,8 +1680,8 @@ class CORE_EXPORT Qgis
      *
      * \since QGIS 3.26
      */
-    enum PointCloudSymbol SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, PointSymbol ) : int
-    {
+    enum class PointCloudSymbol SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, PointSymbol ) : int
+      {
       Square, //!< Renders points as squares
       Circle, //!< Renders points as circles
     };

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -87,7 +87,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
     for ( const Feature &feature : it.value() )
     {
       const QgsRectangle featureBounds = feature.crossSectionGeometry.boundingBox();
-      if ( ( featureBounds.xMinimum() - context.maximumDistanceDelta <= point.distance() ) && ( featureBounds.xMaximum() + context.maximumDistanceDelta >= point.distance() ) )
+      if ( ( featureBounds.xMinimum() - context.maximumPointDistanceDelta <= point.distance() ) && ( featureBounds.xMaximum() + context.maximumPointDistanceDelta >= point.distance() ) )
       {
         switch ( feature.crossSectionGeometry.type() )
         {
@@ -98,11 +98,11 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
               if ( const QgsPoint *candidatePoint = qgsgeometry_cast< const QgsPoint * >( *partIt ) )
               {
                 const double snapDistanceDelta = std::fabs( point.distance() - candidatePoint->x() );
-                if ( snapDistanceDelta > context.maximumDistanceDelta )
+                if ( snapDistanceDelta > context.maximumPointDistanceDelta )
                   continue;
 
                 const double snapHeightDelta = std::fabs( point.elevation() - candidatePoint->y() );
-                if ( snapHeightDelta > context.maximumElevationDelta )
+                if ( snapHeightDelta > context.maximumPointElevationDelta )
                   continue;
 
                 const double snapDistance = candidatePoint->distance( targetPoint );
@@ -128,11 +128,11 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
                   if ( lineString->numPoints() == 2 && qgsDoubleNear( lineString->pointN( 0 ).x(), lineString->pointN( 1 ).x() ) )
                   {
                     const double snapDistanceDelta = std::fabs( point.distance() - lineString->pointN( 0 ).x() );
-                    if ( snapDistanceDelta > context.maximumDistanceDelta )
+                    if ( snapDistanceDelta > context.maximumPointDistanceDelta )
                       continue;
 
                     const double snapHeightDelta = std::fabs( point.elevation() - lineString->pointN( 0 ).y() );
-                    if ( snapHeightDelta <= context.maximumElevationDelta )
+                    if ( snapHeightDelta <= context.maximumPointElevationDelta )
                     {
                       const double snapDistanceP1 = lineString->pointN( 0 ).distance( targetPoint );
                       if ( snapDistanceP1 < bestSnapDistance )
@@ -143,7 +143,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
                     }
 
                     const double snapHeightDelta2 = std::fabs( point.elevation() - lineString->pointN( 1 ).y() );
-                    if ( snapHeightDelta2 <= context.maximumElevationDelta )
+                    if ( snapHeightDelta2 <= context.maximumPointElevationDelta )
                     {
                       const double snapDistanceP2 = lineString->pointN( 1 ).distance( targetPoint );
                       if ( snapDistanceP2 < bestSnapDistance )
@@ -157,7 +157,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
                 }
 
                 const QgsRectangle partBounds = ( *partIt )->boundingBox();
-                if ( point.distance() < partBounds.xMinimum() - context.maximumDistanceDelta || point.distance() > partBounds.xMaximum() + context.maximumDistanceDelta )
+                if ( point.distance() < partBounds.xMinimum() - context.maximumPointDistanceDelta || point.distance() > partBounds.xMaximum() + context.maximumPointDistanceDelta )
                   continue;
 
                 const double snappedDistance = point.distance() < partBounds.xMinimum() ? partBounds.xMinimum()
@@ -171,7 +171,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
                 for ( auto vertexIt = points.vertices_begin(); vertexIt != points.vertices_end(); ++vertexIt )
                 {
                   const double snapHeightDelta = std::fabs( point.elevation() - ( *vertexIt ).y() );
-                  if ( snapHeightDelta > context.maximumElevationDelta )
+                  if ( snapHeightDelta > context.maximumSurfaceElevationDelta )
                     continue;
 
                   const double snapDistance = ( *vertexIt ).distance( targetPoint );
@@ -193,7 +193,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
               if ( const QgsCurve *exterior = qgsgeometry_cast< const QgsPolygon * >( *partIt )->exteriorRing() )
               {
                 const QgsRectangle partBounds = ( *partIt )->boundingBox();
-                if ( point.distance() < partBounds.xMinimum() - context.maximumDistanceDelta || point.distance() > partBounds.xMaximum() + context.maximumDistanceDelta )
+                if ( point.distance() < partBounds.xMinimum() - context.maximumPointDistanceDelta || point.distance() > partBounds.xMaximum() + context.maximumPointDistanceDelta )
                   continue;
 
                 const double snappedDistance = point.distance() < partBounds.xMinimum() ? partBounds.xMinimum()
@@ -206,7 +206,7 @@ QgsProfileSnapResult QgsVectorLayerProfileResults::snapPoint( const QgsProfilePo
                 for ( auto vertexIt = points.vertices_begin(); vertexIt != points.vertices_end(); ++vertexIt )
                 {
                   const double snapHeightDelta = std::fabs( point.elevation() - ( *vertexIt ).y() );
-                  if ( snapHeightDelta > context.maximumElevationDelta )
+                  if ( snapHeightDelta > context.maximumSurfaceElevationDelta )
                     continue;
 
                   const double snapDistance = ( *vertexIt ).distance( targetPoint );

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -34,9 +34,11 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsprofilesnapping.h"
 #include "qgsmaplayerelevationproperties.h"
+#include "qgsapplication.h"
 
 #include <QWheelEvent>
 #include <QTimer>
+#include <QDesktopWidget>
 
 ///@cond PRIVATE
 class QgsElevationProfilePlotItem : public Qgs2DPlot, public QgsPlotCanvasItem
@@ -631,7 +633,7 @@ void QgsElevationProfileCanvas::refresh()
   connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsElevationProfileCanvas::generationFinished );
 
   QgsProfileGenerationContext generationContext;
-
+  generationContext.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
   generationContext.setMaximumErrorMapUnits( MAX_ERROR_PIXELS * ( mProfileCurve->length() ) / mPlotItem->plotArea().width() );
   generationContext.setMapUnitsPerDistancePixel( mProfileCurve->length() / mPlotItem->plotArea().width() );
   mCurrentJob->setContext( generationContext );
@@ -769,6 +771,7 @@ void QgsElevationProfileCanvas::refineResults()
   if ( mCurrentJob )
   {
     QgsProfileGenerationContext context;
+    context.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
     const double plotDistanceRange = mPlotItem->xMaximum() - mPlotItem->xMinimum();
     const double plotElevationRange = mPlotItem->yMaximum() - mPlotItem->yMinimum();
     const double plotDistanceUnitsPerPixel = plotDistanceRange / mPlotItem->plotArea().width();

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -633,6 +633,7 @@ void QgsElevationProfileCanvas::refresh()
   QgsProfileGenerationContext generationContext;
 
   generationContext.setMaximumErrorMapUnits( MAX_ERROR_PIXELS * ( mProfileCurve->length() ) / mPlotItem->plotArea().width() );
+  generationContext.setMapUnitsPerDistancePixel( mProfileCurve->length() / mPlotItem->plotArea().width() );
   mCurrentJob->setContext( generationContext );
 
   mCurrentJob->startGeneration();
@@ -767,6 +768,8 @@ void QgsElevationProfileCanvas::refineResults()
     const double factor = std::pow( 10.0, 1 - std::ceil( std::log10( std::fabs( targetMaxErrorInMapUnits ) ) ) );
     const double roundedErrorInMapUnits = std::floor( targetMaxErrorInMapUnits * factor ) / factor;
     context.setMaximumErrorMapUnits( roundedErrorInMapUnits );
+
+    context.setMapUnitsPerDistancePixel( plotDistanceUnitsPerPixel );
 
     // for similar reasons we round the minimum distance off to multiples of the maximum error in map units
     const double distanceMin = std::floor( ( mPlotItem->xMinimum() - plotDistanceRange * 0.05 ) / context.maximumErrorMapUnits() ) * context.maximumErrorMapUnits();

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -399,12 +399,14 @@ void QgsElevationProfileCanvas::scalePlot( double factor )
 QgsProfileSnapContext QgsElevationProfileCanvas::snapContext() const
 {
   const double toleranceInPixels = QFontMetrics( font() ).horizontalAdvance( ' ' );
-  const double xToleranceInPlotUnits = 2 * ( mPlotItem->xMaximum() - mPlotItem->xMinimum() ) / ( mPlotItem->plotArea().width() ) * toleranceInPixels;
-  const double yToleranceInPlotUnits = 10 * ( mPlotItem->yMaximum() - mPlotItem->yMinimum() ) / ( mPlotItem->plotArea().height() ) * toleranceInPixels;
+  const double xToleranceInPlotUnits = ( mPlotItem->xMaximum() - mPlotItem->xMinimum() ) / ( mPlotItem->plotArea().width() ) * toleranceInPixels;
+  const double yToleranceInPlotUnits = ( mPlotItem->yMaximum() - mPlotItem->yMinimum() ) / ( mPlotItem->plotArea().height() ) * toleranceInPixels;
 
   QgsProfileSnapContext context;
-  context.maximumDistanceDelta = xToleranceInPlotUnits;
-  context.maximumElevationDelta = yToleranceInPlotUnits;
+  context.maximumSurfaceDistanceDelta = 2 * xToleranceInPlotUnits;
+  context.maximumSurfaceElevationDelta = 10 * yToleranceInPlotUnits;
+  context.maximumPointDistanceDelta = 4 * xToleranceInPlotUnits;
+  context.maximumPointElevationDelta = 4 * yToleranceInPlotUnits;
   context.displayRatioElevationVsDistance = ( ( mPlotItem->yMaximum() - mPlotItem->yMinimum() ) / ( mPlotItem->plotArea().height() ) )
       / ( ( mPlotItem->xMaximum() - mPlotItem->xMinimum() ) / ( mPlotItem->plotArea().width() ) );
 

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -663,6 +663,13 @@ void QgsElevationProfileCanvas::generationFinished()
 
     mPlotItem->updatePlot();
   }
+
+  if ( mForceRegenerationAfterCurrentJobCompletes )
+  {
+    mForceRegenerationAfterCurrentJobCompletes = false;
+    mCurrentJob->invalidateAllRefinableSources();
+    scheduleDeferredRegeneration();
+  }
 }
 
 void QgsElevationProfileCanvas::onLayerProfileGenerationPropertyChanged()
@@ -742,6 +749,10 @@ void QgsElevationProfileCanvas::startDeferredRegeneration()
   {
     emit activeJobCountChanged( 1 );
     mCurrentJob->regenerateInvalidatedResults();
+  }
+  else if ( mCurrentJob )
+  {
+    mForceRegenerationAfterCurrentJobCompletes = true;
   }
 
   mDeferredRegenerationScheduled = false;

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -633,7 +633,7 @@ void QgsElevationProfileCanvas::refresh()
   connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsElevationProfileCanvas::generationFinished );
 
   QgsProfileGenerationContext generationContext;
-  generationContext.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
+  generationContext.setDpi( QgsApplication::desktop()->logicalDpiX() );
   generationContext.setMaximumErrorMapUnits( MAX_ERROR_PIXELS * ( mProfileCurve->length() ) / mPlotItem->plotArea().width() );
   generationContext.setMapUnitsPerDistancePixel( mProfileCurve->length() / mPlotItem->plotArea().width() );
   mCurrentJob->setContext( generationContext );
@@ -771,7 +771,7 @@ void QgsElevationProfileCanvas::refineResults()
   if ( mCurrentJob )
   {
     QgsProfileGenerationContext context;
-    context.setScaleFactor( QgsApplication::desktop()->logicalDpiX() / 25.4 );
+    context.setDpi( QgsApplication::desktop()->logicalDpiX() );
     const double plotDistanceRange = mPlotItem->xMaximum() - mPlotItem->xMinimum();
     const double plotElevationRange = mPlotItem->yMaximum() - mPlotItem->yMinimum();
     const double plotDistanceUnitsPerPixel = plotDistanceRange / mPlotItem->plotArea().width();

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -252,6 +252,8 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
 
     bool mZoomFullWhenJobFinished = true;
 
+    bool mForceRegenerationAfterCurrentJobCompletes = false;
+
     static constexpr double MAX_ERROR_PIXELS = 2;
 };
 

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -87,8 +87,8 @@ QgsPointCloudRendererPropertiesWidget::QgsPointCloudRendererPropertiesWidget( Qg
 
   cboRenderers->setCurrentIndex( -1 ); // set no current renderer
 
-  mPointStyleComboBox->addItem( tr( "Square" ), QgsPointCloudRenderer::Square );
-  mPointStyleComboBox->addItem( tr( "Circle" ), QgsPointCloudRenderer::Circle );
+  mPointStyleComboBox->addItem( tr( "Square" ), Qgis::PointCloudSymbol::Square );
+  mPointStyleComboBox->addItem( tr( "Circle" ), Qgis::PointCloudSymbol::Circle );
 
   connect( cboRenderers, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPointCloudRendererPropertiesWidget::rendererChanged );
 
@@ -101,9 +101,9 @@ QgsPointCloudRendererPropertiesWidget::QgsPointCloudRendererPropertiesWidget( Qg
   connect( mPointSizeSpinBox, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, &QgsPointCloudRendererPropertiesWidget::emitWidgetChanged );
   connect( mPointSizeUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsPointCloudRendererPropertiesWidget::emitWidgetChanged );
 
-  mDrawOrderComboBox->addItem( tr( "Default" ), static_cast< int >( QgsPointCloudRenderer::DrawOrder::Default ) );
-  mDrawOrderComboBox->addItem( tr( "Bottom to Top" ), static_cast< int >( QgsPointCloudRenderer::DrawOrder::BottomToTop ) );
-  mDrawOrderComboBox->addItem( tr( "Top to Bottom" ), static_cast< int >( QgsPointCloudRenderer::DrawOrder::TopToBottom ) );
+  mDrawOrderComboBox->addItem( tr( "Default" ), static_cast< int >( Qgis::PointCloudDrawOrder::Default ) );
+  mDrawOrderComboBox->addItem( tr( "Bottom to Top" ), static_cast< int >( Qgis::PointCloudDrawOrder::BottomToTop ) );
+  mDrawOrderComboBox->addItem( tr( "Top to Bottom" ), static_cast< int >( Qgis::PointCloudDrawOrder::TopToBottom ) );
 
   mMaxErrorUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMetersInMapUnits << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                                  << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
@@ -185,11 +185,11 @@ void QgsPointCloudRendererPropertiesWidget::apply()
   mLayer->renderer()->setPointSizeUnit( mPointSizeUnitWidget->unit() );
   mLayer->renderer()->setPointSizeMapUnitScale( mPointSizeUnitWidget->getMapUnitScale() );
 
-  mLayer->renderer()->setPointSymbol( static_cast< QgsPointCloudRenderer::PointSymbol >( mPointStyleComboBox->currentData().toInt() ) );
+  mLayer->renderer()->setPointSymbol( static_cast< Qgis::PointCloudSymbol >( mPointStyleComboBox->currentData().toInt() ) );
 
   mLayer->renderer()->setMaximumScreenError( mMaxErrorSpinBox->value() );
   mLayer->renderer()->setMaximumScreenErrorUnit( mMaxErrorUnitWidget->unit() );
-  mLayer->renderer()->setDrawOrder2d( static_cast< QgsPointCloudRenderer::DrawOrder >( mDrawOrderComboBox->currentData().toInt() ) );
+  mLayer->renderer()->setDrawOrder2d( static_cast< Qgis::PointCloudDrawOrder >( mDrawOrderComboBox->currentData().toInt() ) );
 }
 
 void QgsPointCloudRendererPropertiesWidget::rendererChanged()

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -87,8 +87,8 @@ QgsPointCloudRendererPropertiesWidget::QgsPointCloudRendererPropertiesWidget( Qg
 
   cboRenderers->setCurrentIndex( -1 ); // set no current renderer
 
-  mPointStyleComboBox->addItem( tr( "Square" ), Qgis::PointCloudSymbol::Square );
-  mPointStyleComboBox->addItem( tr( "Circle" ), Qgis::PointCloudSymbol::Circle );
+  mPointStyleComboBox->addItem( tr( "Square" ), static_cast< int >( Qgis::PointCloudSymbol::Square ) );
+  mPointStyleComboBox->addItem( tr( "Circle" ), static_cast< int >( Qgis::PointCloudSymbol::Circle ) );
 
   connect( cboRenderers, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPointCloudRendererPropertiesWidget::rendererChanged );
 
@@ -151,7 +151,7 @@ void QgsPointCloudRendererPropertiesWidget::syncToLayer( QgsMapLayer *layer )
     mPointSizeUnitWidget->setUnit( mLayer->renderer()->pointSizeUnit() );
     mPointSizeUnitWidget->setMapUnitScale( mLayer->renderer()->pointSizeMapUnitScale() );
 
-    mPointStyleComboBox->setCurrentIndex( mPointStyleComboBox->findData( mLayer->renderer()->pointSymbol() ) );
+    mPointStyleComboBox->setCurrentIndex( mPointStyleComboBox->findData( static_cast< int >( mLayer->renderer()->pointSymbol() ) ) );
     mDrawOrderComboBox->setCurrentIndex( mDrawOrderComboBox->findData( static_cast< int >( mLayer->renderer()->drawOrder2d() ) ) );
 
     mMaxErrorSpinBox->setValue( mLayer->renderer()->maximumScreenError() );

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -405,10 +405,10 @@ void QgsHighlight::paint( QPainter *p )
             sizeUnit = QgsUnitTypes::RenderPixels;
             switch ( pcRenderer->pointSymbol() )
             {
-              case QgsPointCloudRenderer::PointSymbol::Circle:
+              case Qgis::PointCloudSymbol::Circle:
                 symbol = Circle;
                 break;
-              case QgsPointCloudRenderer::PointSymbol::Square:
+              case Qgis::PointCloudSymbol::Square:
                 symbol = Square;
                 break;
             }

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -188,6 +188,45 @@
       <string>Profile Chart Appearance</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,1">
+      <item row="2" column="1" colspan="2">
+       <widget class="QgsColorButton" name="mPointColorButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>99999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mPointStyleComboBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="lblTransparency_4">
         <property name="text">
@@ -209,42 +248,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QComboBox" name="mPointStyleComboBox"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="maximum">
-         <double>99999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QgsColorButton" name="mPointColorButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>120</width>
-          <height>0</height>
-         </size>
-        </property>
+      <item row="3" column="0" colspan="3">
+       <widget class="QCheckBox" name="mOpacityByDistanceCheckBox">
         <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Color</string>
+         <string>Apply opacity by distance from curve effect</string>
         </property>
        </widget>
       </item>

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>270</height>
+    <width>413</width>
+    <height>439</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -129,6 +129,129 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="mLayerRenderingGroupBox">
+     <property name="title">
+      <string>Profile Chart Accuracy</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,2,1,0">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="1" colspan="2">
+       <widget class="QgsDoubleSpinBox" name="mMaxErrorSpinBox">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>99999999999.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.300000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QgsUnitSelectionWidget" name="mMaxErrorUnitWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency_2">
+        <property name="text">
+         <string>Maximum error</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Profile Chart Appearance</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblTransparency_4">
+        <property name="text">
+         <string>Point size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QgsUnitSelectionWidget" name="mPointSizeUnitWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mPointStyleComboBox"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>99999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QgsColorButton" name="mPointColorButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -154,6 +277,18 @@
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/python/test_qgsmeshlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsmeshlayerprofilegenerator.py
@@ -112,15 +112,17 @@ class TestQgsMeshLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 0
-        context.maximumElevationDelta = 3
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumSurfaceElevationDelta = 3
+        context.maximumPointDistanceDelta = 0
+        context.maximumPointElevationDelta = 0
         res = r.snapPoint(QgsProfilePoint(0, 70), context)
         self.assertTrue(res.isValid())
         self.assertEqual(res.snappedPoint.distance(), 0)
         self.assertAlmostEqual(res.snappedPoint.elevation(), 71.8, 0)
 
-        context.maximumDistanceDelta = 0
-        context.maximumElevationDelta = 5
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumSurfaceElevationDelta = 5
         res = r.snapPoint(QgsProfilePoint(200, 79), context)
         self.assertTrue(res.isValid())
         self.assertEqual(res.snappedPoint.distance(), 200)

--- a/tests/src/python/test_qgspointcloudelevationproperties.py
+++ b/tests/src/python/test_qgspointcloudelevationproperties.py
@@ -15,7 +15,10 @@ import qgis  # NOQA
 from qgis.core import (
     QgsPointCloudLayerElevationProperties,
     QgsReadWriteContext,
+    QgsUnitTypes,
+    Qgis
 )
+from qgis.PyQt.QtGui import QColor
 
 from qgis.PyQt.QtXml import QDomDocument
 
@@ -30,11 +33,25 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         props = QgsPointCloudLayerElevationProperties(None)
         self.assertEqual(props.zScale(), 1)
         self.assertEqual(props.zOffset(), 0)
+        self.assertTrue(props.pointColor().isValid())
 
         props.setZOffset(0.5)
         props.setZScale(2)
+        props.setMaximumScreenError(0.4)
+        props.setMaximumScreenErrorUnit(QgsUnitTypes.RenderInches)
+        props.setPointSymbol(Qgis.PointCloudSymbol.Circle)
+        props.setPointColor(QColor(255, 0, 255))
+        props.setPointSize(1.2)
+        props.setPointSizeUnit(QgsUnitTypes.RenderPoints)
+
         self.assertEqual(props.zScale(), 2)
         self.assertEqual(props.zOffset(), 0.5)
+        self.assertEqual(props.maximumScreenError(), 0.4)
+        self.assertEqual(props.maximumScreenErrorUnit(), QgsUnitTypes.RenderInches)
+        self.assertEqual(props.pointSymbol(), Qgis.PointCloudSymbol.Circle)
+        self.assertEqual(props.pointColor().name(), '#ff00ff')
+        self.assertEqual(props.pointSize(), 1.2)
+        self.assertEqual(props.pointSizeUnit(), QgsUnitTypes.RenderPoints)
 
         doc = QDomDocument("testdoc")
         elem = doc.createElement('test')
@@ -44,6 +61,22 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         props2.readXml(elem, QgsReadWriteContext())
         self.assertEqual(props2.zScale(), 2)
         self.assertEqual(props2.zOffset(), 0.5)
+        self.assertEqual(props2.maximumScreenError(), 0.4)
+        self.assertEqual(props2.maximumScreenErrorUnit(), QgsUnitTypes.RenderInches)
+        self.assertEqual(props2.pointSymbol(), Qgis.PointCloudSymbol.Circle)
+        self.assertEqual(props2.pointColor().name(), '#ff00ff')
+        self.assertEqual(props2.pointSize(), 1.2)
+        self.assertEqual(props2.pointSizeUnit(), QgsUnitTypes.RenderPoints)
+
+        props2 = props.clone()
+        self.assertEqual(props2.zScale(), 2)
+        self.assertEqual(props2.zOffset(), 0.5)
+        self.assertEqual(props2.maximumScreenError(), 0.4)
+        self.assertEqual(props2.maximumScreenErrorUnit(), QgsUnitTypes.RenderInches)
+        self.assertEqual(props2.pointSymbol(), Qgis.PointCloudSymbol.Circle)
+        self.assertEqual(props2.pointColor().name(), '#ff00ff')
+        self.assertEqual(props2.pointSize(), 1.2)
+        self.assertEqual(props2.pointSizeUnit(), QgsUnitTypes.RenderPoints)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsrasterlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsrasterlayerprofilegenerator.py
@@ -128,15 +128,17 @@ class TestQgsRasterLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 0
-        context.maximumElevationDelta = 3
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumSurfaceElevationDelta = 3
+        context.maximumPointDistanceDelta = 0
+        context.maximumPointElevationDelta = 0
         res = r.snapPoint(QgsProfilePoint(0, 70), context)
         self.assertTrue(res.isValid())
         self.assertEqual(res.snappedPoint.distance(), 0)
         self.assertEqual(res.snappedPoint.elevation(), 72)
 
-        context.maximumDistanceDelta = 0
-        context.maximumElevationDelta = 5
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumSurfaceElevationDelta = 5
         res = r.snapPoint(QgsProfilePoint(200, 79), context)
         self.assertTrue(res.isValid())
         self.assertEqual(res.snappedPoint.distance(), 200)

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -823,22 +823,24 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 1
-        context.maximumElevationDelta = 3
+        context.maximumPointDistanceDelta = 1
+        context.maximumPointElevationDelta = 3
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumSurfaceElevationDelta = 0
         res = r.snapPoint(QgsProfilePoint(15, 14), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 15.89, 1)
         self.assertAlmostEqual(res.snappedPoint.elevation(), 14.36, 1)
 
-        context.maximumDistanceDelta = 2
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 2
+        context.maximumPointElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 55.279, 1)
         self.assertAlmostEqual(res.snappedPoint.elevation(), 16.141, 1)
 
-        context.maximumDistanceDelta = 0.1
-        context.maximumElevationDelta = 0.1
+        context.maximumPointDistanceDelta = 0.1
+        context.maximumPointElevationDelta = 0.1
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertFalse(res.isValid())
 
@@ -871,8 +873,10 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 1
-        context.maximumElevationDelta = 3
+        context.maximumPointDistanceDelta = 1
+        context.maximumPointElevationDelta = 3
+        context.maximumSurfaceElevationDelta = 0
+        context.maximumSurfaceDistanceDelta = 0
         res = r.snapPoint(QgsProfilePoint(15, 14), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 15.89, 1)
@@ -886,8 +890,8 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(15, 35), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 2
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 2
+        context.maximumPointElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 55.279, 1)
@@ -901,8 +905,8 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(55, 36), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 0.1
-        context.maximumElevationDelta = 0.1
+        context.maximumPointDistanceDelta = 0.1
+        context.maximumPointElevationDelta = 0.1
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertFalse(res.isValid())
 
@@ -933,8 +937,10 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 1
-        context.maximumElevationDelta = 3
+        context.maximumPointDistanceDelta = 1
+        context.maximumSurfaceElevationDelta = 3
+        context.maximumPointElevationDelta = 0
+        context.maximumSurfaceDistanceDelta = 0
         res = r.snapPoint(QgsProfilePoint(27, 1.9), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 27.37797, 1)
@@ -943,20 +949,20 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(27, 7), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 3
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 3
+        context.maximumSurfaceElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(42, 3), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 40.7058, 1)
         self.assertAlmostEqual(res.snappedPoint.elevation(), 2.000, 1)
 
-        context.maximumDistanceDelta = 0.01
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 0.01
+        context.maximumSurfaceElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(42, 3), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 0.1
-        context.maximumElevationDelta = 0.1
+        context.maximumPointDistanceDelta = 0.1
+        context.maximumSurfaceElevationDelta = 0.1
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertFalse(res.isValid())
 
@@ -989,8 +995,10 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(-10, -10), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 1
-        context.maximumElevationDelta = 3
+        context.maximumPointDistanceDelta = 1
+        context.maximumSurfaceElevationDelta = 3
+        context.maximumSurfaceDistanceDelta = 0
+        context.maximumPointElevationDelta = 0
         res = r.snapPoint(QgsProfilePoint(27, 1.9), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 27.37797, 1)
@@ -1007,20 +1015,20 @@ class TestQgsVectorLayerProfileGenerator(unittest.TestCase):
         res = r.snapPoint(QgsProfilePoint(27, 7), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 3
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 3
+        context.maximumSurfaceElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(42, 3), context)
         self.assertTrue(res.isValid())
         self.assertAlmostEqual(res.snappedPoint.distance(), 40.7058, 1)
         self.assertAlmostEqual(res.snappedPoint.elevation(), 2.000, 1)
 
-        context.maximumDistanceDelta = 0.01
-        context.maximumElevationDelta = 2
+        context.maximumPointDistanceDelta = 0.01
+        context.maximumSurfaceElevationDelta = 2
         res = r.snapPoint(QgsProfilePoint(42, 3), context)
         self.assertFalse(res.isValid())
 
-        context.maximumDistanceDelta = 0.1
-        context.maximumElevationDelta = 0.1
+        context.maximumPointDistanceDelta = 0.1
+        context.maximumSurfaceElevationDelta = 0.1
         res = r.snapPoint(QgsProfilePoint(55, 16), context)
         self.assertFalse(res.isValid())
 


### PR DESCRIPTION
This PR adds initial support for point cloud layers to show in profile plots.

Supported so far:

- Single color display of points
- Respects the profile curve distance tolerance setting
- Automatic refinement based on plot visible area and scale and user controllable max screen error, just like 2d point cloud renderer (works great for COPC!)
- Control over appearance of points (color, size and shape)
- Snapping to points
- 
Remaining tasks are:

- Respect 2d renderer colors for points (eg classification colors)

Also includes an option to reduce the opacity of points which are further from the profile curve

https://user-images.githubusercontent.com/1829991/165682434-d515d39d-b7d0-4172-ae9c-46e9b67daa8a.mp4


