### PR TITLE
Load raster sublayers from vector tile styles automatically

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1815,3 +1815,14 @@ Qgis.ProjectReadFlag.baseClass = Qgis
 QgsProject.ReadFlags = Qgis.ProjectReadFlags
 Qgis.ProjectReadFlags.baseClass = Qgis
 ProjectReadFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.MapBoxGlStyleSourceType.Vector.__doc__ = "Vector source"
+Qgis.MapBoxGlStyleSourceType.Raster.__doc__ = "Raster source"
+Qgis.MapBoxGlStyleSourceType.RasterDem.__doc__ = "Raster DEM source"
+Qgis.MapBoxGlStyleSourceType.GeoJson.__doc__ = "GeoJSON source"
+Qgis.MapBoxGlStyleSourceType.Image.__doc__ = "Image source"
+Qgis.MapBoxGlStyleSourceType.Video.__doc__ = "Video source"
+Qgis.MapBoxGlStyleSourceType.Unknown.__doc__ = "Other/unknown source type"
+Qgis.MapBoxGlStyleSourceType.__doc__ = 'Available MapBox GL style source types.\n\n.. versionadded:: 3.28\n\n' + '* ``Vector``: ' + Qgis.MapBoxGlStyleSourceType.Vector.__doc__ + '\n' + '* ``Raster``: ' + Qgis.MapBoxGlStyleSourceType.Raster.__doc__ + '\n' + '* ``RasterDem``: ' + Qgis.MapBoxGlStyleSourceType.RasterDem.__doc__ + '\n' + '* ``GeoJson``: ' + Qgis.MapBoxGlStyleSourceType.GeoJson.__doc__ + '\n' + '* ``Image``: ' + Qgis.MapBoxGlStyleSourceType.Image.__doc__ + '\n' + '* ``Video``: ' + Qgis.MapBoxGlStyleSourceType.Video.__doc__ + '\n' + '* ``Unknown``: ' + Qgis.MapBoxGlStyleSourceType.Unknown.__doc__
+# --
+Qgis.MapBoxGlStyleSourceType.baseClass = Qgis

--- a/python/core/auto_additions/qgsmapboxglstyleconverter.py
+++ b/python/core/auto_additions/qgsmapboxglstyleconverter.py
@@ -1,0 +1,9 @@
+# The following has been generated automatically from src/core/vectortile/qgsmapboxglstyleconverter.h
+# monkey patching scoped based enum
+QgsMapBoxGlStyleConverter.PropertyType.Color.__doc__ = "Color property"
+QgsMapBoxGlStyleConverter.PropertyType.Numeric.__doc__ = "Numeric property (e.g. line width, text size)"
+QgsMapBoxGlStyleConverter.PropertyType.Opacity.__doc__ = "Opacity property"
+QgsMapBoxGlStyleConverter.PropertyType.Point.__doc__ = "Point/offset property"
+QgsMapBoxGlStyleConverter.PropertyType.__doc__ = 'Property types, for interpolated value conversion\n\n.. warning::\n\n   This is private API only, and may change in future QGIS versions\n\n' + '* ``Color``: ' + QgsMapBoxGlStyleConverter.PropertyType.Color.__doc__ + '\n' + '* ``Numeric``: ' + QgsMapBoxGlStyleConverter.PropertyType.Numeric.__doc__ + '\n' + '* ``Opacity``: ' + QgsMapBoxGlStyleConverter.PropertyType.Opacity.__doc__ + '\n' + '* ``Point``: ' + QgsMapBoxGlStyleConverter.PropertyType.Point.__doc__
+# --
+QgsMapBoxGlStyleConverter.PropertyType.baseClass = QgsMapBoxGlStyleConverter

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1179,6 +1179,17 @@ The development version
     typedef QFlags<Qgis::ProjectReadFlag> ProjectReadFlags;
 
 
+    enum class MapBoxGlStyleSourceType
+    {
+      Vector,
+      Raster,
+      RasterDem,
+      GeoJson,
+      Image,
+      Video,
+      Unknown,
+    };
+
     static const double DEFAULT_SEARCH_RADIUS_MM;
 
     static const float DEFAULT_MAPTOPIXEL_THRESHOLD;

--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -138,14 +138,132 @@ Sets the layer ID of the layer currently being converted.
 
 };
 
+
+
+
+class QgsMapBoxGlStyleAbstractSource
+{
+%Docstring(signature="appended")
+Abstract base class for MapBox GL style sources.
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 3.28
+%End
+
+%TypeHeaderCode
+#include "qgsmapboxglstyleconverter.h"
+%End
+  public:
+
+%ConvertToSubClassCode
+
+    switch ( sipCpp->type() )
+    {
+      case Qgis::MapBoxGlStyleSourceType::Raster:
+        sipType = sipType_QgsMapBoxGlStyleRasterSource;
+        break;
+      default:
+        sipType = 0;
+        break;
+    }
+%End
+
+    QgsMapBoxGlStyleAbstractSource( const QString &name );
+%Docstring
+Constructor for QgsMapBoxGlStyleAbstractSource.
+%End
+
+    virtual ~QgsMapBoxGlStyleAbstractSource();
+
+    virtual Qgis::MapBoxGlStyleSourceType type() const = 0;
+%Docstring
+Returns the source type.
+%End
+
+    virtual bool setFromJson( const QVariantMap &json, QgsMapBoxGlStyleConversionContext *context ) = 0;
+%Docstring
+Sets the source's state from a ``json`` map.
+%End
+
+    QString name() const;
+%Docstring
+Returns the source's name.
+%End
+
+};
+
+
+class QgsMapBoxGlStyleRasterSource : QgsMapBoxGlStyleAbstractSource
+{
+%Docstring(signature="appended")
+Encapsulates a MapBox GL style raster source.
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 3.28
+%End
+
+%TypeHeaderCode
+#include "qgsmapboxglstyleconverter.h"
+%End
+  public:
+
+    QgsMapBoxGlStyleRasterSource( const QString &name );
+%Docstring
+Constructor for QgsMapBoxGlStyleRasterSource.
+%End
+
+    virtual Qgis::MapBoxGlStyleSourceType type() const;
+
+    virtual bool setFromJson( const QVariantMap &json, QgsMapBoxGlStyleConversionContext *context );
+
+
+    QString attribution() const;
+%Docstring
+Returns the source's attribution text.
+%End
+
+    int minimumZoom() const;
+%Docstring
+Returns the minimum tile zoom for which tiles are available.
+
+.. seealso:: :py:func:`maximumZoom`
+%End
+
+    int maximumZoom() const;
+%Docstring
+Returns the maximum tile zoom for which tiles are available.
+
+.. seealso:: :py:func:`minimumZoom`
+%End
+
+    int tileSize() const;
+%Docstring
+Returns the associated tile size.
+%End
+
+    QStringList tiles() const;
+%Docstring
+Returns the list of tile sources.
+%End
+
+};
+
+
+
 class QgsMapBoxGlStyleConverter
 {
 %Docstring(signature="appended")
 Handles conversion of MapBox GL styles to QGIS vector tile renderers and labeling
 settings.
 
-Conversions are performed by calling :py:func:`~QgsMapBoxGlStyleConversionContext.convert` with either a JSON map or JSON
-string value, and then retrieving the results by calling :py:func:`~QgsMapBoxGlStyleConversionContext.renderer` or :py:func:`~QgsMapBoxGlStyleConversionContext.labeling`
+Conversions are performed by calling :py:func:`~QgsMapBoxGlStyleRasterSource.convert` with either a JSON map or JSON
+string value, and then retrieving the results by calling :py:func:`~QgsMapBoxGlStyleRasterSource.renderer` or :py:func:`~QgsMapBoxGlStyleRasterSource.labeling`
 respectively.
 
 .. versionadded:: 3.16
@@ -154,6 +272,9 @@ respectively.
 %TypeHeaderCode
 #include "qgsmapboxglstyleconverter.h"
 %End
+  public:
+    static const QMetaObject staticMetaObject;
+
   public:
 
     QgsMapBoxGlStyleConverter();
@@ -168,6 +289,14 @@ Constructor for QgsMapBoxGlStyleConverter.
     {
       Success,
       NoLayerList,
+    };
+
+    enum class PropertyType
+    {
+      Color,
+      Numeric,
+      Opacity,
+      Point,
     };
 
     Result convert( const QVariantMap &style, QgsMapBoxGlStyleConversionContext *context = 0 );
@@ -224,15 +353,38 @@ Returns a new instance of a vector tile labeling representing the converted styl
 or ``None`` if the style could not be converted successfully.
 %End
 
+    QList< QgsMapBoxGlStyleAbstractSource * > takeSources() /Factory/;
+%Docstring
+Returns the list of converted sources.
+
+Ownership is transferred to the caller.
+
+.. versionadded:: 3.28
+%End
+
   protected:
 
-    enum PropertyType
-    {
-      Color,
-      Numeric,
-      Opacity,
-      Point,
-    };
+    void parseSources( const QVariantMap &sources, QgsMapBoxGlStyleConversionContext *context = 0 );
+%Docstring
+Parse list of ``sources`` from JSON.
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 3.28
+%End
+
+    void parseRasterSource( const QVariantMap &source, const QString &name, QgsMapBoxGlStyleConversionContext *context = 0 );
+%Docstring
+Parse a raster ``source`` from JSON.
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 3.28
+%End
 
     void parseLayers( const QVariantList &layers, QgsMapBoxGlStyleConversionContext *context = 0 );
 %Docstring

--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -263,14 +263,55 @@ The caller takes ownership of the returned layer.
 
 
 
+class QgsMapBoxGlStyleRasterSubLayer
+{
+%Docstring(signature="appended")
+Encapsulates a MapBox GL style raster sub layer.
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 3.28
+%End
+
+%TypeHeaderCode
+#include "qgsmapboxglstyleconverter.h"
+%End
+  public:
+
+    QgsMapBoxGlStyleRasterSubLayer( const QString &id, const QString &source );
+%Docstring
+Constructor for QgsMapBoxGlStyleRasterSubLayer, with the given ``id`` and ``source``.
+%End
+
+    QString id() const;
+%Docstring
+Returns the layer's ID.
+%End
+
+    QString source() const;
+%Docstring
+Returns the layer's source.
+%End
+
+    QgsPropertyCollection &dataDefinedProperties();
+%Docstring
+Returns a reference to the layer's data defined properties.
+%End
+
+
+};
+
+
 class QgsMapBoxGlStyleConverter
 {
 %Docstring(signature="appended")
 Handles conversion of MapBox GL styles to QGIS vector tile renderers and labeling
 settings.
 
-Conversions are performed by calling :py:func:`~QgsMapBoxGlStyleRasterSource.convert` with either a JSON map or JSON
-string value, and then retrieving the results by calling :py:func:`~QgsMapBoxGlStyleRasterSource.renderer` or :py:func:`~QgsMapBoxGlStyleRasterSource.labeling`
+Conversions are performed by calling :py:func:`~QgsMapBoxGlStyleRasterSubLayer.convert` with either a JSON map or JSON
+string value, and then retrieving the results by calling :py:func:`~QgsMapBoxGlStyleRasterSubLayer.renderer` or :py:func:`~QgsMapBoxGlStyleRasterSubLayer.labeling`
 respectively.
 
 .. versionadded:: 3.16
@@ -360,11 +401,25 @@ Returns a new instance of a vector tile labeling representing the converted styl
 or ``None`` if the style could not be converted successfully.
 %End
 
-    QList< QgsMapBoxGlStyleAbstractSource * > takeSources() /Factory/;
+    QList< QgsMapBoxGlStyleAbstractSource * > sources();
 %Docstring
 Returns the list of converted sources.
 
-Ownership is transferred to the caller.
+.. versionadded:: 3.28
+%End
+
+    QList< QgsMapBoxGlStyleRasterSubLayer > rasterSubLayers() const;
+%Docstring
+Returns a list of raster sub layers contained in the style.
+
+.. versionadded:: 3.28
+%End
+
+    QList< QgsMapLayer * > createSubLayers() const /Factory/;
+%Docstring
+Returns a list of new map layers corresponding to sublayers of the style, e.g. raster layers.
+
+The caller takes ownership of the returned layers.
 
 .. versionadded:: 3.28
 %End

--- a/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -252,6 +252,13 @@ Returns the associated tile size.
 Returns the list of tile sources.
 %End
 
+    QgsRasterLayer *toRasterLayer() const /Factory/;
+%Docstring
+Returns a new raster layer representing the raster source, or ``None`` if the source cannot be represented as a raster layer.
+
+The caller takes ownership of the returned layer.
+%End
+
 };
 
 

--- a/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilelayer.sip.in
@@ -119,6 +119,22 @@ Constructs a new vector tile layer
 
 
 
+    bool loadDefaultStyleAndSubLayers( QString &error, QStringList &warnings, QList< QgsMapLayer * > &subLayers /Out,TransferBack/ );
+%Docstring
+Loads the default style for the layer, and returns ``True`` if the style was
+successfully loaded. Also loads any sub layers (such as raster terrain layers) associated
+with the layer's default style.
+
+The ``error`` string will be filled with a translated error message if an error
+occurs during the style load. The ``warnings`` list will be populated with any
+warning messages generated during the style load (e.g. default style properties
+which could not be converted).
+
+Ownership of the ``subLayers`` is transferrred to the caller.
+
+.. versionadded:: 3.28
+%End
+
     virtual QString loadDefaultMetadata( bool &resultFlag /Out/ );
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2309,7 +2309,8 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 
       QString error;
       QStringList warnings;
-      bool res = layer->loadDefaultStyle( error, warnings );
+      QList< QgsMapLayer * > subLayers;
+      bool res = layer->loadDefaultStyleAndSubLayers( error, warnings, subLayers );
       if ( res && !warnings.empty() )
       {
         QString message = QStringLiteral( "<p>%1</p>" ).arg( tr( "The following warnings were generated while converting the vector tile style:" ) );
@@ -2327,6 +2328,9 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
                                message, Qgis::MessageLevel::Warning );
       }
       addMapLayer( layer );
+
+      for ( QgsMapLayer *subLayer : std::as_const( subLayers ) )
+        addMapLayer( subLayer );
     }
     else if ( u.layerType == QLatin1String( "plugin" ) )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2327,10 +2327,59 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
         showLayerLoadWarnings( tr( "Vector tiles" ), tr( "Style could not be completely converted" ),
                                message, Qgis::MessageLevel::Warning );
       }
-      addMapLayer( layer );
 
-      for ( QgsMapLayer *subLayer : std::as_const( subLayers ) )
-        addMapLayer( subLayer );
+      if ( subLayers.empty() )
+      {
+        addMapLayer( layer );
+      }
+      else
+      {
+        // if there's any sublayers, we add them all to a group to keep things together
+        const QString groupName = layer->name();
+        QgsLayerTreeGroup *group = nullptr;
+        int index { 0 };
+        QgsLayerTreeNode *currentNode { mLayerTreeView->currentNode() };
+        if ( currentNode && currentNode->parent() )
+        {
+          if ( QgsLayerTree::isGroup( currentNode ) )
+          {
+            group = qobject_cast<QgsLayerTreeGroup *>( currentNode )->insertGroup( 0, groupName );
+          }
+          else if ( QgsLayerTree::isLayer( currentNode ) )
+          {
+            const QList<QgsLayerTreeNode *> currentNodeSiblings { currentNode->parent()->children() };
+            int nodeIdx { 0 };
+            for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
+            {
+              nodeIdx++;
+              if ( child == currentNode )
+              {
+                index = nodeIdx;
+                break;
+              }
+            }
+            group = qobject_cast<QgsLayerTreeGroup *>( currentNode->parent() )->insertGroup( index, groupName );
+          }
+          else
+          {
+            group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
+          }
+        }
+        else
+        {
+          group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
+        }
+
+        // sublayers get added first, because we want them to render on top of the vector tile layer (for now, maybe in future we can add support
+        // for rendering them amongst the vector tile layers(!) or for rendering them below the vector tile layer)
+        for ( QgsMapLayer *subLayer : std::as_const( subLayers ) )
+        {
+          QgsProject::instance()->addMapLayer( subLayer, false );
+          group->addLayer( subLayer );
+        }
+        QgsProject::instance()->addMapLayer( layer, false );
+        group->addLayer( layer );
+      }
     }
     else if ( u.layerType == QLatin1String( "plugin" ) )
     {

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2014,6 +2014,23 @@ class CORE_EXPORT Qgis
     Q_FLAG( ProjectReadFlags )
 
     /**
+     * Available MapBox GL style source types.
+     *
+     * \since QGIS 3.28
+     */
+    enum class MapBoxGlStyleSourceType : int
+    {
+      Vector, //!< Vector source
+      Raster, //!< Raster source
+      RasterDem, //!< Raster DEM source
+      GeoJson, //!< GeoJSON source
+      Image, //!< Image source
+      Video, //!< Video source
+      Unknown, //!< Other/unknown source type
+    };
+    Q_ENUM( MapBoxGlStyleSourceType )
+
+    /**
      * Identify search radius in mm
      * \since QGIS 2.3
      */

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -38,6 +38,7 @@
 #include "qgslinesymbol.h"
 #include "qgsapplication.h"
 #include "qgsfontmanager.h"
+#include "qgis.h"
 
 #include <QBuffer>
 #include <QRegularExpression>
@@ -50,6 +51,12 @@ QgsMapBoxGlStyleConverter::Result QgsMapBoxGlStyleConverter::convert( const QVar
 {
   mError.clear();
   mWarnings.clear();
+
+  if ( style.contains( QStringLiteral( "sources" ) ) )
+  {
+    parseSources( style.value( QStringLiteral( "sources" ) ).toMap(), context );
+  }
+
   if ( style.contains( QStringLiteral( "layers" ) ) )
   {
     parseLayers( style.value( QStringLiteral( "layers" ) ).toList(), context );
@@ -67,7 +74,10 @@ QgsMapBoxGlStyleConverter::Result QgsMapBoxGlStyleConverter::convert( const QStr
   return convert( QgsJsonUtils::parseJson( style ).toMap(), context );
 }
 
-QgsMapBoxGlStyleConverter::~QgsMapBoxGlStyleConverter() = default;
+QgsMapBoxGlStyleConverter::~QgsMapBoxGlStyleConverter()
+{
+  qDeleteAll( mSources );
+}
 
 void QgsMapBoxGlStyleConverter::parseLayers( const QVariantList &layers, QgsMapBoxGlStyleConversionContext *context )
 {
@@ -2616,28 +2626,28 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
     QString valueString;
     switch ( type )
     {
-      case Color:
+      case PropertyType::Color:
       {
         const QColor color = parseColor( value, context );
         valueString = QgsExpression::quotedString( color.name() );
         break;
       }
 
-      case Numeric:
+      case PropertyType::Numeric:
       {
         const double v = value.toDouble() * multiplier;
         valueString = QString::number( v );
         break;
       }
 
-      case Opacity:
+      case PropertyType::Opacity:
       {
         const double v = value.toDouble() * maxOpacity;
         valueString = QString::number( v );
         break;
       }
 
-      case Point:
+      case PropertyType::Point:
       {
         valueString = QStringLiteral( "array(%1,%2)" ).arg( value.toList().value( 0 ).toDouble() * multiplier,
                       value.toList().value( 0 ).toDouble() * multiplier );
@@ -2654,7 +2664,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
   QString elseValue;
   switch ( type )
   {
-    case Color:
+    case PropertyType::Color:
     {
       const QColor color = parseColor( json.constLast(), context );
       if ( defaultColor )
@@ -2664,7 +2674,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
       break;
     }
 
-    case Numeric:
+    case PropertyType::Numeric:
     {
       const double v = json.constLast().toDouble() * multiplier;
       if ( defaultNumber )
@@ -2673,7 +2683,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
       break;
     }
 
-    case Opacity:
+    case PropertyType::Opacity:
     {
       const double v = json.constLast().toDouble() * maxOpacity;
       if ( defaultNumber )
@@ -2682,7 +2692,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList( const QVariantList &json,
       break;
     }
 
-    case Point:
+    case PropertyType::Point:
     {
       elseValue = QStringLiteral( "array(%1,%2)" ).arg( json.constLast().toList().value( 0 ).toDouble() * multiplier,
                   json.constLast().toList().value( 0 ).toDouble() * multiplier );
@@ -3369,6 +3379,79 @@ QgsVectorTileLabeling *QgsMapBoxGlStyleConverter::labeling() const
   return mLabeling ? mLabeling->clone() : nullptr;
 }
 
+QList<QgsMapBoxGlStyleAbstractSource *> QgsMapBoxGlStyleConverter::takeSources()
+{
+  QList< QgsMapBoxGlStyleAbstractSource * > sources = mSources;
+  mSources.clear();
+  return sources;
+}
+
+void QgsMapBoxGlStyleConverter::parseSources( const QVariantMap &sources, QgsMapBoxGlStyleConversionContext *context )
+{
+  std::unique_ptr< QgsMapBoxGlStyleConversionContext > tmpContext;
+  if ( !context )
+  {
+    tmpContext = std::make_unique< QgsMapBoxGlStyleConversionContext >();
+    context = tmpContext.get();
+  }
+
+  auto typeFromString = [context]( const QString & string, const QString & name )->Qgis::MapBoxGlStyleSourceType
+  {
+    if ( string.compare( QLatin1String( "vector" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::Vector;
+    else if ( string.compare( QLatin1String( "raster" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::Raster;
+    else if ( string.compare( QLatin1String( "raster-dem" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::RasterDem;
+    else if ( string.compare( QLatin1String( "geojson" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::GeoJson;
+    else if ( string.compare( QLatin1String( "image" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::Image;
+    else if ( string.compare( QLatin1String( "video" ), Qt::CaseInsensitive ) == 0 )
+      return Qgis::MapBoxGlStyleSourceType::Video;
+    context->pushWarning( QObject::tr( "Invalid source type \"%1\" for source \"%2\"" ).arg( string, name ) );
+    return Qgis::MapBoxGlStyleSourceType::Unknown;
+  };
+
+  for ( auto it = sources.begin(); it != sources.end(); ++it )
+  {
+    const QString name = it.key();
+    const QVariantMap jsonSource = it.value().toMap();
+    const QString typeString = jsonSource.value( QStringLiteral( "type" ) ).toString();
+
+    const Qgis::MapBoxGlStyleSourceType type = typeFromString( typeString, name );
+
+    switch ( type )
+    {
+      case Qgis::MapBoxGlStyleSourceType::Raster:
+        parseRasterSource( jsonSource, name, context );
+        break;
+      case Qgis::MapBoxGlStyleSourceType::Vector:
+      case Qgis::MapBoxGlStyleSourceType::RasterDem:
+      case Qgis::MapBoxGlStyleSourceType::GeoJson:
+      case Qgis::MapBoxGlStyleSourceType::Image:
+      case Qgis::MapBoxGlStyleSourceType::Video:
+      case Qgis::MapBoxGlStyleSourceType::Unknown:
+        QgsDebugMsg( QStringLiteral( "Ignoring vector tile style source %1 (%2)" ).arg( name, qgsEnumValueToKey( type ) ) );
+        continue;
+    }
+  }
+}
+
+void QgsMapBoxGlStyleConverter::parseRasterSource( const QVariantMap &source, const QString &name, QgsMapBoxGlStyleConversionContext *context )
+{
+  std::unique_ptr< QgsMapBoxGlStyleConversionContext > tmpContext;
+  if ( !context )
+  {
+    tmpContext = std::make_unique< QgsMapBoxGlStyleConversionContext >();
+    context = tmpContext.get();
+  }
+
+  std::unique_ptr< QgsMapBoxGlStyleRasterSource > raster = std::make_unique< QgsMapBoxGlStyleRasterSource >( name );
+  if ( raster->setFromJson( source, context ) )
+    mSources.append( raster.release() );
+}
+
 bool QgsMapBoxGlStyleConverter::numericArgumentsOnly( const QVariant &bottomVariant, const QVariant &topVariant, double &bottom, double &top )
 {
   if ( bottomVariant.canConvert( QMetaType::Double ) && topVariant.canConvert( QMetaType::Double ) )
@@ -3439,4 +3522,62 @@ QString QgsMapBoxGlStyleConversionContext::layerId() const
 void QgsMapBoxGlStyleConversionContext::setLayerId( const QString &value )
 {
   mLayerId = value;
+}
+
+//
+// QgsMapBoxGlStyleAbstractSource
+//
+QgsMapBoxGlStyleAbstractSource::QgsMapBoxGlStyleAbstractSource( const QString &name )
+  : mName( name )
+{
+}
+
+QString QgsMapBoxGlStyleAbstractSource::name() const
+{
+  return mName;
+}
+
+QgsMapBoxGlStyleAbstractSource::~QgsMapBoxGlStyleAbstractSource() = default;
+
+//
+// QgsMapBoxGlStyleRasterSource
+//
+
+QgsMapBoxGlStyleRasterSource::QgsMapBoxGlStyleRasterSource( const QString &name )
+  : QgsMapBoxGlStyleAbstractSource( name )
+{
+
+}
+
+Qgis::MapBoxGlStyleSourceType QgsMapBoxGlStyleRasterSource::type() const
+{
+  return Qgis::MapBoxGlStyleSourceType::Raster;
+}
+
+bool QgsMapBoxGlStyleRasterSource::setFromJson( const QVariantMap &json, QgsMapBoxGlStyleConversionContext *context )
+{
+  mAttribution = json.value( QStringLiteral( "attribution" ) ).toString();
+
+  const QString scheme = json.value( QStringLiteral( "scheme" ), QStringLiteral( "xyz" ) ).toString();
+  if ( scheme.compare( QLatin1String( "xyz" ) ) == 0 )
+  {
+    // xyz scheme is supported
+  }
+  else
+  {
+    context->pushWarning( QObject::tr( "%1 scheme is not supported for raster source %2" ).arg( scheme, name() ) );
+    return false;
+  }
+
+  mMinZoom = json.value( QStringLiteral( "minzoom" ), QStringLiteral( "0" ) ).toInt();
+  mMaxZoom = json.value( QStringLiteral( "maxzoom" ), QStringLiteral( "22" ) ).toInt();
+  mTileSize = json.value( QStringLiteral( "tileSize" ), QStringLiteral( "512" ) ).toInt();
+
+  const QVariantList tiles = json.value( QStringLiteral( "tiles" ) ).toList();
+  for ( const QVariant &tile : tiles )
+  {
+    mTiles.append( tile.toString() );
+  }
+
+  return true;
 }

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -39,6 +39,8 @@
 #include "qgsapplication.h"
 #include "qgsfontmanager.h"
 #include "qgis.h"
+#include "qgsrasterlayer.h"
+#include "qgsproviderregistry.h"
 
 #include <QBuffer>
 #include <QRegularExpression>
@@ -3580,4 +3582,22 @@ bool QgsMapBoxGlStyleRasterSource::setFromJson( const QVariantMap &json, QgsMapB
   }
 
   return true;
+}
+
+QgsRasterLayer *QgsMapBoxGlStyleRasterSource::toRasterLayer() const
+{
+  QVariantMap parts;
+  parts.insert( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  parts.insert( QStringLiteral( "url" ), mTiles.value( 0 ) );
+
+  if ( mTileSize == 256 )
+    parts.insert( QStringLiteral( "tilePixelRation" ), QStringLiteral( "1" ) );
+  else if ( mTileSize == 512 )
+    parts.insert( QStringLiteral( "tilePixelRation" ), QStringLiteral( "2" ) );
+
+  parts.insert( QStringLiteral( "zmax" ), QString::number( mMaxZoom ) );
+  parts.insert( QStringLiteral( "zmin" ), QString::number( mMinZoom ) );
+
+  std::unique_ptr< QgsRasterLayer > rl = std::make_unique< QgsRasterLayer >( QgsProviderRegistry::instance()->encodeUri( QStringLiteral( "wms" ), parts ), name(), QStringLiteral( "wms" ) );
+  return rl.release();
 }

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -27,6 +27,7 @@ class QgsVectorTileRenderer;
 class QgsVectorTileLabeling;
 class QgsVectorTileBasicRendererStyle;
 class QgsVectorTileBasicLabelingStyle;
+class QgsRasterLayer;
 
 /**
  * Context for a MapBox GL style conversion operation.
@@ -249,7 +250,7 @@ class CORE_EXPORT QgsMapBoxGlStyleRasterSource : public QgsMapBoxGlStyleAbstract
      *
      * \see minimumZoom()
      */
-    int maximumZoom() const { return mMinZoom; }
+    int maximumZoom() const { return mMaxZoom; }
 
     /**
      * Returns the associated tile size.
@@ -260,6 +261,13 @@ class CORE_EXPORT QgsMapBoxGlStyleRasterSource : public QgsMapBoxGlStyleAbstract
      * Returns the list of tile sources.
      */
     QStringList tiles() const { return mTiles; }
+
+    /**
+     * Returns a new raster layer representing the raster source, or NULLPTR if the source cannot be represented as a raster layer.
+     *
+     * The caller takes ownership of the returned layer.
+     */
+    QgsRasterLayer *toRasterLayer() const SIP_FACTORY;
 
   private:
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgsproperty.h"
+#include "qgspropertycollection.h"
 #include <QVariantMap>
 #include <memory>
 #include <QImage>
@@ -281,6 +282,50 @@ class CORE_EXPORT QgsMapBoxGlStyleRasterSource : public QgsMapBoxGlStyleAbstract
 
 
 /**
+ * Encapsulates a MapBox GL style raster sub layer.
+ * \warning This is private API only, and may change in future QGIS versions
+ * \ingroup core
+ * \since QGIS 3.28
+ */
+class CORE_EXPORT QgsMapBoxGlStyleRasterSubLayer
+{
+  public:
+
+    /**
+     * Constructor for QgsMapBoxGlStyleRasterSubLayer, with the given \a id and \a source.
+     */
+    QgsMapBoxGlStyleRasterSubLayer( const QString &id, const QString &source );
+
+    /**
+     * Returns the layer's ID.
+     */
+    QString id() const { return mId; }
+
+    /**
+     * Returns the layer's source.
+     */
+    QString source() const { return mSource; }
+
+    /**
+     * Returns a reference to the layer's data defined properties.
+     */
+    QgsPropertyCollection &dataDefinedProperties() { return mDataDefinedProperties; }
+
+    /**
+     * Returns a reference to the layer's data defined properties.
+     */
+    const QgsPropertyCollection &dataDefinedProperties() const SIP_SKIP { return mDataDefinedProperties; }
+
+  private:
+
+    QString mId;
+    QString mSource;
+    QgsPropertyCollection mDataDefinedProperties;
+
+};
+
+
+/**
  * \ingroup core
  * \brief Handles conversion of MapBox GL styles to QGIS vector tile renderers and labeling
  * settings.
@@ -386,11 +431,25 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
     /**
      * Returns the list of converted sources.
      *
-     * Ownership is transferred to the caller.
+     * \since QGIS 3.28
+     */
+    QList< QgsMapBoxGlStyleAbstractSource * > sources();
+
+    /**
+     * Returns a list of raster sub layers contained in the style.
      *
      * \since QGIS 3.28
      */
-    QList< QgsMapBoxGlStyleAbstractSource * > takeSources() SIP_FACTORY;
+    QList< QgsMapBoxGlStyleRasterSubLayer > rasterSubLayers() const;
+
+    /**
+     * Returns a list of new map layers corresponding to sublayers of the style, e.g. raster layers.
+     *
+     * The caller takes ownership of the returned layers.
+     *
+     * \since QGIS 3.28
+     */
+    QList< QgsMapLayer * > createSubLayers() const SIP_FACTORY;
 
   protected:
 
@@ -726,6 +785,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
     std::unique_ptr< QgsVectorTileLabeling > mLabeling;
 
     QList< QgsMapBoxGlStyleAbstractSource * > mSources;
+    QList< QgsMapBoxGlStyleRasterSubLayer> mRasterSubLayers;
 
 };
 

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -37,6 +37,7 @@
 #include "qgsselectioncontext.h"
 #include "qgsgeometryengine.h"
 #include "qgsvectortilemvtdecoder.h"
+#include "qgsrasterlayer.h"
 
 #include <QUrl>
 #include <QUrlQuery>
@@ -493,6 +494,16 @@ Qgis::MapLayerProperties QgsVectorTileLayer::properties() const
 
 bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings )
 {
+  return loadDefaultStyleAndSubLayersPrivate( error, warnings, nullptr );
+}
+
+bool QgsVectorTileLayer::loadDefaultStyleAndSubLayers( QString &error, QStringList &warnings, QList<QgsMapLayer *> &subLayers )
+{
+  return loadDefaultStyleAndSubLayersPrivate( error, warnings, &subLayers );
+}
+
+bool QgsVectorTileLayer::loadDefaultStyleAndSubLayersPrivate( QString &error, QStringList &warnings, QList<QgsMapLayer *> *subLayers )
+{
   QgsDataSourceUri dsUri;
   dsUri.setEncodedUri( mDataSource );
 
@@ -633,6 +644,12 @@ bool QgsVectorTileLayer::loadDefaultStyle( QString &error, QStringList &warnings
     setRenderer( converter.renderer() );
     setLabeling( converter.labeling() );
     warnings = converter.warnings();
+
+    if ( subLayers )
+    {
+      *subLayers = converter.createSubLayers();
+    }
+
     return true;
   }
   else

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -152,6 +152,22 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
      */
     bool loadDefaultStyle( QString &error, QStringList &warnings ) SIP_SKIP;
 
+    /**
+     * Loads the default style for the layer, and returns TRUE if the style was
+     * successfully loaded. Also loads any sub layers (such as raster terrain layers) associated
+     * with the layer's default style.
+     *
+     * The \a error string will be filled with a translated error message if an error
+     * occurs during the style load. The \a warnings list will be populated with any
+     * warning messages generated during the style load (e.g. default style properties
+     * which could not be converted).
+     *
+     * Ownership of the \a subLayers is transferrred to the caller.
+     *
+     * \since QGIS 3.28
+     */
+    bool loadDefaultStyleAndSubLayers( QString &error, QStringList &warnings, QList< QgsMapLayer * > &subLayers SIP_OUT SIP_TRANSFERBACK );
+
     QString loadDefaultMetadata( bool &resultFlag SIP_OUT ) override;
 
     QString encodedSource( const QString &source, const QgsReadWriteContext &context ) const FINAL;
@@ -296,6 +312,9 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
 
     void setDataSourcePrivate( const QString &dataSource, const QString &baseName, const QString &provider,
                                const QgsDataProvider::ProviderOptions &options, QgsDataProvider::ReadFlags flags ) override;
+
+    bool loadDefaultStyleAndSubLayersPrivate( QString &error, QStringList &warnings, QList< QgsMapLayer * > *subLayers );
+
 
 };
 

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -21,7 +21,8 @@ from qgis.core import (QgsMapBoxGlStyleConverter,
                        QgsApplication,
                        QgsFontManager,
                        QgsSettings,
-                       Qgis
+                       Qgis,
+                       QgsRasterLayer
                        )
 from qgis.testing import start_app, unittest
 
@@ -977,6 +978,12 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertEqual(raster_source.maximumZoom(), 20)
         self.assertEqual(raster_source.tileSize(), 256)
         self.assertEqual(raster_source.tiles(), ['https://yyyyyy/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp'])
+
+        # convert to raster layer
+        rl = raster_source.toRasterLayer()
+        self.assertIsInstance(rl, QgsRasterLayer)
+        self.assertEqual(rl.source(), 'tilePixelRation=1&type=xyz&url=https://yyyyyy/v1/tiles/texturereliefshade/EPSG:3857/%7Bz%7D/%7Bx%7D/%7By%7D.webp&zmax=20&zmin=3')
+        self.assertEqual(rl.providerType(), 'wms')
 
     def testLabelWithStops(self):
         context = QgsMapBoxGlStyleConversionContext()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -15,11 +15,13 @@ from qgis.PyQt.QtCore import QSize, QCoreApplication
 from qgis.PyQt.QtGui import (QColor, QImage)
 from qgis.core import (QgsMapBoxGlStyleConverter,
                        QgsMapBoxGlStyleConversionContext,
+                       QgsMapBoxGlStyleRasterSource,
                        QgsSymbolLayer,
                        QgsWkbTypes,
                        QgsApplication,
                        QgsFontManager,
-                       QgsSettings
+                       QgsSettings,
+                       Qgis
                        )
 from qgis.testing import start_app, unittest
 
@@ -153,7 +155,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             ["Water Transport"],
             "#d8e6f3",
             "#e7e7e7"
-        ], QgsMapBoxGlStyleConverter.Color, conversion_context, 2.5, 200)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Color, conversion_context, 2.5, 200)
         self.assertEqual(res.asExpression(),
                          'CASE WHEN "type" IN (\'Air Transport\',\'Airport\') THEN \'#e6e6e6\' WHEN "type" IN (\'Education\') THEN \'#f7eaca\' WHEN "type" IN (\'Medical Care\') THEN \'#f3d8e7\' WHEN "type" IN (\'Road Transport\') THEN \'#f7f3ca\' WHEN "type" IN (\'Water Transport\') THEN \'#d8e6f3\' ELSE \'#e7e7e7\' END')
         self.assertEqual(default_color.name(), '#e7e7e7')
@@ -166,7 +168,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             ["Index"],
             0.5,
             0.2
-        ], QgsMapBoxGlStyleConverter.Numeric, conversion_context, 2.5, 200)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Numeric, conversion_context, 2.5, 200)
         self.assertEqual(res.asExpression(),
                          'CASE WHEN "type" IN (\'Normal\') THEN 0.625 WHEN "type" IN (\'Index\') THEN 1.25 ELSE 0.5 END')
         self.assertEqual(default_number, 0.5)
@@ -187,7 +189,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             ["Water Transport"],
             "#d8e6f3",
             "#e7e7e7"
-        ], QgsMapBoxGlStyleConverter.Color, conversion_context, 2.5, 200)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Color, conversion_context, 2.5, 200)
         self.assertEqual(res.asExpression(),
                          'CASE WHEN "type" IN (\'Air Transport\',\'Airport\') THEN \'#e6e6e6\' WHEN "type" IN (\'Education\') THEN \'#f7eaca\' WHEN "type" IN (\'Medical Care\') THEN \'#f3d8e7\' WHEN "type" IN (\'Road Transport\') THEN \'#f7f3ca\' WHEN "type" IN (\'Water Transport\') THEN \'#d8e6f3\' ELSE \'#e7e7e7\' END')
         self.assertEqual(default_color.name(), '#e7e7e7')
@@ -202,7 +204,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             0.3,
             18,
             0.6
-        ], QgsMapBoxGlStyleConverter.Numeric, conversion_context, 2.5, 200)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Numeric, conversion_context, 2.5, 200)
         self.assertEqual(res.asExpression(),
                          'CASE WHEN @vector_tile_zoom > 10 AND @vector_tile_zoom <= 15 THEN scale_linear(@vector_tile_zoom,10,15,0.1,0.3) * 2.5 WHEN @vector_tile_zoom > 15 AND @vector_tile_zoom <= 18 THEN scale_linear(@vector_tile_zoom,15,18,0.3,0.6) * 2.5 WHEN @vector_tile_zoom > 18 THEN 1.5 END')
         self.assertEqual(default_number, 0.25)
@@ -287,7 +289,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             0.3,
             18,
             0.6
-        ], QgsMapBoxGlStyleConverter.Opacity, conversion_context, 2)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Opacity, conversion_context, 2)
         self.assertEqual(prop.expressionString(),
                          "CASE WHEN @vector_tile_zoom < 10 THEN set_color_part(@symbol_color, 'alpha', 25.5) WHEN @vector_tile_zoom >= 10 AND @vector_tile_zoom < 15 THEN set_color_part(@symbol_color, 'alpha', scale_linear(@vector_tile_zoom,10,15,25.5,76.5)) WHEN @vector_tile_zoom >= 15 AND @vector_tile_zoom < 18 THEN set_color_part(@symbol_color, 'alpha', scale_linear(@vector_tile_zoom,15,18,76.5,153)) WHEN @vector_tile_zoom >= 18 THEN set_color_part(@symbol_color, 'alpha', 153) END")
 
@@ -301,7 +303,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             0.3,
             18,
             0.6
-        ], QgsMapBoxGlStyleConverter.Numeric, conversion_context, 2)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Numeric, conversion_context, 2)
         self.assertEqual(prop.expressionString(),
                          "CASE WHEN @vector_tile_zoom > 10 AND @vector_tile_zoom <= 15 THEN scale_linear(@vector_tile_zoom,10,15,0.1,0.3) * 2 WHEN @vector_tile_zoom > 15 AND @vector_tile_zoom <= 18 THEN scale_linear(@vector_tile_zoom,15,18,0.3,0.6) * 2 WHEN @vector_tile_zoom > 18 THEN 1.2 END")
         self.assertEqual(default_val, 0.2)
@@ -320,7 +322,7 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
             ["match", ["get", "class"], ["ice", "glacier"], 0.2, 0.3],
             14,
             ["match", ["get", "class"], ["ice", "glacier"], 0, 0.3]
-        ], QgsMapBoxGlStyleConverter.Numeric, conversion_context, 2)
+        ], QgsMapBoxGlStyleConverter.PropertyType.Numeric, conversion_context, 2)
         self.assertEqual(prop.expressionString(),
                          "CASE WHEN @vector_tile_zoom > 5 AND @vector_tile_zoom <= 6 THEN scale_exp(@vector_tile_zoom,5,6,0,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.3 ELSE 0 END,1.5) * 2 WHEN @vector_tile_zoom > 6 AND @vector_tile_zoom <= 10 THEN scale_exp(@vector_tile_zoom,6,10,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.3 ELSE 0 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0 END,1.5) * 2 WHEN @vector_tile_zoom > 10 AND @vector_tile_zoom <= 11 THEN scale_exp(@vector_tile_zoom,10,11,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0.3 END,1.5) * 2 WHEN @vector_tile_zoom > 11 AND @vector_tile_zoom <= 14 THEN scale_exp(@vector_tile_zoom,11,14,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0.2 ELSE 0.3 END,CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0 ELSE 0.3 END,1.5) * 2 WHEN @vector_tile_zoom > 14 THEN ( ( CASE WHEN \"class\" IN ('ice', 'glacier') THEN 0 ELSE 0.3 END ) * 2 ) END")
 
@@ -936,6 +938,45 @@ class TestQgsMapBoxGlStyleConverter(unittest.TestCase):
         self.assertTrue(has_labeling)
         self.assertFalse(labeling_style.labelSettings().isExpression)
         self.assertEqual(labeling_style.labelSettings().fieldName, 'substance')
+
+    def test_parse_raster_source(self):
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "sources": {
+                "Basemaps": {
+                    "type": "vector",
+                    "url": "https://xxxxxx"
+                },
+                "Texture-Relief": {
+                    "tiles": [
+                        "https://yyyyyy/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp"
+                    ],
+                    "type": "raster",
+                    "minzoom": 3,
+                    "maxzoom": 20,
+                    "tileSize": 256,
+                    "attribution": "© 2022",
+                }
+            },
+            "layers": []
+        }
+
+        converter = QgsMapBoxGlStyleConverter()
+        converter.convert(style, context)
+
+        sources = converter.takeSources()
+        self.assertEqual(len(sources), 1)
+
+        raster_source = sources[0]
+        self.assertIsInstance(raster_source, QgsMapBoxGlStyleRasterSource)
+
+        self.assertEqual(raster_source.name(), 'Texture-Relief')
+        self.assertEqual(raster_source.type(), Qgis.MapBoxGlStyleSourceType.Raster)
+        self.assertEqual(raster_source.attribution(), '© 2022')
+        self.assertEqual(raster_source.minimumZoom(), 3)
+        self.assertEqual(raster_source.maximumZoom(), 20)
+        self.assertEqual(raster_source.tileSize(), 256)
+        self.assertEqual(raster_source.tiles(), ['https://yyyyyy/v1/tiles/texturereliefshade/EPSG:3857/{z}/{x}/{y}.webp'])
 
     def testLabelWithStops(self):
         context = QgsMapBoxGlStyleConversionContext()


### PR DESCRIPTION
When loading a new vector tile source into a project, if the associated MapBox GL style includes any raster sublayers, then also load those into the project with converted styles.

Fixes https://github.com/qgis/QGIS/issues/46593

Funded by Toitū Te Whenua Land Information New Zealand

![Peek 2022-06-20 12-31](https://user-images.githubusercontent.com/1829991/174514930-77887a1d-4679-49a2-9ff0-7c360bc0fc01.gif)

