### PR TITLE
Also look below gdal include subdir when detecting gdal on MINGW

### DIFF
--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -18,7 +18,7 @@ INCLUDE (${CMAKE_SOURCE_DIR}/cmake/MacPlistMacros.cmake)
 IF(WIN32)
 
   IF (MINGW)
-    FIND_PATH(GDAL_INCLUDE_DIR gdal.h /usr/local/include /usr/include c:/msys/local/include)
+    FIND_PATH(GDAL_INCLUDE_DIR gdal.h /usr/local/include /usr/include c:/msys/local/include PATH_SUFFIXES gdal)
     FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/local/lib /usr/lib c:/msys/local/lib)
   ENDIF (MINGW)
 


### PR DESCRIPTION
Fixes mingw CI build failure with gdal-3.5.0.