### PR TITLE
Move up the "Place on every part" option in marker and hash line symbol

### DIFF
--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2068,6 +2068,7 @@ void QgsMarkerLineSymbolLayerWidget::setPlacement()
   mOffsetAlongLineUnitWidget->setEnabled( mSpinOffsetAlongLine->isEnabled() );
   mSpinAverageAngleLength->setEnabled( chkRotateMarker->isChecked() && ( mCheckInterval->isChecked() || mCheckCentralPoint->isChecked() ) );
   mAverageAngleUnit->setEnabled( mSpinAverageAngleLength->isEnabled() );
+  mCheckPlaceOnEveryPart->setEnabled( mCheckVertexLast->isChecked() || mCheckVertexFirst->isChecked() );
 
   Qgis::MarkerLinePlacements placements;
   if ( mCheckInterval->isChecked() )
@@ -2345,6 +2346,7 @@ void QgsHashedLineSymbolLayerWidget::setPlacement()
   mOffsetAlongLineUnitWidget->setEnabled( mSpinOffsetAlongLine->isEnabled() );
   mSpinAverageAngleLength->setEnabled( chkRotateMarker->isChecked() && ( mCheckInterval->isChecked() || mCheckCentralPoint->isChecked() ) );
   mAverageAngleUnit->setEnabled( mSpinAverageAngleLength->isEnabled() );
+  mCheckPlaceOnEveryPart->setEnabled( mCheckVertexLast->isChecked() || mCheckVertexFirst->isChecked() );
 
   Qgis::MarkerLinePlacements placements;
   if ( mCheckInterval->isChecked() )

--- a/src/ui/symbollayer/widget_hashline.ui
+++ b/src/ui/symbollayer/widget_hashline.ui
@@ -41,7 +41,7 @@
      <property name="bottomMargin">
       <number>0</number>
      </property>
-     <item row="3" column="1">
+     <item row="0" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
         <widget class="QCheckBox" name="mCheckInterval">
@@ -93,7 +93,7 @@
        </item>
       </layout>
      </item>
-     <item row="6" column="0">
+     <item row="3" column="0">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -109,14 +109,14 @@
        </property>
       </spacer>
      </item>
-     <item row="3" column="2">
+     <item row="0" column="2">
       <widget class="QgsPropertyOverrideButton" name="mIntervalDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="mCheckVertex">
        <property name="toolTip">
         <string>Shows symbols on inner vertices, i.e. all vertices except the first or last</string>
@@ -126,35 +126,35 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="2" column="1">
       <widget class="QCheckBox" name="mCheckVertexLast">
        <property name="text">
         <string>On last vertex</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="1" column="1">
       <widget class="QCheckBox" name="mCheckVertexFirst">
        <property name="text">
         <string>On first vertex</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="4" column="1">
       <widget class="QCheckBox" name="mCheckCentralPoint">
        <property name="text">
         <string>On central point</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="5" column="1">
       <widget class="QCheckBox" name="mCheckSegmentCentralPoint">
        <property name="text">
         <string>On central point of segments</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="6" column="1">
       <widget class="QCheckBox" name="mCheckCurvePoint">
        <property name="text">
         <string>On every curve point</string>
@@ -163,7 +163,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="1" colspan="2">
+   <item row="3" column="1" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -217,14 +217,14 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0" colspan="2">
+     <item row="2" column="0" colspan="2">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Hash length</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="2">
+     <item row="3" column="0" colspan="2">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Hash rotation</string>
@@ -253,14 +253,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="4">
+     <item row="2" column="4">
       <widget class="QgsPropertyOverrideButton" name="mHashLengthDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
+     <item row="2" column="3">
       <widget class="QgsUnitSelectionWidget" name="mHashLengthUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -273,14 +273,14 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="4">
+     <item row="1" column="4">
       <widget class="QgsPropertyOverrideButton" name="mOffsetAlongLineDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
+     <item row="1" column="2">
       <widget class="QgsDoubleSpinBox" name="mSpinOffsetAlongLine">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -305,7 +305,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="2" column="2">
       <widget class="QgsDoubleSpinBox" name="mSpinHashLength">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -327,7 +327,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="4">
+     <item row="3" column="4">
       <widget class="QgsPropertyOverrideButton" name="mHashRotationDDBtn">
        <property name="text">
         <string>…</string>
@@ -337,7 +337,7 @@
      <item row="7" column="2" colspan="3">
       <widget class="QComboBox" name="mRingFilterComboBox"/>
      </item>
-     <item row="2" column="2">
+     <item row="3" column="2">
       <widget class="QgsDoubleSpinBox" name="mHashRotationSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -379,7 +379,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="5">
+     <item row="4" column="0" colspan="5">
       <widget class="QCheckBox" name="chkRotateMarker">
        <property name="text">
         <string>Rotate hash to follow line direction</string>
@@ -442,14 +442,14 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="2">
+     <item row="1" column="0" colspan="2">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Offset along line</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
+     <item row="1" column="3">
       <widget class="QgsUnitSelectionWidget" name="mOffsetAlongLineUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -475,10 +475,10 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="5">
+     <item row="0" column="0" colspan="5">
       <widget class="QCheckBox" name="mCheckPlaceOnEveryPart">
        <property name="toolTip">
-        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will rendered at the first and last vertex for every part of multipart geometries</string>
+        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will also render at the first and last vertex for every part of multipart geometries</string>
        </property>
        <property name="text">
         <string>Place on every part</string>
@@ -519,6 +519,7 @@
   <tabstop>mCheckCentralPoint</tabstop>
   <tabstop>mCheckSegmentCentralPoint</tabstop>
   <tabstop>mCheckCurvePoint</tabstop>
+  <tabstop>mCheckPlaceOnEveryPart</tabstop>
   <tabstop>mSpinOffsetAlongLine</tabstop>
   <tabstop>mOffsetAlongLineUnitWidget</tabstop>
   <tabstop>mOffsetAlongLineDDBtn</tabstop>
@@ -528,7 +529,6 @@
   <tabstop>mHashRotationSpinBox</tabstop>
   <tabstop>mHashRotationDDBtn</tabstop>
   <tabstop>chkRotateMarker</tabstop>
-  <tabstop>mCheckPlaceOnEveryPart</tabstop>
   <tabstop>mSpinAverageAngleLength</tabstop>
   <tabstop>mAverageAngleUnit</tabstop>
   <tabstop>mAverageAngleDDBtn</tabstop>

--- a/src/ui/symbollayer/widget_hashline.ui
+++ b/src/ui/symbollayer/widget_hashline.ui
@@ -481,7 +481,7 @@
         <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will also render at the first and last vertex for every part of multipart geometries</string>
        </property>
        <property name="text">
-        <string>Place on every part</string>
+        <string>Place on every part extremity</string>
        </property>
       </widget>
      </item>

--- a/src/ui/symbollayer/widget_markerline.ui
+++ b/src/ui/symbollayer/widget_markerline.ui
@@ -57,14 +57,14 @@
        </property>
       </spacer>
      </item>
-     <item row="3" column="2">
+     <item row="0" column="2">
       <widget class="QgsPropertyOverrideButton" name="mIntervalDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="0" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
         <widget class="QCheckBox" name="mCheckInterval">
@@ -116,7 +116,7 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="mCheckVertex">
        <property name="toolTip">
         <string>Shows symbols on inner vertices, i.e. all vertices except the first or last</string>
@@ -126,35 +126,35 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="2" column="1">
       <widget class="QCheckBox" name="mCheckVertexLast">
        <property name="text">
         <string>On last vertex</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="1" column="1">
       <widget class="QCheckBox" name="mCheckVertexFirst">
        <property name="text">
         <string>On first vertex</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="4" column="1">
       <widget class="QCheckBox" name="mCheckCentralPoint">
        <property name="text">
         <string>On central point</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="5" column="1">
       <widget class="QCheckBox" name="mCheckSegmentCentralPoint">
        <property name="text">
         <string>On central point of segments</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="6" column="1">
       <widget class="QCheckBox" name="mCheckCurvePoint">
        <property name="text">
         <string>On every curve point</string>
@@ -163,7 +163,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="1" colspan="2">
+   <item row="3" column="1" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -272,7 +272,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
+     <item row="1" column="2">
       <widget class="QgsDoubleSpinBox" name="mSpinOffsetAlongLine">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -310,14 +310,14 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="4">
+     <item row="1" column="4">
       <widget class="QgsPropertyOverrideButton" name="mOffsetAlongLineDDBtn">
        <property name="text">
         <string>…</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
+     <item row="1" column="3">
       <widget class="QgsUnitSelectionWidget" name="mOffsetAlongLineUnitWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -337,7 +337,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="5">
+     <item row="2" column="0" colspan="5">
       <widget class="QCheckBox" name="chkRotateMarker">
        <property name="text">
         <string>Rotate marker to follow line direction</string>
@@ -351,7 +351,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="2">
+     <item row="1" column="0" colspan="2">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Offset along line</string>
@@ -384,10 +384,10 @@
      <item row="5" column="2" colspan="3">
       <widget class="QComboBox" name="mRingFilterComboBox"/>
      </item>
-     <item row="2" column="0" colspan="5">
+     <item row="0" column="0" colspan="5">
       <widget class="QCheckBox" name="mCheckPlaceOnEveryPart">
        <property name="toolTip">
-        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will rendered at the first and last vertex for every part of multipart geometries</string>
+        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will also render at the first and last vertex for every part of multipart geometries</string>
        </property>
        <property name="text">
         <string>Place on every part</string>
@@ -428,11 +428,11 @@
   <tabstop>mCheckCentralPoint</tabstop>
   <tabstop>mCheckSegmentCentralPoint</tabstop>
   <tabstop>mCheckCurvePoint</tabstop>
+  <tabstop>mCheckPlaceOnEveryPart</tabstop>
   <tabstop>mSpinOffsetAlongLine</tabstop>
   <tabstop>mOffsetAlongLineUnitWidget</tabstop>
   <tabstop>mOffsetAlongLineDDBtn</tabstop>
   <tabstop>chkRotateMarker</tabstop>
-  <tabstop>mCheckPlaceOnEveryPart</tabstop>
   <tabstop>mSpinAverageAngleLength</tabstop>
   <tabstop>mAverageAngleUnit</tabstop>
   <tabstop>mAverageAngleDDBtn</tabstop>


### PR DESCRIPTION
Because the option is about placement, it looks more coherent to me to have it close to the other placement options and not in the middle of distance options.
Also tweak description and reorder vertices placement options (more predictable `first -> last -> inner vertices` instead of `inner -> last -> first vertices`)

before/after
![hashlinePart](https://user-images.githubusercontent.com/7983394/173124161-5b6bafb1-2733-45c8-afb2-bde433e253ab.png)
![markerlinePart](https://user-images.githubusercontent.com/7983394/173124263-9bd82b02-67a8-4cf2-be41-ce09554a6e39.png)

