### PR TITLE
ArcGIS REST: Implement support for editing layers

### DIFF
--- a/python/core/auto_additions/qgsarcgisrestutils.py
+++ b/python/core/auto_additions/qgsarcgisrestutils.py
@@ -1,0 +1,9 @@
+# The following has been generated automatically from src/core/providers/arcgis/qgsarcgisrestutils.h
+# monkey patching scoped based enum
+QgsArcGisRestUtils.FeatureToJsonFlag.IncludeGeometry.__doc__ = "Whether to include the geometry definition"
+QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes.__doc__ = "Whether to include any non-objectId attributes"
+QgsArcGisRestUtils.FeatureToJsonFlag.__doc__ = 'Flags which control the behavior of converting features to JSON.\n\n.. versionadded:: 3.28\n\n' + '* ``IncludeGeometry``: ' + QgsArcGisRestUtils.FeatureToJsonFlag.IncludeGeometry.__doc__ + '\n' + '* ``IncludeNonObjectIdAttributes``: ' + QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes.__doc__
+# --
+QgsArcGisRestUtils.FeatureToJsonFlag.baseClass = QgsArcGisRestUtils
+QgsArcGisRestUtils.FeatureToJsonFlags.baseClass = QgsArcGisRestUtils
+FeatureToJsonFlags = QgsArcGisRestUtils  # dirty hack since SIP seems to introduce the flags in module

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -40,6 +40,20 @@ Returns the time zone for datetime values.
 .. seealso:: :py:func:`setTimeZone`
 %End
 
+    void setObjectIdFieldName( const QString &name );
+%Docstring
+Sets the name of the objectId field.
+
+.. seealso:: :py:func:`objectIdFieldName`
+%End
+
+    QString objectIdFieldName() const;
+%Docstring
+Returns the name of the objectId field.
+
+.. seealso:: :py:func:`setObjectIdFieldName`
+%End
+
 };
 
 class QgsArcGisRestUtils
@@ -55,6 +69,9 @@ Utility functions for working with ArcGIS REST services.
 %TypeHeaderCode
 #include "qgsarcgisrestutils.h"
 %End
+  public:
+    static const QMetaObject staticMetaObject;
+
   public:
 
     static QVariant::Type convertFieldType( const QString &type );
@@ -151,10 +168,19 @@ Returns an empty map if the ``crs`` is not valid.
 .. versionadded:: 3.28
 %End
 
+    enum class FeatureToJsonFlag
+    {
+      IncludeGeometry,
+      IncludeNonObjectIdAttributes,
+    };
+
+    typedef QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> FeatureToJsonFlags;
+
+
     static QVariantMap featureToJson( const QgsFeature &feature,
                                       const QgsArcGisRestContext &context,
                                       const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
-                                      bool includeGeometry = true );
+                                      QgsArcGisRestUtils::FeatureToJsonFlags flags = QgsArcGisRestUtils::FeatureToJsonFlags( static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry ) | static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes ) ) );
 %Docstring
 Converts a ``feature`` to an ArcGIS REST JSON representation.
 
@@ -169,6 +195,9 @@ Converts a variant to a REST attribute value.
 %End
 
 };
+
+QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> operator|(QgsArcGisRestUtils::FeatureToJsonFlag f1, QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -194,6 +194,13 @@ Converts a variant to a REST attribute value.
 .. versionadded:: 3.28
 %End
 
+    static QVariantMap fieldDefinitionToJson( const QgsField &field );
+%Docstring
+Converts a ``field``'s definition to an ArcGIS REST JSON representation.
+
+.. versionadded:: 3.28
+%End
+
 };
 
 QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> operator|(QgsArcGisRestUtils::FeatureToJsonFlag f1, QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> f2);

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -153,7 +153,8 @@ Returns an empty map if the ``crs`` is not valid.
 
     static QVariantMap featureToJson( const QgsFeature &feature,
                                       const QgsArcGisRestContext &context,
-                                      const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+                                      const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
+                                      bool includeGeometry = true );
 %Docstring
 Converts a ``feature`` to an ArcGIS REST JSON representation.
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -312,7 +312,7 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
     QgsAttributeMap origValues = ( *sLastUsedValues() )[ mLayer ];
     if ( origValues[idx] != newValues.at( idx ) )
     {
-      QgsDebugMsgLevel( QStringLiteral( "saving %1 for %2" ).arg( ( *sLastUsedValues() )[ mLayer ][idx].toString() ).arg( idx ), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "Saving %1 for %2" ).arg( ( *sLastUsedValues() )[ mLayer ][idx].toString() ).arg( idx ), 2 );
       ( *sLastUsedValues() )[ mLayer ][idx] = newValues.at( idx );
     }
   }

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -312,7 +312,7 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature &feature )
     QgsAttributeMap origValues = ( *sLastUsedValues() )[ mLayer ];
     if ( origValues[idx] != newValues.at( idx ) )
     {
-      QgsDebugMsg( QStringLiteral( "saving %1 for %2" ).arg( ( *sLastUsedValues() )[ mLayer ][idx].toString() ).arg( idx ) );
+      QgsDebugMsgLevel( QStringLiteral( "saving %1 for %2" ).arg( ( *sLastUsedValues() )[ mLayer ][idx].toString() ).arg( idx ), 2 );
       ( *sLastUsedValues() )[ mLayer ][idx] = newValues.at( idx );
     }
   }

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -211,11 +211,17 @@ QVariantMap QgsArcGisRestQueryUtils::queryServiceJSON( const QUrl &url, const QS
   return res;
 }
 
-QUrl QgsArcGisRestQueryUtils::parseUrl( const QUrl &url )
+QUrl QgsArcGisRestQueryUtils::parseUrl( const QUrl &url, bool *isTestEndpoint )
 {
+  if ( isTestEndpoint )
+    *isTestEndpoint = false;
+
   QUrl modifiedUrl( url );
   if ( modifiedUrl.toString().contains( QLatin1String( "fake_qgis_http_endpoint" ) ) )
   {
+    if ( isTestEndpoint )
+      *isTestEndpoint = true;
+
     // Just for testing with local files instead of http:// resources
     QString modifiedUrlString = modifiedUrl.toString();
     // Qt5 does URL encoding from some reason (of the FILTER parameter for example)
@@ -223,7 +229,7 @@ QUrl QgsArcGisRestQueryUtils::parseUrl( const QUrl &url )
     modifiedUrlString.replace( QLatin1String( "fake_qgis_http_endpoint/" ), QLatin1String( "fake_qgis_http_endpoint_" ) );
     QgsDebugMsg( QStringLiteral( "Get %1" ).arg( modifiedUrlString ) );
     modifiedUrlString = modifiedUrlString.mid( QStringLiteral( "http://" ).size() );
-    QString args = modifiedUrlString.mid( modifiedUrlString.indexOf( '?' ) );
+    QString args = modifiedUrlString.indexOf( '?' ) >= 0 ? modifiedUrlString.mid( modifiedUrlString.indexOf( '?' ) ) : QString();
     if ( modifiedUrlString.size() > 150 )
     {
       args = QCryptographicHash::hash( args.toUtf8(), QCryptographicHash::Md5 ).toHex();

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -101,9 +101,13 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
      */
     static void addLayerItems( const std::function<void ( const QString &parentLayerId, ServiceTypeFilter serviceType, QgsWkbTypes::GeometryType geometryType, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter = AllTypes );
 
+    /**
+     * Parses and processes a \a url.
+     */
+    static QUrl parseUrl( const QUrl &url, bool *isTestEndpoint = nullptr );
+
   private:
 
-    static QUrl parseUrl( const QUrl &url );
     static void adjustBaseUrl( QString &baseUrl, const QString &name );
 
     friend class TestQgsArcGisRestUtils;

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1505,3 +1505,56 @@ QVariant QgsArcGisRestUtils::variantToAttributeValue( const QVariant &variant, Q
   }
 }
 
+QVariantMap QgsArcGisRestUtils::fieldDefinitionToJson( const QgsField &field )
+{
+  QVariantMap res;
+  res.insert( QStringLiteral( "name" ), field.name() );
+
+  QString fieldType;
+  switch ( field.type() )
+  {
+    case QVariant::LongLong:
+      fieldType = QStringLiteral( "esriFieldTypeInteger" );
+      break;
+
+    case QVariant::Int:
+      fieldType = QStringLiteral( "esriFieldTypeSmallInteger" );
+      break;
+
+    case QVariant::Double:
+      fieldType = QStringLiteral( "esriFieldTypeDouble" );
+      break;
+
+    case QVariant::String:
+      fieldType = QStringLiteral( "esriFieldTypeString" );
+      break;
+
+    case QVariant::DateTime:
+    case QVariant::Date:
+      fieldType = QStringLiteral( "esriFieldTypeDate" );
+      break;
+
+    case QVariant::ByteArray:
+      fieldType = QStringLiteral( "esriFieldTypeBlob" );
+      break;
+
+    default:
+      // fallback to string
+      fieldType = QStringLiteral( "esriFieldTypeString" );
+      break;
+  }
+  res.insert( QStringLiteral( "type" ), fieldType );
+
+  if ( !field.alias().isEmpty() )
+    res.insert( QStringLiteral( "alias" ), field.alias() );
+
+  // nullable
+  const bool notNullable = field.constraints().constraints() & QgsFieldConstraints::Constraint::ConstraintNotNull;
+  res.insert( QStringLiteral( "nullable" ), !notNullable );
+
+  // editable
+  res.insert( QStringLiteral( "editable" ), true );
+
+  return res;
+}
+

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -868,15 +868,21 @@ QString QgsArcGisRestUtils::convertLabelingExpression( const QString &string )
   QString expression = string;
 
   // Replace a few ArcGIS token to QGIS equivalents
-  expression = expression.replace( QRegularExpression( "(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)(\\s|^)CONCAT(\\s|$)" ), QStringLiteral( "\\4||\\5" ) );
-  expression = expression.replace( QRegularExpression( "(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)(\\s|^)NEWLINE(\\s|$)" ), QStringLiteral( "\\4'\\n'\\5" ) );
+  const thread_local QRegularExpression rx1 = QRegularExpression( QStringLiteral( "(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)(\\s|^)CONCAT(\\s|$)" ) );
+  expression = expression.replace( rx1, QStringLiteral( "\\4||\\5" ) );
+
+  const thread_local QRegularExpression rx2 = QRegularExpression( QStringLiteral( "(?=([^\"\\\\]*(\\\\.|\"([^\"\\\\]*\\\\.)*[^\"\\\\]*\"))*[^\"]*$)(\\s|^)NEWLINE(\\s|$)" ) );
+  expression = expression.replace( rx2, QStringLiteral( "\\4'\\n'\\5" ) );
 
   // ArcGIS's double quotes are single quotes in QGIS
-  expression = expression.replace( QRegularExpression( "\"(.*?(?<!\\\\))\"" ), QStringLiteral( "'\\1'" ) );
-  expression = expression.replace( QRegularExpression( "\\\\\"" ), QStringLiteral( "\"" ) );
+  const thread_local QRegularExpression rx3 = QRegularExpression( QStringLiteral( "\"(.*?(?<!\\\\))\"" ) );
+  expression = expression.replace( rx3, QStringLiteral( "'\\1'" ) );
+  const thread_local QRegularExpression rx4 = QRegularExpression( QStringLiteral( "\\\\\"" ) );
+  expression = expression.replace( rx4, QStringLiteral( "\"" ) );
 
   // ArcGIS's square brakets are double quotes in QGIS
-  expression = expression.replace( QRegularExpression( "\\[([^]]*)\\]" ), QStringLiteral( "\"\\1\"" ) );
+  const thread_local QRegularExpression rx5 = QRegularExpression( QStringLiteral( "\\[([^]]*)\\]" ) );
+  expression = expression.replace( rx5, QStringLiteral( "\"\\1\"" ) );
 
   return expression;
 }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1451,10 +1451,10 @@ QVariantMap QgsArcGisRestUtils::crsToJson( const QgsCoordinateReferenceSystem &c
   return res;
 }
 
-QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs )
+QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs, bool includeGeometry )
 {
   QVariantMap res;
-  if ( feature.hasGeometry() )
+  if ( includeGeometry && feature.hasGeometry() )
   {
     res.insert( QStringLiteral( "geometry" ), geometryToJson( feature.geometry(), context, crs ) );
   }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1451,10 +1451,10 @@ QVariantMap QgsArcGisRestUtils::crsToJson( const QgsCoordinateReferenceSystem &c
   return res;
 }
 
-QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs, bool includeGeometry )
+QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const QgsArcGisRestContext &context, const QgsCoordinateReferenceSystem &crs, QgsArcGisRestUtils::FeatureToJsonFlags flags )
 {
   QVariantMap res;
-  if ( includeGeometry && feature.hasGeometry() )
+  if ( ( flags & FeatureToJsonFlag::IncludeGeometry ) && feature.hasGeometry() )
   {
     res.insert( QStringLiteral( "geometry" ), geometryToJson( feature.geometry(), context, crs ) );
   }
@@ -1463,7 +1463,8 @@ QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const 
   const QgsFields fields = feature.fields();
   for ( const QgsField &field : fields )
   {
-    attributes.insert( field.name(), variantToAttributeValue( feature.attribute( field.name() ), field.type(), context ) );
+    if ( ( flags & FeatureToJsonFlag::IncludeNonObjectIdAttributes ) || field.name() == context.objectIdFieldName() )
+      attributes.insert( field.name(), variantToAttributeValue( feature.attribute( field.name() ), field.type(), context ) );
   }
   if ( !attributes.isEmpty() )
   {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -958,51 +958,55 @@ QDateTime QgsArcGisRestUtils::convertDateTime( const QVariant &value )
 QVariantMap QgsArcGisRestUtils::geometryToJson( const QgsGeometry &geometry, const QgsArcGisRestContext &, const QgsCoordinateReferenceSystem &crs )
 {
   QVariantMap res;
-  switch ( QgsWkbTypes::flatType( geometry.wkbType() ) )
+  if ( geometry.isNull() )
+    return QVariantMap();
+
+  const QgsAbstractGeometry *geom = geometry.constGet()->simplifiedTypeRef();
+  switch ( QgsWkbTypes::flatType( geom->wkbType() ) )
   {
     case QgsWkbTypes::Unknown:
     case QgsWkbTypes::NoGeometry:
       return QVariantMap();
 
     case QgsWkbTypes::Point:
-      res = pointToJson( qgsgeometry_cast< const QgsPoint * >( geometry.constGet() ) );
+      res = pointToJson( qgsgeometry_cast< const QgsPoint * >( geom ) );
       break;
 
     case QgsWkbTypes::LineString:
-      res = lineStringToJson( qgsgeometry_cast< const QgsLineString * >( geometry.constGet() ) );
+      res = lineStringToJson( qgsgeometry_cast< const QgsLineString * >( geom ) );
       break;
 
     case QgsWkbTypes::CircularString:
     case QgsWkbTypes::CompoundCurve:
-      res = curveToJson( qgsgeometry_cast< const QgsCurve * >( geometry.constGet() ) );
+      res = curveToJson( qgsgeometry_cast< const QgsCurve * >( geom ) );
       break;
 
     case QgsWkbTypes::Polygon:
-      res = polygonToJson( qgsgeometry_cast< const QgsPolygon * >( geometry.constGet() ) );
+      res = polygonToJson( qgsgeometry_cast< const QgsPolygon * >( geom ) );
       break;
 
     case QgsWkbTypes::MultiPoint:
-      res = multiPointToJson( qgsgeometry_cast< const QgsMultiPoint * >( geometry.constGet() ) );
+      res = multiPointToJson( qgsgeometry_cast< const QgsMultiPoint * >( geom ) );
       break;
 
     case QgsWkbTypes::MultiLineString:
-      res = multiLineStringToJson( qgsgeometry_cast< const QgsMultiLineString * >( geometry.constGet() ) );
+      res = multiLineStringToJson( qgsgeometry_cast< const QgsMultiLineString * >( geom ) );
       break;
 
     case QgsWkbTypes::MultiCurve:
-      res = multiCurveToJson( qgsgeometry_cast< const QgsMultiCurve * >( geometry.constGet() ) );
+      res = multiCurveToJson( qgsgeometry_cast< const QgsMultiCurve * >( geom ) );
       break;
 
     case QgsWkbTypes::MultiPolygon:
-      res = multiPolygonToJson( qgsgeometry_cast< const QgsMultiPolygon * >( geometry.constGet() ) );
+      res = multiPolygonToJson( qgsgeometry_cast< const QgsMultiPolygon * >( geom ) );
       break;
 
     case QgsWkbTypes::CurvePolygon:
-      res = curvePolygonToJson( qgsgeometry_cast< const QgsCurvePolygon * >( geometry.constGet() ) );
+      res = curvePolygonToJson( qgsgeometry_cast< const QgsCurvePolygon * >( geom ) );
       break;
 
     case QgsWkbTypes::MultiSurface:
-      res = multiSurfaceToJson( qgsgeometry_cast< const QgsMultiSurface * >( geometry.constGet() ) );
+      res = multiSurfaceToJson( qgsgeometry_cast< const QgsMultiSurface * >( geom ) );
       break;
 
     case QgsWkbTypes::GeometryCollection:

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -79,9 +79,25 @@ class CORE_EXPORT QgsArcGisRestContext
      */
     QTimeZone timeZone() const { return mTimeZone; }
 
+    /**
+     * Sets the name of the objectId field.
+     *
+     * \see objectIdFieldName()
+     */
+    void setObjectIdFieldName( const QString &name ) { mObjectIdFieldName = name; }
+
+    /**
+     * Returns the name of the objectId field.
+     *
+     * \see setObjectIdFieldName()
+     */
+    QString objectIdFieldName() const { return mObjectIdFieldName; }
+
   private:
 
     QTimeZone mTimeZone;
+
+    QString mObjectIdFieldName;
 
 };
 
@@ -95,6 +111,8 @@ class CORE_EXPORT QgsArcGisRestContext
  */
 class CORE_EXPORT QgsArcGisRestUtils
 {
+    Q_GADGET
+
   public:
 
     /**
@@ -192,6 +210,26 @@ class CORE_EXPORT QgsArcGisRestUtils
     static QVariantMap crsToJson( const QgsCoordinateReferenceSystem &crs );
 
     /**
+     * Flags which control the behavior of converting features to JSON.
+     *
+     * \since QGIS 3.28
+     */
+    enum class FeatureToJsonFlag : int
+    {
+      IncludeGeometry = 1 << 0, //!< Whether to include the geometry definition
+      IncludeNonObjectIdAttributes = 1 << 1, //!< Whether to include any non-objectId attributes
+    };
+    Q_ENUM( FeatureToJsonFlag );
+
+    /**
+     * Flags which control the behavior of converting features to JSON.
+     *
+     * \since QGIS 3.28
+     */
+    Q_DECLARE_FLAGS( FeatureToJsonFlags, FeatureToJsonFlag )
+    Q_FLAG( FeatureToJsonFlags )
+
+    /**
      * Converts a \a feature to an ArcGIS REST JSON representation.
      *
      * \since QGIS 3.28
@@ -199,7 +237,7 @@ class CORE_EXPORT QgsArcGisRestUtils
     static QVariantMap featureToJson( const QgsFeature &feature,
                                       const QgsArcGisRestContext &context,
                                       const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
-                                      bool includeGeometry = true );
+                                      QgsArcGisRestUtils::FeatureToJsonFlags flags = QgsArcGisRestUtils::FeatureToJsonFlags( static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry ) | static_cast< int >( QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes ) ) );
 
     /**
      * Converts a variant to a REST attribute value.
@@ -277,5 +315,7 @@ class CORE_EXPORT QgsArcGisRestUtils
 
     friend class TestQgsArcGisRestUtils;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsArcGisRestUtils::FeatureToJsonFlags )
 
 #endif // QGSARCGISRESTUTILS_H

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -246,6 +246,13 @@ class CORE_EXPORT QgsArcGisRestUtils
      */
     static QVariant variantToAttributeValue( const QVariant &variant, QVariant::Type expectedType, const QgsArcGisRestContext &context );
 
+    /**
+     * Converts a \a field's definition to an ArcGIS REST JSON representation.
+     *
+     * \since QGIS 3.28
+     */
+    static QVariantMap fieldDefinitionToJson( const QgsField &field );
+
   private:
 
     /**

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -198,7 +198,8 @@ class CORE_EXPORT QgsArcGisRestUtils
      */
     static QVariantMap featureToJson( const QgsFeature &feature,
                                       const QgsArcGisRestContext &context,
-                                      const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+                                      const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
+                                      bool includeGeometry = true );
 
     /**
      * Converts a variant to a REST attribute value.

--- a/src/gui/attributetable/qgsfeatureselectionmodel.cpp
+++ b/src/gui/attributetable/qgsfeatureselectionmodel.cpp
@@ -73,7 +73,7 @@ void QgsFeatureSelectionModel::selectFeatures( const QItemSelection &selection, 
 {
   QgsFeatureIds ids;
 
-  QgsDebugMsg( QStringLiteral( "Index count: %1" ).arg( selection.indexes().size() ) );
+  QgsDebugMsgLevel( QStringLiteral( "Index count: %1" ).arg( selection.indexes().size() ), 2 );
 
   const auto constIndexes = selection.indexes();
   for ( const QModelIndex &index : constIndexes )

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -123,7 +123,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
   if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
     return false;
 
-  if ( mFeatureIterator >= mSource->sharedData()->featureCount() )
+  if ( mFeatureIterator >= mSource->sharedData()->objectIdCount() )
     return false;
 
   if ( mDeferredFeaturesInFilterRectCheck )
@@ -188,7 +188,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
     case QgsFeatureRequest::FilterExpression:
     case QgsFeatureRequest::FilterNone:
     {
-      while ( mFeatureIterator < mSource->sharedData()->featureCount() )
+      while ( mFeatureIterator < mSource->sharedData()->objectIdCount() )
       {
         if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
           return false;

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -196,13 +196,13 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         if ( !mFeatureIdList.empty() && mRemainingFeatureIds.empty() )
           return false;
 
-        if ( mSource->sharedData()->isDeleted( mFeatureIterator ) )
+        bool success = false;
+        bool isDeleted = mSource->sharedData()->isDeleted( mFeatureIterator );
+        if ( !isDeleted )
         {
-          ++mFeatureIterator;
-          continue;
+          success = mSource->sharedData()->getFeature( mFeatureIterator, f, QgsRectangle(), mInterruptionChecker );
         }
 
-        bool success = mSource->sharedData()->getFeature( mFeatureIterator, f, QgsRectangle(), mInterruptionChecker );
         if ( !mFeatureIdList.empty() )
         {
           mRemainingFeatureIds.removeAll( mFeatureIterator );
@@ -214,7 +214,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
           ++mFeatureIterator;
         }
 
-        if ( !mFilterRect.isNull() )
+        if ( success && !mFilterRect.isNull() )
         {
           if ( !f.hasGeometry() )
             success = false;

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -196,6 +196,12 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         if ( !mFeatureIdList.empty() && mRemainingFeatureIds.empty() )
           return false;
 
+        if ( mSource->sharedData()->isDeleted( mFeatureIterator ) )
+        {
+          ++mFeatureIterator;
+          continue;
+        }
+
         bool success = mSource->sharedData()->getFeature( mFeatureIterator, f, QgsRectangle(), mInterruptionChecker );
         if ( !mFeatureIdList.empty() )
         {

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.h
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.h
@@ -30,6 +30,7 @@ class QgsAfsFeatureSource : public QgsAbstractFeatureSource
   public:
     QgsAfsFeatureSource( const std::shared_ptr<QgsAfsSharedData> &sharedData );
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) override;
+
     QgsAfsSharedData *sharedData() const;
 
   protected:

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -522,6 +522,29 @@ bool QgsAfsProvider::deleteAttributes( const QgsAttributeIds &attributes )
   return res;
 }
 
+bool QgsAfsProvider::createAttributeIndex( int field )
+{
+  if ( mAdminUrl.isEmpty() )
+    return false;
+
+  const QStringList adminCapabilities = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
+  if ( !adminCapabilities.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+    return false;
+
+  if ( field < 0 || field >= mSharedData->mFields.count() )
+  {
+    return false;
+  }
+
+  QString error;
+  QgsFeedback feedback;
+  const bool res = mSharedData->addAttributeIndex( mAdminUrl, field, error, &feedback );
+  if ( !res )
+    pushError( tr( "Error while creating attribute index: %1" ).arg( error ) );
+
+  return true;
+}
+
 QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
 {
   QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId
@@ -558,6 +581,7 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
   if ( adminCapabilities.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
   {
     c |= QgsVectorDataProvider::AddAttributes;
+    c |= QgsVectorDataProvider::CreateAttributeIndex;
   }
   if ( adminCapabilities.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
   {

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -75,6 +75,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     mSharedData->mExtent.setYMaximum( coords[3].toDouble( &ymaxOk ) );
     if ( !xminOk || !yminOk || !xmaxOk || !ymaxOk )
       mSharedData->mExtent = QgsRectangle();
+    else
+      mSharedData->mLimitBBox = true;
   }
 
   const QVariantMap layerExtentMap = layerData[QStringLiteral( "extent" )].toMap();

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -287,6 +287,27 @@ QgsLayerMetadata QgsAfsProvider::layerMetadata() const
   return mLayerMetadata;
 }
 
+bool QgsAfsProvider::deleteFeatures( const QgsFeatureIds &ids )
+{
+  if ( !mCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
+    return false;
+
+  return mSharedData->deleteFeatures( ids );
+}
+
+bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
+{
+  if ( !mCapabilityStrings.contains( QLatin1String( "create" ), Qt::CaseInsensitive ) )
+    return false;
+
+  QString error;
+  const bool res = mSharedData->addFeatures( flist, error );
+  if ( !res )
+    pushError( tr( "Error while adding features: %1" ).arg( error ) );
+
+  return res;
+}
+
 QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
 {
   QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -270,7 +270,7 @@ QgsWkbTypes::Type QgsAfsProvider::wkbType() const
 
 long long QgsAfsProvider::featureCount() const
 {
-  return mSharedData->mObjectIds.size();
+  return mSharedData->featureCount();
 }
 
 QgsFields QgsAfsProvider::fields() const

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -64,7 +64,6 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
 
   // Set extent
   QStringList coords = mSharedData->mDataSource.param( QStringLiteral( "bbox" ) ).split( ',' );
-  bool limitBbox = false;
   if ( coords.size() == 4 )
   {
     bool xminOk = false, yminOk = false, xmaxOk = false, ymaxOk = false;
@@ -74,11 +73,6 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     mSharedData->mExtent.setYMaximum( coords[3].toDouble( &ymaxOk ) );
     if ( !xminOk || !yminOk || !xmaxOk || !ymaxOk )
       mSharedData->mExtent = QgsRectangle();
-    else
-    {
-      // user has set a bounding box limit on the layer - so we only EVER fetch features from this extent
-      limitBbox = true;
-    }
   }
 
   const QVariantMap layerExtentMap = layerData[QStringLiteral( "extent" )].toMap();
@@ -228,38 +222,10 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // Read OBJECTIDs of all features: these may not be a continuous sequence,
   // and we need to store these to iterate through the features. This query
   // also returns the name of the ObjectID field.
-  QVariantMap objectIdData = QgsArcGisRestQueryUtils::getObjectIds( mSharedData->mDataSource.param( QStringLiteral( "url" ) ), authcfg,
-                             errorTitle,  errorMessage, mRequestHeaders, limitBbox ? mSharedData->mExtent : QgsRectangle() );
-  if ( objectIdData.isEmpty() )
+  if ( ! mSharedData->getObjectIds( errorMessage ) )
   {
-    appendError( QgsErrorMessage( tr( "getObjectIds failed: %1 - %2" ).arg( errorTitle, errorMessage ), QStringLiteral( "AFSProvider" ) ) );
+    appendError( QgsErrorMessage( errorMessage, QStringLiteral( "AFSProvider" ) ) );
     return;
-  }
-  if ( !objectIdData[QStringLiteral( "objectIdFieldName" )].isValid() || !objectIdData[QStringLiteral( "objectIds" )].isValid() )
-  {
-    appendError( QgsErrorMessage( tr( "Failed to determine objectIdFieldName and/or objectIds" ), QStringLiteral( "AFSProvider" ) ) );
-    return;
-  }
-  mSharedData->mObjectIdFieldName = objectIdData[QStringLiteral( "objectIdFieldName" )].toString();
-  for ( int idx = 0, nIdx = mSharedData->mFields.count(); idx < nIdx; ++idx )
-  {
-    if ( mSharedData->mFields.at( idx ).name() == mSharedData->mObjectIdFieldName )
-    {
-      mObjectIdFieldIdx = idx;
-
-      // primary key is not null, unique
-      QgsFieldConstraints constraints = mSharedData->mFields.at( idx ).constraints();
-      constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
-      constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
-      mSharedData->mFields[ idx ].setConstraints( constraints );
-
-      break;
-    }
-  }
-  const QVariantList objectIds = objectIdData.value( QStringLiteral( "objectIds" ) ).toList();
-  for ( const QVariant &objectId : objectIds )
-  {
-    mSharedData->mObjectIds.append( objectId.toInt() );
   }
 
   // layer metadata

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -337,6 +337,8 @@ bool QgsAfsProvider::changeAttributeValues( const QgsChangedAttributesMap &attrM
   QgsFeatureList updatedFeatures;
   updatedFeatures.reserve( attrMap.size() );
 
+  const int objectIdFieldIndex = mSharedData->mObjectIdFieldIdx;
+
   while ( it.nextFeature( feature ) )
   {
     QgsFeature modifiedFeature = feature;
@@ -344,7 +346,9 @@ bool QgsAfsProvider::changeAttributeValues( const QgsChangedAttributesMap &attrM
     const QgsAttributeMap modifiedAttributes = attrMap.value( feature.id() );
     for ( auto aIt = modifiedAttributes.constBegin(); aIt != modifiedAttributes.constEnd(); ++aIt )
     {
-      // todo -- handle object id
+      if ( aIt.key() == objectIdFieldIndex )
+        continue; // can't modify the objectId field!
+
       modifiedFeature.setAttribute( aIt.key(), aIt.value() );
     }
 
@@ -419,6 +423,7 @@ bool QgsAfsProvider::changeFeatures( const QgsChangedAttributesMap &attrMap, con
 
   QgsFeatureList updatedFeatures;
   updatedFeatures.reserve( attrMap.size() );
+  const int objectIdFieldIndex = mSharedData->mObjectIdFieldIdx;
 
   while ( it.nextFeature( feature ) )
   {
@@ -427,6 +432,9 @@ bool QgsAfsProvider::changeFeatures( const QgsChangedAttributesMap &attrMap, con
     const QgsAttributeMap modifiedAttributes = attrMap.value( feature.id() );
     for ( auto aIt = modifiedAttributes.constBegin(); aIt != modifiedAttributes.constEnd(); ++aIt )
     {
+      if ( aIt.key() == objectIdFieldIndex )
+        continue; // can't modify the objectId field!
+
       modifiedFeature.setAttribute( aIt.key(), aIt.value() );
     }
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -308,6 +308,9 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
   if ( !mCapabilityStrings.contains( QLatin1String( "create" ), Qt::CaseInsensitive ) )
     return false;
 
+  if ( flist.isEmpty() )
+    return true; // for consistency!
+
   QString error;
   QgsFeedback feedback;
   const bool res = mSharedData->addFeatures( flist, error, &feedback );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -316,6 +316,49 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
   return res;
 }
 
+bool QgsAfsProvider::changeAttributeValues( const QgsChangedAttributesMap &attrMap )
+{
+  if ( !mCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+    return false;
+
+  QgsFeatureIds ids;
+  ids.reserve( attrMap.size() );
+  for ( auto it = attrMap.constBegin(); it != attrMap.constEnd(); ++it )
+  {
+    const QgsFeatureId id = it.key();
+    ids << id;
+  }
+
+  // REST API requires a full definition of features, so we have to read their initial values first
+  QgsFeatureIterator it = getFeatures( QgsFeatureRequest().setFilterFids( ids ) );
+  QgsFeature feature;
+
+  QgsFeatureList updatedFeatures;
+  updatedFeatures.reserve( attrMap.size() );
+
+  while ( it.nextFeature( feature ) )
+  {
+    QgsFeature modifiedFeature = feature;
+
+    const QgsAttributeMap modifiedAttributes = attrMap.value( feature.id() );
+    for ( auto aIt = modifiedAttributes.constBegin(); aIt != modifiedAttributes.constEnd(); ++aIt )
+    {
+      // todo -- handle object id
+      modifiedFeature.setAttribute( aIt.key(), aIt.value() );
+    }
+
+    updatedFeatures.append( modifiedFeature );
+  }
+
+  QString error;
+  QgsFeedback feedback;
+  const bool res = mSharedData->updateFeatures( updatedFeatures, false, error, &feedback );
+  if ( !res )
+    pushError( tr( "Error while updating features: %1" ).arg( error ) );
+
+  return res;
+}
+
 QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
 {
   QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -322,6 +322,23 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
   return c;
 }
 
+QgsAttributeList QgsAfsProvider::pkAttributeIndexes() const
+{
+  return QgsAttributeList() << mSharedData->mObjectIdFieldIdx;
+}
+
+QString QgsAfsProvider::defaultValueClause( int fieldId ) const
+{
+  if ( fieldId == mSharedData->mObjectIdFieldIdx )
+    return QStringLiteral( "Autogenerate" );
+  return QString();
+}
+
+bool QgsAfsProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint, const QVariant &value ) const
+{
+  return fieldIndex == mSharedData->mObjectIdFieldIdx && value.toString() == QLatin1String( "Autogenerate" );
+}
+
 void QgsAfsProvider::setDataSourceUri( const QString &uri )
 {
   mSharedData->mDataSource = QgsDataSourceUri( uri );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -70,13 +70,19 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   {
     // if the user has update capability, see if this extends to field definition modification
     QString adminUrl = mSharedData->mDataSource.param( QStringLiteral( "url" ) );
-    adminUrl.replace( QStringLiteral( "/rest/services/" ), QStringLiteral( "/rest/admin/services/" ) );
-    const QVariantMap adminData = QgsArcGisRestQueryUtils::getLayerInfo( adminUrl,
-                                  authcfg, errorTitle, errorMessage, mRequestHeaders );
-    if ( !adminData.isEmpty() )
+
+    // note that for hosted ArcGIS Server the admin url may not match this format (which is how it works for AGOL).
+    // we may want to consider exposing the admin url as an option for users to set
+    if ( adminUrl.contains( QStringLiteral( "/rest/services/" ) ) )
     {
-      mAdminUrl = adminUrl;
-      mAdminData = adminData;
+      adminUrl.replace( QStringLiteral( "/rest/services/" ), QStringLiteral( "/rest/admin/services/" ) );
+      const QVariantMap adminData = QgsArcGisRestQueryUtils::getLayerInfo( adminUrl,
+                                    authcfg, errorTitle, errorMessage, mRequestHeaders );
+      if ( !adminData.isEmpty() )
+      {
+        mAdminUrl = adminUrl;
+        mAdminData = adminData;
+      }
     }
   }
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -61,6 +61,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   }
   mLayerName = layerData[QStringLiteral( "name" )].toString();
   mLayerDescription = layerData[QStringLiteral( "description" )].toString();
+  mCapabilityStrings = layerData[QStringLiteral( "capabilities" )].toString().split( ',' );
 
   // Set extent
   QStringList coords = mSharedData->mDataSource.param( QStringLiteral( "bbox" ) ).split( ',' );
@@ -294,6 +295,22 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
   {
     c = c | QgsVectorDataProvider::CreateLabeling;
   }
+
+  if ( mCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
+  {
+    c |= QgsVectorDataProvider::DeleteFeatures;
+  }
+  if ( mCapabilityStrings.contains( QLatin1String( "create" ), Qt::CaseInsensitive ) )
+  {
+    c |= QgsVectorDataProvider::AddFeatures;
+  }
+  if ( mCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+  {
+    c |= QgsVectorDataProvider::ChangeAttributeValues;
+    c |= QgsVectorDataProvider::ChangeFeatures;
+    c |= QgsVectorDataProvider::ChangeGeometries;
+  }
+
   return c;
 }
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -27,6 +27,7 @@
 #include "qgsruntimeprofiler.h"
 #include "qgsfeedback.h"
 #include "qgsreadwritelocker.h"
+#include "qgsvariantutils.h"
 
 const QString QgsAfsProvider::AFS_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
 const QString QgsAfsProvider::AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Service data provider" );
@@ -221,6 +222,17 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
           QgsArcGisRestUtils::convertDateTime( extent.at( 1 ) ) ) );
     }
   }
+
+  QList<QgsVectorDataProvider::NativeType> types
+  {
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Int ), QStringLiteral( "esriFieldTypeSmallInteger" ), QVariant::Int, -1, -1, 0, 0 ),
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::LongLong ), QStringLiteral( "esriFieldTypeInteger" ), QVariant::LongLong, -1, -1, 0, 0 ),
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::Double ), QStringLiteral( "esriFieldTypeDouble" ), QVariant::Double, 1, 20, 0, 20 ),
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::String ), QStringLiteral( "esriFieldTypeString" ), QVariant::String, -1, -1, -1, -1 ),
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::DateTime ), QStringLiteral( "esriFieldTypeDate" ), QVariant::DateTime, -1, -1, -1, -1 ),
+    QgsVectorDataProvider::NativeType( QgsVariantUtils::typeToDisplayString( QVariant::ByteArray ), QStringLiteral( "esriFieldTypeBlob" ), QVariant::ByteArray, -1, -1, -1, -1 )
+  };
+  setNativeTypes( types );
 
   if ( profile )
     profile->switchTask( tr( "Retrieve object IDs" ) );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -25,6 +25,7 @@
 #include "qgsdataitemprovider.h"
 #include "qgsapplication.h"
 #include "qgsruntimeprofiler.h"
+#include "qgsfeedback.h"
 
 const QString QgsAfsProvider::AFS_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
 const QString QgsAfsProvider::AFS_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Service data provider" );
@@ -292,7 +293,13 @@ bool QgsAfsProvider::deleteFeatures( const QgsFeatureIds &ids )
   if ( !mCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
     return false;
 
-  return mSharedData->deleteFeatures( ids );
+  QString error;
+  QgsFeedback feedback;
+  const bool result = mSharedData->deleteFeatures( ids, error, &feedback );
+  if ( !result )
+    pushError( tr( "Error while deleting features: %1" ).arg( error ) );
+
+  return result;
 }
 
 bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
@@ -301,7 +308,8 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
     return false;
 
   QString error;
-  const bool res = mSharedData->addFeatures( flist, error );
+  QgsFeedback feedback;
+  const bool res = mSharedData->addFeatures( flist, error, &feedback );
   if ( !res )
     pushError( tr( "Error while adding features: %1" ).arg( error ) );
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -62,6 +62,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   mLayerName = layerData[QStringLiteral( "name" )].toString();
   mLayerDescription = layerData[QStringLiteral( "description" )].toString();
   mCapabilityStrings = layerData[QStringLiteral( "capabilities" )].toString().split( ',' );
+  mServerSupportsCurves = layerData.value( QStringLiteral( "allowTrueCurvesUpdates" ), false ).toBool();
 
   // Set extent
   QStringList coords = mSharedData->mDataSource.param( QStringLiteral( "bbox" ) ).split( ',' );
@@ -286,7 +287,9 @@ QgsLayerMetadata QgsAfsProvider::layerMetadata() const
 
 QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
 {
-  QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::ReadLayerMetadata | QgsVectorDataProvider::Capability::ReloadData;
+  QgsVectorDataProvider::Capabilities c = QgsVectorDataProvider::SelectAtId
+                                          | QgsVectorDataProvider::ReadLayerMetadata
+                                          | QgsVectorDataProvider::Capability::ReloadData;
   if ( !mRendererDataMap.empty() )
   {
     c = c | QgsVectorDataProvider::CreateRenderer;
@@ -295,6 +298,9 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
   {
     c = c | QgsVectorDataProvider::CreateLabeling;
   }
+
+  if ( mServerSupportsCurves )
+    c |= QgsVectorDataProvider::CircularGeometries;
 
   if ( mCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
   {

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -82,6 +82,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
       {
         mAdminUrl = adminUrl;
         mAdminData = adminData;
+        mAdminCapabilityStrings = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
       }
     }
   }
@@ -497,8 +498,7 @@ bool QgsAfsProvider::addAttributes( const QList<QgsField> &attributes )
   if ( mAdminUrl.isEmpty() )
     return false;
 
-  const QStringList adminCapabilities = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
-  if ( !adminCapabilities.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+  if ( !mAdminCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
     return false;
 
   QString error;
@@ -515,8 +515,7 @@ bool QgsAfsProvider::deleteAttributes( const QgsAttributeIds &attributes )
   if ( mAdminUrl.isEmpty() )
     return false;
 
-  const QStringList adminCapabilities = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
-  if ( !adminCapabilities.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
+  if ( !mAdminCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
     return false;
 
   QString error;
@@ -533,8 +532,7 @@ bool QgsAfsProvider::createAttributeIndex( int field )
   if ( mAdminUrl.isEmpty() )
     return false;
 
-  const QStringList adminCapabilities = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
-  if ( !adminCapabilities.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+  if ( !mAdminCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
     return false;
 
   if ( field < 0 || field >= mSharedData->mFields.count() )
@@ -583,13 +581,12 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
     c |= QgsVectorDataProvider::ChangeGeometries;
   }
 
-  const QStringList adminCapabilities = mAdminData.value( QStringLiteral( "capabilities" ) ).toString().split( ',' );
-  if ( adminCapabilities.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
+  if ( mAdminCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive ) )
   {
     c |= QgsVectorDataProvider::AddAttributes;
     c |= QgsVectorDataProvider::CreateAttributeIndex;
   }
-  if ( adminCapabilities.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
+  if ( mAdminCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )
   {
     c |= QgsVectorDataProvider::DeleteAttributes;
   }

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -52,9 +52,11 @@ class QgsAfsProvider : public QgsVectorDataProvider
     long long featureCount() const override;
     QgsFields fields() const override;
     QgsLayerMetadata layerMetadata() const override;
+    bool deleteFeatures( const QgsFeatureIds &id ) override;
+    bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+
     /* Read only for the moment
-    bool addFeatures( QgsFeatureList &flist ) override{ return false; }
-    bool deleteFeatures( const QgsFeatureIds &id ) override{ return false; }
+
     bool addAttributes( const QList<QgsField> &attributes ) override{ return false; }
     bool deleteAttributes( const QgsAttributeIds &attributes ) override{ return false; }
     bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override{ return false; }

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -57,12 +57,9 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeAttributeValues( const QgsChangedAttributesMap &attrMap ) override;
     bool changeGeometryValues( const QgsGeometryMap &geometryMap ) override;
     bool changeFeatures( const QgsChangedAttributesMap &attrMap, const QgsGeometryMap &geometryMap ) override;
+    bool addAttributes( const QList<QgsField> &attributes ) override;
+    bool deleteAttributes( const QgsAttributeIds &attributes ) override;
 
-    /* Read only for the moment
-
-    bool addAttributes( const QList<QgsField> &attributes ) override{ return false; }
-    bool deleteAttributes( const QgsAttributeIds &attributes ) override{ return false; }
-    */
     QgsVectorDataProvider::Capabilities capabilities() const override;
     QgsAttributeList pkAttributeIndexes() const override;
     QString defaultValueClause( int fieldId ) const override;
@@ -99,6 +96,8 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QVariantList mLabelingDataList;
     QgsHttpHeaders mRequestHeaders;
     bool mServerSupportsCurves = false;
+    QString mAdminUrl;
+    QVariantMap mAdminData;
 
     /**
      * Clears cache

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -93,6 +93,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;
     QgsHttpHeaders mRequestHeaders;
+    bool mServerSupportsCurves = false;
 
     /**
      * Clears cache

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -61,8 +61,10 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
     */
     QgsVectorDataProvider::Capabilities capabilities() const override;
-    QgsAttributeList pkAttributeIndexes() const override { return QgsAttributeList() << mSharedData->mObjectIdFieldIdx; }
+    QgsAttributeList pkAttributeIndexes() const override;
+    QString defaultValueClause( int fieldId ) const override;
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override { return QgsAttrPalIndexNameHash(); }
+    bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;
 
     /* Inherited from QgsDataProvider */
     QgsCoordinateReferenceSystem crs() const override;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -99,6 +99,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool mServerSupportsCurves = false;
     QString mAdminUrl;
     QVariantMap mAdminData;
+    QStringList mAdminCapabilityStrings;
 
     /**
      * Clears cache

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -61,7 +61,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
     */
     QgsVectorDataProvider::Capabilities capabilities() const override;
-    QgsAttributeList pkAttributeIndexes() const override { return QgsAttributeList() << mObjectIdFieldIdx; }
+    QgsAttributeList pkAttributeIndexes() const override { return QgsAttributeList() << mSharedData->mObjectIdFieldIdx; }
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override { return QgsAttrPalIndexNameHash(); }
 
     /* Inherited from QgsDataProvider */
@@ -86,7 +86,6 @@ class QgsAfsProvider : public QgsVectorDataProvider
   private:
     bool mValid = false;
     std::shared_ptr<QgsAfsSharedData> mSharedData;
-    int mObjectIdFieldIdx = -1;
     QString mLayerName;
     QString mLayerDescription;
     QgsLayerMetadata mLayerMetadata;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -54,13 +54,15 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QgsLayerMetadata layerMetadata() const override;
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
+    bool changeAttributeValues( const QgsChangedAttributesMap &attrMap ) override;
 
     /* Read only for the moment
 
     bool addAttributes( const QList<QgsField> &attributes ) override{ return false; }
     bool deleteAttributes( const QgsAttributeIds &attributes ) override{ return false; }
-    bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override{ return false; }
     bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
+    virtual bool changeFeatures( const QgsChangedAttributesMap &attr_map,
+                                 const QgsGeometryMap &geometry_map );
     */
     QgsVectorDataProvider::Capabilities capabilities() const override;
     QgsAttributeList pkAttributeIndexes() const override;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -55,14 +55,13 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool changeAttributeValues( const QgsChangedAttributesMap &attrMap ) override;
-    bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
+    bool changeGeometryValues( const QgsGeometryMap &geometryMap ) override;
+    bool changeFeatures( const QgsChangedAttributesMap &attrMap, const QgsGeometryMap &geometryMap ) override;
 
     /* Read only for the moment
 
     bool addAttributes( const QList<QgsField> &attributes ) override{ return false; }
     bool deleteAttributes( const QgsAttributeIds &attributes ) override{ return false; }
-    virtual bool changeFeatures( const QgsChangedAttributesMap &attr_map,
-                                 const QgsGeometryMap &geometry_map );
     */
     QgsVectorDataProvider::Capabilities capabilities() const override;
     QgsAttributeList pkAttributeIndexes() const override;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -88,6 +88,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     std::shared_ptr<QgsAfsSharedData> mSharedData;
     QString mLayerName;
     QString mLayerDescription;
+    QStringList mCapabilityStrings;
     QgsLayerMetadata mLayerMetadata;
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -55,12 +55,12 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = QgsFeatureSink::Flags() ) override;
     bool changeAttributeValues( const QgsChangedAttributesMap &attrMap ) override;
+    bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
 
     /* Read only for the moment
 
     bool addAttributes( const QList<QgsField> &attributes ) override{ return false; }
     bool deleteAttributes( const QgsAttributeIds &attributes ) override{ return false; }
-    bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
     virtual bool changeFeatures( const QgsChangedAttributesMap &attr_map,
                                  const QgsGeometryMap &geometry_map );
     */

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -59,6 +59,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeFeatures( const QgsChangedAttributesMap &attrMap, const QgsGeometryMap &geometryMap ) override;
     bool addAttributes( const QList<QgsField> &attributes ) override;
     bool deleteAttributes( const QgsAttributeIds &attributes ) override;
+    bool createAttributeIndex( int field ) override;
 
     QgsVectorDataProvider::Capabilities capabilities() const override;
     QgsAttributeList pkAttributeIndexes() const override;

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -17,12 +17,15 @@
 #include "qgsarcgisrestutils.h"
 #include "qgsarcgisrestquery.h"
 #include "qgslogger.h"
-#include <QUrlQuery>
-#include <QNetworkRequest>
 #include "qgsnetworkaccessmanager.h"
 #include "qgsblockingnetworkrequest.h"
 #include "qgsreadwritelocker.h"
 #include "qgsjsonutils.h"
+
+#include <QUrlQuery>
+#include <QNetworkRequest>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
 
 #include <nlohmann/json.hpp>
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -99,6 +99,12 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
   return true;
 }
 
+quint32 QgsAfsSharedData::featureIdToObjectId( QgsFeatureId id )
+{
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  return mObjectIds.value( id, -1 );
+}
+
 bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect, QgsFeedback *feedback )
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -18,6 +18,16 @@
 #include "qgsarcgisrestquery.h"
 #include "qgslogger.h"
 
+long long QgsAfsSharedData::objectIdCount() const
+{
+  return mObjectIds.size();
+}
+
+long long QgsAfsSharedData::featureCount() const
+{
+  return mObjectIds.size();
+}
+
 void QgsAfsSharedData::clearCache()
 {
   const QMutexLocker locker( &mMutex );
@@ -210,5 +220,5 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
 
 bool QgsAfsSharedData::hasCachedAllFeatures() const
 {
-  return mCache.count() == mObjectIds.count();
+  return mCache.count() == featureCount();
 }

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -312,7 +312,7 @@ bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMess
     }
   }
 
-  // all good!
+  // All good!
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Write );
   int i = 0;
   for ( const QVariant &result : addResults )
@@ -372,7 +372,7 @@ bool QgsAfsSharedData::updateFeatures( const QgsFeatureList &features, bool incl
     }
   }
 
-  // all good. Now we remove the cached versions of features so that they'll get re-fetched from the service
+  // All good. Now we remove the cached versions of features so that they'll get re-fetched from the service
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Write );
   for ( const QgsFeature &feature : features )
   {
@@ -413,7 +413,7 @@ bool QgsAfsSharedData::addFields( const QString &adminUrl, const QList<QgsField>
     return false;
   }
 
-  // all good. Now we remove the cached versions of features so that they'll get re-fetched from the service
+  // All good. Now we remove the cached versions of features so that they'll get re-fetched from the service
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Write );
   mCache.clear();
 
@@ -462,7 +462,7 @@ bool QgsAfsSharedData::deleteFields( const QString &adminUrl, const QgsAttribute
     return false;
   }
 
-  // all good. Now we remove the cached versions of features so that they'll get re-fetched from the service
+  // All good. Now we remove the cached versions of features so that they'll get re-fetched from the service
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Write );
   mCache.clear();
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -124,13 +124,13 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
   objectIds.reserve( stopId );
   for ( int i = startId; i < stopId; ++i )
   {
-    if ( i >= 0 && i < mObjectIds.count() && !mDeletedFeatureIds.contains( i ) )
+    if ( i >= 0 && i < mObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
       objectIds.append( mObjectIds.at( i ) );
   }
 
   if ( objectIds.empty() )
   {
-    QgsDebugMsg( QStringLiteral( "No valid features IDs to fetch" ) );
+    QgsDebugMsgLevel( QStringLiteral( "No valid features IDs to fetch" ), 2 );
     return false;
   }
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -322,18 +322,25 @@ bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMess
   return true;
 }
 
-bool QgsAfsSharedData::updateFeatures( const QgsFeatureList &features, bool includeGeometries, QString &error, QgsFeedback *feedback )
+bool QgsAfsSharedData::updateFeatures( const QgsFeatureList &features, bool includeGeometries, bool includeAttributes, QString &error, QgsFeedback *feedback )
 {
   error.clear();
   QUrl queryUrl( mDataSource.param( QStringLiteral( "url" ) ) + "/updateFeatures" );
 
   QgsArcGisRestContext context;
+  context.setObjectIdFieldName( mObjectIdFieldName );
+
+  QgsArcGisRestUtils::FeatureToJsonFlags flags;
+  if ( includeGeometries )
+    flags |= QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry;
+  if ( includeAttributes )
+    flags |= QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes;
 
   QVariantList featuresJson;
   featuresJson.reserve( features.size() );
   for ( const QgsFeature &feature : features )
   {
-    featuresJson.append( QgsArcGisRestUtils::featureToJson( feature, context, QgsCoordinateReferenceSystem(), includeGeometries ) );
+    featuresJson.append( QgsArcGisRestUtils::featureToJson( feature, context, QgsCoordinateReferenceSystem(), flags ) );
   }
 
   const QString json = QString::fromStdString( QgsJsonUtils::jsonFromVariant( featuresJson ).dump( 2 ) );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -52,7 +52,7 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
   QString errorTitle;
   QString error;
   QVariantMap objectIdData = QgsArcGisRestQueryUtils::getObjectIds( mDataSource.param( QStringLiteral( "url" ) ), mDataSource.authConfigId(),
-                             errorTitle, error, mDataSource.httpHeaders(), !mExtent.isNull() ? mExtent : QgsRectangle() );
+                             errorTitle, error, mDataSource.httpHeaders(), mLimitBBox ? mExtent : QgsRectangle() );
   if ( objectIdData.isEmpty() )
   {
     errorMessage = tr( "getObjectIds failed: %1 - %2" ).arg( errorTitle, error );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -75,6 +75,7 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
       constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
       constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
       mFields[ idx ].setConstraints( constraints );
+      mFields[ idx ].setReadOnly( true );
 
       break;
     }

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -21,11 +21,13 @@
 
 long long QgsAfsSharedData::objectIdCount() const
 {
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mObjectIds.size();
 }
 
 long long QgsAfsSharedData::featureCount() const
 {
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mObjectIds.size();
 }
 
@@ -223,5 +225,6 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
 
 bool QgsAfsSharedData::hasCachedAllFeatures() const
 {
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mCache.count() == featureCount();
 }

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -35,6 +35,7 @@ class QgsAfsSharedData : public QObject
     QgsAfsSharedData() = default;
     long long objectIdCount() const;
     long long featureCount() const;
+    bool isDeleted( QgsFeatureId id ) const { return mDeletedFeatureIds.contains( id ); }
     const QgsFields &fields() const { return mFields; }
     QgsRectangle extent() const { return mExtent; }
     QgsCoordinateReferenceSystem crs() const { return mSourceCRS; }
@@ -44,6 +45,9 @@ class QgsAfsSharedData : public QObject
 
     bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
+
+    bool deleteFeatures( const QgsFeatureIds &id );
+    bool addFeatures( QgsFeatureList &features, QString &error );
 
     bool hasCachedAllFeatures() const;
 
@@ -55,10 +59,12 @@ class QgsAfsSharedData : public QObject
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;
     QgsFields mFields;
+
     QString mObjectIdFieldName;
     int mObjectIdFieldIdx = -1;
 
     QList<quint32> mObjectIds;
+    QSet<QgsFeatureId> mDeletedFeatureIds;
     QMap<QgsFeatureId, QgsFeature> mCache;
     QgsCoordinateReferenceSystem mSourceCRS;
 };

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -48,7 +48,7 @@ class QgsAfsSharedData : public QObject
 
     bool deleteFeatures( const QgsFeatureIds &id, QString &error, QgsFeedback *feedback );
     bool addFeatures( QgsFeatureList &features, QString &error, QgsFeedback *feedback );
-    bool updateFeatures( const QgsFeatureList &features, bool includeGeometries, QString &error, QgsFeedback *feedback );
+    bool updateFeatures( const QgsFeatureList &features, bool includeGeometries, bool includeAttributes, QString &error, QgsFeedback *feedback );
 
     bool hasCachedAllFeatures() const;
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -49,7 +49,7 @@ class QgsAfsSharedData : public QObject
 
   private:
     friend class QgsAfsProvider;
-    QReadWriteLock mReadWriteLock;
+    mutable QReadWriteLock mReadWriteLock{ QReadWriteLock::Recursive };
     QgsDataSourceUri mDataSource;
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -43,6 +43,8 @@ class QgsAfsSharedData : public QObject
 
     bool getObjectIds( QString &errorMessage );
 
+    quint32 featureIdToObjectId( QgsFeatureId id );
+
     bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -22,6 +22,7 @@
 #include "qgsfeature.h"
 #include "qgsdatasourceuri.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsvectordataprovider.h"
 
 class QgsFeedback;
 
@@ -51,6 +52,8 @@ class QgsAfsSharedData : public QObject
     bool deleteFeatures( const QgsFeatureIds &id, QString &error, QgsFeedback *feedback );
     bool addFeatures( QgsFeatureList &features, QString &error, QgsFeedback *feedback );
     bool updateFeatures( const QgsFeatureList &features, bool includeGeometries, bool includeAttributes, QString &error, QgsFeedback *feedback );
+    bool addFields( const QString &adminUrl, const QList<QgsField> &attributes, QString &error, QgsFeedback *feedback );
+    bool deleteFields( const QString &adminUrl, const QgsAttributeIds &attributes, QString &error, QgsFeedback *feedback );
 
     bool hasCachedAllFeatures() const;
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -46,12 +46,15 @@ class QgsAfsSharedData : public QObject
     bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
 
-    bool deleteFeatures( const QgsFeatureIds &id );
-    bool addFeatures( QgsFeatureList &features, QString &error );
+    bool deleteFeatures( const QgsFeatureIds &id, QString &error, QgsFeedback *feedback );
+    bool addFeatures( QgsFeatureList &features, QString &error, QgsFeedback *feedback );
 
     bool hasCachedAllFeatures() const;
 
   private:
+
+    QVariantMap postData( const QUrl &url, const QByteArray &payload, QgsFeedback *feedback, bool &ok, QString &errorText ) const;
+
     friend class QgsAfsProvider;
     mutable QReadWriteLock mReadWriteLock{ QReadWriteLock::Recursive };
     QgsDataSourceUri mDataSource;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -51,6 +51,7 @@ class QgsAfsSharedData : public QObject
     friend class QgsAfsProvider;
     mutable QReadWriteLock mReadWriteLock{ QReadWriteLock::Recursive };
     QgsDataSourceUri mDataSource;
+    bool mLimitBBox = false;
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;
     QgsFields mFields;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -33,7 +33,8 @@ class QgsAfsSharedData : public QObject
     Q_OBJECT
   public:
     QgsAfsSharedData() = default;
-    long long featureCount() const { return mObjectIds.size(); }
+    long long objectIdCount() const;
+    long long featureCount() const;
     const QgsFields &fields() const { return mFields; }
     QgsRectangle extent() const { return mExtent; }
     QgsCoordinateReferenceSystem crs() const { return mSourceCRS; }

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -54,6 +54,7 @@ class QgsAfsSharedData : public QObject
     bool updateFeatures( const QgsFeatureList &features, bool includeGeometries, bool includeAttributes, QString &error, QgsFeedback *feedback );
     bool addFields( const QString &adminUrl, const QList<QgsField> &attributes, QString &error, QgsFeedback *feedback );
     bool deleteFields( const QString &adminUrl, const QgsAttributeIds &attributes, QString &error, QgsFeedback *feedback );
+    bool addAttributeIndex( const QString &adminUrl, int attribute, QString &error, QgsFeedback *feedback );
 
     bool hasCachedAllFeatures() const;
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -48,6 +48,7 @@ class QgsAfsSharedData : public QObject
 
     bool deleteFeatures( const QgsFeatureIds &id, QString &error, QgsFeedback *feedback );
     bool addFeatures( QgsFeatureList &features, QString &error, QgsFeedback *feedback );
+    bool updateFeatures( const QgsFeatureList &features, bool includeGeometries, QString &error, QgsFeedback *feedback );
 
     bool hasCachedAllFeatures() const;
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -49,7 +49,7 @@ class QgsAfsSharedData : public QObject
 
   private:
     friend class QgsAfsProvider;
-    QMutex mMutex;
+    QReadWriteLock mReadWriteLock;
     QgsDataSourceUri mDataSource;
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -39,6 +39,8 @@ class QgsAfsSharedData : public QObject
     QgsCoordinateReferenceSystem crs() const { return mSourceCRS; }
     void clearCache();
 
+    bool getObjectIds( QString &errorMessage );
+
     bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
 
@@ -52,6 +54,8 @@ class QgsAfsSharedData : public QObject
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;
     QgsFields mFields;
     QString mObjectIdFieldName;
+    int mObjectIdFieldIdx = -1;
+
     QList<quint32> mObjectIds;
     QMap<QgsFeatureId, QgsFeature> mCache;
     QgsCoordinateReferenceSystem mSourceCRS;

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -1586,6 +1586,9 @@ class TestPyQgsAFSProvider(unittest.TestCase, ProviderTestCase):
             res = '\n'.join(f.readlines())
             self.assertEqual(res, 'f=json&features=[\n\n  {\n\n    "attributes": {\n\n      "OBJECTID": 11\n\n    }\n\n  }\n\n]')
 
+        # add empty list, should return true for consistency
+        self.assertTrue(vl.dataProvider().addFeatures([]))
+
     def testAddFail(self):
         # add capability
         endpoint = self.basetestpath + '/delete_test_fake_qgis_http_endpoint'

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -35,7 +35,8 @@ from qgis.core import (NULL,
                        QgsVectorDataProviderTemporalCapabilities,
                        QgsFieldConstraints,
                        QgsVectorDataProvider,
-                       QgsFeature
+                       QgsFeature,
+                       QgsGeometry
                        )
 from qgis.testing import (start_app,
                           unittest
@@ -1732,6 +1733,96 @@ class TestPyQgsAFSProvider(unittest.TestCase, ProviderTestCase):
         with open(add_endpoint + "_payload", 'rt') as f:
             res = '\n'.join(f.readlines())
             self.assertEqual(res, 'f=json&features=[\n\n  {\n\n    "attributes": {\n\n      "OBJECTID": 1,\n\n      "name": "xxname",\n\n      "name2": "xxname2",\n\n      "name3": "name3"\n\n    }\n\n  }\n\n]')
+
+    def testChangeGeometriesSuccess(self):
+        # add capability
+        endpoint = self.basetestpath + '/change_geom_test_fake_qgis_http_endpoint'
+        with open(sanitize(endpoint, '?f=json'), 'wb') as f:
+            f.write("""
+                {"currentVersion":10.22,"id":1,"name":"QGIS Test","type":"Feature Layer","description":
+                "QGIS Provider Test Layer","geometryType":"esriGeometryPoint","copyrightText":"not copyright","parentLayer":{"id":2,"name":"QGIS Tests"},"subLayers":[],
+                "minScale":72225,"maxScale":0,
+                "defaultVisibility":true,
+                "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+                "spatialReference":{"wkid":4326,"latestWkid":4326}},
+                "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+                "displayField":"LABEL","typeIdField":null,
+                "fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+                          {"name":"name","type":"esriFieldTypeString","alias":"name","length":100,"domain":null},
+                          {"name":"name2","type":"esriFieldTypeString","alias":"name2","length":100,"domain":null},
+                          {"name":"name3","type":"esriFieldTypeString","alias":"name2","length":100,"domain":null}
+                ],
+                "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+                "capabilities":"Map,Query,Data,Create,Update","maxRecordCount":1000,"supportsStatistics":true,
+                "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+                "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}""".encode(
+                'UTF-8'))
+
+        with open(sanitize(endpoint, '/query?f=json_where=1=1&returnIdsOnly=true'), 'wb') as f:
+            f.write("""
+                {
+                 "objectIdFieldName": "OBJECTID",
+                 "objectIds": [
+                  1
+                 ]
+                }
+                """.encode('UTF-8'))
+
+        with open(sanitize(endpoint,
+                           '/query?f=json&objectIds=1&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false'),
+                  'wb') as f:
+            f.write(("""
+        {
+         "displayFieldName": "name",
+         "fieldAliases": {
+          "name": "name"
+         },
+         "geometryType": "esriGeometryPoint",
+         "spatialReference": {
+          "wkid": 4326,
+          "latestWkid": 4326
+         },
+         "fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+        {"name":"name","type":"esriFieldTypeString","alias":"name","length":100,"domain":null},
+        {"name":"name3","type":"esriFieldTypeString","alias":"name2","length":100,"domain":null},
+        {"name":"name2","type":"esriFieldTypeString","alias":"name2","length":100,"domain":null},
+        {"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null}],
+         "features": [
+          {
+           "attributes": {
+            "OBJECTID": 1,
+            "name": "name1",
+            "name2":"name2",
+            "name3":"name3"
+           },
+           "geometry": {
+            "x": -71.123,
+            "y": 78.23
+           }
+          }
+         ]
+        }""").encode('UTF-8'))
+
+        add_endpoint = sanitize(endpoint, '/updateFeatures')
+        with open(add_endpoint, 'wb') as f:
+            f.write("""{
+  "addResults": [
+    {
+      "objectId": 617,
+      "success": true
+    }
+  ]
+}""".encode('UTF-8'))
+
+        vl = QgsVectorLayer("url='http://" + endpoint + "' crs='epsg:4326'", 'test', 'arcgisfeatureserver')
+        self.assertTrue(vl.isValid())
+
+        res = vl.dataProvider().changeGeometryValues({0: QgsGeometry.fromWkt('Point( 111 222)')})
+        self.assertTrue(res)
+
+        with open(add_endpoint + "_payload", 'rt') as f:
+            res = '\n'.join(f.readlines())
+            self.assertEqual(res, 'f=json&features=[\n\n  {\n\n    "attributes": {\n\n      "OBJECTID": 1\n\n    },\n\n    "geometry": {\n\n      "x": 111.0,\n\n      "y": 222.0\n\n    }\n\n  }\n\n]')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -32,7 +32,8 @@ from qgis.core import (NULL,
                        QgsProviderRegistry,
                        QgsWkbTypes,
                        QgsDataSourceUri,
-                       QgsVectorDataProviderTemporalCapabilities
+                       QgsVectorDataProviderTemporalCapabilities,
+                       QgsFieldConstraints
                        )
 from qgis.testing import (start_app,
                           unittest
@@ -479,6 +480,18 @@ class TestPyQgsAFSProvider(unittest.TestCase, ProviderTestCase):
         parts = {'url': 'http://blah.com', 'crs': 'epsg:4326', 'referer': 'me', 'bounds': QgsRectangle(1, 2, 3, 4)}
         uri = QgsProviderRegistry.instance().encodeUri(self.vl.dataProvider().name(), parts)
         self.assertEqual(uri, " bbox='1,2,3,4' crs='epsg:4326' url='http://blah.com' http-header:referer='me' referer='me'")
+
+    def testFieldProperties(self):
+        self.assertEqual(self.vl.dataProvider().pkAttributeIndexes(), [0])
+        self.assertEqual(self.vl.dataProvider().fields()[0].constraints().constraints(),
+                         QgsFieldConstraints.Constraints(QgsFieldConstraints.ConstraintNotNull | QgsFieldConstraints.ConstraintUnique))
+        self.assertFalse(self.vl.dataProvider().fields()[1].constraints().constraints())
+        self.assertEqual(self.vl.dataProvider().defaultValueClause(0), 'Autogenerate')
+        self.assertFalse(self.vl.dataProvider().defaultValueClause(1))
+
+        self.assertTrue(self.vl.dataProvider().skipConstraintCheck(0, QgsFieldConstraints.ConstraintUnique, 'Autogenerate'))
+        self.assertFalse(self.vl.dataProvider().skipConstraintCheck(0, QgsFieldConstraints.ConstraintUnique, 'aa'))
+        self.assertFalse(self.vl.dataProvider().skipConstraintCheck(1, QgsFieldConstraints.ConstraintUnique, 'aa'))
 
     def testObjectIdDifferentName(self):
         """ Test that object id fields not named OBJECTID work correctly """

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -27,6 +27,7 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsFields,
     QgsField,
+    QgsFieldConstraints,
     QgsFeature,
     QgsArcGisRestContext,
     NULL
@@ -323,6 +324,32 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
         self.assertEqual(res, {'attributes': {
             'a_int_field': 5},
             'geometry': {'x': 1.0, 'y': 2.0}})
+
+    def test_field_to_json(self):
+        field = QgsField('my name', QVariant.LongLong)
+        field.setAlias('my alias')
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'alias': 'my alias', 'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeInteger'})
+        field = QgsField('my name', QVariant.Int)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeSmallInteger'})
+        field = QgsField('my name', QVariant.Double)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeDouble'})
+        field = QgsField('my name', QVariant.String)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeString'})
+        field = QgsField('my name', QVariant.DateTime)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeDate'})
+        field = QgsField('my name', QVariant.ByteArray)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeBlob'})
+
+        # unsupported type
+        field = QgsField('my name', QVariant.Time)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': True, 'type': 'esriFieldTypeString'})
+
+        # not nullable
+        field = QgsField('my name', QVariant.Int)
+        field_constraints = field.constraints()
+        field_constraints.setConstraint(QgsFieldConstraints.Constraint.ConstraintNotNull)
+        field.setConstraints(field_constraints)
+        self.assertEqual(QgsArcGisRestUtils.fieldDefinitionToJson(field), {'editable': True, 'name': 'my name', 'nullable': False, 'type': 'esriFieldTypeSmallInteger'})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -309,7 +309,7 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
                                               'a_null_value': None},
                                'geometry': {'x': 1.0, 'y': 2.0}})
         # without geometry
-        res = QgsArcGisRestUtils.featureToJson(test_feature, context, includeGeometry=False)
+        res = QgsArcGisRestUtils.featureToJson(test_feature, context, flags=QgsArcGisRestUtils.FeatureToJsonFlags(QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes))
         self.assertEqual(res, {'attributes': {'a_boolean_field': True,
                                               'a_datetime_field': 1646395994000,
                                               'a_date_field': 1646352000000,
@@ -317,6 +317,12 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
                                               'a_int_field': 5,
                                               'a_string_field': 'my string value',
                                               'a_null_value': None}})
+        # without attributes
+        context.setObjectIdFieldName('a_int_field')
+        res = QgsArcGisRestUtils.featureToJson(test_feature, context, flags=QgsArcGisRestUtils.FeatureToJsonFlags(QgsArcGisRestUtils.FeatureToJsonFlag.IncludeGeometry))
+        self.assertEqual(res, {'attributes': {
+            'a_int_field': 5},
+            'geometry': {'x': 1.0, 'y': 2.0}})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -96,7 +96,9 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
             ('CircularStringZM (1 2 3 11, 5 4 4 12, 7 2.2 5 13)',
              {'hasM': True, 'hasZ': True, 'curvePaths': [[[1.0, 2.0, 3.0, 11.0],
                                                           {'c': [[7.0, 2.2, 5.0, 13.0], [5.0, 4.0, 4.0, 12.0]]}]]}),
-
+            # compound curve with no curved components should return paths, not curvePaths
+            ('CompoundCurve ((-1 -5, 1 2))',
+             {'hasM': False, 'hasZ': False, 'paths': [[[-1.0, -5.0], [1.0, 2.0]]]}),
             ('CompoundCurve ((-1 -5, 1 2),CircularString (1 2, 5 4, 7 2.20, 10 0.1, 13 4),(13 4, 17 -6))',
              {'hasM': False, 'hasZ': False, 'curvePaths': [[[-1.0, -5.0],
                                                             [1.0, 2.0],

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -295,10 +295,21 @@ class TestQgsArcGisRestUtils(unittest.TestCase):
 
         test_feature = QgsFeature(test_fields)
         test_feature.setAttributes(attributes)
+        test_feature.setGeometry(QgsGeometry.fromWkt('Point(1 2)'))
 
         context = QgsArcGisRestContext()
         context.setTimeZone(QTimeZone.utc())
         res = QgsArcGisRestUtils.featureToJson(test_feature, context)
+        self.assertEqual(res, {'attributes': {'a_boolean_field': True,
+                                              'a_datetime_field': 1646395994000,
+                                              'a_date_field': 1646352000000,
+                                              'a_double_field': 5.5,
+                                              'a_int_field': 5,
+                                              'a_string_field': 'my string value',
+                                              'a_null_value': None},
+                               'geometry': {'x': 1.0, 'y': 2.0}})
+        # without geometry
+        res = QgsArcGisRestUtils.featureToJson(test_feature, context, includeGeometry=False)
         self.assertEqual(res, {'attributes': {'a_boolean_field': True,
                                               'a_datetime_field': 1646395994000,
                                               'a_date_field': 1646352000000,


### PR DESCRIPTION
This PR adds edit support for ArcGIS feature server layers, such as those hosted on ArcGIS online. Assuming the user has appropriate permissions granted for editing a layer, it will unlock the ability to use the native QGIS tools to edit that layer.

Supports:

- [x] Deleting features
- [x] Adding new features
- [x] Curved geometries (only supported for enterprise ArcGIS server, ArcGIS online currently has no support for curves. See https://support.esri.com/en/technical-article/000014684)
- [x] Modifying existing features
- [x] Modifying attributes (creating fields, deleting fields, creating attribute indexes)

This feature was funded by [Naturstyrelsen and Miljøstyrelsen, Danish Ministry of Environment](https://eng.naturstyrelsen.dk/)
