### PR TITLE
[Oracle] Fix edit connection forced port value

### DIFF
--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -58,11 +58,17 @@ QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &
     txtDatabase->setText( settings.value( key + QStringLiteral( "/database" ) ).toString() );
     txtHost->setText( settings.value( key + QStringLiteral( "/host" ) ).toString() );
     QString port = settings.value( key + QStringLiteral( "/port" ) ).toString();
-    if ( port.length() == 0 )
+
+    // User can set database without host and port, meaning he is using a service (tnsnames.ora)
+    // if he sets host, port has to be set also (and vice versa)
+    // https://github.com/qgis/QGIS/issues/38979
+    if ( port.length() == 0
+         && ( !txtHost->text().isEmpty() || txtDatabase->text().isEmpty() ) )
     {
       port = QStringLiteral( "1521" );
     }
     txtPort->setText( port );
+
     txtOptions->setText( settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
     txtWorkspace->setText( settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
     txtSchema->setText( settings.value( key + QStringLiteral( "/schema" ) ).toString() );


### PR DESCRIPTION
## Description

User can set database without host and port, meaning he is using a service (tnsnames.ora)

The QGIS User Interface forced the port to not be empty even if the database is set and the host is empty.

It is an addition to https://github.com/qgis/QGIS/pull/39131 _[Oracle] Fix new connection greyed ok button_ to fix
https://github.com/qgis/QGIS/issues/38979 _Oracle - add/edit connection dialog forces hostname input - conflicts with Oracle Network Connection_

Funded by Ifremer