### PR TITLE
Show also files when using GetDirectory on QgsFileWidget.

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2885,7 +2885,6 @@ void QgsLayoutDesignerDialog::exportAtlasToRaster()
 
   QFileDialog dlg( this, tr( "Export Atlas to Directory" ) );
   dlg.setFileMode( QFileDialog::Directory );
-  dlg.setOption( QFileDialog::ShowDirsOnly, true );
   dlg.setDirectory( lastUsedDir );
   if ( !dlg.exec() )
   {
@@ -3060,7 +3059,6 @@ void QgsLayoutDesignerDialog::exportAtlasToSvg()
 
   QFileDialog dlg( this, tr( "Export Atlas to Directory" ) );
   dlg.setFileMode( QFileDialog::Directory );
-  dlg.setOption( QFileDialog::ShowDirsOnly, true );
   dlg.setDirectory( lastUsedDir );
   if ( !dlg.exec() )
   {
@@ -3279,7 +3277,6 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
 
     QFileDialog dlg( this, tr( "Export Atlas to Directory" ) );
     dlg.setFileMode( QFileDialog::Directory );
-    dlg.setOption( QFileDialog::ShowDirsOnly, true );
     dlg.setDirectory( lastUsedDir );
     if ( !dlg.exec() )
     {

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -2249,7 +2249,7 @@ void QgsOptions::addPluginPath()
                     this,
                     tr( "Choose a directory" ),
                     QDir::toNativeSeparators( QDir::homePath() ),
-                    QFileDialog::ShowDirsOnly
+                    QFileDialog::Options()
                   );
 
   if ( ! myDir.isEmpty() )
@@ -2329,7 +2329,7 @@ void QgsOptions::addTemplatePath()
                     this,
                     tr( "Choose a directory" ),
                     QDir::toNativeSeparators( QDir::homePath() ),
-                    QFileDialog::ShowDirsOnly
+                    QFileDialog::Options()
                   );
 
   if ( ! myDir.isEmpty() )
@@ -2356,7 +2356,7 @@ void QgsOptions::addSVGPath()
                     this,
                     tr( "Choose a directory" ),
                     QDir::toNativeSeparators( QDir::homePath() ),
-                    QFileDialog::ShowDirsOnly
+                    QFileDialog::Options()
                   );
 
   if ( ! myDir.isEmpty() )
@@ -2405,7 +2405,7 @@ void QgsOptions::browseCacheDirectory()
                     this,
                     tr( "Choose a directory" ),
                     QDir::toNativeSeparators( mCacheDirectory->text() ),
-                    QFileDialog::ShowDirsOnly
+                    QFileDialog::Options()
                   );
 
   if ( !myDir.isEmpty() )
@@ -2798,7 +2798,7 @@ void QgsOptions::addLocalizedDataPath()
                     this,
                     tr( "Choose a Directory" ),
                     QDir::homePath(),
-                    QFileDialog::ShowDirsOnly
+                    QFileDialog::Options()
                   );
 
   if ( ! myDir.isEmpty() )

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -582,7 +582,7 @@ void QgsAuthOAuth2Edit::selectCurrentDefinedConfig()
 void QgsAuthOAuth2Edit::getDefinedCustomDir()
 {
   const QString extradir = QFileDialog::getExistingDirectory( this, tr( "Select extra directory to parse" ),
-                           QDir::homePath(), QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks );
+                           QDir::homePath(), QFileDialog::DontResolveSymlinks );
   this->raise();
   this->activateWindow();
 

--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -120,7 +120,7 @@ void QgsExternalResourceConfigDlg::chooseDefaultPath()
     dir = QgsSettings().value( QStringLiteral( "/UI/lastExternalResourceWidgetDefaultPath" ), QDir::toNativeSeparators( QDir::cleanPath( path ) ) ).toString();
   }
 
-  const QString rootName = QFileDialog::getExistingDirectory( this, tr( "Select a Directory" ), dir, QFileDialog::ShowDirsOnly );
+  const QString rootName = QFileDialog::getExistingDirectory( this, tr( "Select a Directory" ), dir, QFileDialog::Options() );
 
   if ( !rootName.isNull() )
     mRootPath->setText( rootName );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -356,7 +356,7 @@ void QgsProcessingLayerOutputDestinationWidget::selectDirectory()
   if ( lastDir.isEmpty() )
     lastDir = settings.value( QStringLiteral( "/Processing/LastOutputPath" ), QDir::homePath() ).toString();
 
-  const QString dirName = QFileDialog::getExistingDirectory( this, tr( "Select Directory" ), lastDir, QFileDialog::ShowDirsOnly );
+  const QString dirName = QFileDialog::getExistingDirectory( this, tr( "Select Directory" ), lastDir, QFileDialog::Options() );
   if ( !dirName.isEmpty() )
   {
     leText->setText( QDir::toNativeSeparators( dirName ) );

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -320,7 +320,7 @@ void QgsFileWidget::openFileDialog()
         break;
       case GetDirectory:
         title = !mDialogTitle.isEmpty() ? mDialogTitle : tr( "Select a directory" );
-        fileName = QFileDialog::getExistingDirectory( this, title, QFileInfo( oldPath ).absoluteFilePath(), mOptions | QFileDialog::ShowDirsOnly );
+        fileName = QFileDialog::getExistingDirectory( this, title, QFileInfo( oldPath ).absoluteFilePath(), mOptions );
         break;
       case SaveFile:
       {

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -2300,8 +2300,7 @@ void QgsStyleManagerDialog::exportItemsPNG()
 {
   QString dir = QFileDialog::getExistingDirectory( this, tr( "Export Selected Symbols as PNG" ),
                 QDir::home().absolutePath(),
-                QFileDialog::ShowDirsOnly
-                | QFileDialog::DontResolveSymlinks );
+                QFileDialog::DontResolveSymlinks );
   exportSelectedItemsImages( dir, QStringLiteral( "png" ), QSize( 32, 32 ) );
 }
 
@@ -2309,8 +2308,7 @@ void QgsStyleManagerDialog::exportItemsSVG()
 {
   QString dir = QFileDialog::getExistingDirectory( this, tr( "Export Selected Symbols as SVG" ),
                 QDir::home().absolutePath(),
-                QFileDialog::ShowDirsOnly
-                | QFileDialog::DontResolveSymlinks );
+                QFileDialog::DontResolveSymlinks );
   exportSelectedItemsImages( dir, QStringLiteral( "svg" ), QSize( 32, 32 ) );
 }
 


### PR DESCRIPTION
## Description

### Why?

When a user selects a directory, it feels safer (and more natural) that the user can see the contents of the directory. For example, making sure that he is choosing the directory with certain files.

If the user wants to get the current behavior, he can set `showDirsOnly` to True.

### Before
![image](https://user-images.githubusercontent.com/1421861/170989967-088fb0fc-06be-4cd9-b04e-e4b5accd0f56.png)

### After
![image](https://user-images.githubusercontent.com/1421861/170990025-38be0eb4-8df6-43b9-8e8a-b8dbf5fb99c2.png)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
