### PR TITLE
Map canvas: avoid pan action freeze after use of middle mouse button …

### DIFF
--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1460,6 +1460,15 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
      */
     void endZoomRect( QPoint pos );
 
+    //! Stop/cancel zooming via rectangle
+    void stopZoomRect();
+
+    //! Start map pan
+    void startPan();
+
+    //! Stop map pan
+    void stopPan();
+
     /**
      * Returns bounding box of feature list (in canvas coordinates)
      * \param ids feature id list


### PR DESCRIPTION
…and then right button (fixes #48645)

The resolution is to stop the pan action, similarly to what is done when
having the pan tool enabled and starting to pan with left button, and
then right clicking to display the contextual menu.

Also fixes as similar issue with shift+middle button (zoom rect action),
followed by right button press event.
