### PR TITLE
fix classified 3d renderer on missing or unordered categories

### DIFF
--- a/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspointcloud3dsymbol_p.cpp
@@ -914,7 +914,6 @@ void QgsClassificationPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex
   {
     categoriesValues.push_back( c.value() );
   }
-  std::sort( categoriesValues.begin(), categoriesValues.end() );
 
   const QSet<int> filteredOutValues = context.getFilteredOutValues();
   for ( int i = 0; i < count; ++i )
@@ -953,13 +952,14 @@ void QgsClassificationPointCloud3DSymbolHandler::processNode( QgsPointCloudIndex
     else
       context.getAttribute( ptr, i * recordSize + attributeOffset, attributeType, iParam );
 
-    if ( filteredOutValues.contains( ( int ) iParam ) )
+    if ( filteredOutValues.contains( ( int ) iParam ) ||
+         ! categoriesValues.contains( ( int ) iParam ) )
       continue;
     outNormal.positions.push_back( QVector3D( p.x(), p.y(), p.z() ) );
 
     // find iParam actual index in the categories list
-    float iParam2 = std::lower_bound( categoriesValues.begin(), categoriesValues.end(), ( int )iParam ) - categoriesValues.begin();
-    outNormal.parameter.push_back( iParam2 + 1 );
+    float iParam2 = categoriesValues.indexOf( ( int )iParam ) + 1;
+    outNormal.parameter.push_back( iParam2 );
   }
 }
 


### PR DESCRIPTION
## Description
This PR should properly fix #48303 as it was only partially addressed with #48835
Now missing categories are not rendered and reordering the categories should not affect their displayed color.

ping @NEDJIMAbelgacem 
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
