### PR TITLE
Add examples to between and not between functions

### DIFF
--- a/resources/function_help/json/BETWEEN
+++ b/resources/function_help/json/BETWEEN
@@ -2,7 +2,7 @@
   "name": "BETWEEN",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Returns TRUE if value is within the specified range. The range is considered inclusive of the bounds. To test for exclusion `NOT BETWEEN` can be used.",
+  "description": "Returns TRUE if value is within the specified range. The range is considered inclusive of the bounds. To test for exclusion NOT BETWEEN can be used.",
   "arguments": [{
     "arg": "lower_bound AND higher_bound",
     "description": "range bounds"
@@ -13,6 +13,15 @@
   }, {
     "expression": "2 BETWEEN 1 AND 3",
     "returns": "TRUE"
+  }, {
+    "expression": "2 BETWEEN 2 AND 3",
+    "returns": "TRUE"
+  }, {
+    "expression": "'B' BETWEEN 'a' AND 'c'",
+    "returns": "FALSE"
+  }, {
+    "expression": "lower('B') BETWEEN 'a' AND 'b'",
+    "returns": "TRUE"
   }],
-  "tags": ["contained", "found"]
+  "tags": ["bound", "contained", "found", "include", "range"]
 }

--- a/resources/function_help/json/BETWEEN
+++ b/resources/function_help/json/BETWEEN
@@ -23,5 +23,5 @@
     "expression": "lower('B') BETWEEN 'a' AND 'b'",
     "returns": "TRUE"
   }],
-  "tags": ["bound", "contained", "found", "include", "range"]
+  "tags": ["bound", "contained", "found", "include", "range", "within"]
 }

--- a/resources/function_help/json/NOT BETWEEN
+++ b/resources/function_help/json/NOT BETWEEN
@@ -13,6 +13,15 @@
   }, {
     "expression": "1.0 NOT BETWEEN 1.1 AND 1.2",
     "returns": "TRUE"
+  }, {
+    "expression": "2 NOT BETWEEN 2 AND 3",
+    "returns": "FALSE"
+  }, {
+    "expression": "'B' NOT BETWEEN 'a' AND 'c'",
+    "returns": "TRUE"
+  }, {
+    "expression": "lower('B') NOT BETWEEN 'a' AND 'b'",
+    "returns": "FALSE"
   }],
-  "tags": ["contained", "found"]
+  "tags": ["bound", "contained", "exclude", "found", "range"]
 }


### PR DESCRIPTION
showcasing equality with bounds value as well as case-sensitivity, with few tags