### PR TITLE
Fix modification of source file during gdal provider test

### DIFF
--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -14,7 +14,10 @@
  ***************************************************************************/
 
 #include <limits>
-#include "gdal.h"
+
+// GDAL includes
+#include <gdal.h>
+#include <cpl_conv.h>
 
 #include "qgstest.h"
 #include <QObject>
@@ -90,6 +93,11 @@ void TestQgsGdalProvider::initTestCase()
   mGdalMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "gdal" ) );
 
   mSupportsNetCDF = static_cast< bool >( GDALGetDriverByName( "netcdf" ) );
+
+  // Disable creation of .aux.xml (stats) files during test run,
+  // to avoid modifying .zip files.
+  // See https://github.com/qgis/QGIS/issues/48846
+  CPLSetConfigOption( "GDAL_PAM_ENABLED", "NO" );
 
 }
 


### PR DESCRIPTION
Disables stats creation during the run of the test
Closes GH-48846
References GH-25830