### PR TITLE
Don't hide parts of the mesh renderer widget if the layer is invalid

### DIFF
--- a/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/gui/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -170,10 +170,10 @@ void QgsRendererMeshPropertiesWidget::syncToLayerPrivate()
   onActiveVectorGroupChanged( mMeshLayer->rendererSettings().activeVectorDatasetGroup() );
 
   const bool hasFaces = ( mMeshLayer->contains( QgsMesh::ElementType::Face ) );
-  mFaceMeshGroupBox->setVisible( hasFaces );
+  mFaceMeshGroupBox->setVisible( hasFaces || !mMeshLayer->isValid() );
 
   const bool hasEdges = ( mMeshLayer->contains( QgsMesh::ElementType::Edge ) );
-  mEdgeMeshGroupBox->setVisible( hasEdges );
+  mEdgeMeshGroupBox->setVisible( hasEdges || !mMeshLayer->isValid() );
 
   QgsSettings settings;
   if ( !settings.contains( QStringLiteral( "/Windows/RendererMeshProperties/tab" ) ) )


### PR DESCRIPTION
In this case their may be useful styling information present in the
layer, and we shouldn't hide it away in case users want to see what
it is/copy it to a valid layer.
