### PR TITLE
Do not set frozen pull-requests as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -49,7 +49,7 @@ jobs:
 
 
         stale-pr-label: 'stale'
-        exempt-pr-labels: 'Merge After Thaw'
+        exempt-pr-labels: 'Merge After Thaw,Frozen'
         days-before-pr-stale: 14
         days-before-pr-close: 7
 


### PR DESCRIPTION
I think the PR was good enough to get frozen by an admin, so there should be no reason a bot would want to close it (or make noise). Would avoid https://github.com/qgis/QGIS/pull/48772#issuecomment-1152857480