### PR TITLE
Propagate line symbol's width and marker symbol's size to geometry generator symbol layer having sub symbols of same types

### DIFF
--- a/src/core/symbology/qgsmarkersymbol.cpp
+++ b/src/core/symbology/qgsmarkersymbol.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmarkersymbol.h"
 #include "qgsmarkersymbollayer.h"
+#include "qgsgeometrygeneratorsymbollayer.h"
 #include "qgssymbollayerutils.h"
 #include "qgspainteffect.h"
 
@@ -156,20 +157,40 @@ void QgsMarkerSymbol::setSize( double s ) const
   const auto constMLayers = mLayers;
   for ( QgsSymbolLayer *layer : constMLayers )
   {
-    if ( layer->type() != Qgis::SymbolType::Marker )
-      continue;
-    QgsMarkerSymbolLayer *markerLayer = static_cast<QgsMarkerSymbolLayer *>( layer );
-    if ( qgsDoubleNear( markerLayer->size(), origSize ) )
-      markerLayer->setSize( s );
-    else if ( !qgsDoubleNear( origSize, 0.0 ) )
+    QgsMarkerSymbolLayer *markerLayer = dynamic_cast<QgsMarkerSymbolLayer *>( layer );
+    if ( markerLayer )
     {
-      // proportionally scale size
-      markerLayer->setSize( markerLayer->size() * s / origSize );
+      if ( qgsDoubleNear( markerLayer->size(), origSize ) )
+      {
+        markerLayer->setSize( s );
+      }
+      else if ( !qgsDoubleNear( origSize, 0.0 ) )
+      {
+        // proportionally scale size
+        markerLayer->setSize( markerLayer->size() * s / origSize );
+      }
+      // also scale offset to maintain relative position
+      if ( !qgsDoubleNear( origSize, 0.0 ) && ( !qgsDoubleNear( markerLayer->offset().x(), 0.0 ) || !qgsDoubleNear( markerLayer->offset().y(), 0.0 ) ) )
+        markerLayer->setOffset( QPointF( markerLayer->offset().x() * s / origSize,
+                                         markerLayer->offset().y() * s / origSize ) );
     }
-    // also scale offset to maintain relative position
-    if ( !qgsDoubleNear( origSize, 0.0 ) && ( !qgsDoubleNear( markerLayer->offset().x(), 0.0 ) || !qgsDoubleNear( markerLayer->offset().y(), 0.0 ) ) )
-      markerLayer->setOffset( QPointF( markerLayer->offset().x() * s / origSize,
-                                       markerLayer->offset().y() * s / origSize ) );
+    else
+    {
+      QgsGeometryGeneratorSymbolLayer *geomGeneratorLayer = dynamic_cast<QgsGeometryGeneratorSymbolLayer *>( layer );
+      if ( geomGeneratorLayer && geomGeneratorLayer->symbolType() == Qgis::SymbolType::Marker )
+      {
+        QgsMarkerSymbol *markerSymbol = qgis::down_cast<QgsMarkerSymbol *>( geomGeneratorLayer->subSymbol() );
+        if ( qgsDoubleNear( markerSymbol->size(), origSize ) )
+        {
+          markerSymbol->setSize( s );
+        }
+        else if ( !qgsDoubleNear( origSize, 0.0 ) )
+        {
+          // proportionally scale the width
+          markerSymbol->setSize( markerSymbol->size() * s / origSize );
+        }
+      }
+    }
   }
 }
 
@@ -180,12 +201,24 @@ double QgsMarkerSymbol::size() const
   const auto constMLayers = mLayers;
   for ( QgsSymbolLayer *layer : constMLayers )
   {
-    if ( layer->type() != Qgis::SymbolType::Marker )
-      continue;
-    const QgsMarkerSymbolLayer *markerLayer = static_cast<const QgsMarkerSymbolLayer *>( layer );
-    double lsize = markerLayer->size();
-    if ( lsize > maxSize )
-      maxSize = lsize;
+    const QgsMarkerSymbolLayer *markerLayer = dynamic_cast<QgsMarkerSymbolLayer *>( layer );
+    if ( markerLayer )
+    {
+      const double lsize = markerLayer->size();
+      if ( lsize > maxSize )
+        maxSize = lsize;
+    }
+    else
+    {
+      QgsGeometryGeneratorSymbolLayer *geomGeneratorLayer = dynamic_cast<QgsGeometryGeneratorSymbolLayer *>( layer );
+      if ( geomGeneratorLayer && geomGeneratorLayer->symbolType() == Qgis::SymbolType::Marker )
+      {
+        QgsMarkerSymbol *markerSymbol = qgis::down_cast<QgsMarkerSymbol *>( geomGeneratorLayer->subSymbol() );
+        const double lsize = markerSymbol->size();
+        if ( lsize > maxSize )
+          maxSize = lsize;
+      }
+    }
   }
   return maxSize;
 }

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -55,6 +55,7 @@ from qgis.core import (QgsGeometry,
                        QgsSymbolLayerUtils,
                        QgsMarkerLineSymbolLayer,
                        QgsArrowSymbolLayer,
+                       QgsGeometryGeneratorSymbolLayer,
                        QgsSymbol,
                        Qgis,
                        QgsSymbolLayer,
@@ -832,6 +833,34 @@ class TestQgsMarkerSymbol(unittest.TestCase):
         markerSymbol.symbolLayer(1).setSize(45)
         self.assertAlmostEqual(markerSymbol.size(context), 45, 3)
         self.assertAlmostEqual(markerSymbol.size(context2), 45, 3)
+
+    def testGeometryGeneratorSize(self):
+        # test marker symbol size propagation to geometry generated sub marker symbols
+        geomGeneratorSymbolLayer = QgsGeometryGeneratorSymbolLayer.create({'geometryModifier': '$geometry'})
+        geomGeneratorSymbolLayer.setSymbolType(QgsSymbol.Marker)
+        geomGeneratorSymbolLayer.subSymbol().setSize(2.5)
+
+        markerSymbol = QgsMarkerSymbol()
+        markerSymbol.deleteSymbolLayer(0)
+        markerSymbol.appendSymbolLayer(geomGeneratorSymbolLayer)
+        self.assertEqual(markerSymbol.size(), 2.5)
+
+        markerSymbol.setSize(10.5)
+        self.assertEqual(markerSymbol.size(), 10.5)
+
+    def testGeometryGeneratorWidth(self):
+        # test line symbol width propagation to geometry generated sub line symbols
+        geomGeneratorSymbolLayer = QgsGeometryGeneratorSymbolLayer.create({'geometryModifier': '$geometry'})
+        geomGeneratorSymbolLayer.setSymbolType(QgsSymbol.Line)
+        geomGeneratorSymbolLayer.subSymbol().setWidth(2.5)
+
+        lineSymbol = QgsLineSymbol()
+        lineSymbol.deleteSymbolLayer(0)
+        lineSymbol.appendSymbolLayer(geomGeneratorSymbolLayer)
+        self.assertEqual(lineSymbol.width(), 2.5)
+
+        lineSymbol.setWidth(10.5)
+        self.assertEqual(lineSymbol.width(), 10.5)
 
     def testAngle(self):
         # test angle and setAngle


### PR DESCRIPTION
## Description

This PR insures that calling a marker symbol's size() / setSize() or a line symbol's width() / setWidth will propagate to geometry generator symbol layer having sub symbols of same type. 

E.g., take this simple one-layer geometry symbol:
![image](https://user-images.githubusercontent.com/1728657/167541036-2e534222-80dc-4958-893f-4bc733468c8a.png)

Notice how the UI wrongly has a width of 0.0. That's now fixed.
