### PR TITLE
[themes] Follow up 216ed99: re-add borders for disabled list/table widgets

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -795,6 +795,8 @@ QAbstractItemView, QListView
 QAbstractItemView:disabled, QListView:disabled
 {
     color: @itemalternativebackground;
+    border: 1px solid @itemdarkbackground;
+    border-radius: 0.15em;
 }
 
 QAbstractItemView::selected, QListView::selected {
@@ -901,6 +903,8 @@ QTableView {
 
 QTableView:disabled {
     color: @itemalternativebackground;
+    border: 1px solid @itemdarkbackground;
+    border-radius: 0.15em;
 }
 
 QTableView::indicator
@@ -925,6 +929,11 @@ QTableView QTableCornerButton::section {
 }
 
 QHeaderView {
+    background-color:transparent;
+    border:0;
+}
+
+QHeaderView:disabled {
     background-color:transparent;
     border:0;
 }

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -795,6 +795,8 @@ QAbstractItemView, QListView
 QAbstractItemView:disabled, QListView:disabled
 {
     color: @itemdarkbackground;
+    border: 1px solid @itemdarkbackground;
+    border-radius: 0px;
 }
 
 QAbstractItemView::selected, QListView::selected {
@@ -926,6 +928,8 @@ QTableView {
 
 QTableView:disabled {
     color: @itemdarkbackground;
+    border: 1px solid @itemdarkbackground;
+    border-radius: 0px;
 }
 
 QTableView::indicator {
@@ -951,6 +955,11 @@ QTableView QTableCornerButton::section {
 }
 
 QHeaderView {
+    background-color:transparent;
+    border:0;
+}
+
+QHeaderView:disabled {
     background-color:transparent;
     border:0;
 }


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/qgis/QGIS/commit/216ed9925b980dc69fcda3ef1ef0dd7c462219b1 . That previous commit disabled a 1px border for disabled QFrame elements. Unknown to the author of the commit at the time (i.e. me), that meant disabled list and table widgets had gone border-less when disabled, which isn't great. 

This PR fixes that regression.

Regression (left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/174472845-a6b921d0-443e-466e-bb79-d14f2cf8b884.png)
