### PR TITLE
use a QExplicitlySharedDataPointer for WFS shared data on the provider

### DIFF
--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -185,7 +185,7 @@ QSet<QString> QgsWFSDataSourceURI::unknownParamKeys() const
   return l_unknownParamKeys;
 }
 
-const QString QgsWFSDataSourceURI::uri() const
+QString QgsWFSDataSourceURI::uri( bool expandAuthConfig ) const
 {
   QgsDataSourceUri theURI( mURI );
   // Add authcfg param back into the uri (must be non-empty value)
@@ -205,8 +205,7 @@ const QString QgsWFSDataSourceURI::uri() const
       theURI.setPassword( mAuth.mPassword );
     }
   }
-  // NOTE: do not expand authcfg here; it is handled during network access
-  return theURI.uri( false );
+  return theURI.uri( expandAuthConfig );
 }
 
 

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -42,8 +42,8 @@ class QgsWFSDataSourceURI
 
     explicit QgsWFSDataSourceURI( const QString &uri );
 
-    //! Returns the URI, avoiding expansion of authentication configuration, which is handled during network access
-    const QString uri() const;
+    //! Returns the URI, optionally with the authentication configuration expanded
+    QString uri( bool expandAuthConfig = false ) const;
 
     //! Returns base URL (with SERVICE=WFS parameter if bIncludeServiceWFS=true)
     QUrl baseURL( bool bIncludeServiceWFS = true ) const;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -776,6 +776,9 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   if ( theSQL == mSubsetString )
     return true;
 
+  // Subset string is in shared data
+  mShared.detach();
+
   // Invalid and cancel current download before altering fields, etc...
   // (crashes might happen if not done at the beginning)
   mShared->invalidateCache();

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -776,8 +776,8 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   if ( theSQL == mSubsetString )
     return true;
 
-  // Subset string is in shared data
-  mShared.detach();
+  // We must not change the subset string of the shared data used in another iterator/data provider ...
+  mShared.reset( mShared->clone() );
 
   // Invalid and cancel current download before altering fields, etc...
   // (crashes might happen if not done at the beginning)

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -137,7 +137,7 @@ class QgsWFSProvider final: public QgsVectorDataProvider
 
   private:
     //! Mutable data shared between provider and feature sources
-    QExplicitlySharedDataPointer<QgsWFSSharedData> mShared;
+    std::shared_ptr<QgsWFSSharedData> mShared;
 
     /**
      * Invalidates cache of shared object

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -137,7 +137,7 @@ class QgsWFSProvider final: public QgsVectorDataProvider
 
   private:
     //! Mutable data shared between provider and feature sources
-    std::shared_ptr<QgsWFSSharedData> mShared;
+    QExplicitlySharedDataPointer<QgsWFSSharedData> mShared;
 
     /**
      * Invalidates cache of shared object

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -47,6 +47,25 @@ bool QgsWFSSharedData::isRestrictedToRequestBBOX() const
   return mURI.isRestrictedToRequestBBOX();
 }
 
+QgsWFSSharedData *QgsWFSSharedData::clone() const
+{
+  QgsWFSSharedData *copy = new QgsWFSSharedData( mURI.uri( true ) );
+  copy->mWFSVersion = mWFSVersion;
+  copy->mGeometryAttribute = mGeometryAttribute;
+  copy->mLayerPropertiesList = mLayerPropertiesList;
+  copy->mMapFieldNameToSrcLayerNameFieldName = mMapFieldNameToSrcLayerNameFieldName;
+  copy->mPageSize = mPageSize;
+  copy->mCaps = mCaps;
+  copy->mHasWarnedAboutMissingFeatureId = mHasWarnedAboutMissingFeatureId;
+  copy->mGetFeatureEPSGDotHonoursEPSGOrder = mGetFeatureEPSGDotHonoursEPSGOrder;
+  copy->mServerPrefersCoordinatesForTransactions_1_1 = mServerPrefersCoordinatesForTransactions_1_1;
+  copy->mWKBType = mWKBType;
+  copy->mWFSFilter = mWFSFilter;
+  copy->mSortBy = mSortBy;
+
+  return copy;
+}
+
 void QgsWFSSharedData::invalidateCacheBaseUnderLock()
 {
 }

--- a/src/providers/wfs/qgswfsshareddata.h
+++ b/src/providers/wfs/qgswfsshareddata.h
@@ -51,6 +51,9 @@ class QgsWFSSharedData : public QObject, public QgsBackgroundCachedSharedData
     //! Set a new filter and return the previous one. Only used to temporarily disable filtering when trying to get layer geometry type.
     QString setWFSFilter( const QString &newFilter ) { QString oldFilter = mWFSFilter; mWFSFilter = newFilter; return oldFilter; }
 
+    //! Creates a deep copy of this shared data
+    QgsWFSSharedData *clone() const;
+
   signals:
 
     //! Raise error


### PR DESCRIPTION
hence we can detach when setting the subset string since it's stored in the shared data

fixes #48465

