### PR TITLE
Use explain plan to estimate featureCount with filter (fixes #48446)

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3749,13 +3749,10 @@ long long QgsPostgresProvider::featureCount() const
   // get total number of features
   QString sql;
 
-  // use estimated metadata even when there is a where clause,
-  // although we get an incorrect feature count for the subset
-  // - but make huge dataset usable.
   long long num = -1;
   if ( !mIsQuery && mUseEstimatedMetadata )
   {
-    if ( relkind() == Relkind::View && connectionRO()->pgVersion() >= 90000 )
+    if ( ( relkind() == Relkind::View || !mSqlWhereClause.isEmpty() ) && connectionRO()->pgVersion() >= 90000 )
     {
       // parse explain output to estimate feature count
       // we don't use pg_class reltuples because it returns 0 for view

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -2534,6 +2534,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             'test', 'postgres')
         self.assertTrue(vl.isValid())
         self.assertTrue(vl.featureCount() > 0)
+        vl.setSubsetString('"pk" = 3')
+        self.assertEqual(vl.featureCount(), 1)
 
     def testFeatureCountEstimatedOnView(self):
         """
@@ -2548,6 +2550,8 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             'test', 'postgres')
         self.assertTrue(vl.isValid())
         self.assertTrue(vl.featureCount() > 0)
+        vl.setSubsetString('"pk" = 3')
+        self.assertEqual(vl.featureCount(), 1)
 
     def testIdentityPk(self):
         """Test a table with identity pk, see GH #29560"""


### PR DESCRIPTION
## Description

Fix for #48446.

With Postgres, when use of estimated metadata is enabled, the featureCount method was not taking the where clause into account if there was one.

Now, if there is a where clause (for filtering) then the estimated featureCount uses the *explain plan* method to be more accurate.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
