### PR TITLE
Fix paste feature to memory layer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11127,10 +11127,9 @@ std::unique_ptr<QgsVectorLayer> QgisApp::pasteToNewMemoryVector()
   // Convert attributes
   for ( auto it = convertedFeatures.begin(); it != convertedFeatures.end(); ++it )
   {
-    for ( int idx = 0; idx < layer->fields().count(); ++idx )
+    for ( int idx = 0; idx < layer->fields().count() && idx < it->attributeCount(); ++idx )
     {
       QVariant attr { it->attribute( idx ) };
-      QString error;
       if ( layer->fields().at( idx ).convertCompatible( attr ) )
       {
         it->setAttribute( idx, attr );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11129,7 +11129,7 @@ std::unique_ptr<QgsVectorLayer> QgisApp::pasteToNewMemoryVector()
   {
     for ( int idx = 0; idx < layer->fields().count() && idx < it->attributeCount(); ++idx )
     {
-      QVariant attr { it->attribute( idx ) };
+      QVariant attr = it->attribute( idx );
       if ( layer->fields().at( idx ).convertCompatible( attr ) )
       {
         it->setAttribute( idx, attr );

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -563,6 +563,7 @@ bool QgsMemoryProvider::deleteFeatures( const QgsFeatureIds &id )
 
 bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
 {
+  bool fieldWasAdded { false };
   for ( QgsField field : attributes )
   {
     if ( !supportedType( field ) )
@@ -597,6 +598,7 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
 
     // add new field as a last one
     mFields.append( field );
+    fieldWasAdded = true;
 
     for ( QgsFeatureMap::iterator fit = mFeatures.begin(); fit != mFeatures.end(); ++fit )
     {
@@ -606,7 +608,7 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
       f.setAttributes( attr );
     }
   }
-  return true;
+  return fieldWasAdded;
 }
 
 bool QgsMemoryProvider::renameAttributes( const QgsFieldNameMap &renamedAttributes )


### PR DESCRIPTION
Fix #48401 by falling back to string type

Also correctly report false when addAttributes fails.

![immagine](https://user-images.githubusercontent.com/142164/169063893-a4f547a0-986a-4fc2-874f-74b4ba43ddf5.png)
