### PR TITLE
Fix switching attribute table to multiedit mode can immediately apply changes to selected features

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1018,7 +1018,8 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
         if ( !mButtonBox->isVisible() )
           mMessageBar->pushItem( mMultiEditUnsavedMessageBarItem );
 
-        emit widgetValueChanged( eww->field().name(), value, !mIsSettingFeature );
+        emit widgetValueChanged( eww->field().name(), value, false );
+        signalEmitted = true;
       }
       break;
     }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1043,7 +1043,11 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
     Q_NOWARN_DEPRECATED_PUSH
     emit attributeChanged( eww->field().name(), value );
     Q_NOWARN_DEPRECATED_POP
-    emit widgetValueChanged( eww->field().name(), value, !mIsSettingFeature );
+    bool attributeHasChanged = !mIsSettingFeature;
+    if ( mMode == QgsAttributeEditorContext::MultiEditMode )
+      attributeHasChanged &= !mIsSettingMultiEditFeatures;
+
+    emit widgetValueChanged( eww->field().name(), value, attributeHasChanged );
   }
 }
 

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -709,12 +709,16 @@ void TestQgsAttributeTable::testCopySelectedRows()
 
   const QgsFeatureList features = clipboard->copyOf();
   QCOMPARE( features.count(), 2 );
-  QCOMPARE( features.at( 0 ).attribute( 0 ), 1 );
-  QCOMPARE( features.at( 0 ).attribute( "col1" ), 2 );
-  QCOMPARE( features.at( 0 ).attribute( "col2" ), QVariant() );
-  QCOMPARE( features.at( 1 ).attribute( "pk" ), 2 );
-  QCOMPARE( features.at( 1 ).attribute( "col1" ), 4 );
-  QCOMPARE( features.at( 1 ).attribute( 2 ), QVariant() );
+
+  const int feature1Index = features.at( 0 ).attribute( 0 ).toInt() == 1 ? 0 : 1;
+  const int feature2Index = feature1Index == 0 ? 1 : 0;
+
+  QCOMPARE( features.at( feature1Index ).attribute( 0 ), 1 );
+  QCOMPARE( features.at( feature1Index ).attribute( "col1" ), 2 );
+  QCOMPARE( features.at( feature1Index ).attribute( "col2" ), QVariant() );
+  QCOMPARE( features.at( feature2Index ).attribute( "pk" ), 2 );
+  QCOMPARE( features.at( feature2Index ).attribute( "col1" ), 4 );
+  QCOMPARE( features.at( feature2Index ).attribute( 2 ), QVariant() );
 
   QCOMPARE( clipboard->crs().authid(), "EPSG:3111" );
 }


### PR DESCRIPTION
Should skip queued backports as it can result in data loss