### PR TITLE
Handle schema names in table sources in QgsSqlStatementParser

### DIFF
--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -711,9 +711,23 @@ Constructor with table name
 Constructor with table name and alias
 %End
 
+        NodeTableDef( const QString &schema, const QString &name, const QString &alias );
+%Docstring
+Constructor with schema, table name and alias
+
+.. versionadded:: 3.28
+%End
+
         QString name() const;
 %Docstring
 Table name
+%End
+
+        QString schema() const;
+%Docstring
+Returns the schema name.
+
+.. versionadded:: 3.28
 %End
 
         QString alias() const;

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -243,7 +243,7 @@ void QgsSQLStatementCollectTableNames::visit( const QgsSQLStatement::NodeColumnR
 
 void QgsSQLStatementCollectTableNames::visit( const QgsSQLStatement::NodeTableDef &n )
 {
-  tableNamesDeclared.insert( n.alias().isEmpty() ? n.name() : n.alias() );
+  tableNamesDeclared.insert( n.alias().isEmpty() ? ( n.schema().isEmpty() ? n.name() : n.schema() + '.' + n.name() ) : n.alias() );
   QgsSQLStatement::RecursiveVisitor::visit( n );
 }
 
@@ -562,7 +562,10 @@ QgsSQLStatement::Node *QgsSQLStatement::NodeSelectedColumn::clone() const
 QString QgsSQLStatement::NodeTableDef::dump() const
 {
   QString ret;
-  ret = quotedIdentifierIfNeeded( mName );
+  if ( !mSchema.isEmpty() )
+    ret += mSchema + '.';
+
+  ret += quotedIdentifierIfNeeded( mName );
   if ( !mAlias.isEmpty() )
   {
     ret += QLatin1String( " AS " );
@@ -573,7 +576,7 @@ QString QgsSQLStatement::NodeTableDef::dump() const
 
 QgsSQLStatement::NodeTableDef *QgsSQLStatement::NodeTableDef::cloneThis() const
 {
-  return new NodeTableDef( mName, mAlias );
+  return new NodeTableDef( mSchema, mName, mAlias );
 }
 
 QgsSQLStatement::Node *QgsSQLStatement::NodeTableDef::clone() const

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -629,8 +629,21 @@ class CORE_EXPORT QgsSQLStatement
         //! Constructor with table name and alias
         NodeTableDef( const QString &name, const QString &alias ) : mName( name ), mAlias( alias ) {}
 
+        /**
+         * Constructor with schema, table name and alias
+         * \since QGIS 3.28
+         */
+        NodeTableDef( const QString &schema, const QString &name, const QString &alias ) : mName( name ), mSchema( schema ), mAlias( alias ) {}
+
         //! Table name
         QString name() const { return mName; }
+
+        /**
+         * Returns the schema name.
+         *
+         * \since QGIS 3.28
+         */
+        QString schema() const { return mSchema; }
 
         //! Table alias
         QString alias() const { return mAlias; }
@@ -645,6 +658,7 @@ class CORE_EXPORT QgsSQLStatement
 
       protected:
         QString mName;
+        QString mSchema;
         QString mAlias;
     };
 

--- a/src/core/qgssqlstatementparser.yy
+++ b/src/core/qgssqlstatementparser.yy
@@ -135,7 +135,7 @@ struct sqlstatement_parser_context
 %token <boolVal> BOOLEAN
 %token NULLVALUE
 
-%token <text> STRING IDENTIFIER
+%token <text> STRING IDENTIFIER IDENTIFIER_WITH_DOT
 
 %token COMMA
 
@@ -575,12 +575,39 @@ table_def:
         $$ = new QgsSQLStatement::NodeTableDef(*$1);
         delete $1;
     }
-
+    | IDENTIFIER '.' IDENTIFIER
+    {
+        $$ = new QgsSQLStatement::NodeTableDef(*$1, *$3, QString());
+        delete $1;
+        delete $3;
+    }
+    | IDENTIFIER '.' IDENTIFIER '.' IDENTIFIER
+    {
+        $$ = new QgsSQLStatement::NodeTableDef(*$1 + '.' + *$3, *$5, QString());
+        delete $1;
+        delete $3;
+        delete $5;
+    }
     | IDENTIFIER as_clause
     {
         $$ = new QgsSQLStatement::NodeTableDef(*$1, *$2);
         delete $1;
         delete $2;
+    }
+    | IDENTIFIER '.' IDENTIFIER as_clause
+    {
+        $$ = new QgsSQLStatement::NodeTableDef(*$1, *$3, *$4);
+        delete $1;
+        delete $3;
+        delete $4;
+    }
+    | IDENTIFIER '.' IDENTIFIER '.' IDENTIFIER as_clause
+    {
+        $$ = new QgsSQLStatement::NodeTableDef(*$1 + '.' + *$3, *$5, *$6);
+        delete $1;
+        delete $3;
+        delete $5;
+        delete $6;
     }
 ;
 

--- a/tests/src/python/test_qgssqlstatement.py
+++ b/tests/src/python/test_qgssqlstatement.py
@@ -47,6 +47,74 @@ class TestQgsSQLStatementCustomFunctions(unittest.TestCase):
         self.assertEqual(column_ref.name(), 'a')
         self.assertEqual(column_ref.tableName(), '')
 
+    def testNominalSimpleWithSchema(self):
+        statement = "SELECT a FROM user.mySchema3.tableName"
+        self.checkNominal(statement)
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 'tableName')
+        self.assertEqual(table.schema(), 'user.mySchema3')
+        self.assertEqual(table.alias(), '')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
+    def testNominalSimpleWithAlias(self):
+        statement = "SELECT a FROM tableName AS myTable"
+        self.checkNominal(statement)
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 'tableName')
+        self.assertEqual(table.alias(), 'myTable')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
+    def testNominalSimpleWithAliasAndSchema(self):
+        statement = "SELECT a FROM dbo.mySchema.tableName AS myTable"
+        self.checkNominal(statement)
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 'tableName')
+        self.assertEqual(table.schema(), 'dbo.mySchema')
+        self.assertEqual(table.alias(), 'myTable')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
     def testNominalSelectDistinct(self):
         statement = "SELECT DISTINCT a FROM t"
         self.checkNominal(statement)

--- a/tests/src/python/test_qgssqlstatement.py
+++ b/tests/src/python/test_qgssqlstatement.py
@@ -47,9 +47,54 @@ class TestQgsSQLStatementCustomFunctions(unittest.TestCase):
         self.assertEqual(column_ref.name(), 'a')
         self.assertEqual(column_ref.tableName(), '')
 
+    def testNominalSimpleQuoted(self):
+        statement = "SELECT a FROM \"t\""
+        self.checkNominal(statement, "SELECT a FROM t")
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 't')
+        self.assertEqual(table.alias(), '')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
     def testNominalSimpleWithSchema(self):
         statement = "SELECT a FROM user.mySchema3.tableName"
         self.checkNominal(statement)
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 'tableName')
+        self.assertEqual(table.schema(), 'user.mySchema3')
+        self.assertEqual(table.alias(), '')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
+    def testNominalSimpleWithSchemaQuoted(self):
+        statement = "SELECT a FROM \"user\".\"mySchema3\".\"tableName\""
+        self.checkNominal(statement, 'SELECT a FROM user.mySchema3.tableName')
         exp = QgsSQLStatement(statement)
         statement_node = exp.rootNode()
         self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
@@ -95,6 +140,29 @@ class TestQgsSQLStatementCustomFunctions(unittest.TestCase):
     def testNominalSimpleWithAliasAndSchema(self):
         statement = "SELECT a FROM dbo.mySchema.tableName AS myTable"
         self.checkNominal(statement)
+        exp = QgsSQLStatement(statement)
+        statement_node = exp.rootNode()
+        self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)
+        tables = statement_node.tables()
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.nodeType(), QgsSQLStatement.ntTableDef)
+        self.assertEqual(table.name(), 'tableName')
+        self.assertEqual(table.schema(), 'dbo.mySchema')
+        self.assertEqual(table.alias(), 'myTable')
+        columns = statement_node.columns()
+        self.assertEqual(len(columns), 1)
+        column = columns[0]
+        self.assertEqual(column.nodeType(), QgsSQLStatement.ntSelectedColumn)
+        column_ref = column.column()
+        self.assertEqual(column.alias(), '')
+        self.assertEqual(column_ref.nodeType(), QgsSQLStatement.ntColumnRef)
+        self.assertEqual(column_ref.name(), 'a')
+        self.assertEqual(column_ref.tableName(), '')
+
+    def testNominalSimpleWithAliasAndSchemaQuoted(self):
+        statement = "SELECT a FROM \"dbo\".\"mySchema\".\"tableName\" AS myTable"
+        self.checkNominal(statement, 'SELECT a FROM dbo.mySchema.tableName AS myTable')
         exp = QgsSQLStatement(statement)
         statement_node = exp.rootNode()
         self.assertEqual(statement_node.nodeType(), QgsSQLStatement.ntSelect)


### PR DESCRIPTION
Without this any "select xxx from some_schema.table" statement will fail to parse 