### PR TITLE
Fix simple marker rotation in dxf export (CW instead of CCW)

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1531,7 +1531,7 @@ bool QgsSimpleMarkerSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScal
   t.translate( shift.x() + off.x(), shift.y() - off.y() );
 
   if ( !qgsDoubleNear( angle, 0.0 ) )
-    t.rotate( angle );
+    t.rotate( -angle );
 
   QPolygonF polygon;
   if ( shapeToPolygon( shape, polygon ) )


### PR DESCRIPTION
Simple marker are rotated counterclockwise (QTransform.rotate) in the dxf export. However in QGIS, the simple marker rotation is clockwise. This PR fixes this issue.