### PR TITLE
Better vector tile font matching

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -1101,7 +1101,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     {
       QString matchedFamily;
       const QStringList textFontParts = fontName.split( ' ' );
-      for ( int i = 1; i < textFontParts.size(); ++i )
+      for ( int i = textFontParts.size() - 1; i >= 1; --i )
       {
         const QString candidateFontFamily = textFontParts.mid( 0, i ).join( ' ' );
         const QString candidateFontStyle = textFontParts.mid( i ).join( ' ' );


### PR DESCRIPTION
When trying to split family from style names, start by assigning more of the input string to the family. This helps with matching
fonts like "Roboto Condensed Bold", where we could otherwise mistakenly assume the "Roboto" word alone represents a valid
font family (when instead we want "Roboto Condensed").
