### PR TITLE
Server: expose composer map item name to project settings

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -717,6 +717,7 @@ namespace QgsWms
 
         QDomElement composerMapElem = doc.createElement( QStringLiteral( "ComposerMap" ) );
         composerMapElem.setAttribute( QStringLiteral( "name" ), QStringLiteral( "map%1" ).arg( mapId ) );
+        composerMapElem.setAttribute( QStringLiteral( "itemName" ), composerMap->displayName() );
         mapId++;
         composerMapElem.setAttribute( QStringLiteral( "width" ), composerMap->rect().width() );
         composerMapElem.setAttribute( QStringLiteral( "height" ), composerMap->rect().height() );

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -115,8 +115,8 @@ Content-Type: text/xml; charset=utf-8
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <ComposerTemplates>
    <ComposerTemplate height="210" width="297" name="mytemplate">
-    <ComposerMap height="26" width="61" name="map0"/>
-    <ComposerMap height="103" width="87" name="map1"/>
+    <ComposerMap itemName="Map 1" height="26" width="61" name="map0"/>
+    <ComposerMap itemName="Map 2" height="103" width="87" name="map1"/>
    </ComposerTemplate>
   </ComposerTemplates>
   <WFSLayers>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -115,8 +115,8 @@ Content-Type: text/xml; charset=utf-8
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <ComposerTemplates>
    <ComposerTemplate height="210" width="297" name="mytemplate">
-    <ComposerMap height="26" width="61" name="map0"/>
-    <ComposerMap height="103" width="87" name="map1"/>
+    <ComposerMap itemName="Map 1" height="26" width="61" name="map0"/>
+    <ComposerMap itemName="Map 2" height="103" width="87" name="map1"/>
    </ComposerTemplate>
   </ComposerTemplates>
   <WFSLayers>


### PR DESCRIPTION
Fix #46143

Whether #46143 is a bug or a feature is not entirely clear, but I think this is a good solution:

the item name is now added as **itemName** to the **GetProjectSettings** XML response

![immagine](https://user-images.githubusercontent.com/142164/170027774-cb9d0d3d-2b18-4ed5-99c0-98dade891f77.png)

the map **name** is an opaque unique value internally handled by the server and it's not meant to be related with the order of map items (which is not well defined anyway).

By exposing the user-defined map names there is now a way to associate the internal name such as `map0` to the user-defined name.

