### PR TITLE
[3D] Add transparent support to points

### DIFF
--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -141,11 +141,13 @@ void QgsPhongMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effec
   Qt3DRender::QParameter *diffuseParameter = new Qt3DRender::QParameter( QStringLiteral( "kd" ), mDiffuse );
   Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "ks" ), mSpecular );
   Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess );
+  Qt3DRender::QParameter *opacityParameter = new Qt3DRender::QParameter( QStringLiteral( "opacity" ), mOpacity );
 
   effect->addParameter( ambientParameter );
   effect->addParameter( diffuseParameter );
   effect->addParameter( specularParameter );
   effect->addParameter( shininessParameter );
+  effect->addParameter( opacityParameter );
 }
 
 QByteArray QgsPhongMaterialSettings::dataDefinedVertexColorsAsByte( const QgsExpressionContext &expressionContext ) const

--- a/src/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/3d/materials/qgsphongmaterialsettings.cpp
@@ -137,15 +137,10 @@ QMap<QString, QString> QgsPhongMaterialSettings::toExportParameters() const
 
 void QgsPhongMaterialSettings::addParametersToEffect( Qt3DRender::QEffect *effect ) const
 {
-  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ka" ), QColor::fromRgbF( 0.05f, 0.05f, 0.05f, 1.0f ) );
-  Qt3DRender::QParameter *diffuseParameter = new Qt3DRender::QParameter( QStringLiteral( "kd" ), QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
-  Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "ks" ), QColor::fromRgbF( 0.01f, 0.01f, 0.01f, 1.0f ) );
-  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), 150.0f );
-
-  diffuseParameter->setValue( mDiffuse );
-  ambientParameter->setValue( mAmbient );
-  specularParameter->setValue( mSpecular );
-  shininessParameter->setValue( mShininess );
+  Qt3DRender::QParameter *ambientParameter = new Qt3DRender::QParameter( QStringLiteral( "ka" ), mAmbient );
+  Qt3DRender::QParameter *diffuseParameter = new Qt3DRender::QParameter( QStringLiteral( "kd" ), mDiffuse );
+  Qt3DRender::QParameter *specularParameter = new Qt3DRender::QParameter( QStringLiteral( "ks" ), mSpecular );
+  Qt3DRender::QParameter *shininessParameter = new Qt3DRender::QParameter( QStringLiteral( "shininess" ), mShininess );
 
   effect->addParameter( ambientParameter );
   effect->addParameter( diffuseParameter );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -943,7 +943,7 @@ void Qgs3DMapScene::finalizeNewEntity( Qt3DCore::QEntity *newEntity )
     }
     else
     {
-      // This handles the phong material with data defined properties and the textured case.
+      // This handles the phong material with data defined properties, the textured case and point (instanced) symbols.
       Qt3DRender::QEffect *effect = material->effect();
       if ( effect )
       {

--- a/src/3d/shaders/instanced.frag
+++ b/src/3d/shaders/instanced.frag
@@ -6,6 +6,7 @@ uniform vec3 ka;                            // Ambient reflectivity
 uniform vec3 kd;                            // Diffuse reflectivity
 uniform vec3 ks;                            // Specular reflectivity
 uniform float shininess;                    // Specular shininess factor
+uniform float opacity;                      // Opacity
 
 uniform vec3 eyePosition;
 
@@ -21,5 +22,5 @@ void main()
     vec3 diffuseColor, specularColor;
     vec3 worldView = normalize(eyePosition - worldPosition);
     adsModel(worldPosition, worldNormal, worldView, shininess, diffuseColor, specularColor);
-    fragColor = vec4( ka + kd * diffuseColor + ks * specularColor, 1.0 );
+    fragColor = vec4( ka + kd * diffuseColor + ks * specularColor, opacity );
 }


### PR DESCRIPTION
An initial transparency support was added to phong material in https://github.com/qgis/QGIS/pull/48499. However, it did not handle the `QgsPoint3DSymbol`.

without opacity
![Capture d’écran du 2022-07-13 20-59-18](https://user-images.githubusercontent.com/497207/178810870-4e6e52a1-f00d-4256-831e-b749d7285fdf.png)

with opacity
![Capture d’écran du 2022-07-13 20-57-52](https://user-images.githubusercontent.com/497207/178810917-19b242a8-8a1c-424b-a10c-90fff2979715.png)

