### PR TITLE
Allow extra dataset group when exporting mesh to raster block

### DIFF
--- a/src/core/mesh/qgsmeshlayerinterpolator.cpp
+++ b/src/core/mesh/qgsmeshlayerinterpolator.cpp
@@ -228,7 +228,7 @@ QgsRasterBlock *QgsMeshUtils::exportRasterBlock(
   std::unique_ptr<QgsTriangularMesh> triangularMesh = std::make_unique<QgsTriangularMesh>();
   triangularMesh->update( nativeMesh.get(), transform );
 
-  const QgsMeshDatasetGroupMetadata metadata = layer.dataProvider()->datasetGroupMetadata( datasetIndex );
+  const QgsMeshDatasetGroupMetadata metadata = layer.datasetGroupMetadata( datasetIndex );
   const QgsMeshDatasetGroupMetadata::DataType scalarDataType = QgsMeshLayerUtils::datasetValuesType( metadata.dataType() );
   const int count =  QgsMeshLayerUtils::datasetValuesCount( nativeMesh.get(), scalarDataType );
   const QgsMeshDataBlock vals = QgsMeshLayerUtils::datasetValues(
@@ -240,7 +240,7 @@ QgsRasterBlock *QgsMeshUtils::exportRasterBlock(
     return nullptr;
 
   const QVector<double> datasetValues = QgsMeshLayerUtils::calculateMagnitudes( vals );
-  const QgsMeshDataBlock activeFaceFlagValues = layer.dataProvider()->areFacesActive(
+  const QgsMeshDataBlock activeFaceFlagValues = layer.areFacesActive(
         datasetIndex,
         0,
         nativeMesh->faces.count() );


### PR DESCRIPTION
Since QGIS 3.16, dataset group indexes are in the scope of the mesh layer, not in the scope of the data provider. That allows to handle with extra dataset groups added to the mesh layer that are no considered by the data provider (virtual or memory dataset group).
The method to export raster block from the python API was never adapted to allow extra dataset group, allowing only dataset group from the provider. That leads to bad indexing of dataset group when calling `QgsMeshUtils::exportRasterBlock()`

This PR fixed this issue.
