### PR TITLE
Virtual vector provider fixes

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -594,6 +594,7 @@ void QgsVirtualLayerProvider::updateStatistics() const
 void QgsVirtualLayerProvider::invalidateStatistics()
 {
   mCachedStatistics = false;
+  emit dataChanged();
 }
 
 QgsFields QgsVirtualLayerProvider::fields() const

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -88,7 +88,7 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
 
   connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );
-  connect( mAddLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::addLayer );
+  connect( mAddLayerBtn, &QAbstractButton::clicked, this, [ = ] { addLayer( true ); } );
   connect( mRemoveLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::removeLayer );
   connect( mImportLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::importLayer );
   connect( mLayersTable->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &QgsVirtualLayerSourceSelect::tableRowChanged );
@@ -308,7 +308,7 @@ void QgsVirtualLayerSourceSelect::testQuery()
   }
 }
 
-void QgsVirtualLayerSourceSelect::addLayer()
+void QgsVirtualLayerSourceSelect::addLayer( bool browseForLayer )
 {
   mLayersTable->insertRow( mLayersTable->rowCount() );
 
@@ -334,7 +334,10 @@ void QgsVirtualLayerSourceSelect::addLayer()
   encodingCombo->setCurrentIndex( encodingCombo->findText( defaultEnc ) );
   mLayersTable->setCellWidget( mLayersTable->rowCount() - 1, LayerColumn::Encoding, encodingCombo );
 
-  sourceWidget->browseForLayer();
+  if ( browseForLayer )
+  {
+    sourceWidget->browseForLayer();
+  }
 }
 
 void QgsVirtualLayerSourceSelect::removeLayer()

--- a/src/providers/virtual/qgsvirtuallayersourceselect.h
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.h
@@ -80,7 +80,7 @@ class QgsVirtualLayerSourceSelect : public QgsAbstractDataSourceWidget, private 
     void testQuery();
     void browseCRS();
     void layerComboChanged( int );
-    void addLayer();
+    void addLayer( bool browseForLayer = false );
     void removeLayer();
     void importLayer();
     void tableRowChanged( const QModelIndex &current, const QModelIndex &previous );


### PR DESCRIPTION
## Description

This PR fixes a frustrating situation with the virtual vector layer provider whereas a feature addition,modification,deletion in a referenced layer wouldn't trigger a repaint of the virtual vector layer. We can finally expect the canvas to reflect up-to-date content without triggering a manual refresh.

@nyalldawson , I've also fixed an issue with your recent improvements in the source select panel.