### PR TITLE
Fix #48942 add 1 timestep to AnimationRange

### DIFF
--- a/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
+++ b/src/core/mesh/qgsmeshdataprovidertemporalcapabilities.cpp
@@ -132,7 +132,8 @@ QgsDateTimeRange QgsMeshDataProviderTemporalCapabilities::timeExtent( const QDat
     if ( !times.isEmpty() )
     {
       durationSinceFirst += times.first();
-      durationSinceLast += times.last();
+      // adding one timestep (length as: times.last() - times.beforeLast)), to be sure we have enough steps
+      durationSinceLast += times.last() + ( times.last() - times[times.length() - 2] );
     }
 
     if ( !end.isValid() || groupReference.addMSecs( durationSinceLast ) > end )


### PR DESCRIPTION
## Description

This small change will Fix #48942 

The TemporalController does not take the last step into account, when loading Mesh layers.

This zip:

[123steps.zip](https://github.com/qgis/QGIS/files/9071375/123steps.zip)

contains 3 netcdf's (ugrid) with 1, 2 and 3 (day) timesteps to test.

WIthout this commit, you will not be able to see the last timestep, without changing the Animation range.

Note that we do the same (add one timestep to the range) for Vector temporal properties:
https://github.com/qgis/QGIS/blob/master/src/core/vector/qgsvectorlayertemporalproperties.cpp#L74
