### PR TITLE
Use OGR instead of spatialite to retrieve tables

### DIFF
--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -360,7 +360,8 @@ QList<QgsSpatiaLiteProviderConnection::TableProperty> QgsSpatiaLiteProviderConne
         QgsSpatiaLiteProviderConnection::TableProperty property;
         property.setTableName( tableName );
         // Create a layer and get information from it
-        std::unique_ptr< QgsVectorLayer > vl = std::make_unique<QgsVectorLayer>( dsUri.uri(), QString(), QLatin1String( "spatialite" ) );
+        // Use OGR because it's way faster
+        std::unique_ptr< QgsVectorLayer > vl = std::make_unique<QgsVectorLayer>( dsUri.database() + "|layername=" + dsUri.table(), QString(), QLatin1String( "ogr" ), QgsVectorLayer::LayerOptions( false, true ) );
         if ( vl->isValid() )
         {
           if ( vl->isSpatial() )


### PR DESCRIPTION
picked from 75d420cb5e ( backport from #47952 to fix #48264)

TBH not tested but from the discussions, it seems it was fixed in newer versions but not in LTR.