### PR TITLE
Fix test analysis processing modification of source files

### DIFF
--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -818,6 +818,14 @@ void TestQgsProcessing::initTestCase()
   QgsSettings settings;
   settings.clear();
 
+  /* Make sure geopackages are not written-to, during tests
+   * See https://github.com/qgis/QGIS/issues/25830
+   * NOTE: this needs to happen _after_
+   * QgsApplication::initQgis()
+   *       as any previously-set value would otherwise disappear.
+   */
+  settings.setValue( "qgis/walForSqlite3", false );
+
   QgsApplication::processingRegistry()->addProvider( new QgsNativeAlgorithms( QgsApplication::processingRegistry() ) );
 }
 

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -275,6 +275,15 @@ void TestQgsProcessingAlgsPt1::initTestCase()
   meshLayer1d->addDatasets( dataDir + "/mesh/lines_els_scalar.dat" );
   meshLayer1d->addDatasets( dataDir + "/mesh/lines_els_vector.dat" );
   QCOMPARE( meshLayer1d->datasetGroupCount(), 3 );
+
+  /* Make sure geopackages are not written-to, during tests
+   * See https://github.com/qgis/QGIS/issues/25830
+   * NOTE: this needs to happen _after_
+   * QgsApplication::initQgis()
+   *       as any previously-set value would otherwise disappear.
+   */
+  QgsSettings().setValue( "qgis/walForSqlite3", false );
+
 }
 
 void TestQgsProcessingAlgsPt1::cleanupTestCase()


### PR DESCRIPTION
Fixes modification of source tree from processing tests ( #48937 ).
Tested with GDAL-3.2.2 locally and with GDAL-3.0.4 by CI ( https://github.com/qgis/QGIS/runs/6839377929?check_suite_focus=true#step:13:194 shows the source file previously modified by this test is NOT modified anymore, with the commits in this PR )