### PR TITLE
Wms wfs filter line

### DIFF
--- a/src/ui/qgsarcgisservicesourceselectbase.ui
+++ b/src/ui/qgsarcgisservicesourceselectbase.ui
@@ -125,19 +125,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayoutFilter">
      <item>
-      <widget class="QLabel" name="labelFilter">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Fi&amp;lter</string>
-       </property>
-       <property name="buddy">
-        <cstring>lineFilter</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QgsFilterLineEdit" name="lineFilter">
        <property name="enabled">
         <bool>true</bool>
@@ -147,6 +134,9 @@
        </property>
        <property name="whatsThis">
         <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+       </property>
+       <property name="showSearchIcon">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -231,14 +221,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsBrowserTreeView</class>
-   <extends>QTreeView</extends>
-   <header>qgsbrowsertreeview.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsBrowserTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgsbrowsertreeview.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsdbsourceselectbase.ui
+++ b/src/ui/qgsdbsourceselectbase.ui
@@ -24,14 +24,7 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="7" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QTreeView" name="mTablesTreeView">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
@@ -44,58 +37,12 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mSearchSettingsButton">
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::MenuButtonPopup</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsFilterLineEdit" name="mSearchTableEdit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="showSearchIcon" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="8" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="connectionsGroupBox">
@@ -183,7 +130,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QCheckBox" name="cbxAllowGeometrylessTables">
@@ -209,6 +156,46 @@
       <widget class="QCheckBox" name="mHoldDialogOpen">
        <property name="text">
         <string>Keep dialog open</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QToolButton" name="mSearchSettingsButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::MenuButtonPopup</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsFilterLineEdit" name="mSearchTableEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="showSearchIcon">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/ui/qgsgeonodesourceselectbase.ui
+++ b/src/ui/qgsgeonodesourceselectbase.ui
@@ -115,26 +115,31 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QTreeView" name="treeView">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+   <item row="7" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
      </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerVisible">
-      <bool>true</bool>
-     </attribute>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayoutFilter">
+     <item>
+      <widget class="QgsFilterLineEdit" name="lineFilter">
+       <property name="showSearchIcon">
+        <bool>true</bool>
+       </property>
+       <property name="qgisRelation" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QCheckBox" name="cbxUseTitleLayerName">
@@ -158,48 +163,34 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayoutFilter">
-     <item>
-      <widget class="QLabel" name="labelFilter">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Filter</string>
-       </property>
-       <property name="buddy">
-        <cstring>lineFilter</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineFilter">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-       <property name="whatsThis">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="4" column="0">
+    <widget class="QTreeView" name="treeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
      </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="headerVisible">
+      <bool>true</bool>
+     </attribute>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbConnections</tabstop>
   <tabstop>btnConnect</tabstop>
@@ -208,7 +199,6 @@
   <tabstop>btnDelete</tabstop>
   <tabstop>btnLoad</tabstop>
   <tabstop>btnSave</tabstop>
-  <tabstop>lineFilter</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>cbxUseTitleLayerName</tabstop>
  </tabstops>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -14,29 +14,101 @@
    <string>Add WFS Layer from a Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QTreeView" name="treeView">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+   <item row="7" column="0">
+    <widget class="QGroupBox" name="gbCRS">
+     <property name="title">
+      <string>Coordinate Reference System</string>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerVisible">
-      <bool>true</bool>
-     </attribute>
+     <layout class="QHBoxLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelCoordRefSys">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>441</width>
+          <height>23</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnChangeSpatialRefSys">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Change…</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QCheckBox" name="cbxFeatureCurrentViewExtent">
-     <property name="text">
-      <string>Only request features overlapping the view extent</string>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QCheckBox" name="cbxUseTitleLayerName">
+       <property name="text">
+        <string>Use title for layer name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mHoldDialogOpen">
+       <property name="text">
+        <string>Keep dialog open</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="8" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>
@@ -141,136 +213,54 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayoutFilter">
-     <item>
-      <widget class="QLabel" name="labelFilter">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Filter</string>
-       </property>
-       <property name="buddy">
-        <cstring>lineFilter</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineFilter">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-       <property name="whatsThis">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="3" column="0">
+    <widget class="QTreeView" name="treeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
      </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="headerVisible">
+      <bool>true</bool>
+     </attribute>
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QGroupBox" name="gbCRS">
-     <property name="title">
-      <string>Coordinate Reference System</string>
+    <widget class="QCheckBox" name="cbxFeatureCurrentViewExtent">
+     <property name="text">
+      <string>Only request features overlapping the view extent</string>
      </property>
-     <layout class="QHBoxLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="labelCoordRefSys">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>441</width>
-          <height>23</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnChangeSpatialRefSys">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Change…</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QCheckBox" name="cbxUseTitleLayerName">
-       <property name="text">
-        <string>Use title for layer name</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mHoldDialogOpen">
-       <property name="text">
-        <string>Keep dialog open</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayoutFilter"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QgsFilterLineEdit" name="lineFilter">
+     <property name="showSearchIcon">
+      <bool>true</bool>
+     </property>
+     <property name="qgisRelation" stdset="0">
+      <string notr="true"/>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbConnections</tabstop>
   <tabstop>btnConnect</tabstop>
@@ -279,7 +269,6 @@
   <tabstop>btnDelete</tabstop>
   <tabstop>btnLoad</tabstop>
   <tabstop>btnSave</tabstop>
-  <tabstop>lineFilter</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>cbxUseTitleLayerName</tabstop>
   <tabstop>mHoldDialogOpen</tabstop>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -264,7 +264,7 @@
            </widget>
           </item>
           <item row="4" column="2">
-           <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+           <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -319,19 +319,6 @@
        <item row="2" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <widget class="QgsFilterLineEdit" name="mLayersFilterLineEdit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -339,7 +326,7 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="showSearchIcon" stdset="0">
+           <property name="showSearchIcon">
             <bool>true</bool>
            </property>
            <property name="qgisRelation" stdset="0">
@@ -421,19 +408,6 @@
        <item row="0" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <widget class="QgsFilterLineEdit" name="mTilesetsFilterLineEdit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -441,7 +415,7 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="showSearchIcon" stdset="0">
+           <property name="showSearchIcon">
             <bool>true</bool>
            </property>
            <property name="qgisRelation" stdset="0">


### PR DESCRIPTION
## Description

Current Provider dialogs for WMS and WFS both have the possibility to search for a string in the layer list.

This PR makes them look the same:
- both use the full width of the dialog
- both use QgsFilterLineEdit now, with showClearButton and showSearchIcon checked

This PR is just editing two .ui files

OLD situation:

![wms-old](https://user-images.githubusercontent.com/731673/165950465-f69af1c2-41c3-4152-ac06-a3644b46448a.png)

![wfs-old](https://user-images.githubusercontent.com/731673/165953402-504c622d-d0a1-44a1-93df-21a36a2b4d21.png)

![tilesets-old](https://user-images.githubusercontent.com/731673/165954382-14bfd953-5428-4a80-aa40-9a613c5ad76f.png)


NEW situation:

![wms-new](https://user-images.githubusercontent.com/731673/165950655-e227ee74-409e-4399-ac94-b4610772b5d1.png)

![wfs-new](https://user-images.githubusercontent.com/731673/165950671-6289fa26-e9d8-47d2-a081-0d68572de8dd.png)

![tilesets-new](https://user-images.githubusercontent.com/731673/165954362-2da0b17a-0ab7-483c-8696-0f36c145930e.png)

