### PR TITLE
[Backport release-3_24] [MetaSearch] fix CSW search when user/passwords are empty (Fix #48201)

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -863,8 +863,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
                 cat = get_catalog_service(self.catalog_url,  # spellok
                                           catalog_type=self.catalog_type,
                                           timeout=self.timeout,
-                                          username=self.catalog_username,
-                                          password=self.catalog_password,
+                                          username=self.catalog_username or None,
+                                          password=self.catalog_password or None,
                                           auth=auth)
                 record = cat.get_record(identifier)
                 if cat.type == 'OGC API - Records':
@@ -957,8 +957,8 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             try:
                 self.catalog = get_catalog_service(
                     self.catalog_url, catalog_type=self.catalog_type,
-                    timeout=self.timeout, username=self.catalog_username,
-                    password=self.catalog_password, auth=auth)
+                    timeout=self.timeout, username=self.catalog_username or None,
+                    password=self.catalog_password or None, auth=auth)
                 return True
             except Exception as err:
                 msg = self.tr('Error connecting to service: {0}').format(err)

--- a/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
+++ b/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
@@ -94,8 +94,14 @@ class NewConnectionDialog(QDialog, BASE_CLASS):
             self.settings.setValue(keyurl, conn_url)
             self.settings.setValue('/MetaSearch/selected', conn_name)
 
-            self.settings.setValue('%s/username' % key, conn_username)
-            self.settings.setValue('%s/password' % key, conn_password)
+            if conn_username != '':
+                self.settings.setValue('%s/username' % key, conn_username)
+            else:
+                self.settings.remove('%s/username' % key)
+            if conn_password != '':
+                self.settings.setValue('%s/password' % key, conn_password)
+            else:
+                self.settings.remove('%s/password' % key)
 
             self.settings.setValue('%s/catalog-type' % key, conn_catalog_type)
 


### PR DESCRIPTION
Backport https://github.com/qgis/QGIS/pull/48288