### PR TITLE
qgsshadowrenderingframegraph: Add a debug overlay

### DIFF
--- a/python/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -642,7 +642,26 @@ Sets whether the camera's view frustum is visualized on the 2D map canvas
 .. versionadded:: 3.26
 %End
 
+    bool isDebugOverlayEnabled() const;
+%Docstring
+Returns whether debug overlay is enabled
 
+.. seealso:: :py:func:`setIsDebugOverlayEnabled`
+
+.. versionadded:: 3.26
+%End
+
+    void setIsDebugOverlayEnabled( bool debugOverlayEnabled );
+%Docstring
+Sets whether debug overlay is enabled
+The debug overlay displays some debugging and profiling information.
+It has been introduced in Qt version 5.15.
+This parameter is transient. It is not saved in the project parameters.
+
+.. seealso:: :py:func:`isDebugOverlayEnabled`
+
+.. versionadded:: 3.26
+%End
 
   signals:
 
@@ -870,6 +889,13 @@ Emitted when the camera's view frustum visualization on the main 2D map canvas i
     void axisSettingsChanged();
 %Docstring
 Emitted when 3d axis rendering settings are changed
+
+.. versionadded:: 3.26
+%End
+
+    void debugOverlayEnabledChanged( bool debugOverlayEnabled );
+%Docstring
+Emitted when the debug overaly is enabled or disabled
 
 .. versionadded:: 3.26
 %End

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -146,6 +146,7 @@ Qgs3DMapScene::Qgs3DMapScene( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine
   connect( &map, &Qgs3DMapSettings::fpsCounterEnabledChanged, this, &Qgs3DMapScene::fpsCounterEnabledChanged );
   connect( &map, &Qgs3DMapSettings::cameraMovementSpeedChanged, this, &Qgs3DMapScene::onCameraMovementSpeedChanged );
   connect( &map, &Qgs3DMapSettings::cameraNavigationModeChanged, this, &Qgs3DMapScene::onCameraNavigationModeChanged );
+  connect( &map, &Qgs3DMapSettings::debugOverlayEnabledChanged, this, &Qgs3DMapScene::onDebugOverlayEnabledChanged );
 
   connect( &map, &Qgs3DMapSettings::axisSettingsChanged, this, &Qgs3DMapScene::on3DAxisSettingsChanged );
 
@@ -1088,6 +1089,12 @@ void Qgs3DMapScene::onDebugDepthMapSettingsChanged()
 {
   QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
   shadowRenderingFrameGraph->setupDepthMapDebugging( mMap.debugDepthMapEnabled(), mMap.debugDepthMapCorner(), mMap.debugDepthMapSize() );
+}
+
+void Qgs3DMapScene::onDebugOverlayEnabledChanged()
+{
+  QgsShadowRenderingFrameGraph *shadowRenderingFrameGraph = mEngine->frameGraph();
+  shadowRenderingFrameGraph->setDebugOverlayEnabled( mMap.isDebugOverlayEnabled() );
 }
 
 void Qgs3DMapScene::onEyeDomeShadingSettingsChanged()

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -206,6 +206,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onDebugDepthMapSettingsChanged();
     void onCameraMovementSpeedChanged();
     void onCameraNavigationModeChanged();
+    void onDebugOverlayEnabledChanged();
 
     void on3DAxisSettingsChanged();
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -92,7 +92,7 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mTerrainRenderingEnabled( other.mTerrainRenderingEnabled )
   , mRendererUsage( other.mRendererUsage )
   , m3dAxisSettings( other.m3dAxisSettings )
-
+  , mIsDebugOverlayEnabled( other.mIsDebugOverlayEnabled )
 {
   for ( QgsAbstract3DRenderer *renderer : std::as_const( other.mRenderers ) )
   {
@@ -915,6 +915,15 @@ void Qgs3DMapSettings::setViewFrustumVisualizationEnabled( bool enabled )
     mVisualizeViewFrustum = enabled;
     emit viewFrustumVisualizationEnabledChanged();
   }
+}
+
+void Qgs3DMapSettings::setIsDebugOverlayEnabled( bool debugOverlayEnabled )
+{
+  if ( debugOverlayEnabled == mIsDebugOverlayEnabled )
+    return;
+
+  mIsDebugOverlayEnabled = debugOverlayEnabled;
+  emit debugOverlayEnabledChanged( mIsDebugOverlayEnabled );
 }
 
 

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -640,6 +640,23 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void set3dAxisSettings( const Qgs3DAxisSettings &axisSettings ) SIP_SKIP;
 
+    /**
+     * Returns whether debug overlay is enabled
+     * \see setIsDebugOverlayEnabled()
+     * \since QGIS 3.26
+     */
+    bool isDebugOverlayEnabled() const { return mIsDebugOverlayEnabled; }
+
+    /**
+     * Sets whether debug overlay is enabled
+     * The debug overlay displays some debugging and profiling information.
+     * It has been introduced in Qt version 5.15.
+     * This parameter is transient. It is not saved in the project parameters.
+     * \see isDebugOverlayEnabled()
+     * \since QGIS 3.26
+     */
+    void setIsDebugOverlayEnabled( bool debugOverlayEnabled );
+
   signals:
 
     /**
@@ -826,6 +843,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void axisSettingsChanged();
 
+    /**
+     * Emitted when the debug overaly is enabled or disabled
+     * \since QGIS 3.26
+     */
+    void debugOverlayEnabledChanged( bool debugOverlayEnabled );
+
   private:
 #ifdef SIP_RUN
     Qgs3DMapSettings &operator=( const Qgs3DMapSettings & );
@@ -894,6 +917,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     Qgis::RendererUsage mRendererUsage;
 
     Qgs3DAxisSettings m3dAxisSettings; //!< 3d axis related configuration
+
+    bool mIsDebugOverlayEnabled = false;
 
 };
 

--- a/src/3d/qgsshadowrenderingframegraph.cpp
+++ b/src/3d/qgsshadowrenderingframegraph.cpp
@@ -57,6 +57,7 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
   // forwaredRenderStateSet    | sortPolicy
   // mFrustumCulling           | transparentObjectsRenderStateSet
   // mForwardClearBuffers      |
+  // mDebugOverlay             |
   mMainCameraSelector = new Qt3DRender::QCameraSelector;
   mMainCameraSelector->setCamera( mMainCamera );
 
@@ -150,6 +151,11 @@ Qt3DRender::QFrameGraphNode *QgsShadowRenderingFrameGraph::constructForwardRende
     blenEquationArgs->setDestinationAlpha( Qt3DRender::QBlendEquationArguments::Blending::OneMinusSource1Alpha );
     transparentObjectsRenderStateSet->addRenderState( blenEquationArgs );
   }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  mDebugOverlay = new Qt3DRender::QDebugOverlay( mForwardClearBuffers );
+  mDebugOverlay->setEnabled( false );
+#endif
 
   // cppcheck wrongly believes transparentObjectsRenderStateSet will leak
   // cppcheck-suppress memleak
@@ -670,4 +676,14 @@ void QgsShadowRenderingFrameGraph::setRenderCaptureEnabled( bool enabled )
     return;
   mRenderCaptureEnabled = enabled;
   mRenderCaptureTargetSelector->setEnabled( mRenderCaptureEnabled );
+}
+
+void QgsShadowRenderingFrameGraph::setDebugOverlayEnabled( bool enabled )
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  mDebugOverlay->setEnabled( enabled );
+#else
+  Q_UNUSED( enabled )
+  qDebug() << "Cannot display debug overlay. Qt version 5.15 or above is needed.";
+#endif
 }

--- a/src/3d/qgsshadowrenderingframegraph.h
+++ b/src/3d/qgsshadowrenderingframegraph.h
@@ -34,6 +34,9 @@
 #include <Qt3DRender/QCullFace>
 #include <Qt3DRender/QPolygonOffset>
 #include <Qt3DRender/QRenderCapture>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+#include <Qt3DRender/QDebugOverlay>
+#endif
 
 #include "qgspointlightsettings.h"
 
@@ -146,6 +149,13 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
      * \since QGIS 3.18
      */
     bool renderCaptureEnabled() const { return mRenderCaptureEnabled; }
+
+    /**
+     * Sets whether debug overlay is enabled
+     * \since QGIS 3.26
+     */
+    void setDebugOverlayEnabled( bool enabled );
+
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
     Qt3DRender::QViewport *mMainViewPort = nullptr;
@@ -163,6 +173,10 @@ class QgsShadowRenderingFrameGraph : public Qt3DCore::QEntity
     // Forward rendering pass texture related objects:
     Qt3DRender::QTexture2D *mForwardColorTexture = nullptr;
     Qt3DRender::QTexture2D *mForwardDepthTexture = nullptr;
+    // QDebugOverlay added in the forward pass
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    Qt3DRender::QDebugOverlay *mDebugOverlay = nullptr;
+#endif
 
     // Shadow rendering pass branch nodes:
     Qt3DRender::QCameraSelector *mLightCameraSelectorShadowPass = nullptr;

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -157,6 +157,11 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   chkShowLightSourceOrigins->setChecked( mMap->showLightSourceOrigins() );
   mFpsCounterCheckBox->setChecked( mMap->isFpsCounterEnabled() );
 
+  mDebugOverlayCheckBox->setChecked( mMap->isDebugOverlayEnabled() );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  mDebugOverlayCheckBox->setVisible( true );
+#endif
+
   groupTerrainShading->setChecked( mMap->isTerrainShadingEnabled() );
   widgetTerrainMaterial->setTechnique( QgsMaterialSettingsRenderingTechnique::TrianglesWithFixedTexture );
   QgsPhongMaterialSettings terrainShadingMaterial = mMap->terrainShadingMaterial();
@@ -370,6 +375,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setShowLightSourceOrigins( chkShowLightSourceOrigins->isChecked() );
   mMap->setIsFpsCounterEnabled( mFpsCounterCheckBox->isChecked() );
   mMap->setTerrainShadingEnabled( groupTerrainShading->isChecked() );
+  mMap->setIsDebugOverlayEnabled( mDebugOverlayCheckBox->isChecked() );
 
   const std::unique_ptr< QgsAbstractMaterialSettings > terrainMaterial( widgetTerrainMaterial->settings() );
   if ( QgsPhongMaterialSettings *phongMaterial = dynamic_cast< QgsPhongMaterialSettings * >( terrainMaterial.get() ) )

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -1025,6 +1025,16 @@
                       </property>
                      </widget>
                     </item>
+                    <item row="12" column="0" colspan="2">
+                     <widget class="QCheckBox" name="mDebugOverlayCheckBox">
+                      <property name="text">
+                       <string>Show debug overlay</string>
+                      </property>
+                      <property name="visible">
+                        <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="3" column="0">
                      <widget class="QLabel" name="label_7">
                       <property name="text">


### PR DESCRIPTION
`QdebugOverlay` is a visual overlay which displays some useful debugging
and profiling information. This allows in particular to quickly see the frame
graph and the scene graph.
It needs at least Qt version 5.15.

For more information, see:
https://www.kdab.com/debugging-profiling-qt-3d-apps/

![image](https://user-images.githubusercontent.com/497207/168554100-408d8b22-d687-4c58-8541-6860b43abb13.png)

