### PR TITLE
fix output items placement when they are added after addition of the algorithm item (fix #48132)

### DIFF
--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -227,8 +227,8 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
     // offsets from algorithm item needed to correctly place output items
     // which does not have valid position assigned (https://github.com/qgis/QGIS/issues/48132)
     QgsProcessingModelComponent *algItem = mChildAlgorithmItems[it.value().childId()]->component();
-    const double output_offset_x = algItem->size().width();
-    double output_offset_y = 1.5 * algItem->size().height();
+    const double outputOffsetX = algItem->size().width();
+    double outputOffsetY = 1.5 * algItem->size().height();
 
     for ( auto outputIt = outputs.constBegin(); outputIt != outputs.constEnd(); ++outputIt )
     {
@@ -244,8 +244,8 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       QPointF pos = outputIt.value().position();
       if ( pos.isNull() )
       {
-        pos = algItem->position() + QPointF( output_offset_x, output_offset_y );
-        output_offset_y += 1.5 * outputIt.value().size().height();
+        pos = algItem->position() + QPointF( outputOffsetX, outputOffsetY );
+        outputOffsetY += 1.5 * outputIt.value().size().height();
       }
       int idx = -1;
       int i = 0;

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -226,8 +226,9 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
 
     // offsets from algorithm item needed to correctly place output items
     // which does not have valid position assigned (https://github.com/qgis/QGIS/issues/48132)
-    double output_offset_x = mChildAlgorithmItems[it.value().childId()]->component()->size().width();
-    double output_offset_y = 1.5 * mChildAlgorithmItems[it.value().childId()]->component()->size().height();
+    QgsProcessingModelComponent *algItem = mChildAlgorithmItems[it.value().childId()]->component();
+    const double output_offset_x = algItem->size().width();
+    double output_offset_y = 1.5 * algItem->size().height();
 
     for ( auto outputIt = outputs.constBegin(); outputIt != outputs.constEnd(); ++outputIt )
     {
@@ -243,7 +244,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       QPointF pos = outputIt.value().position();
       if ( pos.isNull() )
       {
-        pos = mChildAlgorithmItems[it.value().childId()]->component()->position() + QPointF( output_offset_x, output_offset_y );
+        pos = algItem->position() + QPointF( output_offset_x, output_offset_y );
         output_offset_y += 1.5 * outputIt.value().size().height();
       }
       int idx = -1;


### PR DESCRIPTION
## Description
When algorithm item added to a model and output is defined as well, then output item placed near the corresponding algorithm as in the image below
![зображення](https://user-images.githubusercontent.com/776954/169012185-5585c733-df6e-42f8-a60e-a0aa3667716c.png)

However, if output is not defined at this stage but added later by editing algorithm item, output item is placed at the (0,0) position.
![зображення](https://user-images.githubusercontent.com/776954/169013292-d54ae1ad-f000-4022-a8ff-9bc5913c4f96.png)

This happens because in that case output item does not have a valid position assigned.

Fixes #48132.