### PR TITLE
Adjust point cloud URL parsing

### DIFF
--- a/src/core/providers/copc/qgscopcprovider.cpp
+++ b/src/core/providers/copc/qgscopcprovider.cpp
@@ -128,7 +128,7 @@ QgsCopcProvider *QgsCopcProviderMetadata::createProvider( const QString &uri, co
 QList<QgsProviderSublayerDetails> QgsCopcProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags, QgsFeedback * ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  if ( parts.value( QStringLiteral( "path" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
   {
     QgsProviderSublayerDetails details;
     details.setUri( uri );
@@ -146,7 +146,7 @@ QList<QgsProviderSublayerDetails> QgsCopcProviderMetadata::querySublayers( const
 int QgsCopcProviderMetadata::priorityForUri( const QString &uri ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  if ( parts.value( QStringLiteral( "path" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
     return 100;
 
   return 0;
@@ -155,7 +155,7 @@ int QgsCopcProviderMetadata::priorityForUri( const QString &uri ) const
 QList<QgsMapLayerType> QgsCopcProviderMetadata::validLayerTypesForUri( const QString &uri ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  if ( parts.value( QStringLiteral( "path" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().endsWith( ".copc.laz", Qt::CaseSensitivity::CaseInsensitive ) )
     return QList< QgsMapLayerType>() << QgsMapLayerType::PointCloudLayer;
 
   return QList< QgsMapLayerType>();
@@ -163,9 +163,10 @@ QList<QgsMapLayerType> QgsCopcProviderMetadata::validLayerTypesForUri( const QSt
 
 QVariantMap QgsCopcProviderMetadata::decodeUri( const QString &uri ) const
 {
-  const QString path = uri;
   QVariantMap uriComponents;
-  uriComponents.insert( QStringLiteral( "path" ), path );
+  QUrl url = QUrl::fromUserInput( uri );
+  uriComponents.insert( QStringLiteral( "file-name" ), url.fileName() );
+  uriComponents.insert( QStringLiteral( "path" ), uri );
   return uriComponents;
 }
 

--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -124,8 +124,7 @@ QgsEptProvider *QgsEptProviderMetadata::createProvider( const QString &uri, cons
 QList<QgsProviderSublayerDetails> QgsEptProviderMetadata::querySublayers( const QString &uri, Qgis::SublayerQueryFlags, QgsFeedback * ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
-  if ( fi.fileName().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
   {
     QgsProviderSublayerDetails details;
     details.setUri( uri );
@@ -143,8 +142,7 @@ QList<QgsProviderSublayerDetails> QgsEptProviderMetadata::querySublayers( const 
 int QgsEptProviderMetadata::priorityForUri( const QString &uri ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
-  if ( fi.fileName().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
     return 100;
 
   return 0;
@@ -153,8 +151,7 @@ int QgsEptProviderMetadata::priorityForUri( const QString &uri ) const
 QList<QgsMapLayerType> QgsEptProviderMetadata::validLayerTypesForUri( const QString &uri ) const
 {
   const QVariantMap parts = decodeUri( uri );
-  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
-  if ( fi.fileName().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
     return QList< QgsMapLayerType>() << QgsMapLayerType::PointCloudLayer;
 
   return QList< QgsMapLayerType>();
@@ -166,10 +163,8 @@ bool QgsEptProviderMetadata::uriIsBlocklisted( const QString &uri ) const
   if ( !parts.contains( QStringLiteral( "path" ) ) )
     return false;
 
-  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
-
   // internal details only
-  if ( fi.fileName().compare( QLatin1String( "ept-build.json" ), Qt::CaseInsensitive ) == 0 )
+  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
     return true;
 
   return false;
@@ -177,9 +172,10 @@ bool QgsEptProviderMetadata::uriIsBlocklisted( const QString &uri ) const
 
 QVariantMap QgsEptProviderMetadata::decodeUri( const QString &uri ) const
 {
-  const QString path = uri;
   QVariantMap uriComponents;
-  uriComponents.insert( QStringLiteral( "path" ), path );
+  QUrl url = QUrl::fromUserInput( uri );
+  uriComponents.insert( QStringLiteral( "file-name" ), url.fileName() );
+  uriComponents.insert( QStringLiteral( "path" ), uri );
   return uriComponents;
 }
 

--- a/src/core/providers/ept/qgseptprovider.cpp
+++ b/src/core/providers/ept/qgseptprovider.cpp
@@ -163,8 +163,10 @@ bool QgsEptProviderMetadata::uriIsBlocklisted( const QString &uri ) const
   if ( !parts.contains( QStringLiteral( "path" ) ) )
     return false;
 
+  const QFileInfo fi( parts.value( QStringLiteral( "path" ) ).toString() );
+
   // internal details only
-  if ( parts.value( QStringLiteral( "file-name" ) ).toString().compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) == 0 )
+  if ( fi.fileName().compare( QLatin1String( "ept-build.json" ), Qt::CaseInsensitive ) == 0 )
     return true;
 
   return false;

--- a/src/gui/providers/qgspointcloudsourceselect.cpp
+++ b/src/gui/providers/qgspointcloudsourceselect.cpp
@@ -94,7 +94,10 @@ void QgsPointCloudSourceSelect::addButtonClicked()
       return;
     }
 
-    if ( !mPath.endsWith( QLatin1String( "/ept.json" ), Qt::CaseInsensitive ) && !mPath.endsWith( QLatin1String( ".copc.laz" ), Qt::CaseInsensitive ) )
+    QUrl url = QUrl::fromUserInput( mPath );
+    QString fileName = url.fileName();
+
+    if ( fileName.compare( QLatin1String( "ept.json" ), Qt::CaseInsensitive ) != 0 && !fileName.endsWith( QLatin1String( ".copc.laz" ), Qt::CaseInsensitive ) )
     {
       QMessageBox::information( this,
                                 tr( "Add Point Cloud Layers" ),

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -86,7 +86,7 @@ static QString _outCopcFile( const QString &filename )
 {
   const QFileInfo fi( filename );
   const QDir directory = fi.absoluteDir();
-  const QString outputFile = QStringLiteral( "%1/copc_%2.copc.laz" ).arg( directory.absolutePath() ).arg( fi.baseName() );
+  const QString outputFile = QStringLiteral( "%1/%2.copc.laz" ).arg( directory.absolutePath() ).arg( fi.baseName() );
   return outputFile;
 }
 


### PR DESCRIPTION
## Description

Previously when we check for the point cloud URL, we check if the string ends with 'ept.json' or '.copc.laz' but there could be more parameters after the file path in the URL. This PR addresses that by extracting the file name from the URI and making sure to check for validity using the file name not the URL string itself.

Also as suggested by @wonder-sk I removed the "copc_" prefix from files that pdal generates.