### PR TITLE
UUID Generator widget: don't truncate Uuid string if field length >= Uuid string length

### DIFF
--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -25,14 +25,16 @@ QgsUuidWidgetWrapper::QgsUuidWidgetWrapper( QgsVectorLayer *layer, int fieldIdx,
 
 QString QgsUuidWidgetWrapper::createUiid( int maxLength )
 {
-  if ( maxLength <= 0 )
+  QString uuid = QUuid::createUuid().toString();
+
+  if ( maxLength <= 0 || maxLength >= uuid.length() )
   {
-    return QUuid::createUuid().toString();
+    return uuid;
   }
   else
   {
     // trim left "{" and remove -'s... they are wasted characters given that we have a limited length!
-    return QUuid::createUuid().toString().replace( '-', QString() ).mid( 1, maxLength );
+    return uuid.replace( '-', QString() ).mid( 1, maxLength );
   }
 }
 

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -307,7 +307,7 @@ class TestQgsValueMapEditWidget(unittest.TestCase):
 class TestQgsUuidWidget(unittest.TestCase):
 
     def test_create_uuid(self):
-        layer = QgsVectorLayer("none?field=text_no_limit:text(0)&field=text_limit:text(10)", "layer", "memory")
+        layer = QgsVectorLayer("none?field=text_no_limit:text(0)&field=text_limit:text(10)&field=text_38:text(38)", "layer", "memory")
         self.assertTrue(layer.isValid())
         QgsProject.instance().addMapLayer(layer)
 
@@ -317,7 +317,7 @@ class TestQgsUuidWidget(unittest.TestCase):
         feature = QgsFeature(layer.fields())
         wrapper.setFeature(feature)
         val = wrapper.value()
-        # we can't directly check the result, as it will be random, so just check it's general properties
+        # we can't directly check the result, as it will be random, so just check its general properties
         self.assertEqual(len(val), 38)
         self.assertEqual(val[0], '{')
         self.assertEqual(val[-1], '}')
@@ -328,12 +328,23 @@ class TestQgsUuidWidget(unittest.TestCase):
         feature = QgsFeature(layer.fields())
         wrapper.setFeature(feature)
         val = wrapper.value()
-        # we can't directly check the result, as it will be random, so just check it's general properties
+        # we can't directly check the result, as it will be random, so just check its general properties
         self.assertEqual(len(val), 10)
         self.assertNotEqual(val[0], '{')
         self.assertNotEqual(val[-1], '}')
         with self.assertRaises(ValueError):
             val.index('-')
+
+        # limited length text field with length = 38, value must not be truncated
+        wrapper = QgsGui.editorWidgetRegistry().create('UuidGenerator', layer, 2, {}, None, None)
+        _ = wrapper.widget()
+        feature = QgsFeature(layer.fields())
+        wrapper.setFeature(feature)
+        val = wrapper.value()
+        # we can't directly check the result, as it will be random, so just check its general properties
+        self.assertEqual(len(val), 38)
+        self.assertEqual(val[0], '{')
+        self.assertEqual(val[-1], '}')
 
         QgsProject.instance().removeAllMapLayers()
 


### PR DESCRIPTION
## Description

The current behaviour (introduced with https://github.com/qgis/QGIS/pull/45540) is to truncate the generated UUID string if the field has a limited text length, regardless of the length, in order to avoid the generation of UUIDs which are too long to fit in the field.
The proposed new behaviour is to only truncate the generated UUID string if the text length of the field is less then the Uuid string length (38 characters).

Fixes #49240.

P.S. `QgsUuidWidgetWrapper::createUiid` has a typo in its name. Could it be safe to fix it in this or another PR?

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
