### PR TITLE
Fix crash in qgsrelationwidgetwrapper

### DIFF
--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -162,6 +162,10 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
   if ( !w )
   {
     w = QgsGui::relationWidgetRegistry()->create( mRelationEditorId, widgetConfig(), editor );
+    if ( ! editor->layout() )
+    {
+      editor->setLayout( new QVBoxLayout( editor ) );
+    }
     editor->layout()->addWidget( w );
   }
 


### PR DESCRIPTION
Related to #48443, not a fix of the reported issue because the usage of
the widget in the ui is not correct.

Very corner case but a crash is still a crash and we don't like them.