### PR TITLE
Fix termination of QgsPointCloudStatsCalculationTask

### DIFF
--- a/src/core/pointcloud/qgspointcloudstatscalculationtask.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculationtask.cpp
@@ -25,7 +25,10 @@
 ///@cond PRIVATE
 
 QgsPointCloudStatsCalculationTask::QgsPointCloudStatsCalculationTask( QgsPointCloudIndex *index, const QVector<QgsPointCloudAttribute> &attributes, qint64 pointLimit )
-  : QgsTask( tr( "Generating attributes statistics" ) ), mCalculator( index ), mAttributes( attributes ), mPointLimit( pointLimit )
+  : QgsTask( tr( "Generating attributes statistics" ) )
+  , mCalculator( index )
+  , mAttributes( attributes )
+  , mPointLimit( pointLimit )
 {
   mFeedback = new QgsFeedback( this );
 }
@@ -40,7 +43,6 @@ void QgsPointCloudStatsCalculationTask::cancel()
 {
   QgsTask::cancel();
   mFeedback->cancel();
-  emit QgsTask::taskTerminated();
 }
 
 QgsPointCloudStatistics QgsPointCloudStatsCalculationTask::calculationResults() const


### PR DESCRIPTION
Aimed at fixing race condition between in threads used by eptprovider.
References #48778 