### PR TITLE
Add transparency support for 3D Phong material

### DIFF
--- a/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -68,6 +68,13 @@ Returns specular color component
 Returns shininess of the surface
 %End
 
+    float opacity() const;
+%Docstring
+Returns the opacity of the surface
+
+.. versionadded:: 3.26
+%End
+
     virtual QMap<QString, QString> toExportParameters() const;
 
 
@@ -87,6 +94,15 @@ Sets specular color component
 %Docstring
 Sets shininess of the surface
 %End
+
+    void setOpacity( float opacity );
+%Docstring
+Sets shininess of the surface
+
+.. versionadded:: 3.26
+%End
+
+
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
 

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -18,9 +18,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsapplication.h"
 #include "qgsimagecache.h"
-#include <Qt3DExtras/QDiffuseMapMaterial>
-#include <Qt3DExtras/QPhongMaterial>
-#include <Qt3DExtras/QPhongAlphaMaterial>
+#include <Qt3DExtras/QDiffuseSpecularMaterial>
 #include <Qt3DRender/QAttribute>
 #include <Qt3DRender/QBuffer>
 #include <Qt3DRender/QGeometry>
@@ -101,29 +99,16 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::toMaterial( QgsMaterialSettings
       if ( dataDefinedProperties().hasActiveProperties() )
         return dataDefinedMaterial();
 
+      int opacity = mOpacity * 255;
+      Qt3DExtras::QDiffuseSpecularMaterial *material  = new Qt3DExtras::QDiffuseSpecularMaterial;
+      material->setDiffuse( QColor( mDiffuse.red(), mDiffuse.green(), mDiffuse.blue(), opacity ) );
+      material->setAmbient( QColor( mAmbient.red(), mAmbient.green(), mAmbient.blue(), opacity ) );
+      material->setSpecular( QColor( mSpecular.red(), mSpecular.green(), mSpecular.blue(), opacity ) );
+      material->setShininess( mShininess );
       if ( mOpacity != 1 )
       {
-        Qt3DExtras::QPhongAlphaMaterial *material  = new Qt3DExtras::QPhongAlphaMaterial;
-        material->setDiffuse( mDiffuse );
-        material->setAmbient( mAmbient );
-        material->setSpecular( mSpecular );
-        material->setShininess( mShininess );
-        material->setAlpha( mOpacity );
-
-        if ( context.isSelected() )
-        {
-          // update the material with selection colors
-          material->setDiffuse( context.selectionColor() );
-          material->setAmbient( context.selectionColor().darker() );
-        }
-        return material;
+        material->setAlphaBlendingEnabled( true );
       }
-
-      Qt3DExtras::QPhongMaterial *material  = new Qt3DExtras::QPhongMaterial;
-      material->setDiffuse( mDiffuse );
-      material->setAmbient( mAmbient );
-      material->setSpecular( mSpecular );
-      material->setShininess( mShininess );
 
       if ( context.isSelected() )
       {

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -73,6 +73,12 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     //! Returns shininess of the surface
     float shininess() const { return mShininess; }
 
+    /**
+     * Returns the opacity of the surface
+     * \since QGIS 3.26
+     */
+    float opacity() const { return mOpacity; }
+
     QMap<QString, QString> toExportParameters() const override;
 
     //! Sets ambient color component
@@ -83,6 +89,14 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     void setSpecular( const QColor &specular ) { mSpecular = specular; }
     //! Sets shininess of the surface
     void setShininess( float shininess ) { mShininess = shininess; }
+
+    /**
+     * Sets shininess of the surface
+     * \since QGIS 3.26
+     */
+    void setOpacity( float opacity ) { mOpacity = opacity; }
+
+
 
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
@@ -110,6 +124,7 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     QColor mDiffuse{ QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) };
     QColor mSpecular{ QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) };
     float mShininess = 0.0f;
+    float mOpacity = 1.0f;
 
     //! Constructs a material from shader files
     Qt3DRender::QMaterial *dataDefinedMaterial() const;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -26,6 +26,7 @@
 #include <Qt3DExtras/QForwardRenderer>
 #include <Qt3DExtras/QPhongMaterial>
 #include <Qt3DExtras/QPhongAlphaMaterial>
+#include <Qt3DExtras/QDiffuseSpecularMaterial>
 #include <Qt3DExtras/QSphereMesh>
 #include <Qt3DLogic/QFrameAction>
 #include <Qt3DRender/QEffect>
@@ -913,14 +914,17 @@ void Qgs3DMapScene::finalizeNewEntity( Qt3DCore::QEntity *newEntity )
     bm->setViewportSize( mCameraController->viewport().size() );
   }
 
+
   // Finalize adding the 3D transparent objects by adding the layer components to the entities
-  for ( Qt3DExtras::QPhongAlphaMaterial *ph : newEntity->findChildren<Qt3DExtras::QPhongAlphaMaterial *>() )
+  QgsShadowRenderingFrameGraph *frameGraph = mEngine->frameGraph();
+  Qt3DRender::QLayer *layer = frameGraph->transparentObjectLayer();
+  for ( Qt3DExtras::QDiffuseSpecularMaterial *ph : newEntity->findChildren<Qt3DExtras::QDiffuseSpecularMaterial *>() )
   {
+    if ( ph->diffuse().value<QColor>().alphaF() == 1.0f )
+      continue;
     Qt3DCore::QEntity *entity = qobject_cast<Qt3DCore::QEntity *>( ph->parent() );
     if ( !entity )
       continue;
-    QgsShadowRenderingFrameGraph *frameGraph = mEngine->frameGraph();
-    Qt3DRender::QLayer *layer = frameGraph->transparentObjectLayer();
     if ( entity->components().contains( layer ) )
       continue;
     entity->addComponent( layer );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -25,6 +25,7 @@
 #include <Qt3DRender/QSceneLoader>
 #include <Qt3DExtras/QForwardRenderer>
 #include <Qt3DExtras/QPhongMaterial>
+#include <Qt3DExtras/QPhongAlphaMaterial>
 #include <Qt3DExtras/QSphereMesh>
 #include <Qt3DLogic/QFrameAction>
 #include <Qt3DRender/QEffect>
@@ -910,6 +911,19 @@ void Qgs3DMapScene::finalizeNewEntity( Qt3DCore::QEntity *newEntity )
     } );
 
     bm->setViewportSize( mCameraController->viewport().size() );
+  }
+
+  // Finalize adding the 3D transparent objects by adding the layer components to the entities
+  for ( Qt3DExtras::QPhongAlphaMaterial *ph : newEntity->findChildren<Qt3DExtras::QPhongAlphaMaterial *>() )
+  {
+    Qt3DCore::QEntity *entity = qobject_cast<Qt3DCore::QEntity *>( ph->parent() );
+    if ( !entity )
+      continue;
+    QgsShadowRenderingFrameGraph *frameGraph = mEngine->frameGraph();
+    Qt3DRender::QLayer *layer = frameGraph->transparentObjectLayer();
+    if ( entity->components().contains( layer ) )
+      continue;
+    entity->addComponent( layer );
   }
 }
 

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -152,6 +152,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   }
 
   return mMainCameraSelector;
+  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
+  // cppcheck-suppress memleak
 }
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructShadowRenderPass()

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -28,6 +28,8 @@
 #include <Qt3DRender/QGraphicsApiFilter>
 #include <Qt3DRender/QBlendEquation>
 #include <Qt3DRender/QSortPolicy>
+#include <Qt3DRender/QNoDepthMask>
+#include <Qt3DRender/QBlendEquationArguments>
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPreviewPass()
 {
@@ -122,9 +124,6 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   Qt3DRender::QSortPolicy *sortPolicy = new Qt3DRender::QSortPolicy( transparentObjectsLayerFilter );
   QVector<Qt3DRender::QSortPolicy::SortType> sortTypes;
   sortTypes.push_back( Qt3DRender::QSortPolicy::BackToFront );
-  sortTypes.push_back( Qt3DRender::QSortPolicy::Material );
-  sortTypes.push_back( Qt3DRender::QSortPolicy::StateChangeCost );
-  sortTypes.push_back( Qt3DRender::QSortPolicy::FrontToBack );
   sortPolicy->setSortTypes( sortTypes );
 
   Qt3DRender::QRenderStateSet *transparentObjectsRenderStateSet = new Qt3DRender::QRenderStateSet( sortPolicy );
@@ -133,13 +132,23 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
     depthTest->setDepthFunction( Qt3DRender::QDepthTest::Less );
     transparentObjectsRenderStateSet->addRenderState( depthTest );
 
+    Qt3DRender::QNoDepthMask *noDepthMask = new Qt3DRender::QNoDepthMask;
+    transparentObjectsRenderStateSet->addRenderState( noDepthMask );
+
     Qt3DRender::QCullFace *cullFace = new Qt3DRender::QCullFace;
     cullFace->setMode( Qt3DRender::QCullFace::CullingMode::NoCulling );
     transparentObjectsRenderStateSet->addRenderState( cullFace );
 
     Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation;
-    blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Subtract );
+    blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
     transparentObjectsRenderStateSet->addRenderState( blendEquation );
+
+    Qt3DRender::QBlendEquationArguments *blenEquationArgs = new Qt3DRender::QBlendEquationArguments;
+    blenEquationArgs->setSourceRgb( Qt3DRender::QBlendEquationArguments::Blending::One );
+    blenEquationArgs->setDestinationRgb( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
+    blenEquationArgs->setSourceAlpha( Qt3DRender::QBlendEquationArguments::Blending::One );
+    blenEquationArgs->setDestinationAlpha( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
+    transparentObjectsRenderStateSet->addRenderState( blenEquationArgs );
   }
 
   return mMainCameraSelector;

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -49,9 +49,6 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPrev
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRenderPass()
 {
-  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
-  // cppcheck-suppress memleak
-
   // The branch structure:
   // mMainCameraSelector
   // mForwardRenderLayerFilter
@@ -154,6 +151,8 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
     transparentObjectsRenderStateSet->addRenderState( blenEquationArgs );
   }
 
+  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
+  // cppcheck-suppress memleak
   return mMainCameraSelector;
 }
 

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -49,6 +49,9 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructTexturesPrev
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRenderPass()
 {
+  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
+  // cppcheck-suppress memleak
+
   // The branch structure:
   // mMainCameraSelector
   // mForwardRenderLayerFilter
@@ -152,8 +155,6 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   }
 
   return mMainCameraSelector;
-  // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
-  // cppcheck-suppress memleak
 }
 
 Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructShadowRenderPass()

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -78,6 +78,12 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     //! Returns a layer object used to indicate that an entity will be rendered during the forward rendering pass
     Qt3DRender::QLayer *forwardRenderLayer() { return mForwardRenderLayer; }
 
+    /**
+     * Returns a layer object used to indicate that the object is transparent
+     * \since QGIS 3.26
+     */
+    Qt3DRender::QLayer *transparentObjectLayer() { return mTransparentObjectsPassLayer; }
+
     //! Returns the main camera
     Qt3DRender::QCamera *mainCamera() { return mMainCamera; }
     //! Returns the light camera
@@ -220,6 +226,7 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QLayer *mForwardRenderLayer = nullptr;
     Qt3DRender::QLayer *mCastShadowsLayer = nullptr;
     Qt3DRender::QLayer *mDepthRenderPassLayer = nullptr;
+    Qt3DRender::QLayer *mTransparentObjectsPassLayer = nullptr;
 
     QgsPostprocessingEntity *mPostprocessingEntity = nullptr;
 

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -33,11 +33,7 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent )
   connect( mAmbientDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
   connect( mDiffuseDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
   connect( mSpecularDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
-  connect( mOpacitySlider, &QSlider::valueChanged, this, &QgsPhongMaterialWidget::changed );
-  connect( mOpacitySlider, &QSlider::valueChanged, this, [&]( int value )
-  {
-    mOpacityPercentageLabel->setText( QStringLiteral( "%1%" ).arg( value ) );
-  } );
+  connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsPhongMaterialWidget::changed );
 }
 
 QgsMaterialSettingsWidget *QgsPhongMaterialWidget::create()
@@ -105,7 +101,7 @@ void QgsPhongMaterialWidget::setSettings( const QgsAbstractMaterialSettings *set
   btnAmbient->setColor( phongMaterial->ambient() );
   btnSpecular->setColor( phongMaterial->specular() );
   spinShininess->setValue( phongMaterial->shininess() );
-  mOpacitySlider->setValue( phongMaterial->opacity() * 100.0 );
+  mOpacityWidget->setOpacity( phongMaterial->opacity() );
 
   mPropertyCollection = settings->dataDefinedProperties();
 
@@ -121,7 +117,7 @@ QgsAbstractMaterialSettings *QgsPhongMaterialWidget::settings()
   m->setAmbient( btnAmbient->color() );
   m->setSpecular( btnSpecular->color() );
   m->setShininess( spinShininess->value() );
-  m->setOpacity( mOpacitySlider->value() / 100.0 );
+  m->setOpacity( mOpacityWidget->opacity() );
 
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Diffuse, mDiffuseDataDefinedButton->toProperty() );
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Ambient, mAmbientDataDefinedButton->toProperty() );

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -33,6 +33,11 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent )
   connect( mAmbientDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
   connect( mDiffuseDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
   connect( mSpecularDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsPhongMaterialWidget::changed );
+  connect( mOpacitySlider, &QSlider::valueChanged, this, &QgsPhongMaterialWidget::changed );
+  connect( mOpacitySlider, &QSlider::valueChanged, this, [&]( int value )
+  {
+    mOpacityPercentageLabel->setText( QStringLiteral( "%1%" ).arg( value ) );
+  } );
 }
 
 QgsMaterialSettingsWidget *QgsPhongMaterialWidget::create()
@@ -100,6 +105,7 @@ void QgsPhongMaterialWidget::setSettings( const QgsAbstractMaterialSettings *set
   btnAmbient->setColor( phongMaterial->ambient() );
   btnSpecular->setColor( phongMaterial->specular() );
   spinShininess->setValue( phongMaterial->shininess() );
+  mOpacitySlider->setValue( phongMaterial->opacity() * 100.0 );
 
   mPropertyCollection = settings->dataDefinedProperties();
 
@@ -115,6 +121,7 @@ QgsAbstractMaterialSettings *QgsPhongMaterialWidget::settings()
   m->setAmbient( btnAmbient->color() );
   m->setSpecular( btnSpecular->color() );
   m->setShininess( spinShininess->value() );
+  m->setOpacity( mOpacitySlider->value() / 100.0 );
 
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Diffuse, mDiffuseDataDefinedButton->toProperty() );
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Ambient, mAmbientDataDefinedButton->toProperty() );

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -63,13 +63,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinShininess">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="2">
     <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
      <property name="text">
@@ -130,19 +123,6 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QSlider" name="mOpacitySlider">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="lblOpacity">
      <property name="text">
@@ -150,10 +130,13 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="mOpacityPercentageLabel">
-     <property name="text">
-      <string>100%</string>
+   <item row="4" column="1" colspan="2">
+    <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true"/>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QgsDoubleSpinBox" name="spinShininess">
+     <property name="maximum">
+      <double>1000.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -174,6 +157,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -14,13 +14,20 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblShininess">
+   <item row="1" column="2">
+    <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lblDiffuse">
      <property name="toolTip">
-      <string>How shiny smooth surfaces are.</string>
+      <string>Color of light reflected from rough surfaces.</string>
      </property>
      <property name="text">
-      <string>Shininess</string>
+      <string>Diffuse</string>
      </property>
     </widget>
    </item>
@@ -56,6 +63,37 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="1">
+    <widget class="QgsDoubleSpinBox" name="spinShininess">
+     <property name="maximum">
+      <double>1000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblShininess">
+     <property name="toolTip">
+      <string>How shiny smooth surfaces are.</string>
+     </property>
+     <property name="text">
+      <string>Shininess</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="lblSpecular">
      <property name="toolTip">
@@ -63,23 +101,6 @@
      </property>
      <property name="text">
       <string>Specular</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblDiffuse">
-     <property name="toolTip">
-      <string>Color of light reflected from rough surfaces.</string>
-     </property>
-     <property name="text">
-      <string>Diffuse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinShininess">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -109,24 +130,30 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
-     <property name="text">
-      <string>...</string>
+   <item row="4" column="1">
+    <widget class="QSlider" name="mOpacitySlider">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
+   <item row="4" column="0">
+    <widget class="QLabel" name="lblOpacity">
      <property name="text">
-      <string>...</string>
+      <string>Opacity</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+   <item row="4" column="2">
+    <widget class="QLabel" name="mOpacityPercentageLabel">
      <property name="text">
-      <string>...</string>
+      <string>100%</string>
      </property>
     </widget>
    </item>

--- a/src/ui/3d/phongtexturedmaterialwidgetbase.ui
+++ b/src/ui/3d/phongtexturedmaterialwidgetbase.ui
@@ -15,18 +15,21 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="5" column="1">
-    <widget class="QgsDoubleSpinBox" name="textureRotationSpinBox">
+    <widget class="QgsDoubleSpinBox" name="textureScaleSpinBox">
      <property name="suffix">
-      <string> °</string>
+      <string> %</string>
      </property>
      <property name="minimum">
-      <double>-360.000000000000000</double>
+      <double>0.010000000000000</double>
      </property>
      <property name="maximum">
-      <double>360.000000000000000</double>
+      <double>100000.000000000000000</double>
      </property>
      <property name="singleStep">
-      <double>0.500000000000000</double>
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>100.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -34,16 +37,6 @@
     <widget class="QgsDoubleSpinBox" name="spinShininess">
      <property name="maximum">
       <double>1000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lblSpecular">
-     <property name="toolTip">
-      <string>Color of light reflecting from smooth surfaces.</string>
-     </property>
-     <property name="text">
-      <string>Specular</string>
      </property>
     </widget>
    </item>
@@ -63,29 +56,23 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblTextureScale">
+   <item row="4" column="1">
+    <widget class="QgsImageSourceLineEdit" name="textureFile" native="true"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lblSpecular">
+     <property name="toolTip">
+      <string>Color of light reflecting from smooth surfaces.</string>
+     </property>
      <property name="text">
-      <string>Texture scale</string>
+      <string>Specular</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QgsDoubleSpinBox" name="textureScaleSpinBox">
-     <property name="suffix">
-      <string> %</string>
-     </property>
-     <property name="minimum">
-      <double>0.010000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>100.000000000000000</double>
+   <item row="6" column="0">
+    <widget class="QLabel" name="lblTextureRotation">
+     <property name="text">
+      <string>Texture rotation</string>
      </property>
     </widget>
    </item>
@@ -96,6 +83,23 @@
      </property>
      <property name="text">
       <string>Ambient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="lblTextureScale">
+     <property name="text">
+      <string>Texture scale</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="lblShininess">
+     <property name="toolTip">
+      <string>How shiny smooth surfaces are.</string>
+     </property>
+     <property name="text">
+      <string>Shininess</string>
      </property>
     </widget>
    </item>
@@ -115,30 +119,46 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lblTextureRotation">
+   <item row="4" column="0">
+    <widget class="QLabel" name="lblTextureScale_2">
      <property name="text">
-      <string>Texture rotation</string>
+      <string>Diffuse texture</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblShininess">
-     <property name="toolTip">
-      <string>How shiny smooth surfaces are.</string>
+   <item row="6" column="1">
+    <widget class="QgsDoubleSpinBox" name="textureRotationSpinBox">
+     <property name="suffix">
+      <string> °</string>
      </property>
+     <property name="minimum">
+      <double>-360.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>360.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.500000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblOpacity">
      <property name="text">
-      <string>Shininess</string>
+      <string>Opacity</string>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QgsImageSourceLineEdit" name="textureFile" native="true"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblTextureScale_2">
-     <property name="text">
-      <string>Diffuse texture</string>
+    <widget class="QSlider" name="mOpacitySlider">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description
This PR adds support for rendering semi transparent object in 3D:
![Screenshot from 2022-05-12 15-15-00](https://user-images.githubusercontent.com/29183781/168104464-2f1f4c1a-ba6f-4886-956d-96aaf15135c3.png)
The UI adds an opacity widget in the phong material widget, which defaults to 100% (fully opaque).
![Screenshot from 2022-05-12 15-54-58](https://user-images.githubusercontent.com/29183781/168104873-c93931f7-55d9-4ddf-acd7-c1b5429db8bc.png)
## Technical details:
The forward rendering pass is split into 2 parts:
![transparency frame graph](https://user-images.githubusercontent.com/29183781/167630814-5658ac34-ece9-4b83-a75e-de7fc5b0727c.png)
The left side of the branch will clear the screen and render all the opaque objects first, and the left part will take all the transparent objects, sort them using sort policy and render them properly.
The sort policy is necessary to make sure things are ordered and painted in the correct order otherwise some faces which are supposed to be in the back will appear in the front.
### The transparency state sets:
![transparency-state-sets](https://user-images.githubusercontent.com/29183781/168103732-abcfcb57-64f7-4aa9-b0d2-69c8017a2508.png)

Funded by Swedish QGIS user group.
