### PR TITLE
Expose some vector layer management tools for non-sqlite/gpkg formats in browser

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -59,6 +59,7 @@
 #include "qgsvariantutils.h"
 #include "qgsfielddomainwidget.h"
 #include "qgsgeopackagedataitems.h"
+#include "qgsfilebaseddataitemprovider.h"
 
 #include <QFileInfo>
 #include <QMenu>
@@ -1548,15 +1549,25 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
         if ( qobject_cast<QgsLayerItem *>( item ) )
         {
+          QString tableName;
+          if ( QgsProviderSublayerItem *sublayerItem = qobject_cast< QgsProviderSublayerItem * >( item ) )
+          {
+            tableName = sublayerItem->sublayerDetails().name();
+          }
+          if ( tableName.isEmpty() )
+          {
+            tableName = item->name();
+          }
+
           if ( conn2->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::Schemas ) )
           {
             // Ok, this is gross: we lack a connection API for quoting properly...
-            sql = QStringLiteral( "SELECT * FROM %1.%2 LIMIT 10" ).arg( QgsSqliteUtils::quotedIdentifier( item->parent()->name() ), QgsSqliteUtils::quotedIdentifier( item->name() ) );
+            sql = QStringLiteral( "SELECT * FROM %1.%2 LIMIT 10" ).arg( QgsSqliteUtils::quotedIdentifier( item->parent()->name() ), QgsSqliteUtils::quotedIdentifier( tableName ) );
           }
           else
           {
             // Ok, this is gross: we lack a connection API for quoting properly...
-            sql = QStringLiteral( "SELECT * FROM %1 LIMIT 10" ).arg( QgsSqliteUtils::quotedIdentifier( item->name() ) );
+            sql = QStringLiteral( "SELECT * FROM %1 LIMIT 10" ).arg( QgsSqliteUtils::quotedIdentifier( tableName ) );
           }
         }
 

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -73,6 +73,27 @@ QVector<QgsDataItem *> QgsProviderSublayerItem::createChildren()
   return children;
 }
 
+QgsAbstractDatabaseProviderConnection *QgsProviderSublayerItem::databaseConnection() const
+{
+  if ( parent() )
+  {
+    if ( QgsAbstractDatabaseProviderConnection *connection = parent()->databaseConnection() )
+      return connection;
+  }
+
+  if ( mDetails.providerKey() == QLatin1String( "ogr" ) )
+  {
+    if ( QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) )
+    {
+      QVariantMap parts;
+      parts.insert( QStringLiteral( "path" ), path() );
+      return static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( md->encodeUri( parts ), {} ) );
+    }
+  }
+
+  return nullptr;
+}
+
 Qgis::BrowserLayerType QgsProviderSublayerItem::layerTypeFromSublayer( const QgsProviderSublayerDetails &sublayer )
 {
   switch ( sublayer.type() )

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -42,8 +42,8 @@ QgsProviderSublayerItem::QgsProviderSublayerItem( QgsDataItem *parent, const QSt
 {
   mToolTip = details.uri();
 
-  // no children, except for sqlite, which gets special handling because of the unusual situation with the spatialite provider
-  setState( details.driverName() == QLatin1String( "SQLite" ) ? Qgis::BrowserItemState::NotPopulated : Qgis::BrowserItemState::Populated );
+  // no children, except for vector layers, which will show the fields item
+  setState( details.type() == QgsMapLayerType::VectorLayer ? Qgis::BrowserItemState::NotPopulated : Qgis::BrowserItemState::Populated );
 }
 
 QVector<QgsDataItem *> QgsProviderSublayerItem::createChildren()
@@ -52,14 +52,22 @@ QVector<QgsDataItem *> QgsProviderSublayerItem::createChildren()
 
   if ( mDetails.type() == QgsMapLayerType::VectorLayer )
   {
-    // sqlite gets special handling because of the spatialite provider which supports the api required for a fields item.
-    // TODO -- allow read only fields items to be created directly from vector layers, so that all vector layers can show field items.
+    // sqlite gets special handling because it delegates to the dedicated spatialite provider
     if ( mDetails.driverName() == QLatin1String( "SQLite" ) )
     {
       children.push_back( new QgsFieldsItem( this,
                                              path() + QStringLiteral( "/columns/ " ),
                                              QStringLiteral( R"(dbname="%1")" ).arg( parent()->path().replace( '"', QLatin1String( R"(\")" ) ) ),
                                              QStringLiteral( "spatialite" ), QString(), name() ) );
+    }
+    else if ( mDetails.providerKey() == QLatin1String( "ogr" ) )
+    {
+      // otherwise we use the default OGR database connection approach, which is the generic way to handle this
+      // for all OGR layer types
+      children.push_back( new QgsFieldsItem( this,
+                                             path() + QStringLiteral( "/columns/ " ),
+                                             path(),
+                                             QStringLiteral( "ogr" ), QString(), name() ) );
     }
   }
   return children;
@@ -182,15 +190,6 @@ QgsMimeDataUtils::UriList QgsFileDataCollectionItem::mimeUris() const
 
 QgsAbstractDatabaseProviderConnection *QgsFileDataCollectionItem::databaseConnection() const
 {
-  // sqlite gets special handling because of the spatialite provider which supports the api required database connections
-  const QFileInfo fi( mPath );
-  if ( fi.suffix().toLower() != QLatin1String( "sqlite" )  && fi.suffix().toLower() != QLatin1String( "db" ) )
-  {
-    return nullptr;
-  }
-
-  QgsAbstractDatabaseProviderConnection *conn = nullptr;
-
   // test that file is valid with OGR
   if ( OGRGetDriverCount() == 0 )
   {
@@ -211,14 +210,25 @@ QgsAbstractDatabaseProviderConnection *QgsFileDataCollectionItem::databaseConnec
   GDALDriverH hDriver = GDALGetDatasetDriver( hDS.get() );
   QString driverName = GDALGetDriverShortName( hDriver );
 
+  QgsAbstractDatabaseProviderConnection *conn = nullptr;
   if ( driverName == QLatin1String( "SQLite" ) )
   {
-    QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) ) };
-    if ( md )
+    // sqlite gets special handling, as we delegate to the native spatialite provider
+    if ( QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "spatialite" ) ) )
     {
       QgsDataSourceUri uri;
       uri.setDatabase( path( ) );
       conn = static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( uri.uri(), {} ) );
+    }
+  }
+  else
+  {
+    // for all other vector types we use the generic OGR provider
+    if ( QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) )
+    {
+      QVariantMap parts;
+      parts.insert( QStringLiteral( "path" ), path() );
+      conn = static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( md->encodeUri( parts ), {} ) );
     }
   }
   return conn;

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -73,6 +73,11 @@ QVector<QgsDataItem *> QgsProviderSublayerItem::createChildren()
   return children;
 }
 
+QgsProviderSublayerDetails QgsProviderSublayerItem::sublayerDetails() const
+{
+  return mDetails;
+}
+
 QgsAbstractDatabaseProviderConnection *QgsProviderSublayerItem::databaseConnection() const
 {
   if ( parent() )

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -58,6 +58,13 @@ class CORE_EXPORT QgsProviderSublayerItem final: public QgsLayerItem
     QVector<QgsDataItem *> createChildren() override;
     QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 
+    /**
+     * Returns the sublayer details for the item.
+     *
+     * \since QGIS 3.28
+     */
+    QgsProviderSublayerDetails sublayerDetails() const;
+
   private:
 
     static Qgis::BrowserLayerType layerTypeFromSublayer( const QgsProviderSublayerDetails &sublayer );

--- a/src/core/browser/qgsfilebaseddataitemprovider.h
+++ b/src/core/browser/qgsfilebaseddataitemprovider.h
@@ -56,6 +56,7 @@ class CORE_EXPORT QgsProviderSublayerItem final: public QgsLayerItem
     QgsProviderSublayerItem( QgsDataItem *parent, const QString &name, const QgsProviderSublayerDetails &details, const QString &filePath );
     QString layerName() const override;
     QVector<QgsDataItem *> createChildren() override;
+    QgsAbstractDatabaseProviderConnection *databaseConnection() const override;
 
   private:
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -74,6 +74,21 @@ void QgsGeoPackageProviderConnection::remove( const QString &name ) const
   settings.remove( name );
 }
 
+QgsAbstractDatabaseProviderConnection::TableProperty QgsGeoPackageProviderConnection::table( const QString &schema, const QString &name ) const
+{
+  checkCapability( Capability::Tables );
+  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema ) };
+  for ( const auto &t : constTables )
+  {
+    if ( t.tableName() == name )
+    {
+      return t;
+    }
+  }
+  throw QgsProviderConnectionException( QObject::tr( "Table '%1' was not found in schema '%2'" )
+                                        .arg( name, schema ) );
+}
+
 QString QgsGeoPackageProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {
   const auto tableInfo { table( schema, name ) };

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -28,7 +28,6 @@
 #include "qgsfeedback.h"
 #include "qgsogrutils.h"
 #include "qgsfielddomain.h"
-#include "qgsdbquerylog.h"
 
 #include <QTextCodec>
 #include <QRegularExpression>
@@ -136,21 +135,6 @@ void QgsGeoPackageProviderConnection::renameVectorTable( const QString &schema, 
   {
     QgsDebugMsgLevel( QStringLiteral( "Warning: error while updating the styles, perhaps there are no styles stored in this GPKG: %1" ).arg( ex.what() ), 4 );
   }
-}
-
-QgsVectorLayer *QgsGeoPackageProviderConnection::createSqlVectorLayer( const QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions &options ) const
-{
-  QgsProviderMetadata *providerMetadata { QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) };
-  Q_ASSERT( providerMetadata );
-  QMap<QString, QVariant> decoded = providerMetadata->decodeUri( uri() );
-  decoded[ QStringLiteral( "subset" ) ] = options.sql;
-  return new QgsVectorLayer( providerMetadata->encodeUri( decoded ), options.layerName.isEmpty() ? QStringLiteral( "QueryLayer" ) : options.layerName, providerKey() );
-}
-
-QgsAbstractDatabaseProviderConnection::QueryResult QgsGeoPackageProviderConnection::execSql( const QString &sql, QgsFeedback *feedback ) const
-{
-  checkCapability( Capability::ExecuteSql );
-  return executeGdalSqlPrivate( sql, feedback );
 }
 
 void QgsGeoPackageProviderConnection::vacuum( const QString &schema, const QString &name ) const
@@ -364,146 +348,6 @@ void QgsGeoPackageProviderConnection::setDefaultCapabilities()
   };
 }
 
-QgsAbstractDatabaseProviderConnection::QueryResult QgsGeoPackageProviderConnection::executeGdalSqlPrivate( const QString &sql, QgsFeedback *feedback ) const
-{
-
-  QgsDatabaseQueryLogWrapper logWrapper( sql, uri(), providerKey(), QStringLiteral( "QgsGeoPackageProviderConnection" ), QGS_QUERY_LOG_ORIGIN );
-
-  if ( feedback && feedback->isCanceled() )
-  {
-    logWrapper.setCanceled();
-    return QgsAbstractDatabaseProviderConnection::QueryResult();
-  }
-
-  QString errCause;
-  gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
-  if ( hDS )
-  {
-
-    if ( feedback && feedback->isCanceled() )
-    {
-      logWrapper.setCanceled();
-      return QgsAbstractDatabaseProviderConnection::QueryResult();
-    }
-
-    std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-    OGRLayerH ogrLayer( GDALDatasetExecuteSQL( hDS.get(), sql.toUtf8().constData(), nullptr, nullptr ) );
-    std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-
-    // Read fields
-    if ( ogrLayer )
-    {
-
-      auto iterator = std::make_shared<QgsGeoPackageProviderResultIterator>( std::move( hDS ), ogrLayer );
-      QgsAbstractDatabaseProviderConnection::QueryResult results( iterator );
-      results.setQueryExecutionTime( std::chrono::duration_cast<std::chrono::milliseconds>( end - begin ).count() );
-
-      gdal::ogr_feature_unique_ptr fet;
-
-      if ( fet.reset( OGR_L_GetNextFeature( ogrLayer ) ), fet )
-      {
-        // pk column name
-        QString pkColumnName;
-
-        QgsFields fields { QgsOgrUtils::readOgrFields( fet.get(), QTextCodec::codecForName( "UTF-8" ) ) };
-
-        // We try to guess the table name from the FROM clause
-        thread_local const QRegularExpression tableNameRegexp { QStringLiteral( R"re((?<=from|join)\s+(\w+)|"([^"]+)")re" ), QRegularExpression::PatternOption::CaseInsensitiveOption };
-        const auto match { tableNameRegexp.match( sql ) };
-        if ( match.hasMatch() )
-        {
-          pkColumnName = primaryKeyColumnName( match.captured( match.lastCapturedIndex() ) );
-        }
-
-        // fallback to "fid"
-        if ( pkColumnName.isEmpty() )
-        {
-          pkColumnName = QStringLiteral( "fid" );
-        }
-
-        // geom column name
-        QString geomColumnName;
-
-        OGRFeatureDefnH featureDef = OGR_F_GetDefnRef( fet.get() );
-
-        if ( featureDef )
-        {
-          if ( OGR_F_GetGeomFieldCount( fet.get() ) > 0 )
-          {
-            OGRGeomFieldDefnH geomFldDef { OGR_F_GetGeomFieldDefnRef( fet.get(), 0 ) };
-            if ( geomFldDef )
-            {
-              geomColumnName = OGR_GFld_GetNameRef( geomFldDef );
-            }
-          }
-        }
-
-        // May need to prepend PK and append geometry to the columns
-        if ( ! pkColumnName.isEmpty() )
-        {
-          const QRegularExpression pkRegExp { QStringLiteral( R"(^select\s+(\*|%1)[,\s+](.*)from)" ).arg( pkColumnName ),  QRegularExpression::PatternOption::CaseInsensitiveOption };
-          if ( pkRegExp.match( sql.trimmed() ).hasMatch() )
-          {
-            iterator->setPrimaryKeyColumnName( pkColumnName );
-            results.appendColumn( pkColumnName );
-          }
-        }
-
-        // Add other fields
-        for ( const auto &f : std::as_const( fields ) )
-        {
-          results.appendColumn( f.name() );
-        }
-
-        // Append geom
-        if ( ! geomColumnName.isEmpty() )
-        {
-          results.appendColumn( geomColumnName );
-          iterator->setGeometryColumnName( geomColumnName );
-        }
-
-        iterator->setFields( fields );
-      }
-
-      // Check for errors
-      if ( CE_Failure == CPLGetLastErrorType() || CE_Fatal == CPLGetLastErrorType() )
-      {
-        errCause = CPLGetLastErrorMsg( );
-      }
-
-      if ( ! errCause.isEmpty() )
-      {
-        logWrapper.setError( errCause );
-        throw QgsProviderConnectionException( QObject::tr( "Error executing SQL statement %1: %2" ).arg( sql, errCause ) );
-      }
-
-      OGR_L_ResetReading( ogrLayer );
-      iterator->nextRow();
-
-      return results;
-    }
-
-    // Check for errors
-    if ( CE_Failure == CPLGetLastErrorType() || CE_Fatal == CPLGetLastErrorType() )
-    {
-      errCause = CPLGetLastErrorMsg( );
-    }
-
-  }
-  else
-  {
-    errCause = QObject::tr( "There was an error opening GPKG %1!" ).arg( uri() );
-  }
-
-  if ( !errCause.isEmpty() )
-  {
-    logWrapper.setError( errCause );
-    throw QgsProviderConnectionException( QObject::tr( "Error executing SQL %1: %2" ).arg( sql, errCause ) );
-  }
-
-  return QgsAbstractDatabaseProviderConnection::QueryResult();
-}
-
 QString QgsGeoPackageProviderConnection::primaryKeyColumnName( const QString &table ) const
 {
   QString pkName;
@@ -543,86 +387,6 @@ QString QgsGeoPackageProviderConnection::primaryKeyColumnName( const QString &ta
   }
 
   return pkName;
-}
-
-QVariantList QgsGeoPackageProviderResultIterator::nextRowPrivate()
-{
-  const QVariantList currentRow = mNextRow;
-  mNextRow = nextRowInternal();
-  return currentRow;
-}
-
-QVariantList QgsGeoPackageProviderResultIterator::nextRowInternal()
-{
-  QVariantList row;
-  if ( mHDS && mOgrLayer )
-  {
-    gdal::ogr_feature_unique_ptr fet;
-    if ( fet.reset( OGR_L_GetNextFeature( mOgrLayer ) ), fet )
-    {
-      // PK
-      if ( ! mPrimaryKeyColumnName.isEmpty() )
-      {
-        row.push_back( OGR_F_GetFID( fet.get() ) );
-      }
-
-      if ( ! mFields.isEmpty() )
-      {
-        QgsFeature f { QgsOgrUtils::readOgrFeature( fet.get(), mFields, QTextCodec::codecForName( "UTF-8" ) ) };
-        const QgsAttributes constAttrs  = f.attributes();
-        for ( const QVariant &attribute : constAttrs )
-        {
-          row.push_back( attribute );
-        }
-
-        // Geom goes last
-        if ( ! mGeometryColumnName.isEmpty( ) )
-        {
-          row.push_back( f.geometry().asWkt() );
-        }
-
-      }
-      else // Fallback to strings
-      {
-        for ( int i = 0; i < OGR_F_GetFieldCount( fet.get() ); i++ )
-        {
-          row.push_back( QVariant( QString::fromUtf8( OGR_F_GetFieldAsString( fet.get(), i ) ) ) );
-        }
-      }
-    }
-    else
-    {
-      // Release the resources
-      GDALDatasetReleaseResultSet( mHDS.get(), mOgrLayer );
-      mHDS.release();
-    }
-  }
-  return row;
-}
-
-bool QgsGeoPackageProviderResultIterator::hasNextRowPrivate() const
-{
-  return ! mNextRow.isEmpty();
-}
-
-long long QgsGeoPackageProviderResultIterator::rowCountPrivate() const
-{
-  return  mRowCount;
-}
-
-void QgsGeoPackageProviderResultIterator::setFields( const QgsFields &fields )
-{
-  mFields = fields;
-}
-
-void QgsGeoPackageProviderResultIterator::setGeometryColumnName( const QString &geometryColumnName )
-{
-  mGeometryColumnName = geometryColumnName;
-}
-
-void QgsGeoPackageProviderResultIterator::setPrimaryKeyColumnName( const QString &primaryKeyColumnName )
-{
-  mPrimaryKeyColumnName = primaryKeyColumnName;
 }
 
 QgsFields QgsGeoPackageProviderConnection::fields( const QString &schema, const QString &table ) const
@@ -1131,40 +895,10 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsGeoPackageProviderConnection
   } );
 }
 
-QgsAbstractDatabaseProviderConnection::SqlVectorLayerOptions QgsGeoPackageProviderConnection::sqlOptions( const QString &layerSource )
+QString QgsGeoPackageProviderConnection::databaseQueryLogIdentifier() const
 {
-  SqlVectorLayerOptions options;
-  QgsProviderMetadata *providerMetadata { QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) };
-  Q_ASSERT( providerMetadata );
-  QMap<QString, QVariant> decoded = providerMetadata->decodeUri( layerSource );
-  if ( decoded.contains( QStringLiteral( "subset" ) ) )
-  {
-    options.sql = decoded[ QStringLiteral( "subset" ) ].toString();
-  }
-  else if ( decoded.contains( QStringLiteral( "layerName" ) ) )
-  {
-    options.sql = QStringLiteral( "SELECT * FROM %1" ).arg( QgsSqliteUtils::quotedIdentifier( decoded[ QStringLiteral( "layerName" ) ].toString() ) );
-  }
-  return options;
+  return QStringLiteral( "QgsGeoPackageProviderConnection" );
 }
 
-QgsGeoPackageProviderResultIterator::QgsGeoPackageProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer )
-  : mHDS( std::move( hDS ) )
-  , mOgrLayer( ogrLayer )
-{
-  if ( mOgrLayer )
-  {
-    // Do not scan the layer!
-    mRowCount = OGR_L_GetFeatureCount( mOgrLayer, false );
-  }
-}
-
-QgsGeoPackageProviderResultIterator::~QgsGeoPackageProviderResultIterator()
-{
-  if ( mHDS )
-  {
-    GDALDatasetReleaseResultSet( mHDS.get(), mOgrLayer );
-  }
-}
 
 ///@endcond

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -24,36 +24,6 @@
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-
-
-struct QgsGeoPackageProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
-{
-
-    QgsGeoPackageProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer );
-
-    ~QgsGeoPackageProviderResultIterator();
-
-    void setFields( const QgsFields &fields );
-    void setGeometryColumnName( const QString &geometryColumnName );
-    void setPrimaryKeyColumnName( const QString &primaryKeyColumnName );
-
-  private:
-
-    gdal::ogr_datasource_unique_ptr mHDS;
-    OGRLayerH mOgrLayer;
-    QgsFields mFields;
-    QVariantList mNextRow;
-    QString mGeometryColumnName;
-    QString mPrimaryKeyColumnName;
-    long long mRowCount = -1;
-
-    QVariantList nextRowPrivate() override;
-    bool hasNextRowPrivate() const override;
-    long long rowCountPrivate() const override;
-    QVariantList nextRowInternal();
-
-};
-
 class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
 {
   public:
@@ -70,8 +40,6 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
-    QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
-    QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
     void vacuum( const QString &schema, const QString &name ) const override;
     void createSpatialIndex( const QString &schema, const QString &name, const QgsAbstractDatabaseProviderConnection::SpatialIndexOptions &options = QgsAbstractDatabaseProviderConnection::SpatialIndexOptions() ) const override;
     bool spatialIndexExists( const QString &schema, const QString &name, const QString &geometryColumn ) const override;
@@ -81,15 +49,14 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     QIcon icon() const override;
     QgsFields fields( const QString &schema, const QString &table ) const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
-    SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
+
+  protected:
+    QString databaseQueryLogIdentifier() const override;
+    QString primaryKeyColumnName( const QString &table ) const override;
 
   private:
 
     void setDefaultCapabilities();
-    //! Use GDAL to execute SQL
-    QueryResult executeGdalSqlPrivate( const QString &sql, QgsFeedback *feedback = nullptr ) const;
-    //! Returns PK name for table
-    QString primaryKeyColumnName( const QString &table ) const;
 
 };
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -66,6 +66,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
   public:
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
+    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -363,7 +363,7 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
     mCapabilities |= Capability::Spatial;
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,0)
-  mSingleTableDataset = GDALGetMetadataItem( driverMetadata, GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, nullptr ) != nullptr;
+  mSingleTableDataset = GDALGetMetadataItem( hDriver, GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, nullptr ) == nullptr;
 #else
   {
     const QVariantMap uriParts = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) )->decodeUri( uri() );

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -39,9 +39,8 @@
 ///@cond PRIVATE
 
 //
+// QgsOgrProviderResultIterator
 //
-//
-
 
 QgsOgrProviderResultIterator::QgsOgrProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer )
   : mHDS( std::move( hDS ) )
@@ -363,7 +362,7 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
   if ( !CSLFetchBoolean( driverMetadata, GDAL_DCAP_NONSPATIAL, false ) && CSLFetchBoolean( driverMetadata, GDAL_DCAP_VECTOR, false ) )
     mCapabilities |= Capability::Spatial;
 
-#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(13,4,0)
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,0)
   mSingleTableDataset = GDALGetMetadataItem( driverMetadata, GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, nullptr ) != nullptr;
 #else
   {

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -212,14 +212,6 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
   if ( !hDriver )
     return;
 
-  mCapabilities =
-  {
-    Capability::DeleteField, // No generic way in GDAL to test this per driver/dataset yet
-    Capability::AddField, // No generic way in GDAL to test this per driver/dataset yet
-    Capability::CreateVectorTable, // No generic way in GDAL to test this per driver yet, only by opening the dataset in advance in update mode
-    Capability::DropVectorTable, // No generic way in GDAL to test this per driver yet, only by opening the dataset in advance in update mode
-  };
-
   mGeometryColumnCapabilities =
   {
     GeometryColumnCapability::Z, // No generic way in GDAL to test these per driver/dataset yet
@@ -239,6 +231,18 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
 
     if ( OGR_DS_TestCapability( hDS.get(), ODsCMeasuredGeometries ) )
       mGeometryColumnCapabilities |= GeometryColumnCapability::M;
+
+    if ( OGR_DS_TestCapability( hDS.get(), ODsCCreateLayer ) )
+      mCapabilities |= CreateVectorTable;
+
+    if ( OGR_DS_TestCapability( hDS.get(), ODsCDeleteLayer ) )
+      mCapabilities |= DropVectorTable;
+
+    if ( OGR_DS_TestCapability( hDS.get(), OLCCreateField ) )
+      mCapabilities |= AddField;
+
+    if ( OGR_DS_TestCapability( hDS.get(), OLCDeleteField ) )
+      mCapabilities |= DeleteField;
   }
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -23,6 +23,37 @@
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
+
+
+struct QgsOgrProviderResultIterator: public QgsAbstractDatabaseProviderConnection::QueryResult::QueryResultIterator
+{
+
+    QgsOgrProviderResultIterator( gdal::ogr_datasource_unique_ptr hDS, OGRLayerH ogrLayer );
+
+    ~QgsOgrProviderResultIterator();
+
+    void setFields( const QgsFields &fields );
+    void setGeometryColumnName( const QString &geometryColumnName );
+    void setPrimaryKeyColumnName( const QString &primaryKeyColumnName );
+
+  private:
+
+    gdal::ogr_datasource_unique_ptr mHDS;
+    OGRLayerH mOgrLayer;
+    QgsFields mFields;
+    QVariantList mNextRow;
+    QString mGeometryColumnName;
+    QString mPrimaryKeyColumnName;
+    long long mRowCount = -1;
+
+    QVariantList nextRowPrivate() override;
+    bool hasNextRowPrivate() const override;
+    long long rowCountPrivate() const override;
+    QVariantList nextRowInternal();
+
+};
+
+
 /**
  * \ingroup core
  * \class QgsOgrProviderConnection
@@ -44,6 +75,8 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void remove( const QString &name ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
+    QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
+    QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
@@ -51,10 +84,18 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     QgsFieldDomain *fieldDomain( const QString &name ) const override;
     void setFieldDomainName( const QString &fieldName, const QString &schema, const QString &tableName, const QString &domainName ) const override;
     void addFieldDomain( const QgsFieldDomain &domain, const QString &schema ) const override;
+    SqlVectorLayerOptions sqlOptions( const QString &layerSource ) override;
 
   protected:
 
     void setDefaultCapabilities();
+
+    virtual QString databaseQueryLogIdentifier() const;
+
+    virtual QString primaryKeyColumnName( const QString &table ) const;
+
+    //! Use GDAL to execute SQL
+    QueryResult executeGdalSqlPrivate( const QString &sql, QgsFeedback *feedback = nullptr ) const;
 
   private:
     bool mSingleTableDataset = false;

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -43,6 +43,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
+    QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -74,6 +74,8 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
+    QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(),
+        const TableFlags &flags = TableFlags() ) const override;
     QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const override;
     QueryResult execSql( const QString &sql, QgsFeedback *feedback = nullptr ) const override;
     QgsVectorLayer *createSqlVectorLayer( const SqlVectorLayerOptions &options ) const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -56,6 +56,9 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
 
     void setDefaultCapabilities();
 
+  private:
+    bool mSingleTableDataset = false;
+
 };
 
 

--- a/src/core/qgsdbquerylog.cpp
+++ b/src/core/qgsdbquerylog.cpp
@@ -64,13 +64,13 @@ void QgsDatabaseQueryLog::finished( const QgsDatabaseQueryLogEntry &query )
 
 void QgsDatabaseQueryLog::queryStartedPrivate( const QgsDatabaseQueryLogEntry &query )
 {
-  QgsDebugMsg( query.query );
+  QgsDebugMsgLevel( query.query, 2 );
   emit queryStarted( query );
 }
 
 void QgsDatabaseQueryLog::queryFinishedPrivate( const QgsDatabaseQueryLogEntry &query )
 {
-  QgsDebugMsg( query.query );
+  QgsDebugMsgLevel( query.query, 2 );
   emit queryFinished( query );
 }
 

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -176,7 +176,7 @@
         <item>
          <widget class="QPushButton" name="mLoadLayerPushButton">
           <property name="text">
-           <string>Load layer</string>
+           <string>Load Layer</string>
           </property>
          </widget>
         </item>

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2587,14 +2587,16 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertFalse(table.geometryColumnTypes())
         self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Aspatial)
 
+        # test tables
+        conn = metadata.createConnection(TEST_DATA_DIR + '/' + 'featuredataset.gdb', {})
         tables = conn.tables('unused')
-        self.assertEqual(len(tables), 12)
-        table = [t for t in tables if t.tableName() == 'aliases'][0]
-        self.assertEqual(table.tableName(), 'aliases')
+        self.assertGreaterEqual(len(tables), 4)
+        table = [t for t in tables if t.tableName() == 'fd1_lyr1'][0]
+        self.assertEqual(table.tableName(), 'fd1_lyr1')
         self.assertEqual(table.primaryKeyColumns(), ['OBJECTID'])
         self.assertEqual(table.geometryColumnCount(), 1)
         self.assertEqual(len(table.geometryColumnTypes()), 1)
-        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.MultiPolygon)
+        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.Point)
         self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
 
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -48,7 +48,9 @@ from qgis.core import (
     QgsMapLayerType,
     QgsProviderSublayerDetails,
     Qgis,
-    QgsDirectoryItem
+    QgsDirectoryItem,
+    QgsAbstractDatabaseProviderConnection,
+    QgsProviderConnectionException
 )
 
 from qgis.gui import (
@@ -2520,6 +2522,59 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(feature.geometry().wkbType(), QgsWkbTypes.LineString25D)
         self.assertEqual(feature.geometry().vertexAt(1).asWkt(),
                          'PointZ (635660.11699699994642287 1768910.93880999996326864 3.33884099999999995)')
+
+    def test_provider_connection_shp(self):
+        """
+        Test creating connections for OGR provider
+        """
+        layer = QgsVectorLayer(TEST_DATA_DIR + '/' + 'lines.shp', 'lines')
+
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+        # start with a connection which only supports one layer
+        conn = metadata.createConnection(TEST_DATA_DIR + '/' + 'lines.shp', {})
+        self.assertTrue(conn)
+
+        self.assertEqual(conn.tableUri('unused', 'unused'), TEST_DATA_DIR + '/' + 'lines.shp')
+
+        table = conn.table('unused', 'unused')
+        # not set for single layer formats
+        self.assertFalse(table.tableName())
+        self.assertFalse(table.primaryKeyColumns())
+        self.assertEqual(table.geometryColumnCount(), 1)
+        self.assertEqual(len(table.geometryColumnTypes()), 1)
+        self.assertEqual(table.geometryColumnTypes()[0].crs, layer.crs())
+        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.LineString)
+        self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
+
+    def test_provider_connection_gdb(self):
+        """
+        Test creating connections for OGR provider
+        """
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+        # start with a connection which only supports one layer
+        conn = metadata.createConnection(TEST_DATA_DIR + '/' + 'field_alias.gdb', {})
+        self.assertTrue(conn)
+
+        self.assertEqual(conn.tableUri('unused', 'aliases'), TEST_DATA_DIR + '/' + 'field_alias.gdb|layername=aliases')
+
+        with self.assertRaises(QgsProviderConnectionException):
+            conn.table('unused', 'notpresent')
+
+        table = conn.table('unused', 'aliases')
+        self.assertEqual(table.tableName(), 'aliases')
+        self.assertEqual(table.primaryKeyColumns(), ['OBJECTID'])
+        self.assertEqual(table.geometryColumnCount(), 1)
+        self.assertEqual(len(table.geometryColumnTypes()), 1)
+        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.MultiPolygon)
+        self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
+
+        # aspatial table
+        table = conn.table('unused', 'fras_aux_aliases')
+        self.assertEqual(table.tableName(), 'fras_aux_aliases')
+        self.assertEqual(table.primaryKeyColumns(), ['OBJECTID'])
+        self.assertEqual(table.geometryColumnCount(), 0)
+        self.assertFalse(table.geometryColumnTypes())
+        self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Aspatial)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2546,6 +2546,17 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.LineString)
         self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
 
+        tables = conn.tables('unused')
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertFalse(table.tableName())
+        self.assertFalse(table.primaryKeyColumns())
+        self.assertEqual(table.geometryColumnCount(), 1)
+        self.assertEqual(len(table.geometryColumnTypes()), 1)
+        self.assertEqual(table.geometryColumnTypes()[0].crs, layer.crs())
+        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.LineString)
+        self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
+
     def test_provider_connection_gdb(self):
         """
         Test creating connections for OGR provider
@@ -2575,6 +2586,16 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(table.geometryColumnCount(), 0)
         self.assertFalse(table.geometryColumnTypes())
         self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Aspatial)
+
+        tables = conn.tables('unused')
+        self.assertEqual(len(tables), 12)
+        table = [t for t in tables if t.tableName() == 'aliases'][0]
+        self.assertEqual(table.tableName(), 'aliases')
+        self.assertEqual(table.primaryKeyColumns(), ['OBJECTID'])
+        self.assertEqual(table.geometryColumnCount(), 1)
+        self.assertEqual(len(table.geometryColumnTypes()), 1)
+        self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.MultiPolygon)
+        self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsdataitem.py
+++ b/tests/src/python/test_qgsdataitem.py
@@ -90,7 +90,8 @@ class TestQgsDataItem(unittest.TestCase):
         # Check spatialite and gpkg
         spatialite_item = [i for i in children if i.path().endswith('spatialite.db')][0]
         geopackage_item = [i for i in children if i.path().endswith('geopackage.gpkg')][0]
-        textfile_item = [i for i in children if i.path().endswith('.sql')][0]
+        textfile_item = [i for i in children if i.path().endswith('.xml')][0]
+
         self.assertIsNotNone(spatialite_item.databaseConnection())
         self.assertIsNotNone(geopackage_item.databaseConnection())
         self.assertIsNone(textfile_item.databaseConnection())


### PR DESCRIPTION
This PR implements some required fixes to QgsOgrProviderConnection, and then uses this generic connection to expose some of the dataset management capabilites previously available to GPKG/spatialite alone in browser. Specifically:

- showing the "Fields" item which lets users directly add/remove fields from the dataset without having to first open it in a project
- exposing the "New Table" action for creating new layers in a format which OGR supports table creation in (e.g. File Geodatabases, after https://github.com/OSGeo/gdal/pull/5910 lands)
- Executing SQL on any OGR supported datasource, and loading the result as a dynamic SQL layer