### PR TITLE
fix clipping for geocentric projections

### DIFF
--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -235,6 +235,20 @@ Returns the smallest distance between the box and the point ``point``
 
     bool operator==( const QgsBox3d &other ) const;
 
+    void scale( double scaleFactor, const QgsPoint *c = 0 );
+%Docstring
+Scale the rectangle around a center :py:class:`QgsPoint`.
+
+.. versionadded:: 3.21
+%End
+
+    void scale( double scaleFactor, double centerX, double centerY, double centerZ );
+%Docstring
+Scale the rectangle around a center coordinates.
+
+.. versionadded:: 3.21
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -235,7 +235,7 @@ Returns the smallest distance between the box and the point ``point``
 
     bool operator==( const QgsBox3d &other ) const;
 
-    void scale( double scaleFactor, const QgsPoint *c = 0 );
+    void scale( double scaleFactor, const QgsPoint &c = QgsPoint() );
 %Docstring
 Scale the rectangle around a center :py:class:`QgsPoint`.
 

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -235,18 +235,20 @@ Returns the smallest distance between the box and the point ``point``
 
     bool operator==( const QgsBox3d &other ) const;
 
-    void scale( double scaleFactor, const QgsPoint &c = QgsPoint() );
+    void scale( double scaleFactor, const QgsPoint &center = QgsPoint() );
 %Docstring
-Scale the rectangle around a center :py:class:`QgsPoint`.
+Scale the rectangle around a ``center`` :py:class:`QgsPoint`.
 
-.. versionadded:: 3.22
+If no ``center`` point is specified then the current center of the box will be used.
+
+.. versionadded:: 3.26
 %End
 
     void scale( double scaleFactor, double centerX, double centerY, double centerZ );
 %Docstring
 Scale the rectangle around a center coordinates.
 
-.. versionadded:: 3.22
+.. versionadded:: 3.26
 %End
 
 };

--- a/python/core/auto_generated/geometry/qgsbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsbox3d.sip.in
@@ -239,14 +239,14 @@ Returns the smallest distance between the box and the point ``point``
 %Docstring
 Scale the rectangle around a center :py:class:`QgsPoint`.
 
-.. versionadded:: 3.21
+.. versionadded:: 3.22
 %End
 
     void scale( double scaleFactor, double centerX, double centerY, double centerZ );
 %Docstring
 Scale the rectangle around a center coordinates.
 
-.. versionadded:: 3.21
+.. versionadded:: 3.22
 %End
 
 };

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -836,7 +836,7 @@ corresponds to the last point in the line.
 
     QgsBox3d calculateBoundingBox3d() const;
 %Docstring
-Calculates the minimal 3d bounding box for the geometry.
+Calculates the minimal 3D bounding box for the geometry.
 
 .. seealso:: :py:func:`calculateBoundingBox`
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -824,9 +824,11 @@ corresponds to the last point in the line.
 
     QgsBox3d calculateBoundingBox3d() const;
 %Docstring
-Calculator for the minimal 3d bounding box for the geometry.
+Calculates the minimal 3d bounding box for the geometry.
 
 .. seealso:: :py:func:`calculateBoundingBox`
+
+.. versionadded:: 3.22
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -529,17 +529,6 @@ corresponds to the last point in the line.
     }
 %End
 
-    void setPoints( size_t size, const double *x, const double *y, const double *z = 0, const double *m = 0 );
-%Docstring
-Resets the line string to match the specified point data. The line string will
-inherit the dimensionality of the first point in the list.
-
-:param size: point count.
-:param x: array of x data
-:param y: array of y data
-:param z: array of z data, can be null
-:param m: array of m data, can be null
-%End
 
     void setPoints( const QgsPointSequence &points );
 %Docstring
@@ -840,7 +829,7 @@ Calculates the minimal 3D bounding box for the geometry.
 
 .. seealso:: :py:func:`calculateBoundingBox`
 
-.. versionadded:: 3.22
+.. versionadded:: 3.26
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -822,6 +822,13 @@ corresponds to the last point in the line.
 %End
 
 
+    QgsBox3d calculateBoundingBox3d() const;
+%Docstring
+Calculator for the minimal 3d bounding box for the geometry.
+
+.. seealso:: :py:func:`calculateBoundingBox`
+%End
+
   protected:
 
     int compareToSameClass( const QgsAbstractGeometry *other ) const final;

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -529,6 +529,18 @@ corresponds to the last point in the line.
     }
 %End
 
+    void setPoints( qint64 size, const double *x, const double *y, const double *z = 0, const double *m = 0 );
+%Docstring
+Resets the line string to match the specified point data. The line string will
+inherit the dimensionality of the first point in the list.
+
+:param size: point count.
+:param x: array of x data
+:param y: array of y data
+:param z: array of z data, can be null
+:param m: array of m data, can be null
+%End
+
     void setPoints( const QgsPointSequence &points );
 %Docstring
 Resets the line string to match the specified list of points. The line string will

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -529,7 +529,7 @@ corresponds to the last point in the line.
     }
 %End
 
-    void setPoints( qint64 size, const double *x, const double *y, const double *z = 0, const double *m = 0 );
+    void setPoints( size_t size, const double *x, const double *y, const double *z = 0, const double *m = 0 );
 %Docstring
 Resets the line string to match the specified point data. The line string will
 inherit the dimensionality of the first point in the list.

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -358,6 +358,11 @@ corresponds to the last point in the line.
 
 
 
+
+
+
+
+
     double zAt( int index ) const;
 %Docstring
 Returns the z-coordinate of the specified node in the line string.

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -73,7 +73,7 @@ an open shape (linestring).
 %Docstring
 Trims the given polygon to a rectangular box, by modifying the given polygon in place.
 
-:param polygon: polygon as 2D coordinates
+:param pts: polygon as 2D coordinates
 :param clipRect: clipping rectangle
 %End
 

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -69,7 +69,7 @@ an open shape (linestring).
 
 %End
 
-    static void trimPolygon( QPolygonF &polygon, const QgsRectangle &clipRect );
+    static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 %Docstring
 Trims the given polygon to a rectangular box, by modifying the given polygon in place.
 

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -71,18 +71,20 @@ an open shape (linestring).
 
     static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 %Docstring
-Trims the given polygon to a rectangular box. Modify the given polygon.
+Trims the given polygon to a rectangular box, by modifying the given polygon in place.
 
 :param pts: polygon as 2D coordinates
 :param clipRect: clipping rectangle
 %End
 
-    static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
+    static void trimPolygon( QgsLineString &polygon, const QgsBox3d &clipRect );
 %Docstring
-Trims the given polygon to a pseudo 3D box. Modify the given polygon.
+Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.
 
 :param pts: polygon as 2D or 3D coordinates
 :param clipRect: clipping 3D box
+
+.. versionadded:: 3.22
 %End
 
     static QgsLineString clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent );

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -70,8 +70,20 @@ an open shape (linestring).
 %End
 
     static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
+%Docstring
+Trims the given polygon to a rectangular box. Modify the given polygon.
+
+:param pts: polygon as 2D coordinates
+:param clipRect: clipping rectangle
+%End
 
     static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
+%Docstring
+Trims the given polygon to a pseudo 3D box. Modify the given polygon.
+
+:param pts: polygon as 2D or 3D coordinates
+:param clipRect: clipping 3D box
+%End
 
     static QgsLineString clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent );
 %Docstring

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -69,11 +69,11 @@ an open shape (linestring).
 
 %End
 
-    static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
+    static void trimPolygon( QPolygonF &polygon, const QgsRectangle &clipRect );
 %Docstring
 Trims the given polygon to a rectangular box, by modifying the given polygon in place.
 
-:param pts: polygon as 2D coordinates
+:param polygon: polygon as 2D coordinates
 :param clipRect: clipping rectangle
 %End
 
@@ -81,7 +81,7 @@ Trims the given polygon to a rectangular box, by modifying the given polygon in 
 %Docstring
 Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.
 
-:param pts: polygon as 2D or 3D coordinates
+:param polygon: polygon as 2D or 3D coordinates
 :param clipRect: clipping 3D box
 
 .. versionadded:: 3.22

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -77,27 +77,7 @@ Trims the given polygon to a rectangular box, by modifying the given polygon in 
 :param clipRect: clipping rectangle
 %End
 
-    static void trimPolygon( QgsLineString &polygon, const QgsBox3d &clipRect );
-%Docstring
-Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.
 
-:param polygon: polygon as 2D or 3D coordinates
-:param clipRect: clipping 3D box
-
-.. versionadded:: 3.22
-%End
-
-    static QgsLineString clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent );
-%Docstring
-Takes a ``curve`` with 3D coordinates and clips it to clipExtent
-
-:param curve: the linestring to clip
-:param clipExtent: clipping bounds
-
-:return: clipped line coordinates
-
-.. versionadded:: 3.22
-%End
 
     static QPolygonF clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent );
 %Docstring

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -48,7 +48,7 @@ magnitude of the screen coordinates (+/- 32768, i.e. 16 bit integer).
       YMax,
       YMin,
       ZMax,
-      ZMin
+      ZMin,
     };
 
 %If (!ARM) // Not available on ARM sip bindings because of qreal issues
@@ -94,7 +94,17 @@ Takes a ``curve`` with 3D coordinates and clips it to clipExtent
 
 :return: clipped line coordinates
 
-.. versionadded:: 3.21
+.. versionadded:: 3.22
+%End
+
+    static QPolygonF clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent );
+%Docstring
+Takes a linestring and clips it to clipExtent
+
+:param curve: the linestring
+:param clipExtent: clipping bounds
+
+:return: clipped line coordinates
 %End
 
     static QPolygonF clippedLine( const QPolygonF &curve, const QgsRectangle &clipExtent );

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 %Feature ARM // Some parts are not available in sip bindings on ARM because of qreal double vs. float issues
 
 
@@ -45,7 +46,9 @@ magnitude of the screen coordinates (+/- 32768, i.e. 16 bit integer).
       XMax,
       XMin,
       YMax,
-      YMin
+      YMin,
+      ZMax,
+      ZMin
     };
 
 %If (!ARM) // Not available on ARM sip bindings because of qreal issues
@@ -68,19 +71,28 @@ an open shape (linestring).
 
     static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 
-    static QPolygonF clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent );
+    static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
+
+    static QgsLineString clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent );
 %Docstring
-Takes a linestring and clips it to clipExtent
+Takes a ``curve`` with 3D coordinates and clips it to clipExtent
 
 :param curve: the linestring
 :param clipExtent: clipping bounds
 
 :return: clipped line coordinates
+
+.. versionadded:: 3.21
 %End
 
     static QPolygonF clippedLine( const QPolygonF &curve, const QgsRectangle &clipExtent );
 %Docstring
-Takes a ``curve`` and clips it to clipExtent.
+Takes a 2D ``curve`` and clips it to clipExtent.
+
+:param curve: the linestring
+:param clipExtent: clipping bounds
+
+:return: clipped line coordinates
 
 .. versionadded:: 3.16
 %End
@@ -106,6 +118,7 @@ An implementation of the 'Fast clipping' algorithm (Sobkow et al. 1987, Computer
 %End
 
 };
+
 
 
 

--- a/python/core/auto_generated/qgsclipper.sip.in
+++ b/python/core/auto_generated/qgsclipper.sip.in
@@ -91,7 +91,7 @@ Trims the given polygon to a pseudo 3D box, by modifying the given polygon in pl
 %Docstring
 Takes a ``curve`` with 3D coordinates and clips it to clipExtent
 
-:param curve: the linestring
+:param curve: the linestring to clip
 :param clipExtent: clipping bounds
 
 :return: clipped line coordinates

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -134,7 +134,7 @@ bool QgsBox3d::operator==( const QgsBox3d &other ) const
          qgsDoubleNear( mZmax, other.mZmax );
 }
 
-void QgsBox3d::scale( double scaleFactor, const QgsPoint *c )
+void QgsBox3d::   scale( double scaleFactor, const QgsPoint *c )
 {
   // scale from the center
   double centerX, centerY, centerZ;
@@ -155,16 +155,12 @@ void QgsBox3d::scale( double scaleFactor, const QgsPoint *c )
 
 void QgsBox3d::scale( double scaleFactor, double centerX, double centerY, double centerZ )
 {
-  double newX = ( xMaximum() - xMinimum() ) * scaleFactor * 0.5;
-  double newY = ( yMaximum() - yMinimum() ) * scaleFactor * 0.5;
-  double newZ = ( zMaximum() - zMinimum() ) * scaleFactor * 0.5;
+  setXMinimum( centerX + ( xMinimum() - centerX ) * scaleFactor );
+  setXMaximum( centerX + ( xMaximum() - centerX ) * scaleFactor );
 
-  setXMinimum( centerX - newX );
-  setXMaximum( centerX + newX );
+  setYMinimum( centerY + ( yMinimum() - centerY ) * scaleFactor );
+  setYMaximum( centerY + ( yMaximum() - centerY ) * scaleFactor );
 
-  setYMinimum( centerY - newY );
-  setYMaximum( centerY + newY );
-
-  setZMinimum( centerZ - newZ );
-  setZMaximum( centerZ + newZ );
+  setZMinimum( centerZ + ( zMinimum() - centerZ ) * scaleFactor );
+  setZMaximum( centerZ + ( zMaximum() - centerZ ) * scaleFactor );
 }

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -134,15 +134,15 @@ bool QgsBox3d::operator==( const QgsBox3d &other ) const
          qgsDoubleNear( mZmax, other.mZmax );
 }
 
-void QgsBox3d::scale( double scaleFactor, const QgsPoint *c )
+void QgsBox3d::scale( double scaleFactor, const QgsPoint &c )
 {
   // scale from the center
   double centerX, centerY, centerZ;
-  if ( c )
+  if ( !c.isEmpty() )
   {
-    centerX = c->x();
-    centerY = c->y();
-    centerZ = c->z();
+    centerX = c.x();
+    centerY = c.y();
+    centerZ = c.z();
   }
   else
   {

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -133,3 +133,38 @@ bool QgsBox3d::operator==( const QgsBox3d &other ) const
          qgsDoubleNear( mZmin, other.mZmin ) &&
          qgsDoubleNear( mZmax, other.mZmax );
 }
+
+void QgsBox3d::scale( double scaleFactor, const QgsPoint *c )
+{
+  // scale from the center
+  double centerX, centerY, centerZ;
+  if ( c )
+  {
+    centerX = c->x();
+    centerY = c->y();
+    centerZ = c->z();
+  }
+  else
+  {
+    centerX = ( xMinimum() + xMaximum() ) / 2;
+    centerY = ( yMinimum() + yMaximum() ) / 2;
+    centerZ = ( zMinimum() + zMaximum() ) / 2;
+  }
+  scale( scaleFactor, centerX, centerY, centerZ );
+}
+
+void QgsBox3d::scale( double scaleFactor, double centerX, double centerY, double centerZ )
+{
+  double newX = ( xMaximum() - xMinimum() ) * scaleFactor * 0.5;
+  double newY = ( yMaximum() - yMinimum() ) * scaleFactor * 0.5;
+  double newZ = ( zMaximum() - zMinimum() ) * scaleFactor * 0.5;
+
+  setXMinimum( centerX - newX );
+  setXMaximum( centerX + newX );
+
+  setYMinimum( centerY - newY );
+  setYMaximum( centerY + newY );
+
+  setZMinimum( centerZ - newZ );
+  setZMaximum( centerZ + newZ );
+}

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -134,15 +134,15 @@ bool QgsBox3d::operator==( const QgsBox3d &other ) const
          qgsDoubleNear( mZmax, other.mZmax );
 }
 
-void QgsBox3d::scale( double scaleFactor, const QgsPoint &c )
+void QgsBox3d::scale( double scaleFactor, const QgsPoint &center )
 {
   // scale from the center
   double centerX, centerY, centerZ;
-  if ( !c.isEmpty() )
+  if ( !center.isEmpty() )
   {
-    centerX = c.x();
-    centerY = c.y();
-    centerZ = c.z();
+    centerX = center.x();
+    centerY = center.y();
+    centerZ = center.z();
   }
   else
   {

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -134,7 +134,7 @@ bool QgsBox3d::operator==( const QgsBox3d &other ) const
          qgsDoubleNear( mZmax, other.mZmax );
 }
 
-void QgsBox3d::   scale( double scaleFactor, const QgsPoint *c )
+void QgsBox3d::scale( double scaleFactor, const QgsPoint *c )
 {
   // scale from the center
   double centerX, centerY, centerZ;

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -215,6 +215,20 @@ class CORE_EXPORT QgsBox3d
 
     bool operator==( const QgsBox3d &other ) const;
 
+    /**
+     * Scale the rectangle around a center QgsPoint.
+     *
+     * \since QGIS 3.21
+     */
+    void scale( double scaleFactor, const QgsPoint *c = nullptr );
+
+    /**
+     * Scale the rectangle around a center coordinates.
+     *
+     * \since QGIS 3.21
+     */
+    void scale( double scaleFactor, double centerX, double centerY, double centerZ );
+
   private:
 
     QgsRectangle mBounds2d;

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -218,14 +218,14 @@ class CORE_EXPORT QgsBox3d
     /**
      * Scale the rectangle around a center QgsPoint.
      *
-     * \since QGIS 3.21
+     * \since QGIS 3.22
      */
     void scale( double scaleFactor, const QgsPoint *c = nullptr );
 
     /**
      * Scale the rectangle around a center coordinates.
      *
-     * \since QGIS 3.21
+     * \since QGIS 3.22
      */
     void scale( double scaleFactor, double centerX, double centerY, double centerZ );
 

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -216,16 +216,18 @@ class CORE_EXPORT QgsBox3d
     bool operator==( const QgsBox3d &other ) const;
 
     /**
-     * Scale the rectangle around a center QgsPoint.
+     * Scale the rectangle around a \a center QgsPoint.
      *
-     * \since QGIS 3.22
+     * If no \a center point is specified then the current center of the box will be used.
+     *
+     * \since QGIS 3.26
      */
-    void scale( double scaleFactor, const QgsPoint &c = QgsPoint() );
+    void scale( double scaleFactor, const QgsPoint &center = QgsPoint() );
 
     /**
      * Scale the rectangle around a center coordinates.
      *
-     * \since QGIS 3.22
+     * \since QGIS 3.26
      */
     void scale( double scaleFactor, double centerX, double centerY, double centerZ );
 

--- a/src/core/geometry/qgsbox3d.h
+++ b/src/core/geometry/qgsbox3d.h
@@ -23,7 +23,7 @@
 
 #include <QVector3D>
 
-class QgsPoint;
+#include "qgspoint.h"
 
 /**
  * \ingroup core
@@ -220,7 +220,7 @@ class CORE_EXPORT QgsBox3d
      *
      * \since QGIS 3.22
      */
-    void scale( double scaleFactor, const QgsPoint *c = nullptr );
+    void scale( double scaleFactor, const QgsPoint &c = QgsPoint() );
 
     /**
      * Scale the rectangle around a center coordinates.

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1118,48 +1118,45 @@ void QgsLineString::setPoints( size_t size, const double *x, const double *y, co
     return;
   }
 
-  //get wkb type from first point
-  bool hasZ = z != NULL;
-  bool hasM = m != NULL;
+  const bool hasZ = static_cast< bool >( z );
+  const bool hasM = static_cast< bool >( m );
 
-  if ( hasZ )
+  if ( hasZ && hasM )
   {
-    if ( hasM )
-    {
-      const QgsPoint firstPt( *x, *y, *z, *m );
-      setZMTypeFromSubGeometry( &firstPt, QgsWkbTypes::LineString );
-    }
-    else
-    {
-      const QgsPoint firstPt( *x, *y, *z );
-      setZMTypeFromSubGeometry( &firstPt, QgsWkbTypes::LineString );
-    }
+    mWkbType = QgsWkbTypes::LineStringZM;
+  }
+  else if ( hasZ )
+  {
+    mWkbType = QgsWkbTypes::LineStringZ;
   }
   else if ( hasM )
   {
-    const QgsPoint firstPt( *x, *y, std::numeric_limits<double>::quiet_NaN(), *m );
-    setZMTypeFromSubGeometry( &firstPt, QgsWkbTypes::LineString );
+    mWkbType = QgsWkbTypes::LineStringM;
   }
   else
   {
-    const QgsPoint firstPt( *x, *y );
-    setZMTypeFromSubGeometry( &firstPt, QgsWkbTypes::LineString );
+    mWkbType = QgsWkbTypes::LineString;
   }
-
 
   mX.resize( size );
   mY.resize( size );
+  double *destX = mX.data();
+  double *destY = mY.data();
+  double *destZ = nullptr;
   if ( hasZ )
   {
     mZ.resize( size );
+    destZ = mZ.data();
   }
   else
   {
     mZ.clear();
   }
+  double *destM = nullptr;
   if ( hasM )
   {
     mM.resize( size );
+    destM = mM.data();
   }
   else
   {
@@ -1168,19 +1165,16 @@ void QgsLineString::setPoints( size_t size, const double *x, const double *y, co
 
   for ( size_t i = 0; i < size; ++i )
   {
-    mX[i] = *x;
-    mY[i] = *y;
+    *destX++ = *x++;
+    *destY++ = *y++;
     if ( hasZ )
     {
-      mZ[i] = std::isnan( *z ) ? 0 : *z;
-      z++;
+      *destZ++ = *z++;
     }
     if ( hasM )
     {
-      mM[i] = std::isnan( *m ) ? 0 : *m;
-      m++;
+      *destM++ = *m++;
     }
-    x++; y++;
   }
 }
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -591,47 +591,28 @@ QgsRectangle QgsLineString::calculateBoundingBox() const
 
 QgsBox3d QgsLineString::calculateBoundingBox3d() const
 {
-  QgsBox3d out;
+
   if ( mX.empty() )
   {
-    out = QgsBox3d();
+    return QgsBox3d();
   }
 
-  else if ( mBoundingBox.isNull() )
+  if ( mBoundingBox.isNull() )
   {
-    auto result = std::minmax_element( mX.begin(), mX.end() );
-    const double xmin = *result.first;
-    const double xmax = *result.second;
-    result = std::minmax_element( mY.begin(), mY.end() );
-    const double ymin = *result.first;
-    const double ymax = *result.second;
-
-    if ( is3D() )
-    {
-      result = std::minmax_element( mZ.begin(), mZ.end() );
-      const double zmin = *result.first;
-      const double zmax = *result.second;
-      out = QgsBox3d( xmin, ymin, zmin, xmax, ymax, zmax );
-    }
-    else
-    {
-      out = QgsBox3d( xmin, ymin, NAN, xmax, ymax, NAN );
-    }
+    mBoundingBox = calculateBoundingBox();
   }
 
+  QgsBox3d out;
+  if ( is3D() )
+  {
+    auto result = std::minmax_element( mZ.begin(), mZ.end() );
+    const double zmin = *result.first;
+    const double zmax = *result.second;
+    out = QgsBox3d( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), zmin, mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), zmax );
+  }
   else
   {
-    if ( is3D() )
-    {
-      auto result = std::minmax_element( mZ.begin(), mZ.end() );
-      const double zmin = *result.first;
-      const double zmax = *result.second;
-      out = QgsBox3d( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), zmin, mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), zmax );
-    }
-    else
-    {
-      out = QgsBox3d( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), NAN, mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), NAN );
-    }
+    out = QgsBox3d( mBoundingBox.xMinimum(), mBoundingBox.yMinimum(), std::numeric_limits< double >::quiet_NaN(), mBoundingBox.xMaximum(), mBoundingBox.yMaximum(), std::numeric_limits< double >::quiet_NaN() );
   }
   return out;
 }

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1108,7 +1108,7 @@ void QgsLineString::points( QgsPointSequence &pts ) const
   }
 }
 
-void QgsLineString::setPoints( qint64 size, const double *x, const double *y, const double *z, const double *m )
+void QgsLineString::setPoints( size_t size, const double *x, const double *y, const double *z, const double *m )
 {
   clearCache(); //set bounding box invalid
 
@@ -1123,6 +1123,7 @@ void QgsLineString::setPoints( qint64 size, const double *x, const double *y, co
   bool hasM = m != NULL;
 
   if ( hasZ )
+  {
     if ( hasM )
     {
       const QgsPoint firstPt( *x, *y, *z, *m );
@@ -1133,6 +1134,7 @@ void QgsLineString::setPoints( qint64 size, const double *x, const double *y, co
       const QgsPoint firstPt( *x, *y, *z );
       setZMTypeFromSubGeometry( &firstPt, QgsWkbTypes::LineString );
     }
+  }
   else if ( hasM )
   {
     const QgsPoint firstPt( *x, *y, std::numeric_limits<double>::quiet_NaN(), *m );
@@ -1164,7 +1166,7 @@ void QgsLineString::setPoints( qint64 size, const double *x, const double *y, co
     mM.clear();
   }
 
-  for ( qint64 i = 0; i < size; ++i )
+  for ( size_t i = 0; i < size; ++i )
   {
     mX[i] = *x;
     mY[i] = *y;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -574,10 +574,19 @@ bool QgsLineString::fromWkb( QgsConstWkbPtr &wkbPtr )
   return true;
 }
 
+// duplicated code from calculateBoundingBox3d to avoid useless z computation
 QgsRectangle QgsLineString::calculateBoundingBox() const
 {
-  QgsBox3d b = calculateBoundingBox3d();
-  return QgsRectangle( b.xMinimum(), b.yMinimum(), b.xMaximum(), b.yMaximum(), false );
+  if ( mX.empty() )
+    return QgsRectangle();
+
+  auto result = std::minmax_element( mX.begin(), mX.end() );
+  const double xmin = *result.first;
+  const double xmax = *result.second;
+  result = std::minmax_element( mY.begin(), mY.end() );
+  const double ymin = *result.first;
+  const double ymax = *result.second;
+  return QgsRectangle( xmin, ymin, xmax, ymax, false );
 }
 
 QgsBox3d QgsLineString::calculateBoundingBox3d() const

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -601,8 +601,7 @@ QgsBox3d QgsLineString::calculateBoundingBox3d() const
   }
   else
   {
-    // TODO Nan or Inf?
-    return QgsBox3d( xmin, ymin, -HUGE_VAL, xmax, ymax, HUGE_VAL );
+    return QgsBox3d( xmin, ymin, NAN, xmax, ymax, NAN );
   }
 }
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -721,10 +721,21 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #endif
 
     /**
-     * Resets the line string to match the specified list of points. The line string will
-     * inherit the dimensionality of the first point in the list.
-     * \param points new points for line string. If empty, line string will be cleared.
-     */
+    * Resets the line string to match the specified point data. The line string will
+    * inherit the dimensionality of the first point in the list.
+    * \param size point count.
+    * \param x array of x data
+    * \param y array of y data
+    * \param z array of z data, can be null
+    * \param m array of m data, can be null
+    */
+    void setPoints( qint64 size, const double *x, const double *y, const double *z = nullptr, const double *m = nullptr );
+
+    /**
+    * Resets the line string to match the specified list of points. The line string will
+    * inherit the dimensionality of the first point in the list.
+    * \param points new points for line string. If empty, line string will be cleared.
+    */
     void setPoints( const QgsPointSequence &points );
 
     /**

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -988,6 +988,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Calculates the minimal 3d bounding box for the geometry.
      * \see calculateBoundingBox()
+     * \since QGIS 3.22
      */
     QgsBox3d calculateBoundingBox3d() const;
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -721,15 +721,19 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #endif
 
     /**
-    * Resets the line string to match the specified point data. The line string will
-    * inherit the dimensionality of the first point in the list.
+    * Resets the line string to match the specified point data. The line string
+    * dimensionality will be based on whether \a z or \a m arrays are specified.
+    *
     * \param size point count.
     * \param x array of x data
     * \param y array of y data
-    * \param z array of z data, can be null
-    * \param m array of m data, can be null
+    * \param z array of z data, can be NULLPTR
+    * \param m array of m data, can be NULLPTR
+    *
+    * \note Not available from Python bindings
+    * \since QGIS 3.26
     */
-    void setPoints( size_t size, const double *x, const double *y, const double *z = nullptr, const double *m = nullptr );
+    void setPoints( size_t size, const double *x, const double *y, const double *z = nullptr, const double *m = nullptr ) SIP_SKIP;
 
     /**
     * Resets the line string to match the specified list of points. The line string will
@@ -999,7 +1003,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     /**
      * Calculates the minimal 3D bounding box for the geometry.
      * \see calculateBoundingBox()
-     * \since QGIS 3.22
+     * \since QGIS 3.26
      */
     QgsBox3d calculateBoundingBox3d() const;
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -458,6 +458,47 @@ class CORE_EXPORT QgsLineString: public QgsCurve
         return mM.constData();
     }
 
+    /**
+     * Returns the x vertex values as a vector.
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+    */
+    QVector< double > xVector() const SIP_SKIP
+    {
+      return mX;
+    }
+
+    /**
+     * Returns the y vertex values as a vector.
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+    */
+    QVector< double > yVector() const SIP_SKIP
+    {
+      return mY;
+    }
+
+    /**
+     * Returns the z vertex values as a vector.
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+    */
+    QVector< double > zVector() const SIP_SKIP
+    {
+      return mZ;
+    }
+
+    /**
+     * Returns the m vertex values as a vector.
+     * \note Not available in Python bindings
+     * \since QGIS 3.26
+    */
+    QVector< double > mVector() const SIP_SKIP
+    {
+      return mM;
+    }
+
+
 #ifndef SIP_RUN
 
     /**

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -729,7 +729,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     * \param z array of z data, can be null
     * \param m array of m data, can be null
     */
-    void setPoints( qint64 size, const double *x, const double *y, const double *z = nullptr, const double *m = nullptr );
+    void setPoints( size_t size, const double *x, const double *y, const double *z = nullptr, const double *m = nullptr );
 
     /**
     * Resets the line string to match the specified list of points. The line string will

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -27,6 +27,7 @@
 #include "qgscompoundcurve.h"
 
 class QgsLineSegment2D;
+class QgsBox3d;
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
@@ -983,6 +984,12 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     % End
 
 #endif
+
+    /**
+     * Calculator for the minimal 3d bounding box for the geometry.
+     * \see calculateBoundingBox()
+     */
+    QgsBox3d calculateBoundingBox3d() const;
 
   protected:
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -986,7 +986,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #endif
 
     /**
-     * Calculator for the minimal 3d bounding box for the geometry.
+     * Calculates the minimal 3d bounding box for the geometry.
      * \see calculateBoundingBox()
      */
     QgsBox3d calculateBoundingBox3d() const;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -997,7 +997,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #endif
 
     /**
-     * Calculates the minimal 3d bounding box for the geometry.
+     * Calculates the minimal 3D bounding box for the geometry.
      * \see calculateBoundingBox()
      * \since QGIS 3.22
      */

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -43,7 +43,7 @@ QgsLineString QgsClipper::clipped3dLine( const QgsCurve &curve, const QgsBox3d &
   double p1x_c, p1y_c, p1z_c; //clipped end coordinates
   double lastClipX = 0.0, lastClipY = 0.0, lastClipZ = 0.0; // last successfully clipped coordinates
 
-  QgsLineString line;
+  QgsPointSequence seq;
 
   for ( QgsAbstractGeometry::vertex_iterator ite = curve.vertices_begin() ; ite != curve.vertices_end(); ++ite )
   {
@@ -71,30 +71,31 @@ QgsLineString QgsClipper::clipped3dLine( const QgsCurve &curve, const QgsBox3d &
       // TODO: should be in 3D
       if ( clipLineSegment( clipExtent, p0x, p0y, p0z, p1x_c, p1y_c, p1z_c ) )
       {
-        bool newLine = !line.isEmpty() && ( !qgsDoubleNear( p0x, lastClipX )
-                                            || !qgsDoubleNear( p0y, lastClipY )
-                                            || !qgsDoubleNear( p0z, lastClipZ ) );
+        bool newLine = !seq.isEmpty() && ( !qgsDoubleNear( p0x, lastClipX )
+                                           || !qgsDoubleNear( p0y, lastClipY )
+                                           || !qgsDoubleNear( p0z, lastClipZ ) );
         if ( newLine )
         {
           //add edge points to connect old and new line
           // TODO: should be (really) in 3D
-          connectSeparatedLines( lastClipX, lastClipY, lastClipZ, p0x, p0y, p0z, clipExtent, line );
+          connectSeparatedLines( lastClipX, lastClipY, lastClipZ, p0x, p0y, p0z, clipExtent, seq );
         }
-        if ( line.numPoints() == 0 || newLine )
+        if ( seq.isEmpty() || newLine )
         {
           //add first point
-          line.addVertex( QgsPoint( p0x, p0y, p0z ) );
+          seq << QgsPoint( p0x, p0y, p0z ) ;
         }
 
         //add second point
         lastClipX = p1x_c;
         lastClipY = p1y_c;
         lastClipZ = p1z_c;
-        line.addVertex( QgsPoint( p1x_c,  p1y_c,  p1z_c ) );
+        seq << QgsPoint( p1x_c,  p1y_c,  p1z_c ) ;
       }
     }
   }
-  return line;
+
+  return QgsLineString( seq );
 }
 
 QPolygonF QgsClipper::clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent )
@@ -257,7 +258,7 @@ void QgsClipper::connectSeparatedLines( double x0, double y0, double x1, double 
 }
 
 void QgsClipper::connectSeparatedLines( double x0, double y0, double z0, double x1, double y1, double z1,
-                                        const QgsBox3d &clipRect, QgsLineString &pts )
+                                        const QgsBox3d &clipRect, QgsPointSequence &pts )
 {
   // TODO: really relevant and sufficient?
   double meanZ = ( z0 + z1 ) / 2.0;
@@ -271,18 +272,18 @@ void QgsClipper::connectSeparatedLines( double x0, double y0, double z0, double 
     }
     else if ( qgsDoubleNear( y1, clipRect.yMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( x1, clipRect.xMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ ) );
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( y1, clipRect.yMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ );
       return;
     }
   }
@@ -294,18 +295,18 @@ void QgsClipper::connectSeparatedLines( double x0, double y0, double z0, double 
     }
     else if ( qgsDoubleNear( x1, clipRect.xMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( y1, clipRect.yMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ ) );
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( x1, clipRect.xMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ );
       return;
     }
   }
@@ -317,18 +318,18 @@ void QgsClipper::connectSeparatedLines( double x0, double y0, double z0, double 
     }
     else if ( qgsDoubleNear( y1, clipRect.yMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( x1, clipRect.xMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ ) );
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( y1, clipRect.yMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMaximum(), meanZ );
       return;
     }
   }
@@ -340,18 +341,18 @@ void QgsClipper::connectSeparatedLines( double x0, double y0, double z0, double 
     }
     else if ( qgsDoubleNear( x1, clipRect.xMinimum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( y1, clipRect.yMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ ) );
-      pts.addVertex( QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMinimum(), meanZ );
+      pts <<  QgsPoint( clipRect.xMinimum(), clipRect.yMaximum(), meanZ );
       return;
     }
     else if ( qgsDoubleNear( x1, clipRect.xMaximum() ) )
     {
-      pts.addVertex( QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ ) );
+      pts <<  QgsPoint( clipRect.xMaximum(), clipRect.yMinimum(), meanZ );
       return;
     }
   }

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -39,20 +39,16 @@ const double QgsClipper::SMALL_NUM = 1e-12;
 
 QgsLineString QgsClipper::clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent )
 {
-  const int nPoints = curve.numPoints();
-
   double p0x, p0y, p0z, p1x = 0.0, p1y = 0.0, p1z = 0.0; //original coordinates
   double p1x_c, p1y_c, p1z_c; //clipped end coordinates
   double lastClipX = 0.0, lastClipY = 0.0, lastClipZ = 0.0; // last successfully clipped coordinates
 
   QgsLineString line;
 
-  QgsPoint curPoint;
-  QgsVertexId::VertexType type;
-  for ( int i = 0; i < nPoints; ++i )
+  for ( QgsAbstractGeometry::vertex_iterator ite = curve.vertices_begin() ; ite != curve.vertices_end(); ++ite )
   {
-    curve.pointAt( i, curPoint, type );
-    if ( i == 0 )
+    QgsPoint curPoint = *ite;
+    if ( ite == curve.vertices_begin() )
     {
       p1x = curPoint.x();
       p1y = curPoint.y();

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -43,7 +43,7 @@ QgsLineString QgsClipper::clipped3dLine( const QgsCurve &curve, const QgsBox3d &
 
   double p0x, p0y, p0z, p1x = 0.0, p1y = 0.0, p1z = 0.0; //original coordinates
   double p1x_c, p1y_c, p1z_c; //clipped end coordinates
-  double lastClipX = 0.0, lastClipY = 0., lastClipZ = 0.0; //last successfully clipped coords
+  double lastClipX = 0.0, lastClipY = 0.0, lastClipZ = 0.0; // last successfully clipped coordinates
 
   QgsLineString line;
 

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -97,6 +97,11 @@ QgsLineString QgsClipper::clipped3dLine( const QgsCurve &curve, const QgsBox3d &
   return line;
 }
 
+QPolygonF QgsClipper::clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent )
+{
+  return clippedLine( curve.asQPolygonF(), clipExtent );
+}
+
 QPolygonF QgsClipper::clippedLine( const QPolygonF &curve, const QgsRectangle &clipExtent )
 {
   const int nPoints = curve.size();

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -108,15 +108,15 @@ class CORE_EXPORT QgsClipper
     /**
      * Trims the given polygon to a rectangular box, by modifying the given polygon in place.
      *
-     * \param pts polygon as 2D coordinates
+     * \param polygon polygon as 2D coordinates
      * \param clipRect clipping rectangle
      */
-    static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
+    static void trimPolygon( QPolygonF &polygon, const QgsRectangle &clipRect );
 
     /**
      * Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.
      *
-     * \param pts polygon as 2D or 3D coordinates
+     * \param polygon polygon as 2D or 3D coordinates
      * \param clipRect clipping 3D box
      * \since QGIS 3.22
      */

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -104,8 +104,20 @@ class CORE_EXPORT QgsClipper
 
     SIP_END
 
+    /**
+     * Trims the given polygon to a rectangular box. Modify the given polygon.
+     *
+     * \param pts polygon as 2D coordinates
+     * \param clipRect clipping rectangle
+     */
     static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 
+    /**
+     * Trims the given polygon to a pseudo 3D box. Modify the given polygon.
+     *
+     * \param pts polygon as 2D or 3D coordinates
+     * \param clipRect clipping 3D box
+     */
     static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
 
     /**

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -119,7 +119,7 @@ class CORE_EXPORT QgsClipper
      * \param clipRect clipping 3D box
      * \since QGIS 3.22
      */
-    static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
+    static void trimPolygon( QgsLineString &polygon, const QgsBox3d &clipRect );
 
     /**
      * Takes a \a curve with 3D coordinates and clips it to clipExtent

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -108,10 +108,10 @@ class CORE_EXPORT QgsClipper
     /**
      * Trims the given polygon to a rectangular box, by modifying the given polygon in place.
      *
-     * \param polygon polygon as 2D coordinates
+     * \param pts polygon as 2D coordinates
      * \param clipRect clipping rectangle
      */
-    static void trimPolygon( QPolygonF &polygon, const QgsRectangle &clipRect );
+    static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 
     /**
      * Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -126,9 +126,17 @@ class CORE_EXPORT QgsClipper
      * \param curve the linestring
      * \param clipExtent clipping bounds
      * \returns clipped line coordinates
-     * \since QGIS 3.21
+     * \since QGIS 3.22
      */
     static QgsLineString clipped3dLine( const QgsCurve &curve, const QgsBox3d &clipExtent );
+
+    /**
+     * Takes a linestring and clips it to clipExtent
+     * \param curve the linestring
+     * \param clipExtent clipping bounds
+     * \returns clipped line coordinates
+     */
+    static QPolygonF clippedLine( const QgsCurve &curve, const QgsRectangle &clipExtent );
 
     /**
      * Takes a 2D \a curve and clips it to clipExtent.

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -105,7 +105,7 @@ class CORE_EXPORT QgsClipper
     SIP_END
 
     /**
-     * Trims the given polygon to a rectangular box. Modify the given polygon.
+     * Trims the given polygon to a rectangular box, by modifying the given polygon in place.
      *
      * \param pts polygon as 2D coordinates
      * \param clipRect clipping rectangle

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -84,8 +84,8 @@ class CORE_EXPORT QgsClipper
       XMin,
       YMax,
       YMin,
-      ZMax,
-      ZMin
+      ZMax, //!< Maximum Z (since QGIS 3.22)
+      ZMin, //!< Minimum Z (since QGIS 3.22)
     };
 
     SIP_IF_FEATURE( !ARM ) // Not available on ARM sip bindings because of qreal issues

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -206,9 +206,6 @@ class CORE_EXPORT QgsClipper
                                           QgsPoint pt2,
                                           Boundary b, const QgsBox3d &rect );
 
-    //Implementation of 'Fast clipping' algorithm (Sobkow et al. 1987, Computers & Graphics Vol.11, 4, p.459-467)
-    static bool clipLineSegment( double xLeft, double xRight, double yBottom, double yTop, double &x0, double &y0, double &x1, double &y1 );
-
     static bool clipLineSegment( const QgsBox3d &extent, double &x0, double &y0, double &z0, double &x1, double &y1, double &z1 );
 
     /**

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -117,6 +117,7 @@ class CORE_EXPORT QgsClipper
      *
      * \param pts polygon as 2D or 3D coordinates
      * \param clipRect clipping 3D box
+     * \since QGIS 3.22
      */
     static void trimPolygon( QgsLineString &pts, const QgsBox3d &clipRect );
 

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -124,7 +124,7 @@ class CORE_EXPORT QgsClipper
 
     /**
      * Takes a \a curve with 3D coordinates and clips it to clipExtent
-     * \param curve the linestring
+     * \param curve the linestring to clip
      * \param clipExtent clipping bounds
      * \returns clipped line coordinates
      * \since QGIS 3.22

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -113,7 +113,7 @@ class CORE_EXPORT QgsClipper
     static void trimPolygon( QPolygonF &pts, const QgsRectangle &clipRect );
 
     /**
-     * Trims the given polygon to a pseudo 3D box. Modify the given polygon.
+     * Trims the given polygon to a pseudo 3D box, by modifying the given polygon in place.
      *
      * \param pts polygon as 2D or 3D coordinates
      * \param clipRect clipping 3D box

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -147,7 +147,6 @@ QPolygonF QgsSymbol::_getLineString3d( QgsRenderContext &context, const QgsCurve
     //create x, y arrays
     const int nVertices = pointsX.size();
 
-    QString err;
     try
     {
       ct.transformCoords( nVertices, pointsX.data(), pointsY.data(), pointsZ.data(), Qgis::TransformDirection::Forward );

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -83,14 +83,6 @@ Q_NOWARN_DEPRECATED_POP
 
 QPolygonF QgsSymbol::_getLineString( QgsRenderContext &context, const QgsCurve &curve, bool clipToExtent )
 {
-  printf( "_getLineString(in): %d\n", curve.numPoints() );
-  for ( int i = 0 ; i < 10 && i < curve.numPoints(); i++ )
-  {
-    QgsPoint p;
-    QgsVertexId::VertexType t;
-    curve.pointAt( i, p, t );
-    printf( "_getLineString(in):   %f, %f\n", p.x(), p.y() );
-  }
   const unsigned int nPoints = curve.numPoints();
 
   QgsCoordinateTransform ct = context.coordinateTransform();
@@ -157,25 +149,11 @@ QPolygonF QgsSymbol::_getLineString( QgsRenderContext &context, const QgsCurve &
     mtp.transformInPlace( ptr->rx(), ptr->ry() );
   }
 
-  printf( "_getLineString(out): %d\n", out.size() );
-  for ( int i = 0 ; i < 10 && i < out.size(); i++ )
-  {
-    printf( "_getLineString(out):   %f, %f\n", out.at( i ).x(), out.at( i ).y() );
-  }
-
   return out;
 }
 
 QPolygonF QgsSymbol::_getPolygonRing( QgsRenderContext &context, const QgsCurve &curve, const bool clipToExtent, const bool isExteriorRing, const bool correctRingOrientation )
 {
-  printf( "_getPolygonRing(in): %d\n", curve.numPoints() );
-  for ( int i = 0 ; i < 10 && i < curve.numPoints(); i++ )
-  {
-    QgsPoint p;
-    QgsVertexId::VertexType t;
-    curve.pointAt( i, p, t );
-    printf( "_getPolygonRing(in):   %f, %f\n", p.x(), p.y() );
-  }
   const QgsCoordinateTransform ct = context.coordinateTransform();
   const QgsMapToPixel &mtp = context.mapToPixel();
 
@@ -254,11 +232,6 @@ QPolygonF QgsSymbol::_getPolygonRing( QgsRenderContext &context, const QgsCurve 
   if ( !out.empty() && !poly.isClosed() )
     out << out.at( 0 );
 
-  printf( "_getPolygonRing(out): %d\n", out.size() );
-  for ( int i = 0 ; i < 10 && i < out.size(); i++ )
-  {
-    printf( "_getPolygonRing(out):   %f, %f\n", out.at( i ).x(), out.at( i ).y() );
-  }
   return out;
 }
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -120,7 +120,7 @@ QPolygonF QgsSymbol::_getLineString( QgsRenderContext &context, const QgsCurve &
   }
 
   // remove non-finite points, e.g. infinite or NaN points caused by reprojecting errors
-  pts.filterVertices( []( const QgsPoint point )
+  pts.filterVertices( []( const QgsPoint& point )
   {
     if ( point.is3D() )
     {

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -169,9 +169,10 @@ QPolygonF QgsSymbol::_getPolygonRing( QgsRenderContext &context, const QgsCurve 
   if ( correctRingOrientation )
   {
     // ensure consistent polygon ring orientation
-    if ( (isExteriorRing && curve.orientation() != Qgis::AngularDirection::Clockwise) || ( !isExteriorRing && curve.orientation() != Qgis::AngularDirection::CounterClockwise )) {
+    if ( (isExteriorRing && curve.orientation() != Qgis::AngularDirection::Clockwise) || ( !isExteriorRing && curve.orientation() != Qgis::AngularDirection::CounterClockwise ) )
+    {
       poly.reversed()->points( seq );
-      poly.setPoints(seq);
+      poly.setPoints( seq );
     }
   }
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -127,7 +127,7 @@ QPolygonF QgsSymbol::_getLineString3d( QgsRenderContext &context, const QgsCurve
   {
     try
     {
-      pts.transform( ct, QgsCoordinateTransform::TransformDirection::ForwardTransform, true );
+      pts.transform( ct, Qgis::TransformDirection::Forward, true );
     }
     catch ( QgsCsException & )
     {
@@ -177,7 +177,7 @@ QPolygonF QgsSymbol::_getLineString2d( QgsRenderContext &context, const QgsCurve
   QPolygonF pts;
 
   //apply clipping for large lines to achieve a better rendering performance
-  if ( clipToExtent && nPoints > 1 && !( context.flags() & QgsRenderContext::ApplyClipAfterReprojection ) )
+  if ( clipToExtent && nPoints > 1 && !( context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection ) )
   {
     const QgsRectangle e = context.extent();
     const double cw = e.width() / 10;
@@ -210,7 +210,7 @@ QPolygonF QgsSymbol::_getLineString2d( QgsRenderContext &context, const QgsCurve
     return !std::isfinite( point.x() ) || !std::isfinite( point.y() );
   } ), pts.end() );
 
-  if ( clipToExtent && nPoints > 1 && context.flags() & QgsRenderContext::ApplyClipAfterReprojection )
+  if ( clipToExtent && nPoints > 1 && context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection )
   {
     // early clipping was not possible, so we have to apply it here after transformation
     const QgsRectangle e = context.mapExtent();
@@ -276,7 +276,7 @@ QPolygonF QgsSymbol::_getPolygonRing3d( QgsRenderContext &context, const QgsCurv
   {
     try
     {
-      poly.transform( ct, QgsCoordinateTransform::TransformDirection::ForwardTransform, true );
+      poly.transform( ct, Qgis::TransformDirection::Forward, true );
     }
     catch ( QgsCsException & )
     {
@@ -342,7 +342,7 @@ QPolygonF QgsSymbol::_getPolygonRing2d( QgsRenderContext &context, const QgsCurv
   }
 
   //clip close to view extent, if needed
-  if ( clipToExtent && !( context.flags() & QgsRenderContext::ApplyClipAfterReprojection ) && !context.extent().contains( poly.boundingRect() ) )
+  if ( clipToExtent && !( context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection ) && !context.extent().contains( poly.boundingRect() ) )
   {
     const QgsRectangle e = context.extent();
     const double cw = e.width() / 10;
@@ -371,7 +371,7 @@ QPolygonF QgsSymbol::_getPolygonRing2d( QgsRenderContext &context, const QgsCurv
     return !std::isfinite( point.x() ) || !std::isfinite( point.y() );
   } ), poly.end() );
 
-  if ( clipToExtent && context.flags() & QgsRenderContext::ApplyClipAfterReprojection && !context.mapExtent().contains( poly.boundingRect() ) )
+  if ( clipToExtent && context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection && !context.mapExtent().contains( poly.boundingRect() ) )
   {
     // early clipping was not possible, so we have to apply it here after transformation
     const QgsRectangle e = context.mapExtent();

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -97,7 +97,7 @@ QPolygonF QgsSymbol::_getLineString3d( QgsRenderContext &context, const QgsCurve
   const QgsMapToPixel &mtp = context.mapToPixel();
   QgsLineString pts;
 
-  //apply clipping for large lines to achieve a better rendering performance
+  // apply clipping for large lines to achieve a better rendering performance
   if ( clipToExtent && nPoints > 1 && !( context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection ) )
   {
     const QgsRectangle e = context.extent();
@@ -122,7 +122,7 @@ QPolygonF QgsSymbol::_getLineString3d( QgsRenderContext &context, const QgsCurve
     }
   }
 
-  //transform the QPolygonF to screen coordinates
+  // transform the QPolygonF to screen coordinates
   if ( ct.isValid() )
   {
     try
@@ -176,7 +176,7 @@ QPolygonF QgsSymbol::_getLineString2d( QgsRenderContext &context, const QgsCurve
   const QgsMapToPixel &mtp = context.mapToPixel();
   QPolygonF pts;
 
-  //apply clipping for large lines to achieve a better rendering performance
+  // apply clipping for large lines to achieve a better rendering performance
   if ( clipToExtent && nPoints > 1 && !( context.flags() & Qgis::RenderContextFlag::ApplyClipAfterReprojection ) )
   {
     const QgsRectangle e = context.extent();
@@ -190,7 +190,7 @@ QPolygonF QgsSymbol::_getLineString2d( QgsRenderContext &context, const QgsCurve
     pts = curve.asQPolygonF();
   }
 
-  //transform the QPolygonF to screen coordinates
+  // transform the QPolygonF to screen coordinates
   if ( ct.isValid() )
   {
     try

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -109,9 +109,17 @@ QPolygonF QgsSymbol::_getLineString3d( QgsRenderContext &context, const QgsCurve
   else
   {
     // clone...
-    QgsPointSequence seq;
-    curve.points( seq );
-    pts.setPoints( seq );
+    const QgsLineString *tmpLine = reinterpret_cast<const QgsLineString *>( &curve );
+    if ( dynamic_cast<const QgsLineString *>( &curve ) )
+    {
+      pts.setPoints( curve.numPoints(), tmpLine->xData(), tmpLine->yData(), tmpLine->zData(), tmpLine->mData() );
+    }
+    else
+    {
+      QgsPointSequence seq;
+      curve.points( seq );
+      pts.setPoints( seq );
+    }
   }
 
   //transform the QPolygonF to screen coordinates

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -254,7 +254,7 @@ QPolygonF QgsSymbol::_getPolygonRing3d( QgsRenderContext &context, const QgsCurv
   if ( correctRingOrientation )
   {
     // ensure consistent polygon ring orientation
-    if ( (isExteriorRing && curve.orientation() != Qgis::AngularDirection::Clockwise) || ( !isExteriorRing && curve.orientation() != Qgis::AngularDirection::CounterClockwise ) )
+    if ( ( isExteriorRing && curve.orientation() != Qgis::AngularDirection::Clockwise ) || ( !isExteriorRing && curve.orientation() != Qgis::AngularDirection::CounterClockwise ) )
     {
       poly.reversed()->points( seq );
       poly.setPoints( seq );
@@ -335,9 +335,9 @@ QPolygonF QgsSymbol::_getPolygonRing2d( QgsRenderContext &context, const QgsCurv
   if ( correctRingOrientation )
   {
     // ensure consistent polygon ring orientation
-    if ( isExteriorRing && curve.orientation() != QgsCurve::Clockwise )
+    if ( isExteriorRing && curve.orientation() != Qgis::AngularDirection::Clockwise )
       std::reverse( poly.begin(), poly.end() );
-    else if ( !isExteriorRing && curve.orientation() != QgsCurve::CounterClockwise )
+    else if ( !isExteriorRing && curve.orientation() != Qgis::AngularDirection::CounterClockwise )
       std::reverse( poly.begin(), poly.end() );
   }
 

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -825,6 +825,32 @@ class CORE_EXPORT QgsSymbol
 
     QgsPropertyCollection mDataDefinedProperties;
 
+    /**
+     * Creates a line string in screen coordinates from a QgsCurve in map coordinates
+     */
+    static QPolygonF _getLineString2d( QgsRenderContext &context, const QgsCurve &curve, bool clipToExtent = true );
+
+    /**
+     * Creates a line string in screen coordinates from a QgsCurve in map coordinates
+     */
+    static QPolygonF _getLineString3d( QgsRenderContext &context, const QgsCurve &curve, bool clipToExtent = true );
+
+    /**
+     * Creates a polygon ring in screen coordinates from a QgsCurve in map coordinates.
+     *
+     * If \a correctRingOrientation is TRUE then the ring will be oriented to match standard ring orientation, e.g.
+     * clockwise for exterior rings and counter-clockwise for interior rings.
+     */
+    static QPolygonF _getPolygonRing2d( QgsRenderContext &context, const QgsCurve &curve, bool clipToExtent, bool isExteriorRing = false, bool correctRingOrientation = false );
+
+    /**
+     * Creates a polygon ring in screen coordinates from a QgsCurve in map coordinates.
+     *
+     * If \a correctRingOrientation is TRUE then the ring will be oriented to match standard ring orientation, e.g.
+     * clockwise for exterior rings and counter-clockwise for interior rings.
+     */
+    static QPolygonF _getPolygonRing3d( QgsRenderContext &context, const QgsCurve &curve, bool clipToExtent, bool isExteriorRing = false, bool correctRingOrientation = false );
+
     Q_DISABLE_COPY( QgsSymbol )
 
 };

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -642,7 +642,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
 
   // When not single click identify, pass an empty point so some derived attributes may still be computed
   if ( !isSingleClick )
-    point = QgsPointXY();
+    point = QgsPoint();
 
   const int featureCount = identifyVectorLayer( results, layer, featureList, filter ? renderer.get() : nullptr, commonDerivedAttributes,
                            [point, layer, this]( const QgsFeature & feature )->QMap< QString, QString >

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -562,14 +562,14 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
 
   QgsGeometry selectionGeom = geometry;
   bool isPointOrRectangle;
-  QgsPointXY point;
+  QgsPoint point;
   bool isSingleClick = selectionGeom.type() == QgsWkbTypes::PointGeometry;
   if ( isSingleClick )
   {
     isPointOrRectangle = true;
-    point = selectionGeom.asPoint();
+    point = selectionGeom.vertexAt( 0 );
 
-    commonDerivedAttributes = derivedAttributesForPoint( QgsPoint( point ) );
+    commonDerivedAttributes = derivedAttributesForPoint( point );
   }
   else
   {
@@ -695,18 +695,18 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
 
   QgsPoint closestPoint = geometry.vertexAt( vId );
 
-  QgsPointXY closestPointMapCoords = mCanvas->mapSettings().layerToMapCoordinates( layer, QgsPointXY( closestPoint.x(), closestPoint.y() ) );
+  QgsPoint closestPointMapCoords = mCanvas->mapSettings().layerToMapCoordinates( layer, closestPoint );
   derivedAttributes.insert( tr( "Closest vertex X" ), formatXCoordinate( closestPointMapCoords ) );
   derivedAttributes.insert( tr( "Closest vertex Y" ), formatYCoordinate( closestPointMapCoords ) );
 
   if ( closestPoint.is3D() )
   {
-    str = QLocale().toString( closestPoint.z(), 'g', 10 );
+    str = QLocale().toString( closestPointMapCoords.z(), 'g', 10 );
     derivedAttributes.insert( tr( "Closest vertex Z" ), str );
   }
   if ( closestPoint.isMeasure() )
   {
-    str = QLocale().toString( closestPoint.m(), 'g', 10 );
+    str = QLocale().toString( closestPointMapCoords.m(), 'g', 10 );
     derivedAttributes.insert( tr( "Closest vertex M" ), str );
   }
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -567,7 +567,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
   if ( isSingleClick )
   {
     isPointOrRectangle = true;
-    point = selectionGeom.vertexAt( 0 );
+    point = *qgsgeometry_cast< const QgsPoint *>( selectionGeom.constGet() );
 
     commonDerivedAttributes = derivedAttributesForPoint( point );
   }

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -182,7 +182,7 @@ void TestQgs3DUtils::testQgsBox3DScale()
   {
     QgsBox3d box( -1, -1, -1, 1, 1, 1 );
     QgsPoint ref( -1.0, -1.0, -1.0 );
-    box.scale( 3.0, &ref );
+    box.scale( 3.0, ref );
     QCOMPARE( box.width(), 6.0 );
     QCOMPARE( box.height(), 6.0 );
     QCOMPARE( box.depth(), 6.0 );
@@ -193,7 +193,7 @@ void TestQgs3DUtils::testQgsBox3DScale()
   {
     QgsBox3d box( -1, -1, -1, 1, 1, 1 );
     QgsPoint ref( -2.0, 2.0, 0.0 );
-    box.scale( 3.0, &ref );
+    box.scale( 3.0, ref );
     QCOMPARE( box.width(), 6.0 );
     QCOMPARE( box.height(), 6.0 );
     QCOMPARE( box.depth(), 6.0 );

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -40,7 +40,6 @@ class TestQgs3DUtils : public QObject
     void testTransforms();
     void testRayFromScreenPoint();
     void testQgsBox3DDistanceTo();
-    void testQgsBox3DScale();
     void testQgsRay3D();
   private:
 };
@@ -164,42 +163,6 @@ void TestQgs3DUtils::testQgsBox3DDistanceTo()
     const QgsBox3d box( 1, 2, 1, 4, 3, 3 );
     QCOMPARE( box.distanceTo( QVector3D( 1, 2, 1 ) ), 0.0 );
     QCOMPARE( box.distanceTo( QVector3D( 0, 0, 0 ) ), qSqrt( 6.0 ) );
-  }
-}
-
-void TestQgs3DUtils::testQgsBox3DScale()
-{
-  {
-    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
-    box.scale( 3.0 );
-    QCOMPARE( box.width(), 6.0 );
-    QCOMPARE( box.height(), 6.0 );
-    QCOMPARE( box.depth(), 6.0 );
-    QCOMPARE( box.xMinimum(), -3.0 );
-    QCOMPARE( box.yMinimum(), -3.0 );
-    QCOMPARE( box.zMinimum(), -3.0 );
-  }
-  {
-    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
-    QgsPoint ref( -1.0, -1.0, -1.0 );
-    box.scale( 3.0, ref );
-    QCOMPARE( box.width(), 6.0 );
-    QCOMPARE( box.height(), 6.0 );
-    QCOMPARE( box.depth(), 6.0 );
-    QCOMPARE( box.xMinimum(), -1.0 );
-    QCOMPARE( box.yMinimum(), -1.0 );
-    QCOMPARE( box.zMinimum(), -1.0 );
-  }
-  {
-    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
-    QgsPoint ref( -2.0, 2.0, 0.0 );
-    box.scale( 3.0, ref );
-    QCOMPARE( box.width(), 6.0 );
-    QCOMPARE( box.height(), 6.0 );
-    QCOMPARE( box.depth(), 6.0 );
-    QCOMPARE( box.xMinimum(), 1.0 );
-    QCOMPARE( box.yMinimum(), -7.0 );
-    QCOMPARE( box.zMinimum(), -3.0 );
   }
 }
 

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -40,6 +40,7 @@ class TestQgs3DUtils : public QObject
     void testTransforms();
     void testRayFromScreenPoint();
     void testQgsBox3DDistanceTo();
+    void testQgsBox3DScale();
     void testQgsRay3D();
   private:
 };
@@ -163,6 +164,42 @@ void TestQgs3DUtils::testQgsBox3DDistanceTo()
     const QgsBox3d box( 1, 2, 1, 4, 3, 3 );
     QCOMPARE( box.distanceTo( QVector3D( 1, 2, 1 ) ), 0.0 );
     QCOMPARE( box.distanceTo( QVector3D( 0, 0, 0 ) ), qSqrt( 6.0 ) );
+  }
+}
+
+void TestQgs3DUtils::testQgsBox3DScale()
+{
+  {
+    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
+    box.scale( 3.0 );
+    QCOMPARE( box.width(), 6.0 );
+    QCOMPARE( box.height(), 6.0 );
+    QCOMPARE( box.depth(), 6.0 );
+    QCOMPARE( box.xMinimum(), -3.0 );
+    QCOMPARE( box.yMinimum(), -3.0 );
+    QCOMPARE( box.zMinimum(), -3.0 );
+  }
+  {
+    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
+    QgsPoint ref( -1.0, -1.0, -1.0 );
+    box.scale( 3.0, &ref );
+    QCOMPARE( box.width(), 6.0 );
+    QCOMPARE( box.height(), 6.0 );
+    QCOMPARE( box.depth(), 6.0 );
+    QCOMPARE( box.xMinimum(), -1.0 );
+    QCOMPARE( box.yMinimum(), -1.0 );
+    QCOMPARE( box.zMinimum(), -1.0 );
+  }
+  {
+    QgsBox3d box( -1, -1, -1, 1, 1, 1 );
+    QgsPoint ref( -2.0, 2.0, 0.0 );
+    box.scale( 3.0, &ref );
+    QCOMPARE( box.width(), 6.0 );
+    QCOMPARE( box.height(), 6.0 );
+    QCOMPARE( box.depth(), 6.0 );
+    QCOMPARE( box.xMinimum(), 1.0 );
+    QCOMPARE( box.yMinimum(), -7.0 );
+    QCOMPARE( box.zMinimum(), -3.0 );
   }
 }
 

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -107,6 +107,7 @@ class TestQgsLineString: public QObject
     void curveSubstring();
     void interpolatePoint();
     void visitPoints();
+    void setPointsFromData();
 };
 
 void TestQgsLineString::constructorEmpty()
@@ -2961,6 +2962,88 @@ void TestQgsLineString::boundingBoxIntersects()
   QVERIFY( !ls.boundingBoxIntersects( QgsRectangle( 1, 3, 6, 9 ) ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( 11, -10, 13, 12 ) );
   QVERIFY( ls.boundingBoxIntersects( QgsRectangle( 12, 3, 16, 9 ) ) );
+}
+
+
+void TestQgsLineString::setPointsFromData()
+{
+  //setPoints
+  QgsLineString l8;
+  double x [] = {1, 2, 3};
+  double y [] = {2, 3, 4};
+  l8.setPoints( 3, x, y );
+  QVERIFY( !l8.isEmpty() );
+  QCOMPARE( l8.numPoints(), 3 );
+  QCOMPARE( l8.vertexCount(), 3 );
+  QCOMPARE( l8.nCoordinates(), 3 );
+  QCOMPARE( l8.ringCount(), 1 );
+  QCOMPARE( l8.partCount(), 1 );
+  QVERIFY( !l8.is3D() );
+  QVERIFY( !l8.isMeasure() );
+  QCOMPARE( l8.wkbType(), QgsWkbTypes::LineString );
+  QVERIFY( !l8.hasCurvedSegments() );
+  QgsPointSequence pts;
+  l8.points( pts );
+  QCOMPARE( pts, QgsPointSequence() << QgsPoint( 1, 2 ) << QgsPoint( 2, 3 ) << QgsPoint( 3, 4 ) );
+  QCOMPARE( *l8.xData(), 1.0 );
+  QCOMPARE( *( l8.xData() + 1 ), 2.0 );
+  QCOMPARE( *( l8.xData() + 2 ), 3.0 );
+  QCOMPARE( *l8.yData(), 2.0 );
+  QCOMPARE( *( l8.yData() + 1 ), 3.0 );
+  QCOMPARE( *( l8.yData() + 2 ), 4.0 );
+
+  //setPoints with empty list, should clear linestring
+  double x2 [] = {};
+  double y2 [] = {};
+  l8.setPoints( 0, x2, y2 );
+  QVERIFY( l8.isEmpty() );
+  QCOMPARE( l8.numPoints(), 0 );
+  QCOMPARE( l8.vertexCount(), 0 );
+  QCOMPARE( l8.nCoordinates(), 0 );
+  QCOMPARE( l8.ringCount(), 0 );
+  QCOMPARE( l8.partCount(), 0 );
+  QCOMPARE( l8.wkbType(), QgsWkbTypes::LineString );
+  l8.points( pts );
+  QVERIFY( pts.isEmpty() );
+
+  //setPoints with z
+  double x3 [] = {1, 2};
+  double y3 [] = {2, 3};
+  double z3 [] = {3, 4};
+  l8.setPoints( 2, x3, y3, z3 );
+  QCOMPARE( l8.numPoints(), 2 );
+  QVERIFY( l8.is3D() );
+  QVERIFY( !l8.isMeasure() );
+  QCOMPARE( l8.wkbType(), QgsWkbTypes::LineStringZ );
+  l8.points( pts );
+  QCOMPARE( pts, QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 2, 3 ) << QgsPoint( QgsWkbTypes::PointZ, 2, 3, 4 ) );
+
+  //setPoints with m
+  double x4 [] = {1, 2};
+  double y4 [] = {2, 3};
+  double m4 [] = {3, 4};
+  l8.setPoints( 2, x4, y4, nullptr, m4 );
+  QCOMPARE( l8.numPoints(), 2 );
+  QVERIFY( !l8.is3D() );
+  QVERIFY( l8.isMeasure() );
+  QCOMPARE( l8.wkbType(), QgsWkbTypes::LineStringM );
+  l8.points( pts );
+  QCOMPARE( pts, QgsPointSequence() << QgsPoint( QgsWkbTypes::PointM, 1, 2, 0, 3 ) << QgsPoint( QgsWkbTypes::PointM, 2, 3, 0, 4 ) );
+
+  //setPoints with zm
+  double x5 [] = {1, 2};
+  double y5 [] = {2, 3};
+  double z5 [] = {4, 4};
+  double m5 [] = {5, 5};
+  l8.setPoints( 2, x5, y5, z5, m5 );
+  l8.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 4, 5 ) << QgsPoint( QgsWkbTypes::PointZM, 2, 3, 4, 5 ) );
+  QCOMPARE( l8.numPoints(), 2 );
+  QVERIFY( l8.is3D() );
+  QVERIFY( l8.isMeasure() );
+  QCOMPARE( l8.wkbType(), QgsWkbTypes::LineStringZM );
+  l8.points( pts );
+  QCOMPARE( pts, QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 4, 5 ) << QgsPoint( QgsWkbTypes::PointZM, 2, 3, 4, 5 ) );
+
 }
 
 QGSTEST_MAIN( TestQgsLineString )

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -87,6 +87,7 @@ class TestQgsLineString: public QObject
     void closestSegment();
     void sumUpArea();
     void boundingBox();
+    void boundingBox3D();
     void angle();
     void removingVertexRemoveLine();
     void boundary();
@@ -2296,6 +2297,17 @@ void TestQgsLineString::boundingBox()
 
   ls.deleteVertex( QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( 1, 3, 6, 5 ) );
+}
+
+void TestQgsLineString::boundingBox3D()
+{
+  // boudingBox - test 3D boundingbox
+  QgsLineString bb3d;
+  bb3d.setPoints( QgsPointSequence() << QgsPoint( -1.0, -1.0, -1.0 )
+                  << QgsPoint( -2.0, -1.0, -1.0 )
+                  << QgsPoint( 1.0, 2.0, -1.0 )
+                  << QgsPoint( 1.0, 2.0, 2.0 ) );
+  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3d( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
 }
 
 void TestQgsLineString::angle()

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2311,6 +2311,15 @@ void TestQgsLineString::boundingBox3D()
                   << QgsPoint( 1.0, 2.0, -1.0 )
                   << QgsPoint( 1.0, 2.0, 2.0 ) );
   QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3d( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
+  // retrieve again, should use cached values
+  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3d( QgsPoint( -2.0, -1.0, -1.0 ), QgsPoint( 1.0, 2.0, 2.0 ) ) );
+
+  // linestring with z
+  bb3d.setPoints( QgsPointSequence() << QgsPoint( -1.0, -1.0 )
+                  << QgsPoint( -2.0, -1.0 )
+                  << QgsPoint( 1.0, 2.0 )
+                  << QgsPoint( 1.0, 2.0 ) );
+  QCOMPARE( bb3d.calculateBoundingBox3d(), QgsBox3d( QgsPoint( -2.0, -1, std::numeric_limits< double >::quiet_NaN() ), QgsPoint( 1.0, 2.0, std::numeric_limits< double >::quiet_NaN() ) ) );
 }
 
 void TestQgsLineString::angle()

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -4,8 +4,10 @@
     Date                 : August 2021
     Copyright            : (C) 2021 by Loïc Bartoletti
                            (C) 2021 by Antoine Facchini
+                           (C) 2021 by Benoit De Mezzo Facchini
     Email                : loic dot bartoletti at oslandia dot com
                            antoine dot facchini at oslandia dot com
+                           benoit dot de dot mezzo at oslandia dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2301,7 +2301,7 @@ void TestQgsLineString::boundingBox()
 
 void TestQgsLineString::boundingBox3D()
 {
-  // boudingBox - test 3D boundingbox
+  // boundingBox - test 3D boundingbox
   QgsLineString bb3d;
   bb3d.setPoints( QgsPointSequence() << QgsPoint( -1.0, -1.0, -1.0 )
                   << QgsPoint( -2.0, -1.0, -1.0 )

--- a/tests/src/core/testqgsclipper.cpp
+++ b/tests/src/core/testqgsclipper.cpp
@@ -50,77 +50,77 @@ void TestQgsClipper::initTestCase()
 void TestQgsClipper::basicWithZ()
 {
   // QgsClipper is static only
-
-  QgsLineString polygon;
-  polygon.addVertex( QgsPoint( 10.4, 20.5, 10.0 ) );
-  polygon.addVertex( QgsPoint( 20.2, 30.2, 20.0 ) );
-
   QgsBox3d clipRect( 10, 10, 11, 25, 30, 19 );
 
-  QgsClipper::trimPolygon( polygon, clipRect );
+  QVector< double > x = { 10.4, 20.2 };
+  QVector< double > y = {20.5, 30.2 };
+  QVector< double > z = {10.0, 20.0 };
+  QgsClipper::trimPolygon( x, y, z, clipRect );
 
   // Check nothing sticks out.
-  QVERIFY( checkBoundingBox( polygon, clipRect ) );
+  QVERIFY( checkBoundingBox( QgsLineString( x, y, z ), clipRect ) );
   // Check that it didn't clip too much
   QgsBox3d clipRectInner( clipRect );
   clipRectInner.scale( 0.999 );
-  QVERIFY( ! checkBoundingBox( polygon, clipRectInner ) );
+  QVERIFY( ! checkBoundingBox( QgsLineString( x, y, z ), clipRectInner ) );
 
   // A more complex example
-  polygon.clear();
-  polygon.addVertex( QgsPoint( 1.0, 9.0, 1.0 ) );
-  polygon.addVertex( QgsPoint( 11.0, 11.0, 11.0 ) );
-  polygon.addVertex( QgsPoint( 9.0, 1.0, 9.0 ) );
+  x = { 1.0, 11.0, 9.0 };
+  y = { 9.0, 11.0, 1.0 };
+  z = { 1.0, 11.0, 9.0 };
   clipRect = QgsBox3d( 0.0, 0.0, 0.0, 10.0, 10.0, 10.0 );
 
-  QgsClipper::trimPolygon( polygon, clipRect );
+  QgsClipper::trimPolygon( x, y, z, clipRect );
 
   // We should have 5 vertices now?
-  QCOMPARE( polygon.numPoints(), 5 );
+  QCOMPARE( x.size(), 5 );
+  QCOMPARE( y.size(), 5 );
+  QCOMPARE( z.size(), 5 );
   // Check nothing sticks out.
-  QVERIFY( checkBoundingBox( polygon, clipRect ) );
+  QVERIFY( checkBoundingBox( QgsLineString( x, y, z ), clipRect ) );
   // Check that it didn't clip too much
   clipRectInner = clipRect;
   clipRectInner.scale( 0.999 );
-  QVERIFY( ! checkBoundingBox( polygon, clipRectInner ) );
+  QVERIFY( ! checkBoundingBox( QgsLineString( x, y, z ), clipRectInner ) );
 }
 
 void TestQgsClipper::basicWithZInf()
 {
   // QgsClipper is static only
 
-  QgsLineString polygon;
-  polygon.addVertex( QgsPoint( 10.4, 20.5, 10.0 ) );
-  polygon.addVertex( QgsPoint( 20.2, 30.2, 20.0 ) );
+  QVector< double > x { 10.4, 20.2 };
+  QVector< double > y { 20.5, 30.2 };
+  QVector< double > z { 10.0, 20.0 };
 
   QgsBox3d clipRect( 10, 10, -HUGE_VAL, 25, 30, HUGE_VAL );
 
-  QgsClipper::trimPolygon( polygon, clipRect );
+  QgsClipper::trimPolygon( x, y, z, clipRect );
 
   // Check nothing sticks out.
-  QVERIFY( checkBoundingBox( polygon, clipRect ) );
+  QVERIFY( checkBoundingBox( QgsLineString( x, y, z ), clipRect ) );
   // Check that it didn't clip too much
   QgsBox3d clipRectInner( clipRect );
   clipRectInner.scale( 0.999 );
-  QVERIFY( ! checkBoundingBox( polygon, clipRectInner ) );
+  QVERIFY( ! checkBoundingBox( QgsLineString( x, y, z ), clipRectInner ) );
 
   // A more complex example
-  polygon.clear();
-  polygon.addVertex( QgsPoint( 1.0, 9.0, 1.0 ) );
-  polygon.addVertex( QgsPoint( 11.0, 11.0, 11.0 ) );
-  polygon.addVertex( QgsPoint( 9.0, 1.0, 9.0 ) );
+  x = { 1.0, 11.0, 9.0 };
+  y = { 9.0, 11.0, 1.0 };
+  z = { 1.0, 11.0, 9.0 };
   clipRect = QgsBox3d( 0.0, 0.0, 0.0, 10.0, 10.0, 10.0 );
 
-  QgsClipper::trimPolygon( polygon, clipRect );
+  QgsClipper::trimPolygon( x, y, z, clipRect );
 
   // We should have 5 vertices now?
-  QCOMPARE( polygon.numPoints(), 5 );
+  QCOMPARE( x.size(), 5 );
+  QCOMPARE( y.size(), 5 );
+  QCOMPARE( z.size(), 5 );
   // Check nothing sticks out.
-  QVERIFY( checkBoundingBox( polygon, clipRect ) );
+  QVERIFY( checkBoundingBox( QgsLineString( x, y, z ), clipRect ) );
   // Check that it didn't clip too much
   clipRectInner = clipRect;
   clipRectInner.scale( 0.999 );
-  QVERIFY( ! checkBoundingBox( polygon, clipRectInner ) );
+  QVERIFY( ! checkBoundingBox( QgsLineString( x, y, z ), clipRectInner ) );
 }
 
 void TestQgsClipper::basic()

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -182,6 +182,34 @@ class TestQgsBox3d(unittest.TestCase):
         self.assertNotEqual(box1, QgsBox3d(5.0, 16.0, 7.0, 11.0, 13.0, 15.0))
         self.assertNotEqual(box1, QgsBox3d(52.0, 6.0, 7.0, 11.0, 13.0, 15.0))
 
+    def testScaling(self):
+        box1 = QgsBox3d(-1, -1, -1, 1, 1, 1)
+        box1.scale(3.0)
+        self.assertEqual(box1.width(), 6.0)
+        self.assertEqual(box1.height(), 6.0)
+        self.assertEqual(box1.depth(), 6.0)
+        self.assertEqual(box1.xMinimum(), -3.0)
+        self.assertEqual(box1.yMinimum(), -3.0)
+        self.assertEqual(box1.zMinimum(), -3.0)
+
+        box2 = QgsBox3d(-1, -1, -1, 1, 1, 1)
+        box2.scale(3.0, QgsPoint(-1.0, -1.0, -1.0))
+        self.assertEqual(box2.width(), 6.0)
+        self.assertEqual(box2.height(), 6.0)
+        self.assertEqual(box2.depth(), 6.0)
+        self.assertEqual(box2.xMinimum(), -1.0)
+        self.assertEqual(box2.yMinimum(), -1.0)
+        self.assertEqual(box2.zMinimum(), -1.0)
+
+        box3 = QgsBox3d(-1, -1, -1, 1, 1, 1)
+        box3.scale(3.0, QgsPoint(-2.0, 2.0, 0.0))
+        self.assertEqual(box3.width(), 6.0)
+        self.assertEqual(box3.height(), 6.0)
+        self.assertEqual(box3.depth(), 6.0)
+        self.assertEqual(box3.xMinimum(), 1.0)
+        self.assertEqual(box3.yMinimum(), -7.0)
+        self.assertEqual(box3.zMinimum(), -3.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Supersedes https://github.com/qgis/QGIS/pull/44941 -- optimises the changes to clipping logic to avoid the considerable overhead of using QgsPoint/QgsPointSequence objects by replacing those with raw coordinate arrays instead.