### PR TITLE
Gdal provider test improvements backport for 3.22

### DIFF
--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -15,6 +15,10 @@
 
 #include <limits>
 
+// GDAL includes
+#include <gdal.h>
+#include <cpl_conv.h>
+
 #include "qgstest.h"
 #include <QObject>
 #include <QString>
@@ -89,6 +93,11 @@ void TestQgsGdalProvider::initTestCase()
   mGdalMetadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "gdal" ) );
 
   mSupportsNetCDF = static_cast< bool >( GDALGetDriverByName( "netcdf" ) );
+
+  // Disable creation of .aux.xml (stats) files during test run,
+  // to avoid modifying .zip files.
+  // See https://github.com/qgis/QGIS/issues/48846
+  CPLSetConfigOption( "GDAL_PAM_ENABLED", "NO" );
 
 }
 


### PR DESCRIPTION
3.22 backport of gdal provider test improvements:

  - Skip NetCDF tests if unsupported by environment ( #48907 and #48916 )
  - Avoid overriding .zip file in source tree ( #48917 )