### PR TITLE
Fix crash after running model from history dialog

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -490,6 +490,13 @@ This method returns a fallback value of "las".
 .. versionadded:: 3.24
 %End
 
+    static QVariantMap removePointerValuesFromMap( const QVariantMap &map );
+%Docstring
+Removes any raw pointer values from an input ``map``, replacing them with
+appropriate string values where possible.
+
+.. versionadded:: 3.26
+%End
 
 };
 

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -374,7 +374,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       if ( feedback && !skipGenericLogging )
         feedback->setProgressText( QObject::tr( "Running %1 [%2/%3]" ).arg( child.description() ).arg( executed.count() + 1 ).arg( toExecute.count() ) );
 
-      childInputs.insert( childId, childParams );
+      childInputs.insert( childId, QgsProcessingUtils::removePointerValuesFromMap( childParams ) );
       QStringList params;
       for ( auto childParamIt = childParams.constBegin(); childParamIt != childParams.constEnd(); ++childParamIt )
       {

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1323,6 +1323,62 @@ QString QgsProcessingUtils::defaultPointCloudExtension()
   return QStringLiteral( "las" );
 }
 
+QVariantMap QgsProcessingUtils::removePointerValuesFromMap( const QVariantMap &map )
+{
+  auto layerPointerToString = []( QgsMapLayer * layer ) -> QString
+  {
+    if ( layer && layer->providerType() == QLatin1String( "memory" ) )
+      return layer->id();
+    else if ( layer )
+      return layer->source();
+    else
+      return QString();
+  };
+
+  auto cleanPointerValues = [&layerPointerToString]( const QVariant & value ) -> QVariant
+  {
+    if ( QgsMapLayer *layer = qobject_cast< QgsMapLayer * >( value.value< QObject * >() ) )
+    {
+      // don't store pointers in maps for long-term storage
+      return layerPointerToString( layer );
+    }
+    else if ( value.userType() == QMetaType::type( "QPointer< QgsMapLayer >" ) )
+    {
+      // don't store pointers in maps for long-term storage
+      return layerPointerToString( value.value< QPointer< QgsMapLayer > >().data() );
+    }
+    else
+    {
+      return value;
+    }
+  };
+
+  QVariantMap res;
+  for ( auto it = map.constBegin(); it != map.constEnd(); ++it )
+  {
+    if ( it->type() == QVariant::Map )
+    {
+      res.insert( it.key(), removePointerValuesFromMap( it.value().toMap() ) );
+    }
+    else if ( it->type() == QVariant::List )
+    {
+      QVariantList dest;
+      const QVariantList source = it.value().toList();
+      dest.reserve( source.size() );
+      for ( const QVariant &v : source )
+      {
+        dest.append( cleanPointerValues( v ) );
+      }
+      res.insert( it.key(), dest );
+    }
+    else
+    {
+      res.insert( it.key(), cleanPointerValues( it.value() ) );
+    }
+  }
+  return res;
+}
+
 //
 // QgsProcessingFeatureSource
 //

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -494,6 +494,13 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QString defaultPointCloudExtension();
 
+    /**
+     * Removes any raw pointer values from an input \a map, replacing them with
+     * appropriate string values where possible.
+     *
+     * \since QGIS 3.26
+     */
+    static QVariantMap removePointerValuesFromMap( const QVariantMap &map );
 
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -712,6 +712,7 @@ class TestQgsProcessing: public QObject
     void uniqueValues();
     void createIndex();
     void generateTemporaryDestination();
+    void removePointerValuesFromMap();
     void parseDestinationString();
     void createFeatureSink();
 #ifdef ENABLE_PGTEST
@@ -2009,6 +2010,39 @@ void TestQgsProcessing::generateTemporaryDestination()
   f = QFileInfo( def3->generateTemporaryDestination() );
   QCOMPARE( f.completeSuffix(), QString( "gpkg" ) );
 
+}
+
+void TestQgsProcessing::removePointerValuesFromMap()
+{
+  std::unique_ptr< QgsVectorLayer > vl = std::make_unique< QgsVectorLayer >( "Point?crs=epsg:3111", "v1", "memory" );
+  const QString raster1 = QStringLiteral( TEST_DATA_DIR ) + '/' + "landsat_4326.tif";
+  std::unique_ptr< QgsRasterLayer > rl = std::make_unique< QgsRasterLayer >( raster1, "R1" );
+  QPointer< QgsMapLayer > rl1Pointer( rl.get() );
+
+  const QVariantMap source {{ QStringLiteral( "k1" ), 5 },
+    { QStringLiteral( "k2" ), QStringLiteral( "aa" ) },
+    { QStringLiteral( "k3" ), QVariantList() << QStringLiteral( "aa" ) << 3 << QVariant::fromValue( vl.get() ) },
+    {
+      QStringLiteral( "k4" ), QVariantMap{{ QStringLiteral( "kk1" ), 5},
+        {QStringLiteral( "kk2" ), QVariant::fromValue( rl1Pointer ) }}
+    }
+  };
+
+  const QVariantMap res = QgsProcessingUtils::removePointerValuesFromMap( source );
+
+  QCOMPARE( res.size(), 4 );
+  QCOMPARE( res.value( QStringLiteral( "k1" ) ).toInt(), 5 );
+  QCOMPARE( res.value( QStringLiteral( "k2" ) ).toString(), QStringLiteral( "aa" ) );
+  const QVariantList list = res.value( QStringLiteral( "k3" ) ).toList();
+  QCOMPARE( list.size(), 3 );
+  QCOMPARE( list.at( 0 ).toString(), QStringLiteral( "aa" ) );
+  QCOMPARE( list.at( 1 ).toInt(), 3 );
+  QCOMPARE( list.at( 2 ).toString(), vl->id() );
+
+  const QVariantMap subMap = res.value( QStringLiteral( "k4" ) ).toMap();
+  QCOMPARE( subMap.size(), 2 );
+  QCOMPARE( subMap.value( QStringLiteral( "kk1" ) ).toInt(), 5 );
+  QCOMPARE( subMap.value( QStringLiteral( "kk2" ) ).toString(), rl->source() );
 }
 
 void TestQgsProcessing::parseDestinationString()


### PR DESCRIPTION
Ensure we don't store any map layer pointer values for long-term
use, and instead transform them to appropriate string values instead

Fixes #40258
