### PR TITLE
[processing] Fix FILE_TYPE parameter of the "Split Vector Layer" native algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -67,7 +67,7 @@ void QgsSplitVectorLayerAlgorithm::initAlgorithm( const QVariantMap & )
                 QVariant(), QStringLiteral( "INPUT" ) ) );
 
   const QStringList options = QgsVectorFileWriter::supportedFormatExtensions();
-  auto fileTypeParam = std::make_unique < QgsProcessingParameterEnum >( QStringLiteral( "FILE_TYPE" ), QObject::tr( "Output file type" ), options, false, QVariantList() << 0, true );
+  auto fileTypeParam = std::make_unique < QgsProcessingParameterEnum >( QStringLiteral( "FILE_TYPE" ), QObject::tr( "Output file type" ), options, false, 0, true );
   fileTypeParam->setFlags( QgsProcessingParameterDefinition::FlagAdvanced );
   addParameter( fileTypeParam.release() );
 


### PR DESCRIPTION
## Description

Fixes a typo in the `FILE_TYPE` advanced optional parameter definition of the "Split Vector Layer" `native:splitvectorlayer` native algorithm (introduced when the algorithm was ported from Python to C++ with https://github.com/qgis/QGIS/pull/36372 by @alexbruy) that prevents such parameter to be actually optional and to respect the default vector output format set by the user in the Processing setting (behaviour introduced with https://github.com/qgis/QGIS/pull/31973 by @nyalldawson).

Fixes #48108.

This PR needs to be backported.

Unrelated test_provider_eptprovider failure (see https://github.com/qgis/QGIS/issues/48778).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
