### PR TITLE
Fix a crash in QgsExpressionTreeView

### DIFF
--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -873,7 +873,7 @@ bool QgsExpressionItemSearchProxy::filterAcceptsRow( int source_row, const QMode
 void QgsExpressionItemSearchProxy::setFilterString( const QString &string )
 {
   mFilterString = string;
-  invalidateFilter();
+  invalidate();
 }
 
 bool QgsExpressionItemSearchProxy::lessThan( const QModelIndex &left, const QModelIndex &right ) const


### PR DESCRIPTION
Fix #48189

I've spent quite a long time trying to debug this issue deep into QT but I couldn't get to the bottom of it, to trigger the crash you need to set a filter that returns no rows (such as 'asdf'), then click on the QgsLineEdit clear button (clearing the text with CTRL+BACKSPACE or with any other method does not trigger the crash) and type a string that will match something such as 'ss'.

My attempts to replicate the issue through a not interactive python test were unsuccessful but here is a start if you want to try it:

```python

import qgis  # NOQA

from qgis.testing import start_app, unittest
from qgis.gui import *
from qgis.core import *
from qgis.PyQt.QtWidgets import *

QGISAPP = start_app()


class TestQgsExpressionTreeView(unittest.TestCase):

    d = QDialog()
    h = QVBoxLayout(d)
    d.setLayout(h)
    w = QgsExpressionBuilderWidget()
    h.addWidget(w)

    e = w.findChild(QgsFilterLineEdit, 'txtSearchEdit')
    e.setText('asdf')


    d.exec_()

    # Click the clear icon in the search box
    # Type ss to crash!

```
