### PR TITLE
Add setting to respect point cloud coloring in profile plots

### DIFF
--- a/python/core/auto_generated/pointcloud/qgspointcloudattributebyramprenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudattributebyramprenderer.sip.in
@@ -9,6 +9,8 @@
 
 
 
+
+
 class QgsPointCloudAttributeByRampRenderer : QgsPointCloudRenderer
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudblock.sip.in
@@ -44,6 +44,13 @@ Returns raw pointer to data
 Returns number of points that are stored in the block
 %End
 
+    int pointRecordSize() const;
+%Docstring
+Returns the total size of each individual point record.
+
+.. versionadded:: 3.26
+%End
+
     QgsPointCloudAttributeCollection attributes() const;
 %Docstring
 Returns the attributes that are stored in the data block, along with their size
@@ -67,6 +74,7 @@ If a ``size`` larger than ``pointCount``() is used, data for the new points will
 
 .. versionadded:: 3.26
 %End
+
 };
 
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip.in
@@ -201,6 +201,20 @@ Returns the units used for the point size used for drawing points in elevation p
 .. versionadded:: 3.26
 %End
 
+    bool respectLayerColors() const;
+%Docstring
+Returns ``True`` if layer coloring should be respected when rendering elevation profile plots.
+
+.. seealso:: :py:func:`setRespectLayerColors`
+%End
+
+    void setRespectLayerColors( bool enabled );
+%Docstring
+Sets whether layer coloring should be respected when rendering elevation profile plots.
+
+.. seealso:: :py:func:`respectLayerColors`
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -162,6 +162,7 @@ Returns the feedback object used to cancel rendering
 };
 
 
+
 class QgsPointCloudRenderer
 {
 %Docstring(signature="appended")
@@ -250,6 +251,8 @@ not be requested from the provider at rendering time.
    the "X" and "Y" attributes will always be fetched and do not need to be explicitly
    returned here.
 %End
+
+
 
     virtual void startRender( QgsPointCloudRenderContext &context );
 %Docstring

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -253,7 +253,6 @@ not be requested from the provider at rendering time.
 %End
 
 
-
     virtual void startRender( QgsPointCloudRenderContext &context );
 %Docstring
 Must be called when a new render cycle is started. A call to :py:func:`~QgsPointCloudRenderer.startRender` must always

--- a/python/core/auto_generated/pointcloud/qgspointcloudrgbrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrgbrenderer.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsPointCloudRgbRenderer : QgsPointCloudRenderer
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
@@ -233,6 +233,20 @@ Emitted when any of the elevation properties have changed.
 See :py:func:`~QgsMapLayerElevationProperties.renderingPropertyChanged` and :py:func:`~QgsMapLayerElevationProperties.profileGenerationPropertyChanged` for more fine-grained signals.
 %End
 
+    void zOffsetChanged();
+%Docstring
+Emitted when the z offset changes.
+
+.. versionadded:: 3.26
+%End
+
+    void zScaleChanged();
+%Docstring
+Emitted when the z scale changes.
+
+.. versionadded:: 3.26
+%End
+
     void profileRenderingPropertyChanged();
 %Docstring
 Emitted when any of the elevation properties which relate solely to presentation of elevation

--- a/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerelevationproperties.sip.in
@@ -233,7 +233,7 @@ Emitted when any of the elevation properties have changed.
 See :py:func:`~QgsMapLayerElevationProperties.renderingPropertyChanged` and :py:func:`~QgsMapLayerElevationProperties.profileGenerationPropertyChanged` for more fine-grained signals.
 %End
 
-    void renderingPropertyChanged();
+    void profileRenderingPropertyChanged();
 %Docstring
 Emitted when any of the elevation properties which relate solely to presentation of elevation
 results have changed.
@@ -252,7 +252,7 @@ profiles have changed.
 
 .. seealso:: :py:func:`changed`
 
-.. seealso:: :py:func:`renderingPropertyChanged`
+.. seealso:: :py:func:`profileRenderingPropertyChanged`
 
 .. versionadded:: 3.26
 %End

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
@@ -55,6 +55,7 @@ QgsPointCloudElevationPropertiesWidget::QgsPointCloudElevationPropertiesWidget( 
   connect( mMaxErrorUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mPointStyleComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mPointColorButton, &QgsColorButton::colorChanged, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
+  connect( mCheckBoxRespectLayerColors, &QCheckBox::toggled, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
   connect( mOpacityByDistanceCheckBox, &QCheckBox::toggled, this, &QgsPointCloudElevationPropertiesWidget::onChanged );
 }
 
@@ -75,6 +76,7 @@ void QgsPointCloudElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )
   mMaxErrorSpinBox->setValue( properties->maximumScreenError() );
   mMaxErrorUnitWidget->setUnit( properties->maximumScreenErrorUnit() );
   mPointColorButton->setColor( properties->pointColor() );
+  mCheckBoxRespectLayerColors->setChecked( properties->respectLayerColors() );
   mOpacityByDistanceCheckBox->setChecked( properties->applyOpacityByDistanceEffect() );
 
   mBlockUpdates = false;
@@ -95,6 +97,7 @@ void QgsPointCloudElevationPropertiesWidget::apply()
   properties->setMaximumScreenError( mMaxErrorSpinBox->value() );
   properties->setMaximumScreenErrorUnit( mMaxErrorUnitWidget->unit() );
   properties->setPointColor( mPointColorButton->color() );
+  properties->setRespectLayerColors( mCheckBoxRespectLayerColors->isChecked() );
   properties->setApplyOpacityByDistanceEffect( mOpacityByDistanceCheckBox->isChecked() );
 
   mLayer->trigger3DUpdate();

--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.h
@@ -31,6 +31,7 @@ class QgsPointCloudElevationPropertiesWidget : public QgsMapLayerConfigWidget, p
     QgsPointCloudElevationPropertiesWidget( QgsPointCloudLayer *layer, QgsMapCanvas *canvas, QWidget *parent );
 
     void syncToLayer( QgsMapLayer *layer ) final;
+    bool shouldTriggerLayerRepaint() const override { return false; }
 
   public slots:
     void apply() override;

--- a/src/core/mesh/qgsmeshlayerelevationproperties.cpp
+++ b/src/core/mesh/qgsmeshlayerelevationproperties.cpp
@@ -124,7 +124,7 @@ void QgsMeshLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *symbo
 {
   mProfileLineSymbol.reset( symbol );
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 QgsFillSymbol *QgsMeshLayerElevationProperties::profileFillSymbol() const

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.h
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.h
@@ -39,8 +39,10 @@ class CORE_EXPORT QgsPointCloudAttributeByRampRendererPreparedData: public QgsPr
 
     QSet< QString > usedAttributes() const override;
     bool prepareBlock( const QgsPointCloudBlock *block ) override;
+    QColor pointColor( const QgsPointCloudBlock *block, int i, double z ) override SIP_SKIP;
 
     QString attributeName;
+    QgsColorRampShader colorRampShader;
     int attributeOffset = 0;
     bool attributeIsX = false;
     bool attributeIsY = false;
@@ -72,7 +74,6 @@ class CORE_EXPORT QgsPointCloudAttributeByRampRenderer : public QgsPointCloudRen
     QSet< QString > usedAttributes( const QgsPointCloudRenderContext &context ) const override;
     QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) override SIP_FACTORY;
     std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
-    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.h
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.h
@@ -23,6 +23,33 @@
 #include "qgis_sip.h"
 #include "qgscolorrampshader.h"
 
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \brief Prepared data container for QgsPointCloudAttributeByRampRenderer.
+ *
+ * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPointCloudAttributeByRampRendererPreparedData: public QgsPreparedPointCloudRendererData
+{
+  public:
+
+    QSet< QString > usedAttributes() const override;
+    bool prepareBlock( const QgsPointCloudBlock *block ) override;
+
+    QString attributeName;
+    int attributeOffset = 0;
+    bool attributeIsX = false;
+    bool attributeIsY = false;
+    bool attributeIsZ = false;
+    QgsPointCloudAttribute::DataType attributeType;
+};
+#endif
+
+
 /**
  * \ingroup core
  * \brief An RGB renderer for 2d visualisation of point clouds using embedded red, green and blue attributes.
@@ -44,6 +71,8 @@ class CORE_EXPORT QgsPointCloudAttributeByRampRenderer : public QgsPointCloudRen
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     QSet< QString > usedAttributes( const QgsPointCloudRenderContext &context ) const override;
     QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) override SIP_FACTORY;
+    std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
+    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/pointcloud/qgspointcloudblock.cpp
+++ b/src/core/pointcloud/qgspointcloudblock.cpp
@@ -27,6 +27,7 @@ QgsPointCloudBlock::QgsPointCloudBlock(
 )
   : mPointCount( count )
   , mAttributes( attributes )
+  , mRecordSize( mAttributes.pointRecordSize() )
   , mStorage( data )
   , mScale( scale )
   , mOffset( offset )

--- a/src/core/pointcloud/qgspointcloudblock.h
+++ b/src/core/pointcloud/qgspointcloudblock.h
@@ -51,6 +51,13 @@ class CORE_EXPORT QgsPointCloudBlock
     //! Returns number of points that are stored in the block
     int pointCount() const;
 
+    /**
+     * Returns the total size of each individual point record.
+     *
+     * \since QGIS 3.26
+     */
+    int pointRecordSize() const { return mRecordSize; }
+
     //! Returns the attributes that are stored in the data block, along with their size
     QgsPointCloudAttributeCollection attributes() const;
 
@@ -68,9 +75,12 @@ class CORE_EXPORT QgsPointCloudBlock
      * \since QGIS 3.26
      */
     void setPointCount( int size );
+
   private:
-    int mPointCount;
+
+    int mPointCount = 0;
     QgsPointCloudAttributeCollection mAttributes;
+    int mRecordSize = 0;
     QByteArray mStorage;
     QgsVector3D mScale, mOffset;
 };

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.cpp
@@ -353,13 +353,11 @@ bool QgsPointCloudClassifiedRendererPreparedData::prepareBlock( const QgsPointCl
   return true;
 }
 
-QColor QgsPointCloudClassifiedRenderer::pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *, const char *ptr, int i, std::size_t pointRecordSize, double, double, double )
+QColor QgsPointCloudClassifiedRendererPreparedData::pointColor( const QgsPointCloudBlock *block, int i, double )
 {
-  QgsPointCloudClassifiedRendererPreparedData *data = qgis::down_cast< QgsPointCloudClassifiedRendererPreparedData * >( preparedData );
-
   int attributeValue = 0;
-  QgsPointCloudRenderContext::getAttribute( ptr, i * pointRecordSize + data->attributeOffset, data->attributeType, attributeValue );
-  return data->colors.value( attributeValue );
+  QgsPointCloudRenderContext::getAttribute( block->data(), i * block->pointRecordSize() + attributeOffset, attributeType, attributeValue );
+  return colors.value( attributeValue );
 }
 
 

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
@@ -115,6 +115,29 @@ class CORE_EXPORT QgsPointCloudCategory
 
 typedef QList<QgsPointCloudCategory> QgsPointCloudCategoryList;
 
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \brief Prepared data container for QgsPointCloudClassifiedRenderer.
+ *
+ * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPointCloudClassifiedRendererPreparedData: public QgsPreparedPointCloudRendererData
+{
+  public:
+
+    QSet< QString > usedAttributes() const override;
+    bool prepareBlock( const QgsPointCloudBlock *block ) override;
+
+    QgsPointCloudAttribute::DataType attributeType;
+    QHash< int, QColor > colors;
+    QString attributeName;
+    int attributeOffset = 0;
+};
+#endif
 
 /**
  * \ingroup core
@@ -141,6 +164,8 @@ class CORE_EXPORT QgsPointCloudClassifiedRenderer : public QgsPointCloudRenderer
     QStringList legendRuleKeys() const override;
     bool legendItemChecked( const QString &key ) override;
     void checkLegendItem( const QString &key, bool state = true ) override;
+    std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
+    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
+++ b/src/core/pointcloud/qgspointcloudclassifiedrenderer.h
@@ -131,6 +131,7 @@ class CORE_EXPORT QgsPointCloudClassifiedRendererPreparedData: public QgsPrepare
 
     QSet< QString > usedAttributes() const override;
     bool prepareBlock( const QgsPointCloudBlock *block ) override;
+    QColor pointColor( const QgsPointCloudBlock *block, int i, double z ) override SIP_SKIP;
 
     QgsPointCloudAttribute::DataType attributeType;
     QHash< int, QColor > colors;
@@ -165,7 +166,6 @@ class CORE_EXPORT QgsPointCloudClassifiedRenderer : public QgsPointCloudRenderer
     bool legendItemChecked( const QString &key ) override;
     void checkLegendItem( const QString &key, bool state = true ) override;
     std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
-    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
@@ -167,7 +167,7 @@ void QgsPointCloudLayerElevationProperties::setPointSymbol( Qgis::PointCloudSymb
 
   mPointSymbol = symbol;
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 void QgsPointCloudLayerElevationProperties::setPointColor( const QColor &color )
@@ -177,7 +177,7 @@ void QgsPointCloudLayerElevationProperties::setPointColor( const QColor &color )
 
   mPointColor = color;
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 void QgsPointCloudLayerElevationProperties::setApplyOpacityByDistanceEffect( bool apply )
@@ -192,7 +192,7 @@ void QgsPointCloudLayerElevationProperties::setApplyOpacityByDistanceEffect( boo
   if ( mApplyOpacityByDistanceEffect )
     emit profileGenerationPropertyChanged();
   else
-    emit renderingPropertyChanged();
+    emit profileRenderingPropertyChanged();
 }
 
 void QgsPointCloudLayerElevationProperties::setPointSize( double size )
@@ -202,7 +202,7 @@ void QgsPointCloudLayerElevationProperties::setPointSize( double size )
 
   mPointSize = size;
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 void QgsPointCloudLayerElevationProperties::setPointSizeUnit( const QgsUnitTypes::RenderUnit units )
@@ -212,7 +212,7 @@ void QgsPointCloudLayerElevationProperties::setPointSizeUnit( const QgsUnitTypes
 
   mPointSizeUnit = units;
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 void QgsPointCloudLayerElevationProperties::setRespectLayerColors( bool enabled )
@@ -227,5 +227,5 @@ void QgsPointCloudLayerElevationProperties::setRespectLayerColors( bool enabled 
   if ( mRespectLayerColors )
     emit profileGenerationPropertyChanged();
   else
-    emit renderingPropertyChanged();
+    emit profileRenderingPropertyChanged();
 }

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.cpp
@@ -60,7 +60,7 @@ bool QgsPointCloudLayerElevationProperties::readXml( const QDomElement &element,
   mMaximumScreenErrorUnit = QgsUnitTypes::decodeRenderUnit( elevationElement.attribute( QStringLiteral( "max_screen_error_unit" ) ), &ok );
   if ( !ok )
     mMaximumScreenErrorUnit = QgsUnitTypes::RenderMillimeters;
-  mPointSize = elevationElement.attribute( QStringLiteral( "point_size" ), QStringLiteral( "1" ) ).toDouble();
+  mPointSize = elevationElement.attribute( QStringLiteral( "point_size" ), QStringLiteral( "0.6" ) ).toDouble();
   mPointSizeUnit = QgsUnitTypes::decodeRenderUnit( elevationElement.attribute( QStringLiteral( "point_size_unit" ) ), &ok );
   if ( !ok )
     mPointSizeUnit = QgsUnitTypes::RenderMillimeters;

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
@@ -191,6 +191,20 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
      */
     QgsUnitTypes::RenderUnit pointSizeUnit() const { return mPointSizeUnit; }
 
+    /**
+     * Returns TRUE if layer coloring should be respected when rendering elevation profile plots.
+     *
+     * \see setRespectLayerColors()
+     */
+    bool respectLayerColors() const { return mRespectLayerColors; }
+
+    /**
+     * Sets whether layer coloring should be respected when rendering elevation profile plots.
+     *
+     * \see respectLayerColors()
+     */
+    void setRespectLayerColors( bool enabled );
+
   private:
 
     double mMaximumScreenError = 0.3;
@@ -200,6 +214,7 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
     QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
     QColor mPointColor;
+    bool mRespectLayerColors = true;
     bool mApplyOpacityByDistanceEffect = false;
 };
 

--- a/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
+++ b/src/core/pointcloud/qgspointcloudlayerelevationproperties.h
@@ -210,7 +210,7 @@ class CORE_EXPORT QgsPointCloudLayerElevationProperties : public QgsMapLayerElev
     double mMaximumScreenError = 0.3;
     QgsUnitTypes::RenderUnit mMaximumScreenErrorUnit = QgsUnitTypes::RenderMillimeters;
 
-    double mPointSize = 1;
+    double mPointSize = 0.6;
     QgsUnitTypes::RenderUnit mPointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol mPointSymbol = Qgis::PointCloudSymbol::Square;
     QColor mPointColor;

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -622,7 +622,7 @@ void QgsPointCloudLayerProfileGenerator::visitBlock( const QgsPointCloudBlock *b
 
     if ( useRenderer )
     {
-      color = mRenderer->pointColor( mPreparedRendererData.get(), block, ptr, i, recordSize, res.x, res.y, res.z );
+      color = mPreparedRendererData->pointColor( block, i, res.z );
       if ( !color.isValid() )
         continue;
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -156,7 +156,7 @@ void QgsPointCloudLayerProfileResults::renderResults( QgsProfileRenderContext &c
   for ( const PointResult &point : std::as_const( results ) )
   {
     QPointF p = context.worldTransform().map( QPointF( point.distanceAlongCurve, point.z ) );
-    QColor color = point.color; //pointColor;
+    QColor color = respectLayerColors ? point.color : pointColor;
     if ( opacityByDistanceEffect )
       color.setAlphaF( color.alphaF() * ( 1.0 - std::pow( point.distanceFromCurve / tolerance, 0.5 ) ) );
 
@@ -245,6 +245,7 @@ void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbs
   pointSizeUnit = pcGenerator->mPointSizeUnit;
   pointSymbol = pcGenerator->mPointSymbol;
   pointColor = pcGenerator->mPointColor;
+  respectLayerColors = static_cast< bool >( pcGenerator->mRenderer );
   opacityByDistanceEffect = pcGenerator->mOpacityByDistanceEffect;
 }
 
@@ -255,7 +256,7 @@ void QgsPointCloudLayerProfileResults::copyPropertiesFromGenerator( const QgsAbs
 QgsPointCloudLayerProfileGenerator::QgsPointCloudLayerProfileGenerator( QgsPointCloudLayer *layer, const QgsProfileRequest &request )
   : mLayer( layer )
   , mLayerAttributes( layer->attributes() )
-  , mRenderer( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr )
+  , mRenderer( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->respectLayerColors() && mLayer->renderer() ? mLayer->renderer()->clone() : nullptr )
   , mMaximumScreenError( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->maximumScreenError() )
   , mMaximumScreenErrorUnit( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->maximumScreenErrorUnit() )
   , mPointSize( qgis::down_cast< QgsPointCloudLayerElevationProperties* >( layer->elevationProperties() )->pointSize() )

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -23,6 +23,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransformcontext.h"
 #include "qgscoordinatetransform.h"
+#include "qgspointcloudattribute.h"
 #include "qgslinesymbol.h"
 #include "qgsvector3d.h"
 #include "qgsgeos.h"
@@ -41,6 +42,7 @@ class QgsPointCloudIndex;
 class QgsPointCloudRequest;
 class QgsPointCloudBlock;
 class QgsGeos;
+class QgsPreparedPointCloudRendererData;
 
 #define SIP_NO_FILE
 
@@ -139,6 +141,7 @@ class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfile
     void visitBlock( const QgsPointCloudBlock *block, const QgsDoubleRange &zRange );
 
     QPointer< QgsPointCloudLayer > mLayer;
+    QgsPointCloudAttributeCollection mLayerAttributes;
     std::unique_ptr< QgsPointCloudRenderer > mRenderer;
     double mMaximumScreenError = 0.3;
     QgsUnitTypes::RenderUnit mMaximumScreenErrorUnit = QgsUnitTypes::RenderMillimeters;
@@ -172,6 +175,8 @@ class CORE_EXPORT QgsPointCloudLayerProfileGenerator : public QgsAbstractProfile
     std::unique_ptr< QgsAbstractGeometry > mSearchGeometryInLayerCrs;
     std::unique_ptr< QgsGeos > mSearchGeometryInLayerCrsGeometryEngine;
     QgsRectangle mMaxSearchExtentInLayerCrs;
+
+    std::unique_ptr< QgsPreparedPointCloudRendererData > mPreparedRendererData;
 
     std::unique_ptr< QgsPointCloudLayerProfileResults > mResults;
     QVector< QgsPointCloudLayerProfileResults::PointResult > mGatheredPoints;

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.h
@@ -86,6 +86,7 @@ class CORE_EXPORT QgsPointCloudLayerProfileResults : public QgsAbstractProfileRe
     double pointSize = 1;
     QgsUnitTypes::RenderUnit pointSizeUnit = QgsUnitTypes::RenderMillimeters;
     Qgis::PointCloudSymbol pointSymbol = Qgis::PointCloudSymbol::Square;
+    bool respectLayerColors = true;
     QColor pointColor;
     bool opacityByDistanceEffect = false;
 

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -85,11 +85,6 @@ std::unique_ptr<QgsPreparedPointCloudRendererData> QgsPointCloudRenderer::prepar
   return nullptr;
 }
 
-QColor QgsPointCloudRenderer::pointColor( QgsPreparedPointCloudRendererData *, const QgsPointCloudBlock *, const char *, int, std::size_t, double, double, double )
-{
-  return QColor();
-}
-
 void QgsPointCloudRenderer::startRender( QgsPointCloudRenderContext &context )
 {
 #ifdef QGISDEBUG

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -80,6 +80,16 @@ QSet<QString> QgsPointCloudRenderer::usedAttributes( const QgsPointCloudRenderCo
   return QSet< QString >();
 }
 
+std::unique_ptr<QgsPreparedPointCloudRendererData> QgsPointCloudRenderer::prepare()
+{
+  return nullptr;
+}
+
+QColor QgsPointCloudRenderer::pointColor( QgsPreparedPointCloudRendererData *, const QgsPointCloudBlock *, const char *, int, std::size_t, double, double, double )
+{
+  return QColor();
+}
+
 void QgsPointCloudRenderer::startRender( QgsPointCloudRenderContext &context )
 {
 #ifdef QGISDEBUG
@@ -306,3 +316,8 @@ QVector<QVariantMap> QgsPointCloudRenderer::identify( QgsPointCloudLayer *layer,
 
   return selectedPoints;
 }
+
+//
+// QgsPreparedPointCloudRendererData
+//
+QgsPreparedPointCloudRendererData::~QgsPreparedPointCloudRendererData() = default;

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -271,6 +271,15 @@ class CORE_EXPORT QgsPreparedPointCloudRendererData
      */
     virtual bool prepareBlock( const QgsPointCloudBlock *block ) = 0;
 
+    /**
+     * An optimised method of retrieving the color of a point from a point cloud block.
+     *
+     * Before calling this method prepareBlock() must be called for each incoming point cloud block.
+     *
+     * \since QGIS 3.26
+     */
+    virtual QColor pointColor( const QgsPointCloudBlock *block, int i, double z ) = 0;
+
 };
 
 #endif
@@ -389,17 +398,6 @@ class CORE_EXPORT QgsPointCloudRenderer
      * \since QGIS 3.26
      */
     virtual std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() SIP_SKIP;
-
-    /**
-     * An optimised method of retrieving the color of a point from a point cloud block.
-     *
-     * Before calling this method the \a preparedData should be created once upfront by
-     * calling prepare().
-     *
-     * \note Not available in Python bindings
-     * \since QGIS 3.26
-     */
-    virtual QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) SIP_SKIP;
 
     /**
      * Must be called when a new render cycle is started. A call to startRender() must always

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -180,7 +180,7 @@ class CORE_EXPORT QgsPointCloudRenderContext
      * \a type indicates the original data type for the attribute.
      */
     template <typename T>
-    void getAttribute( const char *data, std::size_t offset, QgsPointCloudAttribute::DataType type, T &value ) const
+    static void getAttribute( const char *data, std::size_t offset, QgsPointCloudAttribute::DataType type, T &value )
     {
       switch ( type )
       {
@@ -241,6 +241,39 @@ class CORE_EXPORT QgsPointCloudRenderContext
 
     QgsFeedback *mFeedback = nullptr;
 };
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \class QgsPreparedPointCloudRendererData
+ *
+ * \brief Base class for 2d point cloud renderer prepared data containers.
+ * \note Not available in Python bindings
+ *
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPreparedPointCloudRendererData
+{
+  public:
+
+    virtual ~QgsPreparedPointCloudRendererData();
+
+    /**
+     * Returns the set of attributes used by the prepared point cloud renderer.
+     */
+    virtual QSet< QString > usedAttributes() const = 0;
+
+    /**
+     * Prepares the renderer for using the specified \a block.
+     *
+     * Returns FALSE if preparation failed.
+     */
+    virtual bool prepareBlock( const QgsPointCloudBlock *block ) = 0;
+
+};
+
+#endif
 
 
 /**
@@ -348,6 +381,25 @@ class CORE_EXPORT QgsPointCloudRenderer
      * returned here.
      */
     virtual QSet< QString > usedAttributes( const QgsPointCloudRenderContext &context ) const;
+
+    /**
+     * Returns prepared data container for bulk point color retrieval.
+     *
+     * \note Not available in Python bindings.
+     * \since QGIS 3.26
+     */
+    virtual std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() SIP_SKIP;
+
+    /**
+     * An optimised method of retrieving the color of a point from a point cloud block.
+     *
+     * Before calling this method the \a preparedData should be created once upfront by
+     * calling prepare().
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+     */
+    virtual QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) SIP_SKIP;
 
     /**
      * Must be called when a new render cycle is started. A call to startRender() must always

--- a/src/core/pointcloud/qgspointcloudrgbrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrgbrenderer.h
@@ -24,6 +24,40 @@
 
 #include "qgscontrastenhancement.h"
 
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ * \brief Prepared data container for QgsPointCloudRgbRenderer.
+ *
+ * \note Not available in Python bindings.
+ *
+ * \since QGIS 3.26
+ */
+class CORE_EXPORT QgsPointCloudRgbRendererPreparedData: public QgsPreparedPointCloudRendererData
+{
+  public:
+
+    QSet< QString > usedAttributes() const override;
+    bool prepareBlock( const QgsPointCloudBlock *block ) override;
+
+    QString redAttribute = QStringLiteral( "Red" );
+    QString greenAttribute = QStringLiteral( "Green" );
+    QString blueAttribute = QStringLiteral( "Blue" );
+
+    int redOffset = 0;
+    QgsPointCloudAttribute::DataType redType;
+    bool useRedContrastEnhancement = false;
+    int greenOffset = 0;
+    QgsPointCloudAttribute::DataType greenType;
+    bool useGreenContrastEnhancement = false;
+    int blueOffset = 0;
+    QgsPointCloudAttribute::DataType blueType;
+    bool useBlueContrastEnhancement = false;
+};
+#endif
+
 /**
  * \ingroup core
  * \brief An RGB renderer for 2d visualisation of point clouds using embedded red, green and blue attributes.
@@ -44,6 +78,8 @@ class CORE_EXPORT QgsPointCloudRgbRenderer : public QgsPointCloudRenderer
     void renderBlock( const QgsPointCloudBlock *block, QgsPointCloudRenderContext &context ) override;
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     QSet< QString > usedAttributes( const QgsPointCloudRenderContext &context ) const override;
+    std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
+    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/pointcloud/qgspointcloudrgbrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrgbrenderer.h
@@ -41,10 +41,14 @@ class CORE_EXPORT QgsPointCloudRgbRendererPreparedData: public QgsPreparedPointC
 
     QSet< QString > usedAttributes() const override;
     bool prepareBlock( const QgsPointCloudBlock *block ) override;
+    QColor pointColor( const QgsPointCloudBlock *block, int i, double z ) override;
 
     QString redAttribute = QStringLiteral( "Red" );
     QString greenAttribute = QStringLiteral( "Green" );
     QString blueAttribute = QStringLiteral( "Blue" );
+    std::unique_ptr< QgsContrastEnhancement > redContrastEnhancement;
+    std::unique_ptr< QgsContrastEnhancement > greenContrastEnhancement;
+    std::unique_ptr< QgsContrastEnhancement > blueContrastEnhancement;
 
     int redOffset = 0;
     QgsPointCloudAttribute::DataType redType;
@@ -79,7 +83,6 @@ class CORE_EXPORT QgsPointCloudRgbRenderer : public QgsPointCloudRenderer
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     QSet< QString > usedAttributes( const QgsPointCloudRenderContext &context ) const override;
     std::unique_ptr< QgsPreparedPointCloudRendererData > prepare() override SIP_SKIP;
-    QColor pointColor( QgsPreparedPointCloudRendererData *preparedData, const QgsPointCloudBlock *block, const char *ptr, int i, std::size_t pointRecordSize, double x, double y, double z ) override SIP_SKIP;
 
     /**
      * Creates an RGB renderer from an XML \a element.

--- a/src/core/qgsmaplayerelevationproperties.cpp
+++ b/src/core/qgsmaplayerelevationproperties.cpp
@@ -90,6 +90,7 @@ void QgsMapLayerElevationProperties::setZOffset( double offset )
 
   mZOffset = offset;
   emit changed();
+  emit zOffsetChanged();
   emit profileGenerationPropertyChanged();
 }
 
@@ -100,6 +101,7 @@ void QgsMapLayerElevationProperties::setZScale( double scale )
 
   mZScale = scale;
   emit changed();
+  emit zScaleChanged();
   emit profileGenerationPropertyChanged();
 }
 

--- a/src/core/qgsmaplayerelevationproperties.h
+++ b/src/core/qgsmaplayerelevationproperties.h
@@ -259,6 +259,20 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
     void changed();
 
     /**
+     * Emitted when the z offset changes.
+     *
+     * \since QGIS 3.26
+     */
+    void zOffsetChanged();
+
+    /**
+     * Emitted when the z scale changes.
+     *
+     * \since QGIS 3.26
+     */
+    void zScaleChanged();
+
+    /**
      * Emitted when any of the elevation properties which relate solely to presentation of elevation
      * results have changed.
      *

--- a/src/core/qgsmaplayerelevationproperties.h
+++ b/src/core/qgsmaplayerelevationproperties.h
@@ -266,14 +266,14 @@ class CORE_EXPORT QgsMapLayerElevationProperties : public QObject
      * \see profileGenerationPropertyChanged()
      * \since QGIS 3.26
      */
-    void renderingPropertyChanged();
+    void profileRenderingPropertyChanged();
 
     /**
      * Emitted when any of the elevation properties which relate solely to generation of elevation
      * profiles have changed.
      *
      * \see changed()
-     * \see renderingPropertyChanged()
+     * \see profileRenderingPropertyChanged()
      * \since QGIS 3.26
      */
     void profileGenerationPropertyChanged();

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -152,7 +152,7 @@ void QgsRasterLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *sym
 {
   mProfileLineSymbol.reset( symbol );
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 QgsFillSymbol *QgsRasterLayerElevationProperties::profileFillSymbol() const

--- a/src/core/vector/qgsvectorlayerelevationproperties.cpp
+++ b/src/core/vector/qgsvectorlayerelevationproperties.cpp
@@ -284,7 +284,7 @@ void QgsVectorLayerElevationProperties::setRespectLayerSymbology( bool enabled )
 
   mRespectLayerSymbology = enabled;
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 QgsLineSymbol *QgsVectorLayerElevationProperties::profileLineSymbol() const
@@ -296,7 +296,7 @@ void QgsVectorLayerElevationProperties::setProfileLineSymbol( QgsLineSymbol *sym
 {
   mProfileLineSymbol.reset( symbol );
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 QgsFillSymbol *QgsVectorLayerElevationProperties::profileFillSymbol() const
@@ -308,7 +308,7 @@ void QgsVectorLayerElevationProperties::setProfileFillSymbol( QgsFillSymbol *sym
 {
   mProfileFillSymbol.reset( symbol );
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 QgsMarkerSymbol *QgsVectorLayerElevationProperties::profileMarkerSymbol() const
@@ -320,7 +320,7 @@ void QgsVectorLayerElevationProperties::setProfileMarkerSymbol( QgsMarkerSymbol 
 {
   mProfileMarkerSymbol.reset( symbol );
   emit changed();
-  emit renderingPropertyChanged();
+  emit profileRenderingPropertyChanged();
 }
 
 void QgsVectorLayerElevationProperties::setDefaultProfileLineSymbol( const QColor &color )

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -418,13 +418,13 @@ void QgsElevationProfileCanvas::setupLayerConnections( QgsMapLayer *layer, bool 
   if ( isDisconnect )
   {
     disconnect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileGenerationPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileGenerationPropertyChanged );
-    disconnect( layer->elevationProperties(), &QgsMapLayerElevationProperties::renderingPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
+    disconnect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileRenderingPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
     disconnect( layer, &QgsMapLayer::dataChanged, this, &QgsElevationProfileCanvas::regenerateResultsForLayer );
   }
   else
   {
     connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileGenerationPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileGenerationPropertyChanged );
-    connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::renderingPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
+    connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::profileRenderingPropertyChanged, this, &QgsElevationProfileCanvas::onLayerProfileRendererPropertyChanged );
     connect( layer, &QgsMapLayer::dataChanged, this, &QgsElevationProfileCanvas::regenerateResultsForLayer );
   }
 

--- a/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
+++ b/src/ui/pointcloud/qgspointcloudelevationpropertieswidgetbase.ui
@@ -188,7 +188,34 @@
       <string>Profile Chart Appearance</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,1">
-      <item row="2" column="1" colspan="2">
+      <item row="0" column="1">
+       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="maximum">
+         <double>99999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="QCheckBox" name="mOpacityByDistanceCheckBox">
+        <property name="text">
+         <string>Apply opacity by distance from curve effect</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="mPointStyleComboBox"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
        <widget class="QgsColorButton" name="mPointColorButton">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -204,26 +231,6 @@
         </property>
         <property name="text">
          <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
-        <property name="decimals">
-         <number>6</number>
-        </property>
-        <property name="maximum">
-         <double>99999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QComboBox" name="mPointStyleComboBox"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Color</string>
         </property>
        </widget>
       </item>
@@ -248,10 +255,10 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="QCheckBox" name="mOpacityByDistanceCheckBox">
+      <item row="4" column="0" colspan="3">
+       <widget class="QCheckBox" name="mCheckBoxRespectLayerColors">
         <property name="text">
-         <string>Apply opacity by distance from curve effect</string>
+         <string>Respect layer's coloring</string>
         </property>
        </widget>
       </item>

--- a/tests/src/python/test_qgspointcloudelevationproperties.py
+++ b/tests/src/python/test_qgspointcloudelevationproperties.py
@@ -33,6 +33,7 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         props = QgsPointCloudLayerElevationProperties(None)
         self.assertEqual(props.zScale(), 1)
         self.assertEqual(props.zOffset(), 0)
+        self.assertTrue(props.respectLayerColors())
         self.assertTrue(props.pointColor().isValid())
 
         props.setZOffset(0.5)
@@ -43,6 +44,7 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         props.setPointColor(QColor(255, 0, 255))
         props.setPointSize(1.2)
         props.setPointSizeUnit(QgsUnitTypes.RenderPoints)
+        props.setRespectLayerColors(False)
 
         self.assertEqual(props.zScale(), 2)
         self.assertEqual(props.zOffset(), 0.5)
@@ -52,6 +54,7 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         self.assertEqual(props.pointColor().name(), '#ff00ff')
         self.assertEqual(props.pointSize(), 1.2)
         self.assertEqual(props.pointSizeUnit(), QgsUnitTypes.RenderPoints)
+        self.assertFalse(props.respectLayerColors())
 
         doc = QDomDocument("testdoc")
         elem = doc.createElement('test')
@@ -67,6 +70,7 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         self.assertEqual(props2.pointColor().name(), '#ff00ff')
         self.assertEqual(props2.pointSize(), 1.2)
         self.assertEqual(props2.pointSizeUnit(), QgsUnitTypes.RenderPoints)
+        self.assertFalse(props2.respectLayerColors())
 
         props2 = props.clone()
         self.assertEqual(props2.zScale(), 2)
@@ -77,6 +81,7 @@ class TestQgsPointCloudElevationProperties(unittest.TestCase):
         self.assertEqual(props2.pointColor().name(), '#ff00ff')
         self.assertEqual(props2.pointSize(), 1.2)
         self.assertEqual(props2.pointSizeUnit(), QgsUnitTypes.RenderPoints)
+        self.assertFalse(props2.respectLayerColors())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows point cloud layers in profile charts to show classifications/rgb/etc coloring

https://user-images.githubusercontent.com/1829991/166080484-c6941c0f-9215-4427-b75e-a6ef9b6a4313.mp4

https://user-images.githubusercontent.com/1829991/166080591-1be3e46c-4a26-4f35-a568-44eb6c5af020.mp4


