### PR TITLE
[GDAL provider] Minimal support for GDT_Int64/GDT_UInt64 of GDAL 3.5.0

### DIFF
--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -173,6 +173,14 @@ Qgis::DataType QgsGdalProviderBase::dataTypeFromGdal( const GDALDataType gdalDat
       return Qgis::DataType::CFloat32;
     case GDT_CFloat64:
       return Qgis::DataType::CFloat64;
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
+    case GDT_Int64:
+    case GDT_UInt64:
+      // Lossy conversion
+      // NOTE: remove conversion from/to double in qgsgdalprovider.cpp if using
+      // a native Qgis data type for Int64/UInt64 (look for GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0))
+      return Qgis::DataType::Float64;
+#endif
     case GDT_Unknown:
     case GDT_TypeCount:
       return Qgis::DataType::UnknownDataType;


### PR DESCRIPTION
GDAL 3.5.0 brings GDT_Int64/GDT_UInt64, which triggers compiler warnings
in QGIS due to those new enumeration values not being handled.

We do a minimal handling of them, by exposing them as QGIS Float64
rasters, which is lossy for absolute values larger than 2^53.

A more ambitious fix would be to add proper Int64/UInt64 suppport to
QGIS, but that's more involved.

Not sure if this should be backported