### PR TITLE
Fix crash when removing unavailable layers in the handle unavailable layers dialog

### DIFF
--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -109,6 +109,9 @@ void QgsLayerTreeViewFilterIndicatorProvider::connectSignals( QgsMapLayer *layer
 
 void QgsLayerTreeViewFilterIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
 {
+  if ( !layer )
+    return;
+
   QgsLayerTreeViewIndicatorProvider::disconnectSignals( layer );
   switch ( layer->type() )
   {

--- a/src/app/qgslayertreeviewindicatorprovider.cpp
+++ b/src/app/qgslayertreeviewindicatorprovider.cpp
@@ -85,7 +85,8 @@ void QgsLayerTreeViewIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *
     else if ( QgsLayerTree::isLayer( childNode ) )
     {
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
+      if ( childLayerNode->layer() &&
+           QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
         disconnectSignals( childLayerNode->layer() );
     }
   }


### PR DESCRIPTION
## Description

Stumbled on #48184 while looking into something else; this PR fixes the crash (one pointer check to saveguard from the crash in qgslayertreeviewindicatorprovider.cpp and another to prevent a Qt disconnect-against-null error in qgslayertreeviewfilterindicator.cpp)
