### PR TITLE
Cleanup some noisy test output

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3081,7 +3081,10 @@ void QgsGdalProvider::initBaseDataset()
 
   if ( !mGdalTransformerArg )
   {
+    // silence GDAL "ERROR 1: The transformation is already "north up" or a transformation between pixel/line and georeferenced coordinates cannot be computed" warnings
+    CPLPushErrorHandler( CPLQuietErrorHandler );
     mGdalTransformerArg = GDALCreateGenImgProjTransformer( mGdalBaseDataset, nullptr, nullptr, nullptr, TRUE, 1.0, 0 );
+    CPLPopErrorHandler();
   }
 
   if ( !hasGeoTransform )

--- a/src/core/qgsmultirenderchecker.cpp
+++ b/src/core/qgsmultirenderchecker.cpp
@@ -17,6 +17,12 @@
 #include "qgslayout.h"
 #include <QDebug>
 
+QgsMultiRenderChecker::QgsMultiRenderChecker()
+{
+  if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
+    mEmitCdashMessages = true;
+}
+
 void QgsMultiRenderChecker::setControlName( const QString &name )
 {
   mControlName = name;
@@ -81,7 +87,7 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
     mReport += checker.report();
   }
 
-  if ( !successful )
+  if ( !successful && mEmitCdashMessages )
   {
     const auto constDartMeasurements = dartMeasurements;
     for ( const QgsDartMeasurement &measurement : constDartMeasurements )

--- a/src/core/qgsmultirenderchecker.cpp
+++ b/src/core/qgsmultirenderchecker.cpp
@@ -20,7 +20,7 @@
 QgsMultiRenderChecker::QgsMultiRenderChecker()
 {
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
-    mEmitCdashMessages = true;
+    mIsCiRun = true;
 }
 
 void QgsMultiRenderChecker::setControlName( const QString &name )
@@ -87,7 +87,7 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
     mReport += checker.report();
   }
 
-  if ( !successful && mEmitCdashMessages )
+  if ( !successful && mIsCiRun )
   {
     const auto constDartMeasurements = dartMeasurements;
     for ( const QgsDartMeasurement &measurement : constDartMeasurements )

--- a/src/core/qgsmultirenderchecker.h
+++ b/src/core/qgsmultirenderchecker.h
@@ -146,7 +146,7 @@ class CORE_EXPORT QgsMultiRenderChecker
     int mMaxSizeDifferenceY = 0;
     QgsMapSettings mMapSettings;
 
-    bool mEmitCdashMessages = false;
+    bool mIsCiRun = false;
 };
 
 SIP_FEATURE( TESTS )

--- a/src/core/qgsmultirenderchecker.h
+++ b/src/core/qgsmultirenderchecker.h
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsMultiRenderChecker
     /**
      * Constructor for QgsMultiRenderChecker.
      */
-    QgsMultiRenderChecker() = default;
+    QgsMultiRenderChecker();
 
     virtual ~QgsMultiRenderChecker() = default;
 
@@ -145,6 +145,8 @@ class CORE_EXPORT QgsMultiRenderChecker
     int mMaxSizeDifferenceX = 0;
     int mMaxSizeDifferenceY = 0;
     QgsMapSettings mMapSettings;
+
+    bool mEmitCdashMessages = false;
 };
 
 SIP_FEATURE( TESTS )

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -31,6 +31,8 @@
 QgsRenderChecker::QgsRenderChecker()
   : mBasePath( QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/control_images/" ) ) //defined in CmakeLists.txt
 {
+  if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
+    mEmitCdashMessages = true;
 }
 
 QString QgsRenderChecker::controlImagePath() const
@@ -145,6 +147,9 @@ bool QgsRenderChecker::isKnownAnomaly( const QString &diffImageFile )
 
 void QgsRenderChecker::emitDashMessage( const QgsDartMeasurement &dashMessage )
 {
+  if ( !mEmitCdashMessages )
+    return;
+
   if ( mBufferDashMessages )
     mDashMessages << dashMessage;
   else

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -32,7 +32,7 @@ QgsRenderChecker::QgsRenderChecker()
   : mBasePath( QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/control_images/" ) ) //defined in CmakeLists.txt
 {
   if ( qgetenv( "QGIS_CONTINUOUS_INTEGRATION_RUN" ) == QStringLiteral( "true" ) )
-    mEmitCdashMessages = true;
+    mIsCiRun = true;
 }
 
 QString QgsRenderChecker::controlImagePath() const
@@ -147,7 +147,7 @@ bool QgsRenderChecker::isKnownAnomaly( const QString &diffImageFile )
 
 void QgsRenderChecker::emitDashMessage( const QgsDartMeasurement &dashMessage )
 {
-  if ( !mEmitCdashMessages )
+  if ( !mIsCiRun )
     return;
 
   if ( mBufferDashMessages )
@@ -405,7 +405,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += "<font color=red>Expected image and result image for " + testName + " are different dimensions - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      dumpRenderedImageAsBase64();
+      if ( mIsCiRun )
+        dumpRenderedImageAsBase64();
       return false;
     }
     else
@@ -426,7 +427,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += "<font color=red>Expected image and result image for " + testName + " have different formats (8bit format is expected) - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      dumpRenderedImageAsBase64();
+      if ( mIsCiRun )
+        dumpRenderedImageAsBase64();
       return false;
     }
 
@@ -526,7 +528,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += QLatin1String( "<font color=red>Test failed because render step took too long</font>" );
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      dumpRenderedImageAsBase64();
+      if ( mIsCiRun )
+        dumpRenderedImageAsBase64();
       return false;
     }
     else
@@ -557,6 +560,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   mReport += "<font color=red>Test image and result image for " + testName + " are mismatched</font><br>";
   mReport += QLatin1String( "</td></tr>" );
   mReport += myImagesString;
-  dumpRenderedImageAsBase64();
+  if ( mIsCiRun )
+    dumpRenderedImageAsBase64();
   return false;
 }

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -248,6 +248,7 @@ class CORE_EXPORT QgsRenderChecker
     QString mControlExtension = QStringLiteral( "png" );
     QString mControlPathPrefix;
     QString mControlPathSuffix;
+    bool mEmitCdashMessages = false;
     QVector<QgsDartMeasurement> mDashMessages;
     bool mBufferDashMessages = false;
 }; // class QgsRenderChecker

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -248,7 +248,7 @@ class CORE_EXPORT QgsRenderChecker
     QString mControlExtension = QStringLiteral( "png" );
     QString mControlPathPrefix;
     QString mControlPathSuffix;
-    bool mEmitCdashMessages = false;
+    bool mIsCiRun = false;
     QVector<QgsDartMeasurement> mDashMessages;
     bool mBufferDashMessages = false;
 }; // class QgsRenderChecker

--- a/tests/src/core/testqgslegendrenderer.cpp
+++ b/tests/src/core/testqgslegendrenderer.cpp
@@ -85,7 +85,7 @@ static void _renderLegend( const QString &testName, QgsLayerTreeModel *legendMod
   const int dpi = 96;
   const qreal dpmm = dpi / 25.4;
   const QSize s( size.width() * dpmm, size.height() * dpmm );
-  qDebug() << QStringLiteral( "testName:%1 size=%2x%3 dpmm=%4 s=%5x%6" ).arg( testName ).arg( size.width() ).arg( size.height() ).arg( dpmm ).arg( s.width() ).arg( s.height() );
+  // qDebug() << QStringLiteral( "testName:%1 size=%2x%3 dpmm=%4 s=%5x%6" ).arg( testName ).arg( size.width() ).arg( size.height() ).arg( dpmm ).arg( s.width() ).arg( s.height() );
   QImage img( s, QImage::Format_ARGB32_Premultiplied );
   img.fill( Qt::white );
 
@@ -93,11 +93,13 @@ static void _renderLegend( const QString &testName, QgsLayerTreeModel *legendMod
   painter.setRenderHint( QPainter::Antialiasing, true );
   QgsRenderContext context = QgsRenderContext::fromQPainter( &painter );
 
-  const QgsScopedRenderContextScaleToMm scaleToMm( context );
-  context.setRendererScale( 1000 );
-  context.setMapToPixel( QgsMapToPixel( 1 / ( 0.1 * context.scaleFactor() ) ) );
+  {
+    const QgsScopedRenderContextScaleToMm scaleToMm( context );
+    context.setRendererScale( 1000 );
+    context.setMapToPixel( QgsMapToPixel( 1 / ( 0.1 * context.scaleFactor() ) ) );
 
-  legendRenderer.drawLegend( context );
+    legendRenderer.drawLegend( context );
+  }
   painter.end();
 
   img.save( _fileNameForTest( testName ) );


### PR DESCRIPTION
@rouault I'd love your thoughts on whether silencing the "The transformation is already "north up" or a transformation between pixel/line and georeferenced coordinates cannot be computed" warnings are just noise or indicative of a real isse 