### PR TITLE
Allow compiling o2 with Qt6

### DIFF
--- a/external/o2/src/o0baseauth.cpp
+++ b/external/o2/src/o0baseauth.cpp
@@ -1,5 +1,6 @@
 #include <QDataStream>
 #include <QDebug>
+#include <QIODevice>
 
 #include "o0baseauth.h"
 #include "o0globals.h"

--- a/external/o2/src/o2simplecrypt.cpp
+++ b/external/o2/src/o2simplecrypt.cpp
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QIODevice>
+#include <QRandomGenerator>
 
 O0SimpleCrypt::O0SimpleCrypt():
     m_key(0),
@@ -38,7 +40,6 @@ O0SimpleCrypt::O0SimpleCrypt():
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
-    qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
 }
 
 O0SimpleCrypt::O0SimpleCrypt(quint64 key):
@@ -47,7 +48,6 @@ O0SimpleCrypt::O0SimpleCrypt(quint64 key):
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
-    qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
     splitKey();
 }
 
@@ -113,7 +113,7 @@ QByteArray O0SimpleCrypt::encryptToByteArray(QByteArray plaintext)
     }
 
     //prepend a random char to the string
-    char randomChar = char(qrand() & 0xFF);
+    char randomChar = char(QRandomGenerator::global()->generate() & 0xFF);
     ba = randomChar + integrityProtection + ba;
 
     int pos(0);


### PR DESCRIPTION
Should be compatible down to Qt5.10.

<details>
<summary>General note on the "external" directory</summary>
It's a pity we are maintaining a vendored copy of so many libraries instead of improving a common version with the rest of the world.
</details>