### PR TITLE
Server EXTERNAL_WMS case insensitive

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1971,8 +1971,21 @@ namespace QgsWms
     return param;
   }
 
-  QString QgsWmsParameters::externalWMSUri( const QString &id ) const
+  QString QgsWmsParameters::externalWMSUri( const QString &layerId ) const
   {
+
+    // Param names may be uppercased.
+    QString id { layerId };
+
+    for ( auto it = mExternalWMSParameters.cbegin(); it != mExternalWMSParameters.cend(); ++it )
+    {
+      if ( it.key().compare( id, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+      {
+        id = it.key();
+        break;
+      }
+    }
+
     if ( !mExternalWMSParameters.contains( id ) )
     {
       return QString();

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -819,7 +819,7 @@ bool QgsWmsRenderContext::isExternalLayer( const QString &name ) const
 {
   for ( const auto &layer : mExternalLayers )
   {
-    if ( layer->name().compare( name ) == 0 )
+    if ( layerNickname( *layer ).compare( name ) == 0 )
       return true;
   }
 

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -518,6 +518,7 @@ void QgsWmsRenderContext::searchLayersToRenderStyle()
 
     if ( ! param.mExternalUri.isEmpty() && ( mFlags & AddExternalLayers ) )
     {
+
       std::unique_ptr<QgsMapLayer> layer = std::make_unique< QgsRasterLayer >( param.mExternalUri, param.mNickname, QStringLiteral( "wms" ) );
 
       if ( layer->isValid() )

--- a/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_parameters.cpp
@@ -76,6 +76,26 @@ void TestQgsServerWmsParameters::external_layers()
   QCOMPARE( layers_params[0].mOpacity, 255 );
   QCOMPARE( layers_params[1].mOpacity, 200 );
   QCOMPARE( layers_params[2].mOpacity, 125 );
+
+  // Upper case
+  QUrlQuery query2;
+  query2.addQueryItem( "LAYERS", "EXTERNAL_WMS:external_layer_1,layer,EXTERNAL_WMS:external_layer_2" );
+  query2.addQueryItem( "EXTERNAL_LAYER_1:url", "http://url_1" );
+  query2.addQueryItem( "EXTERNAL_LAYER_1:layers", "layer_1_name" );
+  query2.addQueryItem( "external_layer_2:url", "http://url_2" );
+  query2.addQueryItem( "external_layer_2:layers", "layer_2_name" );
+  query2.addQueryItem( "external_layer_2:opacities", "100" );
+  query2.addQueryItem( "OPACITIES", "255,200,125" );
+
+  const QgsWms::QgsWmsParameters parameters2( query );
+  QList<QgsWms::QgsWmsParametersLayer> layers_params2 = parameters2.layersParameters();
+  QCOMPARE( layers_params2.size(), 3 );
+
+  QgsWms::QgsWmsParametersLayer layer_params2 = layers_params2[0];
+  QCOMPARE( layer_params2.mNickname, QString( "external_layer_1" ) );
+  QCOMPARE( layer_params2.mExternalUri, QString( "layers=layer_1_name&url=http://url_1" ) );
+
+
 }
 
 void TestQgsServerWmsParameters::percent_encoding()


### PR DESCRIPTION
Be tolerant to case when passing EXTERNAL_WMS in the query string.

Fixes #48640

I'd recommend to backport this straight away.