### PR TITLE
Treat las classification as an unsigned char

### DIFF
--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -111,6 +111,8 @@ class _3D_NO_EXPORT QgsPointCloud3DRenderContext : public Qgs3DRenderContext
       switch ( type )
       {
         case QgsPointCloudAttribute::UChar:
+          value = *reinterpret_cast< const unsigned char * >( data + offset );
+          return;
         case QgsPointCloudAttribute::Char:
           value = *( data + offset );
           return;

--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -165,7 +165,7 @@ void QgsLazInfo::parseLazAttributes()
   mAttributes.push_back( QgsPointCloudAttribute( "NumberOfReturns", QgsPointCloudAttribute::Char ) );
   mAttributes.push_back( QgsPointCloudAttribute( "ScanDirectionFlag", QgsPointCloudAttribute::Char ) );
   mAttributes.push_back( QgsPointCloudAttribute( "EdgeOfFlightLine", QgsPointCloudAttribute::Char ) );
-  mAttributes.push_back( QgsPointCloudAttribute( "Classification", QgsPointCloudAttribute::Char ) );
+  mAttributes.push_back( QgsPointCloudAttribute( "Classification", QgsPointCloudAttribute::UChar ) );
   mAttributes.push_back( QgsPointCloudAttribute( "ScanAngleRank", QgsPointCloudAttribute::Short ) );
   mAttributes.push_back( QgsPointCloudAttribute( "UserData", QgsPointCloudAttribute::Char ) );
   mAttributes.push_back( QgsPointCloudAttribute( "PointSourceId", QgsPointCloudAttribute::UShort ) );

--- a/src/core/pointcloud/qgspointcloudattribute.cpp
+++ b/src/core/pointcloud/qgspointcloudattribute.cpp
@@ -206,6 +206,9 @@ void _attribute( const char *data, std::size_t offset, QgsPointCloudAttribute::D
   switch ( type )
   {
     case QgsPointCloudAttribute::UChar:
+      value = *reinterpret_cast< const unsigned char * >( data + offset );
+      return;
+
     case QgsPointCloudAttribute::Char:
       value = *( data + offset );
       return;
@@ -279,6 +282,12 @@ QVariantMap QgsPointCloudAttribute::getAttributeMap( const char *data, std::size
     switch ( attr.type() )
     {
       case QgsPointCloudAttribute::UChar:
+      {
+        const unsigned char value = *reinterpret_cast< const unsigned char * >( data + recordOffset + attributeOffset );
+        map[ attributeName ] = value;
+      }
+      break;
+
       case QgsPointCloudAttribute::Char:
       {
         const char value = *( data + recordOffset + attributeOffset );

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -185,6 +185,8 @@ class CORE_EXPORT QgsPointCloudRenderContext
       switch ( type )
       {
         case QgsPointCloudAttribute::UChar:
+          value = *reinterpret_cast< const unsigned char * >( data + offset );
+          return;
         case QgsPointCloudAttribute::Char:
           value = *( data + offset );
           return;

--- a/src/core/pointcloud/qgspointcloudrendererregistry.cpp
+++ b/src/core/pointcloud/qgspointcloudrendererregistry.cpp
@@ -208,8 +208,9 @@ QgsPointCloudCategoryList QgsPointCloudRendererRegistry::classificationAttribute
   QgsPointCloudCategoryList categories;
   for ( const int &layerClass : layerClasses )
   {
-    const QColor color = layerClass < defaultCategories.size() ? defaultCategories.at( layerClass ).color() : QgsApplication::colorSchemeRegistry()->fetchRandomStyleColor();
-    const QString label = layerClass < defaultCategories.size() ? QgsPointCloudDataProvider::translatedLasClassificationCodes().value( layerClass, QString::number( layerClass ) ) : QString::number( layerClass );
+    const bool isDefaultCategory = layerClass >= 0 && layerClass < defaultCategories.size();
+    const QColor color = isDefaultCategory ? defaultCategories.at( layerClass ).color() : QgsApplication::colorSchemeRegistry()->fetchRandomStyleColor();
+    const QString label = isDefaultCategory ? QgsPointCloudDataProvider::translatedLasClassificationCodes().value( layerClass, QString::number( layerClass ) ) : QString::number( layerClass );
     categories.append( QgsPointCloudCategory( layerClass, color, label ) );
   }
   return categories;

--- a/tests/src/providers/testqgscopcprovider.cpp
+++ b/tests/src/providers/testqgscopcprovider.cpp
@@ -302,7 +302,7 @@ void TestQgsCopcProvider::attributes()
   QCOMPARE( attributes.at( 7 ).name(), QStringLiteral( "EdgeOfFlightLine" ) );
   QCOMPARE( attributes.at( 7 ).type(), QgsPointCloudAttribute::Char );
   QCOMPARE( attributes.at( 8 ).name(), QStringLiteral( "Classification" ) );
-  QCOMPARE( attributes.at( 8 ).type(), QgsPointCloudAttribute::Char );
+  QCOMPARE( attributes.at( 8 ).type(), QgsPointCloudAttribute::UChar );
   QCOMPARE( attributes.at( 9 ).name(), QStringLiteral( "ScanAngleRank" ) );
   QCOMPARE( attributes.at( 9 ).type(), QgsPointCloudAttribute::Short );
   QCOMPARE( attributes.at( 10 ).name(), QStringLiteral( "UserData" ) );


### PR DESCRIPTION
## Description
Las Classification attribute was treated as signed char while the spec defines it as unsigned. This lead to values > 127 being interpreted as negatives

Fix #49155

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
