### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,8 +17,13 @@ on:
   workflow_dispatch:
     # POST https://api.github.com/repos/qgis/QGIS/actions/workflows/2264135/dispatches:
 
+permissions:
+  contents: read
+
 jobs:
   define-strategy:
+    permissions:
+      contents: none
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   ping-author-message:
+    permissions:
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     if: github.event.action != 'closed' && github.event.label.name == 'Needs Documentation'
     runs-on: ubuntu-latest
     name: Write comment to ping author about the future creation of an issue in docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     tags:
       - 'final-*_*_*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     name: Create Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
   - cron: "30 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     if: github.repository_owner == 'qgis'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -2,8 +2,13 @@ name: Remove Labels
 
 on: [issue_comment]
 
+permissions:
+  contents: read
+
 jobs:
   remove_labels:
+    permissions:
+      issues: write  # for actions-ecosystem/action-remove-labels to remove issue labels
     if: contains(github.event.issue.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
