### PR TITLE
One more fix for point cloud unicode paths on windows

### DIFF
--- a/src/core/pointcloud/qgscopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgscopcpointcloudindex.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<QgsPointCloudIndex> QgsCopcPointCloudIndex::clone() const
 void QgsCopcPointCloudIndex::load( const QString &fileName )
 {
   mFileName = fileName;
-  mCopcFile.open( fileName.toStdString(), std::ios::binary );
+  mCopcFile.open( QgsLazDecoder::toNativePath( fileName ), std::ios::binary );
 
   if ( !mCopcFile.is_open() || !mCopcFile.good() )
   {
@@ -356,7 +356,7 @@ void QgsCopcPointCloudIndex::copyCommonProperties( QgsCopcPointCloudIndex *desti
   // QgsCopcPointCloudIndex specific fields
   destination->mIsValid = mIsValid;
   destination->mFileName = mFileName;
-  destination->mCopcFile.open( mFileName.toStdString(), std::ios::binary );
+  destination->mCopcFile.open( QgsLazDecoder::toNativePath( mFileName ), std::ios::binary );
   destination->mCopcInfoVlr = mCopcInfoVlr;
   destination->mHierarchyNodePos = mHierarchyNodePos;
   destination->mOriginalMetadata = mOriginalMetadata;


### PR DESCRIPTION
Refs #41833

Follow up of #48747

Turns out I have previously missed two more locations where toNativePath() needs to be used.
