### PR TITLE
Fix some of the incorrect warnings shown when adding non-earth layers to a non-earth project

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -948,7 +948,7 @@ Qgis.TransformDirection.__doc__ = 'Indicates the direction (forward or inverse) 
 Qgis.TransformDirection.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ = "Indicates that approximate \"ballpark\" results are appropriate for this coordinate transform. See QgsCoordinateTransform.setBallparkTransformsAreAppropriate() for further details."
-Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transfrom between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.transformationIsPossible() and QgsCoordinateTransfrom.isValid()."
+Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.transformationIsPossible() and QgsCoordinateTransfrom.isValid()."
 Qgis.CoordinateTransformationFlag.__doc__ = 'Flags which adjust the coordinate transformations behave.\n\n.. versionadded:: 3.26\n\n' + '* ``BallparkTransformsAreAppropriate``: ' + Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ + '\n' + '* ``IgnoreImpossibleTransformations``: ' + Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__
 # --
 Qgis.CoordinateTransformationFlag.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -946,6 +946,13 @@ QgsCoordinateTransform.ReverseTransform.__doc__ = "Reverse/inverse transform (fr
 Qgis.TransformDirection.__doc__ = 'Indicates the direction (forward or inverse) of a transform.\n\n.. versionadded:: 3.22\n\n' + '* ``ForwardTransform``: ' + Qgis.TransformDirection.Forward.__doc__ + '\n' + '* ``ReverseTransform``: ' + Qgis.TransformDirection.Reverse.__doc__
 # --
 Qgis.TransformDirection.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ = "Indicates that approximate \"ballpark\" results are appropriate for this coordinate transform. See QgsCoordinateTransform.setBallparkTransformsAreAppropriate() for further details."
+Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transfrom between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.transformationIsPossible() and QgsCoordinateTransfrom.isValid()."
+Qgis.CoordinateTransformationFlag.__doc__ = 'Flags which adjust the coordinate transformations behave.\n\n.. versionadded:: 3.26\n\n' + '* ``BallparkTransformsAreAppropriate``: ' + Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ + '\n' + '* ``IgnoreImpossibleTransformations``: ' + Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__
+# --
+Qgis.CoordinateTransformationFlag.baseClass = Qgis
+Qgis.CoordinateTransformationFlags.baseClass = Qgis
 QgsMapSettings.Flag = Qgis.MapSettingsFlag
 # monkey patching scoped based enum
 QgsMapSettings.Antialiasing = Qgis.MapSettingsFlag.Antialiasing

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -948,7 +948,7 @@ Qgis.TransformDirection.__doc__ = 'Indicates the direction (forward or inverse) 
 Qgis.TransformDirection.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ = "Indicates that approximate \"ballpark\" results are appropriate for this coordinate transform. See QgsCoordinateTransform.setBallparkTransformsAreAppropriate() for further details."
-Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.transformationIsPossible() and QgsCoordinateTransfrom.isValid()."
+Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.isTransformationPossible() and QgsCoordinateTransfrom.isValid()."
 Qgis.CoordinateTransformationFlag.__doc__ = 'Flags which adjust the coordinate transformations behave.\n\n.. versionadded:: 3.26\n\n' + '* ``BallparkTransformsAreAppropriate``: ' + Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ + '\n' + '* ``IgnoreImpossibleTransformations``: ' + Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__
 # --
 Qgis.CoordinateTransformationFlag.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -948,7 +948,7 @@ Qgis.TransformDirection.__doc__ = 'Indicates the direction (forward or inverse) 
 Qgis.TransformDirection.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ = "Indicates that approximate \"ballpark\" results are appropriate for this coordinate transform. See QgsCoordinateTransform.setBallparkTransformsAreAppropriate() for further details."
-Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.isTransformationPossible() and QgsCoordinateTransfrom.isValid()."
+Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__ = "Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform.isTransformationPossible() and QgsCoordinateTransform.isValid()."
 Qgis.CoordinateTransformationFlag.__doc__ = 'Flags which adjust the coordinate transformations behave.\n\n.. versionadded:: 3.26\n\n' + '* ``BallparkTransformsAreAppropriate``: ' + Qgis.CoordinateTransformationFlag.BallparkTransformsAreAppropriate.__doc__ + '\n' + '* ``IgnoreImpossibleTransformations``: ' + Qgis.CoordinateTransformationFlag.IgnoreImpossibleTransformations.__doc__
 # --
 Qgis.CoordinateTransformationFlag.baseClass = Qgis

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -145,7 +145,7 @@ Copy constructor
 
     ~QgsCoordinateTransform();
 
-    static bool transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
+    static bool isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
 %Docstring
 Returns ``True`` if it is theoretically possible to transform between ``source`` and ``destination`` CRSes.
 

--- a/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatetransform.sip.in
@@ -52,7 +52,8 @@ Default constructor, creates an invalid QgsCoordinateTransform.
 
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
                                      const QgsCoordinateReferenceSystem &destination,
-                                     const QgsCoordinateTransformContext &context );
+                                     const QgsCoordinateTransformContext &context,
+                                     Qgis::CoordinateTransformationFlags flags = Qgis::CoordinateTransformationFlags() );
 %Docstring
 Constructs a QgsCoordinateTransform to transform from the ``source``
 to ``destination`` coordinate reference system.
@@ -63,6 +64,9 @@ to utilize.
 
 Python scripts should generally use the constructor variant which accepts
 a :py:class:`QgsProject` instance instead of this constructor.
+
+Since QGIS 3.26 the optional ``flags`` argument can be used to specify flags
+which dictate the behavior of the transformation.
 
 .. warning::
 
@@ -85,7 +89,8 @@ a :py:class:`QgsProject` instance instead of this constructor.
 
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
                                      const QgsCoordinateReferenceSystem &destination,
-                                     const QgsProject *project );
+                                     const QgsProject *project,
+                                     Qgis::CoordinateTransformationFlags flags = Qgis::CoordinateTransformationFlags() );
 %Docstring
 Constructs a QgsCoordinateTransform to transform from the ``source``
 to ``destination`` coordinate reference system, when used with the
@@ -103,6 +108,10 @@ correctly respected during coordinate transforms. E.g.
 
        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem("EPSG:3111"),
                                           QgsCoordinateReferenceSystem("EPSG:4326"), QgsProject.instance())
+
+Since QGIS 3.26 the optional ``flags`` argument can be used to specify flags
+which dictate the behavior of the transformation.
+
 
 .. warning::
 
@@ -135,6 +144,22 @@ Copy constructor
 
 
     ~QgsCoordinateTransform();
+
+    static bool transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
+%Docstring
+Returns ``True`` if it is theoretically possible to transform between ``source`` and ``destination`` CRSes.
+
+For example, will return ``False`` if ``source`` and ``destination`` relate to different celestial bodies and
+a transformation between them will never be possible.
+
+.. warning::
+
+   This method tests only if it is theoretically possible to transform between the CRSes, not whether a
+   transform can actually be constructed on the system. It is possible that this method may return ``True``,
+   yet construction of a matching QgsCoordinateTransform fails (e.g. due to missing grid shift files on the system).
+
+.. versionadded:: 3.26
+%End
 
     bool isValid() const;
 %Docstring

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -683,6 +683,15 @@ The development version
       Reverse
     };
 
+    enum class CoordinateTransformationFlag
+    {
+      BallparkTransformsAreAppropriate,
+      IgnoreImpossibleTransformations,
+    };
+
+    typedef QFlags<Qgis::CoordinateTransformationFlag> CoordinateTransformationFlags;
+
+
     enum class MapSettingsFlag
       {
       Antialiasing,
@@ -1193,6 +1202,9 @@ QFlags<Qgis::PlotToolFlag> operator|(Qgis::PlotToolFlag f1, QFlags<Qgis::PlotToo
 QFlags<Qgis::ProfileGeneratorFlag> operator|(Qgis::ProfileGeneratorFlag f1, QFlags<Qgis::ProfileGeneratorFlag> f2);
 
 QFlags<Qgis::ProjectReadFlag> operator|(Qgis::ProjectReadFlag f1, QFlags<Qgis::ProjectReadFlag> f2);
+
+QFlags<Qgis::CoordinateTransformationFlag> operator|(Qgis::CoordinateTransformationFlag f1, QFlags<Qgis::CoordinateTransformationFlag> f2);
+
 
 
 

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -1122,6 +1122,7 @@ while ($LINE_IDX < $LINE_COUNT){
                     my $comment = $+{co};
                     # replace :: with . (changes c++ style namespace/class directives to Python style)
                     $comment =~ s/::/./g;
+                    $comment =~ s/\"/\\"/g;
                     my $compat_name = $+{compat} ? $+{compat} : $enum_member;
                     dbg_info("is_scope_based:$is_scope_based enum_mk_base:$enum_mk_base monkeypatch:$monkeypatch");
                     if ($is_scope_based eq "1" and $enum_member ne "") {

--- a/src/app/qgsgeometryvalidationdock.h
+++ b/src/app/qgsgeometryvalidationdock.h
@@ -54,7 +54,6 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
     void gotoPreviousError();
     void zoomToProblem();
     void zoomToFeature();
-    void updateLayerTransform();
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
     void onRowsInserted();
     void showErrorContextMenu( const QPoint &pos );
@@ -69,13 +68,14 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
 
     void showHighlight( const QModelIndex &current );
 
+    QgsCoordinateTransform layerTransform() const;
+
     ZoomToAction mLastZoomToAction = ZoomToFeature;
     QgsGeometryValidationModel *mGeometryValidationModel = nullptr;
     QgsGeometryValidationService *mGeometryValidationService = nullptr;
     QButtonGroup *mZoomToButtonGroup = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgisApp *mQgisApp = nullptr;
-    QgsCoordinateTransform mLayerTransform;
     QModelIndex currentIndex() const;
     QgsRubberBand *mFeatureRubberband = nullptr;
     QgsRubberBand *mErrorRubberband = nullptr;

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -71,7 +71,7 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
   mHasContext = true;
 #endif
 
-  if ( mIgnoreImpossible && !transformationIsPossible( source, destination ) )
+  if ( mIgnoreImpossible && !isTransformationPossible( source, destination ) )
   {
     d->invalidate();
     return;
@@ -104,7 +104,7 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
   if ( flags & Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations )
     mIgnoreImpossible = true;
 
-  if ( mIgnoreImpossible && !transformationIsPossible( source, destination ) )
+  if ( mIgnoreImpossible && !isTransformationPossible( source, destination ) )
   {
     d->invalidate();
     return;
@@ -167,7 +167,7 @@ QgsCoordinateTransform &QgsCoordinateTransform::operator=( const QgsCoordinateTr
 
 QgsCoordinateTransform::~QgsCoordinateTransform() {} //NOLINT
 
-bool QgsCoordinateTransform::transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
+bool QgsCoordinateTransform::isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
 {
   if ( !source.isValid() || !destination.isValid() )
     return false;
@@ -185,7 +185,7 @@ void QgsCoordinateTransform::setSourceCrs( const QgsCoordinateReferenceSystem &c
   d.detach();
   d->mSourceCRS = crs;
 
-  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  if ( mIgnoreImpossible && !isTransformationPossible( d->mSourceCRS, d->mDestCRS ) )
   {
     d->invalidate();
     return;
@@ -208,7 +208,7 @@ void QgsCoordinateTransform::setDestinationCrs( const QgsCoordinateReferenceSyst
   d.detach();
   d->mDestCRS = crs;
 
-  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  if ( mIgnoreImpossible && !isTransformationPossible( d->mSourceCRS, d->mDestCRS ) )
   {
     d->invalidate();
     return;
@@ -235,7 +235,7 @@ void QgsCoordinateTransform::setContext( const QgsCoordinateTransformContext &co
   mHasContext = true;
 #endif
 
-  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  if ( mIgnoreImpossible && !isTransformationPossible( d->mSourceCRS, d->mDestCRS ) )
   {
     d->invalidate();
     return;

--- a/src/core/proj/qgscoordinatetransform.cpp
+++ b/src/core/proj/qgscoordinatetransform.cpp
@@ -59,13 +59,23 @@ QgsCoordinateTransform::QgsCoordinateTransform()
   d = new QgsCoordinateTransformPrivate();
 }
 
-QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, const QgsCoordinateTransformContext &context )
+QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, const QgsCoordinateTransformContext &context, Qgis::CoordinateTransformationFlags flags )
 {
   mContext = context;
   d = new QgsCoordinateTransformPrivate( source, destination, mContext );
+
+  if ( flags & Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations )
+    mIgnoreImpossible = true;
+
 #ifdef QGISDEBUG
   mHasContext = true;
 #endif
+
+  if ( mIgnoreImpossible && !transformationIsPossible( source, destination ) )
+  {
+    d->invalidate();
+    return;
+  }
 
   if ( !d->checkValidity() )
     return;
@@ -77,9 +87,12 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
     addToCache();
   }
   Q_NOWARN_DEPRECATED_POP
+
+  if ( flags & Qgis::CoordinateTransformationFlag::BallparkTransformsAreAppropriate )
+    mBallparkTransformsAreAppropriate = true;
 }
 
-QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, const QgsProject *project )
+QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, const QgsProject *project, Qgis::CoordinateTransformationFlags flags )
 {
   mContext = project ? project->transformContext() : QgsCoordinateTransformContext();
   d = new QgsCoordinateTransformPrivate( source, destination, mContext );
@@ -88,6 +101,15 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
     mHasContext = true;
 #endif
 
+  if ( flags & Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations )
+    mIgnoreImpossible = true;
+
+  if ( mIgnoreImpossible && !transformationIsPossible( source, destination ) )
+  {
+    d->invalidate();
+    return;
+  }
+
   if ( !d->checkValidity() )
     return;
 
@@ -98,6 +120,9 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
     addToCache();
   }
   Q_NOWARN_DEPRECATED_POP
+
+  if ( flags & Qgis::CoordinateTransformationFlag::BallparkTransformsAreAppropriate )
+    mBallparkTransformsAreAppropriate = true;
 }
 
 QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, int sourceDatumTransform, int destinationDatumTransform )
@@ -142,10 +167,30 @@ QgsCoordinateTransform &QgsCoordinateTransform::operator=( const QgsCoordinateTr
 
 QgsCoordinateTransform::~QgsCoordinateTransform() {} //NOLINT
 
+bool QgsCoordinateTransform::transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
+{
+  if ( !source.isValid() || !destination.isValid() )
+    return false;
+
+#if PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR>=1)
+  if ( source.celestialBodyName() != destination.celestialBodyName() )
+    return false;
+#endif
+
+  return true;
+}
+
 void QgsCoordinateTransform::setSourceCrs( const QgsCoordinateReferenceSystem &crs )
 {
   d.detach();
   d->mSourceCRS = crs;
+
+  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  {
+    d->invalidate();
+    return;
+  }
+
   if ( !d->checkValidity() )
     return;
 
@@ -162,6 +207,13 @@ void QgsCoordinateTransform::setDestinationCrs( const QgsCoordinateReferenceSyst
 {
   d.detach();
   d->mDestCRS = crs;
+
+  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  {
+    d->invalidate();
+    return;
+  }
+
   if ( !d->checkValidity() )
     return;
 
@@ -182,6 +234,13 @@ void QgsCoordinateTransform::setContext( const QgsCoordinateTransformContext &co
 #ifdef QGISDEBUG
   mHasContext = true;
 #endif
+
+  if ( mIgnoreImpossible && !transformationIsPossible( d->mSourceCRS, d->mDestCRS ) )
+  {
+    d->invalidate();
+    return;
+  }
+
   if ( !d->checkValidity() )
     return;
 

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -162,7 +162,7 @@ class CORE_EXPORT QgsCoordinateTransform
      *
      * \since QGIS 3.26
      */
-    static bool transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
+    static bool isTransformationPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
 
     /**
      * Returns TRUE if the coordinate transform is valid, ie both the source and destination

--- a/src/core/proj/qgscoordinatetransform.h
+++ b/src/core/proj/qgscoordinatetransform.h
@@ -73,6 +73,9 @@ class CORE_EXPORT QgsCoordinateTransform
      * Python scripts should generally use the constructor variant which accepts
      * a QgsProject instance instead of this constructor.
      *
+     * Since QGIS 3.26 the optional \a flags argument can be used to specify flags
+     * which dictate the behavior of the transformation.
+     *
      * \warning Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
      * between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
      * however dynamic CRS to dynamic CRS transformations are not currently supported.
@@ -88,7 +91,8 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
                                      const QgsCoordinateReferenceSystem &destination,
-                                     const QgsCoordinateTransformContext &context );
+                                     const QgsCoordinateTransformContext &context,
+                                     Qgis::CoordinateTransformationFlags flags = Qgis::CoordinateTransformationFlags() );
 
     /**
      * Constructs a QgsCoordinateTransform to transform from the \a source
@@ -108,6 +112,9 @@ class CORE_EXPORT QgsCoordinateTransform
      *                                      QgsCoordinateReferenceSystem("EPSG:4326"), QgsProject.instance())
      * \endcode
      *
+     * Since QGIS 3.26 the optional \a flags argument can be used to specify flags
+     * which dictate the behavior of the transformation.
+     *
      * \warning Since QGIS 3.20 The QgsCoordinateTransform class can perform time-dependent transformations
      * between a static and dynamic CRS based on either the source OR destination CRS coordinate epoch,
      * however dynamic CRS to dynamic CRS transformations are not currently supported.
@@ -115,7 +122,8 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
                                      const QgsCoordinateReferenceSystem &destination,
-                                     const QgsProject *project );
+                                     const QgsProject *project,
+                                     Qgis::CoordinateTransformationFlags flags = Qgis::CoordinateTransformationFlags() );
 
     /**
      * Constructs a QgsCoordinateTransform to transform from the \a source
@@ -141,6 +149,20 @@ class CORE_EXPORT QgsCoordinateTransform
     QgsCoordinateTransform &operator=( const QgsCoordinateTransform &o );
 
     ~QgsCoordinateTransform();
+
+    /**
+     * Returns TRUE if it is theoretically possible to transform between \a source and \a destination CRSes.
+     *
+     * For example, will return FALSE if \a source and \a destination relate to different celestial bodies and
+     * a transformation between them will never be possible.
+     *
+     * \warning This method tests only if it is theoretically possible to transform between the CRSes, not whether a
+     * transform can actually be constructed on the system. It is possible that this method may return TRUE,
+     * yet construction of a matching QgsCoordinateTransform fails (e.g. due to missing grid shift files on the system).
+     *
+     * \since QGIS 3.26
+     */
+    static bool transformationIsPossible( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
 
     /**
      * Returns TRUE if the coordinate transform is valid, ie both the source and destination
@@ -702,6 +724,7 @@ class CORE_EXPORT QgsCoordinateTransform
 #endif
 
     mutable QString mLastError;
+    bool mIgnoreImpossible = false;
     bool mBallparkTransformsAreAppropriate = false;
     bool mDisableFallbackHandler = false;
     mutable bool mFallbackOperationOccurred = false;
@@ -729,6 +752,8 @@ class CORE_EXPORT QgsCoordinateTransform
     static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                                 const QgsCoordinateReferenceSystem &destinationCrs,
                                 const QString &desiredOperation )> sFallbackOperationOccurredHandler;
+
+    friend class TestQgsCoordinateTransform;
 
 };
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -878,7 +878,7 @@ void QgsProject::setCrs( const QgsCoordinateReferenceSystem &crs, bool adjustEll
 
     // if annotation layer doesn't have a crs (i.e. in a newly created project), it should
     // initially inherit the project CRS
-    if ( !mMainAnnotationLayer->crs().isValid() )
+    if ( !mMainAnnotationLayer->crs().isValid() || mMainAnnotationLayer->isEmpty() )
       mMainAnnotationLayer->setCrs( crs );
 
     setDirty( true );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1098,6 +1098,26 @@ class CORE_EXPORT Qgis
     Q_ENUM( TransformDirection )
 
     /**
+     * Flags which adjust the coordinate transformations behave.
+     *
+     * \since QGIS 3.26
+     */
+    enum class CoordinateTransformationFlag  : int
+    {
+      BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
+      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transfrom between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::transformationIsPossible() and QgsCoordinateTransfrom::isValid().
+    };
+    Q_ENUM( CoordinateTransformationFlag )
+
+    /**
+     * Coordinate transformation flags.
+     *
+     * \since QGIS 3.26
+     */
+    Q_DECLARE_FLAGS( CoordinateTransformationFlags, CoordinateTransformationFlag )
+    Q_ENUM( CoordinateTransformationFlags )
+
+    /**
      * Flags which adjust the way maps are rendered.
      *
      * \since QGIS 3.22
@@ -1938,6 +1958,8 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SnappingTypes )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::PlotToolFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProfileGeneratorFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProjectReadFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::CoordinateTransformationFlags )
+
 
 
 // hack to workaround warnings when casting void pointers

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1105,7 +1105,7 @@ class CORE_EXPORT Qgis
     enum class CoordinateTransformationFlag  : int
     {
       BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
-      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::transformationIsPossible() and QgsCoordinateTransfrom::isValid().
+      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransfrom::isValid().
     };
     Q_ENUM( CoordinateTransformationFlag )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1105,7 +1105,7 @@ class CORE_EXPORT Qgis
     enum class CoordinateTransformationFlag  : int
     {
       BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
-      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransfrom::isValid().
+      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransform::isValid().
     };
     Q_ENUM( CoordinateTransformationFlag )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1105,7 +1105,7 @@ class CORE_EXPORT Qgis
     enum class CoordinateTransformationFlag  : int
     {
       BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
-      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transfrom between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::transformationIsPossible() and QgsCoordinateTransfrom::isValid().
+      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::transformationIsPossible() and QgsCoordinateTransfrom::isValid().
     };
     Q_ENUM( CoordinateTransformationFlag )
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -448,8 +448,9 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
   QgsRectangle rect;
   if ( !mSettings.visibleExtent().isEmpty() )
   {
-    QgsCoordinateTransform transform( mSettings.destinationCrs(), crs, QgsProject::instance() );
-    transform.setBallparkTransformsAreAppropriate( true );
+    const QgsCoordinateTransform transform( mSettings.destinationCrs(), crs, QgsProject::instance(),
+                                            Qgis::CoordinateTransformationFlag::BallparkTransformsAreAppropriate
+                                            | Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations );
     try
     {
       rect = transform.transformBoundingBox( mSettings.visibleExtent() );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -296,7 +296,7 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
     {
       QgsDebugMsgLevel( QStringLiteral( "renderer has widgetCreateFunction" ), 3 );
       // Current canvas extent (used to calc min/max) in layer CRS
-      const QgsRectangle myExtent = QgsCoordinateTransform::transformationIsPossible( mRasterLayer->crs(), mMapCanvas->mapSettings().destinationCrs() )
+      const QgsRectangle myExtent = QgsCoordinateTransform::isTransformationPossible( mRasterLayer->crs(), mMapCanvas->mapSettings().destinationCrs() )
                                     ? mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() )
                                     : mRasterLayer->extent();
       if ( oldWidget )

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -296,7 +296,9 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
     {
       QgsDebugMsgLevel( QStringLiteral( "renderer has widgetCreateFunction" ), 3 );
       // Current canvas extent (used to calc min/max) in layer CRS
-      const QgsRectangle myExtent = mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
+      const QgsRectangle myExtent = QgsCoordinateTransform::transformationIsPossible( mRasterLayer->crs(), mMapCanvas->mapSettings().destinationCrs() )
+                                    ? mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() )
+                                    : mRasterLayer->extent();
       if ( oldWidget )
       {
         std::unique_ptr< QgsRasterRenderer > oldRenderer( oldWidget->renderer() );

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -38,6 +38,7 @@ class TestQgsCoordinateTransform: public QObject
     void isShortCircuited();
     void contextShared();
     void scaleFactor();
+    void constructorFlags();
     void scaleFactor_data();
     void transform_data();
     void transform();
@@ -53,6 +54,7 @@ class TestQgsCoordinateTransform: public QObject
     void transformErrorOnePoint();
     void testDeprecated4240to4326();
     void testCustomProjTransform();
+    void testTransformationIsPossible();
 };
 
 
@@ -234,6 +236,44 @@ void TestQgsCoordinateTransform::scaleFactor()
     QVERIFY( false );
   }
 
+}
+
+void TestQgsCoordinateTransform::constructorFlags()
+{
+  const QgsCoordinateReferenceSystem srs1( QStringLiteral( "EPSG:3994" ) );
+  const QgsCoordinateReferenceSystem srs2( QStringLiteral( "EPSG:4326" ) );
+
+  // no flags
+  QgsCoordinateTransform tr( srs1, srs2, QgsProject::instance() );
+  QVERIFY( !tr.mBallparkTransformsAreAppropriate );
+  QVERIFY( !tr.isShortCircuited() );
+  QVERIFY( !tr.mIgnoreImpossible );
+
+  QgsCoordinateTransform tr2( srs1, srs2, QgsProject::instance(), Qgis::CoordinateTransformationFlag::BallparkTransformsAreAppropriate );
+  QVERIFY( tr2.mBallparkTransformsAreAppropriate );
+  QVERIFY( !tr2.isShortCircuited() );
+  QVERIFY( !tr2.mIgnoreImpossible );
+
+  QgsCoordinateTransform tr3( srs1, srs2, QgsProject::instance(), Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations | Qgis::CoordinateTransformationFlag::BallparkTransformsAreAppropriate );
+  QVERIFY( tr3.mBallparkTransformsAreAppropriate );
+  QVERIFY( !tr3.isShortCircuited() );
+  QVERIFY( tr3.mIgnoreImpossible );
+
+  QgsCoordinateTransform tr4( srs1, srs2, QgsProject::instance(), Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations );
+  QVERIFY( !tr4.mBallparkTransformsAreAppropriate );
+  QVERIFY( !tr4.isShortCircuited() );
+  QVERIFY( tr4.mIgnoreImpossible );
+
+#if (PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR >= 1 ) )
+  QgsCoordinateTransform tr5( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ),
+                              QgsCoordinateReferenceSystem( QStringLiteral( "ESRI:104903" ) ),
+                              QgsProject::instance(),
+                              Qgis::CoordinateTransformationFlag::IgnoreImpossibleTransformations );
+  QVERIFY( !tr5.mBallparkTransformsAreAppropriate );
+  // crses are from two different celestial bodies, the transform is impossible and should be short-circuited
+  QVERIFY( tr5.isShortCircuited() );
+  QVERIFY( tr5.mIgnoreImpossible );
+#endif
 }
 
 void TestQgsCoordinateTransform::scaleFactor_data()
@@ -758,6 +798,20 @@ void TestQgsCoordinateTransform::testCustomProjTransform()
                             "+step +inv +proj=cart +ellps=WGS84 "
                             "+step +proj=pop +v_3 "
                             "+step +proj=unitconvert +xy_in=rad +xy_out=deg" ) );
+}
+
+void TestQgsCoordinateTransform::testTransformationIsPossible()
+{
+  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) ) );
+  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem() ) );
+  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem() ) );
+
+  QVERIFY( QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) );
+#if (PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR >= 1 ) )
+  // crses from two different celestial bodies => transformation is not possible
+  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ),
+           QgsCoordinateReferenceSystem( QStringLiteral( "ESRI:104903" ) ) ) );
+#endif
 }
 
 

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -802,14 +802,14 @@ void TestQgsCoordinateTransform::testCustomProjTransform()
 
 void TestQgsCoordinateTransform::testTransformationIsPossible()
 {
-  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) ) );
-  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem() ) );
-  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem() ) );
+  QVERIFY( !QgsCoordinateTransform::isTransformationPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) ) );
+  QVERIFY( !QgsCoordinateTransform::isTransformationPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem() ) );
+  QVERIFY( !QgsCoordinateTransform::isTransformationPossible( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem() ) );
 
-  QVERIFY( QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) );
+  QVERIFY( QgsCoordinateTransform::isTransformationPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) );
 #if (PROJ_VERSION_MAJOR>8 || (PROJ_VERSION_MAJOR==8 && PROJ_VERSION_MINOR >= 1 ) )
   // crses from two different celestial bodies => transformation is not possible
-  QVERIFY( !QgsCoordinateTransform::transformationIsPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ),
+  QVERIFY( !QgsCoordinateTransform::isTransformationPossible( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ),
            QgsCoordinateReferenceSystem( QStringLiteral( "ESRI:104903" ) ) ) );
 #endif
 }

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -263,6 +263,24 @@ class TestQgsAnnotationLayer(unittest.TestCase):
         self.assertIsInstance(p2.mainAnnotationLayer().items()[linestring_item_id], QgsAnnotationLineItem)
         self.assertIsInstance(p2.mainAnnotationLayer().items()[marker_item_id], QgsAnnotationMarkerItem)
 
+    def testMainAnnotationLayerCrs(self):
+        p = QgsProject()
+        self.assertEqual(p.crs(), p.mainAnnotationLayer().crs())
+
+        # main annotation layer should follow project crs
+        p.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
+        self.assertEqual(p.crs(), p.mainAnnotationLayer().crs())
+
+        p.setCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        self.assertEqual(p.crs(), p.mainAnnotationLayer().crs())
+
+        # add an item, should lock in the crs for the main annotation layer
+        p.mainAnnotationLayer().addItem(QgsAnnotationPolygonItem(
+            QgsPolygon(QgsLineString([QgsPoint(12, 13), QgsPoint(14, 13), QgsPoint(14, 15), QgsPoint(12, 13)]))))
+
+        p.setCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+        self.assertEqual(p.mainAnnotationLayer().crs().authid(), 'EPSG:4326')
+
     def test_apply_edit(self):
         """
         Test applying edits to a layer


### PR DESCRIPTION
Not a complete fix, but reduces the number of warnings shown from 3 -> 2

Refs https://github.com/qgis/QGIS/issues/42378