### PR TITLE
Don't reset plot extent so often

### DIFF
--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -72,6 +72,12 @@ Triggers a complete regeneration of the profile, causing the profile extraction 
 background.
 %End
 
+    void invalidateCurrentPlotExtent();
+%Docstring
+Invalidates the current plot extent, which means that the visible plot area will be
+recalculated and "zoom full" operation occur when the next profile generation completes.
+%End
+
     void setProject( QgsProject *project );
 %Docstring
 Sets the ``project`` associated with the profile.

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -76,7 +76,7 @@ class QgsElevationProfileWidget : public QWidget
     void populateInitialLayers();
     void updateCanvasLayers();
     void onTotalPendingJobsCountChanged( int count );
-    void setProfileCurve( const QgsGeometry &curve );
+    void setProfileCurve( const QgsGeometry &curve, bool resetView );
     void onCanvasPointHovered( const QgsPointXY &point );
     void updatePlot();
     void scheduleUpdate();

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -631,7 +631,6 @@ void QgsElevationProfileCanvas::refresh()
   }
 
   mCurrentJob = new QgsProfilePlotRenderer( sources, request );
-  mZoomFullWhenJobFinished = true;
   connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsElevationProfileCanvas::generationFinished );
 
   QgsProfileGenerationContext generationContext;
@@ -644,6 +643,11 @@ void QgsElevationProfileCanvas::refresh()
   mPlotItem->setRenderer( mCurrentJob );
 
   emit activeJobCountChanged( 1 );
+}
+
+void QgsElevationProfileCanvas::invalidateCurrentPlotExtent()
+{
+  mZoomFullWhenJobFinished = true;
 }
 
 void QgsElevationProfileCanvas::generationFinished()

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -85,6 +85,12 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     void refresh() override;
 
     /**
+     * Invalidates the current plot extent, which means that the visible plot area will be
+     * recalculated and "zoom full" operation occur when the next profile generation completes.
+     */
+    void invalidateCurrentPlotExtent();
+
+    /**
      * Sets the \a project associated with the profile.
      *
      * This must be set before any layers which utilize terrain based elevation settings can be


### PR DESCRIPTION
Be more picky about when we force a zoom full in the elevation plot,
so that we aren't zooming out when a user makes a change like
increasing the distance tolerance or nudging the curve.
