### PR TITLE
[Backport release-3_26] UUID Generator widget: don't truncate Uuid string if field length >= Uuid string length

### DIFF
--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -25,14 +25,16 @@ QgsUuidWidgetWrapper::QgsUuidWidgetWrapper( QgsVectorLayer *layer, int fieldIdx,
 
 QString QgsUuidWidgetWrapper::createUiid( int maxLength )
 {
-  if ( maxLength <= 0 )
+  QString uuid = QUuid::createUuid().toString();
+
+  if ( maxLength <= 0 || maxLength >= uuid.length() )
   {
-    return QUuid::createUuid().toString();
+    return uuid;
   }
   else
   {
     // trim left "{" and remove -'s... they are wasted characters given that we have a limited length!
-    return QUuid::createUuid().toString().replace( '-', QString() ).mid( 1, maxLength );
+    return uuid.replace( '-', QString() ).mid( 1, maxLength );
   }
 }
 

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -307,7 +307,7 @@ class TestQgsValueMapEditWidget(unittest.TestCase):
 class TestQgsUuidWidget(unittest.TestCase):
 
     def test_create_uuid(self):
-        layer = QgsVectorLayer("none?field=text_no_limit:text(0)&field=text_limit:text(10)", "layer", "memory")
+        layer = QgsVectorLayer("none?field=text_no_limit:text(0)&field=text_limit:text(10)&field=text_38:text(38)", "layer", "memory")
         self.assertTrue(layer.isValid())
         QgsProject.instance().addMapLayer(layer)
 
@@ -317,7 +317,7 @@ class TestQgsUuidWidget(unittest.TestCase):
         feature = QgsFeature(layer.fields())
         wrapper.setFeature(feature)
         val = wrapper.value()
-        # we can't directly check the result, as it will be random, so just check it's general properties
+        # we can't directly check the result, as it will be random, so just check its general properties
         self.assertEqual(len(val), 38)
         self.assertEqual(val[0], '{')
         self.assertEqual(val[-1], '}')
@@ -328,12 +328,23 @@ class TestQgsUuidWidget(unittest.TestCase):
         feature = QgsFeature(layer.fields())
         wrapper.setFeature(feature)
         val = wrapper.value()
-        # we can't directly check the result, as it will be random, so just check it's general properties
+        # we can't directly check the result, as it will be random, so just check its general properties
         self.assertEqual(len(val), 10)
         self.assertNotEqual(val[0], '{')
         self.assertNotEqual(val[-1], '}')
         with self.assertRaises(ValueError):
             val.index('-')
+
+        # limited length text field with length = 38, value must not be truncated
+        wrapper = QgsGui.editorWidgetRegistry().create('UuidGenerator', layer, 2, {}, None, None)
+        _ = wrapper.widget()
+        feature = QgsFeature(layer.fields())
+        wrapper.setFeature(feature)
+        val = wrapper.value()
+        # we can't directly check the result, as it will be random, so just check its general properties
+        self.assertEqual(len(val), 38)
+        self.assertEqual(val[0], '{')
+        self.assertEqual(val[-1], '}')
 
         QgsProject.instance().removeAllMapLayers()
 


### PR DESCRIPTION
Backport https://github.com/qgis/QGIS/pull/49241