### PR TITLE
Select style categories - local and source DBs

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -981,7 +981,21 @@ Export the properties of this layer as SLD style in a QDomDocument
                  during the execution of writeSymbology
 %End
 
-    virtual QString saveDefaultStyle( bool &resultFlag /Out/ );
+    virtual QString saveDefaultStyle( bool &resultFlag /Out/, StyleCategories categories );
+%Docstring
+Save the properties of this layer as the default style
+(either as a .qml file on disk or as a
+record in the users style table in their personal qgis.db)
+
+:param categories: the style categories to be saved (since QGIS 3.26)
+
+:return: - a QString with any status messages
+         - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to save the default style.
+
+.. seealso:: :py:func:`loadNamedStyle`
+%End
+
+ virtual QString saveDefaultStyle( bool &resultFlag /Out/ ) /Deprecated/;
 %Docstring
 Save the properties of this layer as the default style
 (either as a .qml file on disk or as a
@@ -992,6 +1006,8 @@ record in the users style table in their personal qgis.db)
          - resultFlag: a reference to a flag that will be set to ``False`` if we did not manage to save the default style.
 
 .. seealso:: :py:func:`loadNamedStyle`
+
+.. deprecated:: QGIS 3.26
 %End
 
     virtual QString saveNamedStyle( const QString &uri, bool &resultFlag /Out/, StyleCategories categories = AllStyleCategories );

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -934,7 +934,8 @@ Resolves references to other layers (kept as layer IDs after reading XML) into l
 
     virtual void saveStyleToDatabase( const QString &name, const QString &description,
                                       bool useAsDefault, const QString &uiFileContent,
-                                      QString &msgError /Out/ );
+                                      QString &msgError /Out/,
+                                      QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
 %Docstring
 Saves named and sld style of the layer to the style table in the db.
 
@@ -942,6 +943,8 @@ Saves named and sld style of the layer to the style table in the db.
 :param description: A description of the style
 :param useAsDefault: Set to ``True`` if style should be used as the default style for the layer
 :param uiFileContent:
+:param msgError: will be set to a descriptive error message if any occurs
+:param categories: the style categories to be saved.
 
 .. note::
 

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -213,7 +213,7 @@ void QgsAnnotationLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success

--- a/src/app/annotations/qgsannotationlayerproperties.cpp
+++ b/src/app/annotations/qgsannotationlayerproperties.cpp
@@ -213,9 +213,13 @@ void QgsAnnotationLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success
   // or false if the save operation failed
   const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     // let the user know what went wrong

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -232,7 +232,7 @@ void QgsPointCloudLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success

--- a/src/app/pointcloud/qgspointcloudlayerproperties.cpp
+++ b/src/app/pointcloud/qgspointcloudlayerproperties.cpp
@@ -232,9 +232,13 @@ void QgsPointCloudLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success
   // or false if the save operation failed
   const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     // let the user know what went wrong

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9142,6 +9142,20 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
             }
             break;
           }
+          case QgsVectorLayerProperties::Local:
+          {
+            const QString infoWindowTitle = tr( "Save default style to local database" );
+            errorMessage = vlayer->saveDefaultStyle( resultFlag, dlg.styleCategories() );
+            if ( !resultFlag )
+            {
+              mInfoBar->pushMessage( infoWindowTitle, errorMessage, Qgis::MessageLevel::Warning );
+            }
+            else
+            {
+              mInfoBar->pushMessage( infoWindowTitle, tr( "Style saved" ), Qgis::MessageLevel::Success );
+            }
+            break;
+          }
         }
       }
       break;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9083,6 +9083,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
       if ( dlg.exec() )
       {
         bool resultFlag = false;
+        QString errorMessage;
 
         QgsVectorLayerProperties::StyleType type = dlg.currentStyleType();
         switch ( type )
@@ -9090,12 +9091,11 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
           case QgsVectorLayerProperties::QML:
           case QgsVectorLayerProperties::SLD:
           {
-            QString message;
             QString filePath = dlg.outputFilePath();
             if ( type == QgsVectorLayerProperties::QML )
-              message = vlayer->saveNamedStyle( filePath, resultFlag, dlg.styleCategories() );
+              errorMessage = vlayer->saveNamedStyle( filePath, resultFlag, dlg.styleCategories() );
             else
-              message = vlayer->saveSldStyle( filePath, resultFlag );
+              errorMessage = vlayer->saveSldStyle( filePath, resultFlag );
 
             if ( resultFlag )
             {
@@ -9103,7 +9103,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
             }
             else
             {
-              mInfoBar->pushMessage( tr( "Save Style" ), message, Qgis::MessageLevel::Warning );
+              mInfoBar->pushMessage( tr( "Save Style" ), errorMessage, Qgis::MessageLevel::Warning );
             }
 
             break;
@@ -9115,7 +9115,6 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
 
             QgsVectorLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
 
-            QString errorMessage;
             if ( QgsProviderRegistry::instance()->styleExists( vlayer->providerType(), vlayer->source(), dbSettings.name, errorMessage ) )
             {
               if ( QMessageBox::question( nullptr, tr( "Save style in database" ),
@@ -9131,7 +9130,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
               return;
             }
 
-            vlayer->saveStyleToDatabase( dbSettings.name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError );
+            vlayer->saveStyleToDatabase( dbSettings.name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError, dlg.styleCategories() );
 
             if ( !msgError.isNull() )
             {

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -193,9 +193,13 @@ void QgsVectorTileLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success
   // or false if the save operation failed
   const QString myMessage = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     // let the user know what went wrong

--- a/src/app/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/app/vectortile/qgsvectortilelayerproperties.cpp
@@ -193,7 +193,7 @@ void QgsVectorTileLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1322,7 +1322,12 @@ void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg, const 
 
 QString QgsMapLayer::saveDefaultStyle( bool &resultFlag )
 {
-  return saveNamedStyle( styleURI(), resultFlag );
+  return saveDefaultStyle( resultFlag, AllStyleCategories );
+}
+
+QString QgsMapLayer::saveDefaultStyle( bool &resultFlag, StyleCategories categories )
+{
+  return saveNamedStyle( styleURI(), resultFlag, categories );
 }
 
 QString QgsMapLayer::saveNamedMetadata( const QString &uri, bool &resultFlag )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1102,10 +1102,23 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * record in the users style table in their personal qgis.db)
      * \param resultFlag a reference to a flag that will be set to FALSE if
      * we did not manage to save the default style.
+     * \param categories the style categories to be saved (since QGIS 3.26)
      * \returns a QString with any status messages
      * \see loadNamedStyle() and \see saveNamedStyle()
      */
-    virtual QString saveDefaultStyle( bool &resultFlag SIP_OUT );
+    virtual QString saveDefaultStyle( bool &resultFlag SIP_OUT, StyleCategories categories );
+
+    /**
+     * Save the properties of this layer as the default style
+     * (either as a .qml file on disk or as a
+     * record in the users style table in their personal qgis.db)
+     * \param resultFlag a reference to a flag that will be set to FALSE if
+     * we did not manage to save the default style.
+     * \returns a QString with any status messages
+     * \see loadNamedStyle() and \see saveNamedStyle()
+     * \deprecated since QGIS 3.26
+     */
+    Q_DECL_DEPRECATED virtual QString saveDefaultStyle( bool &resultFlag SIP_OUT ) SIP_DEPRECATED;
 
     /**
      * Save the properties of this layer as a named style

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5442,13 +5442,13 @@ bool QgsVectorLayer::deleteStyleFromDatabase( const QString &styleId, QString &m
 
 
 void QgsVectorLayer::saveStyleToDatabase( const QString &name, const QString &description,
-    bool useAsDefault, const QString &uiFileContent, QString &msgError )
+    bool useAsDefault, const QString &uiFileContent, QString &msgError, QgsMapLayer::StyleCategories categories )
 {
 
   QString sldStyle, qmlStyle;
   QDomDocument qmlDocument, sldDocument;
   QgsReadWriteContext context;
-  exportNamedStyle( qmlDocument, msgError, context );
+  exportNamedStyle( qmlDocument, msgError, context, categories );
   if ( !msgError.isNull() )
   {
     return;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -989,6 +989,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param useAsDefault Set to TRUE if style should be used as the default style for the layer
      * \param uiFileContent
      * \param msgError will be set to a descriptive error message if any occurs
+     * \param categories the style categories to be saved.
      *
      *
      * \note Prior to QGIS 3.24, this method would show a message box warning when a
@@ -999,7 +1000,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     virtual void saveStyleToDatabase( const QString &name, const QString &description,
                                       bool useAsDefault, const QString &uiFileContent,
-                                      QString &msgError SIP_OUT );
+                                      QString &msgError SIP_OUT,
+                                      QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
 
     /**
      * Lists all the style in db split into related to the layer and not related to

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -268,7 +268,7 @@ void QgsMeshLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success

--- a/src/gui/mesh/qgsmeshlayerproperties.cpp
+++ b/src/gui/mesh/qgsmeshlayerproperties.cpp
@@ -268,9 +268,13 @@ void QgsMeshLayerProperties::saveDefaultStyle()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success
   // or false if the save operation failed
   QString myMessage = mMeshLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     // let the user know what went wrong

--- a/src/gui/qgsmaplayerloadstyledialog.cpp
+++ b/src/gui/qgsmaplayerloadstyledialog.cpp
@@ -59,8 +59,8 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
   {
     const QgsVectorLayerProperties::StyleType type = currentStyleType();
     QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( mLayer );
-    mFileLabel->setVisible( !vl || type != QgsVectorLayerProperties::StyleType::DB );
-    mFileWidget->setVisible( !vl || type != QgsVectorLayerProperties::StyleType::DB );
+    mFileLabel->setVisible( !vl || ( type != QgsVectorLayerProperties::StyleType::DB && type != QgsVectorLayerProperties::StyleType::Local ) );
+    mFileWidget->setVisible( !vl || ( type != QgsVectorLayerProperties::StyleType::DB && type != QgsVectorLayerProperties::StyleType::Local ) );
     if ( vl )
     {
       mFromDbWidget->setVisible( type == QgsVectorLayerProperties::StyleType::DB );
@@ -76,6 +76,7 @@ QgsMapLayerLoadStyleDialog::QgsMapLayerLoadStyleDialog( QgsMapLayer *layer, QWid
     updateLoadButtonState();
   } );
   mStyleTypeComboBox->addItem( tr( "From File" ), QgsVectorLayerProperties::QML ); // QML is used as entry, but works for SLD too, see currentStyleType()
+  mStyleTypeComboBox->addItem( tr( "Default from local database" ), QgsVectorLayerProperties::Local );
 
   if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( mLayer ) )
   {
@@ -346,7 +347,8 @@ void QgsMapLayerLoadStyleDialog::updateLoadButtonState()
     mLoadButton->setEnabled( ( type == QgsVectorLayerProperties::DB
                                && ( mRelatedTable->selectionModel()->hasSelection() || mOthersTable->selectionModel()->hasSelection()
                                   ) ) ||
-                             ( type != QgsVectorLayerProperties::DB && !mFileWidget->filePath().isEmpty() ) );
+                             ( type != QgsVectorLayerProperties::DB && !mFileWidget->filePath().isEmpty() ) ||
+                             type == QgsVectorLayerProperties::Local );
   }
   else
   {

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -243,7 +243,11 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
   }
 
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   errorMsg = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     QMessageBox::warning( this, tr( "Default Style" ), errorMsg );

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -243,7 +243,7 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
   }
 
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   errorMsg = mLayer->saveDefaultStyle( defaultSavedFlag );

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1553,9 +1553,13 @@ void QgsRasterLayerProperties::saveDefaultStyle_clicked()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success
   // or false if the save operation failed
   QString myMessage = mRasterLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     //let the user know what went wrong

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1553,7 +1553,7 @@ void QgsRasterLayerProperties::saveDefaultStyle_clicked()
 
   // a flag passed by reference
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   // after calling this the above flag will be set true for success

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1277,6 +1277,20 @@ void QgsVectorLayerProperties::saveStyleAs()
         }
         break;
       }
+      case Local:
+      {
+        QString infoWindowTitle = tr( "Save default style to local database" );
+        errorMessage = mLayer->saveDefaultStyle( defaultLoadedFlag, dlg.styleCategories() );
+        if ( !defaultLoadedFlag )
+        {
+          mMessageBar->pushMessage( infoWindowTitle, errorMessage, Qgis::MessageLevel::Warning );
+        }
+        else
+        {
+          mMessageBar->pushMessage( infoWindowTitle, tr( "Style saved" ), Qgis::MessageLevel::Success );
+        }
+        break;
+      }
     }
   }
 }
@@ -1408,6 +1422,8 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
             }
             break;
           }
+          case Local:
+            break;
         }
         styleIndex ++;
       }
@@ -1513,6 +1529,20 @@ void QgsVectorLayerProperties::loadStyle()
           QMessageBox::warning( this, tr( "Load Styles from Database" ),
                                 tr( "The retrieved style is not a valid named style. Error message: %1" )
                                 .arg( errorMsg ) );
+        }
+        break;
+      }
+      case Local:
+      {
+        errorMsg = mLayer->loadNamedStyle( mLayer->styleURI(), defaultLoadedFlag, true, categories );
+        //reset if the default style was loaded OK only
+        if ( defaultLoadedFlag )
+        {
+          syncToLayer();
+        }
+        else
+        {
+          QMessageBox::warning( this, tr( "Load Default Style" ), errorMsg );
         }
         break;
       }

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1091,7 +1091,11 @@ void QgsVectorLayerProperties::saveDefaultStyle_clicked()
   }
 
   bool defaultSavedFlag = false;
+  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // remove the NOWARN_DEPRECATED tags
+  Q_NOWARN_DEPRECATED_PUSH
   errorMsg = mLayer->saveDefaultStyle( defaultSavedFlag );
+  Q_NOWARN_DEPRECATED_POP
   if ( !defaultSavedFlag )
   {
     QMessageBox::warning( this, tr( "Default Style" ), errorMsg );
@@ -1213,6 +1217,7 @@ void QgsVectorLayerProperties::saveStyleAs()
     apply();
 
     bool defaultLoadedFlag = false;
+    QString errorMessage;
 
     StyleType type = dlg.currentStyleType();
     switch ( type )
@@ -1220,12 +1225,11 @@ void QgsVectorLayerProperties::saveStyleAs()
       case QML:
       case SLD:
       {
-        QString message;
         QString filePath = dlg.outputFilePath();
         if ( type == QML )
-          message = mLayer->saveNamedStyle( filePath, defaultLoadedFlag, dlg.styleCategories() );
+          errorMessage = mLayer->saveNamedStyle( filePath, defaultLoadedFlag, dlg.styleCategories() );
         else
-          message = mLayer->saveSldStyle( filePath, defaultLoadedFlag );
+          errorMessage = mLayer->saveSldStyle( filePath, defaultLoadedFlag );
 
         //reset if the default style was loaded OK only
         if ( defaultLoadedFlag )
@@ -1235,7 +1239,7 @@ void QgsVectorLayerProperties::saveStyleAs()
         else
         {
           //let the user know what went wrong
-          QMessageBox::information( this, tr( "Save Style" ), message );
+          QMessageBox::information( this, tr( "Save Style" ), errorMessage );
         }
 
         break;
@@ -1243,11 +1247,9 @@ void QgsVectorLayerProperties::saveStyleAs()
       case DB:
       {
         QString infoWindowTitle = QObject::tr( "Save style to DB (%1)" ).arg( mLayer->providerType() );
-        QString msgError;
 
         QgsVectorLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
 
-        QString errorMessage;
         if ( QgsProviderRegistry::instance()->styleExists( mLayer->providerType(), mLayer->source(), dbSettings.name, errorMessage ) )
         {
           if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
@@ -1263,11 +1265,11 @@ void QgsVectorLayerProperties::saveStyleAs()
           return;
         }
 
-        mLayer->saveStyleToDatabase( dbSettings.name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError );
+        mLayer->saveStyleToDatabase( dbSettings.name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, errorMessage, dlg.styleCategories() );
 
-        if ( !msgError.isNull() )
+        if ( !errorMessage.isNull() )
         {
-          mMessageBar->pushMessage( infoWindowTitle, msgError, Qgis::MessageLevel::Warning );
+          mMessageBar->pushMessage( infoWindowTitle, errorMessage, Qgis::MessageLevel::Warning );
         }
         else
         {
@@ -1393,7 +1395,7 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
               return;
             }
 
-            mLayer->saveStyleToDatabase( name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError );
+            mLayer->saveStyleToDatabase( name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError, dlg.styleCategories() );
 
             if ( !msgError.isNull() )
             {
@@ -1461,21 +1463,20 @@ void QgsVectorLayerProperties::loadStyle()
     mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
     QgsMapLayer::StyleCategories categories = dlg.styleCategories();
     StyleType type = dlg.currentStyleType();
+    bool defaultLoadedFlag = false;
     switch ( type )
     {
       case QML:
       case SLD:
       {
-        QString message;
-        bool defaultLoadedFlag = false;
         QString filePath = dlg.filePath();
         if ( type == SLD )
         {
-          message = mLayer->loadSldStyle( filePath, defaultLoadedFlag );
+          errorMsg = mLayer->loadSldStyle( filePath, defaultLoadedFlag );
         }
         else
         {
-          message = mLayer->loadNamedStyle( filePath, defaultLoadedFlag, true, categories );
+          errorMsg = mLayer->loadNamedStyle( filePath, defaultLoadedFlag, true, categories );
         }
         //reset if the default style was loaded OK only
         if ( defaultLoadedFlag )
@@ -1485,7 +1486,7 @@ void QgsVectorLayerProperties::loadStyle()
         else
         {
           //let the user know what went wrong
-          QMessageBox::warning( this, tr( "Load Style" ), message );
+          QMessageBox::warning( this, tr( "Load Style" ), errorMsg );
         }
         break;
       }

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1091,7 +1091,7 @@ void QgsVectorLayerProperties::saveDefaultStyle_clicked()
   }
 
   bool defaultSavedFlag = false;
-  // One the deprecated `saveDefaultStyle()` method is gone, just
+  // TODO Once the deprecated `saveDefaultStyle()` method is gone, just
   // remove the NOWARN_DEPRECATED tags
   Q_NOWARN_DEPRECATED_PUSH
   errorMsg = mLayer->saveDefaultStyle( defaultSavedFlag );

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -68,6 +68,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
       QML,
       SLD,
       DB,
+      Local,
     };
     Q_ENUM( StyleType )
 #endif

--- a/src/gui/vector/qgsvectorlayersavestyledialog.cpp
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.cpp
@@ -46,9 +46,10 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
   connect( mStyleTypeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
   {
     const QgsVectorLayerProperties::StyleType type = currentStyleType();
-    mSaveToFileWidget->setVisible( type != QgsVectorLayerProperties::DB );
+    mFileLabel->setVisible( type != QgsVectorLayerProperties::DB );
+    mFileWidget->setVisible( type != QgsVectorLayerProperties::DB );
     mSaveToDbWidget->setVisible( type == QgsVectorLayerProperties::DB );
-    mStyleCategoriesListView->setEnabled( type == QgsVectorLayerProperties::QML );
+    mStyleCategoriesListView->setEnabled( type != QgsVectorLayerProperties::SLD );
     mFileWidget->setFilter( type == QgsVectorLayerProperties::QML ? tr( "QGIS Layer Style File (*.qml)" ) : tr( "SLD File (*.sld)" ) );
     updateSaveButtonState();
   } );

--- a/src/gui/vector/qgsvectorlayersavestyledialog.cpp
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.cpp
@@ -32,31 +32,19 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
 
   QgsSettings settings;
 
-  QString providerName = mLayer->providerType();
-  if ( providerName == QLatin1String( "ogr" ) )
-  {
-    providerName = mLayer->dataProvider()->storageType();
-    if ( providerName == QLatin1String( "GPKG" ) )
-      providerName = QStringLiteral( "GeoPackage" );
-  }
-
   const QString myLastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
 
   // save style type combobox
   connect( mStyleTypeComboBox, qOverload<int>( &QComboBox::currentIndexChanged ), this, [ = ]( int )
   {
     const QgsVectorLayerProperties::StyleType type = currentStyleType();
-    mFileLabel->setVisible( type != QgsVectorLayerProperties::DB );
-    mFileWidget->setVisible( type != QgsVectorLayerProperties::DB );
+    mFileLabel->setVisible( type != QgsVectorLayerProperties::DB && type != QgsVectorLayerProperties::Local );
+    mFileWidget->setVisible( type != QgsVectorLayerProperties::DB && type != QgsVectorLayerProperties::Local );
     mSaveToDbWidget->setVisible( type == QgsVectorLayerProperties::DB );
     mStyleCategoriesListView->setEnabled( type != QgsVectorLayerProperties::SLD );
     mFileWidget->setFilter( type == QgsVectorLayerProperties::QML ? tr( "QGIS Layer Style File (*.qml)" ) : tr( "SLD File (*.sld)" ) );
     updateSaveButtonState();
   } );
-  mStyleTypeComboBox->addItem( tr( "As QGIS QML Style File" ), QgsVectorLayerProperties::QML );
-  mStyleTypeComboBox->addItem( tr( "As SLD Style File" ), QgsVectorLayerProperties::SLD );
-  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
-    mStyleTypeComboBox->addItem( tr( "In Database (%1)" ).arg( providerName ), QgsVectorLayerProperties::DB );
 
   // Save to DB setup
   connect( mDbStyleNameEdit, &QLineEdit::textChanged, this, &QgsVectorLayerSaveStyleDialog::updateSaveButtonState );
@@ -91,6 +79,27 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
 
 }
 
+void QgsVectorLayerSaveStyleDialog::populateStyleComboBox()
+{
+  QString providerName = mLayer->providerType();
+  if ( providerName == QLatin1String( "ogr" ) )
+  {
+    providerName = mLayer->dataProvider()->storageType();
+    if ( providerName == QLatin1String( "GPKG" ) )
+      providerName = QStringLiteral( "GeoPackage" );
+  }
+
+  mStyleTypeComboBox->clear();
+  mStyleTypeComboBox->addItem( tr( "As QGIS QML Style File" ), QgsVectorLayerProperties::QML );
+  mStyleTypeComboBox->addItem( tr( "As SLD Style File" ), QgsVectorLayerProperties::SLD );
+
+  if ( mLayer->dataProvider()->isSaveAndLoadStyleToDatabaseSupported() )
+    mStyleTypeComboBox->addItem( tr( "In Database (%1)" ).arg( providerName ), QgsVectorLayerProperties::DB );
+
+  if ( mSaveOnlyCurrentStyle )
+    mStyleTypeComboBox->addItem( tr( "As Default In Local Database" ), QgsVectorLayerProperties::Local );
+}
+
 void QgsVectorLayerSaveStyleDialog::accept()
 {
   QgsSettings().setFlagValue( QStringLiteral( "style/lastStyleCategories" ), styleCategories() );
@@ -116,6 +125,9 @@ void QgsVectorLayerSaveStyleDialog::updateSaveButtonState()
     case QgsVectorLayerProperties::QML:
     case QgsVectorLayerProperties::SLD:
       enabled = ! mFileWidget->filePath().isEmpty();
+      break;
+    case QgsVectorLayerProperties::Local:
+      enabled = true;
       break;
   }
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
@@ -211,6 +223,8 @@ void QgsVectorLayerSaveStyleDialog::setupMultipleStyles()
   mDbStyleDescriptionEdit->setVisible( mSaveOnlyCurrentStyle );
   descriptionLabel->setVisible( mSaveOnlyCurrentStyle );
   mDbStyleUseAsDefault->setVisible( mSaveOnlyCurrentStyle );
+
+  populateStyleComboBox();
 }
 
 bool QgsVectorLayerSaveStyleDialog::saveOnlyCurrentStyle() const

--- a/src/gui/vector/qgsvectorlayersavestyledialog.h
+++ b/src/gui/vector/qgsvectorlayersavestyledialog.h
@@ -73,6 +73,7 @@ class GUI_EXPORT QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::Qgs
 
   private:
     void setupMultipleStyles();
+    void populateStyleComboBox();
     QgsVectorLayer *mLayer = nullptr;
     QgsMapLayerStyleCategoriesModel *mModel;
     QString mUiFileContent;

--- a/src/ui/qgsvectorlayersavestyledialog.ui
+++ b/src/ui/qgsvectorlayersavestyledialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>491</width>
-    <height>535</height>
+    <height>614</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,36 @@
       <string>Save style</string>
      </property>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mStyleTypeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mStylesWidgetLabel">
+     <property name="text">
+      <string>Styles</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QListWidget" name="mStylesWidget"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mFileLabel">
+     <property name="text">
+      <string>File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFileWidget" name="mFileWidget"/>
    </item>
    <item row="3" column="0" colspan="2">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
@@ -36,6 +66,20 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item row="2" column="1">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget">
+        <property name="toolTip">
+         <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="mDbStyleUseAsDefault">
+        <property name="text">
+         <string>Use as default style for this layer</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="nameLabel">
         <property name="text">
@@ -45,9 +89,6 @@
          <cstring>mDbStyleNameEdit</cstring>
         </property>
        </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="descriptionLabel">
@@ -69,101 +110,36 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="mDbStyleUseAsDefault">
-        <property name="text">
-         <string>Use as default style for this layer</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
-        <property name="toolTip">
-         <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mStyleTypeComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QWidget" name="mSaveToFileWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Categories</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>File</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QListView" name="mStyleCategoriesListView">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
-       <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Categories</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QListView" name="mStyleCategoriesListView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QListWidget" name="mStylesWidget"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="mStylesWidgetLabel">
-     <property name="text">
-      <string>Styles</string>
      </property>
     </widget>
    </item>
@@ -180,7 +156,6 @@
  <tabstops>
   <tabstop>mStyleTypeComboBox</tabstop>
   <tabstop>mStylesWidget</tabstop>
-  <tabstop>mStyleCategoriesListView</tabstop>
   <tabstop>mDbStyleNameEdit</tabstop>
   <tabstop>mDbStyleDescriptionEdit</tabstop>
   <tabstop>mDbStyleUseAsDefault</tabstop>


### PR DESCRIPTION
## Description

This PR is in two parts related to vector layer style saving/loading.

### 1. Allow to select the categories when saving in source database

**before**

![image](https://user-images.githubusercontent.com/34267385/165992818-4fecdda0-71b9-4ce9-b2bf-2abf60796c8c.png)


**after**

![image](https://user-images.githubusercontent.com/34267385/165992657-15a66d34-78da-4411-9f31-14a967c2d397.png)


### 2. Allow to select the categories when saving in local database as a default style

Purpose: have the same behavior than the following button but with category selection

![image](https://user-images.githubusercontent.com/34267385/165993226-4e4bdc1a-09cc-40a9-bf9f-5c81e4c39226.png)

![image](https://user-images.githubusercontent.com/34267385/165993311-92f7489d-8ad2-44bc-930d-4432c17a4e32.png)

**Implemented solution**: add `As default in local database` choice in the save style dialog:

![image](https://user-images.githubusercontent.com/34267385/165993666-3be72b7d-0ff5-4ee4-bc47-fb8023535599.png)


To keep the consistency with the load style dialog, this option has also been implemented:

![image](https://user-images.githubusercontent.com/34267385/165993607-bb92956a-cc9b-4893-a88c-11c254ef39dd.png)


