### PR TITLE
add a shortDescription to QgsZonalStatisticsAlgorithm to provide a tooltip hint text

### DIFF
--- a/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
@@ -61,6 +61,11 @@ QString QgsZonalStatisticsAlgorithm::groupId() const
   return QStringLiteral( "rasteranalysis" );
 }
 
+QString QgsZonalStatisticsAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Calculates statistics for a raster layer's values for each feature of an overlapping polygon vector layer." );
+}
+
 QString QgsZonalStatisticsAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm calculates statistics of a raster layer for each feature "


### PR DESCRIPTION
## Description

The "Zonal statistics" algorithm from the Processing Toolbox is missing a tooltip hint text, this is helpful for users to get a short summary of the algorithm on mouseover before clicking in for the full description.
