### PR TITLE
[ui] Add a short one sentence guide in the virtual layer creation dialog

### DIFF
--- a/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
+++ b/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
@@ -45,6 +45,16 @@
     </layout>
    </item>
    <item>
+     <widget class="QLabel" name="mInformationLabel">
+     <property name="text">
+       <string>Build a layer by referring to the current project's vector layer names and/or any configured embedded layer names as tables in the custom SQL query.</string>
+     </property>
+     <property name="wordWrap">
+       <bool>true</bool>
+     </property>
+     </widget>
+   </item>
+   <item>
     <widget class="QgsCollapsibleGroupBox" name="mEmbeddedlLayersGroup">
      <property name="title">
       <string>Embedded layers</string>

--- a/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
+++ b/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
@@ -189,6 +189,13 @@ In particular, saving a virtual layer with embedded layers to a QLR file can be 
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
+       <widget class="QRadioButton" name="mNoGeometryRadio">
+        <property name="text">
+         <string>No geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QRadioButton" name="mAutodetectGeometryRadio">
         <property name="text">
          <string>Autodetect</string>
@@ -199,86 +206,75 @@ In particular, saving a virtual layer with embedded layers to a QLR file can be 
        </widget>
       </item>
       <item>
-       <widget class="QRadioButton" name="mNoGeometryRadio">
+        <widget class="QRadioButton" name="mGeometryRadio">
         <property name="text">
-         <string>No geometry</string>
+          <string>Manually defined</string>
         </property>
-       </widget>
+        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QRadioButton" name="mGeometryRadio">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QFrame" name="mGeometryFrame">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-          <layout class="QFormLayout" name="formLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Geometry column</string>
-             </property>
+        <widget class="QFrame" name="mGeometryFrame">
+        <property name="enabled">
+          <bool>false</bool>
+        </property>
+        <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+          <widget class="QLabel" name="label">
+            <property name="text">
+            <string>Geometry column</string>
+            </property>
+          </widget>
+          </item>
+          <item row="0" column="1">
+          <widget class="QLineEdit" name="mGeometryField">
+            <property name="text">
+            <string>geometry</string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="0">
+          <widget class="QLabel" name="label_3">
+            <property name="text">
+            <string>Type</string>
+            </property>
+          </widget>
+          </item>
+          <item row="1" column="1">
+          <widget class="QComboBox" name="mGeometryType"/>
+          </item>
+          <item row="2" column="0">
+          <widget class="QLabel" name="label_5">
+            <property name="text">
+            <string>CRS</string>
+            </property>
+          </widget>
+          </item>
+          <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+            <widget class="QLineEdit" name="mCRS">
+              <property name="readOnly">
+              <bool>true</bool>
+              </property>
             </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="mGeometryField">
-             <property name="text">
-              <string>geometry</string>
-             </property>
+            </item>
+            <item>
+            <widget class="QToolButton" name="mBrowseCRSBtn">
+              <property name="text">
+              <string>…</string>
+              </property>
             </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Type</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QComboBox" name="mGeometryType"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>CRS</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QLineEdit" name="mCRS">
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QToolButton" name="mBrowseCRSBtn">
-               <property name="text">
-                <string>…</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
+            </item>
           </layout>
-         </widget>
-        </item>
-       </layout>
+          </item>
+        </layout>
+        </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
## Description

Because users otherwise get _no hint_ that they can simply type in a given vector layer name to refer to a project layer (vs. going down the embedded layer alternative)

![image](https://user-images.githubusercontent.com/1728657/174230546-3dac4523-25e6-42f0-b848-0a19fc4a2700.png)


