### PR TITLE
fix(server): Register services known versions

### DIFF
--- a/src/server/services/wfs/qgswfs.cpp
+++ b/src/server/services/wfs/qgswfs.cpp
@@ -47,14 +47,16 @@ namespace QgsWfs
 
       /**
        * Constructor for WFS service.
+       * \param version Version of the WFS service. (since QGIS 3.22.12)
        * \param serverIface Interface for plugins.
        */
-      Service( QgsServerInterface *serverIface )
-        : mServerIface( serverIface )
+      Service( const QString &version, QgsServerInterface *serverIface )
+        : mVersion( version )
+        , mServerIface( serverIface )
       {}
 
       QString name()    const override { return QStringLiteral( "WFS" ); }
-      QString version() const override { return implementationVersion(); }
+      QString version() const override { return mVersion; }
 
       void executeRequest( const QgsServerRequest &request, QgsServerResponse &response,
                            const QgsProject *project ) override
@@ -117,6 +119,7 @@ namespace QgsWfs
       }
 
     private:
+      QString mVersion;
       QgsServerInterface *mServerIface = nullptr;
   };
 
@@ -135,7 +138,8 @@ class QgsWfsModule: public QgsServiceModule
     void registerSelf( QgsServiceRegistry &registry, QgsServerInterface *serverIface ) override
     {
       QgsDebugMsg( QStringLiteral( "WFSModule::registerSelf called" ) );
-      registry.registerService( new  QgsWfs::Service( serverIface ) );
+      registry.registerService( new  QgsWfs::Service( QgsWfs::implementationVersion(), serverIface ) ); // 1.1.0 default version
+      registry.registerService( new  QgsWfs::Service( QStringLiteral( "1.0.0" ), serverIface ) ); // second version
     }
 };
 

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -33,6 +33,7 @@
 #include "qgswmsgetlegendgraphics.h"
 #include "qgswmsparameters.h"
 #include "qgswmsrequest.h"
+#include "qgswmsutils.h"
 
 #define QSTR_COMPARE( str, lit )\
   (str.compare( QLatin1String( lit ), Qt::CaseInsensitive ) == 0)
@@ -156,7 +157,8 @@ class QgsWmsModule: public QgsServiceModule
     void registerSelf( QgsServiceRegistry &registry, QgsServerInterface *serverIface ) override
     {
       QgsDebugMsg( QStringLiteral( "WMSModule::registerSelf called" ) );
-      registry.registerService( new  QgsWms::Service( "1.3.0", serverIface ) );
+      registry.registerService( new  QgsWms::Service( QgsWms::implementationVersion(), serverIface ) ); // 1.3.0 default version
+      registry.registerService( new  QgsWms::Service( QStringLiteral( "1.1.1" ), serverIface ) ); // second supported version
     }
 };
 

--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -30,6 +30,11 @@
 
 namespace QgsWms
 {
+  QString implementationVersion()
+  {
+    return QStringLiteral( "1.3.0" );
+  }
+
   QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings )
   {
     QUrl href;

--- a/src/server/services/wms/qgswmsutils.h
+++ b/src/server/services/wms/qgswmsutils.h
@@ -49,6 +49,12 @@ namespace QgsWms
   };
 
   /**
+   * Returns the highest version supported by this implementation
+   * \since QGIS 3.22.12
+   */
+  QString implementationVersion();
+
+  /**
    * Returns WMS service URL
    */
   QUrl serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
@@ -67,5 +73,3 @@ namespace QgsWms
 } // namespace QgsWms
 
 #endif
-
-


### PR DESCRIPTION
## Description

In QGIS Server only default supported OGC services versions has been registered :

* WMS 1.3.0 even if 1.1.1 is supported
* WFS 1.1.0 even if 1.0.0 is supported
