### PR TITLE
Fix WMS referrer not sent

### DIFF
--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -37,9 +37,16 @@ default constructor
 
     QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
-Constructor from :py:class:`QgsSettings` ``settings`` object
+Constructor from :py:class:`QgsSettings` ``settings`` object and root ``key``
 
 :param settings:
+:param key:
+%End
+
+    QgsHttpHeaders( const QString &key );
+%Docstring
+Constructor from default :py:class:`QgsSettings` object and root ``key``
+
 :param key:
 %End
 
@@ -48,6 +55,13 @@ Constructor from :py:class:`QgsSettings` ``settings`` object
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 %Docstring
 Updates a ``request`` by adding all the HTTP headers
+
+:return: ``True`` if the update succeed
+%End
+
+    bool updateDataSourceUri( QgsDataSourceUri &uri ) const;
+%Docstring
+Updates an ``uri`` by adding all the HTTP headers
 
 :return: ``True`` if the update succeed
 %End

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -82,6 +82,13 @@ Loads headers from the ``settings``
 :param key: sub group path
 %End
 
+    QString sanitizeKey( const QString &key ) const;
+%Docstring
+Returns a cleansed ``key``
+
+:param key: a key to be sanitized
+%End
+
     QVariant &operator[]( const QString &key );
 
 

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsHttpHeaders
 {
 %Docstring(signature="appended")
@@ -50,7 +51,24 @@ Constructor from default :py:class:`QgsSettings` object and root ``key``
 :param key:
 %End
 
+    QgsHttpHeaders( const QDomElement &element );
+%Docstring
+Constructor from a QDomElement ``element``
+
+:param element:
+%End
+
     virtual ~QgsHttpHeaders();
+
+    bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
+%Docstring
+Updates the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
+
+:param settings:
+:param key: sub group path
+
+:return: ``True`` if the update succeed
+%End
 
     bool updateNetworkRequest( QNetworkRequest &request ) const;
 %Docstring
@@ -59,19 +77,25 @@ Updates a ``request`` by adding all the HTTP headers
 :return: ``True`` if the update succeed
 %End
 
-    bool updateDataSourceUri( QgsDataSourceUri &uri ) const;
+    bool updateUrlQuery( QUrlQuery &uri ) const;
 %Docstring
 Updates an ``uri`` by adding all the HTTP headers
 
 :return: ``True`` if the update succeed
 %End
 
-    void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
+    bool updateMap( QVariantMap &map ) const;
 %Docstring
-Updates the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
+Updates a ``map`` by adding all the HTTP headers
 
-:param settings:
-:param key: sub group path
+:return: ``True`` if the update succeed
+%End
+
+    bool updateDomElement( QDomElement &el ) const;
+%Docstring
+Updates a ``map`` by adding all the HTTP headers
+
+:return: ``True`` if the update succeed
 %End
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
@@ -80,6 +104,27 @@ Loads headers from the ``settings``
 
 :param settings:
 :param key: sub group path
+%End
+
+    void setFromUrlQuery( const QUrlQuery &uri );
+%Docstring
+Loads headers from the ``uri``
+
+:param uri:
+%End
+
+    void setFromMap( const QVariantMap &map );
+%Docstring
+Loads headers from the ``map``
+
+:param map:
+%End
+
+    void setFromDomElement( const QDomElement &element );
+%Docstring
+Loads headers from the ``element``
+
+:param element:
 %End
 
     QString sanitizeKey( const QString &key ) const;
@@ -96,6 +141,11 @@ Returns a cleansed ``key``
 %Docstring
 
 :return: the list of all http header keys
+%End
+
+    QString toSpacedString() const;
+%Docstring
+Returns key/value pairs as strings separated by space
 %End
 
 

--- a/python/core/auto_generated/network/qgshttpheaders.sip.in
+++ b/python/core/auto_generated/network/qgshttpheaders.sip.in
@@ -62,7 +62,9 @@ Constructor from a QDomElement ``element``
 
     bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 %Docstring
-Updates the ``settings`` by adding all the http headers in the path "key/KEY_PREFIX/"
+Updates the ``settings`` by adding all the http headers in the path "key/PATH_PREFIX/"
+
+KEY_REFERER value will be available at path "key/PATH_PREFIX/KEY_REFERER" and path "key/KEY_REFERER" (for backward compatibility)
 
 :param settings:
 :param key: sub group path
@@ -88,6 +90,8 @@ Updates an ``uri`` by adding all the HTTP headers
 %Docstring
 Updates a ``map`` by adding all the HTTP headers
 
+KEY_REFERER value will be available at key "KEY_PREFIX+KEY_REFERER" and key "KEY_REFERER" (for backward compatibility)
+
 :return: ``True`` if the update succeed
 %End
 
@@ -95,12 +99,16 @@ Updates a ``map`` by adding all the HTTP headers
 %Docstring
 Updates a ``map`` by adding all the HTTP headers
 
+KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
+
 :return: ``True`` if the update succeed
 %End
 
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 %Docstring
 Loads headers from the ``settings``
+
+key KEY_REFERER will be read at path "key/PATH_PREFIX/KEY_REFERER" and path "key/KEY_REFERER" (for backward compatibility)
 
 :param settings:
 :param key: sub group path
@@ -117,12 +125,16 @@ Loads headers from the ``uri``
 %Docstring
 Loads headers from the ``map``
 
+key KEY_REFERER will be read from key "KEY_PREFIX+KEY_REFERER" and key "KEY_REFERER" (for backward compatibility)
+
 :param map:
 %End
 
     void setFromDomElement( const QDomElement &element );
 %Docstring
 Loads headers from the ``element``
+
+key KEY_REFERER will be read from attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
 
 :param element:
 %End

--- a/python/core/auto_generated/qgsdatasourceuri.sip.in
+++ b/python/core/auto_generated/qgsdatasourceuri.sip.in
@@ -356,6 +356,24 @@ Returns parameter keys used in the uri: specialized ones ("table", "schema", etc
 .. versionadded:: 3.26
 %End
 
+
+    QgsHttpHeaders &httpHeaders();
+%Docstring
+Returns http headers
+%End
+
+    QString httpHeader( const QString &key );
+%Docstring
+Returns the http header value according to ``key``
+%End
+
+    void setHttpHeaders( const QgsHttpHeaders &headers );
+%Docstring
+Sets headers to ``headers``
+
+.. versionadded:: 3.26
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsDataSourceUri: %1>" ).arg( sipCpp->uri( false ) );

--- a/python/core/auto_generated/qgsdatasourceuri.sip.in
+++ b/python/core/auto_generated/qgsdatasourceuri.sip.in
@@ -360,11 +360,15 @@ Returns parameter keys used in the uri: specialized ones ("table", "schema", etc
     QgsHttpHeaders &httpHeaders();
 %Docstring
 Returns http headers
+
+.. versionadded:: 3.26
 %End
 
     QString httpHeader( const QString &key );
 %Docstring
 Returns the http header value according to ``key``
+
+.. versionadded:: 3.26
 %End
 
     void setHttpHeaders( const QgsHttpHeaders &headers );
@@ -381,7 +385,6 @@ Sets headers to ``headers``
 %End
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -19,13 +19,18 @@
  ***************************************************************************/
 
 #include "qgshttpheaders.h"
+#include "qgsdatasourceuri.h"
 #include <QDir>
+#include <QNetworkRequest>
+#include <QUrlQuery>
+#include <QDomElement>
 
 //
 // QgsHttpHeaders
 //
 
-const QString QgsHttpHeaders::KEY_PREFIX = "http-header/";
+const QString QgsHttpHeaders::PATH_PREFIX = "http-header/";
+const QString QgsHttpHeaders::PARAM_PREFIX = "http-header:";
 const QString QgsHttpHeaders::KEY_REFERER = "referer";
 
 QgsHttpHeaders::QgsHttpHeaders() = default;
@@ -46,6 +51,11 @@ QgsHttpHeaders::QgsHttpHeaders( const QString &key )
   setFromSettings( QgsSettings(), key );
 }
 
+QgsHttpHeaders::QgsHttpHeaders( const QDomElement &element )
+{
+  setFromDomElement( element );
+}
+
 QgsHttpHeaders::~QgsHttpHeaders() = default;
 
 bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
@@ -57,22 +67,22 @@ bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
   return true;
 }
 
-bool QgsHttpHeaders::updateDataSourceUri( QgsDataSourceUri &uri ) const
+bool QgsHttpHeaders::updateUrlQuery( QUrlQuery &uri ) const
 {
   for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
   {
-    uri.setParam( ite.key().toUtf8(), ite.value().toString().toUtf8() );
+    uri.addQueryItem( QgsHttpHeaders::PARAM_PREFIX + ite.key().toUtf8(), ite.value().toString().toUtf8() );
   }
   return true;
 }
 
-void QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key ) const
+bool QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key ) const
 {
   QString keyFixed = sanitizeKey( key );
   if ( !keyFixed.isEmpty() )
     keyFixed = keyFixed + "/";
 
-  QString keyHH = keyFixed + QgsHttpHeaders::KEY_PREFIX;
+  QString keyHH = keyFixed + QgsHttpHeaders::PATH_PREFIX;
   settings.remove( keyHH ); // cleanup
   for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
   {
@@ -90,14 +100,48 @@ void QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key )
     if ( k.startsWith( keyFixed ) )
       QgsLogger::debug( QString( "updateSettings in settings: %1=%2" ).arg( k, settings.value( k ).toString() ) );
 #endif
+  return true;
 }
+
+bool QgsHttpHeaders::updateMap( QVariantMap &map ) const
+{
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    map.insert( QgsHttpHeaders::PARAM_PREFIX + ite.key().toUtf8(), ite.value().toString() );
+  }
+
+  if ( mHeaders.contains( QgsHttpHeaders::KEY_REFERER ) )
+  {
+    map.insert( QgsHttpHeaders::KEY_REFERER, mHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
+  }
+
+  return true;
+}
+
+bool QgsHttpHeaders::updateDomElement( QDomElement &el ) const
+{
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    el.setAttribute( QgsHttpHeaders::PARAM_PREFIX + ite.key().toUtf8(), ite.value().toString() );
+  }
+
+  if ( mHeaders.contains( QgsHttpHeaders::KEY_REFERER ) )
+  {
+    el.setAttribute( QgsHttpHeaders::KEY_REFERER, mHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
+  }
+
+  return true;
+}
+
+
+
 
 void QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString &key )
 {
   QString keyFixed = sanitizeKey( key );
   if ( !keyFixed.isEmpty() )
     keyFixed = keyFixed + "/";
-  QString keyHH = keyFixed + QgsHttpHeaders::KEY_PREFIX;
+  QString keyHH = keyFixed + QgsHttpHeaders::PATH_PREFIX;
 
 #if 0
   QgsLogger::debug( QString( "setFromSettings key: %1" ).arg( keyFixed ) );
@@ -116,6 +160,7 @@ void QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString
       mHeaders.insert( name, settings.value( *ite ).toString() );
     }
   }
+
   if ( settings.contains( keyFixed + QgsHttpHeaders::KEY_REFERER ) ) // backward comptibility
   {
     mHeaders[QgsHttpHeaders::KEY_REFERER] = settings.value( keyFixed + QgsHttpHeaders::KEY_REFERER ).toString(); // retrieve value from old location
@@ -126,6 +171,75 @@ void QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString
     QgsLogger::debug( QString( "setFromSettings mHeaders[%1]=%2" ).arg( k, mHeaders[k].toString() ) );
 #endif
 }
+
+void QgsHttpHeaders::setFromUrlQuery( const QUrlQuery &uri )
+{
+  const auto constQueryItems = uri.queryItems( QUrl::ComponentFormattingOption::FullyDecoded );
+  for ( const QPair<QString, QString> &item : constQueryItems )
+  {
+    const QString &key = item.first;
+    if ( key.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+    {
+      QString name = key.right( key.size() - QgsHttpHeaders::PARAM_PREFIX.size() );
+      mHeaders[sanitizeKey( name )] = item.second;
+    }
+  }
+}
+
+void QgsHttpHeaders::setFromMap( const QVariantMap &map )
+{
+  for ( auto ite = map.keyBegin(); ite != map.keyEnd(); ++ite )
+  {
+    QString key = *ite;
+    if ( key.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+    {
+      QString name = key.right( key.size() - QgsHttpHeaders::PARAM_PREFIX.size() );
+      mHeaders[sanitizeKey( name )] = map [key].toString();
+    }
+  }
+
+  if ( map.contains( QgsHttpHeaders::KEY_REFERER ) )
+  {
+    mHeaders[QgsHttpHeaders::KEY_REFERER] = map [QgsHttpHeaders::KEY_REFERER].toString();
+  }
+}
+
+
+void QgsHttpHeaders::setFromDomElement( const QDomElement &el )
+{
+  QDomNamedNodeMap attribs = el.attributes();
+  for ( int i = 0; i < attribs.length(); i++ )
+  {
+    QDomNode item = attribs.item( i );
+    QString key = item.nodeName();
+    if ( key.startsWith( QgsHttpHeaders::PARAM_PREFIX ) )
+    {
+      QString name = key.right( key.size() - QgsHttpHeaders::PARAM_PREFIX.size() );
+      mHeaders[sanitizeKey( name )] = item.nodeValue();
+    }
+  }
+
+  if ( attribs.contains( QgsHttpHeaders::KEY_REFERER ) )
+  {
+    mHeaders[QgsHttpHeaders::KEY_REFERER] = attribs.namedItem( QgsHttpHeaders::KEY_REFERER ).nodeValue();
+  }
+}
+
+QString QgsHttpHeaders::toSpacedString() const
+{
+  QString out;
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    out += QStringLiteral( " %1%2='%3'" ).arg( QgsHttpHeaders::PARAM_PREFIX, ite.key(), ite.value().toString() );
+  }
+
+  if ( !mHeaders [ QgsHttpHeaders::KEY_REFERER ].toString().isEmpty() )
+    out += QStringLiteral( " %1='%2'" ).arg( QgsHttpHeaders::KEY_REFERER, mHeaders [QgsHttpHeaders::KEY_REFERER].toString() );
+
+  return out;
+}
+
+
 
 // To clean the path
 QString QgsHttpHeaders::sanitizeKey( const QString &key ) const

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -94,6 +94,7 @@ bool QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key )
     settings.setValue( keyFixed + QgsHttpHeaders::KEY_REFERER, mHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
   }
 
+// TODO REMOVE!
 #if 0
   QgsLogger::debug( QString( "updateSettings key: %1" ).arg( keyFixed ) );
   for ( auto k : settings.allKeys() )
@@ -198,7 +199,7 @@ void QgsHttpHeaders::setFromMap( const QVariantMap &map )
     }
   }
 
-  if ( map.contains( QgsHttpHeaders::KEY_REFERER ) )
+  if ( map.contains( QgsHttpHeaders::KEY_REFERER ) ) // backward comptibility
   {
     mHeaders[QgsHttpHeaders::KEY_REFERER] = map [QgsHttpHeaders::KEY_REFERER].toString();
   }
@@ -208,6 +209,7 @@ void QgsHttpHeaders::setFromMap( const QVariantMap &map )
 void QgsHttpHeaders::setFromDomElement( const QDomElement &el )
 {
   QDomNamedNodeMap attribs = el.attributes();
+
   for ( int i = 0; i < attribs.length(); i++ )
   {
     QDomNode item = attribs.item( i );
@@ -219,10 +221,11 @@ void QgsHttpHeaders::setFromDomElement( const QDomElement &el )
     }
   }
 
-  if ( attribs.contains( QgsHttpHeaders::KEY_REFERER ) )
+  if ( attribs.contains( QgsHttpHeaders::KEY_REFERER ) ) // backward comptibility
   {
     mHeaders[QgsHttpHeaders::KEY_REFERER] = attribs.namedItem( QgsHttpHeaders::KEY_REFERER ).nodeValue();
   }
+
 }
 
 QString QgsHttpHeaders::toSpacedString() const

--- a/src/core/network/qgshttpheaders.cpp
+++ b/src/core/network/qgshttpheaders.cpp
@@ -25,6 +25,7 @@
 //
 
 const QString QgsHttpHeaders::KEY_PREFIX = "http-header/";
+const QString QgsHttpHeaders::KEY_REFERER = "referer";
 
 QgsHttpHeaders::QgsHttpHeaders() = default;
 
@@ -39,6 +40,11 @@ QgsHttpHeaders::QgsHttpHeaders( const QgsSettings &settings, const QString &key 
   setFromSettings( settings, key );
 }
 
+QgsHttpHeaders::QgsHttpHeaders( const QString &key )
+{
+  setFromSettings( QgsSettings(), key );
+}
+
 QgsHttpHeaders::~QgsHttpHeaders() = default;
 
 bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
@@ -46,6 +52,15 @@ bool QgsHttpHeaders::updateNetworkRequest( QNetworkRequest &request ) const
   for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
   {
     request.setRawHeader( ite.key().toUtf8(), ite.value().toString().toUtf8() );
+  }
+  return true;
+}
+
+bool QgsHttpHeaders::updateDataSourceUri( QgsDataSourceUri &uri ) const
+{
+  for ( auto ite = mHeaders.constBegin(); ite != mHeaders.constEnd(); ++ite )
+  {
+    uri.setParam( ite.key().toUtf8(), ite.value().toString().toUtf8() );
   }
   return true;
 }
@@ -61,9 +76,9 @@ void QgsHttpHeaders::updateSettings( QgsSettings &settings, const QString &key )
     settings.setValue( keyHH  + ite.key(), ite.value() );
   }
 
-  if ( !mHeaders["referer"].toString().isEmpty() && settings.contains( keyFixed + "referer" ) ) // backward comptibility
+  if ( !mHeaders[QgsHttpHeaders::KEY_REFERER].toString().isEmpty() && settings.contains( keyFixed + QgsHttpHeaders::KEY_REFERER ) ) // backward comptibility
   {
-    settings.setValue( keyFixed + "referer", mHeaders["referer"].toString() );
+    settings.setValue( keyFixed + QgsHttpHeaders::KEY_REFERER, mHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
   }
 }
 
@@ -82,9 +97,9 @@ void QgsHttpHeaders::setFromSettings( const QgsSettings &settings, const QString
       mHeaders.insert( name, settings.value( *ite ).toString() );
     }
   }
-  if ( mHeaders["referer"].toString().isEmpty() ) // backward comptibility
+  if ( settings.contains( keyFixed + QgsHttpHeaders::KEY_REFERER ) ) // backward comptibility
   {
-    mHeaders["referer"] = settings.value( keyFixed + "referer" ).toString(); // retrieve value from old location
+    mHeaders[QgsHttpHeaders::KEY_REFERER] = settings.value( keyFixed + QgsHttpHeaders::KEY_REFERER ).toString(); // retrieve value from old location
   }
 }
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -21,12 +21,14 @@
 #ifndef QGSHTTPHEADERS_H
 #define QGSHTTPHEADERS_H
 
-#include <QNetworkRequest>
 #include <QMap>
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgssettingsentry.h"
-#include "qgsdatasourceuri.h"
+
+class QNetworkRequest;
+class QUrlQuery;
+class QDomElement;
 
 /**
  * \ingroup core
@@ -39,15 +41,15 @@ class CORE_EXPORT QgsHttpHeaders
 
 #ifndef SIP_RUN
 
-    /**
-     * Used in settings as the group name
-     */
-    static const QString KEY_PREFIX;
+    //! Used in settings as the group name
+    static const QString PATH_PREFIX;
 
-    /**
-     * Used in settings as the referer key
-     */
+    //! Used in settings as the referer key
     static const QString KEY_REFERER;
+
+    //! Used in uri to pass headers as params
+    static const QString PARAM_PREFIX;
+
 #endif
 
     /**
@@ -74,7 +76,22 @@ class CORE_EXPORT QgsHttpHeaders
      */
     QgsHttpHeaders( const QString &key );
 
+    /**
+     * \brief Constructor from a QDomElement \a element
+     * \param element
+     */
+    QgsHttpHeaders( const QDomElement &element );
+
+    //! default detructor
     virtual ~QgsHttpHeaders();
+
+    /**
+     * \brief Updates the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
+     * \param settings
+     * \param key sub group path
+     * \return TRUE if the update succeed
+     */
+    bool updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
 
     /**
      * \brief Updates a \a request by adding all the HTTP headers
@@ -86,14 +103,19 @@ class CORE_EXPORT QgsHttpHeaders
      * \brief Updates an \a uri by adding all the HTTP headers
      * \return TRUE if the update succeed
      */
-    bool updateDataSourceUri( QgsDataSourceUri &uri ) const;
+    bool updateUrlQuery( QUrlQuery &uri ) const;
 
     /**
-     * \brief Updates the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
-     * \param settings
-     * \param key sub group path
+     * \brief Updates a \a map by adding all the HTTP headers
+     * \return TRUE if the update succeed
      */
-    void updateSettings( QgsSettings &settings, const QString &key = QString() ) const;
+    bool updateMap( QVariantMap &map ) const;
+
+    /**
+     * \brief Updates a \a map by adding all the HTTP headers
+     * \return TRUE if the update succeed
+     */
+    bool updateDomElement( QDomElement &el ) const;
 
     /**
      * \brief Loads headers from the \a settings
@@ -101,6 +123,24 @@ class CORE_EXPORT QgsHttpHeaders
      * \param key sub group path
      */
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
+
+    /**
+     * \brief Loads headers from the \a uri
+     * \param uri
+     */
+    void setFromUrlQuery( const QUrlQuery &uri );
+
+    /**
+     * \brief Loads headers from the \a map
+     * \param map
+     */
+    void setFromMap( const QVariantMap &map );
+
+    /**
+     * \brief Loads headers from the \a element
+     * \param element
+     */
+    void setFromDomElement( const QDomElement &element );
 
     /**
      * \brief Returns a cleansed \a key
@@ -120,6 +160,9 @@ class CORE_EXPORT QgsHttpHeaders
      * \return the list of all http header keys
      */
     QList<QString> keys() const;
+
+    //! Returns key/value pairs as strings separated by space
+    QString toSpacedString() const;
 
 #ifndef SIP_RUN
 

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -26,6 +26,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgssettingsentry.h"
+#include "qgsdatasourceuri.h"
 
 /**
  * \ingroup core
@@ -39,9 +40,14 @@ class CORE_EXPORT QgsHttpHeaders
 #ifndef SIP_RUN
 
     /**
-     * Used in settings
+     * Used in settings as the group name
      */
     static const QString KEY_PREFIX;
+
+    /**
+     * Used in settings as the referer key
+     */
+    static const QString KEY_REFERER;
 #endif
 
     /**
@@ -56,11 +62,17 @@ class CORE_EXPORT QgsHttpHeaders
     QgsHttpHeaders();
 
     /**
-     * \brief Constructor from QgsSettings \a settings object
+     * \brief Constructor from QgsSettings \a settings object and root \a key
      * \param settings
      * \param key
      */
     QgsHttpHeaders( const QgsSettings &settings, const QString &key = QString() );
+
+    /**
+     * \brief Constructor from default QgsSettings object and root \a key
+     * \param key
+     */
+    QgsHttpHeaders( const QString &key );
 
     virtual ~QgsHttpHeaders();
 
@@ -69,6 +81,12 @@ class CORE_EXPORT QgsHttpHeaders
      * \return TRUE if the update succeed
      */
     bool updateNetworkRequest( QNetworkRequest &request ) const;
+
+    /**
+     * \brief Updates an \a uri by adding all the HTTP headers
+     * \return TRUE if the update succeed
+     */
+    bool updateDataSourceUri( QgsDataSourceUri &uri ) const;
 
     /**
      * \brief Updates the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -86,7 +86,10 @@ class CORE_EXPORT QgsHttpHeaders
     virtual ~QgsHttpHeaders();
 
     /**
-     * \brief Updates the \a settings by adding all the http headers in the path "key/KEY_PREFIX/"
+     * \brief Updates the \a settings by adding all the http headers in the path "key/PATH_PREFIX/"
+     *
+     * KEY_REFERER value will be available at path "key/PATH_PREFIX/KEY_REFERER" and path "key/KEY_REFERER" (for backward compatibility)
+     *
      * \param settings
      * \param key sub group path
      * \return TRUE if the update succeed
@@ -107,18 +110,27 @@ class CORE_EXPORT QgsHttpHeaders
 
     /**
      * \brief Updates a \a map by adding all the HTTP headers
+     *
+     * KEY_REFERER value will be available at key "KEY_PREFIX+KEY_REFERER" and key "KEY_REFERER" (for backward compatibility)
+     *
      * \return TRUE if the update succeed
      */
     bool updateMap( QVariantMap &map ) const;
 
     /**
      * \brief Updates a \a map by adding all the HTTP headers
+     *
+     * KEY_REFERER value will be available at attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
+     *
      * \return TRUE if the update succeed
      */
     bool updateDomElement( QDomElement &el ) const;
 
     /**
      * \brief Loads headers from the \a settings
+     *
+     * key KEY_REFERER will be read at path "key/PATH_PREFIX/KEY_REFERER" and path "key/KEY_REFERER" (for backward compatibility)
+     *
      * \param settings
      * \param key sub group path
      */
@@ -132,12 +144,18 @@ class CORE_EXPORT QgsHttpHeaders
 
     /**
      * \brief Loads headers from the \a map
+     *
+     * key KEY_REFERER will be read from key "KEY_PREFIX+KEY_REFERER" and key "KEY_REFERER" (for backward compatibility)
+     *
      * \param map
      */
     void setFromMap( const QVariantMap &map );
 
     /**
      * \brief Loads headers from the \a element
+     *
+     * key KEY_REFERER will be read from attribute "KEY_PREFIX+KEY_REFERER" and attribute "KEY_REFERER" (for backward compatibility)
+     *
      * \param element
      */
     void setFromDomElement( const QDomElement &element );

--- a/src/core/network/qgshttpheaders.h
+++ b/src/core/network/qgshttpheaders.h
@@ -103,6 +103,12 @@ class CORE_EXPORT QgsHttpHeaders
     void setFromSettings( const QgsSettings &settings, const QString &key = QString() );
 
     /**
+     * \brief Returns a cleansed \a key
+     * \param key a key to be sanitized
+     */
+    QString sanitizeKey( const QString &key ) const;
+
+    /**
      * \param key http header key name
      * \return http header value
      */

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -445,15 +445,12 @@ QgsArcGisAsyncQuery::~QgsArcGisAsyncQuery()
     mReply->deleteLater();
 }
 
-void QgsArcGisAsyncQuery::start( const QUrl &url, const QString &authCfg, QByteArray *result, bool allowCache, const QgsStringMap &headers )
+void QgsArcGisAsyncQuery::start( const QUrl &url, const QString &authCfg, QByteArray *result, bool allowCache, const QgsHttpHeaders &headers )
 {
   mResult = result;
   QNetworkRequest request( url );
 
-  for ( auto it = headers.constBegin(); it != headers.constEnd(); ++it )
-  {
-    request.setRawHeader( it.key().toUtf8(), it.value().toUtf8() );
-  }
+  headers.updateNetworkRequest( request );
 
   if ( !authCfg.isEmpty() &&  !QgsApplication::authManager()->updateNetworkRequest( request, authCfg ) )
   {

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -117,7 +117,7 @@ class CORE_EXPORT QgsArcGisAsyncQuery : public QObject
     QgsArcGisAsyncQuery( QObject *parent = nullptr );
     ~QgsArcGisAsyncQuery() override;
 
-    void start( const QUrl &url, const QString &authCfg, QByteArray *result, bool allowCache = false, const QgsStringMap &headers = QgsStringMap() );
+    void start( const QUrl &url, const QString &authCfg, QByteArray *result, bool allowCache = false, const QgsHttpHeaders &headers = QgsHttpHeaders() );
   signals:
     void finished();
     void failed( QString errorTitle, QString errorName );

--- a/src/core/qgsdatasourceuri.h
+++ b/src/core/qgsdatasourceuri.h
@@ -331,10 +331,16 @@ class CORE_EXPORT QgsDataSourceUri
     QgsHttpHeaders httpHeaders() const { return mHttpHeaders; }
 #endif
 
-    //! Returns http headers
+    /**
+     * Returns http headers
+     * \since QGIS 3.26
+     */
     QgsHttpHeaders &httpHeaders() { return mHttpHeaders; }
 
-    //! Returns the http header value according to \a key
+    /**
+     * Returns the http header value according to \a key
+     * \since QGIS 3.26
+     */
     QString httpHeader( const QString &key ) { return mHttpHeaders[key].toString(); }
 
     /**
@@ -403,4 +409,3 @@ class CORE_EXPORT QgsDataSourceUri
 };
 
 #endif //QGSDATASOURCEURI_H
-

--- a/src/core/qgsdatasourceuri.h
+++ b/src/core/qgsdatasourceuri.h
@@ -22,6 +22,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgswkbtypes.h"
+#include "qgshttpheaders.h"
 
 #include <QMap>
 #include <QSet>
@@ -325,6 +326,23 @@ class CORE_EXPORT QgsDataSourceUri
      */
     QSet<QString> parameterKeys() const;
 
+#ifndef SIP_RUN
+    //! Returns http headers
+    QgsHttpHeaders httpHeaders() const { return mHttpHeaders; }
+#endif
+
+    //! Returns http headers
+    QgsHttpHeaders &httpHeaders() { return mHttpHeaders; }
+
+    //! Returns the http header value according to \a key
+    QString httpHeader( const QString &key ) { return mHttpHeaders[key].toString(); }
+
+    /**
+     * Sets headers to \a headers
+     * \since QGIS 3.26
+     */
+    void setHttpHeaders( const QgsHttpHeaders &headers ) { mHttpHeaders = headers; }
+
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
@@ -380,6 +398,8 @@ class CORE_EXPORT QgsDataSourceUri
     QString mSrid;
     //! Generic params store
     QMultiMap<QString, QString> mParams;
+    //! http header store
+    QgsHttpHeaders mHttpHeaders;
 };
 
 #endif //QGSDATASOURCEURI_H

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -62,10 +62,10 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
   mConnectionInfo.append( ",authcfg=" + authcfg );
 
   QgsHttpHeaders httpHeaders( QString( "%3/connections-%1/%2/" ).arg( mService.toLower(), mConnName, QgsSettings::Prefix::QGIS ) );
+  mUri.setHttpHeaders( httpHeaders );
   const QString referer = httpHeaders[QgsHttpHeaders::KEY_REFERER].toString();
   if ( !referer.isEmpty() )
   {
-    mUri.setParam( QStringLiteral( "referer" ), referer );
     mConnectionInfo.append( ",referer=" + referer );
   }
 
@@ -109,8 +109,7 @@ QgsDataSourceUri &QgsOwsConnection::addWmsWcsConnectionSettings( QgsDataSourceUr
   Q_NOWARN_DEPRECATED_POP
 
   const QgsSettings settings;
-  QgsHttpHeaders httpHeaders( settings, settingsKey );
-  httpHeaders.updateDataSourceUri( uri );
+  uri.httpHeaders().setFromSettings( settings, settingsKey );
 
   if ( settings.value( settingsKey + QStringLiteral( "/ignoreGetMapURI" ), false ).toBool() )
   {
@@ -141,8 +140,9 @@ QgsDataSourceUri &QgsOwsConnection::addWmsWcsConnectionSettings( QgsDataSourceUr
 {
   addCommonConnectionSettings( uri, service, connName );
 
-  QgsHttpHeaders httpHeaders( QString( "%3/connections-%1/%2/" ).arg( service.toLower(), connName, QgsSettings::Prefix::QGIS ) );
-  httpHeaders.updateDataSourceUri( uri );
+  QString settingsKey = QString( "%3/connections-%1/%2/" ).arg( service.toLower(), connName, QgsSettings::Prefix::QGIS );
+  const QgsSettings settings;
+  uri.httpHeaders().setFromSettings( settings, settingsKey );
 
   if ( settingsConnectionIgnoreGetMapURI.value( {service.toLower(), connName} ) )
   {

--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -50,10 +50,10 @@ QString QgsVectorTileProviderConnection::encodedUri( const QgsVectorTileProvider
     uri.setUsername( conn.username );
   if ( !conn.password.isEmpty() )
     uri.setPassword( conn.password );
-  if ( !conn.referer.isEmpty() )
-    uri.setParam( QStringLiteral( "referer" ),  conn.referer );
   if ( !conn.styleUrl.isEmpty() )
     uri.setParam( QStringLiteral( "styleUrl" ),  conn.styleUrl );
+
+  uri.setHttpHeaders( conn.httpHeaders );
 
   switch ( conn.serviceType )
   {
@@ -80,8 +80,9 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::decodedUr
   conn.authCfg = dsUri.authConfigId();
   conn.username = dsUri.username();
   conn.password = dsUri.password();
-  conn.referer = dsUri.param( QStringLiteral( "referer" ) );
   conn.styleUrl = dsUri.param( QStringLiteral( "styleUrl" ) );
+
+  conn.httpHeaders = dsUri.httpHeaders();
 
   if ( dsUri.hasParam( QStringLiteral( "serviceType" ) ) )
   {
@@ -118,10 +119,10 @@ QString QgsVectorTileProviderConnection::encodedLayerUri( const QgsVectorTilePro
     uri.setUsername( conn.username );
   if ( !conn.password.isEmpty() )
     uri.setPassword( conn.password );
-  if ( !conn.referer.isEmpty() )
-    uri.setParam( QStringLiteral( "referer" ),  conn.referer );
   if ( !conn.styleUrl.isEmpty() )
     uri.setParam( QStringLiteral( "styleUrl" ),  conn.styleUrl );
+
+  uri.setHttpHeaders( conn.httpHeaders );
 
   switch ( conn.serviceType )
   {
@@ -160,8 +161,9 @@ QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connectio
   conn.authCfg = settings.value( QStringLiteral( "authcfg" ) ).toString();
   conn.username = settings.value( QStringLiteral( "username" ) ).toString();
   conn.password = settings.value( QStringLiteral( "password" ) ).toString();
-  conn.referer = QgsHttpHeaders( settings )[ QStringLiteral( "referer" ) ].toString();
   conn.styleUrl = settings.value( QStringLiteral( "styleUrl" ) ).toString();
+
+  conn.httpHeaders = QgsHttpHeaders( settings );
 
   if ( settings.contains( QStringLiteral( "serviceType" ) ) )
   {
@@ -189,8 +191,9 @@ void QgsVectorTileProviderConnection::addConnection( const QString &name, QgsVec
   settings.setValue( QStringLiteral( "authcfg" ), conn.authCfg );
   settings.setValue( QStringLiteral( "username" ), conn.username );
   settings.setValue( QStringLiteral( "password" ), conn.password );
-  QgsHttpHeaders( QVariantMap( { {QStringLiteral( "referer" ), conn.referer}} ) ).updateSettings( settings );
   settings.setValue( QStringLiteral( "styleUrl" ), conn.styleUrl );
+
+  conn.httpHeaders.updateSettings( settings );
 
   switch ( conn.serviceType )
   {

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -61,8 +61,8 @@ class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderCo
       QString username;
       //! HTTP Basic password
       QString password;
-      //! Referer
-      QString referer;
+      //! HTTP headers
+      QgsHttpHeaders httpHeaders;
 
       //! Optional style URL (will override any default styles)
       QString styleUrl;

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -812,10 +812,8 @@ QByteArray QgsVectorTileLayer::getRawTile( QgsTileXYZ tileID )
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( mDataSource );
   const QString authcfg = dsUri.authConfigId();
-  QgsHttpHeaders headers;
-  headers [QStringLiteral( "referer" ) ] = dsUri.param( QStringLiteral( "referer" ) );
 
-  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange, authcfg, headers );
+  QList<QgsVectorTileRawData> rawTiles = QgsVectorTileLoader::blockingFetchTileRawData( mSourceType, mSourcePath, tileMatrix, QPointF(), tileRange, authcfg, dsUri.httpHeaders() );
   if ( rawTiles.isEmpty() )
     return QByteArray();
   return rawTiles.first().data;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -45,7 +45,7 @@ QgsVectorTileLayerRenderer::QgsVectorTileLayerRenderer( QgsVectorTileLayer *laye
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( layer->source() );
   mAuthCfg = dsUri.authConfigId();
-  mHeaders [QStringLiteral( "referer" ) ] = dsUri.param( QStringLiteral( "referer" ) );
+  mHeaders = dsUri.httpHeaders();
 
   if ( QgsLabelingEngine *engine = context.labelingEngine() )
   {

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -86,8 +86,8 @@ QVariantMap QgsVectorTileProviderMetadata::decodeUri( const QString &uri ) const
   if ( dsUri.hasParam( QStringLiteral( "zmax" ) ) )
     uriComponents.insert( QStringLiteral( "zmax" ), dsUri.param( QStringLiteral( "zmax" ) ) );
 
-  if ( dsUri.hasParam( QStringLiteral( "referer" ) ) )
-    uriComponents.insert( QStringLiteral( "referer" ), dsUri.param( QStringLiteral( "referer" ) ) );
+  dsUri.httpHeaders().updateMap( uriComponents );
+
   if ( dsUri.hasParam( QStringLiteral( "styleUrl" ) ) )
     uriComponents.insert( QStringLiteral( "styleUrl" ), dsUri.param( QStringLiteral( "styleUrl" ) ) );
 
@@ -111,8 +111,8 @@ QString QgsVectorTileProviderMetadata::encodeUri( const QVariantMap &parts ) con
   if ( parts.contains( QStringLiteral( "zmax" ) ) )
     dsUri.setParam( QStringLiteral( "zmax" ), parts[ QStringLiteral( "zmax" ) ].toString() );
 
-  if ( parts.contains( QStringLiteral( "referer" ) ) )
-    dsUri.setParam( QStringLiteral( "referer" ), parts[ QStringLiteral( "referer" ) ].toString() );
+  dsUri.httpHeaders().setFromMap( parts );
+
   if ( parts.contains( QStringLiteral( "styleUrl" ) ) )
     dsUri.setParam( QStringLiteral( "styleUrl" ), parts[ QStringLiteral( "styleUrl" ) ].toString() );
 

--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -51,7 +51,7 @@ void QgsHttpHeaderWidget::addQueryPairRow( const QString &key, const QString &va
   tblwdgQueryPairs->setItem( rowCnt, 0, keyItem );
 
   QTableWidgetItem *valueItem = new QTableWidgetItem( val );
-  keyItem->setFlags( itemFlags );
+  valueItem->setFlags( itemFlags );
   tblwdgQueryPairs->setItem( rowCnt, 1, valueItem );
 }
 
@@ -71,6 +71,14 @@ QgsHttpHeaders QgsHttpHeaderWidget::httpHeaders() const
   {
     querypairs [ "referer" ] = QVariant( mRefererLineEdit->text() ) ;
   }
+
+#if 0
+  for ( auto k : querypairs.keys() )
+  {
+    QgsLogger::debug( QString( "httpHeaders called: %1=%2" ).arg( k, querypairs[k].toString() ) );
+  }
+#endif
+
   return querypairs;
 }
 
@@ -80,7 +88,6 @@ void QgsHttpHeaderWidget::addQueryPair()
   addQueryPairRow( QString(), QString() );
   tblwdgQueryPairs->setFocus();
   tblwdgQueryPairs->setCurrentCell( tblwdgQueryPairs->rowCount() - 1, 0 );
-  tblwdgQueryPairs->edit( tblwdgQueryPairs->currentIndex() );
 }
 
 
@@ -96,10 +103,11 @@ void QgsHttpHeaderWidget::setFromSettings( const QgsSettings &settings, const QS
   QgsHttpHeaders headers;
   headers.setFromSettings( settings, key );
 
+  // clean table
+  for ( int i = tblwdgQueryPairs->rowCount(); i > 0; i-- )
+    tblwdgQueryPairs->removeRow( i - 1 );
+
   // push headers to table
-  tblwdgQueryPairs->clearContents();
-  /*QTableWidgetItem * item;
-  int row = 0;*/
   QList<QString> lst = headers.keys();
   for ( auto ite = lst.constBegin(); ite != lst.constEnd(); ++ite )
   {

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -22,7 +22,7 @@
 
 #include "qgssettings.h"
 #include "qgsmanageconnectionsdialog.h"
-
+#include "qgshttpheaders.h"
 
 QgsManageConnectionsDialog::QgsManageConnectionsDialog( QWidget *parent, Mode mode, Type type, const QString &fileName )
   : QDialog( parent )
@@ -457,9 +457,11 @@ QDomDocument QgsManageConnectionsDialog::saveOWSConnections( const QStringList &
       el.setAttribute( QStringLiteral( "ignoreGetFeatureInfoURI" ), settings.value( path + connections[i] + "/ignoreGetFeatureInfoURI", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "ignoreAxisOrientation" ), settings.value( path + connections[i] + "/ignoreAxisOrientation", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "invertAxisOrientation" ), settings.value( path + connections[i] + "/invertAxisOrientation", false ).toBool() ? "true" : "false" );
-      el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer" ).toString() );
       el.setAttribute( QStringLiteral( "smoothPixmapTransform" ), settings.value( path + connections[i] + "/smoothPixmapTransform", false ).toBool() ? "true" : "false" );
       el.setAttribute( QStringLiteral( "dpiMode" ), settings.value( path + connections[i] + "/dpiMode", "7" ).toInt() );
+
+      QgsHttpHeaders httpHeader( path + connections[ i ] );
+      httpHeader.updateDomElement( el );
     }
 
     path = "/qgis/" + service.toUpper() + '/';
@@ -730,8 +732,10 @@ QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringL
     el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg" ).toString() );
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
     el.setAttribute( QStringLiteral( "tilePixelRatio" ), settings.value( path + "/tilePixelRatio", 0 ).toDouble() );
+
+    QgsHttpHeaders httpHeader( path );
+    httpHeader.updateDomElement( el );
 
     root.appendChild( el );
   }
@@ -754,7 +758,9 @@ QDomDocument QgsManageConnectionsDialog::saveArcgisConnections( const QStringLis
     QDomElement el = doc.createElement( service.toLower() );
     el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
     el.setAttribute( QStringLiteral( "url" ), settings.value( path + connections[ i ] + "/url" ).toString() );
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + connections[ i ] + "/referer" ).toString() );
+
+    QgsHttpHeaders httpHeader( path + connections[ i ] );
+    httpHeader.updateDomElement( el );
 
     path = "/qgis/" + service.toUpper() + '/';
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username" ).toString() );
@@ -788,8 +794,10 @@ QDomDocument QgsManageConnectionsDialog::saveVectorTileConnections( const QStrin
     el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg" ).toString() );
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
-    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
     el.setAttribute( QStringLiteral( "styleUrl" ), settings.value( path + "/styleUrl" ).toString() );
+
+    QgsHttpHeaders httpHeader( path );
+    httpHeader.updateDomElement( el );
 
     root.appendChild( el );
   }
@@ -875,9 +883,12 @@ void QgsManageConnectionsDialog::loadOWSConnections( const QDomDocument &doc, co
     settings.setValue( QString( '/' + connectionName + "/ignoreGetFeatureInfoURI" ), child.attribute( QStringLiteral( "ignoreGetFeatureInfoURI" ) ) == QLatin1String( "true" ) );
     settings.setValue( QString( '/' + connectionName + "/ignoreAxisOrientation" ), child.attribute( QStringLiteral( "ignoreAxisOrientation" ) ) == QLatin1String( "true" ) );
     settings.setValue( QString( '/' + connectionName + "/invertAxisOrientation" ), child.attribute( QStringLiteral( "invertAxisOrientation" ) ) == QLatin1String( "true" ) );
-    settings.setValue( QString( '/' + connectionName + "/referer" ), child.attribute( QStringLiteral( "referer" ) ) );
     settings.setValue( QString( '/' + connectionName + "/smoothPixmapTransform" ), child.attribute( QStringLiteral( "smoothPixmapTransform" ) ) == QLatin1String( "true" ) );
     settings.setValue( QString( '/' + connectionName + "/dpiMode" ), child.attribute( QStringLiteral( "dpiMode" ), QStringLiteral( "7" ) ).toInt() );
+
+    QgsHttpHeaders httpHeader( child );
+    httpHeader.updateSettings( settings, QString( '/' + connectionName ) );
+
     settings.endGroup();
 
     if ( !child.attribute( QStringLiteral( "username" ) ).isEmpty() )
@@ -1538,8 +1549,11 @@ void QgsManageConnectionsDialog::loadXyzTilesConnections( const QDomDocument &do
     settings.setValue( QStringLiteral( "authcfg" ), child.attribute( QStringLiteral( "authcfg" ) ) );
     settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
     settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
-    settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
     settings.setValue( QStringLiteral( "tilePixelRatio" ), child.attribute( QStringLiteral( "tilePixelRatio" ) ) );
+
+    QgsHttpHeaders httpHeader( child );
+    httpHeader.updateSettings( settings );
+
     settings.endGroup();
 
     child = child.nextSiblingElement();
@@ -1620,7 +1634,10 @@ void QgsManageConnectionsDialog::loadArcgisConnections( const QDomDocument &doc,
     // no dups detected or overwrite is allowed
     settings.beginGroup( "/qgis/connections-" + service.toLower() );
     settings.setValue( QString( '/' + connectionName + "/url" ), child.attribute( QStringLiteral( "url" ) ) );
-    settings.setValue( QString( '/' + connectionName + "/referer" ), child.attribute( QStringLiteral( "referer" ) ) );
+
+    QgsHttpHeaders httpHeader( child );
+    httpHeader.updateSettings( settings, QString( '/' + connectionName ) );
+
     settings.endGroup();
 
     settings.beginGroup( "/qgis/" + service.toUpper() + '/' + connectionName );
@@ -1712,8 +1729,10 @@ void QgsManageConnectionsDialog::loadVectorTileConnections( const QDomDocument &
     settings.setValue( QStringLiteral( "authcfg" ), child.attribute( QStringLiteral( "authcfg" ) ) );
     settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
     settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
-    settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
     settings.setValue( QStringLiteral( "styleUrl" ), child.attribute( QStringLiteral( "styleUrl" ) ) );
+
+    QgsHttpHeaders httpHeader( child );
+    httpHeader.updateSettings( settings );
 
     settings.endGroup();
 

--- a/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsarcgisvectortileconnectiondialog.cpp
@@ -57,7 +57,7 @@ void QgsArcgisVectorTileConnectionDialog::setConnection( const QString &name, co
 
   mAuthSettings->setUsername( conn.username );
   mAuthSettings->setPassword( conn.password );
-  mEditReferer->setText( conn.referer );
+  mEditReferer->setText( conn.httpHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
   mAuthSettings->setConfigId( conn.authCfg );
 
   mEditStyleUrl->setText( conn.styleUrl );
@@ -79,7 +79,7 @@ QString QgsArcgisVectorTileConnectionDialog::connectionUri() const
 
   conn.username = mAuthSettings->username();
   conn.password = mAuthSettings->password();
-  conn.referer = mEditReferer->text();
+  conn.httpHeaders[QgsHttpHeaders::KEY_REFERER] = mEditReferer->text();
   conn.authCfg = mAuthSettings->configId( );
 
   conn.styleUrl = mEditStyleUrl->text();

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -56,7 +56,7 @@ void QgsVectorTileConnectionDialog::setConnection( const QString &name, const QS
 
   mAuthSettings->setUsername( conn.username );
   mAuthSettings->setPassword( conn.password );
-  mEditReferer->setText( conn.referer );
+  mEditReferer->setText( conn.httpHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
   mAuthSettings->setConfigId( conn.authCfg );
 
   mEditStyleUrl->setText( conn.styleUrl );
@@ -72,7 +72,7 @@ QString QgsVectorTileConnectionDialog::connectionUri() const
     conn.zMax = mSpinZMax->value();
   conn.username = mAuthSettings->username();
   conn.password = mAuthSettings->password();
-  conn.referer = mEditReferer->text();
+  conn.httpHeaders[QgsHttpHeaders::KEY_REFERER] = mEditReferer->text();
   conn.authCfg = mAuthSettings->configId( );
   conn.styleUrl = mEditStyleUrl->text();
   return QgsVectorTileProviderConnection::encodedUri( conn );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -45,9 +45,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // Get layer info
   QString errorTitle, errorMessage;
 
-  const QString referer = mSharedData->mDataSource.param( QStringLiteral( "referer" ) );
-  if ( !referer.isEmpty() )
-    mRequestHeaders[ QStringLiteral( "referer" )] = referer;
+  mRequestHeaders = mSharedData->mDataSource.httpHeaders();
 
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( QgsApplication::profiler()->groupIsActive( QStringLiteral( "projectload" ) ) )
@@ -433,10 +431,9 @@ QVariantMap QgsAfsProviderMetadata::decodeUri( const QString &uri ) const
     if ( xminOk && yminOk && xmaxOk && ymaxOk )
       components.insert( QStringLiteral( "bounds" ), r );
   }
-  if ( !dsUri.param( QStringLiteral( "referer" ) ).isEmpty() )
-  {
-    components.insert( QStringLiteral( "referer" ), dsUri.param( QStringLiteral( "referer" ) ) );
-  }
+
+  dsUri.httpHeaders().updateMap( components );
+
   if ( !dsUri.param( QStringLiteral( "crs" ) ).isEmpty() )
   {
     components.insert( QStringLiteral( "crs" ), dsUri.param( QStringLiteral( "crs" ) ) );
@@ -463,10 +460,9 @@ QString QgsAfsProviderMetadata::encodeUri( const QVariantMap &parts ) const
   {
     dsUri.setParam( QStringLiteral( "crs" ), parts.value( QStringLiteral( "crs" ) ).toString() );
   }
-  if ( !parts.value( QStringLiteral( "referer" ) ).toString().isEmpty() )
-  {
-    dsUri.setParam( QStringLiteral( "referer" ), parts.value( QStringLiteral( "referer" ) ).toString() );
-  }
+
+  dsUri.httpHeaders().setFromMap( parts );
+
   if ( !parts.value( QStringLiteral( "authcfg" ) ).toString().isEmpty() )
   {
     dsUri.setAuthConfigId( parts.value( QStringLiteral( "authcfg" ) ).toString() );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -60,15 +60,10 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
   QString errorTitle, errorMessage;
 
   const QString authcfg = mDataSource.authConfigId();
-  QgsHttpHeaders headers;
-  const QString referer = mDataSource.param( QStringLiteral( "referer" ) );
-  if ( !referer.isEmpty() )
-    headers[ QStringLiteral( "Referer" )] = referer;
-
   const QVariantMap queryData = QgsArcGisRestQueryUtils::getObjects(
                                   mDataSource.param( QStringLiteral( "url" ) ), authcfg, objectIds, mDataSource.param( QStringLiteral( "crs" ) ), true,
                                   QStringList(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ),
-                                  filterRect, errorTitle, errorMessage, headers, feedback );
+                                  filterRect, errorTitle, errorMessage, mDataSource.httpHeaders(), feedback );
 
   if ( queryData.isEmpty() )
   {
@@ -151,12 +146,8 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
   QString errorText;
 
   const QString authcfg = mDataSource.authConfigId();
-  QgsHttpHeaders headers;
-  const QString referer = mDataSource.param( QStringLiteral( "referer" ) );
-  if ( !referer.isEmpty() )
-    headers[ QStringLiteral( "Referer" )] = referer;
   const QList<quint32> featuresInRect = QgsArcGisRestQueryUtils::getObjectIdsByExtent( mDataSource.param( QStringLiteral( "url" ) ),
-                                        extent, errorTitle, errorText, authcfg, headers, feedback );
+                                        extent, errorTitle, errorText, authcfg, mDataSource.httpHeaders(), feedback );
 
   QgsFeatureIds ids;
   for ( const quint32 id : featuresInRect )

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -195,15 +195,13 @@ QVector<QgsDataItem *> QgsArcGisRestConnectionItem::createChildren()
   const QgsOwsConnection connection( QStringLiteral( "ARCGISFEATURESERVER" ), mConnName );
   const QString url = connection.uri().param( QStringLiteral( "url" ) );
   const QString authcfg = connection.uri().authConfigId();
-  const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
-  QgsHttpHeaders headers;
-  if ( ! referer.isEmpty() )
-    headers[ QStringLiteral( "referer" )] = referer;
+
+  QgsHttpHeaders headers = connection.uri().httpHeaders();
 
   QVector<QgsDataItem *> items;
   if ( !mPortalCommunityEndpoint.isEmpty() && !mPortalContentEndpoint.isEmpty() )
   {
-    items << new QgsArcGisPortalGroupsItem( this, QStringLiteral( "groups" ), authcfg, headers, mPortalCommunityEndpoint, mPortalContentEndpoint );
+    items << new QgsArcGisPortalGroupsItem( this, QStringLiteral( "groups" ), authcfg, connection.uri().httpHeaders(), mPortalCommunityEndpoint, mPortalContentEndpoint );
     items << new QgsArcGisRestServicesItem( this, url, QStringLiteral( "services" ), authcfg, headers );
   }
   else
@@ -573,8 +571,9 @@ QgsArcGisFeatureServiceLayerItem::QgsArcGisFeatureServiceLayerItem( QgsDataItem 
   mUri = QStringLiteral( "crs='%1' url='%2'" ).arg( authid, url );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
-  if ( !headers [ QStringLiteral( "referer" ) ].toString().isEmpty() )
-    mUri += QStringLiteral( " referer='%1'" ).arg( headers[ QStringLiteral( "referer" ) ].toString() );
+
+  mUri += headers.toSpacedString();
+
   setState( Qgis::BrowserItemState::Populated );
   setToolTip( url );
 }
@@ -590,8 +589,9 @@ QgsArcGisMapServiceLayerItem::QgsArcGisMapServiceLayerItem( QgsDataItem *parent,
   mUri = QStringLiteral( "crs='%1' format='%2' layer='%3' url='%4'" ).arg( authid, format, id, trimmedUrl );
   if ( !authcfg.isEmpty() )
     mUri += QStringLiteral( " authcfg='%1'" ).arg( authcfg );
-  if ( !headers [ QStringLiteral( "referer" ) ].toString().isEmpty() )
-    mUri += QStringLiteral( " referer='%1'" ).arg( headers [ QStringLiteral( "referer" ) ].toString() );
+
+  mUri += headers.toSpacedString();
+
   setState( Qgis::BrowserItemState::Populated );
   setToolTip( mPath );
 }

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -52,7 +52,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mAuth.mAuthCfg = uri.authConfigId();
   }
 
-  mAuth.mReferer = uri.param( QStringLiteral( "referer" ) );
+  mAuth.mHttpHeaders = uri.httpHeaders();
   mXyz = false;  // assume WMS / WMTS
 
   if ( uri.hasParam( QStringLiteral( "interpretation" ) ) )

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -656,10 +656,10 @@ struct QgsWmsParserSettings
 
 struct QgsWmsAuthorization
 {
-  QgsWmsAuthorization( const QString &userName = QString(), const QString &password = QString(), const QString &referer = QString(), const QString &authcfg = QString() )
+  QgsWmsAuthorization( const QString &userName = QString(), const QString &password = QString(), const QgsHttpHeaders &httpHeaders = QgsHttpHeaders(), const QString &authcfg = QString() )
     : mUserName( userName )
     , mPassword( password )
-    , mReferer( referer )
+    , mHttpHeaders( httpHeaders )
     , mAuthCfg( authcfg )
   {}
 
@@ -674,10 +674,8 @@ struct QgsWmsAuthorization
       request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUserName, mPassword ).toUtf8().toBase64() );
     }
 
-    if ( !mReferer.isEmpty() )
-    {
-      request.setRawHeader( "Referer", mReferer.toLatin1() );
-    }
+    mHttpHeaders.updateNetworkRequest( request );
+
     return true;
   }
   //! Sets authorization reply
@@ -696,8 +694,8 @@ struct QgsWmsAuthorization
   //! Password for basic http authentication
   QString mPassword;
 
-  //! Referer for http requests
-  QString mReferer;
+  //! headers for http requests
+  QgsHttpHeaders mHttpHeaders;
 
   //! Authentication configuration ID
   QString mAuthCfg;

--- a/src/providers/wms/qgsxyzconnection.cpp
+++ b/src/providers/wms/qgsxyzconnection.cpp
@@ -34,8 +34,9 @@ QString QgsXyzConnection::encodedUri() const
     uri.setUsername( username );
   if ( ! password.isEmpty() )
     uri.setPassword( password );
-  if ( ! referer.isEmpty() )
-    uri.setParam( QStringLiteral( "referer" ), referer );
+
+  uri.setHttpHeaders( httpHeaders );
+
   if ( tilePixelRatio != 0 )
     uri.setParam( QStringLiteral( "tilePixelRatio" ), QString::number( tilePixelRatio ) );
   if ( !interpretation.isEmpty() )
@@ -93,7 +94,9 @@ QgsXyzConnection QgsXyzConnectionUtils::connection( const QString &name )
   conn.authCfg = settings.value( QStringLiteral( "authcfg" ) ).toString();
   conn.username = settings.value( QStringLiteral( "username" ) ).toString();
   conn.password = settings.value( QStringLiteral( "password" ) ).toString();
-  conn.referer = settings.value( QStringLiteral( "referer" ) ).toString();
+
+  conn.httpHeaders.setFromSettings( settings );
+
   conn.tilePixelRatio = settings.value( QStringLiteral( "tilePixelRatio" ), 0 ).toDouble();
   conn.hidden = settings.value( QStringLiteral( "hidden" ) ).toBool();
   conn.interpretation = settings.value( QStringLiteral( "interpretation" ), QString() ).toString();
@@ -137,7 +140,9 @@ void QgsXyzConnectionUtils::addConnection( const QgsXyzConnection &conn )
   settings.setValue( QStringLiteral( "authcfg" ), conn.authCfg );
   settings.setValue( QStringLiteral( "username" ), conn.username );
   settings.setValue( QStringLiteral( "password" ), conn.password );
-  settings.setValue( QStringLiteral( "referer" ), conn.referer );
+
+  conn.httpHeaders.updateSettings( settings );
+
   settings.setValue( QStringLiteral( "tilePixelRatio" ), conn.tilePixelRatio );
   settings.setValue( QStringLiteral( "interpretation" ), conn.interpretation );
   if ( addHiddenProperty )

--- a/src/providers/wms/qgsxyzconnection.h
+++ b/src/providers/wms/qgsxyzconnection.h
@@ -17,6 +17,8 @@
 #define QGSXYZCONNECTION_H
 
 #include <QStringList>
+#include "qgshttpheaders.h"
+
 
 struct QgsXyzConnection
 {
@@ -30,8 +32,8 @@ struct QgsXyzConnection
   QString username;
   // HTTP Basic password
   QString password;
-  // Referer
-  QString referer;
+  // http headers
+  QgsHttpHeaders httpHeaders;
   // tile pixel ratio (0 = unknown (not scaled), 1.0 = 256x256, 2.0 = 512x512)
   double tilePixelRatio = 0;
   bool hidden = false;

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -49,7 +49,7 @@ void QgsXyzConnectionDialog::setConnection( const QgsXyzConnection &conn )
   mSourceWidget->setZMax( conn.zMax );
   mSourceWidget->setUsername( conn.username );
   mSourceWidget->setPassword( conn.password );
-  mSourceWidget->setReferer( conn.referer );
+  mSourceWidget->setReferer( conn.httpHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
   mSourceWidget->setTilePixelRatio( conn.tilePixelRatio );
   mSourceWidget->setAuthCfg( conn.authCfg );
   mSourceWidget->setInterpretation( conn.interpretation );
@@ -64,7 +64,7 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
   conn.zMax = mSourceWidget->zMax();
   conn.username = mSourceWidget->username();
   conn.password = mSourceWidget->password();
-  conn.referer = mSourceWidget->referer();
+  conn.httpHeaders[QgsHttpHeaders::KEY_REFERER] = mSourceWidget->referer();
   conn.tilePixelRatio = mSourceWidget->tilePixelRatio();
   conn.authCfg = mSourceWidget->authcfg( );
   conn.interpretation = mSourceWidget->interpretation();

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -24,6 +24,8 @@
 #include <qgspoint.h>
 #include "qgslogger.h"
 #include "qgsowsconnection.h"
+#include <QNetworkRequest>
+#include <QUrlQuery>
 
 class TestQgsHttpheaders: public QObject
 {
@@ -39,10 +41,17 @@ class TestQgsHttpheaders: public QObject
     void cleanup() {} // will be called after every testfunction.
 
     void sanitize();
+
     void setFromSettingsGoodKey();
     void setFromSettingsBadKey();
     void updateSettings();
+
     void createQgsOwsConnection();
+
+    void updateNetworkRequest();
+    void updateSetUrlQuery();
+    void updateSetMap();
+    void updateSetDomElement();
 };
 
 void TestQgsHttpheaders::initTestCase()
@@ -139,6 +148,108 @@ void TestQgsHttpheaders::createQgsOwsConnection()
   QgsDataSourceUri uri( QString( "https://www.ogc.org/?p1=v1" ) );
   QgsDataSourceUri uri2 = ows.addWmsWcsConnectionSettings( uri, "service", "name" );
   QCOMPARE( uri2.encodedUri(), "https://www.ogc.org/?p1=v1&http-header:other_http_header=value&http-header:referer=http://test.com" );
+}
+
+
+void TestQgsHttpheaders::updateNetworkRequest()
+{
+  const QUrl url( "http://ogc.org" );
+  QNetworkRequest request( url );
+  QgsHttpHeaders h( QVariantMap( { {QStringLiteral( "key1" ), "value1"},  {QgsHttpHeaders::KEY_REFERER, "my_ref"}} ) );
+  h.updateNetworkRequest( request );
+
+  QVERIFY( request.hasRawHeader( "key1" ) );
+  QCOMPARE( request.rawHeader( "key1" ), "value1" );
+
+  QVERIFY( request.hasRawHeader( QByteArray::fromStdString( QgsHttpHeaders::KEY_REFERER.toStdString() ) ) );
+  QCOMPARE( request.rawHeader( QByteArray::fromStdString( QgsHttpHeaders::KEY_REFERER.toStdString() ) ), "my_ref" );
+}
+
+
+void TestQgsHttpheaders::updateSetUrlQuery()
+{
+  QUrlQuery url( "http://ogc.org" );
+  // === update
+  QgsHttpHeaders h( QVariantMap( { {QStringLiteral( "key1" ), "value1"},  {QgsHttpHeaders::KEY_REFERER, "my_ref"}} ) );
+  h.updateUrlQuery( url );
+
+  QVERIFY( url.hasQueryItem( QgsHttpHeaders::PARAM_PREFIX +  "key1" ) );
+  QCOMPARE( url.queryItemValue( QgsHttpHeaders::PARAM_PREFIX +  "key1" ), "value1" );
+
+  QVERIFY( url.hasQueryItem( QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( url.queryItemValue( QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER ), "my_ref" );
+
+  // TODO mandatory or not?
+  /*QVERIFY( url.hasQueryItem( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( url.queryItemValue( QgsHttpHeaders::KEY_REFERER ), "my_ref" );*/
+
+  // === setFrom
+  QgsHttpHeaders h2;
+  /*  url.removeQueryItem(QgsHttpHeaders::KEY_REFERER);
+    url.addQueryItem( QgsHttpHeaders::KEY_REFERER, "my_ref_root" ); // overwrite root ref to ckeck backward compatibility
+    */
+  h2.setFromUrlQuery( url );
+  QVERIFY( h2.keys().contains( QStringLiteral( "key1" ) ) );
+  QCOMPARE( h2 [ QStringLiteral( "key1" ) ].toString(), QStringLiteral( "value1" ) );
+  QVERIFY( h2.keys().contains( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( h2 [QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "my_ref" ) );
+
+}
+
+
+void TestQgsHttpheaders::updateSetMap()
+{
+  QVariantMap map;
+  // === update
+  QgsHttpHeaders h( QVariantMap( { {QStringLiteral( "key1" ), "value1"},  {QgsHttpHeaders::KEY_REFERER, "my_ref"}} ) );
+  h.updateMap( map );
+
+  QVERIFY( map.contains( QgsHttpHeaders::PARAM_PREFIX +  "key1" ) );
+  QCOMPARE( map[QgsHttpHeaders::PARAM_PREFIX +  "key1"], "value1" );
+
+  QVERIFY( map.contains( QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( map[QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER], "my_ref" );
+
+  QVERIFY( map.contains( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( map[QgsHttpHeaders::KEY_REFERER], "my_ref" );
+
+  // === setFrom
+  QgsHttpHeaders h2;
+  map[QgsHttpHeaders::KEY_REFERER] = "my_ref_root"; // overwrite root ref to ckeck backward compatibility
+  h2.setFromMap( map );
+  QVERIFY( h2.keys().contains( QStringLiteral( "key1" ) ) );
+  QCOMPARE( h2 [ QStringLiteral( "key1" ) ].toString(), QStringLiteral( "value1" ) );
+  QVERIFY( h2.keys().contains( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( h2 [QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "my_ref_root" ) );
+}
+
+
+void TestQgsHttpheaders::updateSetDomElement()
+{
+  QDomDocument doc( QStringLiteral( "connections" ) );
+  QDomElement element = doc.createElement( "qgs" );
+  // === update
+  QgsHttpHeaders h( QVariantMap( { {QStringLiteral( "key1" ), "value1"},  {QgsHttpHeaders::KEY_REFERER, "my_ref"}} ) );
+  h.updateDomElement( element );
+
+  QVERIFY( element.hasAttribute( QgsHttpHeaders::PARAM_PREFIX +  "key1" ) );
+  QCOMPARE( element.attribute( QgsHttpHeaders::PARAM_PREFIX +  "key1" ), "value1" );
+
+  QVERIFY( element.hasAttribute( QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( element.attribute( QgsHttpHeaders::PARAM_PREFIX +  QgsHttpHeaders::KEY_REFERER ), "my_ref" );
+
+  // TODO mandatory or not?
+  QVERIFY( element.hasAttribute( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( element.attribute( QgsHttpHeaders::KEY_REFERER ), "my_ref" );
+
+  // === setFrom
+  QgsHttpHeaders h2;
+  element.setAttribute( QgsHttpHeaders::KEY_REFERER, "my_ref_root" ); // overwrite root ref to ckeck backward compatibility
+  h2.setFromDomElement( element );
+  QVERIFY( h2.keys().contains( QStringLiteral( "key1" ) ) );
+  QCOMPARE( h2 [ QStringLiteral( "key1" ) ].toString(), QStringLiteral( "value1" ) );
+  QVERIFY( h2.keys().contains( QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( h2 [QgsHttpHeaders::KEY_REFERER ].toString(), QStringLiteral( "my_ref_root" ) );
 }
 
 QGSTEST_MAIN( TestQgsHttpheaders )

--- a/tests/src/core/testqgshttpheaders.cpp
+++ b/tests/src/core/testqgshttpheaders.cpp
@@ -75,8 +75,8 @@ void TestQgsHttpheaders::setFromSettings( const QString &keyBase )
   settings.remove( keyBase ); // cleanup
 
   settings.setValue( keyBase + outOfHeaderKey, "value" );
-  settings.setValue( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1", "value1" );
-  settings.setValue( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER, "valueHH_R" );
+  settings.setValue( keyBase + QgsHttpHeaders::PATH_PREFIX + "key1", "value1" );
+  settings.setValue( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER, "valueHH_R" );
 
   QgsHttpHeaders h( settings, keyBase );
   QVERIFY( ! h.keys().contains( outOfHeaderKey ) );
@@ -99,26 +99,26 @@ void TestQgsHttpheaders::updateSettings()
 
   QgsHttpHeaders h( QVariantMap( { {QStringLiteral( "key1" ), "value1"}} ) );
   h.updateSettings( settings, keyBase );
-  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1" ) );
-  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + "key1" ).toString(), "value1" );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::PATH_PREFIX + "key1" ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::PATH_PREFIX + "key1" ).toString(), "value1" );
 
   QVERIFY( ! settings.contains( keyBase + QgsHttpHeaders::KEY_REFERER ) );
-  QVERIFY( ! settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
+  QVERIFY( ! settings.contains( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
 
   // at old location
   settings.remove( keyBase + QgsHttpHeaders::KEY_REFERER );
   h [QgsHttpHeaders::KEY_REFERER] = QStringLiteral( "http://gg.com" );
 
   h.updateSettings( settings, keyBase );
-  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
-  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER ).toString(), "http://gg.com" );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER ).toString(), "http://gg.com" );
   QVERIFY( ! settings.contains( keyBase + QgsHttpHeaders::KEY_REFERER ) );
 
   // test backward compatibility
   settings.setValue( keyBase + QgsHttpHeaders::KEY_REFERER, "paf" ) ; // legacy referer, should be overridden
   h.updateSettings( settings, keyBase );
-  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
-  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER ).toString(), "http://gg.com" );
+  QVERIFY( settings.contains( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER ) );
+  QCOMPARE( settings.value( keyBase + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER ).toString(), "http://gg.com" );
   QVERIFY( settings.contains( keyBase + QgsHttpHeaders::KEY_REFERER ) );
   QCOMPARE( settings.value( keyBase + QgsHttpHeaders::KEY_REFERER ).toString(), "http://gg.com" );
 }
@@ -127,18 +127,18 @@ void TestQgsHttpheaders::updateSettings()
 void TestQgsHttpheaders::createQgsOwsConnection()
 {
   QgsSettings settings;
-  settings.setValue( QString( QgsSettings::Prefix::QGIS ) + "/connections-service/name/" + QgsHttpHeaders::KEY_PREFIX + QgsHttpHeaders::KEY_REFERER,
+  settings.setValue( QString( QgsSettings::Prefix::QGIS ) + "/connections-service/name/" + QgsHttpHeaders::PATH_PREFIX + QgsHttpHeaders::KEY_REFERER,
                      "http://test.com" );
-  settings.setValue( QString( QgsSettings::Prefix::QGIS ) + "/connections-service/name/" + QgsHttpHeaders::KEY_PREFIX + "other_http_header",
+  settings.setValue( QString( QgsSettings::Prefix::QGIS ) + "/connections-service/name/" + QgsHttpHeaders::PATH_PREFIX + "other_http_header",
                      "value" );
 
   QgsOwsConnection ows( "service", "name" );
   QCOMPARE( ows.connectionInfo(), ",authcfg=,referer=http://test.com" );
-  QCOMPARE( ows.uri().encodedUri(), "referer=http://test.com&url" );
+  QCOMPARE( ows.uri().encodedUri(), "url&http-header:other_http_header=value&http-header:referer=http://test.com" );
 
   QgsDataSourceUri uri( QString( "https://www.ogc.org/?p1=v1" ) );
   QgsDataSourceUri uri2 = ows.addWmsWcsConnectionSettings( uri, "service", "name" );
-  QCOMPARE( uri2.encodedUri(), "https://www.ogc.org/?p1=v1&other_http_header=value&referer=http://test.com" );
+  QCOMPARE( uri2.encodedUri(), "https://www.ogc.org/?p1=v1&http-header:other_http_header=value&http-header:referer=http://test.com" );
 }
 
 QGSTEST_MAIN( TestQgsHttpheaders )

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -478,7 +478,7 @@ class TestPyQgsAFSProvider(unittest.TestCase, ProviderTestCase):
         """
         parts = {'url': 'http://blah.com', 'crs': 'epsg:4326', 'referer': 'me', 'bounds': QgsRectangle(1, 2, 3, 4)}
         uri = QgsProviderRegistry.instance().encodeUri(self.vl.dataProvider().name(), parts)
-        self.assertEqual(uri, " bbox='1,2,3,4' crs='epsg:4326' referer='me' url='http://blah.com'")
+        self.assertEqual(uri, " bbox='1,2,3,4' crs='epsg:4326' url='http://blah.com' http-header:referer='me' referer='me'")
 
     def testObjectIdDifferentName(self):
         """ Test that object id fields not named OBJECTID work correctly """

--- a/tests/src/python/test_qgsgeonodeconnection.py
+++ b/tests/src/python/test_qgsgeonodeconnection.py
@@ -57,7 +57,7 @@ class TestQgsGeoNodeConnection(unittest.TestCase):
         uri = c.uri()
         c.addWmsConnectionSettings(uri)
 
-        self.assertEqual(uri.param('referer'), 'my_ref')
+        self.assertEqual(uri.httpHeader('referer'), 'my_ref')
         self.assertEqual(uri.param('IgnoreGetMapUrl'), '1')
         self.assertEqual(uri.param('IgnoreGetFeatureInfoUrl'), '1')
         self.assertEqual(uri.param('SmoothPixmapTransform'), '1')

--- a/tests/src/python/test_qgsowsconnection.py
+++ b/tests/src/python/test_qgsowsconnection.py
@@ -54,7 +54,7 @@ class TestQgsOwsConnection(unittest.TestCase):
         uri = c.uri()
 
         self.assertEqual(uri.param('url'), 'aaa.bbb.com')
-        self.assertEqual(uri.param('referer'), 'my_ref')
+        self.assertEqual(uri.httpHeader('referer'), 'my_ref')
         self.assertEqual(uri.param('IgnoreGetMapUrl'), '1')
         self.assertEqual(uri.param('IgnoreGetFeatureInfoUrl'), '1')
         self.assertEqual(uri.param('SmoothPixmapTransform'), '1')
@@ -66,7 +66,7 @@ class TestQgsOwsConnection(unittest.TestCase):
         uri = QgsDataSourceUri()
         QgsOwsConnection.addWmsWcsConnectionSettings(uri, 'qgis/connections-wms/test/')
 
-        self.assertEqual(uri.param('referer'), 'my_ref')
+        self.assertEqual(uri.httpHeader('referer'), 'my_ref')
         self.assertEqual(uri.param('IgnoreGetMapUrl'), '1')
         self.assertEqual(uri.param('IgnoreGetFeatureInfoUrl'), '1')
         self.assertEqual(uri.param('SmoothPixmapTransform'), '1')

--- a/tests/src/python/test_qgsvectortile.py
+++ b/tests/src/python/test_qgsvectortile.py
@@ -110,13 +110,13 @@ class TestVectorTile(unittest.TestCase):
         uri = md.encodeUri(parts)
         self.assertEqual(uri, 'type=xyz&url=https://fake.new.server/%7Bx%7D/%7By%7D/%7Bz%7D.png&zmax=2&zmin=0')
 
-        uri = 'type=xyz&serviceType=arcgis&url=https://fake.server/%7Bx%7D/%7By%7D/%7Bz%7D.png&zmax=2&referer=https://qgis.org/&styleUrl=https://qgis.org/'
+        uri = 'type=xyz&serviceType=arcgis&url=https://fake.server/%7Bx%7D/%7By%7D/%7Bz%7D.png&zmax=2&http-header:referer=https://qgis.org/&styleUrl=https://qgis.org/'
         parts = md.decodeUri(uri)
-        self.assertEqual(parts, {'type': 'xyz', 'serviceType': 'arcgis', 'url': 'https://fake.server/{x}/{y}/{z}.png', 'zmax': '2', 'referer': 'https://qgis.org/', 'styleUrl': 'https://qgis.org/'})
+        self.assertEqual(parts, {'type': 'xyz', 'serviceType': 'arcgis', 'url': 'https://fake.server/{x}/{y}/{z}.png', 'zmax': '2', 'http-header:referer': 'https://qgis.org/', 'referer': 'https://qgis.org/', 'styleUrl': 'https://qgis.org/'})
 
         parts['url'] = 'https://fake.new.server/{x}/{y}/{z}.png'
         uri = md.encodeUri(parts)
-        self.assertEqual(uri, 'referer=https://qgis.org/&serviceType=arcgis&styleUrl=https://qgis.org/&type=xyz&url=https://fake.new.server/%7Bx%7D/%7By%7D/%7Bz%7D.png&zmax=2')
+        self.assertEqual(uri, 'serviceType=arcgis&styleUrl=https://qgis.org/&type=xyz&url=https://fake.new.server/%7Bx%7D/%7By%7D/%7Bz%7D.png&zmax=2&http-header:referer=https://qgis.org/')
 
     def testZoomRange(self):
         """


### PR DESCRIPTION
Fix issue #48532 

* add constructor without QgsSettings, using default
* add new const QgsHttpHeaders::KEY_REFERER
* add test for QgsOwsConnection
* QgsOwsConnection:
  * fix usage of "referer" by using QgsHttpHeaders
  * replace "qgis/" prefix by QgsSettings::Prefix::QGIS

