### PR TITLE
Read ept/copc index before generating copc with PDAL

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -395,13 +395,14 @@ void QgsPointCloudLayer::setDataSourcePrivate( const QString &dataSource, const 
     loadDefaultStyleFlag = true;
   }
 
-  if ( !mLayerOptions.skipIndexGeneration && mDataProvider && mDataProvider->isValid() )
+  if ( !mLayerOptions.skipIndexGeneration && mDataProvider && mDataProvider->indexingState() != QgsPointCloudDataProvider::PointCloudIndexGenerationState::Indexed )
   {
     mDataProvider->generateIndex();
-    if ( !mLayerOptions.skipStatisticsCalculation && !mDataProvider->hasStatisticsMetadata() && mDataProvider->indexingState() == QgsPointCloudDataProvider::PointCloudIndexGenerationState::Indexed )
-    {
-      calculateStatistics();
-    }
+  }
+
+  if ( !mLayerOptions.skipStatisticsCalculation && mDataProvider && !mDataProvider->hasStatisticsMetadata() && mDataProvider->indexingState() == QgsPointCloudDataProvider::PointCloudIndexGenerationState::Indexed )
+  {
+    calculateStatistics();
   }
 
   // Note: we load the statistics from the data provider regardless of it being an existing metadata (do not check fot hasStatisticsMetadata)

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -46,7 +46,7 @@ QgsPdalProvider::QgsPdalProvider(
   const QgsDataProvider::ProviderOptions &options,
   QgsDataProvider::ReadFlags flags, bool generateCopc )
   : QgsPointCloudDataProvider( uri, options, flags )
-  , mIndex( new QgsCopcPointCloudIndex )
+  , mIndex( nullptr )
   , mGenerateCopc( generateCopc )
 {
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
@@ -71,7 +71,7 @@ QgsRectangle QgsPdalProvider::extent() const
 
 QgsPointCloudAttributeCollection QgsPdalProvider::attributes() const
 {
-  return mIndex->attributes();
+  return mIndex.get() ? mIndex->attributes() : QgsPointCloudAttributeCollection();
 }
 
 static QString _outEptDir( const QString &filename )
@@ -92,7 +92,7 @@ static QString _outCopcFile( const QString &filename )
 
 void QgsPdalProvider::generateIndex()
 {
-  if ( mRunningIndexingTask || mIndex->isValid() )
+  if ( mRunningIndexingTask || ( mIndex.get() && mIndex->isValid() ) )
     return;
 
   if ( anyIndexingTaskExists() )
@@ -121,7 +121,7 @@ void QgsPdalProvider::generateIndex()
 
 QgsPointCloudDataProvider::PointCloudIndexGenerationState QgsPdalProvider::indexingState()
 {
-  if ( mIndex->isValid() )
+  if ( mIndex.get() && mIndex->isValid() )
     return PointCloudIndexGenerationState::Indexed;
   else if ( mRunningIndexingTask )
     return PointCloudIndexGenerationState::Indexing;
@@ -131,34 +131,34 @@ QgsPointCloudDataProvider::PointCloudIndexGenerationState QgsPdalProvider::index
 
 void QgsPdalProvider::loadIndex( )
 {
-  if ( mIndex->isValid() )
+  if ( mIndex.get() && mIndex->isValid() )
     return;
-  if ( mGenerateCopc )
+  // Try to load copc index
+  if ( !mIndex.get() || !mIndex->isValid() )
   {
     const QString outputFile = _outCopcFile( dataSourceUri() );
     const QFileInfo fi( outputFile );
     if ( fi.isFile() )
     {
+      mIndex.reset( new QgsCopcPointCloudIndex );
       mIndex->load( outputFile );
     }
-    else
-    {
-      QgsDebugMsgLevel( QStringLiteral( "pdalprovider: copc index %1 is not correctly loaded" ).arg( outputFile ), 2 );
-    }
   }
-  else
+  // Try to load ept index
+  if ( !mIndex.get() || !mIndex->isValid() )
   {
     const QString outputDir = _outEptDir( dataSourceUri() );
     const QString outEptJson = QStringLiteral( "%1/ept.json" ).arg( outputDir );
     const QFileInfo fi( outEptJson );
     if ( fi.isFile() )
     {
+      mIndex.reset( new QgsEptPointCloudIndex );
       mIndex->load( outEptJson );
     }
-    else
-    {
-      QgsDebugMsgLevel( QStringLiteral( "pdalprovider: ept index %1 is not correctly loaded" ).arg( outEptJson ), 2 );
-    }
+  }
+  if ( !mIndex.get() || !mIndex->isValid() )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "pdalprovider: neither copc or ept index for dataset %1 is not correctly loaded" ).arg( dataSourceUri() ), 2 );
   }
 }
 

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -71,7 +71,7 @@ QgsRectangle QgsPdalProvider::extent() const
 
 QgsPointCloudAttributeCollection QgsPdalProvider::attributes() const
 {
-  return mIndex.get() ? mIndex->attributes() : QgsPointCloudAttributeCollection();
+  return mIndex ? mIndex->attributes() : QgsPointCloudAttributeCollection();
 }
 
 static QString _outEptDir( const QString &filename )
@@ -92,7 +92,7 @@ static QString _outCopcFile( const QString &filename )
 
 void QgsPdalProvider::generateIndex()
 {
-  if ( mRunningIndexingTask || ( mIndex.get() && mIndex->isValid() ) )
+  if ( mRunningIndexingTask || ( mIndex && mIndex->isValid() ) )
     return;
 
   if ( anyIndexingTaskExists() )
@@ -121,7 +121,7 @@ void QgsPdalProvider::generateIndex()
 
 QgsPointCloudDataProvider::PointCloudIndexGenerationState QgsPdalProvider::indexingState()
 {
-  if ( mIndex.get() && mIndex->isValid() )
+  if ( mIndex && mIndex->isValid() )
     return PointCloudIndexGenerationState::Indexed;
   else if ( mRunningIndexingTask )
     return PointCloudIndexGenerationState::Indexing;
@@ -131,10 +131,10 @@ QgsPointCloudDataProvider::PointCloudIndexGenerationState QgsPdalProvider::index
 
 void QgsPdalProvider::loadIndex( )
 {
-  if ( mIndex.get() && mIndex->isValid() )
+  if ( mIndex && mIndex->isValid() )
     return;
   // Try to load copc index
-  if ( !mIndex.get() || !mIndex->isValid() )
+  if ( !mIndex || !mIndex->isValid() )
   {
     const QString outputFile = _outCopcFile( dataSourceUri() );
     const QFileInfo fi( outputFile );
@@ -145,7 +145,7 @@ void QgsPdalProvider::loadIndex( )
     }
   }
   // Try to load ept index
-  if ( !mIndex.get() || !mIndex->isValid() )
+  if ( !mIndex || !mIndex->isValid() )
   {
     const QString outputDir = _outEptDir( dataSourceUri() );
     const QString outEptJson = QStringLiteral( "%1/ept.json" ).arg( outputDir );
@@ -156,7 +156,7 @@ void QgsPdalProvider::loadIndex( )
       mIndex->load( outEptJson );
     }
   }
-  if ( !mIndex.get() || !mIndex->isValid() )
+  if ( !mIndex || !mIndex->isValid() )
   {
     QgsDebugMsgLevel( QStringLiteral( "pdalprovider: neither copc or ept index for dataset %1 is not correctly loaded" ).arg( dataSourceUri() ), 2 );
   }

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -62,7 +62,7 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
     qint64 mPointCount = 0;
 
     QVariantMap mOriginalMetadata;
-    std::unique_ptr<QgsCopcPointCloudIndex> mIndex;
+    std::unique_ptr<QgsPointCloudIndex> mIndex;
     QgsPdalIndexingTask *mRunningIndexingTask = nullptr;
     bool mGenerateCopc = true;
     static QQueue<QgsPdalProvider *> sIndexingQueue;


### PR DESCRIPTION
## Description
Previously the PDAL provider will generate a COPC index even when an EPT index was generated previously (with an older QGIS version for example). This PR makes sure we check for existing EPT index as well to avoid indexing the same file again.