### PR TITLE
fallback to EPSG:4326 as output CRS in Nominatim geocoder algorithm (fix #48385)

### DIFF
--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
@@ -44,6 +44,12 @@ QStringList QgsBatchNominatimGeocodeAlgorithm::tags() const
   return QObject::tr( "geocode,nominatim,batch,bulk,address,match" ).split( ',' );
 }
 
+QgsCoordinateReferenceSystem QgsBatchNominatimGeocodeAlgorithm::outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const
+{
+  mOutputCrs = inputCrs.isValid() ? inputCrs : QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  return mOutputCrs;
+}
+
 QgsBatchNominatimGeocodeAlgorithm *QgsBatchNominatimGeocodeAlgorithm::createInstance() const
 {
   return new QgsBatchNominatimGeocodeAlgorithm();

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.h
@@ -48,11 +48,13 @@ class QgsBatchNominatimGeocodeAlgorithm : public QgsBatchGeocodeAlgorithm
     QgsBatchNominatimGeocodeAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
+    QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
 
     QgsNominatimGeocoder mNominatimGeocoder;
+    mutable QgsCoordinateReferenceSystem mOutputCrs;
 
 };
 


### PR DESCRIPTION
## Description

Batch Nominatim Geocoder algorithm sets output CRS from input layer. But if input is a geometry-less table output layer does not have a CRS assigned which should be EPSG:4326 in this case.

Fixes #48385.