### PR TITLE
[feature] split vector layer: add field as prefix option

### DIFF
--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -65,6 +65,9 @@ void QgsSplitVectorLayerAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
   addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Unique ID field" ),
                 QVariant(), QStringLiteral( "INPUT" ) ) );
+  std::unique_ptr< QgsProcessingParameterBoolean > prefixFieldParam = std::make_unique< QgsProcessingParameterBoolean >( QStringLiteral( "PREFIX_FIELD" ),
+      QObject::tr( "Add field prefix to file names" ), true );
+  addParameter( prefixFieldParam.release() );
 
   const QStringList options = QgsVectorFileWriter::supportedFormatExtensions();
   auto fileTypeParam = std::make_unique < QgsProcessingParameterEnum >( QStringLiteral( "FILE_TYPE" ), QObject::tr( "Output file type" ), options, false, 0, true );
@@ -104,7 +107,12 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
   const QgsWkbTypes::Type geometryType = source->wkbType();
   const int fieldIndex = fields.lookupField( fieldName );
   const QSet< QVariant > uniqueValues = source->uniqueValues( fieldIndex );
-  const QString baseName = outputDir + QDir::separator() + fieldName;
+  QString baseName = outputDir + QDir::separator();
+
+  if ( parameterAsBool( parameters, QStringLiteral( "PREFIX_FIELD" ), context ) )
+  {
+    baseName.append( fieldName + "_" );
+  }
 
   int current = 0;
   const double step = uniqueValues.size() > 0 ? 100.0 / uniqueValues.size() : 1;
@@ -122,15 +130,15 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
     QString fileName;
     if ( ( *it ).isNull() )
     {
-      fileName = QStringLiteral( "%1_NULL.%2" ).arg( baseName ).arg( outputFormat );
+      fileName = QStringLiteral( "%1NULL.%2" ).arg( baseName ).arg( outputFormat );
     }
     else if ( ( *it ).toString().isEmpty() )
     {
-      fileName = QStringLiteral( "%1_EMPTY.%2" ).arg( baseName ).arg( outputFormat );
+      fileName = QStringLiteral( "%1EMPTY.%2" ).arg( baseName ).arg( outputFormat );
     }
     else
     {
-      fileName = QStringLiteral( "%1_%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
+      fileName = QStringLiteral( "%1%2.%3" ).arg( baseName ).arg( ( *it ).toString() ).arg( outputFormat );
     }
     feedback->pushInfo( QObject::tr( "Creating layer: %1" ).arg( fileName ) );
 


### PR DESCRIPTION
As described in #49442, the split vector layer algorithm currently prefixes each
output layer with the name of the field along which the layer was split. This PR
adds a checkbox allowing users to enable or disable this behaviour, giving the choice
of whether or not output layers should be prefixed.

Closes #49442