### PR TITLE
[positioning] Add missing equal-to operator to the QgsSatelliteInfo class

### DIFF
--- a/python/core/auto_generated/gps/qgsgpsconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsgpsconnection.sip.in
@@ -37,6 +37,10 @@ Encapsulates information relating to a GPS satellite.
     double azimuth;
 
     int signal;
+
+    bool operator==( const QgsSatelliteInfo &other ) const;
+
+    bool operator!=( const QgsSatelliteInfo &other ) const;
 };
 
 class QgsGpsInformation

--- a/src/core/gps/qgsgpsconnection.h
+++ b/src/core/gps/qgsgpsconnection.h
@@ -88,6 +88,20 @@ class CORE_EXPORT QgsSatelliteInfo
      * Signal strength (0-99dB), or -1 if not available.
      */
     int signal = -1;
+
+    bool operator==( const QgsSatelliteInfo &other ) const
+    {
+      return id == other.id &&
+             inUse == other.inUse &&
+             elevation == other.elevation &&
+             azimuth == other.azimuth &&
+             signal == other.signal;
+    }
+
+    bool operator!=( const QgsSatelliteInfo &other ) const
+    {
+      return !operator==( other );
+    }
 };
 
 /**


### PR DESCRIPTION
## Description

Because it's useful, and at times needed.