### PR TITLE
Use new driver metadata in GDAL 3.6 to determine connection capabilities

### DIFF
--- a/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/providers/qgsabstractdatabaseproviderconnection.sip.in
@@ -363,7 +363,10 @@ This information is calculated from the geometry columns types.
       Z,
       M,
       SinglePart,
-      Curves
+      Curves,
+      SinglePoint,
+      SingleLineString,
+      SinglePolygon,
     };
 
     typedef QFlags<QgsAbstractDatabaseProviderConnection::GeometryColumnCapability> GeometryColumnCapabilities;

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -340,7 +340,9 @@ void QgsGeoPackageProviderConnection::setDefaultCapabilities()
   {
     GeometryColumnCapability::Z,
     GeometryColumnCapability::M,
-    GeometryColumnCapability::SinglePart,
+    GeometryColumnCapability::SingleLineString,
+    GeometryColumnCapability::SinglePoint,
+    GeometryColumnCapability::SinglePolygon,
     GeometryColumnCapability::Curves
   };
   mSqlLayerDefinitionCapabilities =

--- a/src/core/providers/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/providers/qgsabstractdatabaseproviderconnection.h
@@ -518,9 +518,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     {
       Z = 1 << 1,                    //!< Supports Z dimension
       M = 1 << 2,                    //!< Supports M dimension
-      SinglePart = 1 << 3,           //!< Multi and single part types are distinct types
-      Curves = 1 << 4                //!< Supports curves
+      SinglePart = 1 << 3,           //!< Multi and single part types are distinct types. Deprecated since QGIS 3.28 -- use the granular SinglePoint/SingleLineString/SinglePolygon capabilities instead.
+      Curves = 1 << 4,                //!< Supports curves
+      SinglePoint = 1 << 5,            //!< Supports single point types (as distinct from multi point types) (since QGIS 3.28)
+      SingleLineString = 1 << 6,       //!< Supports single linestring types (as distinct from multi line types) (since QGIS 3.28)
+      SinglePolygon = 1 << 7,          //!< Supports single polygon types (as distinct from multi polygon types) (since QGIS 3.28)
     };
+    // TODO QGIS 4.0 -- remove SinglePart
 
     Q_ENUM( GeometryColumnCapability )
     Q_DECLARE_FLAGS( GeometryColumnCapabilities, GeometryColumnCapability )

--- a/src/gui/qgsnewvectortabledialog.cpp
+++ b/src/gui/qgsnewvectortabledialog.cpp
@@ -140,7 +140,9 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
   mCrs->setShowAccuracyWarnings( true );
 
   // geometry types
+  Q_NOWARN_DEPRECATED_PUSH
   const bool hasSinglePart { conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePart ) };
+  Q_NOWARN_DEPRECATED_POP
 
   const auto addGeomItem = [this]( QgsWkbTypes::Type type )
   {
@@ -148,13 +150,13 @@ QgsNewVectorTableDialog::QgsNewVectorTableDialog( QgsAbstractDatabaseProviderCon
   };
 
   mGeomTypeCbo->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconTableLayer.svg" ) ), tr( "No Geometry" ), QgsWkbTypes::Type::NoGeometry );
-  if ( hasSinglePart )
+  if ( hasSinglePart || conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePoint ) )
     addGeomItem( QgsWkbTypes::Type::Point );
   addGeomItem( QgsWkbTypes::Type::MultiPoint );
-  if ( hasSinglePart )
+  if ( hasSinglePart || conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SingleLineString ) )
     addGeomItem( QgsWkbTypes::Type::LineString );
   addGeomItem( QgsWkbTypes::Type::MultiLineString );
-  if ( hasSinglePart )
+  if ( hasSinglePart || conn->geometryColumnCapabilities().testFlag( QgsAbstractDatabaseProviderConnection::GeometryColumnCapability::SinglePolygon ) )
     addGeomItem( QgsWkbTypes::Type::Polygon );
   addGeomItem( QgsWkbTypes::Type::MultiPolygon );
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -82,7 +82,9 @@ void QgsPostgresProviderConnection::setDefaultCapabilities()
   {
     GeometryColumnCapability::Z,
     GeometryColumnCapability::M,
-    GeometryColumnCapability::SinglePart,
+    GeometryColumnCapability::SinglePoint,
+    GeometryColumnCapability::SingleLineString,
+    GeometryColumnCapability::SinglePolygon,
     GeometryColumnCapability::Curves
   };
   mSqlLayerDefinitionCapabilities =

--- a/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteproviderconnection.cpp
@@ -454,7 +454,9 @@ void QgsSpatiaLiteProviderConnection::setDefaultCapabilities()
   {
     GeometryColumnCapability::Z,
     GeometryColumnCapability::M,
-    GeometryColumnCapability::SinglePart,
+    GeometryColumnCapability::SinglePoint,
+    GeometryColumnCapability::SingleLineString,
+    GeometryColumnCapability::SinglePolygon,
   };
   mSqlLayerDefinitionCapabilities =
   {


### PR DESCRIPTION
Avoids some hardcoded assumptions and allows the OGR connection api to dynamically adapt to the actual format capabilities.