### PR TITLE
feat: Open layers in a read only mode with Qgis::ProjectReadFlag::ForceReadOnlyLayers

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1918,7 +1918,10 @@ QgsProject.FlagDontLoad3DViews.__doc__ = "Skip loading 3D views (since QGIS 3.26
 QgsProject.DontLoadProjectStyles = Qgis.ProjectReadFlag.DontLoadProjectStyles
 QgsProject.DontLoadProjectStyles.is_monkey_patched = True
 QgsProject.DontLoadProjectStyles.__doc__ = "Skip loading project style databases (deprecated -- use ProjectCapability.ProjectStyles flag instead)"
-Qgis.ProjectReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. note::\n\n   Prior to QGIS 3.26 this was available as :py:class:`QgsProject`.ReadFlag\n\n.. versionadded:: 3.26\n\n' + '* ``FlagDontResolveLayers``: ' + Qgis.ProjectReadFlag.DontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + Qgis.ProjectReadFlag.DontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + Qgis.ProjectReadFlag.TrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + Qgis.ProjectReadFlag.DontStoreOriginalStyles.__doc__ + '\n' + '* ``FlagDontLoad3DViews``: ' + Qgis.ProjectReadFlag.DontLoad3DViews.__doc__ + '\n' + '* ``DontLoadProjectStyles``: ' + Qgis.ProjectReadFlag.DontLoadProjectStyles.__doc__
+QgsProject.ForceReadOnlyLayers = Qgis.ProjectReadFlag.ForceReadOnlyLayers
+QgsProject.ForceReadOnlyLayers.is_monkey_patched = True
+QgsProject.ForceReadOnlyLayers.__doc__ = "Open layers in a read-only mode. (since QGIS 3.28)"
+Qgis.ProjectReadFlag.__doc__ = 'Flags which control project read behavior.\n\n.. note::\n\n   Prior to QGIS 3.26 this was available as :py:class:`QgsProject`.ReadFlag\n\n.. versionadded:: 3.26\n\n' + '* ``FlagDontResolveLayers``: ' + Qgis.ProjectReadFlag.DontResolveLayers.__doc__ + '\n' + '* ``FlagDontLoadLayouts``: ' + Qgis.ProjectReadFlag.DontLoadLayouts.__doc__ + '\n' + '* ``FlagTrustLayerMetadata``: ' + Qgis.ProjectReadFlag.TrustLayerMetadata.__doc__ + '\n' + '* ``FlagDontStoreOriginalStyles``: ' + Qgis.ProjectReadFlag.DontStoreOriginalStyles.__doc__ + '\n' + '* ``FlagDontLoad3DViews``: ' + Qgis.ProjectReadFlag.DontLoad3DViews.__doc__ + '\n' + '* ``DontLoadProjectStyles``: ' + Qgis.ProjectReadFlag.DontLoadProjectStyles.__doc__ + '\n' + '* ``ForceReadOnlyLayers``: ' + Qgis.ProjectReadFlag.ForceReadOnlyLayers.__doc__
 # --
 Qgis.ProjectReadFlag.baseClass = Qgis
 QgsProject.ReadFlags = Qgis.ProjectReadFlags

--- a/python/core/auto_generated/providers/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/providers/qgsdataprovider.sip.in
@@ -77,6 +77,7 @@ Abstract base class for spatial data provider implementations.
       FlagLoadDefaultStyle,
       SkipGetExtent,
       SkipFullScan,
+      ForceReadOnly,
     };
     typedef QFlags<QgsDataProvider::ReadFlag> ReadFlags;
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1226,6 +1226,7 @@ The development version
       DontStoreOriginalStyles,
       DontLoad3DViews,
       DontLoadProjectStyles,
+      ForceReadOnlyLayers,
     };
 
     typedef QFlags<Qgis::ProjectReadFlag> ProjectReadFlags;

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -644,6 +644,7 @@ or layer with temporary data (as temporary mesh layer dataset)
       FlagDontResolveLayers,
       FlagTrustLayerMetadata,
       FlagReadExtentFromXml,
+      FlagForceReadOnly,
     };
     typedef QFlags<QgsMapLayer::ReadFlag> ReadFlags;
 

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1842,7 +1842,9 @@ If you need only the count of committed features call this method on this layer'
 %Docstring
 Makes layer read-only (editing disabled) or not
 
-:return: ``False`` if the layer is in editing yet
+:return: ``False`` if the layer is in editing yet or if the data source is in read-only mode
+
+.. seealso:: :py:func:`readOnlyChanged`
 %End
 
     virtual bool supportsEditing() const;
@@ -3014,6 +3016,8 @@ Will be emitted whenever the edit form configuration of this layer changes.
 %Docstring
 Emitted when the read only state of this layer is changed.
 Only applies to manually set readonly state, not to the edit mode.
+
+.. seealso:: :py:func:`setReadOnly`
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -370,6 +370,7 @@ Constructor for LayerOptions.
 
       bool skipCrsValidation;
 
+      bool forceReadOnly;
     };
 
     struct DeleteContext

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -49,6 +49,7 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_API_RESOURCES_DIRECTORY,
       QGIS_SERVER_API_WFS3_MAX_LIMIT,
       QGIS_SERVER_TRUST_LAYER_METADATA,
+      QGIS_SERVER_FORCE_READONLY_LAYERS,
       QGIS_SERVER_DISABLE_GETPRINT,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES,
       QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS,
@@ -278,6 +279,16 @@ The default value is ``False``, this value can be changed by setting the environ
 variable QGIS_SERVER_TRUST_LAYER_METADATA.
 
 .. versionadded:: 3.16
+%End
+
+    bool forceReadOnlyLayers() const;
+%Docstring
+Returns ``True`` if the reading flag force layer read only is activated.
+
+The default value is ``False``, this value can be changed by setting the environment
+variable QGIS_SERVER_FORCE_READONLY_LAYERS.
+
+.. versionadded:: 3.28
 %End
 
     bool getPrintDisabled() const;

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -255,7 +255,8 @@ void QgsStatusBarCoordinatesWidget::world()
   }
   const QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.gpkg|layername=countries" );
   const QFileInfo fileInfo = QFileInfo( fileName );
-  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  options.forceReadOnly = true;
   QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
       tr( "World Map" ), QStringLiteral( "ogr" ), options );
   // Register this layer with the layers registry
@@ -384,4 +385,3 @@ void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible()
     mLineEdit->setMaximumWidth( width );
   }
 }
-

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -67,6 +67,10 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
   {
     flags |= QgsDataProvider::FlagTrustDataSource;
   }
+  if ( mReadFlags & QgsMapLayer::FlagForceReadOnly )
+  {
+    flags |= QgsDataProvider::ForceReadOnly;
+  }
   setDataSourcePrivate( meshLayerPath, baseName, providerKey, providerOptions, flags );
   resetDatasetGroupTreeItem();
   setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -151,6 +151,10 @@ bool QgsPointCloudLayer::readXml( const QDomNode &layerNode, QgsReadWriteContext
     {
       flags |= QgsDataProvider::FlagTrustDataSource;
     }
+    if ( mReadFlags & QgsMapLayer::FlagForceReadOnly )
+    {
+      flags |= QgsDataProvider::ForceReadOnly;
+    }
     setDataSource( mDataSource, mLayerName, mProviderKey, providerOptions, flags );
     const QDomNode subset = layerNode.namedItem( QStringLiteral( "subset" ) );
     const QString subsetText = subset.toElement().text();
@@ -899,5 +903,3 @@ void QgsPointCloudLayer::resetRenderer()
 
   emit rendererChanged();
 }
-
-

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1380,6 +1380,9 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   // Propagate trust layer metadata flag
   if ( ( mFlags & Qgis::ProjectFlag::TrustStoredLayerStatistics ) || ( flags & Qgis::ProjectReadFlag::TrustLayerMetadata ) )
     layerFlags |= QgsMapLayer::FlagTrustLayerMetadata;
+  // Propagate open layers in read-only mode
+  if ( ( flags & Qgis::ProjectReadFlag::ForceReadOnlyLayers ) )
+    layerFlags |= QgsMapLayer::FlagForceReadOnly;
 
   profile.switchTask( tr( "Load layer source" ) );
   const bool layerIsValid = mapLayer->readLayerXml( layerElem, context, layerFlags ) && mapLayer->isValid();

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -418,7 +418,14 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
   QgsCPLHTTPFetchOverrider oCPLHTTPFetcher( mAuthCfg );
   QgsSetCPLHTTPFetchOverriderInitiatorClass( oCPLHTTPFetcher, QStringLiteral( "QgsOgrProvider" ) );
 
-  open( OpenModeInitial );
+  if ( mReadFlags & QgsDataProvider::ForceReadOnly )
+  {
+    open( OpenModeForceReadOnly );
+  }
+  else
+  {
+    open( OpenModeInitial );
+  }
 
   QList<NativeType> nativeTypes;
   if ( mOgrOrigLayer )

--- a/src/core/providers/qgsdataprovider.h
+++ b/src/core/providers/qgsdataprovider.h
@@ -125,6 +125,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
       FlagLoadDefaultStyle = 1 << 2, //!< Reset the layer's style to the default for the datasource
       SkipGetExtent = 1 << 3, //!< Skip the extent from provider
       SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) (since QGIS 3.24)
+      ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode (since QGIS 3.28)
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2098,6 +2098,7 @@ class CORE_EXPORT Qgis
       DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
       DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views (since QGIS 3.26)
       DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
+      ForceReadOnlyLayers = 1 << 6, //!< Open layers in a read-only mode. (since QGIS 3.28)
     };
     Q_ENUM( ProjectReadFlag )
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -640,6 +640,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
       FlagDontResolveLayers = 1 << 0, //!< Don't resolve layer paths or create data providers for layers.
       FlagTrustLayerMetadata = 1 << 1, //!< Trust layer metadata. Improves layer load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on layer load. Since QGIS 3.16
       FlagReadExtentFromXml = 1 << 2, //!< Read extent from xml and skip get extent from provider.
+      FlagForceReadOnly = 1 << 3, //!< Force open as read only.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2069,6 +2069,10 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     {
       flags |= QgsDataProvider::FlagTrustDataSource;
     }
+    if ( mReadFlags & QgsMapLayer::FlagForceReadOnly )
+    {
+      flags |= QgsDataProvider::ForceReadOnly;
+    }
     // read extent
     if ( mReadFlags & QgsMapLayer::FlagReadExtentFromXml )
     {

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -186,6 +186,10 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
     {
       providerFlags |= QgsDataProvider::FlagLoadDefaultStyle;
     }
+    if ( options.forceReadOnly )
+    {
+      providerFlags |= QgsDataProvider::ForceReadOnly;
+    }
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, providerFlags );
   }
 
@@ -1586,6 +1590,10 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // for invalid layer sources, we fallback to stored wkbType if available
     if ( elem.hasAttribute( QStringLiteral( "wkbType" ) ) )
       mWkbType = qgsEnumKeyToValue( elem.attribute( QStringLiteral( "wkbType" ) ), mWkbType );
+  }
+  if ( mReadFlags & QgsMapLayer::FlagForceReadOnly )
+  {
+    flags |= QgsDataProvider::ForceReadOnly;
   }
 
   QDomElement pkeyElem = pkeyNode.toElement();

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -486,6 +486,18 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        */
       bool skipCrsValidation = false;
 
+      /**
+       * Controls whether the layer is forced to be load as Read Only
+       *
+       * If TRUE, then the layer's provider will only check read capabilities.
+       * Write capabilities will be skipped.
+       *
+       * If FALSE (the default), the layer's provider will check the
+       * edition capabilities based on user rights or file rights or
+       * others.
+       * \since QGIS 3.28
+       */
+      bool forceReadOnly = false;
     };
 
     /**
@@ -1725,7 +1737,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Makes layer read-only (editing disabled) or not
-     * \returns FALSE if the layer is in editing yet
+     * \returns FALSE if the layer is in editing yet or if the data source is in read-only mode
+     *
+     * \see readOnlyChanged()
      */
     bool setReadOnly( bool readonly = true );
 
@@ -2792,6 +2806,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Emitted when the read only state of this layer is changed.
      * Only applies to manually set readonly state, not to the edit mode.
      *
+     * \see setReadOnly()
+     *
      * \since QGIS 3.0
      */
     void readOnlyChanged();
@@ -2830,7 +2846,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature() );
 
     /**
-     * Returns TRUE if the provider is in read-only mode
+     * Returns TRUE if the layer is in read-only mode
+     *
+     * \note the layer can be in read-only mode by construction or by action
+     * \see QgsVectorLayer::LayerOptions.forceReadOnly
+     * \see QgsMapLayer::FlagForceReadOnly
+     * \see setReadOnly()
+     * \see readOnlyChanged()
      */
     bool isReadOnly() const FINAL;
 
@@ -2893,7 +2915,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! The user-defined actions that are accessed from the Identify Results dialog box
     QgsActionManager *mActions = nullptr;
 
-    //! Flag indicating whether the layer is in read-only mode (editing disabled) or not
+    //! Flag indicating whether the layer has been created in read-only mode (editing disabled) or not
+    bool mDataSourceReadOnly = false;
+
+    /**
+     * Flag indicating whether the layer has been converted in read-only mode (editing disabled) or not
+     * \see setReadOnly()
+     * \see readOnlyChanged()
+     * \see isReadOnly()
+     */
     bool mReadOnly = false;
 
     /**

--- a/src/gui/qgscoordinateboundspreviewmapwidget.cpp
+++ b/src/gui/qgscoordinateboundspreviewmapwidget.cpp
@@ -35,7 +35,9 @@ QgsCoordinateBoundsPreviewMapWidget::QgsCoordinateBoundsPreviewMapWidget( QWidge
   setDestinationCrs( srs );
 
   const QString layerPath = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.gpkg|layername=countries" );
-  mLayers << new QgsVectorLayer( layerPath );
+  QgsVectorLayer::LayerOptions options;
+  options.forceReadOnly = true;
+  mLayers << new QgsVectorLayer( layerPath, tr( "World Map" ), QStringLiteral( "ogr" ), options );
   setLayers( mLayers );
   mPanTool = new QgsMapToolPan( this );
   setMapTool( mPanTool );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -803,6 +803,13 @@ bool QgsOracleProvider::hasSufficientPermsAndCapabilities()
   QSqlQuery qry( *conn );
   if ( !mIsQuery )
   {
+    if ( mReadFlags & QgsDataProvider::ForceReadOnly )
+    {
+      // Does not check editable capabilities
+      qry.finish();
+
+      return true;
+    }
     if ( conn->currentUser() == mOwnerName )
     {
       // full set of privileges for the owner

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1521,7 +1521,8 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     }
 
     bool inRecovery = false;
-
+    // Check if the database is still in recovery after a database crash
+    // or you are connected to a (read-only) standby server
     if ( connectionRO()->pgVersion() >= 90000 )
     {
       testAccess = connectionRO()->LoggedPQexec( "QgsPostgresProvider",  QStringLiteral( "SELECT pg_is_in_recovery()" ) );
@@ -1539,7 +1540,9 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
       mEnabledCapabilities |= QgsVectorDataProvider::SelectAtId;
     }
 
-    if ( !inRecovery )
+    // Do not check the editable capabilities if the provider has been forced to be
+    // in read-only mode or if the database is still in recovery
+    if ( !inRecovery || !( mReadFlags & QgsDataProvider::ForceReadOnly ) )
     {
       if ( connectionRO()->pgVersion() >= 80400 )
       {

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -117,6 +117,11 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
       {
         readFlags |= Qgis::ProjectReadFlag::TrustLayerMetadata;
       }
+      // Activate force layer read only flag
+      if ( settings->forceReadOnlyLayers() )
+      {
+        readFlags |= Qgis::ProjectReadFlag::ForceReadOnlyLayers;
+      }
       // Activate don't load layouts flag
       if ( settings->getPrintDisabled() )
       {
@@ -334,4 +339,3 @@ void QgsNullCacheStrategy::entryInserted( const QString &path )
 {
   Q_UNUSED( path )
 }
-

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -164,6 +164,18 @@ void QgsServerSettings::initSettings()
                                       };
   mSettings[ sTrustLayerMetadata.envVar ] = sTrustLayerMetadata;
 
+
+  // force to open layers in read-only mode
+  const Setting sForceReadOnlyLayers = { QgsServerSettingsEnv::QGIS_SERVER_FORCE_READONLY_LAYERS,
+                                         QgsServerSettingsEnv::DEFAULT_VALUE,
+                                         QStringLiteral( "Force to open layers in read-only mode" ),
+                                         QString(),
+                                         QVariant::Bool,
+                                         QVariant( false ),
+                                         QVariant()
+                                       };
+  mSettings[ sForceReadOnlyLayers.envVar ] = sForceReadOnlyLayers;
+
   // don't load layouts
   const Setting sDontLoadLayouts = { QgsServerSettingsEnv::QGIS_SERVER_DISABLE_GETPRINT,
                                      QgsServerSettingsEnv::DEFAULT_VALUE,
@@ -612,6 +624,11 @@ bool QgsServerSettings::trustLayerMetadata() const
   return value( QgsServerSettingsEnv::QGIS_SERVER_TRUST_LAYER_METADATA ).toBool();
 }
 
+bool QgsServerSettings::forceReadOnlyLayers() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_FORCE_READONLY_LAYERS ).toBool();
+}
+
 bool QgsServerSettings::getPrintDisabled() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_DISABLE_GETPRINT ).toBool();
@@ -677,4 +694,3 @@ QStringList QgsServerSettings::allowedExtraSqlTokens() const
   }
   return strVal.split( ',' );
 }
-

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -67,6 +67,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //!< Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
       QGIS_SERVER_API_WFS3_MAX_LIMIT, //!< Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
       QGIS_SERVER_TRUST_LAYER_METADATA, //!< Trust layer metadata. Improves project read time. (since QGIS 3.16).
+      QGIS_SERVER_FORCE_READONLY_LAYERS, //!< Force to open layers in read-only mode. (since QGIS 3.28).
       QGIS_SERVER_DISABLE_GETPRINT, //!< Disabled WMS GetPrint request and don't load layouts. Improves project read time. (since QGIS 3.16).
       QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES, //!< Directories used by the landing page service to find .qgs and .qgz projects (since QGIS 3.16)
       QGIS_SERVER_LANDING_PAGE_PROJECTS_PG_CONNECTIONS, //!< PostgreSQL connection strings used by the landing page service to find projects (since QGIS 3.16)
@@ -279,6 +280,16 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.16
      */
     bool trustLayerMetadata() const;
+
+    /**
+     * Returns TRUE if the reading flag force layer read only is activated.
+     *
+     * The default value is FALSE, this value can be changed by setting the environment
+     * variable QGIS_SERVER_FORCE_READONLY_LAYERS.
+     *
+     * \since QGIS 3.28
+     */
+    bool forceReadOnlyLayers() const;
 
     /**
      * Returns TRUE if WMS GetPrint request is disabled and the project's


### PR DESCRIPTION
## Description

In most cases of use of QGIS Server, it is not necessary to access the layers in write mode.
The read-only mode is sufficient.

We would like to introduce a new flag `Qgis::ProjectReadFlag::ForceLayerReadOnly` to
open layers in a read-only mode when the project is read. To activate this flag for QGIS Server,
the environmental variable `QGIS_SERVER_FORCE_READONLY_LAYERS` can be defined.

In addition with `Qgis::ProjectReadFlag::ForceLayerReadOnly`, new flags are available for reading 
layer XML `QgsMapLayer::FlagForceReadOnly` and for dataprovider contruction `QgsDataProvider::ForceReadOnly`.

The `QgsVectorLayer::LayerOptions` has been extended by adding a new property `forceReadOnly` to programmatically open a layer in read only mode.

Funded by Ifremer https://wwz.ifremer.fr/
