### PR TITLE
Fix crash in QgsVectorLayerUndoCommand

### DIFF
--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -231,3 +231,4 @@ if (ENABLE_PGTEST)
 endif()
 
 add_subdirectory(geometry)
+add_subdirectory(vector)

--- a/tests/src/core/vector/CMakeLists.txt
+++ b/tests/src/core/vector/CMakeLists.txt
@@ -1,0 +1,23 @@
+#####################################################
+# Don't forget to include output directory, otherwise
+# the UI file won't be wrapped!
+get_filename_component(PARENT_DIR ../ ABSOLUTE)
+
+include_directories(
+  ${PARENT_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/src/test
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+#############################################################
+# Tests:
+
+set(TESTS
+  testqgsvectorlayereditbuffer.cpp
+  testqgsvectorlayerundocommand.cpp
+  )
+
+foreach(TESTSRC ${TESTS})
+  add_qgis_test(${TESTSRC} MODULE core_vector LINKEDLIBRARIES qgis_core)
+endforeach(TESTSRC)

--- a/tests/src/core/vector/testqgsvectorlayereditbuffer.cpp
+++ b/tests/src/core/vector/testqgsvectorlayereditbuffer.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+     testqgsvectorlayereditbuffer.cpp
+     --------------------------------------
+    Date                 : May 2022
+    Copyright            : (C) 2022 by Sandro Santilli
+    Email                : strk at kbt dot io
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayereditbuffer.h"
+
+class TestQgsVectorLayerEditBuffer: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void constructor();
+  private:
+    QgsVectorLayer *mLayerPoint = nullptr;
+};
+
+//runs before all tests
+void TestQgsVectorLayerEditBuffer::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  mLayerPoint = new QgsVectorLayer( "Point", "layer point", "memory" );
+  QVERIFY( mLayerPoint->isValid() );
+}
+
+//runs after all tests
+void TestQgsVectorLayerEditBuffer::cleanupTestCase()
+{
+  delete mLayerPoint;
+
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVectorLayerEditBuffer::constructor()
+{
+  QgsVectorLayerEditBuffer buf( mLayerPoint );
+  QVERIFY( ! buf.isModified() );
+
+  // TODO: buf.addedFeatures().isEmpty()
+  // TODO: buf.allAddedOrEditedFeatures().isEmpty()
+  // TODO: buf.changedAttributeValues().isEmpty()
+  // TODO: all other inspector methods
+}
+
+
+QGSTEST_MAIN( TestQgsVectorLayerEditBuffer )
+#include "testqgsvectorlayereditbuffer.moc"
+
+
+
+

--- a/tests/src/core/vector/testqgsvectorlayerundocommand.cpp
+++ b/tests/src/core/vector/testqgsvectorlayerundocommand.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+     testqgsvectorlayerundocommand.cpp
+     --------------------------------------
+    Date                 : May 2022
+    Copyright            : (C) 2022 by Sandro Santilli
+    Email                : strk at kbt dot io
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerundocommand.h"
+
+class TestQgsVectorLayerUndoCommand: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+
+    void baseClass();
+    void changeAttribute();
+
+  private:
+    QgsVectorLayer *mLayerPoint = nullptr;
+    QgsVectorLayerEditBuffer *mLayerEditBuffer = nullptr;
+};
+
+//runs before all tests
+void TestQgsVectorLayerUndoCommand::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  mLayerPoint = new QgsVectorLayer( "Point", "layer point", "memory" );
+  QVERIFY( mLayerPoint->isValid() );
+
+  mLayerEditBuffer = new QgsVectorLayerEditBuffer( mLayerPoint );
+}
+
+//runs after all tests
+void TestQgsVectorLayerUndoCommand::cleanupTestCase()
+{
+  delete mLayerEditBuffer;
+  delete mLayerPoint;
+
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVectorLayerUndoCommand::baseClass()
+{
+  QgsVectorLayerUndoCommand cmd( mLayerEditBuffer );
+
+  QCOMPARE( cmd.layer(), mLayerPoint );
+  QCOMPARE( cmd.id(), -1 ); // we should not need an override for this
+}
+
+void TestQgsVectorLayerUndoCommand::changeAttribute()
+{
+  std::unique_ptr< QgsVectorLayerUndoCommandChangeAttribute > cmd;
+
+  // Should this be allowed at all, when fid is nonexistent ?
+  cmd.reset( new QgsVectorLayerUndoCommandChangeAttribute(
+               mLayerEditBuffer,
+               1, // Positive (not-new) non-existent FID
+               0, "newvalue", "oldvalue" ) );
+  QCOMPARE( cmd->layer(), mLayerPoint );
+  QCOMPARE( cmd->id(), -1 );
+  cmd->undo();
+
+  // Test for https://github.com/qgis/QGIS/issues/23243
+  cmd.reset( new QgsVectorLayerUndoCommandChangeAttribute(
+               mLayerEditBuffer,
+               -1, // Negative (new) non-existent FID
+               0, "newvalue", "oldvalue" ) );
+  QCOMPARE( cmd->layer(), mLayerPoint );
+  QCOMPARE( cmd->id(), -1 );
+  cmd->undo();
+}
+
+
+QGSTEST_MAIN( TestQgsVectorLayerUndoCommand )
+#include "testqgsvectorlayerundocommand.moc"
+
+
+
+


### PR DESCRIPTION
Avoids a crash upon discarding changes involving creation of a new
feature and changing of one of its attributes.

Fixes GH-23243 -- includes testcases