### PR TITLE
Fix relation editor ESC and referenced save

### DIFF
--- a/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
@@ -52,6 +52,9 @@ Change the layer edited by the map tool
     virtual void deactivate();
 
 
+    virtual void keyPressEvent( QKeyEvent *e );
+
+
   signals:
 
     void digitizingCompleted( const QgsFeature &feature );
@@ -65,6 +68,13 @@ Emitted whenever the digitizing has been successfully completed
 %Docstring
 Emitted whenever the digitizing has been ended without digitizing
 any feature
+%End
+
+    void digitizingCanceled();
+%Docstring
+Emitted when the digitizing process was interrupted by the user.
+
+.. versionadded:: 3.28
 %End
 
   protected:

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -145,6 +145,7 @@ void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
   {
     emit digitizingCanceled();
   }
+  QgsMapToolCaptureLayerGeometry::keyPressEvent( e );
 }
 
 bool QgsMapToolDigitizeFeature::checkGeometryType() const

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -139,6 +139,14 @@ void QgsMapToolDigitizeFeature::deactivate()
   emit digitizingFinished();
 }
 
+void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
+{
+  if ( e->key() == Qt::Key_Escape )
+  {
+    emit digitizingCanceled();
+  }
+}
+
 bool QgsMapToolDigitizeFeature::checkGeometryType() const
 {
   return mCheckGeometryType;

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -56,6 +56,9 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
     void activate() override;
     void deactivate() override;
 
+    // Overridden to emit digitizingCanceled when ESC is pressed
+    void keyPressEvent( QKeyEvent *e ) override;
+
   signals:
 
     /**
@@ -69,6 +72,12 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
      * any feature
      */
     void digitizingFinished();
+
+    /**
+     * Emitted when the digitizing process was interrupted by the user.
+     * \since QGIS 3.28
+     */
+    void digitizingCanceled();
 
   protected:
 
@@ -118,6 +127,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCaptureLayerGeomet
     bool mCheckGeometryType;
 
     friend class TestQgsRelationReferenceWidget;
+
 };
 
 #endif // QGSMAPTOOLDIGITIZEFEATURE_H

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -437,7 +437,8 @@ void QgsRelationEditorWidget::addFeatureGeometry()
   setMapTool( mMapToolDigitize );
 
   connect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
-  connect( mEditorContext.mapCanvas(), &QgsMapCanvas::keyPressed, this, &QgsRelationEditorWidget::onKeyPressed );
+
+  connect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCanceled, this, &QgsRelationEditorWidget::onDigitizingCanceled );
 
   if ( auto *lMainMessageBar = mEditorContext.mainMessageBar() )
   {
@@ -454,8 +455,7 @@ void QgsRelationEditorWidget::addFeatureGeometry()
 void QgsRelationEditorWidget::onDigitizingCompleted( const QgsFeature &feature )
 {
   QgsAbstractRelationEditorWidget::addFeature( feature.geometry() );
-
-  unsetMapTool();
+  digitizingFinished();
 }
 
 void QgsRelationEditorWidget::multiEditItemSelectionChanged()
@@ -590,7 +590,6 @@ void QgsRelationEditorWidget::unsetMapTool()
   // this will call mapToolDeactivated
   mapCanvas->unsetMapTool( mMapToolDigitize );
 
-  disconnect( mapCanvas, &QgsMapCanvas::keyPressed, this, &QgsRelationEditorWidget::onKeyPressed );
   disconnect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
 }
 
@@ -779,15 +778,17 @@ QTreeWidgetItem *QgsRelationEditorWidget::createMultiEditTreeWidgetItem( const Q
   return treeWidgetItem;
 }
 
-void QgsRelationEditorWidget::onKeyPressed( QKeyEvent *e )
+void QgsRelationEditorWidget::onDigitizingCanceled( )
 {
-  if ( e->key() == Qt::Key_Escape )
-  {
-    window()->setVisible( true );
-    window()->raise();
-    window()->activateWindow();
-    unsetMapTool();
-  }
+  digitizingFinished();
+}
+
+void QgsRelationEditorWidget::digitizingFinished( )
+{
+  window()->setVisible( true );
+  window()->raise();
+  window()->activateWindow();
+  unsetMapTool();
 }
 
 void QgsRelationEditorWidget::mapToolDeactivated()

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -207,12 +207,13 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsAbstractRelationEditorWidge
     void toggleEditing( bool state );
     void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );
     void mapToolDeactivated();
-    void onKeyPressed( QKeyEvent *e );
     void onDigitizingCompleted( const QgsFeature &feature );
-
+    void onDigitizingCanceled( );
     void multiEditItemSelectionChanged();
 
   private:
+
+    void digitizingFinished( );
 
     enum class MultiEditFeatureType : int
     {


### PR DESCRIPTION
Fixes #47387 and another bug (unreported or #40549 ?)
where digitizing the referencing feature of a newly added
referenced feature (in transaction mode) failed due to the
form being closed and the reference feature not saved.

The new behavior is that the form is brought back after the
digitizing of the referencing feature has been completed or
user-interrupted, this way the referenced layer form can be
saved or dismissed as expected.

Funded by: ARPA Piemonte
