### PR TITLE
Use extent renderer while calculating point cloud statistics

### DIFF
--- a/src/core/pointcloud/qgspointcloudrendererregistry.cpp
+++ b/src/core/pointcloud/qgspointcloudrendererregistry.cpp
@@ -98,6 +98,12 @@ QgsPointCloudRenderer *QgsPointCloudRendererRegistry::defaultRenderer( const Qgs
     return new QgsPointCloudExtentRenderer();
   }
 
+  // If we are calculating statistics, we default to the extent renderer until the statistics calculation finishes
+  if ( layer->statisticsCalculationState() == QgsPointCloudLayer::PointCloudStatisticsCalculationState::Calculating )
+  {
+    return new QgsPointCloudExtentRenderer();
+  }
+
   const QgsPointCloudAttributeCollection attributes = provider->attributes();
 
   //if red/green/blue attributes are present, then default to a RGB renderer


### PR DESCRIPTION
## Description
It is better to use the extent renderer while calculating the statistics and then later switch the renderer than using a renderer taking into account the statistics are not calculating, 