### PR TITLE
Fix unicode EPT/COPC paths on Windows

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -141,7 +141,7 @@ QgsPointCloudBlock *QgsCopcPointCloudIndex::nodeData( const IndexedPointCloudNod
   requestAttributes.extend( attributes(), filterExpression.referencedAttributes() );
 
   QByteArray rawBlockData( blockSize, Qt::Initialization::Uninitialized );
-  std::ifstream file( mFileName.toStdString(), std::ios::binary );
+  std::ifstream file( QgsLazDecoder::toNativePath( mFileName ), std::ios::binary );
   file.seekg( blockOffset );
   file.read( rawBlockData.data(), blockSize );
 

--- a/src/core/pointcloud/qgslazdecoder.cpp
+++ b/src/core/pointcloud/qgslazdecoder.cpp
@@ -37,6 +37,11 @@
 #include "lazperf/las.hpp"
 #include <lazperf/lazperf.hpp>
 
+#if defined(_MSC_VER)
+#define UNICODE
+#include <locale>
+#include <codecvt>
+#endif
 
 ///@cond PRIVATE
 
@@ -545,8 +550,7 @@ QgsPointCloudBlock *QgsLazDecoder::decompressLaz( const QString &filename,
     const QgsPointCloudAttributeCollection &requestedAttributes,
     QgsPointCloudExpression &filterExpression )
 {
-  const QByteArray arr = filename.toUtf8();
-  std::ifstream file( arr.constData(), std::ios::binary );
+  std::ifstream file( toNativePath( filename ), std::ios::binary );
 
   return __decompressLaz<std::ifstream>( file, requestedAttributes, filterExpression );
 }
@@ -620,5 +624,18 @@ QgsPointCloudBlock *QgsLazDecoder::decompressCopc( const QByteArray &data, QgsLa
   block->setPointCount( pointCount - skippedPoints );
   return block.release();
 }
+
+#if defined(_MSC_VER)
+std::wstring QgsLazDecoder::toNativePath( const QString &filename )
+{
+  std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+  return converter.from_bytes( filename.toStdString() );
+}
+#else
+std::string QgsLazDecoder::toNativePath( const QString &filename )
+{
+  return filename.toStdString();
+}
+#endif
 
 ///@endcond

--- a/src/core/pointcloud/qgslazdecoder.h
+++ b/src/core/pointcloud/qgslazdecoder.h
@@ -27,6 +27,8 @@
 #include "lazperf/lazperf.hpp"
 #include "lazperf/readers.hpp"
 
+#include <string>
+
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
@@ -88,6 +90,20 @@ class QgsLazDecoder
     static QgsPointCloudBlock *decompressLaz( const QByteArray &data, const QgsPointCloudAttributeCollection &requestedAttributes, QgsPointCloudExpression &filterExpression );
     static QgsPointCloudBlock *decompressCopc( const QString &filename, QgsLazInfo &lazInfo, uint64_t blockOffset, uint64_t blockSize, int32_t pointCount, const QgsPointCloudAttributeCollection &requestedAttributes, QgsPointCloudExpression &filterExpression );
     static QgsPointCloudBlock *decompressCopc( const QByteArray &data, QgsLazInfo &lazInfo, int32_t pointCount, const QgsPointCloudAttributeCollection &requestedAttributes, QgsPointCloudExpression &filterExpression );
+
+#if defined(_MSC_VER)
+
+    /**
+     * Converts Unicode path to MSVC's wide string (file streams in MSVC c++ library
+     * expect paths in the active code page, not UTF-8, but they provide variants
+     * with std::wstring to deal with unicode paths)
+     */
+    static std::wstring toNativePath( const QString &filename );
+#else
+    //! Converts Unicode path to UTF-8 encoded string
+    static std::string toNativePath( const QString &filename );
+#endif
+
 };
 
 ///@endcond


### PR DESCRIPTION
Hopefully the last bit to finally make non-ascii paths works for EPT and COPC providers on Windows

Fixes #41833