### PR TITLE
Harmonize margins within the relations drag-and-drop designer settings

### DIFF
--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -37,6 +37,7 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
     case QgsAttributesFormProperties::DnDTreeItemData::Relation:
     {
       QGridLayout *layout = new QGridLayout;
+      layout->setContentsMargins( 0, 0, 0, 0);
       QgsAttributeWidgetRelationEditWidget *editWidget = new QgsAttributeWidgetRelationEditWidget( this );
       editWidget->setRelationEditorConfiguration( itemData.relationEditorConfiguration(), itemData.name() );
       mSpecificEditWidget = editWidget;

--- a/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/gui/attributeformconfig/qgsattributewidgetedit.cpp
@@ -37,7 +37,7 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
     case QgsAttributesFormProperties::DnDTreeItemData::Relation:
     {
       QGridLayout *layout = new QGridLayout;
-      layout->setContentsMargins( 0, 0, 0, 0);
+      layout->setContentsMargins( 0, 0, 0, 0 );
       QgsAttributeWidgetRelationEditWidget *editWidget = new QgsAttributeWidgetRelationEditWidget( this );
       editWidget->setRelationEditorConfiguration( itemData.relationEditorConfiguration(), itemData.name() );
       mSpecificEditWidget = editWidget;

--- a/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgetrelationeditwidget.ui
@@ -7,13 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>340</width>
-    <height>316</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Attribute Widget Relation Edit Widget</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="mLabelLabel">
      <property name="text">
@@ -54,6 +57,16 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mCardinalityLabel_2">
+     <property name="text">
+      <string>Widget Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="mWidgetTypeComboBox"/>
+   </item>
    <item row="4" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mWidgetTypeGroupBox">
      <property name="title">
@@ -64,29 +77,6 @@
        <layout class="QVBoxLayout" name="mWidgetTypePlaceholderLayout"/>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <spacer name="mVerticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="mWidgetTypeComboBox"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mCardinalityLabel_2">
-     <property name="text">
-      <string>Widget Type</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgsrelationeditorconfigwidgetbase.ui
+++ b/src/ui/qgsrelationeditorconfigwidgetbase.ui
@@ -14,6 +14,18 @@
    <string>Attribute Widget Relation Edit Widget</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QCheckBox" name="mShowFirstFeature">
      <property name="toolTip">


### PR DESCRIPTION
Still ugly and crowded but a harmonized ugliness
before (from 3.22)
![image](https://user-images.githubusercontent.com/7983394/174201550-3d5761a8-0259-4696-9389-caecfc8eb958.png)
after (master)
![image](https://user-images.githubusercontent.com/7983394/174201495-dc17a22c-7e3a-4fd0-b395-97eff0eda362.png)
