### PR TITLE
Add resolution and extent fields to GDAL Grid plugins

### DIFF
--- a/python/plugins/processing/algs/gdal/GridAverage.py
+++ b/python/plugins/processing/algs/gdal/GridAverage.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterString,
@@ -43,6 +44,10 @@ pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 class GridAverage(GdalAlgorithm):
     INPUT = 'INPUT'
     Z_FIELD = 'Z_FIELD'
+    WIDTH = 'WIDTH'
+    HEIGHT = 'HEIGHT'
+    UNITS = 'UNITS'
+    EXTENT = 'EXTENT'
     RADIUS_1 = 'RADIUS_1'
     RADIUS_2 = 'RADIUS_2'
     MIN_POINTS = 'MIN_POINTS'
@@ -59,6 +64,8 @@ class GridAverage(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
+        self.units = [self.tr("Pixels"),
+                self.tr("Georeferenced units")]
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Point layer'),
                                                               [QgsProcessing.TypeVectorPoint]))
@@ -71,6 +78,23 @@ class GridAverage(GdalAlgorithm):
                                                     optional=True)
         z_field_param.setFlags(z_field_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(z_field_param)
+
+        self.addParameter(QgsProcessingParameterEnum(self.UNITS,
+                                                     self.tr('Output raster size units'),
+                                                     self.units))
+        self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
+                                                       self.tr('Width/Horizontal resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
+                                                       self.tr('Height/Vertical resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
+                                                       self.tr('Output extent'),
+                                                       optional=True))
 
         self.addParameter(QgsProcessingParameterNumber(self.RADIUS_1,
                                                        self.tr('The first radius of search ellipse'),
@@ -154,6 +178,23 @@ class GridAverage(GdalAlgorithm):
         if fieldName:
             arguments.append('-zfield')
             arguments.append(fieldName)
+
+        units = self.parameterAsEnum(parameters, self.UNITS, context)
+        if units == 0:
+            arguments.append('-outsize')
+        else:
+            arguments.append('-tr')
+        arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
+        arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
+
+        extent = self.parameterAsExtent(parameters, self.EXTENT, context)
+        if not extent.isNull():
+            arguments.append('-txe')
+            arguments.append(extent.xMinimum())
+            arguments.append(extent.xMaximum())
+            arguments.append('-tye')
+            arguments.append(extent.yMinimum())
+            arguments.append(extent.yMaximum())
 
         params = 'average'
         params += ':radius1={}'.format(self.parameterAsDouble(parameters, self.RADIUS_1, context))

--- a/python/plugins/processing/algs/gdal/GridAverage.py
+++ b/python/plugins/processing/algs/gdal/GridAverage.py
@@ -81,17 +81,20 @@ class GridAverage(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridDataMetrics.py
+++ b/python/plugins/processing/algs/gdal/GridDataMetrics.py
@@ -89,17 +89,20 @@ class GridDataMetrics(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridInverseDistance.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistance.py
@@ -88,17 +88,20 @@ class GridInverseDistance(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
@@ -82,17 +82,20 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterString,
@@ -43,6 +44,10 @@ pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
     INPUT = 'INPUT'
     Z_FIELD = 'Z_FIELD'
+    WIDTH = 'WIDTH'
+    HEIGHT = 'HEIGHT'
+    UNITS = 'UNITS'
+    EXTENT = 'EXTENT'
     POWER = 'POWER'
     SMOOTHING = 'SMOOTHING'
     RADIUS = 'RADIUS'
@@ -60,6 +65,8 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
+        self.units = [self.tr("Pixels"),
+                self.tr("Georeferenced units")]
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Point layer'),
                                                               [QgsProcessing.TypeVectorPoint]))
@@ -72,6 +79,23 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
                                                     optional=True)
         z_field_param.setFlags(z_field_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(z_field_param)
+
+        self.addParameter(QgsProcessingParameterEnum(self.UNITS,
+                                                     self.tr('Output raster size units'),
+                                                     self.units))
+        self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
+                                                       self.tr('Width/Horizontal resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
+                                                       self.tr('Height/Vertical resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
+                                                       self.tr('Output extent'),
+                                                       optional=True))
 
         self.addParameter(QgsProcessingParameterNumber(self.POWER,
                                                        self.tr('Weighting power'),
@@ -161,6 +185,23 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
         if fieldName:
             arguments.append('-zfield')
             arguments.append(fieldName)
+
+        units = self.parameterAsEnum(parameters, self.UNITS, context)
+        if units == 0:
+            arguments.append('-outsize')
+        else:
+            arguments.append('-tr')
+        arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
+        arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
+
+        extent = self.parameterAsExtent(parameters, self.EXTENT, context)
+        if not extent.isNull():
+            arguments.append('-txe')
+            arguments.append(extent.xMinimum())
+            arguments.append(extent.xMaximum())
+            arguments.append('-tye')
+            arguments.append(extent.yMinimum())
+            arguments.append(extent.yMaximum())
 
         params = 'invdistnn'
         params += ':power={}'.format(self.parameterAsDouble(parameters, self.POWER, context))

--- a/python/plugins/processing/algs/gdal/GridLinear.py
+++ b/python/plugins/processing/algs/gdal/GridLinear.py
@@ -79,17 +79,20 @@ class GridLinear(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridLinear.py
+++ b/python/plugins/processing/algs/gdal/GridLinear.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterString,
@@ -44,6 +45,10 @@ class GridLinear(GdalAlgorithm):
 
     INPUT = 'INPUT'
     Z_FIELD = 'Z_FIELD'
+    WIDTH = 'WIDTH'
+    HEIGHT = 'HEIGHT'
+    UNITS = 'UNITS'
+    EXTENT = 'EXTENT'
     RADIUS = 'RADIUS'
     NODATA = 'NODATA'
     OPTIONS = 'OPTIONS'
@@ -57,6 +62,8 @@ class GridLinear(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
+        self.units = [self.tr("Pixels"),
+                self.tr("Georeferenced units")]
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Point layer'),
                                                               [QgsProcessing.TypeVectorPoint]))
@@ -69,6 +76,23 @@ class GridLinear(GdalAlgorithm):
                                                     optional=True)
         z_field_param.setFlags(z_field_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(z_field_param)
+
+        self.addParameter(QgsProcessingParameterEnum(self.UNITS,
+                                                     self.tr('Output raster size units'),
+                                                     self.units))
+        self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
+                                                       self.tr('Width/Horizontal resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
+                                                       self.tr('Height/Vertical resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
+                                                       self.tr('Output extent'),
+                                                       optional=True))
 
         self.addParameter(QgsProcessingParameterNumber(self.RADIUS,
                                                        self.tr('Search distance '),
@@ -137,6 +161,23 @@ class GridLinear(GdalAlgorithm):
         if fieldName:
             arguments.append('-zfield')
             arguments.append(fieldName)
+
+        units = self.parameterAsEnum(parameters, self.UNITS, context)
+        if units == 0:
+            arguments.append('-outsize')
+        else:
+            arguments.append('-tr')
+        arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
+        arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
+
+        extent = self.parameterAsExtent(parameters, self.EXTENT, context)
+        if not extent.isNull():
+            arguments.append('-txe')
+            arguments.append(extent.xMinimum())
+            arguments.append(extent.xMaximum())
+            arguments.append('-tye')
+            arguments.append(extent.yMinimum())
+            arguments.append(extent.yMaximum())
 
         params = 'linear'
         params += ':radius={}'.format(self.parameterAsDouble(parameters, self.RADIUS, context))

--- a/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
@@ -80,17 +80,20 @@ class GridNearestNeighbor(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterEnum(self.UNITS,
                                                      self.tr('Output raster size units'),
-                                                     self.units))
+                                                     self.units,
+                                                     optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
                                                        self.tr('Width/Horizontal resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
                                                        self.tr('Height/Vertical resolution'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=0.0))
+                                                       defaultValue=0.0,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Output extent'),
                                                        optional=True))

--- a/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterEnum,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterString,
@@ -43,6 +44,10 @@ pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 class GridNearestNeighbor(GdalAlgorithm):
     INPUT = 'INPUT'
     Z_FIELD = 'Z_FIELD'
+    WIDTH = 'WIDTH'
+    HEIGHT = 'HEIGHT'
+    UNITS = 'UNITS'
+    EXTENT = 'EXTENT'
     RADIUS_1 = 'RADIUS_1'
     RADIUS_2 = 'RADIUS_2'
     ANGLE = 'ANGLE'
@@ -58,6 +63,8 @@ class GridNearestNeighbor(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
+        self.units = [self.tr("Pixels"),
+                self.tr("Georeferenced units")]
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
                                                               self.tr('Point layer'),
                                                               [QgsProcessing.TypeVectorPoint]))
@@ -70,6 +77,23 @@ class GridNearestNeighbor(GdalAlgorithm):
                                                     optional=True)
         z_field_param.setFlags(z_field_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(z_field_param)
+
+        self.addParameter(QgsProcessingParameterEnum(self.UNITS,
+                                                     self.tr('Output raster size units'),
+                                                     self.units))
+        self.addParameter(QgsProcessingParameterNumber(self.WIDTH,
+                                                       self.tr('Width/Horizontal resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterNumber(self.HEIGHT,
+                                                       self.tr('Height/Vertical resolution'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       minValue=0.0,
+                                                       defaultValue=0.0))
+        self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
+                                                       self.tr('Output extent'),
+                                                       optional=True))
 
         self.addParameter(QgsProcessingParameterNumber(self.RADIUS_1,
                                                        self.tr('The first radius of search ellipse'),
@@ -149,6 +173,23 @@ class GridNearestNeighbor(GdalAlgorithm):
         if fieldName:
             arguments.append('-zfield')
             arguments.append(fieldName)
+
+        units = self.parameterAsEnum(parameters, self.UNITS, context)
+        if units == 0:
+            arguments.append('-outsize')
+        else:
+            arguments.append('-tr')
+        arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
+        arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
+
+        extent = self.parameterAsExtent(parameters, self.EXTENT, context)
+        if not extent.isNull():
+            arguments.append('-txe')
+            arguments.append(extent.xMinimum())
+            arguments.append(extent.xMaximum())
+            arguments.append('-tye')
+            arguments.append(extent.yMinimum())
+            arguments.append(extent.yMaximum())
 
         params = 'nearest'
         params += ':radius1={}'.format(self.parameterAsDouble(parameters, self.RADIUS_1, context))


### PR DESCRIPTION
## Description

GDAL Grid plugins (Moving Average, Linear, ...) were missing the options for non default resolutions and extents.
This made it difficult to generate outputs at resolutions less than 1m.
I have transferred the resolution and extent settings from GDAL rasterize.

![image](https://user-images.githubusercontent.com/26135231/173492514-f2788f43-3994-45d9-9ad3-bb52b2f96edd.png)
