### PR TITLE
[Oracle] Fix getSchemas request to not get all system tables

### DIFF
--- a/src/providers/oracle/qgsoracleproviderconnection.cpp
+++ b/src/providers/oracle/qgsoracleproviderconnection.cpp
@@ -1632,7 +1632,8 @@ QStringList QgsOracleProviderConnection::schemas( ) const
   checkCapability( Capability::Schemas );
   QStringList schemas;
 
-  QList<QVariantList> users = executeSqlPrivate( QStringLiteral( "SELECT USERNAME FROM ALL_USERS" ) ).rows();
+  // get only non system schemas/users
+  QList<QVariantList> users = executeSqlPrivate( QStringLiteral( "SELECT USERNAME FROM ALL_USERS where ORACLE_MAINTAINED = 'N' AND USERNAME NOT IN ( 'PDBADMIN', 'HR' )" ) ).rows();
   for ( QVariantList userInfos : users )
     schemas << userInfos.at( 0 ).toString();
 

--- a/tests/src/python/test_qgsproviderconnection_oracle.py
+++ b/tests/src/python/test_qgsproviderconnection_oracle.py
@@ -192,9 +192,12 @@ class TestPyQgsProviderConnectionOracle(unittest.TestCase, TestPyQgsProviderConn
     def test_schemas(self):
         """Test schemas retrieval"""
 
+        # may be added by previous test
+        self.execSQLCommand('DROP USER OTHER_USER CASCADE', ignore_errors=True)
+
         md = QgsProviderRegistry.instance().providerMetadata('oracle')
         conn = md.createConnection(self.uri, {})
-        self.assertTrue('QGIS' in conn.schemas())
+        self.assertEqual(conn.schemas(), ['QGIS'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

This PR changes the request in *QgsOracleProviderConnection* to retrieve only the non system schemas. 

System schemas contains a lot of tables and when *Execute SQL* dialog is opened, QGIS is parsing all this schemas table and columns to provide auto-completion. Even if this is run in another thread, it slows down significantly the computer for nothing.

It's quite the same as what is done in [Postgres](https://github.com/qgis/QGIS/blob/master/src/providers/postgres/qgspostgresconn.cpp#L1022).