### PR TITLE
[GUI] Vector layer dialog: hide NATIVE_DATA option of GeoJSON driver (fixes #48004)

### DIFF
--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -709,6 +709,12 @@ void QgsOgrSourceSelect::fillOpenOptions()
       continue;
     }
 
+    // QGIS data model doesn't support the OGRFeature native data concept
+    // (typically used for GeoJSON "foreign" members). Hide it to avoid setting
+    // wrong expectations to users (https://github.com/qgis/QGIS/issues/48004)
+    if ( EQUAL( pszOptionName, "NATIVE_DATA" ) )
+      continue;
+
     const char *pszType = CPLGetXMLValue( psItem, "type", nullptr );
     QStringList options;
     if ( pszType && EQUAL( pszType, "string-select" ) )


### PR DESCRIPTION
QGIS data model doesn't support the OGRFeature native data concept
(typically used for GeoJSON "foreign" members). Hide it to avoid setting
wrong expectations to users (https://github.com/qgis/QGIS/issues/48004)
