### PR TITLE
Change 3D renderer defaults and UI minor changes

### DIFF
--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -174,8 +174,8 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
 
   const QString symbolType = elemSymbol.attribute( QStringLiteral( "type" ) );
   mShowBoundingBoxes = elem.attribute( QStringLiteral( "show-bounding-boxes" ), QStringLiteral( "0" ) ).toInt();
-  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "1.0" ) ).toDouble();
-  mPointBudget = elem.attribute( QStringLiteral( "point-budget" ), QStringLiteral( "1000000" ) ).toInt();
+  mMaximumScreenError = elem.attribute( QStringLiteral( "max-screen-error" ), QStringLiteral( "3.0" ) ).toDouble();
+  mPointBudget = elem.attribute( QStringLiteral( "point-budget" ), QStringLiteral( "5000000" ) ).toInt();
 
   if ( symbolType == QLatin1String( "single-color" ) )
     mSymbol.reset( new QgsSingleColorPointCloud3DSymbol );

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -300,9 +300,9 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
   private:
     QgsMapLayerRef mLayerRef; //!< Layer used to extract mesh data from
     std::unique_ptr< QgsPointCloud3DSymbol > mSymbol;
-    double mMaximumScreenError = 1.0;
+    double mMaximumScreenError = 3.0;
     bool mShowBoundingBoxes = false;
-    int mPointBudget = 1000000;
+    int mPointBudget = 5000000;
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/symbols/qgspointcloud3dsymbol.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol.cpp
@@ -103,7 +103,7 @@ void QgsPointCloud3DSymbol::readBaseXml( const QDomElement &elem, const QgsReadW
 {
   Q_UNUSED( context )
 
-  mPointSize = elem.attribute( QStringLiteral( "point-size" ), QStringLiteral( "2.0" ) ).toFloat();
+  mPointSize = elem.attribute( QStringLiteral( "point-size" ), QStringLiteral( "3.0" ) ).toFloat();
   mRenderAsTriangles = elem.attribute( QStringLiteral( "render-as-triangles" ), QStringLiteral( "0" ) ).toInt() == 1;
   mHorizontalTriangleFilter = elem.attribute( QStringLiteral( "horizontal-triangle-filter" ), QStringLiteral( "0" ) ).toInt() == 1;
   mHorizontalFilterThreshold = elem.attribute( QStringLiteral( "horizontal-filter-threshold" ), QStringLiteral( "10.0" ) ).toFloat();

--- a/src/3d/symbols/qgspointcloud3dsymbol.h
+++ b/src/3d/symbols/qgspointcloud3dsymbol.h
@@ -166,7 +166,7 @@ class _3D_EXPORT QgsPointCloud3DSymbol : public QgsAbstract3DSymbol SIP_ABSTRACT
     void copyBaseSettings( QgsAbstract3DSymbol *destination ) const override;
 
   protected:
-    float mPointSize = 2.0;
+    float mPointSize = 3.0;
     bool mRenderAsTriangles = false;
     bool mHorizontalTriangleFilter = false;
     float mHorizontalFilterThreshold = 10.0;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -658,12 +658,6 @@ double QgsPointCloud3DSymbolWidget::pointBudget() const
   return mPointBudgetSpinBox->value();
 }
 
-
-void QgsPointCloud3DSymbolWidget::setPointCloudSize( int size )
-{
-  mPointCloudSizeLabel->setText( QStringLiteral( "%1 points" ).arg( size ) );
-}
-
 bool QgsPointCloud3DSymbolWidget::showBoundingBoxes() const
 {
   return mShowBoundingBoxesCheckBox->isChecked();

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -134,6 +134,13 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   mClassifiedRenderingLayout->addWidget( mClassifiedRendererWidget );
 
   connect( mClassifiedRendererWidget, &QgsPointCloudClassifiedRendererWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
+
+  mPointSizeSpinBox->setToolTip( tr( "The size of 1 dataset point in pixels" ) );
+  labelPointSize->setToolTip( tr( "The size of 1 dataset point in pixels" ) );
+  mMaxScreenErrorSpinBox->setToolTip( tr( "Represents the size of the smallest chunk to be rendered in pixels, the less the value the more chunks will be rendered" ) );
+  labelMaxScreenError->setToolTip( tr( "Represents the size of the smallest chunk to be rendered in pixels, the less the value the more chunks will be rendered" ) );
+  mPointBudgetSpinBox->setToolTip( tr( "Sets the number of points that will be renderered simultaniously at most" ) );
+  labelPointBudget->setToolTip( tr( "Sets the number of points that will be renderered simultaniously at most" ) );
 }
 
 void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -136,7 +136,7 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
   connect( mClassifiedRendererWidget, &QgsPointCloudClassifiedRendererWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
 
   mPointSizeSpinBox->setToolTip( tr( "The size of each point in pixels" ) );
-  mMaxScreenErrorSpinBox->setToolTip( tr( "The size in pixels of the smallest chunk to be rendered.\nRaising this value will result in a less detailed scene which can improve performance" ) );
+  mMaxScreenErrorSpinBox->setToolTip( tr( "The distance in pixels between the points of the smallest chunk to be rendered.\nRaising this value will result in a less detailed scene which can improve performance" ) );
   mPointBudgetSpinBox->setToolTip( tr( "The maximum number of points that will be rendered simultaneously.\nRaising this value may allow missing chunks to be rendered while lowering it may improve performance" ) );
 }
 

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -135,12 +135,9 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
 
   connect( mClassifiedRendererWidget, &QgsPointCloudClassifiedRendererWidget::widgetChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
 
-  mPointSizeSpinBox->setToolTip( tr( "The size of 1 dataset point in pixels" ) );
-  labelPointSize->setToolTip( tr( "The size of 1 dataset point in pixels" ) );
-  mMaxScreenErrorSpinBox->setToolTip( tr( "Represents the size of the smallest chunk to be rendered in pixels, the less the value the more chunks will be rendered" ) );
-  labelMaxScreenError->setToolTip( tr( "Represents the size of the smallest chunk to be rendered in pixels, the less the value the more chunks will be rendered" ) );
-  mPointBudgetSpinBox->setToolTip( tr( "Sets the number of points that will be renderered simultaniously at most" ) );
-  labelPointBudget->setToolTip( tr( "Sets the number of points that will be renderered simultaniously at most" ) );
+  mPointSizeSpinBox->setToolTip( tr( "The size of each point in pixels" ) );
+  mMaxScreenErrorSpinBox->setToolTip( tr( "The size in pixels of the smallest chunk to be rendered.\nRaising this value will result in a less detailed scene which can improve performance" ) );
+  mPointBudgetSpinBox->setToolTip( tr( "The maximum number of points that will be rendered simultaneously.\nRaising this value may allow missing chunks to be rendered while lowering it may improve performance" ) );
 }
 
 void QgsPointCloud3DSymbolWidget::setSymbol( QgsPointCloud3DSymbol *symbol )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -45,8 +45,6 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setPointBudget( double budget );
     double pointBudget() const;
 
-    void setPointCloudSize( int size );
-
     void connectChildPanels( QgsPanelWidget *parent );
 
   private slots:

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -40,7 +40,7 @@ QgsPointCloudLayer3DRendererWidget::QgsPointCloudLayer3DRendererWidget( QgsPoint
   connect( mWidgetPointCloudSymbol, &QgsPointCloud3DSymbolWidget::changed, this, &QgsPointCloudLayer3DRendererWidget::widgetChanged );
 }
 
-void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3DRenderer *renderer, QgsPointCloudLayer *layer )
+void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3DRenderer *renderer )
 {
   if ( renderer != nullptr )
   {
@@ -91,7 +91,7 @@ void QgsPointCloudLayer3DRendererWidget::syncToLayer( QgsMapLayer *layer )
     pointCloudRenderer = static_cast<QgsPointCloudLayer3DRenderer *>( r );
     pointCloudRenderer->setSymbol( mWidgetPointCloudSymbol->symbol() );
   }
-  setRenderer( pointCloudRenderer, qobject_cast< QgsPointCloudLayer * >( layer ) );
+  setRenderer( pointCloudRenderer );
   mWidgetPointCloudSymbol->setEnabled( true );
 }
 
@@ -118,7 +118,7 @@ QgsMapLayerConfigWidget *QgsPointCloudLayer3DRendererWidgetFactory::createWidget
     return nullptr;
   QgsPointCloudLayer3DRendererWidget *widget = new QgsPointCloudLayer3DRendererWidget( pointCloudLayer, canvas, parent );
   if ( pointCloudLayer )
-    widget->setRenderer( dynamic_cast<QgsPointCloudLayer3DRenderer *>( pointCloudLayer->renderer3D() ), pointCloudLayer );
+    widget->setRenderer( dynamic_cast<QgsPointCloudLayer3DRenderer *>( pointCloudLayer->renderer3D() ) );
   return widget;
 }
 

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -49,8 +49,6 @@ void QgsPointCloudLayer3DRendererWidget::setRenderer( const QgsPointCloudLayer3D
     mWidgetPointCloudSymbol->setMaximumScreenError( renderer->maximumScreenError() );
     mWidgetPointCloudSymbol->setShowBoundingBoxes( renderer->showBoundingBoxes() );
   }
-  if ( layer )
-    mWidgetPointCloudSymbol->setPointCloudSize( layer->pointCount() );
 }
 
 QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.h
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.h
@@ -40,7 +40,7 @@ class QgsPointCloudLayer3DRendererWidget : public QgsMapLayerConfigWidget
     void setDockMode( bool dockMode ) override;
 
     //! no transfer of ownership
-    void setRenderer( const QgsPointCloudLayer3DRenderer *renderer, QgsPointCloudLayer *layer );
+    void setRenderer( const QgsPointCloudLayer3DRenderer *renderer );
     //! no transfer of ownership
     QgsPointCloudLayer3DRenderer *renderer();
 

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>581</width>
-    <height>551</height>
+    <height>553</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -43,6 +43,49 @@
       </property>
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_7">
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelPointSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Point size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelMaxScreenError">
+          <property name="text">
+           <string>Maximum screen space error</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>3.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="labelPointBudget">
+          <property name="text">
+           <string>Point budget</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1" colspan="2">
          <widget class="QDoubleSpinBox" name="mPointBudgetSpinBox">
           <property name="enabled">
@@ -65,67 +108,10 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="labelPointBudget">
-          <property name="text">
-           <string>Point budget</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QLabel" name="mPointCloudSizeLabel">
-          <property name="text">
-           <string>10000</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="labelPointCloudSize">
-          <property name="text">
-           <string>Point cloud size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelPointSize">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Point size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelMaxScreenError">
-          <property name="text">
-           <string>Maximum screen space error</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1" colspan="2">
          <widget class="QgsDoubleSpinBox" name="mMaxScreenErrorSpinBox">
           <property name="maximum">
            <double>100000.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>3.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximum">
-           <double>10.000000000000000</double>
           </property>
           <property name="value">
            <double>3.000000000000000</double>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -48,16 +48,25 @@
           <property name="enabled">
            <bool>true</bool>
           </property>
+          <property name="decimals">
+           <number>0</number>
+          </property>
           <property name="minimum">
            <double>100000.000000000000000</double>
           </property>
           <property name="maximum">
            <double>99999999.000000000000000</double>
           </property>
+          <property name="singleStep">
+           <double>100000.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>5000000.000000000000000</double>
+          </property>
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="labelPointBudget">
           <property name="text">
            <string>Point budget</string>
           </property>
@@ -71,14 +80,14 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
+         <widget class="QLabel" name="labelPointCloudSize">
           <property name="text">
            <string>Point cloud size</string>
           </property>
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="lblTransparency_4">
+         <widget class="QLabel" name="labelPointSize">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
             <horstretch>0</horstretch>
@@ -91,7 +100,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="labelMaxScreenError">
           <property name="text">
            <string>Maximum screen space error</string>
           </property>
@@ -103,7 +112,7 @@
            <double>100000.000000000000000</double>
           </property>
           <property name="value">
-           <double>1.000000000000000</double>
+           <double>3.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -119,7 +128,7 @@
            <double>10.000000000000000</double>
           </property>
           <property name="value">
-           <double>2.000000000000000</double>
+           <double>3.000000000000000</double>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
## Description
- Switch 3D point size default to 3px
- Switch 3D maximum screen space error default to 3px
- Switch 3D point budget to 5M
- Add tooltips to 3D renderer settings UI
- Make point budget spinbox have 0 decimals and increment in 100k steps
- Remove point cloud size label