### PR TITLE
Fix digitizing on rotated map canvas

### DIFF
--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -91,6 +91,8 @@ Sets vertex marker icon type
 %Docstring
 Sets whether the vertices are drawn
 %End
+    virtual void updatePosition();
+
 
   protected:
     virtual void paint( QPainter *painter );

--- a/src/gui/qgsgeometryrubberband.cpp
+++ b/src/gui/qgsgeometryrubberband.cpp
@@ -177,11 +177,15 @@ QgsRectangle QgsGeometryRubberBand::rubberBandRectangle() const
   qreal w = ( ( mIconSize - 1 ) / 2 + mPen.width() ); // in canvas units
 
   QgsRectangle r;  // in canvas units
-  QgsVertexIterator vit = mGeometry->vertices();
-  while ( vit.hasNext() )
+  QgsRectangle rectMap = mGeometry->boundingBox();  // in map units
+  QList<QgsPointXY> pl;
+  pl << QgsPointXY( rectMap.xMinimum(), rectMap.yMinimum() )
+     << QgsPointXY( rectMap.xMinimum(), rectMap.yMaximum() )
+     << QgsPointXY( rectMap.xMaximum(), rectMap.yMaximum() )
+     << QgsPointXY( rectMap.xMaximum(), rectMap.yMinimum() );
+
+  for ( QgsPointXY &p : pl )
   {
-    const QgsPoint point = vit.next();
-    QgsPointXY p( point.x(), point.y() );
     p = toCanvasCoordinates( p );
     // no need to normalize the rectangle -- we know it is already normal
     QgsRectangle rect( p.x() - w, p.y() - w, p.x() + w, p.y() + w, false );

--- a/src/gui/qgsgeometryrubberband.cpp
+++ b/src/gui/qgsgeometryrubberband.cpp
@@ -168,8 +168,41 @@ void QgsGeometryRubberBand::setVertexDrawingEnabled( bool isVerticesDrawn )
 
 QgsRectangle QgsGeometryRubberBand::rubberBandRectangle() const
 {
-  const qreal scale = mMapCanvas->mapUnitsPerPixel();
-  const qreal s = ( mIconSize - 1 ) / 2.0 * scale;
-  const qreal p = mPen.width() * scale;
-  return mGeometry->boundingBox().buffered( s + p );
+  if ( !mGeometry || mGeometry->isEmpty() )
+  {
+    return QgsRectangle();
+  }
+  const QgsMapToPixel &m2p = *( mMapCanvas->getCoordinateTransform() );
+
+  qreal w = ( ( mIconSize - 1 ) / 2 + mPen.width() ); // in canvas units
+
+  QgsRectangle r;  // in canvas units
+  QgsVertexIterator vit = mGeometry->vertices();
+  while ( vit.hasNext() )
+  {
+    const QgsPoint point = vit.next();
+    QgsPointXY p( point.x(), point.y() );
+    p = toCanvasCoordinates( p );
+    // no need to normalize the rectangle -- we know it is already normal
+    QgsRectangle rect( p.x() - w, p.y() - w, p.x() + w, p.y() + w, false );
+    r.combineExtentWith( rect );
+  }
+
+  // This is an hack to pass QgsMapCanvasItem::setRect what it
+  // expects (encoding of position and size of the item)
+  qreal res = m2p.mapUnitsPerPixel();
+  QgsPointXY topLeft = m2p.toMapCoordinates( r.xMinimum(), r.yMinimum() );
+  QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + r.width()*res, topLeft.y() - r.height()*res );
+
+  return rect;
+}
+
+void QgsGeometryRubberBand::updatePosition()
+{
+  // re-compute rectangle
+  // See https://github.com/qgis/QGIS/issues/20566
+  // NOTE: could be optimized by saving map-extent
+  //       of rubberband and simply re-projecting
+  //       that to device-rectangle on "updatePosition"
+  setRect( rubberBandRectangle() );
 }

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -115,6 +115,7 @@ class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
     void setIconType( IconType iconType ) { mIconType = iconType; }
     //! Sets whether the vertices are drawn
     void setVertexDrawingEnabled( bool isVerticesDrawn );
+    void updatePosition() override;
 
   protected:
     void paint( QPainter *painter ) override;


### PR DESCRIPTION
## Description
Docstrings of `QgsMapCanvasItem::setRect()` should probably be changed, as the rect *is not* the actual bounding box but rather encodes the top left corner and scaled width

Fix #25095

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
