### PR TITLE
Fix estimated featureCount on Oracle views

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2481,33 +2481,49 @@ long long QgsOracleProvider::featureCount() const
   if ( mFeaturesCounted >= 0 || !conn )
     return mFeaturesCounted;
 
-  // get total number of features
+  QSqlQuery qry( *conn );
   QString sql;
 
-  // use estimated metadata even when there is a where clause,
-  // although we get an incorrect feature count for the subset
-  // - but make huge dataset usable.
-  QVariantList args;
-  if ( !mIsQuery && mUseEstimatedMetadata )
-  {
-    sql = QString( "SELECT num_rows FROM all_tables WHERE owner=? AND table_name=?" );
-    args << mOwnerName << mTableName;
-  }
-  else
+  // If we do not use estimated metadata or if it is a query, we perform a true count
+  if ( !mUseEstimatedMetadata || mIsQuery )
   {
     sql = QString( "SELECT count(*) FROM %1" ).arg( mQuery );
-
     if ( !mSqlWhereClause.isEmpty() )
-    {
       sql += " WHERE " + mSqlWhereClause;
+    if ( LoggedExecStatic( qry, sql, QVariantList(), mUri.uri() ) && qry.next() )
+      mFeaturesCounted = qry.value( 0 ).toLongLong();
+  }
+  // Else, to estimate feature count, if it is a view or there is a where clause we use the explain plan
+  else if ( !mSqlWhereClause.isEmpty() || relkind() == QgsOracleProvider::View )
+  {
+    sql = QString( "explain plan for select 1 from %1" ).arg( mTableName );
+    if ( !mSqlWhereClause.isEmpty() )
+      sql += " WHERE " + mSqlWhereClause;
+    if ( LoggedExecStatic( qry,
+                           sql,
+                           QVariantList(),
+                           mUri.uri() ) &&
+         LoggedExecStatic( qry,
+                           QStringLiteral( "SELECT dbms_xplan.display_plan(format=>'basic,rows', type=>'xml') FROM dual" ),
+                           QVariantList(),
+                           mUri.uri() ) &&
+         qry.next() )
+    {
+      QDomDocument plan;
+      plan.setContent( qry.value( 0 ).toString() );
+      const QDomNodeList nList = plan.elementsByTagName( "card" );
+      if ( nList.length() == 2 )
+        mFeaturesCounted = nList.item( 0 ).toElement().text().toLongLong();
+      else
+        QgsLogger::warning( QStringLiteral( "Cannot parse XML explain result to estimate feature count : %1" ).arg( plan.toString() ) );
     }
   }
-
-  QSqlQuery qry( *conn );
-
-  if ( LoggedExecStatic( qry, sql, QVariantList( ), mUri.uri() ) && qry.next() )
+  // Else, to estimate feature count, we use the stats
+  else
   {
-    mFeaturesCounted = qry.value( 0 ).toLongLong();
+    sql = QString( "SELECT num_rows FROM all_tables WHERE owner=? AND table_name=?" );
+    if ( LoggedExecStatic( qry, sql, QVariantList() << mOwnerName << mTableName, mUri.uri() ) && qry.next() )
+      mFeaturesCounted = qry.value( 0 ).toLongLong();
   }
 
   qry.finish();
@@ -2515,6 +2531,39 @@ long long QgsOracleProvider::featureCount() const
   QgsDebugMsgLevel( "number of features: " + QString::number( mFeaturesCounted ), 2 );
 
   return mFeaturesCounted;
+}
+
+QgsOracleProvider::Relkind QgsOracleProvider::relkind() const
+{
+  if ( mKind != Relkind::NotSet )
+    return mKind;
+
+  QgsOracleConn *conn = connectionRO();
+  if ( mIsQuery || !conn )
+  {
+    mKind = Relkind::Unknown;
+  }
+  else
+  {
+    QSqlQuery qry( *conn );
+    QString type;
+    const QString sql = QStringLiteral( "SELECT object_type FROM all_objects WHERE object_name=? and owner=?" );
+    if ( LoggedExecStatic( qry, sql, QVariantList() << mTableName << mOwnerName, mUri.uri() ) && qry.next() )
+      type = qry.value( 0 ).toString();
+
+    mKind = Relkind::Unknown;
+
+    if ( type == QLatin1String( "TABLE" ) )
+    {
+      mKind = Relkind::Table;
+    }
+    else if ( type == QLatin1String( "VIEW" ) )
+    {
+      mKind = Relkind::View;
+    }
+  }
+
+  return mKind;
 }
 
 QgsRectangle QgsOracleProvider::extent() const

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -78,6 +78,15 @@ class QgsOracleProvider final: public QgsVectorDataProvider
       const QMap<QString, QVariant> *options = nullptr
     );
 
+    enum Relkind
+    {
+      NotSet,
+      Unknown,
+      Table,
+      View,
+    };
+    Q_ENUM( Relkind )
+
     /**
      * Constructor for the provider. The uri must be in the following format:
      * host=localhost user=gsherman dbname=test password=xxx table=test.alaska (the_geom)
@@ -195,6 +204,12 @@ class QgsOracleProvider final: public QgsVectorDataProvider
     void handlePostCloneOperations( QgsVectorDataProvider *source ) override;
 
   private:
+
+    /**
+     * \returns relation kind
+     */
+    Relkind relkind() const;
+
     QString whereClause( QgsFeatureId featureId, QVariantList &args ) const;
     QString pkParamWhereClause() const;
 
@@ -267,6 +282,11 @@ class QgsOracleProvider final: public QgsVectorDataProvider
      * SQL statement used to limit the features retrieved
      */
     QString mSqlWhereClause;
+
+    /**
+     * Kind of relation
+     */
+    mutable Relkind mKind = Relkind::NotSet;
 
     /**
      * Data type for the primary key

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -692,6 +692,38 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         self.check_geom(multi_surface_z, fid, 'MultiSurfaceZ (CurvePolygonZ(CompoundCurveZ (CircularStringZ (-1 -5 1, 5 -7 2, 17 -6 3), (17 -6 3, -1 -5 1))), CurvePolygonZ (CircularStringZ (1 3 1, 7 3 2, 4 7 3, 3 5 4, 1 3 1)))', check_valid=False)
         fid += 1
 
+    def testFeatureCount(self):
+        self.execSQLCommand('CREATE OR REPLACE VIEW QGIS.VIEW_POLY_DATA AS SELECT * FROM QGIS.POLY_DATA')
+        self.execSQLCommand("BEGIN DBMS_STATS.GATHER_TABLE_STATS('QGIS', 'SOME_DATA'); END;")
+
+        view_layer = QgsVectorLayer(self.dbconn + ' sslmode=disable table="QGIS"."VIEW_POLY_DATA" key=\'pk\'',
+                                    'test', 'oracle')
+        self.assertTrue(view_layer.isValid())
+        self.assertGreater(view_layer.featureCount(), 0)
+        self.assertTrue(view_layer.setSubsetString('"pk" = 5'))
+        self.assertGreaterEqual(view_layer.featureCount(), 0)
+
+        view_layer_estimated = QgsVectorLayer(self.dbconn + ' sslmode=disable estimatedmetadata=true table="QGIS"."VIEW_POLY_DATA" key=\'pk\'',
+                                              'test', 'oracle')
+        self.assertTrue(view_layer_estimated.isValid())
+        self.assertGreater(view_layer_estimated.featureCount(), 0)
+        self.assertTrue(view_layer_estimated.setSubsetString('"pk" = 5'))
+        self.assertGreaterEqual(view_layer_estimated.featureCount(), 0)
+
+        self.assertGreater(self.vl.featureCount(), 0)
+        self.assertTrue(self.vl.setSubsetString('"pk" = 3'))
+        self.assertGreaterEqual(self.vl.featureCount(), 1)
+        self.assertTrue(self.vl.setSubsetString(''))
+
+        vl_estimated = QgsVectorLayer(self.dbconn + ' sslmode=disable estimatedmetadata=true table="QGIS"."SOME_DATA"',
+                                      'test', 'oracle')
+        self.assertTrue(vl_estimated.isValid())
+        self.assertGreater(vl_estimated.featureCount(), 0)
+        self.assertTrue(vl_estimated.setSubsetString('"pk" = 3'))
+        self.assertGreaterEqual(vl_estimated.featureCount(), 1)
+
+        self.execSQLCommand('DROP VIEW QGIS.VIEW_POLY_DATA')
+
     def testNestedInsert(self):
         tg = QgsTransactionGroup()
         tg.addLayer(self.vl)


### PR DESCRIPTION
## Description

With Oracle provider, the esimated feature count is not working for views.

This PR implements a way to detect if the estimation must be performed on a view or a table and adapts the sql requests accordingly.

It also handles the presence of a filter (where clause of layer subset string).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
