### PR TITLE
Use snapped point for elevation canvas when showing map point in map canvas

### DIFF
--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -213,9 +213,11 @@ Converts a plot point to the equivalent canvas point.
 Emitted when the number of active background jobs changes.
 %End
 
-    void canvasPointHovered( const QgsPointXY &point );
+    void canvasPointHovered( const QgsPointXY &point, const QgsProfilePoint &profilePoint );
 %Docstring
 Emitted when the mouse hovers over the specified point (in canvas coordinates).
+
+The ``profilePoint`` argument gives the hovered profile point, which may be snapped.
 %End
 
   public slots:

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -453,19 +453,19 @@ void QgsElevationProfileWidget::setProfileCurve( const QgsGeometry &curve, bool 
   scheduleUpdate();
 }
 
-void QgsElevationProfileWidget::onCanvasPointHovered( const QgsPointXY &point )
+void QgsElevationProfileWidget::onCanvasPointHovered( const QgsPointXY &, const QgsProfilePoint &profilePoint )
 {
   if ( !mMapPointRubberBand )
     return;
 
-  const QgsPointXY mapPoint = mCanvas->toMapCoordinates( point );
+  const QgsGeometry mapPoint = mProfileCurve.interpolate( profilePoint.distance() );
   if ( mapPoint.isEmpty() )
   {
     mMapPointRubberBand->hide();
   }
   else
   {
-    mMapPointRubberBand->setToGeometry( QgsGeometry::fromPointXY( mapPoint ) );
+    mMapPointRubberBand->setToGeometry( mapPoint );
     mMapPointRubberBand->show();
   }
 }

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -48,6 +48,7 @@ class QgsLayerTreeRegistryBridge;
 class QgsElevationProfileToolIdentify;
 class QgsElevationProfileToolMeasure;
 class QLabel;
+class QgsProfilePoint;
 
 class QgsElevationProfileWidget : public QWidget
 {
@@ -80,7 +81,7 @@ class QgsElevationProfileWidget : public QWidget
     void updateCanvasLayers();
     void onTotalPendingJobsCountChanged( int count );
     void setProfileCurve( const QgsGeometry &curve, bool resetView );
-    void onCanvasPointHovered( const QgsPointXY &point );
+    void onCanvasPointHovered( const QgsPointXY &point, const QgsProfilePoint &profilePoint );
     void updatePlot();
     void scheduleUpdate();
     void clear();

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -621,7 +621,7 @@ void QgsElevationProfileCanvas::mouseMoveEvent( QMouseEvent *e )
     mCrossHairsItem->setPoint( plotPoint );
     mCrossHairsItem->show();
   }
-  emit canvasPointHovered( e->pos() );
+  emit canvasPointHovered( e->pos(), plotPoint );
 }
 
 QRectF QgsElevationProfileCanvas::plotArea() const

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -232,8 +232,10 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
 
     /**
      * Emitted when the mouse hovers over the specified point (in canvas coordinates).
+     *
+     * The \a profilePoint argument gives the hovered profile point, which may be snapped.
      */
-    void canvasPointHovered( const QgsPointXY &point );
+    void canvasPointHovered( const QgsPointXY &point, const QgsProfilePoint &profilePoint );
 
   public slots:
 


### PR DESCRIPTION
If the elevation profile mouse cursor is snapped, then use the snapped position when drawing the marker on the map canvas to indicate the
cursor position

Otherwise things are misleading -- the elevation profile will show
snapped results yet the corresponding canvas point may be slightly
displaced from what the elevation plot is showing
