### PR TITLE
Fix source tree modifications by PostgreSQL tests

### DIFF
--- a/.docker/docker-compose-testing-postgres.yml
+++ b/.docker/docker-compose-testing-postgres.yml
@@ -23,6 +23,5 @@ services:
     environment:
       - LANG=C.UTF-8
       - LC_ALL=en_US.UTF-8
-      - QGIS_TEST_ACCEPT_GITSTATUS_CHECK_FAILURE=1
     cap_add:
       - NET_ADMIN


### PR DESCRIPTION
PR aimed at fixing source tree modification from PostgreSQL tests.
These are currently:
< 	modified:   tests/testdata/analysis/dem.tif.aux.xml
< 	modified:   tests/testdata/analysis/slope.tif.aux.xml
< 	modified:   tests/testdata/point_clouds/copc/lone-star.copc.laz
< 	modified:   tests/testdata/zip/landsat_b1.zip

As reported in: https://github.com/qgis/QGIS/runs/6753897882?check_suite_focus=true#step:13:413

References #31980
References #25830 - repository files modified by `make check`