### PR TITLE
[fix] inconsistent access to plugin metadata "update_date"

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1031,7 +1031,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     }
 
     QString dateUpdatedStr;
-    if ( ! metadata->value( QStringLiteral( "update_date" ) ).isEmpty() )
+    if ( ! metadata->value( QStringLiteral( "update_date_stable" ) ).isEmpty() )
     {
       const QDateTime dateUpdated = QDateTime::fromString( metadata->value( QStringLiteral( "update_date_stable" ) ).trimmed(), Qt::ISODate );
       if ( dateUpdated.isValid() )


### PR DESCRIPTION
update_date metadata item was inconsistently accessed by key "update_date" and "update_date_stable" => fixed by changing to "update_date_stable"