### PR TITLE
Bugfix {usage} template parameter in XYZ tiles

### DIFF
--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -435,7 +435,7 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
 
   for ( int i = 1; i <= nBands; ++i )
   {
-    iter->startRasterRead( i, nCols, nRows, outputExtent );
+    iter->startRasterRead( i, nCols, nRows, outputExtent, feedback );
     if ( destProvider && destHasNoDataValueList.value( i - 1 ) ) // no tiles
     {
       destProvider->setNoDataValue( i, destNoDataValueList.value( i - 1 ) );


### PR DESCRIPTION
## Description

Fixes #49217 
Relates to PR #46731 

This PR adds `feedback` parameter to the `writeDataRaster()` method

Unlike in the `writeImageRaster()` method, where `feedback` is provided to as a input parameter to `startRasterRead()`,
https://github.com/qgis/QGIS/blob/master/src/core/raster/qgsrasterfilewriter.cpp#L644
```
iter->startRasterRead( 1, nCols, nRows, outputExtent, feedback );
```
the `feedback` parameter is not provided to `startRasterRead()`  in the `writeDataRaster()` method
https://github.com/qgis/QGIS/blob/master/src/core/raster/qgsrasterfilewriter.cpp#L438
```
  for ( int i = 1; i <= nBands; ++i )
  {
    iter->startRasterRead( i, nCols, nRows, outputExtent );
    if ( destProvider && destHasNoDataValueList.value( i - 1 ) ) // no tiles
    {
      destProvider->setNoDataValue( i, destNoDataValueList.value( i - 1 ) );
    }
  }
```
Without the `feedback` provided the `{usage}` template replacement fails in:
https://github.com/qgis/QGIS/blob/master/src/providers/wms/qgswmsprovider.cpp#L1713-L1726
```
    if ( turl.contains( QLatin1String( "{usage}" ) ) && feedback )
    {
      switch ( feedback->renderContext().rendererUsage() )
      {
        case Qgis::RendererUsage::View:
          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
          break;
        case Qgis::RendererUsage::Export:
          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
          break;
        case Qgis::RendererUsage::Unknown:
          turl.replace( QLatin1String( "{usage}" ), QString() );
          break;
      }
```
This results in bad tiles requests, such as:
```
https://api.maptiler.com/tiles/terrain-rgb/12/2151/1438.png?usage=%7Busage%7D&signature=FC8rVajFXdvEP6OPsqIMozl7ukiNEs9rl5x_WoCO17Y%3D&key=9686bed528a9421ea02f05dddd16b68c&signature=C9f7xyyUnt3U-Tqzh6aey3NgXdie-IyKSQli4naeuyg=
```
instead of 
```
https://api.maptiler.com/tiles/terrain-rgb/12/2151/1438.png?usage=export&signature=FC8rVajFXdvEP6OPsqIMozl7ukiNEs9rl5x_WoCO17Y%3D&key=9686bed528a9421ea02f05dddd16b68c&signature=C9f7xyyUnt3U-Tqzh6aey3NgXdie-IyKSQli4naeuyg=
```