### PR TITLE
Add missing Q_OBJECT macros and enable clazy check missing-qobject-macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,7 +887,7 @@ if (WITH_CORE)
   if (WITH_CLAZY)
     set(CMAKE_CXX_BASE_FLAGS "${CMAKE_CXX_FLAGS}")
     #  qcolor-from-literal crashes clang with clazy 1.11
-    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count")
+    set(CLAZY_BASE_CHECKS "connect-3arg-lambda,lambda-unique-connection,empty-qstringliteral,fully-qualified-moc-types,lowercase-qml-type-name,qfileinfo-exists,qmap-with-pointer-key,unused-non-trivial-variable,overridden-signal,qdeleteall,qstring-left,skipped-base-method,isempty-vs-count,missing-qobject-macro")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_BASE_FLAGS} -Xclang -plugin-arg-clazy -Xclang ${CLAZY_BASE_CHECKS}")
 
     if (WERROR AND NOT ${QGISDEBUG})

--- a/python/gui/auto_generated/processing/qgsprocessingaggregatewidgets.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingaggregatewidgets.sip.in
@@ -224,8 +224,9 @@ Moves up currently selected field
 Moves down currently selected field
 %End
 
-      public:
 };
+
+
 
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -146,9 +146,9 @@ Moves up currently selected field
 Moves down the currently selected field
 %End
 
-      public:
-      public:
 };
+
+
 
 
 /************************************************************************

--- a/src/app/devtools/networklogger/qgsnetworklogger.h
+++ b/src/app/devtools/networklogger/qgsnetworklogger.h
@@ -131,6 +131,7 @@ class QgsNetworkLogger : public QAbstractItemModel
  */
 class QgsNetworkLoggerProxyModel : public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/app/devtools/querylogger/qgsappquerylogger.h
+++ b/src/app/devtools/querylogger/qgsappquerylogger.h
@@ -112,6 +112,7 @@ class QgsAppQueryLogger : public QAbstractItemModel
  */
 class QgsDatabaseQueryLoggerProxyModel : public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/app/maptools/qgsmaptoolshapecircle2points.h
+++ b/src/app/maptools/qgsmaptoolshapecircle2points.h
@@ -40,6 +40,7 @@ class APP_EXPORT QgsMapToolShapeCircle2PointsMetadata : public QgsMapToolShapeMe
 
 class APP_EXPORT QgsMapToolShapeCircle2Points : public QgsMapToolShapeCircleAbstract
 {
+    Q_OBJECT
   public:
     QgsMapToolShapeCircle2Points( QgsMapToolCapture *parentTool )
       : QgsMapToolShapeCircleAbstract( QgsMapToolShapeCircle2PointsMetadata::TOOL_ID, parentTool )

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -22,27 +22,6 @@
 #include "qgsvectorlayer.h"
 
 
-#ifndef SIP_RUN
-class RelationNameEditorDelegate: public QStyledItemDelegate
-{
-  public:
-    RelationNameEditorDelegate( const QList<int> &editableColumns, QObject *parent = nullptr )
-      : QStyledItemDelegate( parent )
-      , mEditableColumns( editableColumns )
-    {}
-
-    virtual QWidget *createEditor( QWidget *parentWidget, const QStyleOptionViewItem &option, const QModelIndex &index ) const
-    {
-      if ( mEditableColumns.contains( index.column() ) )
-        return QStyledItemDelegate::createEditor( parentWidget, option, index );
-
-      return nullptr;
-    }
-  private:
-    QList<int> mEditableColumns;
-};
-#endif
-
 QgsRelationManagerDialog::QgsRelationManagerDialog( QgsRelationManager *relationMgr, QWidget *parent )
   : QWidget( parent )
   , Ui::QgsRelationManagerDialogBase()

--- a/src/app/qgsrelationmanagerdialog.h
+++ b/src/app/qgsrelationmanagerdialog.h
@@ -56,4 +56,24 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
     QString getUniqueId( const QString &idTmpl, const QString &ids ) const;
 };
 
+class RelationNameEditorDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+  public:
+    RelationNameEditorDelegate( const QList<int> &editableColumns, QObject *parent = nullptr )
+      : QStyledItemDelegate( parent )
+      , mEditableColumns( editableColumns )
+    {}
+
+    virtual QWidget *createEditor( QWidget *parentWidget, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+    {
+      if ( mEditableColumns.contains( index.column() ) )
+        return QStyledItemDelegate::createEditor( parentWidget, option, index );
+
+      return nullptr;
+    }
+  private:
+    QList<int> mEditableColumns;
+};
+
 #endif // QGSRELATIONMANAGERDIALOG_H

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -29,30 +29,6 @@
 #include "qgsapplication.h"
 #include "qgsscalewidget.h"
 
-class SnapTypeMenu: public QMenu
-{
-  public:
-    SnapTypeMenu( const QString &title, QWidget *parent = nullptr )
-      : QMenu( title, parent ) {}
-
-    void mouseReleaseEvent( QMouseEvent *e )
-    {
-      QAction *action = activeAction();
-      if ( action )
-        action->trigger();
-      else
-        QMenu::mouseReleaseEvent( e );
-    }
-
-    // set focus to parent so that mTypeButton is not displayed
-    void hideEvent( QHideEvent *e )
-    {
-      qobject_cast<QWidget *>( parent() )->setFocus();
-      QMenu::hideEvent( e );
-    }
-};
-
-
 QgsSnappingLayerDelegate::QgsSnappingLayerDelegate( QgsMapCanvas *canvas, QObject *parent )
   : QItemDelegate( parent )
   , mCanvas( canvas )
@@ -70,7 +46,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
     QToolButton *mTypeButton = new QToolButton( parent );
     mTypeButton->setToolTip( tr( "Snapping Type" ) );
     mTypeButton->setPopupMode( QToolButton::InstantPopup );
-    SnapTypeMenu *typeMenu = new SnapTypeMenu( tr( "Set Snapping Mode" ), parent );
+    SnappingLayerDelegateTypeMenu *typeMenu = new SnappingLayerDelegateTypeMenu( tr( "Set Snapping Mode" ), parent );
 
     for ( Qgis::SnappingType type : qgsEnumList<Qgis::SnappingType>() )
     {

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -102,4 +102,29 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
     void hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings );
 };
 
+class SnappingLayerDelegateTypeMenu: public QMenu
+{
+    Q_OBJECT
+
+  public:
+    SnappingLayerDelegateTypeMenu( const QString &title, QWidget *parent = nullptr )
+      : QMenu( title, parent ) {}
+
+    void mouseReleaseEvent( QMouseEvent *e )
+    {
+      QAction *action = activeAction();
+      if ( action )
+        action->trigger();
+      else
+        QMenu::mouseReleaseEvent( e );
+    }
+
+    // set focus to parent so that mTypeButton is not displayed
+    void hideEvent( QHideEvent *e )
+    {
+      qobject_cast<QWidget *>( parent() )->setFocus();
+      QMenu::hideEvent( e );
+    }
+};
+
 #endif // QGSSNAPPINGLAYERTREEVIEW_H

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -47,22 +47,6 @@
 #include "modeltest.h"
 #endif
 
-class SnapTypeMenu: public QMenu
-{
-  public:
-    SnapTypeMenu( const QString &title, QWidget *parent = nullptr )
-      : QMenu( title, parent ) {}
-
-    void mouseReleaseEvent( QMouseEvent *e )
-    {
-      QAction *action = activeAction();
-      if ( action )
-        action->trigger();
-      else
-        QMenu::mouseReleaseEvent( e );
-    }
-};
-
 QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas, QWidget *parent )
   : QWidget( parent )
   , mProject( project )

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -182,4 +182,21 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     void cleanGroup( QgsLayerTreeNode *node );
 };
 
+class SnapTypeMenu: public QMenu
+{
+    Q_OBJECT
+  public:
+    SnapTypeMenu( const QString &title, QWidget *parent = nullptr )
+      : QMenu( title, parent ) {}
+
+    void mouseReleaseEvent( QMouseEvent *e )
+    {
+      QAction *action = activeAction();
+      if ( action )
+        action->trigger();
+      else
+        QMenu::mouseReleaseEvent( e );
+    }
+};
+
 #endif

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -730,6 +730,7 @@ class CORE_EXPORT QgsDataDefinedSizeLegendNode : public QgsLayerTreeModelLegendN
  */
 class CORE_EXPORT QgsVectorLabelLegendNode : public QgsLayerTreeModelLegendNode
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/core/providers/copc/qgscopcprovider.h
+++ b/src/core/providers/copc/qgscopcprovider.h
@@ -66,6 +66,7 @@ class QgsCopcProvider: public QgsPointCloudDataProvider
 
 class QgsCopcProviderMetadata : public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsCopcProviderMetadata();
     QIcon icon() const override;

--- a/src/core/providers/ept/qgseptprovider.h
+++ b/src/core/providers/ept/qgseptprovider.h
@@ -62,6 +62,7 @@ class QgsEptProvider: public QgsPointCloudDataProvider
 
 class QgsEptProviderMetadata : public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsEptProviderMetadata();
     QIcon icon() const override;

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -370,6 +370,7 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
  */
 class QgsGdalProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsGdalProviderMetadata();
     QIcon icon() const override;

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -101,6 +101,8 @@ class QgsMemoryProvider final: public QgsVectorDataProvider
 
 class QgsMemoryProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
+
   public:
     QgsMemoryProviderMetadata();
     QIcon icon() const override;

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
@@ -189,6 +189,8 @@ class CORE_EXPORT QgsMeshMemoryDataProvider final: public QgsMeshDataProvider
 
 class QgsMeshMemoryProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
+
   public:
     QgsMeshMemoryProviderMetadata();
     QIcon icon() const override;

--- a/src/core/providers/ogr/qgsogrprovidermetadata.h
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.h
@@ -28,6 +28,7 @@ email                : nyall dot dawson at gmail dot com
  */
 class QgsOgrProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
 
     QgsOgrProviderMetadata();

--- a/src/core/vectortile/qgsvectortileprovidermetadata.h
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.h
@@ -29,6 +29,7 @@
  */
 class QgsVectorTileProviderMetadata : public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsVectorTileProviderMetadata();
     QIcon icon() const override;

--- a/src/gui/layout/qgsgeopdflayertreemodel.h
+++ b/src/gui/layout/qgsgeopdflayertreemodel.h
@@ -75,6 +75,7 @@ class GUI_EXPORT QgsGeoPdfLayerTreeModel : public QgsMapLayerModel
 ///@cond PRIVATE
 class GUI_EXPORT QgsGeoPdfLayerFilteredTreeModel : public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
 
     QgsGeoPdfLayerFilteredTreeModel( QgsGeoPdfLayerTreeModel *sourceModel, QObject *parent = nullptr );

--- a/src/gui/maptools/qgsmaptoolcapturelayergeometry.h
+++ b/src/gui/maptools/qgsmaptoolcapturelayergeometry.h
@@ -29,6 +29,7 @@ class QgsMapCanvas;
  */
 class GUI_EXPORT QgsMapToolCaptureLayerGeometry : public QgsMapToolCapture
 {
+    Q_OBJECT
   public:
     //! Constructor
     QgsMapToolCaptureLayerGeometry( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode )

--- a/src/gui/mesh/qgsmeshdatasetgrouptreeview.h
+++ b/src/gui/mesh/qgsmeshdatasetgrouptreeview.h
@@ -126,6 +126,7 @@ class QgsMeshDatasetGroupTreeModel : public QAbstractItemModel
  */
 class QgsMeshAvailableDatasetGroupTreeModel: public QgsMeshDatasetGroupTreeModel
 {
+    Q_OBJECT
   public:
     QgsMeshAvailableDatasetGroupTreeModel( QObject *parent = nullptr );
 
@@ -146,6 +147,7 @@ class QgsMeshAvailableDatasetGroupTreeModel: public QgsMeshDatasetGroupTreeModel
  */
 class  QgsMeshDatasetGroupProxyModel: public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
     QgsMeshDatasetGroupProxyModel( QAbstractItemModel *sourceModel );
 
@@ -301,6 +303,7 @@ class GUI_EXPORT QgsMeshActiveDatasetGroupTreeView : public QTreeView
  */
 class GUI_EXPORT QgsMeshDatasetGroupListModel: public QAbstractListModel
 {
+    Q_OBJECT
   public:
     explicit QgsMeshDatasetGroupListModel( QObject *parent );
 

--- a/src/gui/mesh/qgsmeshstaticdatasetwidget.h
+++ b/src/gui/mesh/qgsmeshstaticdatasetwidget.h
@@ -35,6 +35,7 @@ class QgsMeshDataProvider;
  */
 class QgsMeshDatasetListModel: public QAbstractListModel
 {
+    Q_OBJECT
   public:
     //! Constructor
     QgsMeshDatasetListModel( QObject *parent );

--- a/src/gui/processing/models/qgsmodeldesignerinputstreewidget.h
+++ b/src/gui/processing/models/qgsmodeldesignerinputstreewidget.h
@@ -34,6 +34,7 @@ class QMimeData;
  */
 class QgsModelDesignerInputsTreeWidget : public QTreeWidget
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/gui/processing/models/qgsmodelinputreorderwidget.h
+++ b/src/gui/processing/models/qgsmodelinputreorderwidget.h
@@ -72,6 +72,7 @@ class GUI_EXPORT QgsModelInputReorderWidget : public QWidget, private Ui::QgsMod
  */
 class GUI_EXPORT QgsModelInputReorderDialog : public QDialog
 {
+    Q_OBJECT
 
   public:
 

--- a/src/gui/processing/qgsprocessingaggregatewidgets.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.cpp
@@ -27,6 +27,7 @@
 #include <QTableView>
 #include <mutex>
 
+
 //
 // QgsAggregateMappingModel
 //
@@ -365,9 +366,9 @@ QgsAggregateMappingWidget::QgsAggregateMappingWidget( QWidget *parent,
 
   mModel = new QgsAggregateMappingModel( sourceFields, this );
   mTableView->setModel( mModel );
-  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::SourceExpression ), new QgsFieldMappingWidget::ExpressionDelegate( this ) );
-  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::Aggregate ), new QgsAggregateMappingWidget::AggregateDelegate( mTableView ) );
-  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::DestinationType ), new QgsFieldMappingWidget::TypeDelegate( mTableView ) );
+  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::SourceExpression ), new QgsFieldMappingExpressionDelegate( this ) );
+  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::Aggregate ), new QgsAggregateMappingDelegate( mTableView ) );
+  mTableView->setItemDelegateForColumn( static_cast<int>( QgsAggregateMappingModel::ColumnDataIndex::DestinationType ), new QgsFieldMappingTypeDelegate( mTableView ) );
   updateColumns();
   // Make sure columns are updated when rows are added
   connect( mModel, &QgsAggregateMappingModel::rowsInserted, this, [ = ] { updateColumns(); } );
@@ -510,22 +511,23 @@ std::list<int> QgsAggregateMappingWidget::selectedRows()
 }
 
 
+/// @cond PRIVATE
 
 //
 // AggregateDelegate
 //
 
-QgsAggregateMappingWidget::AggregateDelegate::AggregateDelegate( QObject *parent )
+QgsAggregateMappingDelegate::QgsAggregateMappingDelegate( QObject *parent )
   : QStyledItemDelegate( parent )
 {
 }
 
-QWidget *QgsAggregateMappingWidget::AggregateDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex & ) const
+QWidget *QgsAggregateMappingDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex & ) const
 {
   Q_UNUSED( option )
   QComboBox *editor = new QComboBox( parent );
 
-  const QStringList aggregateList { QgsAggregateMappingWidget::AggregateDelegate::aggregates() };
+  const QStringList aggregateList { aggregates() };
   int i = 0;
   for ( const QString &aggregate : aggregateList )
   {
@@ -540,13 +542,13 @@ QWidget *QgsAggregateMappingWidget::AggregateDelegate::createEditor( QWidget *pa
            [ = ]( int currentIndex )
   {
     Q_UNUSED( currentIndex )
-    const_cast< QgsAggregateMappingWidget::AggregateDelegate *>( this )->emit commitData( editor );
+    const_cast< QgsAggregateMappingDelegate *>( this )->emit commitData( editor );
   } );
 
   return editor;
 }
 
-void QgsAggregateMappingWidget::AggregateDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
+void QgsAggregateMappingDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
 {
   QComboBox *editorWidget { qobject_cast<QComboBox *>( editor ) };
   if ( ! editorWidget )
@@ -556,7 +558,7 @@ void QgsAggregateMappingWidget::AggregateDelegate::setEditorData( QWidget *edito
   editorWidget->setCurrentIndex( editorWidget->findData( value ) );
 }
 
-void QgsAggregateMappingWidget::AggregateDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
+void QgsAggregateMappingDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
 {
   QComboBox *editorWidget { qobject_cast<QComboBox *>( editor ) };
   if ( ! editorWidget )
@@ -566,7 +568,7 @@ void QgsAggregateMappingWidget::AggregateDelegate::setModelData( QWidget *editor
   model->setData( index, currentValue, Qt::EditRole );
 }
 
-const QStringList QgsAggregateMappingWidget::AggregateDelegate::aggregates()
+const QStringList QgsAggregateMappingDelegate::aggregates()
 {
   static QStringList sAggregates;
   static std::once_flag initialized;
@@ -597,3 +599,4 @@ const QStringList QgsAggregateMappingWidget::AggregateDelegate::aggregates()
   return sAggregates;
 }
 
+/// @endcond

--- a/src/gui/processing/qgsprocessingaggregatewidgets.h
+++ b/src/gui/processing/qgsprocessingaggregatewidgets.h
@@ -232,26 +232,32 @@ class GUI_EXPORT QgsAggregateMappingWidget : public QgsPanelWidget
     void updateColumns();
     //! Returns selected row indexes in ascending order
     std::list<int> selectedRows( );
-
-
-    class AggregateDelegate: public QStyledItemDelegate
-    {
-
-      public:
-
-        AggregateDelegate( QObject *parent = nullptr );
-
-        // QAbstractItemDelegate interface
-        QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-        void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
-        void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
-
-      private:
-        //! Returns a static list of supported aggregates
-        static const QStringList aggregates();
-    };
-
 };
 
+/// @cond PRIVATE
+
+#ifndef SIP_RUN
+
+class QgsAggregateMappingDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QgsAggregateMappingDelegate( QObject *parent = nullptr );
+
+    // QAbstractItemDelegate interface
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+
+  private:
+    //! Returns a static list of supported aggregates
+    static const QStringList aggregates();
+};
+
+#endif
+
+/// @endcond
 
 #endif // QGSPROCESSINGAGGREGATEWIDGETS_H

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.h
@@ -32,6 +32,7 @@ class QToolButton;
 
 class GUI_EXPORT QgsProcessingDxfLayerDetailsWidget : public QgsPanelWidget, private Ui::QgsProcessingDxfLayerDetailsWidget
 {
+    Q_OBJECT
   public:
     QgsProcessingDxfLayerDetailsWidget( const QVariant &value, QgsProject *project );
 

--- a/src/gui/processing/qgsprocessingmeshdatasetwidget.h
+++ b/src/gui/processing/qgsprocessingmeshdatasetwidget.h
@@ -103,6 +103,8 @@ class GUI_EXPORT QgsProcessingMeshDatasetGroupsWidgetWrapper  : public QgsAbstra
 
 class GUI_EXPORT QgsProcessingMeshDatasetGroupsParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
 {
+    Q_OBJECT
+
   public:
     QgsProcessingMeshDatasetGroupsParameterDefinitionWidget( QgsProcessingContext &context,
         const QgsProcessingParameterWidgetContext &widgetContext,
@@ -118,6 +120,7 @@ class GUI_EXPORT QgsProcessingMeshDatasetGroupsParameterDefinitionWidget : publi
 class GUI_EXPORT QgsProcessingMeshDatasetTimeWidget : public QWidget, private Ui::QgsProcessingMeshDatasetTimeWidgetBase
 {
     Q_OBJECT
+
   public:
     QgsProcessingMeshDatasetTimeWidget( QWidget *parent = nullptr,
                                         const QgsProcessingParameterMeshDatasetTime *param = nullptr,
@@ -203,6 +206,8 @@ class GUI_EXPORT QgsProcessingMeshDatasetTimeWidgetWrapper  : public QgsAbstract
 
 class GUI_EXPORT QgsProcessingMeshDatasetTimeParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
 {
+    Q_OBJECT
+
   public:
     QgsProcessingMeshDatasetTimeParameterDefinitionWidget( QgsProcessingContext &context,
         const QgsProcessingParameterWidgetContext &widgetContext,

--- a/src/gui/processing/qgsprocessingtininputlayerswidget.cpp
+++ b/src/gui/processing/qgsprocessingtininputlayerswidget.cpp
@@ -33,7 +33,7 @@ QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersWidget( QgsProject
   onLayerChanged( mComboLayers->currentLayer() );
 
   mTableView->setModel( &mInputLayersModel );
-  mTableView->setItemDelegateForColumn( 1, new Delegate( mTableView ) );
+  mTableView->setItemDelegateForColumn( 1, new QgsProcessingTinInputLayersDelegate( mTableView ) );
 }
 
 QVariant QgsProcessingTinInputLayersWidget::value() const
@@ -137,23 +137,23 @@ void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersWidget::onLay
   emit changed();
 }
 
-QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::QgsProcessingTinInputLayersModel( QgsProject *project ):
+QgsProcessingTinInputLayersModel::QgsProcessingTinInputLayersModel( QgsProject *project ):
   mProject( project )
 {}
 
-int QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::rowCount( const QModelIndex &parent ) const
+int QgsProcessingTinInputLayersModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent );
   return mInputLayers.count();
 }
 
-int QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::columnCount( const QModelIndex &parent ) const
+int QgsProcessingTinInputLayersModel::columnCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent );
   return 3;
 }
 
-QVariant QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::data( const QModelIndex &index, int role ) const
+QVariant QgsProcessingTinInputLayersModel::data( const QModelIndex &index, int role ) const
 {
   if ( !index.isValid() )
     return QVariant();
@@ -233,7 +233,7 @@ QVariant QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::da
   return QVariant();
 }
 
-bool QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::setData( const QModelIndex &index, const QVariant &value, int role )
+bool QgsProcessingTinInputLayersModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
   if ( index.column() == 1 && role == Qt::EditRole )
   {
@@ -244,7 +244,7 @@ bool QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::setDat
   return false;
 }
 
-Qt::ItemFlags QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::flags( const QModelIndex &index ) const
+Qt::ItemFlags QgsProcessingTinInputLayersModel::flags( const QModelIndex &index ) const
 {
   if ( !index.isValid() )
     return Qt::NoItemFlags;
@@ -255,7 +255,7 @@ Qt::ItemFlags QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersMode
   return QAbstractTableModel::flags( index );
 }
 
-QVariant QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::headerData( int section, Qt::Orientation orientation, int role ) const
+QVariant QgsProcessingTinInputLayersModel::headerData( int section, Qt::Orientation orientation, int role ) const
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole )
   {
@@ -279,14 +279,14 @@ QVariant QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::he
   return QVariant();
 }
 
-void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::addLayer( QgsProcessingParameterTinInputLayers::InputLayer &layer )
+void QgsProcessingTinInputLayersModel::addLayer( QgsProcessingParameterTinInputLayers::InputLayer &layer )
 {
   beginInsertRows( QModelIndex(), mInputLayers.count() - 1, mInputLayers.count() - 1 );
   mInputLayers.append( layer );
   endInsertRows();
 }
 
-void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::removeLayer( int index )
+void QgsProcessingTinInputLayersModel::removeLayer( int index )
 {
   if ( index < 0 || index >= mInputLayers.count() )
     return;
@@ -295,22 +295,22 @@ void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::remove
   endRemoveRows();
 }
 
-void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::clear()
+void QgsProcessingTinInputLayersModel::clear()
 {
   mInputLayers.clear();
 }
 
-QList<QgsProcessingParameterTinInputLayers::InputLayer> QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::layers() const
+QList<QgsProcessingParameterTinInputLayers::InputLayer> QgsProcessingTinInputLayersModel::layers() const
 {
   return mInputLayers;
 }
 
-void QgsProcessingTinInputLayersWidget::QgsProcessingTinInputLayersModel::setProject( QgsProject *project )
+void QgsProcessingTinInputLayersModel::setProject( QgsProject *project )
 {
   mProject = project;
 }
 
-QWidget *QgsProcessingTinInputLayersWidget::Delegate::createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+QWidget *QgsProcessingTinInputLayersDelegate::createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
   Q_UNUSED( option );
   Q_UNUSED( index );
@@ -320,7 +320,7 @@ QWidget *QgsProcessingTinInputLayersWidget::Delegate::createEditor( QWidget *par
   return comboType;
 }
 
-void QgsProcessingTinInputLayersWidget::Delegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
+void QgsProcessingTinInputLayersDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
 {
   QComboBox *comboType = qobject_cast<QComboBox *>( editor );
   Q_ASSERT( comboType );
@@ -333,7 +333,7 @@ void QgsProcessingTinInputLayersWidget::Delegate::setEditorData( QWidget *editor
     comboType->setCurrentIndex( 0 );
 }
 
-void QgsProcessingTinInputLayersWidget::Delegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
+void QgsProcessingTinInputLayersDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
 {
   QComboBox *comboType = qobject_cast<QComboBox *>( editor );
   Q_ASSERT( comboType );

--- a/src/gui/processing/qgsprocessingtininputlayerswidget.h
+++ b/src/gui/processing/qgsprocessingtininputlayerswidget.h
@@ -27,6 +27,49 @@
 
 /// @cond PRIVATE
 
+class QgsProcessingTinInputLayersModel: public QAbstractTableModel
+{
+    Q_OBJECT
+  public:
+    enum Roles
+    {
+      Type = Qt::UserRole
+    };
+
+    QgsProcessingTinInputLayersModel( QgsProject *project );
+
+    int rowCount( const QModelIndex &parent ) const override;
+    int columnCount( const QModelIndex &parent ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+
+    void addLayer( QgsProcessingParameterTinInputLayers::InputLayer &layer );
+    void removeLayer( int index );
+    void clear();
+
+    QList<QgsProcessingParameterTinInputLayers::InputLayer> layers() const;
+
+    void setProject( QgsProject *project );
+
+  private:
+    QList<QgsProcessingParameterTinInputLayers::InputLayer> mInputLayers;
+    QgsProject *mProject = nullptr;
+};
+
+class QgsProcessingTinInputLayersDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+  public:
+    QgsProcessingTinInputLayersDelegate( QObject *parent ): QStyledItemDelegate( parent ) {}
+
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+};
+
+
 class GUI_EXPORT QgsProcessingTinInputLayersWidget: public QWidget, private Ui::QgsProcessingTinInputLayersWidgetBase
 {
     Q_OBJECT
@@ -46,45 +89,6 @@ class GUI_EXPORT QgsProcessingTinInputLayersWidget: public QWidget, private Ui::
     void onLayersRemove();
 
   private:
-    class QgsProcessingTinInputLayersModel: public QAbstractTableModel
-    {
-      public:
-        enum Roles
-        {
-          Type = Qt::UserRole
-        };
-
-        QgsProcessingTinInputLayersModel( QgsProject *project );
-
-        int rowCount( const QModelIndex &parent ) const override;
-        int columnCount( const QModelIndex &parent ) const override;
-        QVariant data( const QModelIndex &index, int role ) const override;
-        bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
-        Qt::ItemFlags flags( const QModelIndex &index ) const override;
-        QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
-
-        void addLayer( QgsProcessingParameterTinInputLayers::InputLayer &layer );
-        void removeLayer( int index );
-        void clear();
-
-        QList<QgsProcessingParameterTinInputLayers::InputLayer> layers() const;
-
-        void setProject( QgsProject *project );
-
-      private:
-        QList<QgsProcessingParameterTinInputLayers::InputLayer> mInputLayers;
-        QgsProject *mProject = nullptr;
-    };
-
-    class Delegate: public QStyledItemDelegate
-    {
-      public:
-        Delegate( QObject *parent ): QStyledItemDelegate( parent ) {}
-
-        QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-        void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
-        void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
-    };
 
     QgsProcessingTinInputLayersModel mInputLayersModel;
 };

--- a/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingvectortilewriterlayerswidgetwrapper.h
@@ -33,6 +33,7 @@ class QToolButton;
 
 class QgsProcessingVectorTileWriteLayerDetailsWidget : public QgsPanelWidget, private Ui::QgsProcessingVectorTileWriterLayerDetailsWidget
 {
+    Q_OBJECT
   public:
     QgsProcessingVectorTileWriteLayerDetailsWidget( const QVariant &value, QgsProject *project );
 

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -685,6 +685,7 @@ class GUI_EXPORT QgsProcessingParameterWidgetFactoryInterface
  */
 class GUI_EXPORT QgsProcessingHiddenWidgetWrapper: public QgsAbstractProcessingParameterWidgetWrapper
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/gui/qgsdatabaseschemacombobox.h
+++ b/src/gui/qgsdatabaseschemacombobox.h
@@ -29,6 +29,7 @@ class QgsAbstractDatabaseProviderConnection;
 #ifndef SIP_RUN
 class GUI_EXPORT QgsDatabaseSchemaComboBoxSortModel: public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
     explicit QgsDatabaseSchemaComboBoxSortModel( QObject *parent = nullptr );
   protected:

--- a/src/gui/qgsdatabasetablecombobox.h
+++ b/src/gui/qgsdatabasetablecombobox.h
@@ -29,6 +29,7 @@ class QgsAbstractDatabaseProviderConnection;
 #ifndef SIP_RUN
 class GUI_EXPORT QgsDatabaseTableComboBoxSortModel: public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
     explicit QgsDatabaseTableComboBoxSortModel( QObject *parent = nullptr );
   protected:

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -29,6 +29,7 @@
  */
 class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpressionStoreDialogBase
 {
+    Q_OBJECT
   public:
 
     /**

--- a/src/gui/qgsfieldmappingwidget.h
+++ b/src/gui/qgsfieldmappingwidget.h
@@ -154,35 +154,44 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget
     //! Returns selected row indexes in ascending order
     std::list<int> selectedRows( );
 
-    class ExpressionDelegate: public QStyledItemDelegate
-    {
-
-      public:
-
-        ExpressionDelegate( QObject *parent = nullptr );
-
-        // QAbstractItemDelegate interface
-        QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-        void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
-        void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
-    };
-
-    class TypeDelegate: public QStyledItemDelegate
-    {
-
-      public:
-
-        TypeDelegate( QObject *parent = nullptr );
-
-        // QAbstractItemDelegate interface
-        QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-        void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
-        void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
-    };
-
     friend class QgsAggregateMappingWidget;
 
 };
 
+/// @cond PRIVATE
+
+#ifndef SIP_RUN
+
+class QgsFieldMappingExpressionDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QgsFieldMappingExpressionDelegate( QObject *parent = nullptr );
+
+    // QAbstractItemDelegate interface
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+};
+
+class QgsFieldMappingTypeDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+
+    QgsFieldMappingTypeDelegate( QObject *parent = nullptr );
+
+    // QAbstractItemDelegate interface
+    QWidget *createEditor( QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+    void setEditorData( QWidget *editor, const QModelIndex &index ) const override;
+    void setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const override;
+};
+
+#endif
+
+/// @endcond
 
 #endif // QGSFIELDMAPPINGWIDGET_H

--- a/src/gui/qgsnewvectortabledialog.h
+++ b/src/gui/qgsnewvectortabledialog.h
@@ -46,6 +46,7 @@ class QgsNewVectorTableFieldModel;
  */
 class GUI_EXPORT QgsNewVectorTableDialog : public QDialog, private Ui_QgsNewVectorTableDialogBase
 {
+    Q_OBJECT
   public:
 
     /**
@@ -146,6 +147,7 @@ class GUI_EXPORT QgsNewVectorTableDialog : public QDialog, private Ui_QgsNewVect
 #ifndef SIP_RUN
 class QgsNewVectorTableDialogFieldsDelegate: public QStyledItemDelegate
 {
+    Q_OBJECT
   public:
 
     QgsNewVectorTableDialogFieldsDelegate( const QList< QgsVectorDataProvider::NativeType> &typeList, QObject *parent = nullptr );
@@ -168,6 +170,7 @@ class QgsNewVectorTableDialogFieldsDelegate: public QStyledItemDelegate
 
 class QgsNewVectorTableFieldModel: public QgsFieldModel
 {
+    Q_OBJECT
 
   public:
 

--- a/src/gui/qgsproviderconnectioncombobox.h
+++ b/src/gui/qgsproviderconnectioncombobox.h
@@ -28,6 +28,7 @@ class QgsProviderConnectionModel;
 #ifndef SIP_RUN
 class GUI_EXPORT QgsProviderConnectionComboBoxSortModel: public QSortFilterProxyModel
 {
+    Q_OBJECT
   public:
     explicit QgsProviderConnectionComboBoxSortModel( QObject *parent = nullptr );
   protected:

--- a/src/gui/qgstabbarproxystyle.h
+++ b/src/gui/qgstabbarproxystyle.h
@@ -36,6 +36,7 @@
  */
 class GUI_EXPORT QgsTabBarProxyStyle : public QgsProxyStyle
 {
+    Q_OBJECT
   public:
 
     QgsTabBarProxyStyle( QTabBar *tabBar );

--- a/src/gui/vector/qgsdiagramproperties.cpp
+++ b/src/gui/vector/qgsdiagramproperties.cpp
@@ -52,24 +52,6 @@
 #include <QStyledItemDelegate>
 #include <QRandomGenerator>
 
-/**
- * \ingroup gui
- * \class EditBlockerDelegate
- */
-class EditBlockerDelegate: public QStyledItemDelegate
-{
-  public:
-    EditBlockerDelegate( QObject *parent = nullptr )
-      : QStyledItemDelegate( parent )
-    {}
-
-    QWidget *createEditor( QWidget *, const QStyleOptionViewItem &, const QModelIndex & ) const override
-    {
-      return nullptr;
-    }
-};
-
-
 QgsExpressionContext QgsDiagramProperties::createExpressionContext() const
 {
   QgsExpressionContext expContext;

--- a/src/gui/vector/qgsdiagramproperties.h
+++ b/src/gui/vector/qgsdiagramproperties.h
@@ -123,6 +123,23 @@ class GUI_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
 };
 
 
+/**
+ * \ingroup gui
+ * \class EditBlockerDelegate
+ */
+class EditBlockerDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+  public:
+    EditBlockerDelegate( QObject *parent = nullptr )
+      : QStyledItemDelegate( parent )
+    {}
+
+    QWidget *createEditor( QWidget *, const QStyleOptionViewItem &, const QModelIndex & ) const override
+    {
+      return nullptr;
+    }
+};
 
 
 #endif // QGSDIAGRAMPROPERTIES_H

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -102,6 +102,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
 
 class QgsAfsProviderMetadata: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsAfsProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -222,6 +222,7 @@ class QgsAmsTiledImageDownloadHandler : public QObject
 
 class QgsAmsProviderMetadata: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsAmsProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -254,6 +254,7 @@ class QgsDelimitedTextProvider final: public QgsVectorDataProvider
 
 class QgsDelimitedTextProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsDelimitedTextProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/geonode/CMakeLists.txt
+++ b/src/providers/geonode/CMakeLists.txt
@@ -13,6 +13,10 @@ if (WITH_GUI)
   )
 endif()
 
+set(GEONODE_HDRS
+  qgsgeonodeprovider.h
+)
+
 ########################################################
 # Build
 
@@ -21,7 +25,7 @@ include_directories(
   ${CMAKE_BINARY_DIR}/src/ui
 )
 
-add_library(provider_geonode MODULE ${GEONODE_SRCS})
+add_library(provider_geonode MODULE ${GEONODE_SRCS} ${GEONODE_HDRS})
 
 # require c++17
 target_compile_features(provider_geonode PRIVATE cxx_std_17)
@@ -50,4 +54,3 @@ endif()
 install (TARGETS provider_geonode
   RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}
   LIBRARY DESTINATION ${QGIS_PLUGIN_DIR})
-

--- a/src/providers/geonode/qgsgeonodeprovider.h
+++ b/src/providers/geonode/qgsgeonodeprovider.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                              qgsgeonodeprovider.cpp
+                              qgsgeonodeprovider.h
                               ----------------------
     begin                : September 2017
     copyright            : (C) 2017 by Nyall Dawson
@@ -15,31 +15,24 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifndef QGSGEONODEPROVIDERMETADATA_H
+#define QGSGEONODEPROVIDERMETADATA_H
+
 #include <QList>
 
-#include "qgsgeonodeprovider.h"
+#include "qgis.h"
+#include "qgsprovidermetadata.h"
+#include "qgsgeonodedataitems.h"
+#include "qgsapplication.h"
 
-static const QString PROVIDER_KEY = QStringLiteral( "geonode" );
-static const QString PROVIDER_DESCRIPTION = QStringLiteral( "GeoNode provider" );
-
-QgsGeoNodeProviderMetadata::QgsGeoNodeProviderMetadata()
-  : QgsProviderMetadata( PROVIDER_KEY, PROVIDER_DESCRIPTION )
+class QgsGeoNodeProviderMetadata: public QgsProviderMetadata
 {
-}
+    Q_OBJECT
+  public:
+    QgsGeoNodeProviderMetadata();
 
-QIcon QgsGeoNodeProviderMetadata::icon() const
-{
-  return QgsApplication::getThemeIcon( QStringLiteral( "mIconGeonode.svg" ) );
-}
+    QIcon icon() const override;
+    QList<QgsDataItemProvider *> dataItemProviders() const override;
+};
 
-QList<QgsDataItemProvider *> QgsGeoNodeProviderMetadata::dataItemProviders() const
-{
-  QList<QgsDataItemProvider *> providers;
-  providers << new QgsGeoNodeDataItemProvider();
-  return providers;
-}
-
-QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
-{
-  return new QgsGeoNodeProviderMetadata();
-}
+#endif // QGSGEONODEPROVIDERMETADATA_H

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -119,6 +119,7 @@ class QgsGPXProvider final: public QgsVectorDataProvider
 
 class QgsGpxProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsGpxProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/hana/qgshanaprovider.h
+++ b/src/providers/hana/qgshanaprovider.h
@@ -172,6 +172,8 @@ class QgsHanaProvider final : public QgsVectorDataProvider
 
 class QgsHanaProviderMetadata : public QgsProviderMetadata
 {
+    Q_OBJECT
+
   public:
     QgsHanaProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -141,6 +141,7 @@ class QgsMdalProvider : public QgsMeshDataProvider
 
 class QgsMdalProviderMetadata: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsMdalProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -397,16 +397,16 @@ bool QgsMssqlNewConnection::testPrimaryKeyInGeometryColumns() const
   return test;
 }
 
-QgsMssqlNewConnection::SchemaModel::SchemaModel( QObject *parent ): QAbstractListModel( parent )
+SchemaModel::SchemaModel( QObject *parent ): QAbstractListModel( parent )
 {}
 
-int QgsMssqlNewConnection::SchemaModel::rowCount( const QModelIndex &parent ) const
+int SchemaModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
   return mSchemas.count();
 }
 
-QVariant QgsMssqlNewConnection::SchemaModel::data( const QModelIndex &index, int role ) const
+QVariant SchemaModel::data( const QModelIndex &index, int role ) const
 {
   if ( !index.isValid() || index.row() >= mSchemas.count() )
     return QVariant();
@@ -430,7 +430,7 @@ QVariant QgsMssqlNewConnection::SchemaModel::data( const QModelIndex &index, int
   return QVariant();
 }
 
-bool QgsMssqlNewConnection::SchemaModel::setData( const QModelIndex &index, const QVariant &value, int role )
+bool SchemaModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
   if ( !index.isValid() || index.row() >= mSchemas.count() )
     return false;
@@ -451,28 +451,28 @@ bool QgsMssqlNewConnection::SchemaModel::setData( const QModelIndex &index, cons
   return false;
 }
 
-Qt::ItemFlags QgsMssqlNewConnection::SchemaModel::flags( const QModelIndex &index ) const
+Qt::ItemFlags SchemaModel::flags( const QModelIndex &index ) const
 {
   return QAbstractListModel::flags( index ) | Qt::ItemFlag::ItemIsUserCheckable;
 }
 
-QStringList QgsMssqlNewConnection::SchemaModel::uncheckedSchemas() const
+QStringList SchemaModel::uncheckedSchemas() const
 {
   return mExcludedSchemas;
 }
 
 
-QString QgsMssqlNewConnection::SchemaModel::dataBaseName() const
+QString SchemaModel::dataBaseName() const
 {
   return mDataBaseName;
 }
 
-void QgsMssqlNewConnection::SchemaModel::setDataBaseName( const QString &dataBaseName )
+void SchemaModel::setDataBaseName( const QString &dataBaseName )
 {
   mDataBaseName = dataBaseName;
 }
 
-void QgsMssqlNewConnection::SchemaModel::setSettings( const QString &database, const QStringList &schemas, const QStringList &excludedSchemas )
+void SchemaModel::setSettings( const QString &database, const QStringList &schemas, const QStringList &excludedSchemas )
 {
   beginResetModel();
   mDataBaseName = database;
@@ -481,13 +481,13 @@ void QgsMssqlNewConnection::SchemaModel::setSettings( const QString &database, c
   endResetModel();
 }
 
-void QgsMssqlNewConnection::SchemaModel::checkAll()
+void SchemaModel::checkAll()
 {
   mExcludedSchemas.clear();
   emit dataChanged( index( 0, 0, QModelIndex() ), index( mSchemas.count() - 1, 0, QModelIndex() ) );
 }
 
-void QgsMssqlNewConnection::SchemaModel::unCheckAll()
+void SchemaModel::unCheckAll()
 {
   mExcludedSchemas = mSchemas;
   emit dataChanged( index( 0, 0, QModelIndex() ), index( mSchemas.count() - 1, 0, QModelIndex() ) );

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -25,6 +25,43 @@
 
 class QgsMssqlDatabase;
 
+//! Class that reprents a model to display available schemas on a database and choose which will be displayed in QGIS
+class SchemaModel: public QAbstractListModel
+{
+    Q_OBJECT
+  public:
+    SchemaModel( QObject *parent = nullptr );
+
+    int rowCount( const QModelIndex &parent ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+
+    //! Returns the unchecked schemas
+    QStringList uncheckedSchemas() const;
+
+    //! Returns the database name represented by the model
+    QString dataBaseName() const;
+
+    //! Sets the database nale represented by the model
+    void setDataBaseName( const QString &dataBaseName );
+
+    //! Sets the settings for \a database
+    void setSettings( const QString &database, const QStringList &schemas, const QStringList &excludedSchemas );
+
+    //! Checks all schemas
+    void checkAll();
+
+    //! Unchecks all schemas
+    void unCheckAll();
+
+  private:
+    QString mDataBaseName;
+    QStringList mSchemas;
+    QStringList mExcludedSchemas;
+
+};
+
 /**
  * \class QgsMssqlNewConnection
  * \brief Dialog to allow the user to configure and save connection
@@ -59,41 +96,6 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     void onPrimaryKeyFromGeometryToggled( bool checked );
 
   private:
-    //! Class that reprents a model to display available schemas on a database and choose which will be displayed in QGIS
-    class SchemaModel: public QAbstractListModel
-    {
-      public:
-        SchemaModel( QObject *parent = nullptr );
-
-        int rowCount( const QModelIndex &parent ) const override;
-        QVariant data( const QModelIndex &index, int role ) const override;
-        bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
-        Qt::ItemFlags flags( const QModelIndex &index ) const override;
-
-        //! Returns the unchecked schemas
-        QStringList uncheckedSchemas() const;
-
-        //! Returns the database name represented by the model
-        QString dataBaseName() const;
-
-        //! Sets the database nale represented by the model
-        void setDataBaseName( const QString &dataBaseName );
-
-        //! Sets the settings for \a database
-        void setSettings( const QString &database, const QStringList &schemas, const QStringList &excludedSchemas );
-
-        //! Checks all schemas
-        void checkAll();
-
-        //! Unchecks all schemas
-        void unCheckAll();
-
-      private:
-        QString mDataBaseName;
-        QStringList mSchemas;
-        QStringList mExcludedSchemas;
-
-    };
 
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -296,6 +296,7 @@ class QgsMssqlSharedData
 
 class QgsMssqlProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsMssqlProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/pdal/qgspdalprovider.h
+++ b/src/providers/pdal/qgspdalprovider.h
@@ -70,6 +70,8 @@ class QgsPdalProvider: public QgsPointCloudDataProvider
 
 class QgsPdalProviderMetadata : public QgsProviderMetadata
 {
+    Q_OBJECT
+
   public:
     QgsPdalProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -599,6 +599,7 @@ class QgsPostgresSharedData
 
 class QgsPostgresProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsPostgresProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -246,6 +246,7 @@ struct QgsPostgresRasterProviderException: public std::exception
 
 class QgsPostgresRasterProviderMetadata: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsPostgresRasterProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -421,6 +421,7 @@ class QgsSpatiaLiteProvider final: public QgsVectorDataProvider
 
 class QgsSpatiaLiteProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsSpatiaLiteProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -135,6 +135,7 @@ class QgsVirtualLayerProvider final: public QgsVectorDataProvider
 
 class QgsVirtualLayerProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsVirtualLayerProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.h
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.h
@@ -91,6 +91,7 @@ class QgsVirtualRasterProvider : public QgsRasterDataProvider
 
 class QgsVirtualRasterProviderMetadata: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsVirtualRasterProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -447,6 +447,7 @@ class QgsWcsDownloadHandler : public QObject
 
 class QgsWcsProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsWcsProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/wfs/qgsoapifprovider.h
+++ b/src/providers/wfs/qgsoapifprovider.h
@@ -121,6 +121,7 @@ class QgsOapifProvider final: public QgsVectorDataProvider
 
 class QgsOapifProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsOapifProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -215,6 +215,7 @@ class QgsWFSProvider final: public QgsVectorDataProvider
 
 class QgsWfsProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsWfsProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -724,6 +724,7 @@ Q_DECLARE_TYPEINFO( QgsWmsProvider::TilePosition, Q_PRIMITIVE_TYPE );
 
 class QgsWmsProviderMetadata final: public QgsProviderMetadata
 {
+    Q_OBJECT
   public:
     QgsWmsProviderMetadata();
     QIcon icon() const override;

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -205,6 +205,7 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
  */
 class QgsWmsInterpretationComboBox : public QComboBox
 {
+    Q_OBJECT
   public:
     //! Constructor
     QgsWmsInterpretationComboBox( QWidget *parent = nullptr );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -639,6 +639,7 @@ class DummyParameterType : public QgsProcessingParameterType
 
 class DummyPluginLayer: public QgsPluginLayer
 {
+    Q_OBJECT
   public:
 
     DummyPluginLayer( const QString &layerType, const QString &layerName ): QgsPluginLayer( layerType, layerName )

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -5020,6 +5020,7 @@ void TestQgsProcessingAlgsPt1::setLayerEncoding()
 
 class TestProcessingFeedback : public QgsProcessingFeedback
 {
+    Q_OBJECT
   public:
 
     void reportError( const QString &error, bool ) override

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -1353,6 +1353,7 @@ void TestQgsProcessingAlgsPt2::convertGpxFeatureType()
 
 class TestProcessingFeedback : public QgsProcessingFeedback
 {
+    Q_OBJECT
   public:
 
     void reportError( const QString &error, bool ) override

--- a/tests/src/core/testqgsbrowserproxymodel.cpp
+++ b/tests/src/core/testqgsbrowserproxymodel.cpp
@@ -47,6 +47,7 @@ class TestQgsBrowserProxyModel : public QObject
 
 class TestCollectionItem: public QgsDataCollectionItem
 {
+    Q_OBJECT
   public:
 
     TestCollectionItem( QgsDataItem *parent, const QString &name, const QString &path = QString(), const QString &providerKey = QString() )

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -1096,6 +1096,7 @@ void TestQgsNetworkAccessManager::fetchTimeout()
 
 class FunctionThread : public QThread
 {
+    Q_OBJECT
   public:
     FunctionThread( const std::function<bool()> &f ) : m_f( f ), m_result( false ) {}
     bool getResult() const

--- a/tests/src/core/testqgsogrprovider.cpp
+++ b/tests/src/core/testqgsogrprovider.cpp
@@ -280,6 +280,7 @@ void TestQgsOgrProvider::encodeUri()
 
 class ReadVectorLayer : public QThread
 {
+    Q_OBJECT
 
   public :
     ReadVectorLayer( const QString &filePath, QMutex &mutex, QWaitCondition &waitForVlCreation, QWaitCondition &waitForProcessEvents )

--- a/tests/src/core/testqgsruntimeprofiler.cpp
+++ b/tests/src/core/testqgsruntimeprofiler.cpp
@@ -93,6 +93,7 @@ void TestQgsRuntimeProfiler::testGroups()
 
 class ProfileInThread : public QThread
 {
+    Q_OBJECT
 
   public :
     ProfileInThread( QgsRuntimeProfiler *mainProfiler )

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -184,6 +184,7 @@ class TestWidgetFactory : public QgsProcessingParameterWidgetFactoryInterface
 
 class DummyPluginLayer: public QgsPluginLayer
 {
+    Q_OBJECT
   public:
 
     DummyPluginLayer( const QString &layerType, const QString &layerName ): QgsPluginLayer( layerType, layerName )

--- a/tests/src/gui/testqgsannotationitemguiregistry.cpp
+++ b/tests/src/gui/testqgsannotationitemguiregistry.cpp
@@ -72,6 +72,7 @@ class TestItem : public QgsAnnotationItem // clazy:exclude=missing-qobject-macro
 
 class TestItemWidget: public QgsAnnotationItemBaseWidget
 {
+    Q_OBJECT
   public:
 
     TestItemWidget( QWidget *parent )


### PR DESCRIPTION
Follows #48457 to force use of Q_OBJECT macros everytime it is necessary

I had to remove inner classes or cpp classes, and so I renamed them this way:

- QgsAggregateMappingWidget::AggregateDelegate -> QgsAggregateMappingDelegate
- QgsFieldMappingWidget::ExpressionDelegate -> QgsFieldMappingExpressionDelegate
- QgsFieldMappingWidget::TypeDelegate -> QgsFieldMappingTypeDelegate
- QgsProcessingTinInputLayersWidget::Delegate -> QgsProcessingTinInputLayersDelegate
- QgsMssqlNewConnection::SchemaModel -> SchemaModel
- SnapTypeMenu -> SnappingLayerDelegateTypeMenu
