### PR TITLE
Stale out PR after 1 month, close stale PRs after 3 months

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         stale-pr-message: >
           The QGIS project highly values your contribution and would love to see
           this work merged!
-          Unfortunately this PR has not had any activity in the last 14 days and
+          Unfortunately this PR has not had any activity in the last month and
           is being automatically marked as "stale".
           If you think this pull request should be merged, please check
 
@@ -35,13 +35,13 @@ jobs:
           In case you should have any uncertainty, please leave a comment and we will
           be happy to help you proceed with this pull request.
 
-          If there is no further activity on this pull request, it will be closed in a
-          week.
+          If there is no further activity on this pull request, it will be closed in
+          3 months.
 
 
         close-pr-message: >
           While we hate to see this happen, this PR has been automatically closed because
-          it has not had any activity in the last 21 days. If this pull request should be
+          it has not had any activity in the last 4 months. If this pull request should be
           reconsidered, please follow the guidelines in the previous comment and reopen
           this pull request. Or, if you have any further questions, just ask! We love to
           help, and if there's anything the QGIS project can do to help push this PR forward
@@ -50,8 +50,8 @@ jobs:
 
         stale-pr-label: 'stale'
         exempt-pr-labels: 'Merge After Thaw,Frozen'
-        days-before-pr-stale: 14
-        days-before-pr-close: 7
+        days-before-pr-stale: 30
+        days-before-pr-close: 90
 
         stale-issue-message: >
           The QGIS project highly values your report and would love to see it addressed.


### PR DESCRIPTION
This gives developers a timeframe of 4 months to continue work
which may have left pending from a previous release.

See https://github.com/qgis/QGIS/pull/47404