### PR TITLE
Make sure the ok button for polymorphic relations is enabled after validation

### DIFF
--- a/src/app/qgsrelationaddpolymorphicdialog.cpp
+++ b/src/app/qgsrelationaddpolymorphicdialog.cpp
@@ -118,6 +118,8 @@ void QgsRelationAddPolymorphicDialog::addFieldsRow()
 
   referencingField->setLayer( mReferencingLayerComboBox->currentLayer() );
 
+  connect( referencingField, &QgsFieldComboBox::fieldChanged, this, [ = ]( QString fieldName ) { Q_UNUSED( fieldName ); updateDialogButtons(); } );
+
   mFieldsMappingTable->insertRow( index );
   mFieldsMappingTable->setCellWidget( index, 0, referencedPolymorphicField );
   mFieldsMappingTable->setCellWidget( index, 1, referencingField );
@@ -230,7 +232,6 @@ void QgsRelationAddPolymorphicDialog::updateDialogButtons()
 bool QgsRelationAddPolymorphicDialog::isDefinitionValid()
 {
   bool isValid = true;
-  return isValid;
   QgsMapLayer *referencedLayer = mReferencingLayerComboBox->currentLayer();
   isValid &= referencedLayer && referencedLayer->isValid();
 

--- a/src/app/qgsrelationaddpolymorphicdialog.cpp
+++ b/src/app/qgsrelationaddpolymorphicdialog.cpp
@@ -118,7 +118,7 @@ void QgsRelationAddPolymorphicDialog::addFieldsRow()
 
   referencingField->setLayer( mReferencingLayerComboBox->currentLayer() );
 
-  connect( referencingField, &QgsFieldComboBox::fieldChanged, this, [ = ]( QString fieldName ) { Q_UNUSED( fieldName ); updateDialogButtons(); } );
+  connect( referencingField, &QgsFieldComboBox::fieldChanged, this, [ = ]( const QString & ) { updateDialogButtons(); } );
 
   mFieldsMappingTable->insertRow( index );
   mFieldsMappingTable->setCellWidget( index, 0, referencedPolymorphicField );


### PR DESCRIPTION
As pointed in https://github.com/qgis/QGIS/pull/41009#issuecomment-1112223446
there was an early return that was probably a leftover from local tests
and somehow passed the review. To facilitate proper validation, a new
event had to be added on the `referencingField` combo, which triggers
the form validation and enabling the ok button respectively.

Thank you @troopa81 for bringing my attention.
