### PR TITLE
Fix raster histogram widget for multiband color renderer and other renderers' contrast enhancement

### DIFF
--- a/python/gui/auto_generated/raster/qgsmultibandcolorrendererwidget.sip.in
+++ b/python/gui/auto_generated/raster/qgsmultibandcolorrendererwidget.sip.in
@@ -40,6 +40,12 @@ Sets the widget state from the specified renderer.
 
     virtual int selectedBand( int index = 0 );
 
+
+    virtual QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const;
+
+    virtual void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm );
+
+
     virtual void doComputations();
 
     virtual QgsRasterMinMaxWidget *minMaxWidget();

--- a/python/gui/auto_generated/raster/qgsrasterrendererwidget.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterrendererwidget.sip.in
@@ -85,6 +85,20 @@ Load programmatically with current values
 Returns min/max widget when it exists.
 %End
 
+    virtual QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const;
+%Docstring
+Returns the constrast enhancement ``algorithm`` to be used by the raster renderer.
+
+.. versionadded:: 3.26
+%End
+
+    virtual void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm );
+%Docstring
+Sets the constrast enhancement ``algorithm`` to be used by the raster renderer.
+
+.. versionadded:: 3.26
+%End
+
   signals:
 
     void widgetChanged();

--- a/python/gui/auto_generated/raster/qgssinglebandgrayrendererwidget.sip.in
+++ b/python/gui/auto_generated/raster/qgssinglebandgrayrendererwidget.sip.in
@@ -38,6 +38,12 @@ Sets the widget state from the specified renderer.
     virtual void setMax( const QString &value, int index = 0 );
 
     virtual int selectedBand( int index = 0 );
+
+    virtual QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const;
+
+    virtual void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm );
+
+
     virtual void doComputations();
 
     virtual QgsRasterMinMaxWidget *minMaxWidget();

--- a/python/gui/auto_generated/raster/qgssinglebandpseudocolorrendererwidget.sip.in
+++ b/python/gui/auto_generated/raster/qgssinglebandpseudocolorrendererwidget.sip.in
@@ -42,15 +42,18 @@ Creates new raster renderer widget
     virtual QgsRasterMinMaxWidget *minMaxWidget();
 
 
-    int currentBand() const;
-%Docstring
-Returns the current raster band number
-%End
-
     void setFromRenderer( const QgsRasterRenderer *r );
 %Docstring
 Sets the widget state from the specified renderer.
 %End
+
+    virtual QString min( int index = 0 );
+    virtual QString max( int index = 0 );
+    virtual void setMin( const QString &value, int index = 0 );
+
+    virtual void setMax( const QString &value, int index = 0 );
+
+    virtual int selectedBand( int index = 0 );
 
   public slots:
     void loadMinMax( int bandNo, double min, double max );

--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -137,15 +137,6 @@ void QgsMultiBandColorRendererWidget::setCustomMinMaxValues( QgsMultiBandColorRe
     return;
   }
 
-  if ( mContrastEnhancementAlgorithmComboBox->currentData().toInt() ==
-       QgsContrastEnhancement::NoEnhancement )
-  {
-    r->setRedContrastEnhancement( nullptr );
-    r->setGreenContrastEnhancement( nullptr );
-    r->setBlueContrastEnhancement( nullptr );
-    return;
-  }
-
   QgsContrastEnhancement *redEnhancement = nullptr;
   QgsContrastEnhancement *greenEnhancement = nullptr;
   QgsContrastEnhancement *blueEnhancement = nullptr;
@@ -217,6 +208,7 @@ void QgsMultiBandColorRendererWidget::onBandChanged( int index )
 
 void QgsMultiBandColorRendererWidget::mRedMinLineEdit_textChanged( const QString & )
 {
+  qDebug() << "CHANGED";
   minMaxModified();
 }
 
@@ -247,6 +239,7 @@ void QgsMultiBandColorRendererWidget::mBlueMaxLineEdit_textChanged( const QStrin
 
 void QgsMultiBandColorRendererWidget::minMaxModified()
 {
+  qDebug() << "999";
   if ( !mDisableMinMaxWidgetRefresh )
   {
     if ( ( QgsContrastEnhancement::ContrastEnhancementAlgorithm )( mContrastEnhancementAlgorithmComboBox->currentData().toInt() ) == QgsContrastEnhancement::NoEnhancement )
@@ -400,9 +393,11 @@ QString QgsMultiBandColorRendererWidget::max( int index )
 void QgsMultiBandColorRendererWidget::setMin( const QString &value, int index )
 {
   mDisableMinMaxWidgetRefresh = true;
+  qDebug() << "000";
   switch ( index )
   {
     case 0:
+      qDebug() << "111";
       mRedMinLineEdit->setText( value );
       break;
     case 1:

--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -208,7 +208,6 @@ void QgsMultiBandColorRendererWidget::onBandChanged( int index )
 
 void QgsMultiBandColorRendererWidget::mRedMinLineEdit_textChanged( const QString & )
 {
-  qDebug() << "CHANGED";
   minMaxModified();
 }
 
@@ -239,7 +238,6 @@ void QgsMultiBandColorRendererWidget::mBlueMaxLineEdit_textChanged( const QStrin
 
 void QgsMultiBandColorRendererWidget::minMaxModified()
 {
-  qDebug() << "999";
   if ( !mDisableMinMaxWidgetRefresh )
   {
     if ( ( QgsContrastEnhancement::ContrastEnhancementAlgorithm )( mContrastEnhancementAlgorithmComboBox->currentData().toInt() ) == QgsContrastEnhancement::NoEnhancement )
@@ -393,11 +391,9 @@ QString QgsMultiBandColorRendererWidget::max( int index )
 void QgsMultiBandColorRendererWidget::setMin( const QString &value, int index )
 {
   mDisableMinMaxWidgetRefresh = true;
-  qDebug() << "000";
   switch ( index )
   {
     case 0:
-      qDebug() << "111";
       mRedMinLineEdit->setText( value );
       break;
     case 1:
@@ -446,4 +442,16 @@ int QgsMultiBandColorRendererWidget::selectedBand( int index )
       break;
   }
   return -1;
+}
+
+QgsContrastEnhancement::ContrastEnhancementAlgorithm QgsMultiBandColorRendererWidget::contrastEnhancementAlgorithm() const
+{
+  return static_cast<QgsContrastEnhancement::ContrastEnhancementAlgorithm>( mContrastEnhancementAlgorithmComboBox->currentData().toInt() );
+}
+
+void QgsMultiBandColorRendererWidget::setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm )
+{
+  mDisableMinMaxWidgetRefresh = true;
+  mContrastEnhancementAlgorithmComboBox->setCurrentIndex( mContrastEnhancementAlgorithmComboBox->findData( static_cast<int>( algorithm ) ) );
+  mDisableMinMaxWidgetRefresh = false;
 }

--- a/src/gui/raster/qgsmultibandcolorrendererwidget.h
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.h
@@ -54,6 +54,10 @@ class GUI_EXPORT QgsMultiBandColorRendererWidget: public QgsRasterRendererWidget
     void setMin( const QString &value, int index = 0 ) override;
     void setMax( const QString &value, int index = 0 ) override;
     int selectedBand( int index = 0 ) override;
+
+    QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const override;
+    void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm ) override;
+
     void doComputations() override;
     QgsRasterMinMaxWidget *minMaxWidget() override { return mMinMaxWidget; }
 

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -933,9 +933,9 @@ void QgsRasterHistogramWidget::applyHistoMin()
     return;
 
   const int bandNo = cboHistoBand->currentIndex() + 1;
-  const QList< int > mySelectedBands = rendererSelectedBands();
+  const QList< int > selectedBands = rendererSelectedBands();
   QString min;
-  for ( int i = 0; i <= mySelectedBands.size(); i++ )
+  for ( int i = 0; i <= selectedBands.size(); i++ )
   {
     if ( bandNo == mRendererWidget->selectedBand( i ) )
     {
@@ -943,6 +943,10 @@ void QgsRasterHistogramWidget::applyHistoMin()
       if ( mHistoUpdateStyleToMinMax && mRendererWidget->min( i ) != min )
       {
         mRendererWidget->setMin( min, i );
+        if ( mRendererWidget->contrastEnhancementAlgorithm() == QgsContrastEnhancement::NoEnhancement )
+        {
+          mRendererWidget->setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum );
+        }
         if ( mRendererWidget->minMaxWidget() )
         {
           mRendererWidget->minMaxWidget()->userHasSetManualMinMaxValues();
@@ -978,6 +982,10 @@ void QgsRasterHistogramWidget::applyHistoMax()
       if ( mHistoUpdateStyleToMinMax && mRendererWidget->max( i ) != max )
       {
         mRendererWidget->setMax( max, i );
+        if ( mRendererWidget->contrastEnhancementAlgorithm() == QgsContrastEnhancement::NoEnhancement )
+        {
+          mRendererWidget->setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum );
+        }
         if ( mRendererWidget->minMaxWidget() )
         {
           mRendererWidget->minMaxWidget()->userHasSetManualMinMaxValues();
@@ -1165,7 +1173,8 @@ QList< int > QgsRasterHistogramWidget::rendererSelectedBands()
     return mySelectedBands;
   }
 
-  if ( mRendererName == QLatin1String( "singlebandgray" ) )
+  if ( mRendererName == QLatin1String( "singlebandgray" ) ||
+       mRendererName == QLatin1String( "singlebandpseudocolor" ) )
   {
     mySelectedBands << mRendererWidget->selectedBand();
   }
@@ -1187,7 +1196,8 @@ QPair< QString, QString > QgsRasterHistogramWidget::rendererMinMax( int bandNo )
   if ( ! mRendererWidget )
     return myMinMax;
 
-  if ( mRendererName == QLatin1String( "singlebandgray" ) )
+  if ( mRendererName == QLatin1String( "singlebandgray" ) ||
+       mRendererName == QLatin1String( "singlebandpseudocolor" ) )
   {
     if ( bandNo == mRendererWidget->selectedBand() )
     {

--- a/src/gui/raster/qgsrasterrendererwidget.h
+++ b/src/gui/raster/qgsrasterrendererwidget.h
@@ -19,6 +19,7 @@
 #define QGSRASTERRENDERERWIDGET_H
 
 #include "qgsrectangle.h"
+#include "qgscontrastenhancement.h"
 #include "qgis.h"
 
 #include <QWidget>
@@ -93,10 +94,22 @@ class GUI_EXPORT QgsRasterRendererWidget: public QWidget
     virtual int selectedBand( int index = 0 ) { Q_UNUSED( index ) return -1; }
 
     //! Load programmatically with current values
-    virtual void doComputations() { }
+    virtual void doComputations() {}
 
     //! Returns min/max widget when it exists.
     virtual QgsRasterMinMaxWidget *minMaxWidget() { return nullptr; }
+
+    /**
+     * Returns the constrast enhancement \a algorithm to be used by the raster renderer.
+     * \since QGIS 3.26
+     */
+    virtual QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const { return QgsContrastEnhancement::NoEnhancement; }
+
+    /**
+     * Sets the constrast enhancement \a algorithm to be used by the raster renderer.
+     * \since QGIS 3.26
+     */
+    virtual void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm ) { Q_UNUSED( algorithm ) return; }
 
   signals:
 

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -251,3 +251,15 @@ void QgsSingleBandGrayRendererWidget::showLegendSettings()
     }
   }
 }
+
+QgsContrastEnhancement::ContrastEnhancementAlgorithm QgsSingleBandGrayRendererWidget::contrastEnhancementAlgorithm() const
+{
+  return static_cast<QgsContrastEnhancement::ContrastEnhancementAlgorithm>( mContrastEnhancementComboBox->currentData().toInt() );
+}
+
+void QgsSingleBandGrayRendererWidget::setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm )
+{
+  mDisableMinMaxWidgetRefresh = true;
+  mContrastEnhancementComboBox->setCurrentIndex( mContrastEnhancementComboBox->findData( static_cast<int>( algorithm ) ) );
+  mDisableMinMaxWidgetRefresh = false;
+}

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.h
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.h
@@ -50,7 +50,11 @@ class GUI_EXPORT QgsSingleBandGrayRendererWidget: public QgsRasterRendererWidget
     QString max( int index = 0 ) override { Q_UNUSED( index ) return mMaxLineEdit->text(); }
     void setMin( const QString &value, int index = 0 ) override;
     void setMax( const QString &value, int index = 0 ) override;
-    int selectedBand( int index = 0 ) override { Q_UNUSED( index ) return mGrayBandComboBox->currentIndex() + 1; }
+    int selectedBand( int index = 0 ) override { Q_UNUSED( index ) return mGrayBandComboBox->currentBand(); }
+
+    QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm() const override;
+    void setContrastEnhancementAlgorithm( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm ) override;
+
     void doComputations() override;
     QgsRasterMinMaxWidget *minMaxWidget() override { return mMinMaxWidget; }
 

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -133,11 +133,6 @@ void QgsSingleBandPseudoColorRendererWidget::doComputations()
 
 QgsRasterMinMaxWidget *QgsSingleBandPseudoColorRendererWidget::minMaxWidget() { return mMinMaxWidget; }
 
-int QgsSingleBandPseudoColorRendererWidget::currentBand() const
-{
-  return mBandComboBox->currentBand();
-}
-
 void QgsSingleBandPseudoColorRendererWidget::setMapCanvas( QgsMapCanvas *canvas )
 {
   QgsRasterRendererWidget::setMapCanvas( canvas );
@@ -293,4 +288,18 @@ QString QgsSingleBandPseudoColorRendererWidget::displayValueWithMaxPrecision( co
     // Use QLocale default
     return QLocale().toString( value, 'g' );
   }
+}
+
+void QgsSingleBandPseudoColorRendererWidget::setMin( const QString &value, int )
+{
+  mMinLineEdit->setText( value );
+  minMaxModified();
+  mColorRampShaderWidget->classify();
+}
+
+void QgsSingleBandPseudoColorRendererWidget::setMax( const QString &value, int )
+{
+  mMaxLineEdit->setText( value );
+  minMaxModified();
+  mColorRampShaderWidget->classify();
 }

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -53,13 +53,16 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void doComputations() override;
     QgsRasterMinMaxWidget *minMaxWidget() override;
 
-    //! Returns the current raster band number
-    int currentBand() const;
-
     /**
      * Sets the widget state from the specified renderer.
      */
     void setFromRenderer( const QgsRasterRenderer *r );
+
+    QString min( int index = 0 ) override { Q_UNUSED( index ) return mMinLineEdit->text(); }
+    QString max( int index = 0 ) override { Q_UNUSED( index ) return mMaxLineEdit->text(); }
+    void setMin( const QString &value, int index = 0 ) override;
+    void setMax( const QString &value, int index = 0 ) override;
+    int selectedBand( int index = 0 ) override { Q_UNUSED( index ) return mBandComboBox->currentBand(); }
 
   public slots:
     //! called when new min/max values are loaded


### PR DESCRIPTION
## Description

Alright, I've been driven mad one time too many. This PR fixes a really bad UX whereas a user could add a 3-band color raster, open the styling panel, go to the histogram tab, set minimum and maximum values for the three bands by clicking on the histogram, only to discover all picked values are lost when switching to the renderer tab.

The problem above had to do with the multiband color renderer widget not remembering minimum / maximum values when the contrast enhancement is set to none. That's pretty bad, it also meant momentarily switching contrast off would also fail to preserve values.

The second UX issue fixed here has to do with contrast handling while picking values through the histogram. Prior to this PR, setting a minimum and maximum values for bands through the histogram would _not_ switch contrast on if not already active. In contrast, users manually edit the values through the renderer panel's line edit widgets would turn contrast on. Now, when users set  values through the histogram, the contrast enhancement will be switched on if inactive :tada: I've seen first-hand users I trained being confused when playing with the histogram and not seeing anything happening on the canvas.

Lastly, the PR fixes the histogram's interaction with the single band pseudo color renderer.