### PR TITLE
Fix a server WFS GetFeature issue with wrong projected envelope

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1224,24 +1224,19 @@ namespace QgsWfs
                                   ! srsName.startsWith( QLatin1String( "EPSG:" ) ) };
 
           // If requested SRS (srsName) is different from rect CRS (crs) we need to transform the envelope
-          QgsRectangle crsCorrectedRect { rect ? *rect : QgsRectangle() };
           QgsCoordinateTransform transform;
           transform.setSourceCrs( crs );
           transform.setDestinationCrs( QgsCoordinateReferenceSystem( srsName ) );
-          QgsGeometry exportGeom { QgsGeometry::fromRect( *rect ) };
+          QgsRectangle crsCorrectedRect { rect ? *rect : QgsRectangle() };
+
           try
           {
-            if ( exportGeom.transform( transform ) == Qgis::GeometryOperationResult::Success )
-            {
-              crsCorrectedRect = exportGeom.boundingBox();
-            }
+            crsCorrectedRect = transform.transformBoundingBox( crsCorrectedRect );
           }
           catch ( QgsException &cse )
           {
             Q_UNUSED( cse )
           }
-
-          exportGeom.transform( transform );
 
           QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( &crsCorrectedRect, doc, srsName, invertAxis, prec );
           if ( !envElem.isNull() )

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1222,7 +1222,28 @@ namespace QgsWfs
           const bool invertAxis { mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) &&
                                   crs.hasAxisInverted() &&
                                   ! srsName.startsWith( QLatin1String( "EPSG:" ) ) };
-          QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( rect, doc, srsName, invertAxis, prec );
+
+          // If requested SRS (srsName) is different from rect CRS (crs) we need to transform the envelope
+          QgsRectangle crsCorrectedRect { rect ? *rect : QgsRectangle() };
+          QgsCoordinateTransform transform;
+          transform.setSourceCrs( crs );
+          transform.setDestinationCrs( QgsCoordinateReferenceSystem( srsName ) );
+          QgsGeometry exportGeom { QgsGeometry::fromRect( *rect ) };
+          try
+          {
+            if ( exportGeom.transform( transform ) == Qgis::GeometryOperationResult::Success )
+            {
+              crsCorrectedRect = exportGeom.boundingBox();
+            }
+          }
+          catch ( QgsException &cse )
+          {
+            Q_UNUSED( cse )
+          }
+
+          exportGeom.transform( transform );
+
+          QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( &crsCorrectedRect, doc, srsName, invertAxis, prec );
           if ( !envElem.isNull() )
           {
             if ( crs.isValid() && srsName.isEmpty() )

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -866,6 +866,38 @@ class TestQgsServerWFS(QgsServerTestBase):
         self.assertEqual([c[:4] for c in e.findall('.//')[0].text.split(' ')], ['7.25', '44.7'])
         self.assertEqual([c[:4] for c in e.findall('.//')[1].text.split(' ')], ['7.29', '44.8'])
 
+        query_string = "?" + "&".join(["%s=%s" % i for i in list({
+            "SERVICE": "WFS",
+            "REQUEST": "GetFeature",
+            "VERSION": "1.1.0",
+            "TYPENAME": "layer",
+            "SRSNAME": "EPSG:4326",
+            "BBOX": "7.2,44.5,8.2,45.1,EPSG:4326"
+        }.items())])
+
+        header, body = self._execute_request_project(query_string, project)
+        root = et.fromstring(body)
+        e = root.findall('.//gml:Envelope', root.nsmap)[0]
+        self.assertEqual(e.attrib, {'srsName': 'EPSG:4326'})
+        self.assertEqual([c[:4] for c in e.findall('.//')[0].text.split(' ')], ['7.2', '44.5'])
+        self.assertEqual([c[:4] for c in e.findall('.//')[1].text.split(' ')], ['8.2', '45.1'])
+
+        query_string = "?" + "&".join(["%s=%s" % i for i in list({
+            "SERVICE": "WFS",
+            "REQUEST": "GetFeature",
+            "VERSION": "1.1.0",
+            "TYPENAME": "layer",
+            "SRSNAME": "EPSG:4326",
+            "BBOX": "807305,5589555,812191,5592878,EPSG:3857"
+        }.items())])
+
+        header, body = self._execute_request_project(query_string, project)
+        root = et.fromstring(body)
+        e = root.findall('.//gml:Envelope', root.nsmap)[0]
+        self.assertEqual(e.attrib, {'srsName': 'EPSG:4326'})
+        self.assertEqual([c[:4] for c in e.findall('.//')[0].text.split(' ')], ['7.25', '44.7'])
+        self.assertEqual([c[:4] for c in e.findall('.//')[1].text.split(' ')], ['7.29', '44.8'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #48642

When requesting GetFeature on a single layer, the collection's
envelope was always in layer's CRS ignoring SRSNAME.