### PR TITLE
Tear away from line threshold should be based on canvas font metrics, not label font

### DIFF
--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -225,7 +225,7 @@ void QgsMapToolMoveLabel::cadCanvasPressEvent( QgsMapMouseEvent *e )
       clearHoveredLabel();
 
       mCurrentLabel = LabelDetails( labelPos, canvas() );
-      mLabelTearFromLineThreshold = QFontMetrics( mCurrentLabel.settings.format().font() ).horizontalAdvance( 'X' ) * 5;
+      mLabelTearFromLineThreshold = QFontMetrics( mCanvas->font() ).horizontalAdvance( 'X' ) * 5;
 
       QgsVectorLayer *vlayer = mCurrentLabel.layer;
       if ( !vlayer )


### PR DESCRIPTION
Otherwise very large /small label fonts mess up the threshold
