### PR TITLE
Fix GRASS7/SAGA UnicodeDecodeError in QGIS of Windows-Japanese or others

### DIFF
--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -397,7 +397,7 @@ class Grass7Utils:
             """
             try:
                 return stdout.readline()
-            except Exception as e:
+            except UnicodeDecodeError:
                 return '???'  # replaced-text
 
         with subprocess.Popen(

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -384,11 +384,10 @@ class Grass7Utils:
             if sys.version_info >= (3, 6):
                 kw['encoding'] = "cp{}".format(Grass7Utils.getWindowsCodePage())
 
-        def readline_with_recover(stdout):
-            """A method wrapping stdout.readline() with try-except.
-            This is a workaround for decoding stdout from GRASS cmd
-            because there are environments where it is difficult to avoid UnicodeDecodeError.
 
+        def readline_with_recover(stdout):
+            """A method wrapping stdout.readline() with try-except recovering.
+            detailed in https://github.com/qgis/QGIS/pull/49226
             Args:
                 stdout: io.TextIOWrapper - proc.stdout
 

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -387,7 +387,7 @@ class Grass7Utils:
         def readline_with_recover(stdout):
             """A method wrapping stdout.readline() with try-except.
             This is a workaround for decoding stdout from GRASS cmd
-            because there are enviroments where it is difficult to avoid UnicodeDecodeError.
+            because there are environments where it is difficult to avoid UnicodeDecodeError.
 
             Args:
                 stdout: io.TextIOWrapper - proc.stdout

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -384,7 +384,6 @@ class Grass7Utils:
             if sys.version_info >= (3, 6):
                 kw['encoding'] = "cp{}".format(Grass7Utils.getWindowsCodePage())
 
-
         def readline_with_recover(stdout):
             """A method wrapping stdout.readline() with try-except recovering.
             detailed in https://github.com/qgis/QGIS/pull/49226

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -398,7 +398,7 @@ class Grass7Utils:
             try:
                 return stdout.readline()
             except Exception as e:
-                return '???'  # replaced-text
+                return ''  # replaced-text
 
         with subprocess.Popen(
                 command,

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -398,7 +398,7 @@ class Grass7Utils:
             try:
                 return stdout.readline()
             except Exception as e:
-                return '???' # replaced-text
+                return '???'  # replaced-text
 
         with subprocess.Popen(
                 command,

--- a/python/plugins/grassprovider/Grass7Utils.py
+++ b/python/plugins/grassprovider/Grass7Utils.py
@@ -397,7 +397,7 @@ class Grass7Utils:
             """
             try:
                 return stdout.readline()
-            except Exception as e:
+            except UnicodeDecodeError:
                 return ''  # replaced-text
 
         with subprocess.Popen(

--- a/python/plugins/sagaprovider/SagaUtils.py
+++ b/python/plugins/sagaprovider/SagaUtils.py
@@ -172,6 +172,20 @@ def executeSaga(feedback):
         )
     ]
 
+    def readline_with_recover(stdout):
+        """A method wrapping stdout.readline() with try-except recovering.
+        detailed in https://github.com/qgis/QGIS/pull/49226
+        Args:
+            stdout: io.TextIOWrapper - proc.stdout
+
+        Returns:
+            str: read line or replaced text when recovered
+        """
+        try:
+            return stdout.readline()
+        except Exception as e:
+            return ''  # replaced-text
+
     with subprocess.Popen(
         command,
         shell=True,
@@ -181,7 +195,7 @@ def executeSaga(feedback):
         universal_newlines=True,
     ) as proc:
         try:
-            for line in iter(proc.stdout.readline, ''):
+            for line in iter(lambda: readline_with_recover(proc.stdout), ''):
                 if '%' in line:
                     s = ''.join(x for x in line if x.isdigit())
                     try:

--- a/python/plugins/sagaprovider/SagaUtils.py
+++ b/python/plugins/sagaprovider/SagaUtils.py
@@ -183,7 +183,7 @@ def executeSaga(feedback):
         """
         try:
             return stdout.readline()
-        except Exception as e:
+        except UnicodeDecodeError:
             return ''  # replaced-text
 
     with subprocess.Popen(


### PR DESCRIPTION
related #29845 (closed but not solved)

## Description

- In Windows10(Japanese), any GRASS7 commands don't work since the version that become to use .msi installer as far as I know.
- In above condition QGIS, `UnicodeDecodeError` occurs in GRASS7-processings apparently in decoding `stdout` from GRASS7 via `cmd`.
- I tried to decode in many patterns with encoding or so on but it is dificult to solve this.
- So, I wrote a workaround to wrap `UnicodeDecodeError`.  IMHO this is not the best solution but better than GRASS7 doesn't work for a long time. Besides, This error occurs in logging GRASS7 stdout so  there is no change for the process itself.