### PR TITLE
Apply opacities on external layers when use layer ids

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -114,7 +114,9 @@ QgsWmsParametersLayer QgsWmsRenderContext::parameters( const QgsMapLayer &layer 
 {
   QgsWmsParametersLayer parameters;
 
-  for ( const auto &params : mParameters.layersParameters() )
+  const QList<QgsWmsParametersLayer> cLayerParams { mParameters.layersParameters() };
+
+  for ( const auto &params : std::as_const( cLayerParams ) )
   {
     if ( params.mNickname == layerNickname( layer ) )
     {
@@ -266,7 +268,13 @@ bool QgsWmsRenderContext::updateExtent() const
 QString QgsWmsRenderContext::layerNickname( const QgsMapLayer &layer ) const
 {
   QString name = layer.shortName();
-  if ( QgsServerProjectUtils::wmsUseLayerIds( *mProject ) )
+  // For external layers we cannot use the layer id because it's not known to the client, use layer name instead.
+  if ( QgsServerProjectUtils::wmsUseLayerIds( *mProject ) &&
+       std::find_if( mExternalLayers.cbegin(), mExternalLayers.cend(),
+                     [ &layer ]( const QgsMapLayer * l )
+{
+  return l->id() == layer.id();
+  } ) == mExternalLayers.cend() )
   {
     name = layer.id();
   }


### PR DESCRIPTION
Fixes an unreported bug when using layer ids and external WMS
layers: opacities were ignored for the external layers.

This was caused by the layerNickname() returning the layer id
which is not known to the client and cannot be used for external
layers, layer name is used instead.

I thought about adding a test but a rendering test on an external WMS is a recipe for another unreliable test and I'd rather prefer not to add another one.

Followup: https://github.com/qgis/QGIS/pull/42084