### PR TITLE
Virtual vector provider's tiny UI harmonization

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6207,10 +6207,8 @@ void QgisApp::addVirtualLayer()
   }
   dts->setMapCanvas( mMapCanvas );
   dts->setBrowserModel( mBrowserModel );
-  connect( dts, SIGNAL( addVectorLayer( QString, QString, QString ) ),
-           this, SLOT( onVirtualLayerAdded( QString, QString ) ) );
-  connect( dts, SIGNAL( replaceVectorLayer( QString, QString, QString, QString ) ),
-           this, SLOT( replaceSelectedVectorLayer( QString, QString, QString, QString ) ) );
+  connect( dts, &QgsAbstractDataSourceWidget::addVectorLayer, this, &QgisApp::addVectorLayer );
+  connect( dts, &QgsAbstractDataSourceWidget::replaceVectorLayer, this, &QgisApp::replaceSelectedVectorLayer );
   dts->exec();
   delete dts;
 }
@@ -14948,11 +14946,6 @@ int QgisApp::addDatabaseToolBarIcon( QAction *qAction )
 {
   mDatabaseToolBar->addAction( qAction );
   return 0;
-}
-
-void QgisApp::onVirtualLayerAdded( const QString &uri, const QString &layerName )
-{
-  addVectorLayer( uri, layerName, QStringLiteral( "virtual" ) );
 }
 
 QAction *QgisApp::addDatabaseToolBarWidget( QWidget *widget )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1527,8 +1527,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Add an icon to the Database toolbar
     int addDatabaseToolBarIcon( QAction *qAction );
 
-    void onVirtualLayerAdded( const QString &uri, const QString &layerName );
-
     /**
      * Add a widget to the database toolbar.
      * To remove this widget again, call removeDatabaseToolBarIcon()

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -77,6 +77,10 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
   setupButtons( buttonBox );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVirtualLayerSourceSelect::showHelp );
 
+  QPushButton *pbn = new QPushButton( tr( "Test" ) );
+  buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
+  connect( pbn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
+
   mGeometryType->addItem( QgsIconUtils::iconForWkbType( QgsWkbTypes::Point ), tr( "Point" ), static_cast< long long >( QgsWkbTypes::Point ) );
   mGeometryType->addItem( QgsIconUtils::iconForWkbType( QgsWkbTypes::LineString ), tr( "LineString" ), static_cast< long long >( QgsWkbTypes::LineString ) );
   mGeometryType->addItem( QgsIconUtils::iconForWkbType( QgsWkbTypes::Polygon ), tr( "Polygon" ), static_cast< long long >( QgsWkbTypes::Polygon ) );
@@ -86,7 +90,6 @@ QgsVirtualLayerSourceSelect::QgsVirtualLayerSourceSelect( QWidget *parent, Qt::W
 
   mQueryEdit->setLineNumbersVisible( true );
 
-  connect( mTestButton, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::testQuery );
   connect( mBrowseCRSBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::browseCRS );
   connect( mAddLayerBtn, &QAbstractButton::clicked, this, [ = ] { addLayer( true ); } );
   connect( mRemoveLayerBtn, &QAbstractButton::clicked, this, &QgsVirtualLayerSourceSelect::removeLayer );
@@ -489,7 +492,7 @@ void QgsVirtualLayerSourceSelect::addButtonClicked()
     }
     else
     {
-      emit addVectorLayer( def.toString(), layerName );
+      emit addVectorLayer( def.toString(), layerName, QStringLiteral( "virtual" ) );
     }
   }
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::None )

--- a/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
+++ b/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
@@ -274,25 +274,14 @@ In particular, saving a virtual layer with embedded layers to a QLR file can be 
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QPushButton" name="mTestButton">
-       <property name="text">
-        <string>Test</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::NoButton</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+      </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Description

This PR improves the location of the virtual vector provider's source select dialog test button by placing it inside the button box to harmonize it with the same test button in the query builder:
![Screenshot from 2022-06-17 08-49-10](https://user-images.githubusercontent.com/1728657/174206468-88f1c97d-5d6c-4506-a0dc-a801943979ef.png)

It has the nice side effect of better exposing the help button visually.