### PR TITLE
Remove rows when rolling back in transaction mode

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -76,9 +76,9 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
   connect( mLayer, &QgsVectorLayer::beforeRollBack, this,  &QgsAttributeTableModel::bulkEditCommandStarted );
   connect( mLayer, &QgsVectorLayer::afterRollBack, this, [ = ]
   {
-    mIsRollingBack = true;
+    mIsCleaningUpAfterRollback = true;
     bulkEditCommandEnded();
-    mIsRollingBack = false;
+    mIsCleaningUpAfterRollback = false;
   } );
 
   connect( mLayer, &QgsVectorLayer::editCommandEnded, this, &QgsAttributeTableModel::editCommandEnded );
@@ -865,7 +865,7 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
                     3 );
 
   // Remove added rows on rollback
-  if ( mIsRollingBack )
+  if ( mIsCleaningUpAfterRollback )
   {
     for ( const int fid : std::as_const( mInsertedRowsChanges ) )
     {

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -74,7 +74,12 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
 
   connect( mLayer, &QgsVectorLayer::editCommandStarted, this, &QgsAttributeTableModel::bulkEditCommandStarted );
   connect( mLayer, &QgsVectorLayer::beforeRollBack, this,  &QgsAttributeTableModel::bulkEditCommandStarted );
-  connect( mLayer, &QgsVectorLayer::afterRollBack, this, &QgsAttributeTableModel::bulkEditCommandEnded );
+  connect( mLayer, &QgsVectorLayer::afterRollBack, this, [ = ]
+  {
+    mIsRollingBack = true;
+    bulkEditCommandEnded();
+    mIsRollingBack = false;
+  } );
 
   connect( mLayer, &QgsVectorLayer::editCommandEnded, this, &QgsAttributeTableModel::editCommandEnded );
   connect( mLayerCache, &QgsVectorLayerCache::attributeValueChanged, this, &QgsAttributeTableModel::attributeValueChanged );
@@ -170,12 +175,23 @@ bool QgsAttributeTableModel::removeRows( int row, int count, const QModelIndex &
     return false;
 
   if ( !mResettingModel )
+  {
     beginRemoveRows( parent, row, row + count - 1 );
+  }
 
 #ifdef QGISDEBUG
   if ( 3 <= QgsLogger::debugLevel() )
     QgsDebugMsgLevel( QStringLiteral( "remove %2 rows at %1 (rows %3, ids %4)" ).arg( row ).arg( count ).arg( mRowIdMap.size() ).arg( mIdRowMap.size() ), 3 );
 #endif
+
+  if ( mBulkEditCommandRunning && !mResettingModel )
+  {
+    for ( int i = row; i < row + count; i++ )
+    {
+      const QgsFeatureId fid { rowToId( row ) };
+      mInsertedRowsChanges.removeOne( fid );
+    }
+  }
 
   // clean old references
   for ( int i = row; i < row + count; i++ )
@@ -256,6 +272,10 @@ void QgsAttributeTableModel::featureAdded( QgsFeatureId fid )
       if ( !mResettingModel )
         endInsertRows();
       reload( index( rowCount() - 1, 0 ), index( rowCount() - 1, columnCount() ) );
+      if ( mBulkEditCommandRunning && !mResettingModel )
+      {
+        mInsertedRowsChanges.append( fid );
+      }
     }
   }
 }
@@ -833,7 +853,7 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
   mBulkEditCommandRunning = false;
   // Full model update if the changed rows are more than half the total rows
   // or if their count is > layer cache size
-  const int changeCount( mAttributeValueChanges.count() );
+  const int changeCount( std::max( mAttributeValueChanges.count(), mInsertedRowsChanges.count() ) );
   const bool fullModelUpdate = changeCount > mLayerCache->cacheSize() ||
                                changeCount > rowCount() * 0.5;
 
@@ -843,6 +863,21 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
                     .arg( fullModelUpdate ? QStringLiteral( "full" ) :  QStringLiteral( "incremental" ) )
                     .arg( rowCount() ),
                     3 );
+
+  // Remove added rows on rollback
+  if ( mIsRollingBack )
+  {
+    for ( const int fid : std::as_const( mInsertedRowsChanges ) )
+    {
+      const int row( idToRow( fid ) );
+      if ( row < 0 )
+      {
+        continue;
+      }
+      removeRow( row );
+    }
+  }
+
   // Invalidates the whole model
   if ( fullModelUpdate )
   {
@@ -852,6 +887,7 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
   }
   else
   {
+
     int minRow = rowCount();
     int minCol = columnCount();
     int maxRow = 0;
@@ -867,6 +903,7 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
       maxRow = std::max<int>( row, maxRow );
       maxCol = std::max<int>( col, maxCol );
     }
+
     emit dataChanged( createIndex( minRow, minCol ), createIndex( maxRow, maxCol ) );
   }
   mAttributeValueChanges.clear();

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -395,6 +395,12 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     //! Changed attribute values within a bulk edit command
     QMap<QPair<QgsFeatureId, int>, QVariant> mAttributeValueChanges;
 
+    //! Inserted feature IDs within a bulk edit command
+    QList<QgsFeatureId> mInsertedRowsChanges;
+
+    //! TRUE if triggered by afterRollback()
+    bool mIsRollingBack = false;
+
     friend class TestQgsAttributeTable;
 
 };

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -399,7 +399,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     QList<QgsFeatureId> mInsertedRowsChanges;
 
     //! TRUE if triggered by afterRollback()
-    bool mIsRollingBack = false;
+    bool mIsCleaningUpAfterRollback = false;
 
     friend class TestQgsAttributeTable;
 


### PR DESCRIPTION
Fixes #48171

Or, more precisely, fixes the behavior described in the
comment:
https://github.com/qgis/QGIS/issues/48171#issuecomment-1132709901


Given the spaghetti-code of the the attribute table I would not recommend backporting for now.