### PR TITLE
Fix QueryLayer support in HANA

### DIFF
--- a/src/providers/hana/qgshanafeatureiterator.cpp
+++ b/src/providers/hana/qgshanafeatureiterator.cpp
@@ -146,7 +146,6 @@ bool QgsHanaFeatureIterator::rewind()
 
 bool QgsHanaFeatureIterator::close()
 {
-
   if ( mClosed )
     return false;
 

--- a/src/providers/hana/qgshanaprovider.cpp
+++ b/src/providers/hana/qgshanaprovider.cpp
@@ -372,12 +372,6 @@ QgsHanaProvider::QgsHanaProvider(
     this->appendError( QgsErrorMessage( message, QStringLiteral( "SAP HANA" ) ) );
   };
 
-  if ( mSchemaName.isEmpty() || mTableName.isEmpty() )
-  {
-    appendError( tr( "Schema or table name cannot be empty" ) );
-    return;
-  }
-
   QgsHanaConnectionRef conn( mUri );
   if ( conn.isNull() )
   {
@@ -393,6 +387,12 @@ QgsHanaProvider::QgsHanaProvider(
   }
   else
   {
+    if ( mSchemaName.isEmpty() || mTableName.isEmpty() )
+    {
+      appendError( tr( "Schema or table name cannot be empty" ) );
+      return;
+    }
+
     mIsQuery = false;
     mQuerySource = QStringLiteral( "%1.%2" ).arg(
                      QgsHanaUtils::quotedIdentifier( mSchemaName ),

--- a/src/providers/hana/qgshanaproviderconnection.cpp
+++ b/src/providers/hana/qgshanaproviderconnection.cpp
@@ -82,6 +82,21 @@ QgsHanaProviderConnection::QgsHanaProviderConnection( const QString &uri, const 
 
 void QgsHanaProviderConnection::setCapabilities()
 {
+  mGeometryColumnCapabilities =
+  {
+    //GeometryColumnCapability::Curves, not fully supported yet
+    GeometryColumnCapability::Z,
+    GeometryColumnCapability::M,
+    GeometryColumnCapability::SinglePart
+  };
+  mSqlLayerDefinitionCapabilities =
+  {
+    Qgis::SqlLayerDefinitionCapability::SubsetStringFilter,
+    Qgis::SqlLayerDefinitionCapability::PrimaryKeys,
+    Qgis::SqlLayerDefinitionCapability::GeometryColumn,
+    Qgis::SqlLayerDefinitionCapability::UnstableFeatureIds,
+  };
+
   /*
    * Capability::DropSchema         | CREATE SCHEMA from SYSTEMPRIVILEGE
    * Capability::CreateSchema       | CREATE SCHEMA from SYSTEMPRIVILEGE

--- a/src/providers/hana/qgshanaproviderconnection.h
+++ b/src/providers/hana/qgshanaproviderconnection.h
@@ -19,6 +19,7 @@
 
 #include "qgsabstractdatabaseproviderconnection.h"
 #include "qgshanaconnection.h"
+#include "qgshanaconnectionpool.h"
 #include "qgshanaresultset.h"
 
 struct QgsHanaEmptyProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
@@ -32,11 +33,12 @@ struct QgsHanaEmptyProviderResultIterator: public QgsAbstractDatabaseProviderCon
 
 struct QgsHanaProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
 {
-    QgsHanaProviderResultIterator( QgsHanaResultSetRef &&resultSet );
+    QgsHanaProviderResultIterator( QgsHanaConnectionRef &&conn, QgsHanaResultSetRef &&resultSet );
 
   private:
+    QgsHanaConnectionRef mConnection;
     QgsHanaResultSetRef mResultSet;
-    unsigned short mNumColumns = 0;
+    const unsigned short mNumColumns = 0;
     bool mNextRow = false;
 
     // QueryResultIterator interface


### PR DESCRIPTION
This PR fixes the following issues in the HANA plugin:
- The QgsQueryResultWidget dialog for HANA misses some UI fields in the "Load as new layer" panel.
- HANA's query layer cannot be added to the project.
- QGIS crashes when a HANA connection is expired in the QgsQueryResultWidget dialog.