### PR TITLE
Fix layout attribute table crasher

### DIFF
--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -45,6 +45,11 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
     return QgsApplication::nullRepresentation();
   }
 
+  if ( fieldIndex < 0 || fieldIndex >= layer->fields().size() )
+  {
+    return value.toString();
+  }
+
   const QgsField field = layer->fields().at( fieldIndex );
   const bool fieldIsoFormat = config.value( QStringLiteral( "field_iso_format" ), false ).toBool();
   const QString fieldFormat = config.value( QStringLiteral( "field_format" ), defaultFormat( field.type() ) ).toString();

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -566,13 +566,10 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
 
     for ( const QgsLayoutTableColumn &column : std::as_const( mColumns ) )
     {
-      int idx = layer->fields().lookupField( column.attribute() );
-
       QgsConditionalStyle style;
-
+      int idx = layer->fields().lookupField( column.attribute() );
       if ( idx != -1 )
       {
-
         QVariant val = f.attributes().at( idx );
 
         if ( mUseConditionalStyling )
@@ -597,11 +594,11 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
           }
           else
           {
-            cache = fieldFormatter->createCache( mVectorLayer.get(), idx, setup.config() );
+            cache = fieldFormatter->createCache( layer, idx, setup.config() );
             mLayerCache.insert( column.attribute(), cache );
           }
 
-          val = fieldFormatter->representValue( mVectorLayer.get(), idx, setup.config(), cache, val );
+          val = fieldFormatter->representValue( layer, idx, setup.config(), cache, val );
         }
 
         QVariant v = val.isNull() ? QString() : replaceWrapChar( val );


### PR DESCRIPTION
## Description

@elpaso , this is a follow up to this commit (https://github.com/qgis/QGIS/commit/854be5a8224a568d2c91e95889dd8db9ff06bbcb) -- the vector layer used to fetch the represented value was wrong (we're using sourceLayer(), not mVectorLayer, in that function).

Crasher reported here (https://github.com/opengisch/QField/issues/2962).