### PR TITLE
[windows] Allow compiling with UNICODE defined

### DIFF
--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -1133,7 +1133,11 @@ bool QgsOgrProviderUtils::IsLocalFile( const QString &path )
        ( dirName[2] == '\\' || dirName[2] == '/' ) )
   {
     dirName.resize( 3 );
+#ifdef UNICODE
+    return GetDriveType( qUtf16Printable( dirName ) ) != DRIVE_REMOTE;
+#else
     return GetDriveType( dirName.toLatin1().constData() ) != DRIVE_REMOTE;
+#endif
   }
   return true;
 #elif defined(Q_OS_LINUX)

--- a/src/core/qgsarchive.cpp
+++ b/src/core/qgsarchive.cpp
@@ -83,8 +83,14 @@ bool QgsArchive::zip( const QString &filename )
 #ifdef Q_OS_WIN
   // Clear temporary flag (see GH #32118)
   DWORD dwAttrs;
+#ifdef UNICODE
+  dwAttrs = GetFileAttributes( qUtf16Printable( tmpFile.fileName() ) );
+  SetFileAttributes( qUtf16Printable( tmpFile.fileName() ), dwAttrs & ~ FILE_ATTRIBUTE_TEMPORARY );
+#else
   dwAttrs = GetFileAttributes( tmpFile.fileName().toLocal8Bit( ).data( ) );
   SetFileAttributes( tmpFile.fileName().toLocal8Bit( ).data( ), dwAttrs & ~ FILE_ATTRIBUTE_TEMPORARY );
+#endif
+
 #endif // Q_OS_WIN
 
   // save zip archive


### PR DESCRIPTION
```
/usr/x86_64-w64-mingw32/sys-root/mingw/include/fileapi.h:76:49: note:   initializing argument 1 of 'UINT GetDriveTypeW(LPCWSTR)'
   76 |   WINBASEAPI UINT WINAPI GetDriveTypeW (LPCWSTR lpRootPathName);
      |                                         ~~~~~~~~^~~~~~~~~~~~~~

## Description
```