### PR TITLE
[3D] qgs3dmapcanvaswidget: Prevent configure dialog from being modal

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -394,7 +394,7 @@ void Qgs3DMapCanvasWidget::configure()
 
   Qgs3DMapSettings *map = mCanvas->map();
   Qgs3DMapConfigWidget *w = new Qgs3DMapConfigWidget( map, mMainCanvas, mCanvas, dlg );
-  QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Apply | QDialogButtonBox::Cancel | QDialogButtonBox::Help, dlg );
+  QDialogButtonBox *buttons = new QDialogButtonBox( QDialogButtonBox::Apply | QDialogButtonBox::Close | QDialogButtonBox::Help, dlg );
 
   auto applyConfig = [ = ]()
   {


### PR DESCRIPTION
When changing a parameter, it is difficult to check the result without
closing the parameter dialog because it always stays on top.
This issue is fixed by removing its modal state.

cc @wonder-sk @benoitdm-oslandia 