### PR TITLE
[3D] Add transparent support to the datadefined case of phong material

### DIFF
--- a/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
+++ b/python/3d/auto_generated/materials/qgsphongmaterialsettings.sip.in
@@ -97,7 +97,7 @@ Sets shininess of the surface
 
     void setOpacity( float opacity );
 %Docstring
-Sets shininess of the surface
+Sets opacity of the surface
 
 .. versionadded:: 3.26
 %End

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -249,6 +249,7 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::dataDefinedMaterial() const
   technique->addRenderPass( renderPass );
 
   eff->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess ) );
+  eff->addParameter( new Qt3DRender::QParameter( QStringLiteral( "opacity" ), mOpacity ) );
 
   eff->addTechnique( technique );
   material->setEffect( eff );

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -248,7 +248,7 @@ Qt3DRender::QMaterial *QgsPhongMaterialSettings::dataDefinedMaterial() const
   renderPass->setShaderProgram( shaderProgram );
   technique->addRenderPass( renderPass );
 
-  technique->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess ) );
+  eff->addParameter( new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess ) );
 
   eff->addTechnique( technique );
   material->setEffect( eff );

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -115,6 +115,7 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     {
       return mAmbient == other.mAmbient &&
              mDiffuse == other.mDiffuse &&
+             mOpacity == other.mOpacity &&
              mSpecular == other.mSpecular &&
              mShininess == other.mShininess;
     }

--- a/src/3d/materials/qgsphongmaterialsettings.h
+++ b/src/3d/materials/qgsphongmaterialsettings.h
@@ -91,7 +91,7 @@ class _3D_EXPORT QgsPhongMaterialSettings : public QgsAbstractMaterialSettings
     void setShininess( float shininess ) { mShininess = shininess; }
 
     /**
-     * Sets shininess of the surface
+     * Sets opacity of the surface
      * \since QGIS 3.26
      */
     void setOpacity( float opacity ) { mOpacity = opacity; }

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1252,4 +1252,3 @@ void Qgs3DMapScene::on3DAxisSettingsChanged()
     }
   }
 }
-

--- a/src/3d/shaders/phongDataDefined.vert
+++ b/src/3d/shaders/phongDataDefined.vert
@@ -40,4 +40,3 @@ void main()
     // Calculate vertex position in clip coordinates
     gl_Position = modelViewProjection * vec4(vertexPosition, 1.0);
 }
-

--- a/src/3d/shaders/phongDataDefined.vert
+++ b/src/3d/shaders/phongDataDefined.vert
@@ -24,6 +24,7 @@ uniform mat3 modelNormalMatrix;
 uniform mat4 modelViewProjection;
 
 uniform float texCoordScale;
+uniform float opacity;
 
 void main()
 {
@@ -33,9 +34,9 @@ void main()
 
 
     // colors defined data
-    vs_out.ambient=vec4(dataDefinedAmbiantColor,1.0);
-    vs_out.diffuse=vec4(dataDefinedDiffuseColor,1.0);
-    vs_out.specular=vec4(dataDefinedSpecularColor,1.0);
+    vs_out.ambient = vec4(dataDefinedAmbiantColor, opacity);
+    vs_out.diffuse = vec4(dataDefinedDiffuseColor, opacity);
+    vs_out.specular = vec4(dataDefinedSpecularColor, opacity);
 
     // Calculate vertex position in clip coordinates
     gl_Position = modelViewProjection * vec4(vertexPosition, 1.0);


### PR DESCRIPTION
An initial transparency support was added to phong material in https://github.com/qgis/QGIS/pull/48499. However, it did not handle the datadefined case. This PR fills the gap by adding the `opacity` value to the different color attributes. 

without opacity
![pas d'opacité](https://user-images.githubusercontent.com/497207/178275665-8c16182f-7ded-4171-9085-3d7cd11beeec.png)

50% opacity
![opacité 50%](https://user-images.githubusercontent.com/497207/178275725-065a2781-9047-4001-878b-cf5785470da4.png)

cc @NEDJIMAbelgacem @wonder-sk @benoitdm-oslandia 