### PR TITLE
Make "Filter by geometry type" alg also available via Processing Toolbox

### DIFF
--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
@@ -36,19 +36,12 @@ QStringList QgsFilterByGeometryAlgorithm::tags() const
 
 QString QgsFilterByGeometryAlgorithm::group() const
 {
-  return QObject::tr( "Modeler tools" );
+  return QObject::tr( "Vector selection" );
 }
 
 QString QgsFilterByGeometryAlgorithm::groupId() const
 {
-  return QStringLiteral( "modelertools" );
-}
-
-QgsProcessingAlgorithm::Flags QgsFilterByGeometryAlgorithm::flags() const
-{
-  Flags f = QgsProcessingAlgorithm::flags();
-  f |= QgsProcessingAlgorithm::FlagHideFromToolbox;
-  return f;
+  return QStringLiteral( "vectorselection" );
 }
 
 void QgsFilterByGeometryAlgorithm::initAlgorithm( const QVariantMap & )

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.h
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.h
@@ -34,7 +34,6 @@ class QgsFilterByGeometryAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsFilterByGeometryAlgorithm() = default;
-    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;


### PR DESCRIPTION
## Description
Currently the very useful algorithm `Filter by geometry type` is not available via the Processing Toolbox but there are use cases for having it also there, e.g. splitting a WFS layer with mixed feature geometries into single layers.

Examples:
- WFS: https://xplanung.freiburg.de/xplansyn-wfs/services/xplansynwfs


- Feature type: `xplan:BP_AnpflanzungBindungErhaltung` 
![image](https://user-images.githubusercontent.com/20856381/178494420-871e04ba-208a-4d00-845f-dc14c376639c.png)

- Feature type: `xplan:BP_Bereich`
![image](https://user-images.githubusercontent.com/20856381/178494857-d1a7d404-85b8-413c-8f1a-9e94f7393dea.png)





 



