### PR TITLE
Don't redraw 3d point clouds when layer profile chart settings are changed

### DIFF
--- a/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
+++ b/src/app/pointcloud/qgspointcloudelevationpropertieswidget.cpp
@@ -89,6 +89,9 @@ void QgsPointCloudElevationPropertiesWidget::apply()
 
   QgsPointCloudLayerElevationProperties *properties = qgis::down_cast< QgsPointCloudLayerElevationProperties * >( mLayer->elevationProperties() );
 
+  const bool changed3DrelatedProperties = !qgsDoubleNear( mOffsetZSpinBox->value(), properties->zOffset() )
+                                          || !qgsDoubleNear( mScaleZSpinBox->value(), properties->zScale() );
+
   properties->setZOffset( mOffsetZSpinBox->value() );
   properties->setZScale( mScaleZSpinBox->value() );
   properties->setPointSize( mPointSizeSpinBox->value() );
@@ -100,7 +103,8 @@ void QgsPointCloudElevationPropertiesWidget::apply()
   properties->setRespectLayerColors( mCheckBoxRespectLayerColors->isChecked() );
   properties->setApplyOpacityByDistanceEffect( mOpacityByDistanceCheckBox->isChecked() );
 
-  mLayer->trigger3DUpdate();
+  if ( changed3DrelatedProperties )
+    mLayer->trigger3DUpdate();
 }
 
 void QgsPointCloudElevationPropertiesWidget::onChanged()


### PR DESCRIPTION
@uclaros I think you reported this somewhere, but I can't find a ticket now...