### PR TITLE
fix mesh calculator dialog time combo boxes

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -695,7 +695,7 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
   mEndTimeComboBox->clear();
 
   // populate combos
-  for ( auto it = times.begin(); it != times.end(); ++it )
+  for ( auto it = times.constBegin(); it != times.constEnd(); ++it )
   {
     double time = it.value();
     const QString strTime = layer->formatTime( time );

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -689,17 +689,15 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
     }
   }
 
-  const QList<qint64> keys = times.keys();
-
   mStartTimeComboBox->blockSignals( true );
   mEndTimeComboBox->blockSignals( true );
   mStartTimeComboBox->clear();
   mEndTimeComboBox->clear();
 
   // populate combos
-  for ( const qint64 &key : keys )
+  for ( auto it = times.begin(); it != times.end(); ++it )
   {
-    double time = times[key];
+    double time = it.value();
     const QString strTime = layer->formatTime( time );
     mStartTimeComboBox->addItem( strTime, time );
     mEndTimeComboBox->addItem( strTime, time );

--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -673,23 +673,23 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
   const QgsMeshDataProvider *dp = layer->dataProvider();
 
   // extract all times from all datasets
-  QMap<QString, double> times;
+  QMap<qint64, double> times;
 
-  for ( int groupIndex = 0; groupIndex < dp->datasetGroupCount(); ++groupIndex )
+  const QList<int> groupIndexes = layer->datasetGroupsIndexes();
+  for ( int dsgi : groupIndexes )
   {
-    for ( int datasetIndex = 0; datasetIndex < dp->datasetCount( groupIndex ); ++datasetIndex )
+    int datasetCount = layer->datasetCount( QgsMeshDatasetIndex( dsgi, 0 ) );
+    for ( int datasetIndex = 0; datasetIndex < datasetCount; ++datasetIndex )
     {
-      const QgsMeshDatasetMetadata meta = dp->datasetMetadata( QgsMeshDatasetIndex( groupIndex, datasetIndex ) );
-      const double time = meta.time();
-      const QString timestr = layer->formatTime( time );
-
-      times[timestr] = time;
+      qint64 timeMs = layer->datasetRelativeTimeInMilliseconds( QgsMeshDatasetIndex( dsgi, datasetIndex ) );
+      if ( timeMs == INVALID_MESHLAYER_TIME )
+        continue;
+      const QgsMeshDatasetMetadata meta = dp->datasetMetadata( QgsMeshDatasetIndex( dsgi, datasetIndex ) );
+      times[timeMs] = meta.time();
     }
   }
 
-  // sort by text
-  auto keys = times.keys();
-  keys.sort();
+  const QList<qint64> keys = times.keys();
 
   mStartTimeComboBox->blockSignals( true );
   mEndTimeComboBox->blockSignals( true );
@@ -697,10 +697,12 @@ void QgsMeshCalculatorDialog::repopulateTimeCombos()
   mEndTimeComboBox->clear();
 
   // populate combos
-  for ( const QString &key : keys )
+  for ( const qint64 &key : keys )
   {
-    mStartTimeComboBox->addItem( key, times[key] );
-    mEndTimeComboBox->addItem( key, times[key] );
+    double time = times[key];
+    const QString strTime = layer->formatTime( time );
+    mStartTimeComboBox->addItem( strTime, time );
+    mEndTimeComboBox->addItem( strTime, time );
   }
 
   mStartTimeComboBox->blockSignals( false );


### PR DESCRIPTION
Before this fix, the combo box to select time extent could have time steps not ordered correctly.