### PR TITLE
[ui] Add a set to null / clear current symbol action to the symbol button

### DIFF
--- a/python/gui/auto_generated/qgscolorrampbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorrampbutton.sip.in
@@ -139,7 +139,7 @@ Returns whether random colors option is shown in the button's drop-down menu.
 
     bool isRandomColorRamp() const;
 %Docstring
-Returns ``True`` if the current color is null.
+Returns ``True`` if the current color ramp is random.
 
 .. seealso:: :py:func:`setShowNull`
 
@@ -168,7 +168,7 @@ Returns whether the set to null (clear) option is shown in the button's drop-dow
 
     bool isNull() const;
 %Docstring
-Returns ``True`` if the current color is null.
+Returns ``True`` if the current color ramp is null.
 
 .. seealso:: :py:func:`setShowNull`
 

--- a/python/gui/auto_generated/qgssymbolbutton.sip.in
+++ b/python/gui/auto_generated/qgssymbolbutton.sip.in
@@ -181,6 +181,52 @@ color or string representation of a color, then no change is applied.
 .. seealso:: :py:func:`copyColor`
 %End
 
+    void setShowNull( bool showNull );
+%Docstring
+Sets whether a set to null (clear) option is shown in the button's drop-down menu.
+
+:param showNull: set to ``True`` to show a null option
+
+.. seealso:: :py:func:`showNull`
+
+.. seealso:: :py:func:`isNull`
+
+.. versionadded:: 3.26
+%End
+
+    bool showNull() const;
+%Docstring
+Returns whether the set to null (clear) option is shown in the button's drop-down menu.
+
+.. seealso:: :py:func:`setShowNull`
+
+.. seealso:: :py:func:`isNull`
+
+.. versionadded:: 3.26
+%End
+
+    bool isNull() const;
+%Docstring
+Returns ``True`` if the current color is null.
+
+.. seealso:: :py:func:`setShowNull`
+
+.. seealso:: :py:func:`showNull`
+
+.. versionadded:: 3.26
+%End
+
+    void setToNull();
+%Docstring
+Sets symbol to to null.
+
+.. seealso:: :py:func:`setShowNull`
+
+.. seealso:: :py:func:`showNull`
+
+.. versionadded:: 3.26
+%End
+
   signals:
 
     void changed();

--- a/python/gui/auto_generated/qgssymbolbutton.sip.in
+++ b/python/gui/auto_generated/qgssymbolbutton.sip.in
@@ -207,7 +207,7 @@ Returns whether the set to null (clear) option is shown in the button's drop-dow
 
     bool isNull() const;
 %Docstring
-Returns ``True`` if the current color is null.
+Returns ``True`` if the current symbol is null.
 
 .. seealso:: :py:func:`setShowNull`
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -948,6 +948,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mStyleFillSymbol->setSymbolType( Qgis::SymbolType::Fill );
   mStyleFillSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Fill ) );
 
+  mStyleColorRampSymbol->setShowNull( true );
   mStyleColorRampSymbol->setColorRamp( QgsProject::instance()->styleSettings()->defaultColorRamp() );
 
   mStyleTextFormat->setShowNullFormat( true );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -943,11 +943,11 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mStyleMarkerSymbol->setSymbolType( Qgis::SymbolType::Marker );
   mStyleMarkerSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Marker ) );
 
-  mStyleMarkerSymbol->setShowNull( true );
+  mStyleLineSymbol->setShowNull( true );
   mStyleLineSymbol->setSymbolType( Qgis::SymbolType::Line );
   mStyleLineSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Line ) );
 
-  mStyleMarkerSymbol->setShowNull( true );
+  mStyleFillSymbol->setShowNull( true );
   mStyleFillSymbol->setSymbolType( Qgis::SymbolType::Fill );
   mStyleFillSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Fill ) );
 
@@ -955,7 +955,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mStyleColorRampSymbol->setColorRamp( QgsProject::instance()->styleSettings()->defaultColorRamp() );
 
   mStyleTextFormat->setShowNullFormat( true );
-  mStyleTextFormat->setNoFormatString( tr( "Clear Default Text Format" ) );
+  mStyleTextFormat->setNoFormatString( tr( "Clear Current Text Format" ) );
   QgsTextFormat textFormat = QgsProject::instance()->styleSettings()->defaultTextFormat();
   if ( textFormat.isValid() )
   {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -939,12 +939,15 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   twWCSLayers->verticalHeader()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
   // Default styles
+  mStyleMarkerSymbol->setShowNull( true );
   mStyleMarkerSymbol->setSymbolType( Qgis::SymbolType::Marker );
   mStyleMarkerSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Marker ) );
 
+  mStyleMarkerSymbol->setShowNull( true );
   mStyleLineSymbol->setSymbolType( Qgis::SymbolType::Line );
   mStyleLineSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Line ) );
 
+  mStyleMarkerSymbol->setShowNull( true );
   mStyleFillSymbol->setSymbolType( Qgis::SymbolType::Fill );
   mStyleFillSymbol->setSymbol( QgsProject::instance()->styleSettings()->defaultSymbol( Qgis::SymbolType::Fill ) );
 

--- a/src/gui/qgscolorrampbutton.cpp
+++ b/src/gui/qgscolorrampbutton.cpp
@@ -234,6 +234,7 @@ void QgsColorRampButton::prepareMenu()
   if ( mShowNull )
   {
     QAction *nullAction = new QAction( tr( "Clear Current Ramp" ), this );
+    nullAction->setEnabled( !isNull() );
     mMenu->addAction( nullAction );
     connect( nullAction, &QAction::triggered, this, &QgsColorRampButton::setToNull );
   }

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -137,7 +137,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
     bool showRandomColorRamp() const { return mShowRandomColorRamp; }
 
     /**
-     * Returns TRUE if the current color is null.
+     * Returns TRUE if the current color ramp is random.
      * \see setShowNull()
      * \see showNull()
      */
@@ -159,7 +159,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
     bool showNull() const;
 
     /**
-     * Returns TRUE if the current color is null.
+     * Returns TRUE if the current color ramp is null.
      * \see setShowNull()
      * \see showNull()
      */

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -421,6 +421,14 @@ void QgsSymbolButton::prepareMenu()
     mMenu->addAction( pasteSymbolAction );
     connect( pasteSymbolAction, &QAction::triggered, this, &QgsSymbolButton::pasteSymbol );
 
+    if ( mShowNull )
+    {
+      QAction *nullAction = new QAction( tr( "Clear Current Symbol" ), this );
+      nullAction->setEnabled( !isNull() );
+      mMenu->addAction( nullAction );
+      connect( nullAction, &QAction::triggered, this, &QgsSymbolButton::setToNull );
+    }
+
     mMenu->addSeparator();
 
     QgsColorWheel *colorWheel = new QgsColorWheel( mMenu );
@@ -716,4 +724,24 @@ QString QgsSymbolButton::dialogTitle() const
 QgsSymbol *QgsSymbolButton::symbol()
 {
   return mSymbol.get();
+}
+
+void QgsSymbolButton::setShowNull( bool showNull )
+{
+  mShowNull = showNull;
+}
+
+bool QgsSymbolButton::showNull() const
+{
+  return mShowNull;
+}
+
+bool QgsSymbolButton::isNull() const
+{
+  return !mSymbol;
+}
+
+void QgsSymbolButton::setToNull()
+{
+  setSymbol( nullptr );
 }

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -400,35 +400,37 @@ void QgsSymbolButton::prepareMenu()
   mMenu->addAction( configureAction );
   connect( configureAction, &QAction::triggered, this, &QgsSymbolButton::showSettingsDialog );
 
+  QAction *copySymbolAction = new QAction( tr( "Copy Symbol" ), this );
+  copySymbolAction->setEnabled( !isNull() );
+  mMenu->addAction( copySymbolAction );
+  connect( copySymbolAction, &QAction::triggered, this, &QgsSymbolButton::copySymbol );
+
+  QAction *pasteSymbolAction = new QAction( tr( "Paste Symbol" ), this );
+  //enable or disable paste action based on current clipboard contents. We always show the paste
+  //action, even if it's disabled, to give hint to the user that pasting symbols is possible
+  std::unique_ptr< QgsSymbol > tempSymbol( QgsSymbolLayerUtils::symbolFromMimeData( QApplication::clipboard()->mimeData() ) );
+  if ( tempSymbol && tempSymbol->type() == mType )
+  {
+    const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+    pasteSymbolAction->setIcon( QgsSymbolLayerUtils::symbolPreviewIcon( tempSymbol.get(), QSize( iconSize, iconSize ), 1 ) );
+  }
+  else
+  {
+    pasteSymbolAction->setEnabled( false );
+  }
+  mMenu->addAction( pasteSymbolAction );
+  connect( pasteSymbolAction, &QAction::triggered, this, &QgsSymbolButton::pasteSymbol );
+
+  if ( mShowNull )
+  {
+    QAction *nullAction = new QAction( tr( "Clear Current Symbol" ), this );
+    nullAction->setEnabled( !isNull() );
+    mMenu->addAction( nullAction );
+    connect( nullAction, &QAction::triggered, this, &QgsSymbolButton::setToNull );
+  }
+
   if ( mSymbol )
   {
-    QAction *copySymbolAction = new QAction( tr( "Copy Symbol" ), this );
-    mMenu->addAction( copySymbolAction );
-    connect( copySymbolAction, &QAction::triggered, this, &QgsSymbolButton::copySymbol );
-    QAction *pasteSymbolAction = new QAction( tr( "Paste Symbol" ), this );
-    //enable or disable paste action based on current clipboard contents. We always show the paste
-    //action, even if it's disabled, to give hint to the user that pasting symbols is possible
-    std::unique_ptr< QgsSymbol > tempSymbol( QgsSymbolLayerUtils::symbolFromMimeData( QApplication::clipboard()->mimeData() ) );
-    if ( tempSymbol && tempSymbol->type() == mType )
-    {
-      const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
-      pasteSymbolAction->setIcon( QgsSymbolLayerUtils::symbolPreviewIcon( tempSymbol.get(), QSize( iconSize, iconSize ), 1 ) );
-    }
-    else
-    {
-      pasteSymbolAction->setEnabled( false );
-    }
-    mMenu->addAction( pasteSymbolAction );
-    connect( pasteSymbolAction, &QAction::triggered, this, &QgsSymbolButton::pasteSymbol );
-
-    if ( mShowNull )
-    {
-      QAction *nullAction = new QAction( tr( "Clear Current Symbol" ), this );
-      nullAction->setEnabled( !isNull() );
-      mMenu->addAction( nullAction );
-      connect( nullAction, &QAction::triggered, this, &QgsSymbolButton::setToNull );
-    }
-
     mMenu->addSeparator();
 
     QgsColorWheel *colorWheel = new QgsColorWheel( mMenu );

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -222,7 +222,7 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
     bool showNull() const;
 
     /**
-     * Returns TRUE if the current color is null.
+     * Returns TRUE if the current symbol is null.
      * \see setShowNull()
      * \see showNull()
      * \since QGIS 3.26

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -204,6 +204,39 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
      */
     void pasteColor();
 
+    /**
+     * Sets whether a set to null (clear) option is shown in the button's drop-down menu.
+     * \param showNull set to TRUE to show a null option
+     * \see showNull()
+     * \see isNull()
+     * \since QGIS 3.26
+     */
+    void setShowNull( bool showNull );
+
+    /**
+     * Returns whether the set to null (clear) option is shown in the button's drop-down menu.
+     * \see setShowNull()
+     * \see isNull()
+     * \since QGIS 3.26
+     */
+    bool showNull() const;
+
+    /**
+     * Returns TRUE if the current color is null.
+     * \see setShowNull()
+     * \see showNull()
+     * \since QGIS 3.26
+     */
+    bool isNull() const;
+
+    /**
+     * Sets symbol to to null.
+     * \see setShowNull()
+     * \see showNull()
+     * \since QGIS 3.26
+     */
+    void setToNull();
+
   signals:
 
     /**
@@ -276,6 +309,8 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
     QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
 
     bool mPickingColor = false;
+
+    bool mShowNull = false;
 
     /**
      * Regenerates the text preview. If \a color is specified, a temporary color preview


### PR DESCRIPTION
## Description

This PR adds a method to clear the current symbol attached to a symbol button. Screenshot time:
![image](https://user-images.githubusercontent.com/1728657/167347365-f1c6c36b-5214-4d1a-b727-0f12640446f2.png)

This was needed to allow for users to clear any default symbol following the revamp work done and merged earlier today. I'm sure it'll come in handy to others too :)