### PR TITLE
Expose field domain management and new table creation in browser in generic way for non-gpkg OGR sources

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -710,6 +710,13 @@ This is supported on providers with the Capability.ListFieldDomains capability o
 .. versionadded:: 3.26
 %End
 
+    virtual QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const;
+%Docstring
+Returns a list of field domain types which are supported by the provider.
+
+.. versionadded:: 3.28
+%End
+
     virtual QgsFieldDomain *fieldDomain( const QString &name ) const throw( QgsProviderConnectionException ) /Factory/;
 %Docstring
 Returns the field domain with the specified ``name`` from the provider.

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1613,7 +1613,8 @@ QString QgsFieldDomainItemGuiProvider::name()
 void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext context )
 {
   if ( qobject_cast< QgsFieldDomainsItem * >( item )
-       || qobject_cast< QgsGeoPackageCollectionItem * >( item ) )
+       || qobject_cast< QgsGeoPackageCollectionItem * >( item )
+       || qobject_cast< QgsFileDataCollectionItem * >( item ) )
   {
     QString providerKey;
     QString connectionUri;
@@ -1627,6 +1628,11 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
     {
       providerKey = QStringLiteral( "ogr" );
       connectionUri = gpkgItem->path().remove( QStringLiteral( "gpkg:/" ) );
+    }
+    else if ( QgsFileDataCollectionItem *fileItem = qobject_cast< QgsFileDataCollectionItem * >( item ) )
+    {
+      providerKey = QStringLiteral( "ogr" );
+      connectionUri = fileItem->path();
     }
 
     // Check if domain creation is supported

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1646,12 +1646,6 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
         QMenu *createFieldDomainMenu = new QMenu( tr( "New Field Domain" ), menu );
         menu->addMenu( createFieldDomainMenu );
 
-        QAction *rangeDomainAction = new QAction( QObject::tr( "New Range Domain…" ) );
-        createFieldDomainMenu->addAction( rangeDomainAction );
-        QAction *codedDomainAction = new QAction( QObject::tr( "New Coded Values Domain…" ) );
-        createFieldDomainMenu->addAction( codedDomainAction );
-        QAction *globDomainAction = new QAction( QObject::tr( "New Glob Domain…" ) );
-        createFieldDomainMenu->addAction( globDomainAction );
         QPointer< QgsDataItem > itemWeakPointer( item );
 
         auto createDomain = [context, itemWeakPointer, md, connectionUri]( Qgis::FieldDomainType type )
@@ -1677,18 +1671,38 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
             }
           }
         };
-        connect( rangeDomainAction, &QAction::triggered, this, [ = ]
+
+        const QList< Qgis::FieldDomainType > supportedDomainTypes = conn->supportedFieldDomainTypes();
+
+        if ( supportedDomainTypes.contains( Qgis::FieldDomainType::Range ) )
         {
-          createDomain( Qgis::FieldDomainType::Range );
-        } );
-        connect( codedDomainAction, &QAction::triggered, this, [ = ]
+          QAction *rangeDomainAction = new QAction( QObject::tr( "New Range Domain…" ) );
+          createFieldDomainMenu->addAction( rangeDomainAction );
+          connect( rangeDomainAction, &QAction::triggered, this, [ = ]
+          {
+            createDomain( Qgis::FieldDomainType::Range );
+          } );
+        }
+
+        if ( supportedDomainTypes.contains( Qgis::FieldDomainType::Coded ) )
         {
-          createDomain( Qgis::FieldDomainType::Coded );
-        } );
-        connect( globDomainAction, &QAction::triggered, this, [ = ]
+          QAction *codedDomainAction = new QAction( QObject::tr( "New Coded Values Domain…" ) );
+          createFieldDomainMenu->addAction( codedDomainAction );
+          connect( codedDomainAction, &QAction::triggered, this, [ = ]
+          {
+            createDomain( Qgis::FieldDomainType::Coded );
+          } );
+        }
+
+        if ( supportedDomainTypes.contains( Qgis::FieldDomainType::Glob ) )
         {
-          createDomain( Qgis::FieldDomainType::Glob );
-        } );
+          QAction *globDomainAction = new QAction( QObject::tr( "New Glob Domain…" ) );
+          createFieldDomainMenu->addAction( globDomainAction );
+          connect( globDomainAction, &QAction::triggered, this, [ = ]
+          {
+            createDomain( Qgis::FieldDomainType::Glob );
+          } );
+        }
       }
     }
   }

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -895,6 +895,16 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsGeoPackageProviderConnection
   } );
 }
 
+QList<Qgis::FieldDomainType> QgsGeoPackageProviderConnection::supportedFieldDomainTypes() const
+{
+  return
+  {
+    Qgis::FieldDomainType::Coded,
+    Qgis::FieldDomainType::Glob,
+    Qgis::FieldDomainType::Range
+  };
+}
+
 QString QgsGeoPackageProviderConnection::databaseQueryLogIdentifier() const
 {
   return QStringLiteral( "QgsGeoPackageProviderConnection" );

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -49,6 +49,7 @@ class QgsGeoPackageProviderConnection : public QgsOgrProviderConnection
     QIcon icon() const override;
     QgsFields fields( const QString &schema, const QString &table ) const override;
     QMultiMap<Qgis::SqlKeywordCategory, QStringList> sqlDictionary() override;
+    QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const override;
 
   protected:
     QString databaseQueryLogIdentifier() const override;

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -388,6 +388,12 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
   mCapabilities |= DeleteField;
 
   gdal::ogr_datasource_unique_ptr hDS( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
+  if ( !hDS )
+  {
+    // fallback to read only otherwise
+    hDS.reset( GDALOpenEx( uri().toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr ) );
+  }
+
   if ( hDS )
   {
     if ( OGR_DS_TestCapability( hDS.get(), ODsCCurveGeometries ) )

--- a/src/core/providers/ogr/qgsogrproviderconnection.h
+++ b/src/core/providers/ogr/qgsogrproviderconnection.h
@@ -83,6 +83,7 @@ class QgsOgrProviderConnection : public QgsAbstractDatabaseProviderConnection
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     QList<QgsVectorDataProvider::NativeType> nativeTypes() const override;
     QStringList fieldDomainNames() const override;
+    QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const override;
     QgsFieldDomain *fieldDomain( const QString &name ) const override;
     void setFieldDomainName( const QString &fieldName, const QString &schema, const QString &tableName, const QString &domainName ) const override;
     void addFieldDomain( const QgsFieldDomain &domain, const QString &schema ) const override;

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.cpp
@@ -1014,6 +1014,11 @@ QMultiMap<Qgis::SqlKeywordCategory, QStringList> QgsAbstractDatabaseProviderConn
   };
 }
 
+QList<Qgis::FieldDomainType> QgsAbstractDatabaseProviderConnection::supportedFieldDomainTypes() const
+{
+  return {};
+}
+
 void QgsAbstractDatabaseProviderConnection::createVectorTable( const QString &schema,
     const QString &name,
     const QgsFields &fields,

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -824,6 +824,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual QStringList fieldDomainNames() const SIP_THROW( QgsProviderConnectionException );
 
     /**
+     * Returns a list of field domain types which are supported by the provider.
+     *
+     * \since QGIS 3.28
+     */
+    virtual QList< Qgis::FieldDomainType > supportedFieldDomainTypes() const;
+
+    /**
      * Returns the field domain with the specified \a name from the provider.
      *
      * The caller takes ownership of the return object. Will return NULLPTR if no matching field domain is found.


### PR DESCRIPTION
This PR generalises some of the existing GeoPackage specific management options through browser, making them available to any OGR supported datasource which offers those capabilities. Specifically:

- Field domain management capabilities (creation and listing domains) is now generic
- New table creation capability is now generic

This pairs nicely with https://github.com/OSGeo/gdal/pull/5910, and with a recent GDAL build means that users can manage field domains and create new tables in an existing ESRI FileGeodatabase database.

Funded by Provincie Gelderland 