### PR TITLE
Skip netcdf tests if corresponding driver is not available

### DIFF
--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -70,6 +70,8 @@ class TestQgsGdalProvider : public QObject
   private:
     QString mTestDataDir;
     QString mReport;
+    bool mSupportsNetCDF;
+
 };
 
 //runs before all tests
@@ -81,6 +83,9 @@ void TestQgsGdalProvider::initTestCase()
 
   mTestDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
   mReport = QStringLiteral( "<h1>GDAL Provider Tests</h1>\n" );
+
+  mSupportsNetCDF = GDALGetDriverByName( "netcdf" ) != NULL;
+
 }
 
 //runs after all tests
@@ -481,49 +486,56 @@ void TestQgsGdalProvider::testGdalProviderQuerySublayers()
   rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
   QVERIFY( rl->isValid() );
 
-  // netcdf file
-  res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc" );
-  QCOMPARE( res.count(), 8 );
-  QCOMPARE( res.at( 0 ).layerNumber(), 1 );
-  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "cell_node" ) );
-  QCOMPARE( res.at( 0 ).description(), QStringLiteral( "[320x4] cell_node (32-bit integer)" ) );
-  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":cell_node" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
-  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
-  QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "netCDF" ) );
-  rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 0 ).toLayer( options ) ) );
-  QVERIFY( rl->isValid() );
-  QCOMPARE( res.at( 1 ).layerNumber(), 2 );
-  QCOMPARE( res.at( 1 ).name(), QStringLiteral( "layerface_Z" ) );
-  QCOMPARE( res.at( 1 ).description(), QStringLiteral( "[37x3520] layerface_Z (32-bit floating-point)" ) );
-  QCOMPARE( res.at( 1 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":layerface_Z" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
-  QCOMPARE( res.at( 1 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 1 ).type(), QgsMapLayerType::RasterLayer );
-  QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "netCDF" ) );
-  rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
-  QVERIFY( rl->isValid() );
+  if ( mSupportsNetCDF )
+  {
+    // netcdf file
+    res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc" );
+    QCOMPARE( res.count(), 8 );
+    QCOMPARE( res.at( 0 ).layerNumber(), 1 );
+    QCOMPARE( res.at( 0 ).name(), QStringLiteral( "cell_node" ) );
+    QCOMPARE( res.at( 0 ).description(), QStringLiteral( "[320x4] cell_node (32-bit integer)" ) );
+    QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":cell_node" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+    QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+    QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "netCDF" ) );
+    rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 0 ).toLayer( options ) ) );
+    QVERIFY( rl->isValid() );
+    QCOMPARE( res.at( 1 ).layerNumber(), 2 );
+    QCOMPARE( res.at( 1 ).name(), QStringLiteral( "layerface_Z" ) );
+    QCOMPARE( res.at( 1 ).description(), QStringLiteral( "[37x3520] layerface_Z (32-bit floating-point)" ) );
+    QCOMPARE( res.at( 1 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":layerface_Z" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+    QCOMPARE( res.at( 1 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 1 ).type(), QgsMapLayerType::RasterLayer );
+    QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "netCDF" ) );
+    rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
+    QVERIFY( rl->isValid() );
 
-  // netcdf with open options
-  res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES" );
-  QCOMPARE( res.count(), 8 );
-  QCOMPARE( res.at( 0 ).layerNumber(), 1 );
-  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "cell_node" ) );
-  QCOMPARE( res.at( 0 ).description(), QStringLiteral( "[320x4] cell_node (32-bit integer)" ) );
-  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":cell_node|option:HONOUR_VALID_RANGE=YES" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
-  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
-  QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "netCDF" ) );
-  rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 0 ).toLayer( options ) ) );
-  QVERIFY( rl->isValid() );
-  QCOMPARE( res.at( 1 ).layerNumber(), 2 );
-  QCOMPARE( res.at( 1 ).name(), QStringLiteral( "layerface_Z" ) );
-  QCOMPARE( res.at( 1 ).description(), QStringLiteral( "[37x3520] layerface_Z (32-bit floating-point)" ) );
-  QCOMPARE( res.at( 1 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":layerface_Z|option:HONOUR_VALID_RANGE=YES" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
-  QCOMPARE( res.at( 1 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 1 ).type(), QgsMapLayerType::RasterLayer );
-  QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "netCDF" ) );
-  rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
-  QVERIFY( rl->isValid() );
+    // netcdf with open options
+    res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES" );
+    QCOMPARE( res.count(), 8 );
+    QCOMPARE( res.at( 0 ).layerNumber(), 1 );
+    QCOMPARE( res.at( 0 ).name(), QStringLiteral( "cell_node" ) );
+    QCOMPARE( res.at( 0 ).description(), QStringLiteral( "[320x4] cell_node (32-bit integer)" ) );
+    QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":cell_node|option:HONOUR_VALID_RANGE=YES" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+    QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+    QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "netCDF" ) );
+    rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 0 ).toLayer( options ) ) );
+    QVERIFY( rl->isValid() );
+    QCOMPARE( res.at( 1 ).layerNumber(), 2 );
+    QCOMPARE( res.at( 1 ).name(), QStringLiteral( "layerface_Z" ) );
+    QCOMPARE( res.at( 1 ).description(), QStringLiteral( "[37x3520] layerface_Z (32-bit floating-point)" ) );
+    QCOMPARE( res.at( 1 ).uri(), QStringLiteral( "NETCDF:\"%1/mesh/trap_steady_05_3D.nc\":layerface_Z|option:HONOUR_VALID_RANGE=YES" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+    QCOMPARE( res.at( 1 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 1 ).type(), QgsMapLayerType::RasterLayer );
+    QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "netCDF" ) );
+    rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
+    QVERIFY( rl->isValid() );
+  }
+  else
+  {
+    QSKIP( "NetCDF based tests require the netcdf GDAL driver" );
+  }
 
   // aigrid file
   res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/aigrid" );
@@ -676,23 +688,30 @@ void TestQgsGdalProvider::testGdalProviderQuerySublayersFastScan()
   QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
   QVERIFY( res.at( 0 ).skippedContainerScan() );
 
-  // netcdf file
-  res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc", Qgis::SublayerQueryFlag::FastScan );
-  QCOMPARE( res.count(), 1 );
-  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "trap_steady_05_3D" ) );
-  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc" );
-  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
-  QVERIFY( res.at( 0 ).skippedContainerScan() );
+  if ( mSupportsNetCDF )
+  {
+    // netcdf file
+    res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc", Qgis::SublayerQueryFlag::FastScan );
+    QCOMPARE( res.count(), 1 );
+    QCOMPARE( res.at( 0 ).name(), QStringLiteral( "trap_steady_05_3D" ) );
+    QCOMPARE( res.at( 0 ).uri(), QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc" );
+    QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+    QVERIFY( res.at( 0 ).skippedContainerScan() );
 
-  // netcdf with open options
-  res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES", Qgis::SublayerQueryFlag::FastScan );
-  QCOMPARE( res.count(), 1 );
-  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "trap_steady_05_3D" ) );
-  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES" );
-  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
-  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
-  QVERIFY( res.at( 0 ).skippedContainerScan() );
+    // netcdf with open options
+    res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES", Qgis::SublayerQueryFlag::FastScan );
+    QCOMPARE( res.count(), 1 );
+    QCOMPARE( res.at( 0 ).name(), QStringLiteral( "trap_steady_05_3D" ) );
+    QCOMPARE( res.at( 0 ).uri(), QStringLiteral( TEST_DATA_DIR ) + "/mesh/trap_steady_05_3D.nc|option:HONOUR_VALID_RANGE=YES" );
+    QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+    QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+    QVERIFY( res.at( 0 ).skippedContainerScan() );
+  }
+  else
+  {
+    QSKIP( "NetCDF tests require the netcdf GDAL driver" );
+  }
 
   // aigrid, pointing to .adf file
   res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/aigrid/hdr.adf", Qgis::SublayerQueryFlag::FastScan );


### PR DESCRIPTION
Closes #48905
Closes #48906

When the `netcdf` driver is not supported by the GDAL library installed on the system, this patch makes the testsuite still pass by skipping the  corresponding tests. The skip is done using QSKIP so the user should theoretically have a way to tell that not all tests are being run (although `ctest` doesn't seem to give visibility to that count)