### PR TITLE
Change project style disabling from being a project load flag to a new project "capability"

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1808,13 +1808,20 @@ QgsProject.FlagDontLoad3DViews.is_monkey_patched = True
 QgsProject.FlagDontLoad3DViews.__doc__ = "Skip loading 3D views (since QGIS 3.26)"
 QgsProject.DontLoadProjectStyles = Qgis.ProjectReadFlag.DontLoadProjectStyles
 QgsProject.DontLoadProjectStyles.is_monkey_patched = True
-QgsProject.DontLoadProjectStyles.__doc__ = "Skip loading project style databases (since QGIS 3.26)"
+QgsProject.DontLoadProjectStyles.__doc__ = "Skip loading project style databases (deprecated -- use ProjectCapability.ProjectStyles flag instead)"
 Qgis.ProjectReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. note::\n\n   Prior to QGIS 3.26 this was available as :py:class:`QgsProject`.ReadFlag\n\n.. versionadded:: 3.26\n\n' + '* ``FlagDontResolveLayers``: ' + Qgis.ProjectReadFlag.DontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + Qgis.ProjectReadFlag.DontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + Qgis.ProjectReadFlag.TrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + Qgis.ProjectReadFlag.DontStoreOriginalStyles.__doc__ + '\n' + '* ``FlagDontLoad3DViews``: ' + Qgis.ProjectReadFlag.DontLoad3DViews.__doc__ + '\n' + '* ``DontLoadProjectStyles``: ' + Qgis.ProjectReadFlag.DontLoadProjectStyles.__doc__
 # --
 Qgis.ProjectReadFlag.baseClass = Qgis
 QgsProject.ReadFlags = Qgis.ProjectReadFlags
 Qgis.ProjectReadFlags.baseClass = Qgis
 ProjectReadFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+Qgis.ProjectCapability.ProjectStyles.__doc__ = "Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects."
+Qgis.ProjectCapability.__doc__ = 'Flags which control project capabilities.\n\nThese flags are specific upfront on creation of a :py:class:`QgsProject` object, and can\nbe used to selectively enable potentially costly functionality for the project.\n\n.. versionadded:: 3.26.1\n\n' + '* ``ProjectStyles``: ' + Qgis.ProjectCapability.ProjectStyles.__doc__
+# --
+Qgis.ProjectCapability.baseClass = Qgis
+Qgis.ProjectCapabilities.baseClass = Qgis
+ProjectCapabilities = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.MapBoxGlStyleSourceType.Vector.__doc__ = "Vector source"
 Qgis.MapBoxGlStyleSourceType.Raster.__doc__ = "Raster source"

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -65,11 +65,14 @@ Set the current project singleton instance to ``project``
 .. versionadded:: 3.10.11
 %End
 
-    explicit QgsProject( QObject *parent /TransferThis/ = 0 );
+    explicit QgsProject( QObject *parent /TransferThis/ = 0, Qgis::ProjectCapabilities capabilities = Qgis::ProjectCapability::ProjectStyles );
 %Docstring
 Create a new QgsProject.
 
 Most of the time you want to use :py:func:`QgsProject.instance()` instead as many components of QGIS work with the singleton.
+
+Since QGIS 3.26.1 the ``capabilities`` argument specifies optional capabilities which can be selectively
+enabled for the project. These affect the QgsProject object for its entire lifetime.
 %End
 
     ~QgsProject();
@@ -98,6 +101,14 @@ Returns the project's title.
 .. note::
 
    Since QGIS 3.2 this is just a shortcut to retrieving the title from the project's :py:func:`~QgsProject.metadata`.
+%End
+
+    Qgis::ProjectCapabilities capabilities() const;
+%Docstring
+Returns the project's capabilities, which dictate optional functionality
+which can be selectively enabled for a QgsProject object.
+
+.. versionadded:: 3.26.1
 %End
 
     Qgis::ProjectFlags flags() const;

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1179,6 +1179,14 @@ The development version
     typedef QFlags<Qgis::ProjectReadFlag> ProjectReadFlags;
 
 
+    enum class ProjectCapability
+    {
+      ProjectStyles,
+    };
+
+    typedef QFlags<Qgis::ProjectCapability> ProjectCapabilities;
+
+
     enum class MapBoxGlStyleSourceType
     {
       Vector,
@@ -1307,6 +1315,8 @@ QFlags<Qgis::PlotToolFlag> operator|(Qgis::PlotToolFlag f1, QFlags<Qgis::PlotToo
 QFlags<Qgis::ProfileGeneratorFlag> operator|(Qgis::ProfileGeneratorFlag f1, QFlags<Qgis::ProfileGeneratorFlag> f2);
 
 QFlags<Qgis::ProjectReadFlag> operator|(Qgis::ProjectReadFlag f1, QFlags<Qgis::ProjectReadFlag> f2);
+
+QFlags<Qgis::ProjectCapability> operator|(Qgis::ProjectCapability f1, QFlags<Qgis::ProjectCapability> f2);
 
 QFlags<Qgis::CoordinateTransformationFlag> operator|(Qgis::CoordinateTransformationFlag f1, QFlags<Qgis::CoordinateTransformationFlag> f2);
 

--- a/src/analysis/processing/qgsprojectstylealgorithms.cpp
+++ b/src/analysis/processing/qgsprojectstylealgorithms.cpp
@@ -202,8 +202,8 @@ QVariantMap QgsStyleFromProjectAlgorithm::processAlgorithm( const QVariantMap &p
   if ( !mProjectPath.isEmpty() )
   {
     // load project from path
-    QgsProject p;
-    if ( !p.read( mProjectPath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontLoad3DViews | Qgis::ProjectReadFlag::DontLoadProjectStyles ) )
+    QgsProject p( nullptr, Qgis::ProjectCapabilities() );
+    if ( !p.read( mProjectPath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontLoad3DViews ) )
     {
       throw QgsProcessingException( QObject::tr( "Could not read project %1" ).arg( mProjectPath ) );
     }

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1133,9 +1133,9 @@ void QgsProjectItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
       QgsSaveToStyleVisitor visitor( &style );
 
-      QgsProject p;
+      QgsProject p( nullptr, Qgis::ProjectCapabilities() );
       QgsTemporaryCursorOverride override( Qt::WaitCursor );
-      if ( p.read( projectPath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontStoreOriginalStyles | Qgis::ProjectReadFlag::DontLoad3DViews | Qgis::ProjectReadFlag::DontLoadProjectStyles ) )
+      if ( p.read( projectPath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontStoreOriginalStyles | Qgis::ProjectReadFlag::DontLoad3DViews ) )
       {
         p.accept( &visitor );
         override.release();

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -491,12 +491,11 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
 {
   QVector<QgsDataItem *> childItems;
 
-  QgsProject p;
+  QgsProject p( nullptr, Qgis::ProjectCapabilities() );
   if ( !p.read( mPath, Qgis::ProjectReadFlag::DontResolveLayers
                 | Qgis::ProjectReadFlag::DontLoadLayouts
                 | Qgis::ProjectReadFlag::DontStoreOriginalStyles
-                | Qgis::ProjectReadFlag::DontLoad3DViews
-                | Qgis::ProjectReadFlag::DontLoadProjectStyles ) )
+                | Qgis::ProjectReadFlag::DontLoad3DViews ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -366,8 +366,9 @@ void removeKey_( const QString &scope,
   }
 }
 
-QgsProject::QgsProject( QObject *parent )
+QgsProject::QgsProject( QObject *parent, Qgis::ProjectCapabilities capabilities )
   : QObject( parent )
+  , mCapabilities( capabilities )
   , mLayerStore( new QgsMapLayerStore( this ) )
   , mBadLayerHandler( new QgsProjectBadLayerHandler() )
   , mSnappingConfig( this )

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -153,8 +153,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * Create a new QgsProject.
      *
      * Most of the time you want to use QgsProject::instance() instead as many components of QGIS work with the singleton.
+     *
+     * Since QGIS 3.26.1 the \a capabilities argument specifies optional capabilities which can be selectively
+     * enabled for the project. These affect the QgsProject object for its entire lifetime.
      */
-    explicit QgsProject( QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsProject( QObject *parent SIP_TRANSFERTHIS = nullptr, Qgis::ProjectCapabilities capabilities = Qgis::ProjectCapability::ProjectStyles );
 
     ~QgsProject() override;
 
@@ -176,6 +179,14 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note Since QGIS 3.2 this is just a shortcut to retrieving the title from the project's metadata().
     */
     QString title() const;
+
+    /**
+     * Returns the project's capabilities, which dictate optional functionality
+     * which can be selectively enabled for a QgsProject object.
+     *
+     * \since QGIS 3.26.1
+     */
+    Qgis::ProjectCapabilities capabilities() const { return mCapabilities; }
 
     /**
      * Returns the project's flags, which dictate the behavior of the project.
@@ -2161,6 +2172,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     //! Returns the property definition used for a data defined server property
     static QgsPropertiesDefinition &dataDefinedServerPropertyDefinitions();
+
+    Qgis::ProjectCapabilities mCapabilities;
 
     std::unique_ptr< QgsMapLayerStore > mLayerStore;
 

--- a/src/core/project/qgsprojectstylesettings.cpp
+++ b/src/core/project/qgsprojectstylesettings.cpp
@@ -122,7 +122,7 @@ void QgsProjectStyleSettings::reset()
 
   clearStyles();
 
-  if ( mProject )
+  if ( mProject && ( mProject->capabilities() & Qgis::ProjectCapability::ProjectStyles ) )
   {
     const QString stylePath = mProject->createAttachedFile( QStringLiteral( "styles.db" ) );
     QgsStyle *style = new QgsStyle();
@@ -165,7 +165,7 @@ QgsStyle *QgsProjectStyleSettings::projectStyle()
   return mProjectStyle;
 }
 
-bool QgsProjectStyleSettings::readXml( const QDomElement &element, const QgsReadWriteContext &context, Qgis::ProjectReadFlags flags )
+bool QgsProjectStyleSettings::readXml( const QDomElement &element, const QgsReadWriteContext &context, Qgis::ProjectReadFlags )
 {
   mRandomizeDefaultSymbolColor = element.attribute( QStringLiteral( "RandomizeDefaultSymbolColor" ), QStringLiteral( "0" ) ).toInt();
   mDefaultSymbolOpacity = element.attribute( QStringLiteral( "DefaultSymbolOpacity" ), QStringLiteral( "1.0" ) ).toDouble();
@@ -218,7 +218,7 @@ bool QgsProjectStyleSettings::readXml( const QDomElement &element, const QgsRead
 
   {
     clearStyles();
-    if ( !( flags & Qgis::ProjectReadFlag::DontLoadProjectStyles ) )
+    if ( !mProject || ( mProject->capabilities() & Qgis::ProjectCapability::ProjectStyles ) )
     {
       const QDomElement styleDatabases = element.firstChildElement( QStringLiteral( "databases" ) );
       if ( !styleDatabases.isNull() )
@@ -236,7 +236,7 @@ bool QgsProjectStyleSettings::readXml( const QDomElement &element, const QgsRead
         }
       }
 
-      if ( mProject )
+      if ( mProject && ( mProject->capabilities() & Qgis::ProjectCapability::ProjectStyles ) )
       {
         const QString projectStyleId = element.attribute( QStringLiteral( "projectStyleId" ) );
         const QString projectStyleFile = mProject->resolveAttachmentIdentifier( projectStyleId );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1999,7 +1999,7 @@ class CORE_EXPORT Qgis
       TrustLayerMetadata SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustLayerMetadata ) = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
       DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
       DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views (since QGIS 3.26)
-      DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (since QGIS 3.26)
+      DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
     };
     Q_ENUM( ProjectReadFlag )
 
@@ -2012,6 +2012,28 @@ class CORE_EXPORT Qgis
      */
     Q_DECLARE_FLAGS( ProjectReadFlags, ProjectReadFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsProject, ReadFlags )
     Q_FLAG( ProjectReadFlags )
+
+    /**
+     * Flags which control project capabilities.
+     *
+     * These flags are specific upfront on creation of a QgsProject object, and can
+     * be used to selectively enable potentially costly functionality for the project.
+     *
+     * \since QGIS 3.26.1
+     */
+    enum class ProjectCapability : int
+    {
+      ProjectStyles = 1 << 0, //!< Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects.
+    };
+    Q_ENUM( ProjectCapability )
+
+    /**
+     * Flags which control project capabilities.
+     *
+     * \since QGIS 3.26.1
+     */
+    Q_DECLARE_FLAGS( ProjectCapabilities, ProjectCapability )
+    Q_FLAG( ProjectCapabilities )
 
     /**
      * Available MapBox GL style source types.
@@ -2171,6 +2193,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SnappingTypes )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::PlotToolFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProfileGeneratorFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProjectReadFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProjectCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::CoordinateTransformationFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::RasterTemporalCapabilityFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SelectionFlags )

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -609,8 +609,7 @@ int main( int argc, char *argv[] )
                                          Qgis::ProjectReadFlag::DontResolveLayers
                                          | Qgis::ProjectReadFlag::DontLoadLayouts
                                          | Qgis::ProjectReadFlag::DontStoreOriginalStyles
-                                         | Qgis::ProjectReadFlag::DontLoad3DViews
-                                         | Qgis::ProjectReadFlag::DontLoadProjectStyles ) )
+                                         | Qgis::ProjectReadFlag::DontLoad3DViews ) )
     {
       std::cout << QObject::tr( "Project file not found, the option will be ignored." ).toStdString() << std::endl;
     }

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -98,7 +98,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
 {
   if ( !mProjectCache[ path ] )
   {
-    std::unique_ptr<QgsProject> prj( new QgsProject() );
+    // disable the project style database -- this incurs unwanted cost and is not required
+    std::unique_ptr<QgsProject> prj( new QgsProject( nullptr, Qgis::ProjectCapabilities() ) );
 
     // This is required by virtual layers that call QgsProject::instance() inside the constructor :(
     QgsProject::setInstance( prj.get() );
@@ -108,8 +109,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
 
     // Always skip original styles storage
     Qgis::ProjectReadFlags readFlags = Qgis::ProjectReadFlag::DontStoreOriginalStyles
-                                       | Qgis::ProjectReadFlag::DontLoad3DViews
-                                       | Qgis::ProjectReadFlag::DontLoadProjectStyles;
+                                       | Qgis::ProjectReadFlag::DontLoad3DViews;
     if ( settings )
     {
       // Activate trust layer metadata flag


### PR DESCRIPTION
This avoids the unwanted cost of initialising a blank style database
whenever QgsProject::clear is called and project styles are not
required (eg. for server)

Hopefully fixes regression in server project load times