### PR TITLE
qgscameracontroller: Ensure to compute correct position conversions

### DIFF
--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -282,6 +282,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
      */
     double sampleDepthBuffer( const QImage &buffer, int px, int py );
 
+    bool screenPointToWorldPos( QPoint position, Qt3DRender::QCamera *cameraBefore, double &depth, QVector3D &worldPosition );
+
   private:
     //! Camera that is being controlled
     Qt3DRender::QCamera *mCamera = nullptr;


### PR DESCRIPTION
Qgs3DUtils::screenPointToWorldPos() converts the clicked mouse
position to the corresponding 3D world coordinates. It relies on some
camera parameters (fnear, ffar and depth) for the conversion. Such
parameters can become incorrect (NaN or zero) when the camera gets
lost. Ideally, this should never happen. However, It should be
possible to mitigate such issues.

By adding a lambda function to screenPointToWorldPos(), it allows
to detect NaN values and prevents the propagation of wrong
calculations.

cc @benoitdm-oslandia @wonder-sk 