### PR TITLE
Use identifier metadata for raster names when querying sublayers if present

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3820,7 +3820,13 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
 
         QString name;
         const QVariantMap parts = decodeUri( uri );
-        if ( !parts.value( QStringLiteral( "vsiSuffix" ) ).toString().isEmpty() )
+
+        const QString identifier = GDALGetMetadataItem( dataset.get(), "IDENTIFIER", "" );
+        if ( !identifier.isEmpty() )
+        {
+          name = identifier;
+        }
+        else if ( !parts.value( QStringLiteral( "vsiSuffix" ) ).toString().isEmpty() )
         {
           name = parts.value( QStringLiteral( "vsiSuffix" ) ).toString();
           if ( name.startsWith( '/' ) )

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -495,6 +495,16 @@ void TestQgsGdalProvider::testGdalProviderQuerySublayers()
   QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "GPKG" ) );
   rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
   QVERIFY( rl->isValid() );
+  // geopackage with one raster layer with an identifier
+  res = mGdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/qgis_server/test_project_wms_grouped_layers.gpkg" );
+  QCOMPARE( res.count(), 1 );
+  QCOMPARE( res.at( 0 ).layerNumber(), 1 );
+  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "osm" ) );
+  QCOMPARE( res.at( 0 ).description(), QString() );
+  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "%1/qgis_server/test_project_wms_grouped_layers.gpkg" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+  QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "GPKG" ) );
 
   // aigrid file
   res = mGdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/aigrid" );


### PR DESCRIPTION
Gives nicer layer name in some circumstances vs just using the container filename
