### PR TITLE
Disable style capabilities in server landing page

### DIFF
--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -252,7 +252,7 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
       // Old projects do not have view extent information, we have no choice than
       // re-read the project and extract the information from there
     {
-      QgsProject temporaryProject;
+      QgsProject temporaryProject( nullptr, Qgis::ProjectCapabilities() );
       QObject::connect( &temporaryProject, &QgsProject::readProject, qApp, [ & ]( const QDomDocument & projectDoc )
       {
         const QDomNodeList canvasElements { projectDoc.elementsByTagName( QStringLiteral( "mapcanvas" ) ) };


### PR DESCRIPTION
## Description


This is a follow up to b2eb37a17f0a9053bd41bc6f0b0e1d6a8d1e6a10

Disable project style when loading projects in landing-page: this increase loading time of projects by a factor 10.