### PR TITLE
Update the 2D renderer once the point cloud statistics are calculated

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -239,6 +239,7 @@ bool QgsPointCloudLayer::readStyle( const QDomNode &node, QString &, QgsReadWrit
     if ( !mRenderer )
     {
       setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( this ) );
+      mUsingDefaultRenderer = true;
     }
   }
 
@@ -427,6 +428,7 @@ void QgsPointCloudLayer::setDataSourcePrivate( const QString &dataSource, const 
       {
         defaultLoadedFlag = true;
         setRenderer( defaultRenderer.release() );
+        mUsingDefaultRenderer = true;
       }
     }
 
@@ -439,6 +441,7 @@ void QgsPointCloudLayer::setDataSourcePrivate( const QString &dataSource, const 
     {
       // all else failed, create default renderer
       setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( this ) );
+      mUsingDefaultRenderer = true;
     }
   }
 }
@@ -506,6 +509,7 @@ QString QgsPointCloudLayer::loadDefaultStyle( bool &resultFlag )
     {
       resultFlag = true;
       setRenderer( defaultRenderer.release() );
+      mUsingDefaultRenderer = true;
       return QString();
     }
   }
@@ -886,9 +890,10 @@ void QgsPointCloudLayer::resetRenderer()
   {
     calculateStatistics();
   }
-  if ( !mRenderer || mRenderer->type() == QLatin1String( "extent" ) )
+  if ( !mRenderer || mUsingDefaultRenderer || mRenderer->type() == QLatin1String( "extent" ) )
   {
     setRenderer( QgsPointCloudRendererRegistry::defaultRenderer( this ) );
+    mUsingDefaultRenderer = true;
   }
   triggerRepaint();
 

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -295,6 +295,8 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractPro
     QgsPointCloudStatistics mStatistics;
     PointCloudStatisticsCalculationState mStatisticsCalculationState = PointCloudStatisticsCalculationState::NotStarted;
     long mStatsCalculationTask = 0;
+
+    bool mUsingDefaultRenderer = false;
 };
 
 


### PR DESCRIPTION
## Description
Using this file (~700mb):
https://media.githubusercontent.com/media/sceneserver/copc/main/naarden-vesting.copc.laz

When the file is loaded by QGIS, we get the default renderer for RGB but with the incorrect range of RGB values (0-65535) since the correct range wasn't calculated from the statistics yet.
This PR addresses that by making the point cloud layer able to update its default 2D renderer after being set before.
