### PR TITLE
fix 3D crash from axis when invalid CRS

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -407,7 +407,10 @@ void Qgs3DAxis::createAxisScene()
 
       const QList< Qgis::CrsAxisDirection > axisDirections = mCrs.axisOrdering();
 
-      mTextX->setText( QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisDirections.at( 0 ) ) );
+      if ( axisDirections.length() > 0 )
+        mTextX->setText( QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisDirections.at( 0 ) ) );
+      else
+        mTextY->setText( "X?" );
 
       if ( axisDirections.length() > 1 )
         mTextY->setText( QgsCoordinateReferenceSystemUtils::axisDirectionToAbbreviatedString( axisDirections.at( 1 ) ) );


### PR DESCRIPTION
`axisDirections` can be empty, for example, if the CRS is invalid.