### PR TITLE
Fix difference algorithm when differencing a point results in a null geometry

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/difference_points_vs_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/difference_points_vs_polys.gml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ difference_points_vs_polys.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>2 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.0">
+      <ogr:fid>points.0</ogr:fid>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.1">
+      <ogr:fid>points.1</ogr:fid>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.2">
+      <ogr:fid>points.2</ogr:fid>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2 5</gml:lowerCorner><gml:upperCorner>2 5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="difference_points_vs_polys.geom.3"><gml:pointMember><gml:Point gml:id="difference_points_vs_polys.geom.3.0"><gml:pos>2 5</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.3</ogr:fid>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.4">
+      <ogr:fid>points.4</ogr:fid>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-5 0</gml:lowerCorner><gml:upperCorner>-5 0</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="difference_points_vs_polys.geom.5"><gml:pointMember><gml:Point gml:id="difference_points_vs_polys.geom.5.0"><gml:pos>-5 0</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.5</ogr:fid>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.6">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 8</gml:lowerCorner><gml:upperCorner>-1 8</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiPoint srsName="urn:ogc:def:crs:EPSG::4326" gml:id="difference_points_vs_polys.geom.6"><gml:pointMember><gml:Point gml:id="difference_points_vs_polys.geom.6.0"><gml:pos>-1 8</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint></ogr:geometryProperty>
+      <ogr:fid>points.6</ogr:fid>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.7">
+      <ogr:fid>points.7</ogr:fid>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:difference_points_vs_polys gml:id="difference_points_vs_polys.8">
+      <ogr:fid>points.8</ogr:fid>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:difference_points_vs_polys>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/difference_points_vs_polys.xsd
+++ b/python/plugins/processing/tests/testdata/expected/difference_points_vs_polys.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="difference_points_vs_polys" type="ogr:difference_points_vs_polys_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="difference_points_vs_polys_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -435,6 +435,24 @@ tests:
           geometry:
             normalize: True
 
+  - algorithm: native:difference
+    name: Difference points vs polys
+    params:
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      OVERLAY:
+        name: polys.gml|layername=polys2
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/difference_points_vs_polys.gml
+        type: vector
+        compare:
+          fields:
+            fid: skip
+            gml_id: skip
+
   - algorithm: native:symmetricaldifference
     name: Test Symmetrical Difference A - B (basic)
     params:

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -163,7 +163,7 @@ void QgsOverlayUtils::difference( const QgsFeatureSource &sourceA, const QgsFeat
         geom = geom.difference( geomB );
       }
 
-      if ( !sanitizeDifferenceResult( geom, geometryType ) )
+      if ( !geom.isNull() && !sanitizeDifferenceResult( geom, geometryType ) )
         continue;
 
       const QgsAttributes attrsA( featA.attributes() );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1368,7 +1368,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
       const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, geos );
       unsigned int nPoints = 0;
       GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
-      return  nPoints > 0 ? std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() ) : std::make_unique< QgsPoint >();
+      return nPoints > 0 ? std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() ) : nullptr;
     }
     case GEOS_LINESTRING:
     {


### PR DESCRIPTION
Fixes #49291

An alternative to https://github.com/qgis/QGIS/pull/49294 which doesn't re-introduce the api break fixed by https://github.com/qgis/QGIS/pull/41260/commits/8730268766f825882434b858c81d089bada23bba