### PR TITLE
Some API improvements to handling OGR database sources

### DIFF
--- a/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidermetadata.sip.in
@@ -148,6 +148,7 @@ library object.
       PriorityForUri,
       LayerTypesForUri,
       QuerySublayers,
+      CreateDatabase,
     };
     typedef QFlags<QgsProviderMetadata::ProviderMetadataCapability> ProviderMetadataCapabilities;
 
@@ -425,6 +426,27 @@ eg. "yes" value will be returned as ``True``, 0 will be returned as ``False``
 %End
 
 
+
+    virtual bool createDatabase( const QString &uri, QString &errorMessage /Out/ );
+%Docstring
+Creates a new empty database at the specified ``uri``.
+
+This method can be used for supported providers to construct a new empty database. For instance, the OGR provider
+metadata :py:func:`~QgsProviderMetadata.createDatabase` method can be used to create new empty GeoPackage or FileGeodatabase databases.
+
+:param uri: destination URI for newly created database.
+
+:return: - ``True`` if the database was successfully created
+         - errorMessage: will be set to a descriptive error message if the database could not be successfully created.
+
+
+.. note::
+
+   This method is only supported by providers which return the QgsProviderMetadata.ProviderMetadataCapability.CreateDatabase capability.
+
+
+.. versionadded:: 3.28
+%End
 
     virtual QgsRasterDataProvider *createRasterDataProvider(
       const QString &uri,

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1804,7 +1804,7 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
   const bool clean = _getMapLayers( *doc, brokenNodes, flags );
 
   // review the integrity of the retrieved map layers
-  if ( !clean )
+  if ( !clean && !( flags & Qgis::ProjectReadFlag::DontResolveLayers ) )
   {
     QgsDebugMsg( QStringLiteral( "Unable to get map layers from project file." ) );
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -411,130 +411,15 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
 
   open( OpenModeInitial );
 
-  int nMaxIntLen = 11;
-  int nMaxInt64Len = 21;
-  int nMaxDoubleLen = 20;
-  int nMaxDoublePrec = 15;
-  int nDateLen = 8;
-  if ( mGDALDriverName == QLatin1String( "GPKG" ) )
-  {
-    // GPKG only supports field length for text (and binary)
-    nMaxIntLen = 0;
-    nMaxInt64Len = 0;
-    nMaxDoubleLen = 0;
-    nMaxDoublePrec = 0;
-    nDateLen = 0;
-  }
-
   QList<NativeType> nativeTypes;
-  nativeTypes
-      << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Int ), QStringLiteral( "integer" ), QVariant::Int, 0, nMaxIntLen )
-      << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), QStringLiteral( "integer64" ), QVariant::LongLong, 0, nMaxInt64Len )
-      << QgsVectorDataProvider::NativeType( tr( "Decimal number (real)" ), QStringLiteral( "double" ), QVariant::Double, 0, nMaxDoubleLen, 0, nMaxDoublePrec )
-      << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::String ), QStringLiteral( "string" ), QVariant::String, 0, 65535 );
-
-  if ( mGDALDriverName == QLatin1String( "GPKG" ) )
-    nativeTypes << QgsVectorDataProvider::NativeType( tr( "JSON (string)" ), QStringLiteral( "JSON" ), QVariant::Map, 0, 0, 0, 0, QVariant::String );
-
-  bool supportsDate = true;
-  bool supportsTime = mGDALDriverName != QLatin1String( "ESRI Shapefile" ) && mGDALDriverName != QLatin1String( "GPKG" );
-  bool supportsDateTime = mGDALDriverName != QLatin1String( "ESRI Shapefile" );
-  bool supportsBinary = false;
-  bool supportIntegerList = false;
-  bool supportInteger64List = false;
-  bool supportRealList = false;
-  bool supportsStringList = false;
-  const char *pszDataTypes = nullptr;
   if ( mOgrOrigLayer )
   {
-    pszDataTypes = GDALGetMetadataItem( mOgrOrigLayer->driver(), GDAL_DMD_CREATIONFIELDDATATYPES, nullptr );
+    nativeTypes = QgsOgrUtils::nativeFieldTypesForDriver( mOgrOrigLayer->driver() );
   }
-  // For drivers that advertise their data type, use that instead of the
-  // above hardcoded defaults.
-  if ( pszDataTypes )
-  {
-    char **papszTokens = CSLTokenizeString2( pszDataTypes, " ", 0 );
-    supportsDate = CSLFindString( papszTokens, "Date" ) >= 0;
-    supportsTime = CSLFindString( papszTokens, "Time" ) >= 0;
-    supportsDateTime = CSLFindString( papszTokens, "DateTime" ) >= 0;
-    supportsBinary = CSLFindString( papszTokens, "Binary" ) >= 0;
-    supportIntegerList = CSLFindString( papszTokens, "IntegerList" ) >= 0;
-    supportInteger64List = CSLFindString( papszTokens, "Integer64List" ) >= 0;
-    supportRealList = CSLFindString( papszTokens, "RealList" ) >= 0;
-    supportsStringList = CSLFindString( papszTokens, "StringList" ) >= 0;
-    CSLDestroy( papszTokens );
-  }
-
-  // Older versions of GDAL incorrectly report that shapefiles support
-  // DateTime.
-#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,2,0)
-  if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
-  {
-    supportsDateTime = false;
-  }
-#endif
-
-  if ( supportsDate )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Date ), QStringLiteral( "date" ), QVariant::Date, nDateLen, nDateLen );
-  }
-  if ( supportsTime )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Time ), QStringLiteral( "time" ), QVariant::Time );
-  }
-  if ( supportsDateTime )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), QStringLiteral( "datetime" ), QVariant::DateTime );
-  }
-  if ( supportsBinary )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), QStringLiteral( "binary" ), QVariant::ByteArray );
-  }
-  if ( supportIntegerList )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Int ), QStringLiteral( "integerlist" ), QVariant::List, 0, 0, 0, 0, QVariant::Int );
-  }
-  if ( supportInteger64List )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::LongLong ), QStringLiteral( "integer64list" ), QVariant::List, 0, 0, 0, 0, QVariant::LongLong );
-  }
-  if ( supportRealList )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::List, QVariant::Double ), QStringLiteral( "doublelist" ), QVariant::List, 0, 0, 0, 0, QVariant::Double );
-  }
-  if ( supportsStringList )
-  {
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::StringList ), QStringLiteral( "stringlist" ), QVariant::List, 0, 0, 0, 0, QVariant::String );
-  }
-
-  bool supportsBoolean = false;
+  setNativeTypes( nativeTypes );
 
   // layer metadata
   loadMetadata();
-
-  if ( mOgrOrigLayer )
-  {
-    const char *pszDataSubTypes = GDALGetMetadataItem( mOgrOrigLayer->driver(), GDAL_DMD_CREATIONFIELDDATASUBTYPES, nullptr );
-    if ( pszDataSubTypes && strstr( pszDataSubTypes, "Boolean" ) )
-      supportsBoolean = true;
-  }
-
-  if ( supportsBoolean )
-  {
-    // boolean data type
-    nativeTypes
-        << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool );
-  }
-
-  setNativeTypes( nativeTypes );
 
   QgsOgrConnPool::instance()->ref( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
 }

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -104,14 +104,22 @@ bool QgsOgrProviderMetadata::createDatabase( const QString &uri, QString &errorM
   char **metadata = GDALGetMetadata( poDriver, nullptr );
 
   if ( !CSLFetchBoolean( metadata, GDAL_DCAP_VECTOR, false )
-       || !CSLFetchBoolean( metadata, GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, false )
-       || !CSLFetchBoolean( metadata, GDAL_DCAP_CREATE, false )
-     )
+       || !CSLFetchBoolean( metadata, GDAL_DCAP_CREATE, false ) )
   {
     errorMessage = tr( "The %1 driver does not support database creation" )
                    .arg( driverName );
     return false;
   }
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,4,0)
+  if ( !CSLFetchBoolean( metadata, GDAL_DCAP_MULTIPLE_VECTOR_LAYERS, false ) )
+  {
+    errorMessage = tr( "The %1 driver does not support database creation" )
+                   .arg( driverName );
+    return false;
+  }
+#endif
+
 
   gdal::ogr_datasource_unique_ptr hDS( OGR_Dr_CreateDataSource( poDriver, path.toUtf8().constData(), nullptr ) );
   if ( !hDS )

--- a/src/core/providers/ogr/qgsogrprovidermetadata.h
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.h
@@ -55,6 +55,7 @@ class QgsOgrProviderMetadata final: public QgsProviderMetadata
       QMap<int, int> &oldToNewAttrIdxMap,
       QString &errorMessage,
       const QMap<QString, QVariant> *options ) override;
+    bool createDatabase( const QString &uri, QString &errorMessage ) override;
 
     // -----
     bool styleExists( const QString &uri, const QString &styleId, QString &errorCause ) override;

--- a/src/core/providers/qgsprovidermetadata.cpp
+++ b/src/core/providers/qgsprovidermetadata.cpp
@@ -192,6 +192,12 @@ Qgis::VectorExportResult QgsProviderMetadata::createEmptyLayer(
   return Qgis::VectorExportResult::ErrorProviderUnsupportedFeature;
 }
 
+bool QgsProviderMetadata::createDatabase( const QString &, QString &errorMessage )
+{
+  errorMessage = QObject::tr( "The %1 provider does not support database creation" ).arg( key() );
+  return false;
+}
+
 QgsRasterDataProvider *QgsProviderMetadata::createRasterDataProvider(
   const QString &, const QString &,
   int, Qgis::DataType, int,

--- a/src/core/providers/qgsprovidermetadata.h
+++ b/src/core/providers/qgsprovidermetadata.h
@@ -190,6 +190,7 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
       PriorityForUri = 1 << 0, //!< Indicates that the metadata can calculate a priority for a URI
       LayerTypesForUri = 1 << 1, //!< Indicates that the metadata can determine valid layer types for a URI
       QuerySublayers = 1 << 2, //!< Indicates that the metadata can query sublayers for a URI (since QGIS 3.22)
+      CreateDatabase = 1 << 3, //!< Indicates that the metadata can create new empty databases (since QGIS 3.28)
     };
     Q_DECLARE_FLAGS( ProviderMetadataCapabilities, ProviderMetadataCapability )
 
@@ -501,6 +502,23 @@ class CORE_EXPORT QgsProviderMetadata : public QObject
         QString &errorMessage,
         const QMap<QString, QVariant> *options );
 #endif
+
+    /**
+     * Creates a new empty database at the specified \a uri.
+     *
+     * This method can be used for supported providers to construct a new empty database. For instance, the OGR provider
+     * metadata createDatabase() method can be used to create new empty GeoPackage or FileGeodatabase databases.
+     *
+     * \param uri destination URI for newly created database.
+     * \param errorMessage will be set to a descriptive error message if the database could not be successfully created.
+     *
+     * \returns TRUE if the database was successfully created
+     *
+     * \note This method is only supported by providers which return the QgsProviderMetadata::ProviderMetadataCapability::CreateDatabase capability.
+     *
+     * \since QGIS 3.28
+     */
+    virtual bool createDatabase( const QString &uri, QString &errorMessage SIP_OUT );
 
     /**
      * Creates a new instance of the raster data provider.

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -2068,8 +2068,8 @@ QList<QgsVectorDataProvider::NativeType> QgsOgrUtils::nativeFieldTypesForDriver(
     nativeTypes << QgsVectorDataProvider::NativeType( QObject::tr( "JSON (string)" ), QStringLiteral( "JSON" ), QVariant::Map, 0, 0, 0, 0, QVariant::String );
 
   bool supportsDate = true;
-  bool supportsTime = driverName != QLatin1String( "ESRI Shapefile" ) && driverName != QLatin1String( "GPKG" );
-  bool supportsDateTime = driverName != QLatin1String( "ESRI Shapefile" );
+  bool supportsTime = true;
+  bool supportsDateTime = true;
   bool supportsBinary = false;
   bool supportIntegerList = false;
   bool supportInteger64List = false;

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgsfeature.h"
+#include "qgsvectordataprovider.h"
 
 #include <ogr_api.h>
 #include <gdal.h>
@@ -395,6 +396,13 @@ class CORE_EXPORT QgsOgrUtils
      * \since QGIS 3.26
      */
     static QVariant stringToVariant( OGRFieldType type, OGRFieldSubType subType, const QString &string ) SIP_SKIP;
+
+    /**
+     * Returns the list of native field types supported for a \a driver.
+     *
+     * \since QGIS 3.28
+     */
+    static QList<QgsVectorDataProvider::NativeType> nativeFieldTypesForDriver( GDALDriverH driver ) SIP_SKIP;
 
 #ifndef SIP_RUN
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,3,0)

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -432,7 +432,7 @@ QWidget *QgsNewVectorTableDialogFieldsDelegate::createEditor( QWidget *parent, c
       connect( cbo, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsNewVectorTableDialogFieldsDelegate::onFieldTypeChanged );
       for ( const auto &f : std::as_const( mTypeList ) )
       {
-        cbo->addItem( f.mTypeDesc, f.mTypeName );
+        cbo->addItem( QgsFields::iconForFieldType( f.mType, f.mSubType ), f.mTypeDesc, f.mTypeName );
       }
       return cbo;
     }

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -50,7 +50,8 @@ from qgis.core import (
     Qgis,
     QgsDirectoryItem,
     QgsAbstractDatabaseProviderConnection,
-    QgsProviderConnectionException
+    QgsProviderConnectionException,
+    QgsProviderMetadata
 )
 
 from qgis.gui import (
@@ -2598,6 +2599,26 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(len(table.geometryColumnTypes()), 1)
         self.assertEqual(table.geometryColumnTypes()[0].wkbType, QgsWkbTypes.Point)
         self.assertEqual(table.flags(), QgsAbstractDatabaseProviderConnection.TableFlag.Vector)
+
+    def testCreateEmptyDatabase(self):
+        """ Test creating an empty database via the provider metadata """
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+        self.assertTrue(metadata.capabilities() & QgsProviderMetadata.ProviderMetadataCapability.CreateDatabase)
+
+        # empty path should error out
+        ok, err = metadata.createDatabase('')
+        self.assertFalse(ok)
+        self.assertTrue(err)
+
+        # invalid driver should error out
+        ok, err = metadata.createDatabase('aaa.xyz')
+        self.assertFalse(ok)
+        self.assertTrue(err)
+
+        # non-database driver should error out
+        ok, err = metadata.createDatabase('aaa.shp')
+        self.assertFalse(ok)
+        self.assertTrue(err)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -2616,7 +2616,7 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertTrue(err)
 
         # non-database driver should error out
-        ok, err = metadata.createDatabase('aaa.shp')
+        ok, err = metadata.createDatabase('aaa.tif')
         self.assertFalse(ok)
         self.assertTrue(err)
 

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -43,6 +43,7 @@ from qgis.core import (Qgis,
                        QgsDataProvider,
                        QgsVectorDataProvider,
                        QgsLayerMetadata,
+                       QgsProviderMetadata,
                        NULL)
 from qgis.PyQt.QtCore import QCoreApplication, QVariant, QDate, QTime, QDateTime, Qt, QTemporaryDir, QFileInfo
 from qgis.PyQt.QtXml import QDomDocument
@@ -2577,6 +2578,23 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         vl = QgsVectorLayer('{}'.format(tmpfile) + '|geometryType=CurvePolygon', 'test', 'ogr')
         got = [feat for feat in vl.getFeatures()]
         self.assertEqual(len(got), 2)
+
+    def testCreateEmptyDatabase(self):
+        """ Test creating an empty database via the provider metadata """
+        metadata = QgsProviderRegistry.instance().providerMetadata('ogr')
+        self.assertTrue(metadata.capabilities() & QgsProviderMetadata.ProviderMetadataCapability.CreateDatabase)
+
+        with tempfile.TemporaryDirectory() as dest_dir:
+            database_path = os.path.join(dest_dir, 'new_gpkg.gpkg')
+            ok, err = metadata.createDatabase(database_path)
+            self.assertTrue(ok)
+            self.assertFalse(err)
+            self.assertTrue(os.path.exists(database_path))
+
+            # try to create again, should error out
+            ok, err = metadata.createDatabase(database_path)
+            self.assertFalse(ok)
+            self.assertTrue(err)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a few API building blocks for more generic handling of OGR supported database type datasets:

- A new "createDatabase" interface has been added to QgsProviderMetadata which can be used for supported providers to create new empty databases. It's implemented only for the OGR provider for now, and can be used to create empty databases for formats supported by GDAL. Specifically it's intended for use for creating new empty GeoPackage and ESRI FileGeodatabase databases in a suitably generic manner (but it also works for any GDAL vector driver which offers the create dataset capability)
- The field type handling for the OGR provider and database connection has been improved so that it works correctly for OGR supported datasets which are currently empty. This is an performance optimisation, but also fixes a bug where it was impossible to use the browser "New Table" action to create a new table in an empty GPKG/FileGeodatabase/... dataset.

A follow up PR after this one will add support for direct creation of empty OGR supported database files through the browser (ie. right click a folder - New - ESRI FileGeodatabase).

