### PR TITLE
qgscamerapose: Fix pitch max value to avoid rotation computation error

### DIFF
--- a/src/3d/qgscamerapose.cpp
+++ b/src/3d/qgscamerapose.cpp
@@ -61,9 +61,10 @@ void QgsCameraPose::setPitchAngle( float pitch )
 {
   // prevent going over the head
   // prevent bug in QgsCameraPose::updateCamera when updating camera rotation.
-  // With a mPitchAngle < 0.2, QQuaternion::fromEulerAngles( mPitchAngle, mHeadingAngle, 0 ) will return bad rotation angle.
+  // With a mPitchAngle < 0.2 or > 179.8, QQuaternion::fromEulerAngles( mPitchAngle, mHeadingAngle, 0 )
+  // will return bad rotation angle.
   // See https://bugreports.qt.io/browse/QTBUG-72103
-  mPitchAngle = std::clamp( pitch, 0.2f, 180.0f );
+  mPitchAngle = std::clamp( pitch, 0.2f, 179.8f );
 }
 
 void QgsCameraPose::updateCamera( Qt3DRender::QCamera *camera )


### PR DESCRIPTION
This is a similar fix to b173af9a2e5097b7542668c640acb30819563be0
which fixed the pitch min value.

With a mPitchAngle > 179.8, QQuaternion::fromEulerAngles(
mPitchAngle, mHeadingAngle, 0 ) will return bad rotation angles.

This is fixed is Qt6, but it has not been backported to Qt5.
See: https://bugreports.qt.io/browse/QTBUG-72103

cc @benoitdm-oslandia @lbartoletti @wonder-sk 

