### PR TITLE
[ui] Implement scroll wheel action for {symbol,color} buttons

### DIFF
--- a/python/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorbutton.sip.in
@@ -532,6 +532,9 @@ Reimplemented to reset button appearance after drag leave
 Reimplemented to accept dropped colors
 %End
 
+    virtual void wheelEvent( QWheelEvent *event );
+
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgssymbolbutton.sip.in
+++ b/python/gui/auto_generated/qgssymbolbutton.sip.in
@@ -264,6 +264,9 @@ Emitted when the symbol's settings are changed.
     virtual void dropEvent( QDropEvent *e );
 
 
+    virtual void wheelEvent( QWheelEvent *event );
+
+
 };
 
 /************************************************************************

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -424,14 +424,18 @@ void QgsColorButton::wheelEvent( QWheelEvent *event )
 {
   if ( mAllowOpacity && isEnabled() && !isNull() )
   {
-    const int increment = ( ( event->modifiers() & Qt::ControlModifier ) ? 80 : 25 ) *
-                          ( event->angleDelta().y() > 0 ? 1 : -1 );
-    const int alpha = std::min( std::max( 0, mColor.alpha() + increment ), 255 );
-    mColor.setAlpha( alpha );
+    const double increment = ( ( event->modifiers() & Qt::ControlModifier ) ? 0.25 : 0.1 ) *
+                             ( event->angleDelta().y() > 0 ? 1 : -1 );
+    const double alpha = std::min( std::max( 0.0, mColor.alphaF() + increment ), 1.0 );
+    mColor.setAlphaF( alpha );
 
     setButtonBackground();
     emit colorChanged( mColor );
     event->accept();
+  }
+  else
+  {
+    QToolButton::wheelEvent( event );
   }
 }
 

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -420,6 +420,21 @@ void QgsColorButton::dropEvent( QDropEvent *e )
   }
 }
 
+void QgsColorButton::wheelEvent( QWheelEvent *event )
+{
+  if ( mAllowOpacity && isEnabled() && !isNull() )
+  {
+    const int increment = ( ( event->modifiers() & Qt::ControlModifier ) ? 80 : 25 ) *
+                          ( event->angleDelta().y() > 0 ? 1 : -1 );
+    const int alpha = std::min( std::max( 0, mColor.alpha() + increment ), 255 );
+    mColor.setAlpha( alpha );
+
+    setButtonBackground();
+    emit colorChanged( mColor );
+    event->accept();
+  }
+}
+
 void QgsColorButton::setValidColor( const QColor &newColor )
 {
   if ( newColor.isValid() )

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -461,6 +461,8 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      */
     void dropEvent( QDropEvent *e ) override;
 
+    void wheelEvent( QWheelEvent *event ) override;
+
   private:
 
     Behavior mBehavior = QgsColorButton::ShowDialog;

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -395,11 +395,11 @@ void QgsSymbolButton::wheelEvent( QWheelEvent *event )
     bool symbolChanged = false;
     const double increment = ( ( event->modifiers() & Qt::ControlModifier ) ? 0.1 : 1 ) *
                              event->angleDelta().y() > 0 ? 1 : -1;
-    switch ( mType )
+    switch ( mSymbol->type() )
     {
       case Qgis::SymbolType::Marker:
       {
-        QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( mSymbol.get() );
+        QgsMarkerSymbol *marker = qgis::down_cast<QgsMarkerSymbol *>( mSymbol.get() );
         if ( marker )
         {
           const double size = std::max( 0.0, marker->size() + increment );
@@ -411,7 +411,7 @@ void QgsSymbolButton::wheelEvent( QWheelEvent *event )
 
       case Qgis::SymbolType::Line:
       {
-        QgsLineSymbol *line = dynamic_cast<QgsLineSymbol *>( mSymbol.get() );
+        QgsLineSymbol *line = qgis::down_cast<QgsLineSymbol *>( mSymbol.get() );
         if ( line )
         {
           const double width = std::max( 0.0, line->width() + increment );
@@ -433,6 +433,10 @@ void QgsSymbolButton::wheelEvent( QWheelEvent *event )
     }
 
     event->accept();
+  }
+  else
+  {
+    QToolButton::wheelEvent( event );
   }
 }
 

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -388,6 +388,54 @@ void QgsSymbolButton::dropEvent( QDropEvent *e )
   updatePreview();
 }
 
+void QgsSymbolButton::wheelEvent( QWheelEvent *event )
+{
+  if ( isEnabled() && mSymbol )
+  {
+    bool symbolChanged = false;
+    const double increment = ( ( event->modifiers() & Qt::ControlModifier ) ? 0.1 : 1 ) *
+                             event->angleDelta().y() > 0 ? 1 : -1;
+    switch ( mType )
+    {
+      case Qgis::SymbolType::Marker:
+      {
+        QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( mSymbol.get() );
+        if ( marker )
+        {
+          const double size = std::max( 0.0, marker->size() + increment );
+          marker->setSize( size );
+          symbolChanged = true;
+        }
+        break;
+      }
+
+      case Qgis::SymbolType::Line:
+      {
+        QgsLineSymbol *line = dynamic_cast<QgsLineSymbol *>( mSymbol.get() );
+        if ( line )
+        {
+          const double width = std::max( 0.0, line->width() + increment );
+          line->setWidth( width );
+          symbolChanged = true;
+        }
+        break;
+      }
+
+      case Qgis::SymbolType::Fill:
+      case Qgis::SymbolType::Hybrid:
+        break;
+    }
+
+    if ( symbolChanged )
+    {
+      updatePreview();
+      emit changed();
+    }
+
+    event->accept();
+  }
+}
+
 void QgsSymbolButton::prepareMenu()
 {
   //we need to tear down and rebuild this menu every time it is shown. Otherwise the space allocated to any

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -267,6 +267,8 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
     // Reimplemented to accept dropped colors
     void dropEvent( QDropEvent *e ) override;
 
+    void wheelEvent( QWheelEvent *event ) override;
+
   private slots:
 
     void showSettingsDialog();


### PR DESCRIPTION
## Description

I've gotten used to a mouse wheel action with the font button, so much so I'm expecting one for symbol buttons. Let's implement :)

This PR implements the following mouse wheel action for the symbol button: 
- for marker symbols, the marker size increases / decreases
- for line symbols, the line width increases / decreases

https://user-images.githubusercontent.com/1728657/167389295-9be7d103-34c2-47d2-8a6d-f77f199e6cc7.mp4

A mouse wheel action for opacity-enabled color button:

https://user-images.githubusercontent.com/1728657/167394895-287020ea-239b-46c0-93d0-59e79692c202.mp4

