### PR TITLE
Tweaks to container edit widgets in Drag-and-drop form

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -39,7 +39,7 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
   mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
-  mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
+  mVisibilityExpressionWidget->setAllowEmptyFieldName( true );
   mVisibilityExpressionWidget->setLayer( layer );
   mVisibilityExpressionWidget->setExpression( itemData.visibilityExpression()->expression() );
   mColumnCountSpinBox->setValue( itemData.columnCount() );
@@ -75,7 +75,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );
-  visibilityExpression.setEnabled( mControlVisibilityGroupBox->isChecked() );
+  visibilityExpression.setEnabled( true );
   itemData.setVisibilityExpression( visibilityExpression );
 
   QgsOptionalExpression collapsedExpression;

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -37,7 +37,6 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
 
   mTitleLineEdit->setText( itemData.name() );
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
-  mShowLabelCheckBox->setEnabled( itemData.showAsGroupBox() ); // show label makes sense for group box, not for tabs
   mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
   mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
@@ -53,8 +52,6 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
 
   mFormLabelFormatWidget->setLabelStyle( itemData.labelStyle() );
 
-  // show label makes sense for group box, not for tabs
-  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mShowLabelCheckBox, &QCheckBox::setEnabled );
   connect( mShowAsGroupBox, &QCheckBox::stateChanged, mCollapsedCheckBox, &QCheckBox::setEnabled );
   connect( mShowAsGroupBox, &QCheckBox::stateChanged, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
 }

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -75,7 +75,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );
-  visibilityExpression.setEnabled( true );
+  visibilityExpression.setEnabled( !mVisibilityExpressionWidget->currentText().isEmpty() );
   itemData.setVisibilityExpression( visibilityExpression );
 
   QgsOptionalExpression collapsedExpression;

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -14,19 +14,18 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
-     <property name="title">
-      <string>Control Visibility by Expression</string>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Control visibility</string>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true">
+     <property name="toolTip">
+      <string>Controls container's visibility using an expression</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true"/>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="9" column="0" colspan="2">
@@ -171,7 +170,6 @@
   <tabstop>mShowLabelCheckBox</tabstop>
   <tabstop>mTitleLineEdit</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
-  <tabstop>mControlVisibilityGroupBox</tabstop>
   <tabstop>mShowAsGroupBox</tabstop>
   <tabstop>mCollapsedCheckBox</tabstop>
   <tabstop>mControlCollapsedGroupBox</tabstop>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -14,17 +14,17 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Control visibility</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="3" column="1">
     <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true">
      <property name="toolTip">
-      <string>Controls container's visibility using an expression</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;lt;html&amp;gt;&amp;lt;head/&amp;gt;&amp;lt;body&amp;gt;&amp;lt;p&amp;gt;Controls container's visibility using an expression.&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;span style=&amp;quot; font-style:italic;&amp;quot;&amp;gt;Comment out or delete the expression to deactivate the option.&amp;lt;/span&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;/body&amp;gt;&amp;lt;/html&amp;gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -77,14 +77,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Columns</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="2" column="1">
     <widget class="QgsSpinBox" name="mColumnCountSpinBox">
      <property name="minimum">
       <number>1</number>
@@ -101,10 +101,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="1" column="1">
     <widget class="QLineEdit" name="mTitleLineEdit"/>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Title</string>


### PR DESCRIPTION
makes the "show label" accessible for tabs Fixes  #49493
and use a direct access to expression widget for visibility control instead of an intermediate checkbox  fixes #49496
Before
![image](https://user-images.githubusercontent.com/7983394/181389803-38641fba-4797-49c7-a44c-bfd858bf18df.png)

After
![Capture d’écran du 2022-07-28 01-05-08](https://user-images.githubusercontent.com/7983394/181389571-b327118f-00ff-40c6-85b5-b6719b3d273f.png)

