### PR TITLE
Fix oracle attr order in queries

### DIFF
--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -28,6 +28,8 @@
 
 #include <QObject>
 
+#include <algorithm>
+
 QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsOracleFeatureSource>( source, ownSource, request )
 {
@@ -107,6 +109,9 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
   }
   else
     mAttributeList = mSource->mFields.allAttributesList();
+
+  // Sort for query planners peace of mind: https://github.com/qgis/QGIS/issues/35309
+  std::sort( mAttributeList.begin(), mAttributeList.end() );
 
   bool limitAtProvider = ( mRequest.limit() >= 0 ) && mRequest.spatialFilterType() != Qgis::SpatialFilterType::DistanceWithin;
   QString whereClause;


### PR DESCRIPTION
Fixes #35309

Long story short: there are multiple places where the attributes are manipulated as QSet (which is not ordered) I guess to avoid duplicates and converted back to a list.

I tried to fix it at an higher level in order to fix it for all providers but then provider iterators like oracle choose to process them again, so it's safer to apply the sorting in the iterator itself when all the possible processing are done.

