### PR TITLE
Fixes for 3d axis view

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -445,9 +445,9 @@ void Qgs3DAxis::createMenu()
   if ( mMode == Mode::Off )
     typeOffAct->setChecked( true );
 
-  QAction *typeCrsAct = new QAction( tr( "Cr&s" ), mMenu );
+  QAction *typeCrsAct = new QAction( tr( "Coordinate Reference &System" ), mMenu );
   typeCrsAct->setCheckable( true );
-  typeCrsAct->setStatusTip( tr( "Crs 3D axis" ) );
+  typeCrsAct->setStatusTip( tr( "Coordinate Reference System 3D axis" ) );
   if ( mMode == Mode::Crs )
     typeCrsAct->setChecked( true );
 
@@ -478,7 +478,7 @@ void Qgs3DAxis::createMenu()
   if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorLeft )
     hPosLeftAct->setChecked( true );
 
-  QAction *hPosMiddleAct = new QAction( tr( "&Middle" ), mMenu );
+  QAction *hPosMiddleAct = new QAction( tr( "&Center" ), mMenu );
   hPosMiddleAct->setCheckable( true );
   if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorHorizontalCenter )
     hPosMiddleAct->setChecked( true );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -438,7 +438,7 @@ void Qgs3DAxis::createMenu()
 {
   mMenu = new QMenu();
 
-  // ============== axis type menu
+  // axis type menu
   QAction *typeOffAct = new QAction( tr( "&Off" ), mMenu );
   typeOffAct->setCheckable( true );
   typeOffAct->setStatusTip( tr( "Disable 3D axis" ) );
@@ -472,7 +472,7 @@ void Qgs3DAxis::createMenu()
   typeMenu->addAction( typeCubeAct );
   mMenu->addMenu( typeMenu );
 
-  // ============== horizontal position menu
+  // horizontal position menu
   QAction *hPosLeftAct = new QAction( tr( "&Left" ), mMenu );
   hPosLeftAct->setCheckable( true );
   if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
@@ -503,7 +503,7 @@ void Qgs3DAxis::createMenu()
   horizPosMenu->addAction( hPosRightAct );
   mMenu->addMenu( horizPosMenu );
 
-  // ============== vertical position menu
+  // vertical position menu
   QAction *vPosTopAct = new QAction( tr( "&Top" ), mMenu );
   vPosTopAct->setCheckable( true );
   if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
@@ -534,7 +534,7 @@ void Qgs3DAxis::createMenu()
   vertPosMenu->addAction( vPosBottomAct );
   mMenu->addMenu( vertPosMenu );
 
-  // ============== axis view menu
+  // axis view menu
   QAction *viewHomeAct = new QAction( tr( "&Home" ) + "\t Ctrl+1", mMenu );
   QAction *viewTopAct = new QAction( tr( "&Top" ) + "\t Ctrl+5", mMenu );
   QAction *viewNorthAct = new QAction( tr( "&North" ) + "\t Ctrl+8", mMenu );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -475,17 +475,17 @@ void Qgs3DAxis::createMenu()
   // horizontal position menu
   QAction *hPosLeftAct = new QAction( tr( "&Left" ), mMenu );
   hPosLeftAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
+  if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorLeft )
     hPosLeftAct->setChecked( true );
 
   QAction *hPosMiddleAct = new QAction( tr( "&Middle" ), mMenu );
   hPosMiddleAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Middle )
+  if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorHorizontalCenter )
     hPosMiddleAct->setChecked( true );
 
   QAction *hPosRightAct = new QAction( tr( "&Right" ), mMenu );
   hPosRightAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::End )
+  if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorRight )
     hPosRightAct->setChecked( true );
 
   QActionGroup *hPosGroup = new QActionGroup( mMenu );
@@ -493,9 +493,9 @@ void Qgs3DAxis::createMenu()
   hPosGroup->addAction( hPosMiddleAct );
   hPosGroup->addAction( hPosRightAct );
 
-  connect( hPosLeftAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( AxisViewportPosition::Begin );} );
-  connect( hPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( AxisViewportPosition::Middle );} );
-  connect( hPosRightAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( AxisViewportPosition::End );} );
+  connect( hPosLeftAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( Qt::AnchorPoint::AnchorLeft );} );
+  connect( hPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( Qt::AnchorPoint::AnchorHorizontalCenter );} );
+  connect( hPosRightAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( Qt::AnchorPoint::AnchorRight );} );
 
   auto horizPosMenu = new QMenu( QStringLiteral( "Horizontal Position" ), mMenu );
   horizPosMenu->addAction( hPosLeftAct );
@@ -506,17 +506,17 @@ void Qgs3DAxis::createMenu()
   // vertical position menu
   QAction *vPosTopAct = new QAction( tr( "&Top" ), mMenu );
   vPosTopAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
+  if ( mAxisViewportVertPos == Qt::AnchorPoint::AnchorTop )
     vPosTopAct->setChecked( true );
 
   QAction *vPosMiddleAct = new QAction( tr( "&Middle" ), mMenu );
   vPosMiddleAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Middle )
+  if ( mAxisViewportVertPos == Qt::AnchorPoint::AnchorVerticalCenter )
     vPosMiddleAct->setChecked( true );
 
   QAction *vPosBottomAct = new QAction( tr( "&Bottom" ), mMenu );
   vPosBottomAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::End )
+  if ( mAxisViewportVertPos == Qt::AnchorPoint::AnchorBottom )
     vPosBottomAct->setChecked( true );
 
   QActionGroup *vPosGroup = new QActionGroup( mMenu );
@@ -524,9 +524,9 @@ void Qgs3DAxis::createMenu()
   vPosGroup->addAction( vPosMiddleAct );
   vPosGroup->addAction( vPosBottomAct );
 
-  connect( vPosTopAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( AxisViewportPosition::Begin );} );
-  connect( vPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( AxisViewportPosition::Middle );} );
-  connect( vPosBottomAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( AxisViewportPosition::End );} );
+  connect( vPosTopAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( Qt::AnchorPoint::AnchorTop );} );
+  connect( vPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( Qt::AnchorPoint::AnchorVerticalCenter );} );
+  connect( vPosBottomAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( Qt::AnchorPoint::AnchorBottom );} );
 
   QMenu *vertPosMenu = new QMenu( QStringLiteral( "Vertical Position" ), mMenu );
   vertPosMenu->addAction( vPosTopAct );
@@ -608,7 +608,7 @@ void Qgs3DAxis::onAxisModeChanged( Qgs3DAxis::Mode mode )
   mMapSettings.set3dAxisSettings( s );
 }
 
-void Qgs3DAxis::onAxisHorizPositionChanged( AxisViewportPosition pos )
+void Qgs3DAxis::onAxisHorizPositionChanged( Qt::AnchorPoint pos )
 {
   setAxisViewportPosition( mAxisViewportSize, mAxisViewportVertPos, pos );
   Qgs3DAxisSettings s = mMapSettings.get3dAxisSettings();
@@ -616,7 +616,7 @@ void Qgs3DAxis::onAxisHorizPositionChanged( AxisViewportPosition pos )
   mMapSettings.set3dAxisSettings( s );
 }
 
-void Qgs3DAxis::onAxisVertPositionChanged( AxisViewportPosition pos )
+void Qgs3DAxis::onAxisVertPositionChanged( Qt::AnchorPoint pos )
 {
   setAxisViewportPosition( mAxisViewportSize, pos, mAxisViewportHorizPos );
   Qgs3DAxisSettings s = mMapSettings.get3dAxisSettings();
@@ -908,7 +908,7 @@ void Qgs3DAxis::createAxis( Qt::Axis axisType )
 }
 
 
-void Qgs3DAxis::setAxisViewportPosition( int axisViewportSize, AxisViewportPosition axisViewportVertPos, AxisViewportPosition axisViewportHorizPos )
+void Qgs3DAxis::setAxisViewportPosition( int axisViewportSize, Qt::AnchorPoint axisViewportVertPos, Qt::AnchorPoint axisViewportHorizPos )
 {
   mAxisViewportSize = axisViewportSize;
   mAxisViewportVertPos = axisViewportVertPos;
@@ -924,16 +924,16 @@ void Qgs3DAxis::onAxisViewportSizeUpdate( int )
 
   float xRatio;
   float yRatio;
-  if ( mAxisViewportHorizPos == AxisViewportPosition::Begin )
+  if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorLeft )
     xRatio = 0.0f;
-  else if ( mAxisViewportHorizPos == AxisViewportPosition::Middle )
+  else if ( mAxisViewportHorizPos == Qt::AnchorPoint::AnchorHorizontalCenter )
     xRatio = 0.5 - widthRatio / 2.0;
   else
     xRatio = 1.0 - widthRatio;
 
-  if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
+  if ( mAxisViewportVertPos == Qt::AnchorPoint::AnchorTop )
     yRatio = 0.0f;
-  else if ( mAxisViewportVertPos == AxisViewportPosition::Middle )
+  else if ( mAxisViewportVertPos == Qt::AnchorPoint::AnchorVerticalCenter )
     yRatio = 0.5 - heightRatio / 2.0;
   else
     yRatio = 1.0 - heightRatio;

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -47,7 +47,6 @@ Qgs3DAxis::Qgs3DAxis( Qt3DExtras::Qt3DWindow *parentWindow
   , mMapScene( mapScene )
   , mCameraController( cameraCtrl )
   , mCrs( map.crs() )
-  , mPreviousCursor( Qt::ArrowCursor )
 {
   mAxisViewport = constructAxisViewport( parent3DScene );
   mAxisViewport->setParent( mParentWindow->activeFrameGraph() );
@@ -70,6 +69,12 @@ Qgs3DAxis::Qgs3DAxis( Qt3DExtras::Qt3DWindow *parentWindow
   createMenu();
 
   init3DObjectPicking();
+}
+
+Qgs3DAxis::~Qgs3DAxis()
+{
+  delete mMenu;
+  mMenu = nullptr;
 }
 
 void Qgs3DAxis::init3DObjectPicking( )
@@ -431,24 +436,28 @@ void Qgs3DAxis::createAxisScene()
 
 void Qgs3DAxis::createMenu()
 {
-  mMenu = new QMenu;
+  mMenu = new QMenu();
+
   // ============== axis type menu
-  auto typeOffAct = new QAction( tr( "&Off" ), this );
+  QAction *typeOffAct = new QAction( tr( "&Off" ), mMenu );
   typeOffAct->setCheckable( true );
   typeOffAct->setStatusTip( tr( "Disable 3D axis" ) );
-  if ( mMode == Mode::Off ) typeOffAct->setChecked( true );
+  if ( mMode == Mode::Off )
+    typeOffAct->setChecked( true );
 
-  auto typeCrsAct = new QAction( tr( "Cr&s" ), this );
+  QAction *typeCrsAct = new QAction( tr( "Cr&s" ), mMenu );
   typeCrsAct->setCheckable( true );
   typeCrsAct->setStatusTip( tr( "Crs 3D axis" ) );
-  if ( mMode == Mode::Crs ) typeCrsAct->setChecked( true );
+  if ( mMode == Mode::Crs )
+    typeCrsAct->setChecked( true );
 
-  auto typeCubeAct = new QAction( tr( "&Cube" ), this );
+  QAction *typeCubeAct = new QAction( tr( "&Cube" ), mMenu );
   typeCubeAct->setCheckable( true );
   typeCubeAct->setStatusTip( tr( "Cube 3D axis" ) );
-  if ( mMode == Mode::Cube ) typeCubeAct->setChecked( true );
+  if ( mMode == Mode::Cube )
+    typeCubeAct->setChecked( true );
 
-  auto typeGroup = new QActionGroup( this );
+  QActionGroup *typeGroup = new QActionGroup( mMenu );
   typeGroup->addAction( typeOffAct );
   typeGroup->addAction( typeCrsAct );
   typeGroup->addAction( typeCubeAct );
@@ -457,26 +466,29 @@ void Qgs3DAxis::createMenu()
   connect( typeCrsAct, &QAction::triggered, this, [this]( bool ) {onAxisModeChanged( Mode::Crs );} );
   connect( typeCubeAct, &QAction::triggered, this, [this]( bool ) {onAxisModeChanged( Mode::Cube );} );
 
-  auto typeMenu = new QMenu( QStringLiteral( "Axis type" ) );
+  QMenu *typeMenu = new QMenu( QStringLiteral( "Axis Type" ), mMenu );
   typeMenu->addAction( typeOffAct );
   typeMenu->addAction( typeCrsAct );
   typeMenu->addAction( typeCubeAct );
   mMenu->addMenu( typeMenu );
 
   // ============== horizontal position menu
-  auto hPosLeftAct = new QAction( tr( "&Left" ), this );
+  QAction *hPosLeftAct = new QAction( tr( "&Left" ), mMenu );
   hPosLeftAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Begin ) hPosLeftAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
+    hPosLeftAct->setChecked( true );
 
-  auto hPosMiddleAct = new QAction( tr( "&Middle" ), this );
+  QAction *hPosMiddleAct = new QAction( tr( "&Middle" ), mMenu );
   hPosMiddleAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Middle ) hPosMiddleAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::Middle )
+    hPosMiddleAct->setChecked( true );
 
-  auto hPosRightAct = new QAction( tr( "&Right" ), this );
+  QAction *hPosRightAct = new QAction( tr( "&Right" ), mMenu );
   hPosRightAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::End ) hPosRightAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::End )
+    hPosRightAct->setChecked( true );
 
-  auto hPosGroup = new QActionGroup( this );
+  QActionGroup *hPosGroup = new QActionGroup( mMenu );
   hPosGroup->addAction( hPosLeftAct );
   hPosGroup->addAction( hPosMiddleAct );
   hPosGroup->addAction( hPosRightAct );
@@ -485,26 +497,29 @@ void Qgs3DAxis::createMenu()
   connect( hPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( AxisViewportPosition::Middle );} );
   connect( hPosRightAct, &QAction::triggered, this, [this]( bool ) {onAxisHorizPositionChanged( AxisViewportPosition::End );} );
 
-  auto horizPosMenu = new QMenu( QStringLiteral( "Horizontal position" ) );
+  auto horizPosMenu = new QMenu( QStringLiteral( "Horizontal Position" ), mMenu );
   horizPosMenu->addAction( hPosLeftAct );
   horizPosMenu->addAction( hPosMiddleAct );
   horizPosMenu->addAction( hPosRightAct );
   mMenu->addMenu( horizPosMenu );
 
   // ============== vertical position menu
-  auto vPosTopAct = new QAction( tr( "&Top" ), this );
+  QAction *vPosTopAct = new QAction( tr( "&Top" ), mMenu );
   vPosTopAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Begin ) vPosTopAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::Begin )
+    vPosTopAct->setChecked( true );
 
-  auto vPosMiddleAct = new QAction( tr( "&Middle" ), this );
+  QAction *vPosMiddleAct = new QAction( tr( "&Middle" ), mMenu );
   vPosMiddleAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::Middle ) vPosMiddleAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::Middle )
+    vPosMiddleAct->setChecked( true );
 
-  auto vPosBottomAct = new QAction( tr( "&Bottom" ), this );
+  QAction *vPosBottomAct = new QAction( tr( "&Bottom" ), mMenu );
   vPosBottomAct->setCheckable( true );
-  if ( mAxisViewportVertPos == AxisViewportPosition::End ) vPosBottomAct->setChecked( true );
+  if ( mAxisViewportVertPos == AxisViewportPosition::End )
+    vPosBottomAct->setChecked( true );
 
-  auto vPosGroup = new QActionGroup( this );
+  QActionGroup *vPosGroup = new QActionGroup( mMenu );
   vPosGroup->addAction( vPosTopAct );
   vPosGroup->addAction( vPosMiddleAct );
   vPosGroup->addAction( vPosBottomAct );
@@ -513,20 +528,20 @@ void Qgs3DAxis::createMenu()
   connect( vPosMiddleAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( AxisViewportPosition::Middle );} );
   connect( vPosBottomAct, &QAction::triggered, this, [this]( bool ) {onAxisVertPositionChanged( AxisViewportPosition::End );} );
 
-  auto vertPosMenu = new QMenu( QStringLiteral( "Vertical position" ) );
+  QMenu *vertPosMenu = new QMenu( QStringLiteral( "Vertical Position" ), mMenu );
   vertPosMenu->addAction( vPosTopAct );
   vertPosMenu->addAction( vPosMiddleAct );
   vertPosMenu->addAction( vPosBottomAct );
   mMenu->addMenu( vertPosMenu );
 
   // ============== axis view menu
-  auto viewHomeAct = new QAction( tr( "&Home" ) + "\t Ctrl+1", this );
-  auto viewTopAct = new QAction( tr( "&Top" ) + "\t Ctrl+5", this );
-  auto viewNorthAct = new QAction( tr( "&North" ) + "\t Ctrl+8", this );
-  auto viewEastAct = new QAction( tr( "&East" ) + "\t Ctrl+6", this );
-  auto viewSouthAct = new QAction( tr( "&South" ) + "\t Ctrl+2", this );
-  auto viewWestAct = new QAction( tr( "&West" ) + "\t Ctrl+4", this );
-  auto viewBottomAct = new QAction( tr( "&Bottom" ), this );
+  QAction *viewHomeAct = new QAction( tr( "&Home" ) + "\t Ctrl+1", mMenu );
+  QAction *viewTopAct = new QAction( tr( "&Top" ) + "\t Ctrl+5", mMenu );
+  QAction *viewNorthAct = new QAction( tr( "&North" ) + "\t Ctrl+8", mMenu );
+  QAction *viewEastAct = new QAction( tr( "&East" ) + "\t Ctrl+6", mMenu );
+  QAction *viewSouthAct = new QAction( tr( "&South" ) + "\t Ctrl+2", mMenu );
+  QAction *viewWestAct = new QAction( tr( "&West" ) + "\t Ctrl+4", mMenu );
+  QAction *viewBottomAct = new QAction( tr( "&Bottom" ), mMenu );
 
   connect( viewHomeAct, &QAction::triggered, this, &Qgs3DAxis::onCameraViewChangeHome );
   connect( viewTopAct, &QAction::triggered, this, &Qgs3DAxis::onCameraViewChangeTop );
@@ -544,27 +559,27 @@ void Qgs3DAxis::createMenu()
       qDebug() << "NO CANVAS!";
     else
     {
-      auto shortcutHome = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_1 ), mapCanvas );
+      QShortcut *shortcutHome = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_1 ), mapCanvas );
       connect( shortcutHome, &QShortcut::activated, this, [this]( ) {onCameraViewChangeHome();} );
 
-      auto shortcutTop = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_5 ), mapCanvas );
+      QShortcut *shortcutTop = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_5 ), mapCanvas );
       connect( shortcutTop, &QShortcut::activated, this, [this]( ) {onCameraViewChangeTop();} );
 
-      auto shortcutNorth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_8 ), mapCanvas );
+      QShortcut *shortcutNorth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_8 ), mapCanvas );
       connect( shortcutNorth, &QShortcut::activated, this, [this]( ) {onCameraViewChangeNorth();} );
 
-      auto shortcutEast = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_6 ), mapCanvas );
+      QShortcut *shortcutEast = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_6 ), mapCanvas );
       connect( shortcutEast, &QShortcut::activated, this, [this]( ) {onCameraViewChangeEast();} );
 
-      auto shortcutSouth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_2 ), mapCanvas );
+      QShortcut *shortcutSouth = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_2 ), mapCanvas );
       connect( shortcutSouth, &QShortcut::activated, this, [this]( ) {onCameraViewChangeSouth();} );
 
-      auto shortcutWest = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_4 ), mapCanvas );
+      QShortcut *shortcutWest = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_4 ), mapCanvas );
       connect( shortcutWest, &QShortcut::activated, this, [this]( ) {onCameraViewChangeWest();} );
     }
   }
 
-  auto viewMenu = new QMenu( QStringLiteral( "Camera view" ) );
+  QMenu *viewMenu = new QMenu( QStringLiteral( "Camera View" ), mMenu );
   viewMenu->addAction( viewHomeAct );
   viewMenu->addAction( viewTopAct );
   viewMenu->addAction( viewNorthAct );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -66,7 +66,8 @@ Qgs3DAxis::Qgs3DAxis( Qt3DExtras::Qt3DWindow *parentWindow
 
   createAxisScene();
 
-  createMenu();
+  mMenu = new QMenu();
+  connect( mMenu, &QMenu::aboutToShow, this, &Qgs3DAxis::populateMenu );
 
   init3DObjectPicking();
 }
@@ -434,9 +435,9 @@ void Qgs3DAxis::createAxisScene()
   }
 }
 
-void Qgs3DAxis::createMenu()
+void Qgs3DAxis::populateMenu()
 {
-  mMenu = new QMenu();
+  mMenu->clear();
 
   // axis type menu
   QAction *typeOffAct = new QAction( tr( "&Off" ), mMenu );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -376,9 +376,9 @@ void Qgs3DAxis::createAxisScene()
     mAxisRoot->setObjectName( "3DAxis_AxisRoot" );
     mAxisRoot->addComponent( mAxisSceneLayer );
 
-    createAxis( Axis::X );
-    createAxis( Axis::Y );
-    createAxis( Axis::Z );
+    createAxis( Qt::Axis::XAxis );
+    createAxis( Qt::Axis::YAxis );
+    createAxis( Qt::Axis::ZAxis );
 
     mCubeRoot = new Qt3DCore::QEntity;
     mCubeRoot->setParent( mAxisSceneEntity );
@@ -780,7 +780,7 @@ Qt3DExtras::QText2DEntity *Qgs3DAxis::addCubeText( const QString &text, float te
   return textEntity;
 }
 
-void Qgs3DAxis::createAxis( const Qgs3DAxis::Axis &axisType )
+void Qgs3DAxis::createAxis( Qt::Axis axisType )
 {
   float cylinderRadius = 0.05 * mCylinderLength;
   float coneLength = 0.3 * mCylinderLength;
@@ -795,7 +795,7 @@ void Qgs3DAxis::createAxis( const Qgs3DAxis::Axis &axisType )
 
   switch ( axisType )
   {
-    case Axis::X:
+    case Qt::Axis::XAxis:
       mText_X = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mText_X->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
       connect( mText_X, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )
@@ -812,7 +812,7 @@ void Qgs3DAxis::createAxis( const Qgs3DAxis::Axis &axisType )
       name = "3DAxis_axisX";
       break;
 
-    case Axis::Y:
+    case Qt::Axis::YAxis:
       mText_Y = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mText_Y->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
       connect( mText_Y, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )
@@ -829,7 +829,7 @@ void Qgs3DAxis::createAxis( const Qgs3DAxis::Axis &axisType )
       name = "3DAxis_axisY";
       break;
 
-    case Axis::Z:
+    case Qt::Axis::ZAxis:
       mText_Z = new Qt3DExtras::QText2DEntity( );  // object initialization in two step:
       mText_Z->setParent( mTwoDLabelSceneEntity ); // see https://bugreports.qt.io/browse/QTBUG-77139
       connect( mText_Z, &Qt3DExtras::QText2DEntity::textChanged, this, [this]( const QString & text )

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -160,7 +160,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
                                        const QSize &destSize );
 
   private slots:
-    // ========= private slots
+
     void onCameraUpdate( );
     void onAxisViewportSizeUpdate( int val = 0 );
 
@@ -180,7 +180,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void onCameraViewChangeBottom( UNUSED bool fake = true ) {onCameraViewChange( 180.0, 0.0 );}
 
   private:
-    // ========= private functions
+
     void createAxisScene();
     void createAxis( const Axis &axis );
     void createCube( );
@@ -195,12 +195,11 @@ class _3D_EXPORT Qgs3DAxis : public QObject
 
     // axis picking and menu
     void init3DObjectPicking( );
-    virtual bool eventFilter( QObject *watched, QEvent *event );
+    bool eventFilter( QObject *watched, QEvent *event ) override;
     void createMenu();
     void hideMenu();
     void displayMenuAt( const QPoint &position );
 
-    // ========= private attributes
     Qgs3DMapSettings &mMapSettings;
     Qt3DExtras::Qt3DWindow *mParentWindow = nullptr;
     Qgs3DMapScene *mMapScene = nullptr;

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -69,6 +69,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      */
     Qgs3DAxis( Qt3DExtras::Qt3DWindow *parentWindow,  Qt3DCore::QEntity *parent3DScene,
                Qgs3DMapScene *mapScene, QgsCameraController *camera, Qgs3DMapSettings &map );
+    ~Qgs3DAxis() override;
 
     /**
      * \brief The Axis enum

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -36,7 +36,6 @@
 #include <QtWidgets/QMenu>
 
 #define SIP_NO_FILE
-#define UNUSED __attribute__((__unused__))
 
 class QgsCameraController;
 class Qgs3DMapSettings;
@@ -76,9 +75,9 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      */
     enum class Axis
     {
-      X = 1,
-      Y = 2,
-      Z = 3
+      X = 1, //!< X Axis
+      Y = 2, //!< Y Axis
+      Z = 3, //!< Z Axis
     };
     Q_ENUM( Axis )
 
@@ -87,11 +86,9 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      */
     enum class AxisViewportPosition
     {
-      //! top or left
-      Begin = 1,
-      Middle = 2,
-      //! bottom or right
-      End = 3
+      Begin = 1, //!< Top or left
+      Middle = 2, //!< Middle
+      End = 3, //!< Bottom or right
     };
     Q_ENUM( AxisViewportPosition )
 
@@ -100,12 +97,9 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      */
     enum class Mode
     {
-      //! disabled
-      Off = 1,
-      //! CRS specific.
-      Crs = 2,
-      //! Cube with label
-      Cube = 3
+      Off = 1, //!< Hide 3d axis
+      Crs = 2, //!< Respect CRS directions
+      Cube = 3, //!< Abstract cube mode
     };
     Q_ENUM( Mode )
 
@@ -171,13 +165,13 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void onAxisVertPositionChanged( AxisViewportPosition pos );
     void onCameraViewChange( float pitch, float yaw );
 
-    void onCameraViewChangeHome( UNUSED bool fake = true ) { onCameraViewChange( 45.0, 45.0 ); }
-    void onCameraViewChangeTop( UNUSED bool fake = true ) {onCameraViewChange( 0.0, 90.0 );}
-    void onCameraViewChangeNorth( UNUSED bool fake = true ) {onCameraViewChange( 90.0, 180.0 );}
-    void onCameraViewChangeEast( UNUSED bool fake = true ) {onCameraViewChange( 90.0, 90.0 );}
-    void onCameraViewChangeSouth( UNUSED bool fake = true ) {onCameraViewChange( 90.0, 0.0 );}
-    void onCameraViewChangeWest( UNUSED bool fake = true ) {onCameraViewChange( 90.0, -90.0 );}
-    void onCameraViewChangeBottom( UNUSED bool fake = true ) {onCameraViewChange( 180.0, 0.0 );}
+    void onCameraViewChangeHome( ) { onCameraViewChange( 45.0, 45.0 ); }
+    void onCameraViewChangeTop( ) {onCameraViewChange( 0.0, 90.0 );}
+    void onCameraViewChangeNorth( ) {onCameraViewChange( 90.0, 180.0 );}
+    void onCameraViewChangeEast( ) {onCameraViewChange( 90.0, 90.0 );}
+    void onCameraViewChangeSouth( ) {onCameraViewChange( 90.0, 0.0 );}
+    void onCameraViewChangeWest( ) {onCameraViewChange( 90.0, -90.0 );}
+    void onCameraViewChangeBottom() {onCameraViewChange( 180.0, 0.0 );}
 
   private:
 

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -150,6 +150,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     void onCameraViewChangeSouth( ) {onCameraViewChange( 90.0, 0.0 );}
     void onCameraViewChangeWest( ) {onCameraViewChange( 90.0, -90.0 );}
     void onCameraViewChangeBottom() {onCameraViewChange( 180.0, 0.0 );}
+    void populateMenu();
 
   private:
 
@@ -168,7 +169,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     // axis picking and menu
     void init3DObjectPicking( );
     bool eventFilter( QObject *watched, QEvent *event ) override;
-    void createMenu();
+
     void hideMenu();
     void displayMenuAt( const QPoint &position );
 

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -71,17 +71,6 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     ~Qgs3DAxis() override;
 
     /**
-     * \brief The Axis enum
-     */
-    enum class Axis
-    {
-      X = 1, //!< X Axis
-      Y = 2, //!< Y Axis
-      Z = 3, //!< Z Axis
-    };
-    Q_ENUM( Axis )
-
-    /**
      * \brief The AxisViewportPosition enum
      */
     enum class AxisViewportPosition
@@ -176,7 +165,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
   private:
 
     void createAxisScene();
-    void createAxis( const Axis &axis );
+    void createAxis( Qt::Axis axis );
     void createCube( );
     void setEnableCube( bool show );
     void setEnableAxis( bool show );

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -71,17 +71,6 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     ~Qgs3DAxis() override;
 
     /**
-     * \brief The AxisViewportPosition enum
-     */
-    enum class AxisViewportPosition
-    {
-      Begin = 1, //!< Top or left
-      Middle = 2, //!< Middle
-      End = 3, //!< Bottom or right
-    };
-    Q_ENUM( AxisViewportPosition )
-
-    /**
      * \brief The Mode enum
      */
     enum class Mode
@@ -109,7 +98,7 @@ class _3D_EXPORT Qgs3DAxis : public QObject
      * @param axisViewportVertPos start vertical position
      * @param axisViewportHorizPos start horizontal position
      */
-    void setAxisViewportPosition( int axisViewportSize, AxisViewportPosition axisViewportVertPos, AxisViewportPosition axisViewportHorizPos );
+    void setAxisViewportPosition( int axisViewportSize, Qt::AnchorPoint axisViewportVertPos, Qt::AnchorPoint axisViewportHorizPos );
 
     /**
      * \brief Returns axis viewport size
@@ -119,12 +108,12 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     /**
      * \brief Returns axis viewport horizontal position
      */
-    AxisViewportPosition axisViewportHorizontalPosition() const { return mAxisViewportHorizPos;}
+    Qt::AnchorPoint axisViewportHorizontalPosition() const { return mAxisViewportHorizPos;}
 
     /**
      * \brief Returns axis viewport vertical position
      */
-    AxisViewportPosition axisViewportVerticalPosition() const { return mAxisViewportVertPos;}
+    Qt::AnchorPoint axisViewportVerticalPosition() const { return mAxisViewportVertPos;}
 
     /**
      * \brief project a 3D position from sourceCamera (in sourceViewport) to a 2D position for destCamera (in destViewport). destCamera and the destViewport act as a billboarding layer. The labels displayed by this process will always face the camera.
@@ -150,8 +139,8 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     // axis picking and menu
     void onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits );
     void onAxisModeChanged( Qgs3DAxis::Mode mode );
-    void onAxisHorizPositionChanged( AxisViewportPosition pos );
-    void onAxisVertPositionChanged( AxisViewportPosition pos );
+    void onAxisHorizPositionChanged( Qt::AnchorPoint pos );
+    void onAxisVertPositionChanged( Qt::AnchorPoint pos );
     void onCameraViewChange( float pitch, float yaw );
 
     void onCameraViewChangeHome( ) { onCameraViewChange( 45.0, 45.0 ); }
@@ -190,8 +179,8 @@ class _3D_EXPORT Qgs3DAxis : public QObject
 
     float mCylinderLength = 40.0f;
     int mAxisViewportSize = 4.0 * mCylinderLength;
-    AxisViewportPosition mAxisViewportVertPos = AxisViewportPosition::Begin;
-    AxisViewportPosition mAxisViewportHorizPos = AxisViewportPosition::End;
+    Qt::AnchorPoint mAxisViewportVertPos = Qt::AnchorPoint::AnchorTop;
+    Qt::AnchorPoint mAxisViewportHorizPos = Qt::AnchorPoint::AnchorRight;
     int mFontSize = 10;
 
     Qt3DCore::QEntity *mAxisSceneEntity = nullptr;

--- a/src/3d/qgs3daxis.h
+++ b/src/3d/qgs3daxis.h
@@ -202,9 +202,9 @@ class _3D_EXPORT Qgs3DAxis : public QObject
 
     // ========= private attributes
     Qgs3DMapSettings &mMapSettings;
-    Qt3DExtras::Qt3DWindow *mParentWindow;
-    Qgs3DMapScene *mMapScene;
-    QgsCameraController *mCameraController;
+    Qt3DExtras::Qt3DWindow *mParentWindow = nullptr;
+    Qgs3DMapScene *mMapScene = nullptr;
+    QgsCameraController *mCameraController = nullptr;
 
     float mCylinderLength = 40.0f;
     int mAxisViewportSize = 4.0 * mCylinderLength;
@@ -212,32 +212,38 @@ class _3D_EXPORT Qgs3DAxis : public QObject
     AxisViewportPosition mAxisViewportHorizPos = AxisViewportPosition::End;
     int mFontSize = 10;
 
-    Qt3DCore::QEntity *mAxisSceneEntity;
-    Qt3DRender::QLayer *mAxisSceneLayer;
-    Qt3DRender::QCamera *mAxisCamera;
-    Qt3DRender::QViewport *mAxisViewport;
+    Qt3DCore::QEntity *mAxisSceneEntity = nullptr;
+    Qt3DRender::QLayer *mAxisSceneLayer = nullptr;
+    Qt3DRender::QCamera *mAxisCamera = nullptr;
+    Qt3DRender::QViewport *mAxisViewport = nullptr;
 
     Qgs3DAxis::Mode mMode = Mode::Crs;
     Qt3DCore::QEntity *mAxisRoot = nullptr;
     Qt3DCore::QEntity *mCubeRoot = nullptr;
     QList<Qt3DExtras::QText2DEntity *> mCubeLabels;
 
-    Qt3DExtras::QText2DEntity *mText_X, *mText_Y, *mText_Z;
-    QVector3D mTextCoord_X, mTextCoord_Y, mTextCoord_Z;
-    Qt3DCore::QTransform *mTextTransform_X = nullptr, *mTextTransform_Y = nullptr, *mTextTransform_Z = nullptr;
+    Qt3DExtras::QText2DEntity *mText_X = nullptr;
+    Qt3DExtras::QText2DEntity *mText_Y = nullptr;
+    Qt3DExtras::QText2DEntity *mText_Z = nullptr;
+    QVector3D mTextCoord_X;
+    QVector3D mTextCoord_Y;
+    QVector3D mTextCoord_Z;
+    Qt3DCore::QTransform *mTextTransform_X = nullptr;
+    Qt3DCore::QTransform *mTextTransform_Y = nullptr;
+    Qt3DCore::QTransform *mTextTransform_Z = nullptr;
     QgsCoordinateReferenceSystem mCrs;
     QVector3D mPreviousVector;
 
-    Qt3DRender::QCamera *mTwoDLabelCamera;
-    Qt3DCore::QEntity *mTwoDLabelSceneEntity;
-    Qt3DRender::QViewport *mTwoDLabelViewport;
+    Qt3DRender::QCamera *mTwoDLabelCamera  = nullptr;
+    Qt3DCore::QEntity *mTwoDLabelSceneEntity = nullptr;
+    Qt3DRender::QViewport *mTwoDLabelViewport = nullptr;
 
     // axis picking and menu
-    Qt3DRender::QScreenRayCaster *mScreenRayCaster;
+    Qt3DRender::QScreenRayCaster *mScreenRayCaster = nullptr;
     QPoint mLastClickedPos;
     Qt::MouseButton mLastClickedButton;
-    QCursor mPreviousCursor;
-    QMenu *mMenu;
+    QCursor mPreviousCursor = Qt::ArrowCursor;
+    QMenu *mMenu = nullptr;
 
 };
 

--- a/src/3d/qgs3daxissettings.cpp
+++ b/src/3d/qgs3daxissettings.cpp
@@ -61,20 +61,20 @@ void Qgs3DAxisSettings::readXml( const QDomElement &element, const QgsReadWriteC
     mMode = Qgs3DAxis::Mode::Cube;
 
   const QString horizontalStr = element.attribute( QStringLiteral( "horizontal" ) );
-  if ( horizontalStr == QLatin1String( "Begin" ) )
-    mHorizontalPosition = Qgs3DAxis::AxisViewportPosition::Begin;
+  if ( horizontalStr == QLatin1String( "Left" ) )
+    mHorizontalPosition = Qt::AnchorPoint::AnchorLeft;
   else if ( horizontalStr == QLatin1String( "Middle" ) )
-    mHorizontalPosition = Qgs3DAxis::AxisViewportPosition::Middle;
-  else if ( horizontalStr == QLatin1String( "End" ) )
-    mHorizontalPosition = Qgs3DAxis::AxisViewportPosition::End;
+    mHorizontalPosition = Qt::AnchorPoint::AnchorHorizontalCenter;
+  else if ( horizontalStr == QLatin1String( "Right" ) )
+    mHorizontalPosition = Qt::AnchorPoint::AnchorRight;
 
   const QString verticalStr = element.attribute( QStringLiteral( "vertical" ) );
-  if ( verticalStr == QLatin1String( "Begin" ) )
-    mVerticalPosition = Qgs3DAxis::AxisViewportPosition::Begin;
+  if ( verticalStr == QLatin1String( "Top" ) )
+    mVerticalPosition = Qt::AnchorPoint::AnchorTop;
   else if ( verticalStr == QLatin1String( "Middle" ) )
-    mVerticalPosition = Qgs3DAxis::AxisViewportPosition::Middle;
-  else if ( verticalStr == QLatin1String( "End" ) )
-    mVerticalPosition = Qgs3DAxis::AxisViewportPosition::End;
+    mVerticalPosition = Qt::AnchorPoint::AnchorVerticalCenter;
+  else if ( verticalStr == QLatin1String( "Bottom" ) )
+    mVerticalPosition = Qt::AnchorPoint::AnchorBottom;
 }
 
 void Qgs3DAxisSettings::writeXml( QDomElement &element, const QgsReadWriteContext & ) const
@@ -98,13 +98,13 @@ void Qgs3DAxisSettings::writeXml( QDomElement &element, const QgsReadWriteContex
 
   switch ( mHorizontalPosition )
   {
-    case Qgs3DAxis::AxisViewportPosition::Begin:
-      str = QLatin1String( "Begin" );
+    case Qt::AnchorPoint::AnchorLeft:
+      str = QLatin1String( "Left" );
       break;
-    case Qgs3DAxis::AxisViewportPosition::Middle:
+    case Qt::AnchorPoint::AnchorHorizontalCenter:
       str = QLatin1String( "Middle" );
       break;
-    case Qgs3DAxis::AxisViewportPosition::End:
+    case Qt::AnchorPoint::AnchorRight:
     default:
       str = QLatin1String( "End" );
       break;
@@ -113,15 +113,15 @@ void Qgs3DAxisSettings::writeXml( QDomElement &element, const QgsReadWriteContex
 
   switch ( mVerticalPosition )
   {
-    case Qgs3DAxis::AxisViewportPosition::Begin:
-      str = QLatin1String( "Begin" );
+    case Qt::AnchorPoint::AnchorBottom:
+      str = QLatin1String( "Bottom" );
       break;
-    case Qgs3DAxis::AxisViewportPosition::Middle:
+    case Qt::AnchorPoint::AnchorVerticalCenter:
       str = QLatin1String( "Middle" );
       break;
-    case Qgs3DAxis::AxisViewportPosition::End:
+    case Qt::AnchorPoint::AnchorTop:
     default:
-      str = QLatin1String( "End" );
+      str = QLatin1String( "Top" );
       break;
   }
   element.setAttribute( QStringLiteral( "vertical" ), str );

--- a/src/3d/qgs3daxissettings.h
+++ b/src/3d/qgs3daxissettings.h
@@ -59,20 +59,20 @@ class _3D_EXPORT Qgs3DAxisSettings
     void setMode( Qgs3DAxis::Mode type ) { mMode = type; }
 
     //! Returns the horizontal position for the 3d axis
-    Qgs3DAxis::AxisViewportPosition horizontalPosition() const { return mHorizontalPosition; }
+    Qt::AnchorPoint horizontalPosition() const { return mHorizontalPosition; }
     //! Sets the horizontal position for the 3d axis
-    void setHorizontalPosition( const Qgs3DAxis::AxisViewportPosition &position ) { mHorizontalPosition = position; }
+    void setHorizontalPosition( Qt::AnchorPoint position ) { mHorizontalPosition = position; }
 
     //! Returns the vertical position for the 3d axis
-    Qgs3DAxis::AxisViewportPosition verticalPosition() const { return mVerticalPosition; }
+    Qt::AnchorPoint verticalPosition() const { return mVerticalPosition; }
     //! Sets the vertical position for the 3d axis
-    void setVerticalPosition( const Qgs3DAxis::AxisViewportPosition &position ) { mVerticalPosition = position; }
+    void setVerticalPosition( Qt::AnchorPoint position ) { mVerticalPosition = position; }
 
   private:
     Qgs3DAxis::Mode mMode = Qgs3DAxis::Mode::Crs;
-    Qgs3DAxis::AxisViewportPosition mHorizontalPosition = Qgs3DAxis::AxisViewportPosition::End;
-    Qgs3DAxis::AxisViewportPosition mVerticalPosition = Qgs3DAxis::AxisViewportPosition::Begin;
-    ;
+    Qt::AnchorPoint mHorizontalPosition = Qt::AnchorPoint::AnchorRight;
+    Qt::AnchorPoint mVerticalPosition = Qt::AnchorPoint::AnchorTop;
+
 };
 
 #endif // QGS3DAXISSETTINGS_H

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -195,6 +195,17 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   // ==================
   // Page: 3D axis
+  mCbo3dAxisType->addItem( tr( "Coordinate Reference System" ), static_cast< int >( Qgs3DAxis::Mode::Crs ) );
+  mCbo3dAxisType->addItem( tr( "Cube" ), static_cast< int >( Qgs3DAxis::Mode::Cube ) );
+
+  mCbo3dAxisHorizPos->addItem( tr( "Left" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Begin ) );
+  mCbo3dAxisHorizPos->addItem( tr( "Center" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Middle ) );
+  mCbo3dAxisHorizPos->addItem( tr( "Right" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::End ) );
+
+  mCbo3dAxisVertPos->addItem( tr( "Top" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Begin ) );
+  mCbo3dAxisVertPos->addItem( tr( "Middle" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Middle ) );
+  mCbo3dAxisVertPos->addItem( tr( "Bottom" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::End ) );
+
   init3DAxisPage();
 
   // ==================
@@ -508,11 +519,10 @@ void Qgs3DMapConfigWidget::validate()
 
 void Qgs3DMapConfigWidget::init3DAxisPage()
 {
-  connect( mGroupBox3dAxis, &QGroupBox::toggled, this, &Qgs3DMapConfigWidget::on3DAxisChanged ); // skip-keyword-check
-  connect( mCbo3dAxisType, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged ); // skip-keyword-check
-  connect( mCbo3dAxisHorizPos, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged ); // skip-keyword-check
-  connect( mCbo3dAxisVertPos, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged );  // skip-keyword-check
-
+  connect( mGroupBox3dAxis, &QGroupBox::toggled, this, &Qgs3DMapConfigWidget::on3DAxisChanged );
+  connect( mCbo3dAxisType, qOverload<int>( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged );
+  connect( mCbo3dAxisHorizPos, qOverload<int>( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged );
+  connect( mCbo3dAxisVertPos, qOverload<int>( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::on3DAxisChanged );
 
   Qgs3DAxisSettings s = mMap->get3dAxisSettings();
 
@@ -521,11 +531,11 @@ void Qgs3DMapConfigWidget::init3DAxisPage()
   else
   {
     mGroupBox3dAxis->setChecked( true );
-    mCbo3dAxisType->setCurrentIndex( ( int )s.mode() - 2 );
+    mCbo3dAxisType->setCurrentIndex( mCbo3dAxisType->findData( static_cast< int >( s.mode() ) ) );
   }
 
-  mCbo3dAxisHorizPos->setCurrentIndex( ( int )s.horizontalPosition() - 1 );
-  mCbo3dAxisVertPos->setCurrentIndex( ( int )s.verticalPosition() - 1 );
+  mCbo3dAxisHorizPos->setCurrentIndex( mCbo3dAxisHorizPos->findData( static_cast< int >( s.horizontalPosition() ) ) );
+  mCbo3dAxisVertPos->setCurrentIndex( mCbo3dAxisVertPos->findData( static_cast< int >( s.verticalPosition() ) ) );
 }
 
 void Qgs3DMapConfigWidget::on3DAxisChanged()
@@ -533,11 +543,9 @@ void Qgs3DMapConfigWidget::on3DAxisChanged()
   if ( m3DMapCanvas->scene()->get3DAxis() )
   {
     Qgs3DAxisSettings s = mMap->get3dAxisSettings();
-    Qgs3DAxis::Mode m;
+    Qgs3DAxis::Mode m = Qgs3DAxis::Mode::Off;
     if ( mGroupBox3dAxis->isChecked() )
-      m = ( Qgs3DAxis::Mode )( mCbo3dAxisType->currentIndex() + 2 );
-    else
-      m = Qgs3DAxis::Mode::Off;
+      m = static_cast< Qgs3DAxis::Mode >( mCbo3dAxisType->currentData().toInt() );
 
     if ( m3DMapCanvas->scene()->get3DAxis()->mode() != m )
     {
@@ -546,8 +554,8 @@ void Qgs3DMapConfigWidget::on3DAxisChanged()
     }
     else
     {
-      Qgs3DAxis::AxisViewportPosition hPos = ( Qgs3DAxis::AxisViewportPosition )( mCbo3dAxisHorizPos->currentIndex() + 1 );
-      Qgs3DAxis::AxisViewportPosition vPos = ( Qgs3DAxis::AxisViewportPosition )( mCbo3dAxisVertPos->currentIndex() + 1 );
+      Qgs3DAxis::AxisViewportPosition hPos = static_cast< Qgs3DAxis::AxisViewportPosition >( mCbo3dAxisHorizPos->currentData().toInt() );
+      Qgs3DAxis::AxisViewportPosition vPos = static_cast< Qgs3DAxis::AxisViewportPosition >( mCbo3dAxisVertPos->currentData().toInt() );
 
       if ( m3DMapCanvas->scene()->get3DAxis()->axisViewportHorizontalPosition() != hPos
            || m3DMapCanvas->scene()->get3DAxis()->axisViewportVerticalPosition() != vPos )
@@ -559,6 +567,5 @@ void Qgs3DMapConfigWidget::on3DAxisChanged()
 
     if ( s != mMap->get3dAxisSettings() )
       mMap->set3dAxisSettings( s );
-
   }
 }

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -198,13 +198,13 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   mCbo3dAxisType->addItem( tr( "Coordinate Reference System" ), static_cast< int >( Qgs3DAxis::Mode::Crs ) );
   mCbo3dAxisType->addItem( tr( "Cube" ), static_cast< int >( Qgs3DAxis::Mode::Cube ) );
 
-  mCbo3dAxisHorizPos->addItem( tr( "Left" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Begin ) );
-  mCbo3dAxisHorizPos->addItem( tr( "Center" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Middle ) );
-  mCbo3dAxisHorizPos->addItem( tr( "Right" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::End ) );
+  mCbo3dAxisHorizPos->addItem( tr( "Left" ), static_cast< int >( Qt::AnchorPoint::AnchorLeft ) );
+  mCbo3dAxisHorizPos->addItem( tr( "Center" ), static_cast< int >( Qt::AnchorPoint::AnchorHorizontalCenter ) );
+  mCbo3dAxisHorizPos->addItem( tr( "Right" ), static_cast< int >( Qt::AnchorPoint::AnchorRight ) );
 
-  mCbo3dAxisVertPos->addItem( tr( "Top" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Begin ) );
-  mCbo3dAxisVertPos->addItem( tr( "Middle" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::Middle ) );
-  mCbo3dAxisVertPos->addItem( tr( "Bottom" ), static_cast< int >( Qgs3DAxis::AxisViewportPosition::End ) );
+  mCbo3dAxisVertPos->addItem( tr( "Top" ), static_cast< int >( Qt::AnchorPoint::AnchorTop ) );
+  mCbo3dAxisVertPos->addItem( tr( "Middle" ), static_cast< int >( Qt::AnchorPoint::AnchorVerticalCenter ) );
+  mCbo3dAxisVertPos->addItem( tr( "Bottom" ), static_cast< int >( Qt::AnchorPoint::AnchorBottom ) );
 
   init3DAxisPage();
 
@@ -554,8 +554,8 @@ void Qgs3DMapConfigWidget::on3DAxisChanged()
     }
     else
     {
-      Qgs3DAxis::AxisViewportPosition hPos = static_cast< Qgs3DAxis::AxisViewportPosition >( mCbo3dAxisHorizPos->currentData().toInt() );
-      Qgs3DAxis::AxisViewportPosition vPos = static_cast< Qgs3DAxis::AxisViewportPosition >( mCbo3dAxisVertPos->currentData().toInt() );
+      const Qt::AnchorPoint hPos = static_cast< Qt::AnchorPoint >( mCbo3dAxisHorizPos->currentData().toInt() );
+      const Qt::AnchorPoint vPos = static_cast< Qt::AnchorPoint >( mCbo3dAxisVertPos->currentData().toInt() );
 
       if ( m3DMapCanvas->scene()->get3DAxis()->axisViewportHorizontalPosition() != hPos
            || m3DMapCanvas->scene()->get3DAxis()->axisViewportVerticalPosition() != vPos )

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>775</width>
-    <height>620</height>
+    <width>881</width>
+    <height>665</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -136,24 +136,6 @@
          </item>
          <item>
           <property name="text">
-           <string>3d axis</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIcon3dAxis.svg</normaloff>:/images/themes/default/mIcon3dAxis.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Navigation sync</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../images/images.qrc">
-            <normaloff>:/images/themes/default/sync_views.svg</normaloff>:/images/themes/default/sync_views.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
            <string>Advanced</string>
           </property>
           <property name="toolTip">
@@ -197,7 +179,7 @@
        <item>
         <widget class="QStackedWidget" name="m3DOptionsStackedWidget">
          <property name="currentIndex">
-          <number>4</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="mPageTerrain">
           <layout class="QVBoxLayout" name="verticalLayout_61">
@@ -223,8 +205,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>722</width>
-                <height>604</height>
+                <width>280</width>
+                <height>301</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutTerrain">
@@ -435,7 +417,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>77</width>
-                <height>43</height>
+                <height>47</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutLight">
@@ -518,8 +500,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>149</width>
-                <height>43</height>
+                <width>151</width>
+                <height>47</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutShadow">
@@ -608,8 +590,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>234</width>
-                <height>220</height>
+                <width>816</width>
+                <height>649</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutCameraSkybox">
@@ -692,6 +674,78 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="mGroupBox3dAxis">
+                 <property name="title">
+                  <string>Show 3D Axis</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QFormLayout" name="formLayout_2">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLabel3dAxisType_2">
+                    <property name="text">
+                     <string>Axis type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QComboBox" name="mCbo3dAxisType"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="mLabel3dAxisHorizPos_2">
+                    <property name="text">
+                     <string>Horizontal position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QComboBox" name="mCbo3dAxisHorizPos"/>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="mLabel3dAxisVertPos_2">
+                    <property name="text">
+                     <string>Vertical position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QComboBox" name="mCbo3dAxisVertPos"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
+                  <string>Navigation Synchronization</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_8">
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="mSync2DTo3DCheckbox">
+                    <property name="text">
+                     <string>2D Map View Follows 3D Camera</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QCheckBox" name="mSync3DTo2DCheckbox">
+                    <property name="text">
+                     <string>3D Camera Follows 2D Map View</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QCheckBox" name="mVisualizeExtentCheckBox">
+                    <property name="text">
+                     <string>Show Visible Camera Area in 2D Map View</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="groupSkyboxSettings">
                  <property name="title">
                   <string>Show Skybox</string>
@@ -714,226 +768,6 @@
                   <size>
                    <width>20</width>
                    <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="mPage3dAxis">
-          <layout class="QVBoxLayout" name="verticalLayout_162">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QgsScrollArea" name="scrollArea3dAxis">
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="widgetResizable">
-              <bool>true</bool>
-             </property>
-             <widget class="QWidget" name="scrollArea3dAxisContents">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>717</width>
-                <height>604</height>
-               </rect>
-              </property>
-              <layout class="QVBoxLayout" name="gridLayout_77">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="mGroupBox3dAxis">
-                 <property name="title">
-                  <string>3d axis</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="horizontalSpacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mLabel3dAxisType">
-                    <property name="text">
-                     <string>Axis type</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mCbo3dAxisType</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QComboBox" name="mCbo3dAxisType">
-                    <item>
-                     <property name="text">
-                      <string comment="0">Crs</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string comment="1">Cube</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="mLabel3dAxisHorizPos">
-                    <property name="text">
-                     <string>Horizontal position</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QComboBox" name="mCbo3dAxisHorizPos">
-                    <item>
-                     <property name="text">
-                      <string>Left</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Middle</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Right</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="mLabel3dAxisVertPos">
-                    <property name="text">
-                     <string>Vertical position</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QComboBox" name="mCbo3dAxisVertPos">
-                    <item>
-                     <property name="text">
-                      <string>Top</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Middle</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Bottom</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <spacer name="verticalSpacer_2">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="mPage2DCanvasSync">
-          <layout class="QGridLayout" name="gridLayout_4">
-           <item row="0" column="0">
-            <widget class="QgsScrollArea" name="scrollArea">
-             <property name="widgetResizable">
-              <bool>true</bool>
-             </property>
-             <widget class="QWidget" name="scrollAreaWidgetContents">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>711</width>
-                <height>584</height>
-               </rect>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_7">
-               <item row="0" column="0" colspan="2">
-                <widget class="QCheckBox" name="mSync2DTo3DCheckbox">
-                 <property name="text">
-                  <string>2D Map View Follows 3D Camera</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="mSync3DTo2DCheckbox">
-                 <property name="text">
-                  <string>3D Camera Follows 2D Map View</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0" colspan="2">
-                <widget class="QCheckBox" name="mVisualizeExtentCheckBox">
-                 <property name="text">
-                  <string>Show Visible Camera Area in 2D Map View</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0" colspan="2">
-                <spacer name="verticalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
                   </size>
                  </property>
                 </spacer>
@@ -968,8 +802,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>708</width>
-                <height>690</height>
+                <width>802</width>
+                <height>732</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayoutAdvanced">
@@ -1292,6 +1126,12 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -1300,12 +1140,6 @@
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>


### PR DESCRIPTION
Follow up https://github.com/qgis/QGIS/pull/48109

This:

- fixes a bunch of non-standard code conventions, leaks, old practice
- fixes HIG capitalisation violations
- moves both the "synchronize view" and "3d axis" settings to the existing camera settings page, as it's overkill to have separate pages containing a very small number of widgets for the sync/axis settings
