### PR TITLE
Fix crash when opening project properties

### DIFF
--- a/src/app/project/qgsprojectelevationsettingswidget.cpp
+++ b/src/app/project/qgsprojectelevationsettingswidget.cpp
@@ -150,20 +150,11 @@ bool QgsProjectElevationSettingsWidget::isValid()
 //
 
 QgsProjectElevationSettingsWidgetFactory::QgsProjectElevationSettingsWidgetFactory( QObject *parent )
-  : QgsOptionsWidgetFactory()
+  : QgsOptionsWidgetFactory( tr( "Terrain" ), QgsApplication::getThemeIcon( QStringLiteral( "mLayoutItem3DMap.svg" ) ) )
 {
   setParent( parent );
 }
 
-QString QgsProjectElevationSettingsWidgetFactory::title() const
-{
-  return tr( "Terrain" );
-}
-
-QIcon QgsProjectElevationSettingsWidgetFactory::icon() const
-{
-  return QgsApplication::getThemeIcon( QStringLiteral( "mLayoutItem3DMap.svg" ) );
-}
 
 QgsOptionsPageWidget *QgsProjectElevationSettingsWidgetFactory::createWidget( QWidget *parent ) const
 {

--- a/src/app/project/qgsprojectelevationsettingswidget.h
+++ b/src/app/project/qgsprojectelevationsettingswidget.h
@@ -46,9 +46,6 @@ class QgsProjectElevationSettingsWidgetFactory : public QgsOptionsWidgetFactory
   public:
     explicit QgsProjectElevationSettingsWidgetFactory( QObject *parent = nullptr );
 
-    QString title() const override;
-    QIcon icon() const override;
-
     QgsOptionsPageWidget *createWidget( QWidget *parent = nullptr ) const override;
 };
 


### PR DESCRIPTION
crashed only in debug mode because of checkPageWidgetNameMap
