### PR TITLE
Attempt to control line labels anchor clip widgets stretching

### DIFF
--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -219,6 +219,13 @@ void QgsLabelingGui::showLineAnchorSettings()
   else
   {
     QgsLabelSettingsWidgetDialog dialog( widget, this );
+
+    dialog.buttonBox()->addButton( QDialogButtonBox::Help );
+    connect( dialog.buttonBox(), &QDialogButtonBox::helpRequested, this, [ = ]
+    {
+      QgsHelp::openHelp( QStringLiteral( "style_library/label_settings.html#placement-for-line-layers" ) );
+    } );
+
     if ( dialog.exec() )
     {
       applySettings();

--- a/src/ui/labeling/qgslabellineanchorwidgetbase.ui
+++ b/src/ui/labeling/qgslabellineanchorwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>271</width>
-    <height>315</height>
+    <width>280</width>
+    <height>380</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,12 +26,12 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0" colspan="2">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Label Anchoring</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1,0">
+     <layout class="QGridLayout" name="gridLayout_4">
       <item row="2" column="1">
        <widget class="QComboBox" name="mClippingComboBox"/>
       </item>
@@ -42,7 +42,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
+      <item row="0" column="0" colspan="3">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>&lt;b&gt;Controls the position along the line which labels will be placed close to.&lt;/b&gt;</string>
@@ -89,7 +89,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Text Anchor</string>
@@ -118,7 +118,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Placement Behavior</string>
@@ -147,7 +147,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -184,7 +184,12 @@
   <tabstop>mPercentPlacementComboBox</tabstop>
   <tabstop>mLinePlacementDDBtn</tabstop>
   <tabstop>mCustomPlacementSpinBox</tabstop>
+  <tabstop>mClippingComboBox</tabstop>
+  <tabstop>mLineClippingDDBtn</tabstop>
+  <tabstop>mAnchorTextPointComboBox</tabstop>
+  <tabstop>mAnchorTextPointDDBtn</tabstop>
   <tabstop>mAnchorTypeComboBox</tabstop>
+  <tabstop>mAnchorTypeDDBtn</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/labeling/qgslabellineanchorwidgetbase.ui
+++ b/src/ui/labeling/qgslabellineanchorwidgetbase.ui
@@ -32,11 +32,17 @@
       <string>Label Anchoring</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="mClippingComboBox"/>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="3" column="0">
+       <widget class="QLabel" name="clippinglabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Clipping</string>
         </property>
@@ -44,6 +50,12 @@
       </item>
       <item row="0" column="0" colspan="3">
        <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>&lt;b&gt;Controls the position along the line which labels will be placed close to.&lt;/b&gt;</string>
         </property>
@@ -52,39 +64,50 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="2">
        <widget class="QgsPropertyOverrideButton" name="mLineClippingDDBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>…</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="3">
-       <layout class="QGridLayout" name="gridLayout_2">
-        <property name="topMargin">
-         <number>10</number>
+      <item row="1" column="2">
+       <widget class="QgsPropertyOverrideButton" name="mLinePlacementDDBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <item row="0" column="2">
-         <widget class="QgsPropertyOverrideButton" name="mLinePlacementDDBtn">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="3">
-         <widget class="QgsDoubleSpinBox" name="mCustomPlacementSpinBox">
-          <property name="suffix">
-           <string> %</string>
-          </property>
-          <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QComboBox" name="mPercentPlacementComboBox"/>
-        </item>
-       </layout>
+        <property name="text">
+         <string>…</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QgsDoubleSpinBox" name="mCustomPlacementSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="suffix">
+         <string> %</string>
+        </property>
+        <property name="maximum">
+         <double>100.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QComboBox" name="mPercentPlacementComboBox"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
and various fixes in the dialog
This is what happens when you resize the line anchor settings dialog

![labelslineanchorspaced](https://user-images.githubusercontent.com/7983394/180652543-1ba97d2d-4165-42d3-800e-bb706032e685.png)
 After the PR
![labelslineanchorspaced2](https://user-images.githubusercontent.com/7983394/180652852-636c241a-42a9-43f4-aed0-15052019e06f.png)

This is the best I could come to (without adding a scrollbar), after some time... If someone knows how to avoid the clipping widgets shrink...
