### PR TITLE
Support more pdal pointcloud formats

### DIFF
--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -28,9 +28,9 @@
 #include "qgsprovidersublayerdetails.h"
 #include "qgsproviderutils.h"
 
-#include <pdal/io/LasReader.hpp>
-#include <pdal/io/LasHeader.hpp>
 #include <pdal/Options.hpp>
+#include <pdal/StageFactory.hpp>
+#include <pdal/Reader.hpp>
 
 #include <QQueue>
 #include <QFileInfo>
@@ -241,44 +241,41 @@ bool QgsPdalProvider::load( const QString &uri )
 {
   try
   {
-    const pdal::Option las_opt( "filename", uri.toStdString() );
-    pdal::Options las_opts;
-    las_opts.add( las_opt );
-    pdal::LasReader las_reader;
-    las_reader.setOptions( las_opts );
-    pdal::PointTable table;
-    las_reader.prepare( table );
-    const pdal::LasHeader &las_header = las_reader.header();
+    pdal::StageFactory stageFactory;
+    const std::string driver( stageFactory.inferReaderDriver( uri.toStdString() ) );
+    if ( driver.empty() )
+      throw std::runtime_error( "No driver for " + uri.toStdString() );
 
-    const std::string tableMetadata = pdal::Utils::toJSON( table.metadata() );
-    const QVariantMap readerMetadata = QgsJsonUtils::parseJson( tableMetadata ).toMap().value( QStringLiteral( "root" ) ).toMap();
-    // source metadata is only value present here!
-    if ( !readerMetadata.empty() )
-      mOriginalMetadata = readerMetadata.constBegin().value().toMap();
+    if ( pdal::Reader *reader = dynamic_cast<pdal::Reader *>( stageFactory.createStage( driver ) ) )
+    {
+      pdal::Options options;
+      options.add( pdal::Option( "filename", uri.toStdString() ) );
+      reader->setOptions( options );
+      const pdal::QuickInfo quickInfo( reader->preview() );
 
-    // extent
-    /*
-    double scale_x = las_header.scaleX();
-    double scale_y = las_header.scaleY();
-    double scale_z = las_header.scaleZ();
+      const std::string tableMetadata = pdal::Utils::toJSON( reader->getMetadata() );
+      const QVariantMap readerMetadata = QgsJsonUtils::parseJson( tableMetadata ).toMap().value( QStringLiteral( "root" ) ).toMap();
+      // source metadata is only value present here!
+      if ( !readerMetadata.empty() )
+        mOriginalMetadata = readerMetadata.constBegin().value().toMap();
 
-    double offset_x = las_header.offsetX();
-    double offset_y = las_header.offsetY();
-    double offset_z = las_header.offsetZ();
-    */
+      const double xmin = quickInfo.m_bounds.minx;
+      const double xmax = quickInfo.m_bounds.maxx;
+      const double ymin = quickInfo.m_bounds.miny;
+      const double ymax = quickInfo.m_bounds.maxy;
+      mExtent = QgsRectangle( xmin, ymin, xmax, ymax );
 
-    const double xmin = las_header.minX();
-    const double xmax = las_header.maxX();
-    const double ymin = las_header.minY();
-    const double ymax = las_header.maxY();
-    mExtent = QgsRectangle( xmin, ymin, xmax, ymax );
+      mPointCount = quickInfo.m_pointCount;
 
-    mPointCount = las_header.pointCount();
-
-    // projection
-    const QString wkt = QString::fromStdString( las_reader.getSpatialReference().getWKT() );
-    mCrs = QgsCoordinateReferenceSystem::fromWkt( wkt );
-    return true;
+      // projection
+      const QString wkt = QString::fromStdString( quickInfo.m_srs.getWKT() );
+      mCrs = QgsCoordinateReferenceSystem::fromWkt( wkt );
+      return quickInfo.valid();
+    }
+    else
+    {
+      throw std::runtime_error( "No reader for " + driver );
+    }
   }
   catch ( pdal::pdal_error &error )
   {
@@ -287,6 +284,10 @@ bool QgsPdalProvider::load( const QString &uri )
     return false;
   }
 }
+
+QString QgsPdalProviderMetadata::sFilterString;
+QStringList QgsPdalProviderMetadata::sExtensions;
+bool QgsPdalProviderMetadata::sSupportedFormatsPopulated;
 
 QgsPdalProviderMetadata::QgsPdalProviderMetadata():
   QgsProviderMetadata( PROVIDER_KEY, PROVIDER_DESCRIPTION )
@@ -327,7 +328,7 @@ int QgsPdalProviderMetadata::priorityForUri( const QString &uri ) const
   if ( filePath.endsWith( QStringLiteral( ".copc.laz" ), Qt::CaseSensitivity::CaseInsensitive ) )
     return 0;
 
-  if ( fi.suffix().compare( QLatin1String( "las" ), Qt::CaseInsensitive ) == 0 || fi.suffix().compare( QLatin1String( "laz" ), Qt::CaseInsensitive ) == 0 )
+  if ( sExtensions.contains( fi.suffix(), Qt::CaseInsensitive ) )
     return 100;
 
   return 0;
@@ -338,7 +339,7 @@ QList<QgsMapLayerType> QgsPdalProviderMetadata::validLayerTypesForUri( const QSt
   const QVariantMap parts = decodeUri( uri );
   QString filePath = parts.value( QStringLiteral( "path" ) ).toString();
   const QFileInfo fi( filePath );
-  if ( fi.suffix().compare( QLatin1String( "las" ), Qt::CaseInsensitive ) == 0 || fi.suffix().compare( QLatin1String( "laz" ), Qt::CaseInsensitive ) == 0 || filePath.endsWith( QStringLiteral( ".copc.laz" ), Qt::CaseInsensitive ) )
+  if ( sExtensions.contains( fi.suffix(), Qt::CaseInsensitive ) )
     return QList<QgsMapLayerType>() << QgsMapLayerType::PointCloudLayer;
 
   return QList<QgsMapLayerType>();
@@ -350,7 +351,7 @@ QList<QgsProviderSublayerDetails> QgsPdalProviderMetadata::querySublayers( const
   QString filePath = parts.value( QStringLiteral( "path" ) ).toString();
   const QFileInfo fi( filePath );
 
-  if ( fi.suffix().compare( QLatin1String( "las" ), Qt::CaseInsensitive ) == 0 || fi.suffix().compare( QLatin1String( "laz" ), Qt::CaseInsensitive ) == 0 || filePath.endsWith( QStringLiteral( ".copc.laz" ), Qt::CaseInsensitive ) )
+  if ( sExtensions.contains( fi.suffix(), Qt::CaseInsensitive ) )
   {
     QgsProviderSublayerDetails details;
     details.setUri( uri );
@@ -376,8 +377,10 @@ QString QgsPdalProviderMetadata::filters( QgsProviderMetadata::FilterType type )
       return QString();
 
     case QgsProviderMetadata::FilterType::FilterPointCloud:
-      // TODO get the available/supported filters from PDAL library
-      return QObject::tr( "PDAL Point Clouds" ) + QStringLiteral( " (*.laz *.las *.LAZ *.LAS)" );
+      if ( !sSupportedFormatsPopulated )
+        buildSupportedPointCloudFileFilterAndExtensions();
+
+      return sFilterString;
   }
   return QString();
 }
@@ -396,6 +399,39 @@ QString QgsPdalProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
   const QString path = parts.value( QStringLiteral( "path" ) ).toString();
   return path;
+}
+
+void QgsPdalProviderMetadata::buildSupportedPointCloudFileFilterAndExtensions()
+{
+  sExtensions.clear();
+  sFilterString.clear();
+
+  const pdal::StageFactory f;
+  pdal::PluginManager<pdal::Stage>::loadAll();
+  const pdal::StringList stages = pdal::PluginManager<pdal::Stage>::names();
+  pdal::StageExtensions &extensions = pdal::PluginManager<pdal::Stage>::extensions();
+
+  // Let's call the defaultReader() method just so we trigger the private method extensions.load()
+  extensions.defaultReader( "laz" );
+
+  const QStringList allowedReaders { QStringLiteral( "readers.las" ),
+                                     QStringLiteral( "readers.e57" ),
+                                     QStringLiteral( "readers.bpf" ) };
+  for ( const auto &stage : stages )
+  {
+    if ( ! allowedReaders.contains( QString::fromStdString( stage ) ) )
+      continue;
+
+    const pdal::StringList readerExtensions = extensions.extensions( stage );
+    for ( const auto &extension : readerExtensions )
+    {
+      sExtensions.append( QString::fromStdString( extension ) );
+    }
+  }
+  sExtensions.sort();
+  const QString extensionsString = QStringLiteral( "*." ).append( sExtensions.join( QStringLiteral( " *." ) ) );
+  sFilterString = tr( "PDAL Point Clouds" ) + QString( " (%1 %2)" ).arg( extensionsString, extensionsString.toUpper() );
+  sSupportedFormatsPopulated = true;
 }
 
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()

--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -251,14 +251,16 @@ bool QgsPdalProvider::load( const QString &uri )
       pdal::Options options;
       options.add( pdal::Option( "filename", uri.toStdString() ) );
       reader->setOptions( options );
-      const pdal::QuickInfo quickInfo( reader->preview() );
+      pdal::PointTable table;
+      reader->prepare( table );
 
-      const std::string tableMetadata = pdal::Utils::toJSON( reader->getMetadata() );
+      const std::string tableMetadata = pdal::Utils::toJSON( table.metadata() );
       const QVariantMap readerMetadata = QgsJsonUtils::parseJson( tableMetadata ).toMap().value( QStringLiteral( "root" ) ).toMap();
       // source metadata is only value present here!
       if ( !readerMetadata.empty() )
         mOriginalMetadata = readerMetadata.constBegin().value().toMap();
 
+      const pdal::QuickInfo quickInfo( reader->preview() );
       const double xmin = quickInfo.m_bounds.minx;
       const double xmax = quickInfo.m_bounds.maxx;
       const double ymin = quickInfo.m_bounds.miny;

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -83,6 +83,13 @@ class QgsPdalProviderMetadata : public QgsProviderMetadata
     QString filters( FilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
     QList< QgsMapLayerType > supportedLayerTypes() const override;
+
+  private:
+    static bool sSupportedFormatsPopulated;
+    static QString sFilterString;
+    static QStringList sExtensions;
+    void buildSupportedPointCloudFileFilterAndExtensions();
+
 };
 
 #endif // QGSPDALPROVIDER_H

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -85,7 +85,6 @@ class QgsPdalProviderMetadata : public QgsProviderMetadata
     QList< QgsMapLayerType > supportedLayerTypes() const override;
 
   private:
-    static bool sSupportedFormatsPopulated;
     static QString sFilterString;
     static QStringList sExtensions;
     void buildSupportedPointCloudFileFilterAndExtensions();

--- a/tests/src/providers/testqgspdalprovider.cpp
+++ b/tests/src/providers/testqgspdalprovider.cpp
@@ -95,11 +95,19 @@ void TestQgsPdalProvider::filters()
   QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "pdal" ) );
   QVERIFY( metadata );
 
-  QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud ), QStringLiteral( "PDAL Point Clouds (*.laz *.las *.LAZ *.LAS)" ) );
+  const QString metadataFilters = metadata->filters( QgsProviderMetadata::FilterType::FilterPointCloud );
+  QVERIFY( metadataFilters.contains( "*.laz" ) );
+  QVERIFY( metadataFilters.contains( "*.las" ) );
+  QVERIFY( metadataFilters.contains( "*.LAZ" ) );
+  QVERIFY( metadataFilters.contains( "*.LAS" ) );
+
   QCOMPARE( metadata->filters( QgsProviderMetadata::FilterType::FilterVector ), QString() );
 
   const QString registryPointCloudFilters = QgsProviderRegistry::instance()->filePointCloudFilters();
-  QVERIFY( registryPointCloudFilters.contains( "(*.laz *.las *.LAZ *.LAS)" ) );
+  QVERIFY( registryPointCloudFilters.contains( "*.laz" ) );
+  QVERIFY( registryPointCloudFilters.contains( "*.las" ) );
+  QVERIFY( registryPointCloudFilters.contains( "*.LAZ" ) );
+  QVERIFY( registryPointCloudFilters.contains( "*.LAS" ) );
 }
 
 void TestQgsPdalProvider::encodeUri()


### PR DESCRIPTION
## Description
This PR allows loading e57 and bpf pointcloud files, granted that PDAL is built with support for those readers.
The pointclouds will be indexed into COPCs using untwine before loaded, similar to how LAS/LAZ files are treated.

More PDAL formats can be easily whitelisted in the future, if tested that work well with untwine.


Fix #45271

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
