### PR TITLE
Enable Journal Wal, increase Timeout use only sqlite transaction

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -424,6 +424,7 @@ class MBTilesWriter:
         self._zoom_ds = None
         bounds = ','.join(map(str, self.extent))
         self._execute_sqlite("UPDATE metadata SET value='{}' WHERE name='bounds'".format(bounds))
+        
         # Set Journal Mode back to default
         self._execute_sqlite("PRAGMA journal_mode=DELETE")
 

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -359,6 +359,9 @@ class MBTilesWriter:
         ds = driver.Create(self.filename, 1, 1, 1, options=['TILE_FORMAT=%s' % tile_format] + options)
         ds = None
 
+        # faster sqlite processing for parallel access https://stackoverflow.com/questions/15143871/simplest-way-to-retry-sqlite-query-if-db-is-locked
+        self._execute_sqlite("PRAGMA journal_mode=WAL")
+
         self._execute_sqlite(
             "INSERT INTO metadata(name, value) VALUES ('{}', '{}');".format('minzoom', self.min_zoom),
             "INSERT INTO metadata(name, value) VALUES ('{}', '{}');".format('maxzoom', self.max_zoom),
@@ -368,7 +371,9 @@ class MBTilesWriter:
         self._zoom = None
 
     def _execute_sqlite(self, *commands):
-        conn = sqlite3.connect(self.filename)
+        # wait_timeout = default timeout is 5 seconds increase it for slower disk access and more Threads to 120 seconds
+        # isolation_level = None Uses sqlite AutoCommit and disable phyton transaction management feature. https://docs.python.org/3/library/sqlite3.html#sqlite3-controlling-transactions
+        conn = sqlite3.connect(self.filename, timeout = 120, isolation_level = None)
         for cmd in commands:
             conn.execute(cmd)
         conn.commit()
@@ -419,6 +424,8 @@ class MBTilesWriter:
         self._zoom_ds = None
         bounds = ','.join(map(str, self.extent))
         self._execute_sqlite("UPDATE metadata SET value='{}' WHERE name='bounds'".format(bounds))
+        # Set Journal Mode back to default
+        self._execute_sqlite("PRAGMA journal_mode=DELETE")
 
 
 class TilesXYZAlgorithmMBTiles(TilesXYZAlgorithmBase):

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -373,7 +373,7 @@ class MBTilesWriter:
     def _execute_sqlite(self, *commands):
         # wait_timeout = default timeout is 5 seconds increase it for slower disk access and more Threads to 120 seconds
         # isolation_level = None Uses sqlite AutoCommit and disable phyton transaction management feature. https://docs.python.org/3/library/sqlite3.html#sqlite3-controlling-transactions
-        conn = sqlite3.connect(self.filename, timeout = 120, isolation_level = None)
+        conn = sqlite3.connect(self.filename, timeout=120, isolation_level=None)
         for cmd in commands:
             conn.execute(cmd)
         conn.commit()
@@ -424,7 +424,7 @@ class MBTilesWriter:
         self._zoom_ds = None
         bounds = ','.join(map(str, self.extent))
         self._execute_sqlite("UPDATE metadata SET value='{}' WHERE name='bounds'".format(bounds))
-        
+
         # Set Journal Mode back to default
         self._execute_sqlite("PRAGMA journal_mode=DELETE")
 

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -424,7 +424,6 @@ class MBTilesWriter:
         self._zoom_ds = None
         bounds = ','.join(map(str, self.extent))
         self._execute_sqlite("UPDATE metadata SET value='{}' WHERE name='bounds'".format(bounds))
-
         # Set Journal Mode back to default
         self._execute_sqlite("PRAGMA journal_mode=DELETE")
 


### PR DESCRIPTION
## Description

Fixes Multithreading issues with Mbtile Creation on slow disks and or Machines with a lot of threads.

See discussion here:
https://github.com/qgis/QGIS/issues/47738

Fixes#47738

Main Changes:
1) Enabled WAL. Faster Multithreading Operation with a lot of threads. At finish of the export the Journal_mode is set back to Delete (Sqlite Default)
2) Increased Timeout to 120 (5 Seconds is the default caused timeouts and 60 seconds worked too but I put in a safety margin of 60 seconds).
3) Set isolation_level to none, so that the Python Transaction handling is not used but only the Sqlite Autocommit one (Faster Performance and therefore less locks
4) I tested it on 3 Exports, which didn't work beforehand, afterwards they ran successfully through without any exceptions.

