### PR TITLE
feat(postgres): Define application name for Postgres connection

### DIFF
--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -63,6 +63,7 @@ Provides some enum describing the environment currently supported for configurat
       QGIS_SERVER_PROJECT_CACHE_CHECK_INTERVAL,
       QGIS_SERVER_PROJECT_CACHE_STRATEGY,
       QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS,
+      QGIS_SERVER_APPLICATION_NAME,
     };
 };
 
@@ -337,6 +338,16 @@ Returns the list of strings that represent the allowed extra SQL tokens
 accepted as components of a feature filter.
 The default value is an empty string, the value can be changed by setting the environment
 variable QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS.
+
+.. versionadded:: 3.28
+%End
+
+    QString applicationName() const;
+%Docstring
+Returns the QGIS Server application name.
+The default value is the concatenation of :py:func:`QgsApplication.applicationName()`
+and :py:func:`QgsApplication.platform()` separated by a space, the value can be changed
+by setting the environment variable QGIS_SERVER_APPLICATION_NAME.
 
 .. versionadded:: 3.28
 %End

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -209,6 +209,14 @@ bool QgsServer::init()
   // configuration
   sSettings()->load();
 
+  // override settings
+  QgsSettings settings;
+  settings.setValue(
+    QStringLiteral( "PostgreSQL/application_name" ),
+    sSettings()->applicationName(),
+    QgsSettings::Providers
+  );
+
   // init and configure logger
   QgsServerLogger::instance();
   QgsServerLogger::instance()->setLogLevel( sSettings()->logLevel() );
@@ -613,4 +621,3 @@ void QgsServer::initPython()
   }
 }
 #endif
-

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -379,6 +379,16 @@ void QgsServerSettings::initSettings()
                                          };
   mSettings[ sAllowedExtraSqlTokens.envVar ] = sAllowedExtraSqlTokens;
 
+  const Setting sApplicationName = { QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME,
+                                     QgsServerSettingsEnv::DEFAULT_VALUE,
+                                     QStringLiteral( "The QGIS Server application name" ),
+                                     QStringLiteral( "/qgis/server_application_name" ),
+                                     QVariant::String,
+                                     QVariant( "" ),
+                                     QVariant()
+                                   };
+  mSettings[ sApplicationName.envVar ] = sApplicationName;
+
 }
 
 void QgsServerSettings::load()
@@ -693,4 +703,14 @@ QStringList QgsServerSettings::allowedExtraSqlTokens() const
     return QStringList();
   }
   return strVal.split( ',' );
+}
+
+QString QgsServerSettings::applicationName() const
+{
+  const QString strVal { value( QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME ).toString().trimmed() };
+  if ( strVal.isEmpty() )
+  {
+    return QStringLiteral( "%1 %2" ).arg( QgsApplication::applicationName(), QgsApplication::platform() );
+  }
+  return strVal;
 }

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -81,6 +81,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_PROJECT_CACHE_CHECK_INTERVAL, //! Set the interval for cache invalidation strategy 'interval', default to 0 which select the legacy File system watcher  (since QGIS 3.26).
       QGIS_SERVER_PROJECT_CACHE_STRATEGY, //! Set the project cache strategy. Possible values are 'filesystem', 'periodic' or 'off' (since QGIS 3.26).
       QGIS_SERVER_ALLOWED_EXTRA_SQL_TOKENS, //! Adds these tokens to the list of allowed tokens that the services accept when filtering features (since QGIS 3.28).
+      QGIS_SERVER_APPLICATION_NAME, //! Define the QGIS Server application name.
     };
     Q_ENUM( EnvVar )
 };
@@ -338,6 +339,16 @@ class SERVER_EXPORT QgsServerSettings
      * \since QGIS 3.28
      */
     QStringList allowedExtraSqlTokens() const;
+
+    /**
+     * Returns the QGIS Server application name.
+     * The default value is the concatenation of QgsApplication::applicationName()
+     * and QgsApplication::platform() separated by a space, the value can be changed
+     * by setting the environment variable QGIS_SERVER_APPLICATION_NAME.
+     *
+     * \since QGIS 3.28
+     */
+    QString applicationName() const;
 
     /**
      * Returns the string representation of a setting.


### PR DESCRIPTION
## Description

The name of the application that connects to PostgreSQL is always QGIS even if it is QGIS Server or another application that uses the QGIS API.

We propose to be able to modify the name of the application that is used by QGIS to connect to PostgreSQL according to the configuration used.
This will make it easier to differentiate between QGIS Server and QGIS Desktop in PostgreSQL logs. It will also be possible to differentiate profiles, installations, or others in PostgreSQL logs.

The settings will be `application_name` in `PostgreSQL` section.

Funded by 3liz https://3liz.com