### PR TITLE
Split Options Rendering tab into more contextual and less scarying tabs

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -22,8 +22,8 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_40">
+   <item row="0" column="0">
     <widget class="QSplitter" name="mOptionsSplitter">
      <property name="enabled">
       <bool>true</bool>
@@ -151,8 +151,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>856</width>
-                <height>1223</height>
+                <width>843</width>
+                <height>992</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>617</width>
-                <height>1135</height>
+                <width>843</width>
+                <height>1068</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1489,8 +1489,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>673</width>
-                <height>575</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1733,8 +1733,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>648</width>
-                <height>118</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1816,8 +1816,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>702</width>
-                <height>895</height>
+                <width>843</width>
+                <height>745</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2215,8 +2215,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>447</width>
-                <height>431</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -2436,8 +2436,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>772</width>
-                <height>1396</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2454,673 +2454,438 @@
                 <number>0</number>
                </property>
                <item row="0" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
-                 <property name="title">
-                  <string>Rendering Behavior</string>
+                <widget class="QTabWidget" name="tabWidget_2">
+                 <property name="currentIndex">
+                  <number>2</number>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_9">
-                  <item>
-                   <widget class="QCheckBox" name="chkAddedVisibility">
-                    <property name="text">
-                     <string>By default new la&amp;yers added to the map should be displayed</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="chkUseRenderCaching">
-                    <property name="text">
-                     <string>Use render caching where possible to speed up redraws</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_26">
-                    <item>
-                     <widget class="QCheckBox" name="chkParallelRendering">
-                      <property name="text">
-                       <string>Render layers in parallel using many CPU cores</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="Line" name="line_6">
-                      <property name="orientation">
-                       <enum>Qt::Vertical</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QCheckBox" name="chkMaxThreads">
-                      <property name="text">
-                       <string>Max cores to use</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="spinMaxThreads"/>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_41">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_4">
-                    <item>
-                     <widget class="QLabel" name="label_56">
-                      <property name="text">
-                       <string>Map update interval</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsSpinBox" name="spinMapUpdateInterval">
-                      <property name="suffix">
-                       <string> ms</string>
-                      </property>
-                      <property name="maximum">
-                       <number>999999</number>
-                      </property>
-                      <property name="singleStep">
-                       <number>50</number>
-                      </property>
-                      <property name="value">
-                       <number>250</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_46">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <widget class="QgsCollapsibleGroupBox" name="mSimplifyDrawingGroupBox">
-                    <property name="title">
-                     <string>Enable feature si&amp;mplification by default for newly added layers</string>
-                    </property>
-                    <property name="flat">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="_14">
-                     <item row="0" column="1" colspan="4">
-                      <widget class="QLabel" name="label_59">
-                       <property name="text">
-                        <string>&lt;b&gt;Note:&lt;/b&gt; Feature simplification may speed up rendering but can result in rendering inconsistencies</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QLabel" name="label_65">
-                       <property name="text">
-                        <string>Simplification threshold (higher values result in more simplification)</string>
-                       </property>
-                       <property name="margin">
-                        <number>2</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QgsDoubleSpinBox" name="mSimplifyDrawingSpinBox">
-                       <property name="toolTip">
-                        <string>Higher values result in more simplification</string>
-                       </property>
-                       <property name="decimals">
-                        <number>2</number>
-                       </property>
-                       <property name="minimum">
-                        <double>1.000000000000000</double>
-                       </property>
-                       <property name="maximum">
-                        <double>5.000000000000000</double>
-                       </property>
-                       <property name="singleStep">
-                        <double>0.200000000000000</double>
-                       </property>
-                       <property name="value">
-                        <double>1.000000000000000</double>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="3">
-                      <widget class="QLabel" name="mSimplifyDrawingPx">
-                       <property name="text">
-                        <string>pixels</string>
-                       </property>
-                       <property name="margin">
-                        <number>2</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="4">
-                      <spacer name="horizontalSpacer_40">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>20</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLabel" name="mSimplifyAlgorithmLabel">
-                       <property name="toolTip">
-                        <string>This algorithm is only applied to simplify on local side</string>
-                       </property>
-                       <property name="text">
-                        <string>Simplification algorithm</string>
-                       </property>
-                       <property name="margin">
-                        <number>2</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="2">
-                      <widget class="QComboBox" name="mSimplifyAlgorithmComboBox"/>
-                     </item>
-                     <item row="3" column="1" colspan="4">
-                      <widget class="QCheckBox" name="mSimplifyDrawingAtProvider">
-                       <property name="text">
-                        <string>Simplify on provider side if possible</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="1">
-                      <widget class="QLabel" name="mSimplifyMaxScaleLabel">
-                       <property name="text">
-                        <string>Maximum scale at which the layer should be simplified (1:1 always simplifies)</string>
-                       </property>
-                       <property name="margin">
-                        <number>2</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="2">
-                      <widget class="QgsScaleComboBox" name="mSimplifyMaximumScaleComboBox">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_5">
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <widget class="QLabel" name="labelMagnifier">
-                      <property name="text">
-                       <string>Magnification level</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QgsDoubleSpinBox" name="doubleSpinBoxMagnifierDefault"/>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_4">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Expanding</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_8">
-                 <property name="title">
-                  <string>Rendering Quality</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="_5">
-                  <property name="leftMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>11</number>
-                  </property>
-                  <item>
-                   <widget class="QCheckBox" name="chkAntiAliasing">
-                    <property name="text">
-                     <string>Make lines appear less jagged at the expense of some drawing performance</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mSegmentationGroupBox">
-                 <property name="title">
-                  <string>Curve Segmentation</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_20">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mSegmentationToleranceLabel">
-                    <property name="text">
-                     <string>Segmentation tolerance</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QgsDoubleSpinBox" name="mSegmentationToleranceSpinBox"/>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="mToleranceTypeLabel">
-                    <property name="text">
-                     <string>Tolerance type</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QComboBox" name="mToleranceTypeComboBox"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_14">
-                 <property name="title">
-                  <string>Rasters</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_10">
-                  <item>
-                   <widget class="QWidget" name="widget" native="true">
-                    <layout class="QGridLayout" name="gridLayout_35">
-                     <property name="leftMargin">
-                      <number>0</number>
+                 <widget class="QWidget" name="RenderingGeneralTab">
+                  <attribute name="title">
+                   <string>General</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_42">
+                   <item>
+                    <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
+                     <property name="title">
+                      <string>Rendering Behavior</string>
                      </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_21">
-                       <property name="text">
-                        <string>RGB band selection</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <layout class="QHBoxLayout" name="horizontalLayoutRGB">
-                       <item>
-                        <widget class="QLabel" name="label_22">
-                         <property name="text">
-                          <string>Red band</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="spnRed"/>
-                       </item>
-                       <item>
-                        <widget class="QLabel" name="label_23">
-                         <property name="text">
-                          <string>Green band</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="spnGreen"/>
-                       </item>
-                       <item>
-                        <widget class="QLabel" name="label_24">
-                         <property name="text">
-                          <string>Blue band</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QgsSpinBox" name="spnBlue"/>
-                       </item>
-                       <item>
-                        <spacer name="horizontalSpacer_20">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="lbldefaultZoomedInResampling">
-                       <property name="text">
-                        <string>Zoomed in resampling</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QComboBox" name="mZoomedInResamplingComboBox"/>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="lbldefaultZoomedOutResampling">
-                       <property name="text">
-                        <string>Zoomed out resampling</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
-                     </item>
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="lbldefaultOversampling">
-                       <property name="text">
-                        <string>Oversampling</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="1">
-                      <layout class="QHBoxLayout" name="horizontalLayoutOversampling">
-                       <item>
-                        <widget class="QgsDoubleSpinBox" name="spnOversampling"/>
-                       </item>
-                       <item>
-                        <spacer name="horizontalSpacer_25">
-                         <property name="orientation">
-                          <enum>Qt::Horizontal</enum>
-                         </property>
-                         <property name="sizeHint" stdset="0">
-                          <size>
-                           <width>40</width>
-                           <height>20</height>
-                          </size>
-                         </property>
-                        </spacer>
-                       </item>
-                      </layout>
-                     </item>
-                     <item row="4" column="0">
-                      <widget class="QCheckBox" name="mCbEarlyResampling">
-                       <property name="text">
-                        <string>Early resampling</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QgsCollapsibleGroupBox" name="groupBox_17">
-                    <property name="title">
-                     <string>Contrast enhancement</string>
-                    </property>
-                    <property name="flat">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_11">
-                     <item>
-                      <layout class="QGridLayout" name="gridLayout_33">
-                       <item row="4" column="2">
-                        <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandSingleByte"/>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLabel" name="label_50">
-                         <property name="text">
-                          <string>Algorithm</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignCenter</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="1">
-                        <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmSingleBand"/>
-                       </item>
-                       <item row="3" column="0">
-                        <widget class="QLabel" name="label_37">
-                         <property name="text">
-                          <string>Single band gray</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="2">
-                        <widget class="QLabel" name="label_51">
-                         <property name="text">
-                          <string>Limits (minimum/maximum)</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignCenter</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="2">
-                        <widget class="QComboBox" name="cboxContrastEnhancementLimitsSingleBand"/>
-                       </item>
-                       <item row="4" column="1">
-                        <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandSingleByte"/>
-                       </item>
-                       <item row="4" column="0">
-                        <widget class="QLabel" name="label_38">
-                         <property name="text">
-                          <string>Multi band color (byte / band) </string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="5" column="0">
-                        <widget class="QLabel" name="label_39">
-                         <property name="text">
-                          <string>Multi band color (&gt; byte / band) </string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="5" column="1">
-                        <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandMultiByte"/>
-                       </item>
-                       <item row="5" column="2">
-                        <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandMultiByte"/>
-                       </item>
-                      </layout>
-                     </item>
-                     <item>
-                      <widget class="QWidget" name="widget_4" native="true">
-                       <layout class="QHBoxLayout" name="horizontalLayout_23">
-                        <property name="leftMargin">
-                         <number>0</number>
+                     <layout class="QVBoxLayout" name="verticalLayout_9">
+                      <item>
+                       <widget class="QCheckBox" name="chkAddedVisibility">
+                        <property name="text">
+                         <string>By default new la&amp;yers added to the map should be displayed</string>
                         </property>
-                        <property name="topMargin">
-                         <number>0</number>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QCheckBox" name="chkUseRenderCaching">
+                        <property name="text">
+                         <string>Use render caching where possible to speed up redraws</string>
                         </property>
-                        <property name="rightMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="bottomMargin">
-                         <number>0</number>
-                        </property>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QWidget" name="widget_5" native="true">
-                       <layout class="QHBoxLayout" name="horizontalLayout_24">
-                        <property name="leftMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="topMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="rightMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="bottomMargin">
-                         <number>0</number>
-                        </property>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="Line" name="line">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QWidget" name="widget_6" native="true">
-                       <layout class="QHBoxLayout" name="horizontalLayout_25">
-                        <property name="leftMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="topMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="rightMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="bottomMargin">
-                         <number>0</number>
-                        </property>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QWidget" name="widget_7" native="true">
-                       <layout class="QHBoxLayout" name="horizontalLayout_18">
-                        <property name="leftMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="topMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="rightMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="bottomMargin">
-                         <number>0</number>
-                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_26">
                         <item>
-                         <widget class="QLabel" name="label_36">
+                         <widget class="QCheckBox" name="chkParallelRendering">
                           <property name="text">
-                           <string>Cumulative pixel count cut limits</string>
+                           <string>Render layers in parallel using many CPU cores</string>
                           </property>
                          </widget>
                         </item>
                         <item>
-                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutLowerDoubleSpinBox">
-                          <property name="decimals">
-                           <number>1</number>
+                         <widget class="Line" name="line_6">
+                          <property name="orientation">
+                           <enum>Qt::Vertical</enum>
                           </property>
                          </widget>
                         </item>
                         <item>
-                         <widget class="QLabel" name="label_34">
+                         <widget class="QCheckBox" name="chkMaxThreads">
                           <property name="text">
-                           <string>-</string>
+                           <string>Max cores to use</string>
                           </property>
                          </widget>
                         </item>
                         <item>
-                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutUpperDoubleSpinBox">
-                          <property name="decimals">
-                           <number>1</number>
-                          </property>
-                         </widget>
+                         <widget class="QgsSpinBox" name="spinMaxThreads"/>
                         </item>
                         <item>
-                         <widget class="QLabel" name="label_35">
-                          <property name="text">
-                           <string>%</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <spacer name="horizontalSpacer_18">
+                         <spacer name="horizontalSpacer_41">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
                           </property>
                           <property name="sizeHint" stdset="0">
                            <size>
-                            <width>123</width>
+                            <width>40</width>
                             <height>20</height>
                            </size>
                           </property>
                          </spacer>
                         </item>
                        </layout>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QWidget" name="widget_2" native="true">
-                       <layout class="QHBoxLayout" name="horizontalLayout_20">
-                        <property name="leftMargin">
-                         <number>0</number>
+                      </item>
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout_411">
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_56">
+                          <property name="text">
+                           <string>Map update interval</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QgsSpinBox" name="spinMapUpdateInterval">
+                          <property name="suffix">
+                           <string> ms</string>
+                          </property>
+                          <property name="maximum">
+                           <number>999999</number>
+                          </property>
+                          <property name="singleStep">
+                           <number>50</number>
+                          </property>
+                          <property name="value">
+                           <number>250</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2">
+                         <spacer name="horizontalSpacer_46">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QLabel" name="labelMagnifier">
+                          <property name="text">
+                           <string>Magnification level</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QgsDoubleSpinBox" name="doubleSpinBoxMagnifierDefault"/>
+                        </item>
+                       </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsCollapsibleGroupBox" name="groupBox_22">
+                     <property name="title">
+                      <string>Debugging</string>
+                     </property>
+                     <layout class="QVBoxLayout" name="verticalLayout_35">
+                      <item>
+                       <widget class="QLabel" name="label_55">
+                        <property name="text">
+                         <string>Show these events in the Log Message panel (under Rendering tab)</string>
                         </property>
-                        <property name="topMargin">
-                         <number>0</number>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout_6">
+                        <item row="0" column="0">
+                         <spacer name="horizontalSpacer_37">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeType">
+                           <enum>QSizePolicy::Fixed</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>8</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QCheckBox" name="mLogCanvasRefreshChkBx">
+                          <property name="text">
+                           <string>Map canvas refresh</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_13">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="RenderingRasterTab">
+                  <attribute name="title">
+                   <string>Raster</string>
+                  </attribute>
+                  <layout class="QGridLayout" name="gridLayout_41">
+                   <item row="0" column="0">
+                    <widget class="QgsCollapsibleGroupBox" name="BandsResamplingGrpbox">
+                     <property name="title">
+                      <string>Bands and Resampling</string>
+                     </property>
+                     <layout class="QGridLayout" name="gridLayout_35">
+                      <item row="3" column="0">
+                       <widget class="QLabel" name="lbldefaultOversampling">
+                        <property name="text">
+                         <string>Oversampling</string>
                         </property>
-                        <property name="rightMargin">
-                         <number>0</number>
+                       </widget>
+                      </item>
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="label_21">
+                        <property name="text">
+                         <string>RGB band selection</string>
                         </property>
-                        <property name="bottomMargin">
-                         <number>0</number>
+                       </widget>
+                      </item>
+                      <item row="0" column="6">
+                       <widget class="QgsSpinBox" name="spnBlue">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
                         </property>
-                        <item>
+                       </widget>
+                      </item>
+                      <item row="0" column="1">
+                       <widget class="QLabel" name="label_22">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Red band</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="3">
+                       <widget class="QLabel" name="label_23">
+                        <property name="text">
+                         <string>Green band</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="2">
+                       <widget class="QgsSpinBox" name="spnRed">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="4">
+                       <widget class="QgsSpinBox" name="spnGreen">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QLabel" name="lbldefaultZoomedInResampling">
+                        <property name="text">
+                         <string>Zoomed in resampling</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="4" column="0">
+                       <widget class="QCheckBox" name="mCbEarlyResampling">
+                        <property name="text">
+                         <string>Early resampling</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="5">
+                       <widget class="QLabel" name="label_24">
+                        <property name="text">
+                         <string>Blue band</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="0">
+                       <widget class="QLabel" name="lbldefaultZoomedOutResampling">
+                        <property name="text">
+                         <string>Zoomed out resampling</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="1" colspan="2">
+                       <widget class="QComboBox" name="mZoomedInResamplingComboBox"/>
+                      </item>
+                      <item row="2" column="1" colspan="2">
+                       <widget class="QComboBox" name="mZoomedOutResamplingComboBox"/>
+                      </item>
+                      <item row="3" column="1" colspan="2">
+                       <widget class="QgsDoubleSpinBox" name="spnOversampling"/>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QgsCollapsibleGroupBox" name="groupBox_17">
+                     <property name="title">
+                      <string>Contrast Enhancement</string>
+                     </property>
+                     <property name="flat">
+                      <bool>true</bool>
+                     </property>
+                     <layout class="QVBoxLayout" name="verticalLayout_11">
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout_33">
+                        <item row="3" column="2">
+                         <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandSingleByte"/>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QLabel" name="label_50">
+                          <property name="text">
+                           <string>Algorithm</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmSingleBand"/>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QLabel" name="label_37">
+                          <property name="text">
+                           <string>Single band gray</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2">
+                         <widget class="QLabel" name="label_51">
+                          <property name="text">
+                           <string>Limits (minimum/maximum)</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <widget class="QComboBox" name="cboxContrastEnhancementLimitsSingleBand"/>
+                        </item>
+                        <item row="2" column="1">
+                         <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandSingleByte"/>
+                        </item>
+                        <item row="2" column="0">
+                         <widget class="QLabel" name="label_38">
+                          <property name="text">
+                           <string>Multi band color (byte / band) </string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="0">
+                         <widget class="QLabel" name="label_39">
+                          <property name="text">
+                           <string>Multi band color (&gt; byte / band) </string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="1">
+                         <widget class="QComboBox" name="cboxContrastEnhancementAlgorithmMultiBandMultiByte"/>
+                        </item>
+                        <item row="3" column="2">
+                         <widget class="QComboBox" name="cboxContrastEnhancementLimitsMultiBandMultiByte"/>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <widget class="Line" name="line">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout_39">
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_36">
+                          <property name="text">
+                           <string>Cumulative pixel count cut limits</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="3">
+                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutUpperDoubleSpinBox">
+                          <property name="decimals">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QgsDoubleSpinBox" name="mRasterCumulativeCutLowerDoubleSpinBox">
+                          <property name="decimals">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="4">
+                         <widget class="QLabel" name="label_35">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>%</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2">
+                         <widget class="QLabel" name="label_34">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>-</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="0">
                          <widget class="QLabel" name="label_25">
                           <property name="text">
                            <string>Standard deviation multiplier</string>
                           </property>
                          </widget>
                         </item>
-                        <item>
+                        <item row="1" column="1">
                          <widget class="QgsDoubleSpinBox" name="spnThreeBandStdDev">
                           <property name="maximum">
                            <double>10.000000000000000</double>
@@ -3130,83 +2895,199 @@
                           </property>
                          </widget>
                         </item>
-                        <item>
-                         <spacer name="horizontalSpacer_21">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>258</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
                        </layout>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item row="2" column="0">
+                    <spacer name="verticalSpacer_14">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                 <widget class="QWidget" name="RenderingVectorTab">
+                  <attribute name="title">
+                   <string>Vector</string>
+                  </attribute>
+                  <layout class="QVBoxLayout" name="verticalLayout_44">
+                   <item>
+                    <widget class="QgsCollapsibleGroupBox" name="mSimplifyDrawingGroupBox">
+                     <property name="title">
+                      <string>Enable feature si&amp;mplification by default for newly added layers</string>
+                     </property>
+                     <property name="flat">
+                      <bool>true</bool>
+                     </property>
+                     <property name="checkable">
+                      <bool>true</bool>
+                     </property>
+                     <layout class="QGridLayout" name="_14">
+                      <item row="0" column="0" colspan="3">
+                       <widget class="QLabel" name="label_59">
+                        <property name="text">
+                         <string>&lt;b&gt;Note:&lt;/b&gt; Feature simplification may speed up rendering but can result in rendering inconsistencies</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="0">
+                       <widget class="QLabel" name="label_65">
+                        <property name="text">
+                         <string>Simplification threshold (higher values result in more simplification)</string>
+                        </property>
+                        <property name="margin">
+                         <number>2</number>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="1">
+                       <widget class="QgsDoubleSpinBox" name="mSimplifyDrawingSpinBox">
+                        <property name="toolTip">
+                         <string>Higher values result in more simplification</string>
+                        </property>
+                        <property name="decimals">
+                         <number>2</number>
+                        </property>
+                        <property name="minimum">
+                         <double>1.000000000000000</double>
+                        </property>
+                        <property name="maximum">
+                         <double>5.000000000000000</double>
+                        </property>
+                        <property name="singleStep">
+                         <double>0.200000000000000</double>
+                        </property>
+                        <property name="value">
+                         <double>1.000000000000000</double>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="2">
+                       <widget class="QLabel" name="mSimplifyDrawingPx">
+                        <property name="text">
+                         <string>pixels</string>
+                        </property>
+                        <property name="margin">
+                         <number>2</number>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="0">
+                       <widget class="QLabel" name="mSimplifyAlgorithmLabel">
+                        <property name="toolTip">
+                         <string>This algorithm is only applied to simplify on local side</string>
+                        </property>
+                        <property name="text">
+                         <string>Simplification algorithm</string>
+                        </property>
+                        <property name="margin">
+                         <number>2</number>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="1">
+                       <widget class="QComboBox" name="mSimplifyAlgorithmComboBox"/>
+                      </item>
+                      <item row="3" column="0" colspan="3">
+                       <widget class="QCheckBox" name="mSimplifyDrawingAtProvider">
+                        <property name="text">
+                         <string>Simplify on provider side if possible</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="4" column="0">
+                       <widget class="QLabel" name="mSimplifyMaxScaleLabel">
+                        <property name="text">
+                         <string>Maximum scale at which the layer should be simplified (1:1 always simplifies)</string>
+                        </property>
+                        <property name="margin">
+                         <number>2</number>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="4" column="1">
+                       <widget class="QgsScaleComboBox" name="mSimplifyMaximumScaleComboBox">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsCollapsibleGroupBox" name="groupBox_8">
+                     <property name="title">
+                      <string>Rendering Quality</string>
+                     </property>
+                     <layout class="QVBoxLayout" name="_5">
+                      <item>
+                       <widget class="QCheckBox" name="chkAntiAliasing">
+                        <property name="text">
+                         <string>Make lines appear less jagged at the expense of some drawing performance</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QgsCollapsibleGroupBox" name="mSegmentationGroupBox">
+                     <property name="title">
+                      <string>Curve Segmentation</string>
+                     </property>
+                     <layout class="QGridLayout" name="gridLayout_20">
+                      <item row="1" column="0">
+                       <widget class="QLabel" name="mToleranceTypeLabel">
+                        <property name="text">
+                         <string>Tolerance type</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="1">
+                       <widget class="QComboBox" name="mToleranceTypeComboBox"/>
+                      </item>
+                      <item row="0" column="1">
+                       <widget class="QgsDoubleSpinBox" name="mSegmentationToleranceSpinBox"/>
+                      </item>
+                      <item row="0" column="0">
+                       <widget class="QLabel" name="mSegmentationToleranceLabel">
+                        <property name="text">
+                         <string>Segmentation tolerance</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_15">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
                 </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="groupBox_22">
-                 <property name="title">
-                  <string>Debugging</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_35">
-                  <item>
-                   <widget class="QLabel" name="label_55">
-                    <property name="text">
-                     <string>Show these events in the Log Message panel (under Rendering tab)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QGridLayout" name="gridLayout_6">
-                    <item row="0" column="0">
-                     <spacer name="horizontalSpacer_37">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Fixed</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>8</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QCheckBox" name="mLogCanvasRefreshChkBx">
-                      <property name="text">
-                       <string>Map canvas refresh</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <spacer name="verticalSpacer_6">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>
@@ -3241,8 +3122,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>523</width>
-                <height>435</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3712,8 +3593,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>678</width>
-                <height>850</height>
+                <width>843</width>
+                <height>712</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -4243,8 +4124,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>608</width>
-                <height>1229</height>
+                <width>843</width>
+                <height>1000</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4946,8 +4827,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>139</width>
-                <height>255</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -5126,8 +5007,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>546</width>
-                <height>606</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -5458,8 +5339,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>712</width>
-                <height>828</height>
+                <width>857</width>
+                <height>695</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5939,8 +5820,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -5968,7 +5849,7 @@ p, li { white-space: pre-wrap; }
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QFrame" name="mButtonBoxFrame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -6213,22 +6094,23 @@ p, li { white-space: pre-wrap; }
   <tabstop>mLocalizedDataPathListWidget</tabstop>
   <tabstop>mBtnRemoveHiddenPath</tabstop>
   <tabstop>mListHiddenBrowserPaths</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>mOptionsScrollArea_02</tabstop>
+  <tabstop>cmbEditCreateOptions</tabstop>
+  <tabstop>pbnEditCreateOptions</tabstop>
+  <tabstop>pbnEditPyramidsOptions</tabstop>
+  <tabstop>lstRasterDrivers</tabstop>
+  <tabstop>lstVectorDrivers</tabstop>
   <tabstop>mOptionsScrollArea_04</tabstop>
+  <tabstop>tabWidget_2</tabstop>
   <tabstop>chkAddedVisibility</tabstop>
   <tabstop>chkUseRenderCaching</tabstop>
   <tabstop>chkParallelRendering</tabstop>
   <tabstop>chkMaxThreads</tabstop>
   <tabstop>spinMaxThreads</tabstop>
   <tabstop>spinMapUpdateInterval</tabstop>
-  <tabstop>mSimplifyDrawingGroupBox</tabstop>
-  <tabstop>mSimplifyDrawingSpinBox</tabstop>
-  <tabstop>mSimplifyAlgorithmComboBox</tabstop>
-  <tabstop>mSimplifyDrawingAtProvider</tabstop>
-  <tabstop>mSimplifyMaximumScaleComboBox</tabstop>
   <tabstop>doubleSpinBoxMagnifierDefault</tabstop>
-  <tabstop>chkAntiAliasing</tabstop>
-  <tabstop>mSegmentationToleranceSpinBox</tabstop>
-  <tabstop>mToleranceTypeComboBox</tabstop>
+  <tabstop>mLogCanvasRefreshChkBx</tabstop>
   <tabstop>spnRed</tabstop>
   <tabstop>spnGreen</tabstop>
   <tabstop>spnBlue</tabstop>
@@ -6239,13 +6121,20 @@ p, li { white-space: pre-wrap; }
   <tabstop>cboxContrastEnhancementAlgorithmSingleBand</tabstop>
   <tabstop>cboxContrastEnhancementLimitsSingleBand</tabstop>
   <tabstop>cboxContrastEnhancementAlgorithmMultiBandSingleByte</tabstop>
-  <tabstop>cboxContrastEnhancementLimitsMultiBandSingleByte</tabstop>
   <tabstop>cboxContrastEnhancementAlgorithmMultiBandMultiByte</tabstop>
   <tabstop>cboxContrastEnhancementLimitsMultiBandMultiByte</tabstop>
+  <tabstop>cboxContrastEnhancementLimitsMultiBandSingleByte</tabstop>
   <tabstop>mRasterCumulativeCutLowerDoubleSpinBox</tabstop>
   <tabstop>mRasterCumulativeCutUpperDoubleSpinBox</tabstop>
   <tabstop>spnThreeBandStdDev</tabstop>
-  <tabstop>mLogCanvasRefreshChkBx</tabstop>
+  <tabstop>mSimplifyDrawingGroupBox</tabstop>
+  <tabstop>mSimplifyDrawingSpinBox</tabstop>
+  <tabstop>mSimplifyAlgorithmComboBox</tabstop>
+  <tabstop>mSimplifyDrawingAtProvider</tabstop>
+  <tabstop>mSimplifyMaximumScaleComboBox</tabstop>
+  <tabstop>chkAntiAliasing</tabstop>
+  <tabstop>mSegmentationToleranceSpinBox</tabstop>
+  <tabstop>mToleranceTypeComboBox</tabstop>
   <tabstop>mOptionsScrollArea_06</tabstop>
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>
@@ -6267,8 +6156,8 @@ p, li { white-space: pre-wrap; }
   <tabstop>mKeepBaseUnitCheckBox</tabstop>
   <tabstop>mDistanceUnitsComboBox</tabstop>
   <tabstop>mAreaUnitsComboBox</tabstop>
-  <tabstop>mCustomizeCoordinateFormatButton</tabstop>
   <tabstop>mAngleUnitsComboBox</tabstop>
+  <tabstop>mCustomizeCoordinateFormatButton</tabstop>
   <tabstop>mCustomizeBearingFormatButton</tabstop>
   <tabstop>spinZoomFactor</tabstop>
   <tabstop>mListGlobalScales</tabstop>
@@ -6277,16 +6166,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>pbnDefaultScaleValues</tabstop>
   <tabstop>pbnImportScales</tabstop>
   <tabstop>pbnExportScales</tabstop>
-  <tabstop>scrollArea</tabstop>
-  <tabstop>mColorSchemesComboBox</tabstop>
-  <tabstop>mSchemeToolButton</tabstop>
-  <tabstop>mTreeCustomColors</tabstop>
-  <tabstop>mButtonAddColor</tabstop>
-  <tabstop>mButtonRemoveColor</tabstop>
-  <tabstop>mButtonCopyColors</tabstop>
-  <tabstop>mButtonPasteColors</tabstop>
-  <tabstop>mButtonImportColors</tabstop>
-  <tabstop>mButtonExportColors</tabstop>
   <tabstop>mOptionsScrollArea_07</tabstop>
   <tabstop>chkDisableAttributeValuesDlg</tabstop>
   <tabstop>chkReuseLastValues</tabstop>
@@ -6316,6 +6195,16 @@ p, li { white-space: pre-wrap; }
   <tabstop>mTracingConvertToCurveCheckBox</tabstop>
   <tabstop>mTracingCustomAngleToleranceSpinBox</tabstop>
   <tabstop>mTracingCustomDistanceToleranceSpinBox</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>mColorSchemesComboBox</tabstop>
+  <tabstop>mTreeCustomColors</tabstop>
+  <tabstop>mSchemeToolButton</tabstop>
+  <tabstop>mButtonAddColor</tabstop>
+  <tabstop>mButtonRemoveColor</tabstop>
+  <tabstop>mButtonCopyColors</tabstop>
+  <tabstop>mButtonPasteColors</tabstop>
+  <tabstop>mButtonImportColors</tabstop>
+  <tabstop>mButtonExportColors</tabstop>
   <tabstop>mOptionsScrollArea_12</tabstop>
   <tabstop>mComposerFontComboBox</tabstop>
   <tabstop>mGridStyleComboBox</tabstop>
@@ -6327,13 +6216,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mBtnAddTemplatePath</tabstop>
   <tabstop>mBtnRemoveTemplatePath</tabstop>
   <tabstop>mListComposerTemplatePaths</tabstop>
-  <tabstop>mOptionsScrollArea_02</tabstop>
-  <tabstop>tabWidget</tabstop>
-  <tabstop>cmbEditCreateOptions</tabstop>
-  <tabstop>pbnEditCreateOptions</tabstop>
-  <tabstop>pbnEditPyramidsOptions</tabstop>
-  <tabstop>lstRasterDrivers</tabstop>
-  <tabstop>lstVectorDrivers</tabstop>
   <tabstop>mAuthConfigsGrpBx</tabstop>
   <tabstop>mOptionsScrollArea_10</tabstop>
   <tabstop>mNetworkTimeoutSpinBox</tabstop>
@@ -6346,8 +6228,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mBrowseCacheDirectory</tabstop>
   <tabstop>mCacheSize</tabstop>
   <tabstop>mClearCache</tabstop>
-  <tabstop>mAutoClearAccessCache</tabstop>
-  <tabstop>mClearAccessCache</tabstop>
   <tabstop>grpProxy</tabstop>
   <tabstop>mProxyTypeComboBox</tabstop>
   <tabstop>leProxyHost</tabstop>
@@ -6358,6 +6238,8 @@ p, li { white-space: pre-wrap; }
   <tabstop>mGPUEnableCheckBox</tabstop>
   <tabstop>mOpenClDevicesCombo</tabstop>
   <tabstop>mGPUInfoTextBrowser</tabstop>
+  <tabstop>mAutoClearAccessCache</tabstop>
+  <tabstop>mClearAccessCache</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
[This dialog](https://docs.qgis.org/3.22/en/_images/rendering_menu.png) was quite high and i found hard to get the scope of the options. Here's a proposal to make it clearer, less scarying (and easier to screenshot and document), mainly moving the blocks.
Also cleans up the layout, less widgets misalignment
and fix the whole Options dialog's tab order
After:
![image](https://user-images.githubusercontent.com/7983394/180147638-4bcdfb12-50e5-438e-ab65-453ce0addac7.png)

![image](https://user-images.githubusercontent.com/7983394/180147581-4ebc1fce-79e7-49f3-90ff-e5e0214528c0.png)

![image](https://user-images.githubusercontent.com/7983394/180147725-edc6537d-ae42-45e9-b6fb-9ae800a109f8.png)
