### PR TITLE
ignore non-existent items when collecting selected options in multipleselection widget (fix #47728)

### DIFF
--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -95,9 +95,15 @@ QVariantList QgsProcessingMultipleSelectionPanelWidget::selectedOptions() const
   bool hasModelSources = false;
   for ( int i = 0; i < mModel->rowCount(); ++i )
   {
-    if ( mModel->item( i )->checkState() == Qt::Checked )
+    QStandardItem *item = mModel->item( i );
+    if ( !item )
     {
-      const QVariant option = mModel->item( i )->data( Qt::UserRole );
+      continue;
+    }
+
+    if ( item->checkState() == Qt::Checked )
+    {
+      const QVariant option = item->data( Qt::UserRole );
 
       if ( option.canConvert< QgsProcessingModelChildParameterSource >() )
         hasModelSources = true;


### PR DESCRIPTION
## Description
Dragging multiple items in Processing multipleselection widget crashes QGIS when selected options are collected. As move operation involves creation and deletion of items we should check whether item is valid before accessing its methods.

Fixes #47728.