### PR TITLE
correctly restore state of the Processing settings when search text is cleared (fix #34543)

### DIFF
--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -132,14 +132,13 @@ class ConfigDialog(BASE, WIDGET):
             text = str(text.lower())
         else:
             text = str(self.searchBox.text().lower())
-        found = self._filterItem(self.model.invisibleRootItem(), text)
+        found = self._filterItem(self.model.invisibleRootItem(), text, False if text else True)
 
         self.auto_adjust_columns = False
         if text:
             self.tree.expandAll()
         else:
             self.tree.collapseAll()
-
         self.adjustColumns()
         self.auto_adjust_columns = True
 


### PR DESCRIPTION
## Description
Processing settings tree is not restored after clearing removing text from the filter field in the top-left corner of the QGIS options dialog. To bring it back one have to close and re-open QGIS settings dialog.

Fixes #34543.