### PR TITLE
[Topology checker] Fix dialog for gaps. Fixes #29136

### DIFF
--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -227,7 +227,7 @@ void checkDock::errorListClicked( const QModelIndex &index )
 
   fl.layer->getFeatures( QgsFeatureRequest().setFilterFid( fl.feature.id() ) ).nextFeature( f );
   g = f.geometry();
-  if ( g.isNull() )
+  if ( g.isNull() && mErrorList.at( row )->name() != QObject::tr( "gaps" ) )
   {
     QgsMessageLog::logMessage( tr( "Invalid first geometry" ), tr( "Topology plugin" ) );
     QMessageBox::information( this, tr( "Topology test" ), tr( "Feature not found in the layer.\nThe layer has probably changed.\nRun topology check again." ) );
@@ -260,7 +260,7 @@ void checkDock::errorListClicked( const QModelIndex &index )
 
   fl.layer->getFeatures( QgsFeatureRequest().setFilterFid( fl.feature.id() ) ).nextFeature( f );
   g = f.geometry();
-  if ( g.isNull() )
+  if ( g.isNull() && mErrorList.at( row )->name() != QObject::tr( "gaps" ) )
   {
     QgsMessageLog::logMessage( tr( "Invalid second geometry" ), tr( "Topology plugin" ) );
     QMessageBox::information( this, tr( "Topology test" ), tr( "Feature not found in the layer.\nThe layer has probably changed.\nRun topology check again." ) );


### PR DESCRIPTION
## Description

Topology checker dialog shows an incorrect warning dialog when clicking on a row with a gap.

The dialog is waiting a geometry from a layer. However, a gap cannot be a geometry from a layer -- this is the reason the Feature ID is always this very big negative number.

So, introducing a condition to not show this false warning, resolve the issue.

before:

![image](https://user-images.githubusercontent.com/7521540/169814048-d132b0af-0d4a-4412-b5d5-dbdfce67df4d.png)

after:

![fix_dialog_topologychecker-2022-05-23_12 08 30 mkv](https://user-images.githubusercontent.com/7521540/169814197-65076239-a2c0-4ad3-8efe-9615f5635b19.gif)
