### PR TITLE
avoid deleting mesh dataset name when renaming

### DIFF
--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -779,6 +779,7 @@ QVariant QgsMeshAvailableDatasetGroupTreeModel::data( const QModelIndex &index, 
   switch ( role )
   {
     case Qt::DisplayRole:
+    case Qt::EditRole:
     case Name:
       return textDisplayed( index );
 


### PR DESCRIPTION
Before the PR, double clicking on the mesh dataset goup name (in the "Source" tab of the mesh layer properties) leads to delete the current name before editing it.