### PR TITLE
Don't try to install OWSLib on mingw builds

### DIFF
--- a/ms-windows/mingw/mingwdeps.sh
+++ b/ms-windows/mingw/mingwdeps.sh
@@ -30,7 +30,6 @@ dnf install -y --nogpgcheck \
   mingw64-python3-markupsafe \
   mingw64-python3-numpy \
   mingw64-python3-opencv \
-  mingw64-python3-OWSLib \
   mingw64-python3-pillow \
   mingw64-python3-psycopg2 \
   mingw64-python3-pygments \


### PR DESCRIPTION
This package is currently unavailable, and is only used by the CSW plugin
