### PR TITLE
Fix hovering features in attribute table in dark themes selects them

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -129,6 +129,12 @@ void QgsFeatureListView::setCurrentFeatureEdited( bool state )
 
 void QgsFeatureListView::mousePressEvent( QMouseEvent *event )
 {
+  if ( event->button() != Qt::LeftButton )
+  {
+    QListView::mousePressEvent( event );
+    return;
+  }
+
   if ( mModel )
   {
     const QPoint pos = event->pos();
@@ -137,13 +143,13 @@ void QgsFeatureListView::mousePressEvent( QMouseEvent *event )
 
     if ( QgsFeatureListViewDelegate::EditElement == mItemDelegate->positionToElement( event->pos() ) )
     {
-
-      mEditSelectionDrag = true;
+      mDragMode = DragMode::MoveSelection;
       if ( index.isValid() )
         setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
     }
     else
     {
+      mDragMode = DragMode::ExpandSelection;
       mFeatureSelectionModel->enableSync( false );
       selectRow( index, true );
       repaintRequested();
@@ -251,17 +257,25 @@ void QgsFeatureListView::mouseMoveEvent( QMouseEvent *event )
   if ( mModel )
   {
     const QPoint pos = event->pos();
-
     const QModelIndex index = indexAt( pos );
 
-    if ( mEditSelectionDrag )
+    switch ( mDragMode )
     {
-      if ( index.isValid() )
-        setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
-    }
-    else
-    {
-      selectRow( index, false );
+      case QgsFeatureListView::DragMode::Inactive:
+        break;
+
+      case QgsFeatureListView::DragMode::ExpandSelection:
+      {
+        selectRow( index, false );
+        break;
+      }
+
+      case QgsFeatureListView::DragMode::MoveSelection:
+      {
+        if ( index.isValid() )
+          setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
+        break;
+      }
     }
   }
   else
@@ -272,17 +286,24 @@ void QgsFeatureListView::mouseMoveEvent( QMouseEvent *event )
 
 void QgsFeatureListView::mouseReleaseEvent( QMouseEvent *event )
 {
-  Q_UNUSED( event )
+  if ( event->button() != Qt::LeftButton )
+  {
+    QListView::mouseReleaseEvent( event );
+    return;
+  }
 
-  if ( mEditSelectionDrag )
+  switch ( mDragMode )
   {
-    mEditSelectionDrag = false;
+    case QgsFeatureListView::DragMode::ExpandSelection:
+      if ( mFeatureSelectionModel )
+        mFeatureSelectionModel->enableSync( true );
+      break;
+    case QgsFeatureListView::DragMode::Inactive:
+    case QgsFeatureListView::DragMode::MoveSelection:
+      break;
   }
-  else
-  {
-    if ( mFeatureSelectionModel )
-      mFeatureSelectionModel->enableSync( true );
-  }
+
+  mDragMode = DragMode::Inactive;
 }
 
 void QgsFeatureListView::keyPressEvent( QKeyEvent *event )

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -251,7 +251,16 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     QgsIFeatureSelectionManager *mOwnedFeatureSelectionManager = nullptr;
     QgsIFeatureSelectionManager *mFeatureSelectionManager = nullptr;
     QgsFeatureListViewDelegate *mItemDelegate = nullptr;
-    bool mEditSelectionDrag = false; // Is set to true when the user initiated a left button click over an edit button and still keeps pressing //!< TODO
+
+    enum class DragMode
+    {
+      Inactive,
+      ExpandSelection,
+      MoveSelection
+    };
+
+    DragMode mDragMode = DragMode::Inactive;
+
     int mRowAnchor = 0;
     QItemSelectionModel::SelectionFlags mCtrlDragSelectionFlag;
 


### PR DESCRIPTION
The previous code was relying on the assumption that mouse tracking
would only ever be active on the list if a mouse button was currently
being held down -- this isn't true on the dark themes, which use
hover state theming which causes mouse tracking to be enabled
even when buttons are not pressed.

Rework the code to avoid the assumption.

Fixes #48914
