### PR TITLE
[Backport release-3_22] [MetaSearch] fix CSW search when user/passwords are empty (Fix #48201)

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -858,14 +858,14 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             with OverrideCursor(Qt.WaitCursor):
                 if auth is not None:
                     cat = CatalogueServiceWeb(self.catalog_url, timeout=self.timeout,  # spellok
-                                              username=self.catalog_username,
-                                              password=self.catalog_password,
+                                              username=self.catalog_username or None,
+                                              password=self.catalog_password or None,
                                               auth=auth)
                 else:
                     # older owslib version without the auth keyword
                     cat = CatalogueServiceWeb(self.catalog_url, timeout=self.timeout,  # spellok
-                                              username=self.catalog_username,
-                                              password=self.catalog_password)
+                                              username=self.catalog_username or None,
+                                              password=self.catalog_password or None)
 
                 cat.getrecordbyid(
                     [self.catalog.records[identifier].identifier])
@@ -956,15 +956,15 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
                 if auth is not None:
                     self.catalog = CatalogueServiceWeb(self.catalog_url,  # spellok
                                                        timeout=self.timeout,
-                                                       username=self.catalog_username,
-                                                       password=self.catalog_password,
+                                                       username=self.catalog_username or None,
+                                                       password=self.catalog_password or None,
                                                        auth=auth)
                 else:
                     # older owslib version without the auth keyword
                     self.catalog = CatalogueServiceWeb(self.catalog_url,  # spellok
                                                        timeout=self.timeout,
-                                                       username=self.catalog_username,
-                                                       password=self.catalog_password)
+                                                       username=self.catalog_username or None,
+                                                       password=self.catalog_password or None)
                 return True
             except ExceptionReport as err:
                 msg = self.tr('Error connecting to service: {0}').format(err)

--- a/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
+++ b/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
@@ -89,8 +89,14 @@ class NewConnectionDialog(QDialog, BASE_CLASS):
             self.settings.setValue(keyurl, conn_url)
             self.settings.setValue('/MetaSearch/selected', conn_name)
 
-            self.settings.setValue('%s/username' % key, conn_username)
-            self.settings.setValue('%s/password' % key, conn_password)
+            if conn_username != '':
+                self.settings.setValue('%s/username' % key, conn_username)
+            else:
+                self.settings.remove('%s/username' % key)
+            if conn_password != '':
+                self.settings.setValue('%s/password' % key, conn_password)
+            else:
+                self.settings.remove('%s/password' % key)
 
             QDialog.accept(self)
 


### PR DESCRIPTION
Backport https://github.com/qgis/QGIS/pull/48288