### PR TITLE
form designer: disallow empty container titles

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -65,6 +65,11 @@ void QgsAttributeFormContainerEdit::registerExpressionContextGenerator( QgsExpre
   mCollapsedExpressionWidget->registerExpressionContextGenerator( generator );
 }
 
+QString QgsAttributeFormContainerEdit::name()
+{
+  return mTitleLineEdit->text();
+}
+
 void QgsAttributeFormContainerEdit::updateItemData()
 {
   QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.h
@@ -45,6 +45,8 @@ class GUI_EXPORT QgsAttributeFormContainerEdit: public QWidget, private Ui_QgsAt
      */
     void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
 
+    QString name();
+
     void updateItemData();
 
   private:

--- a/src/gui/qgsaddtaborgroup.cpp
+++ b/src/gui/qgsaddtaborgroup.cpp
@@ -24,6 +24,7 @@
 #include <QTreeWidgetItem>
 #include <QComboBox>
 #include <QRadioButton>
+#include <QMessageBox>
 
 QgsAddTabOrGroup::QgsAddTabOrGroup( QgsVectorLayer *lyr, const QList < TabPair > &tabList, QTreeWidgetItem *currentTab, QWidget *parent )
   : QDialog( parent )
@@ -88,6 +89,13 @@ void QgsAddTabOrGroup::accept()
 {
   if ( mColumnCountSpinBox->value() > 0 )
   {
+    if ( name().isEmpty() )
+    {
+      QMessageBox::warning( this, tr( "Add Container for %1" ).arg( mLayer->name() ),
+                            tr( "No name specified. Please specify a name to create a new container." ) );
+      return;
+    }
+
     if ( mGroupButton->isChecked() )
     {
       QgsSettings().setValue( QStringLiteral( "/qgis/attributeForm/defaultGroupColumnCount" ), mColumnCountSpinBox->value() );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -857,9 +857,16 @@ void QgsAttributesFormProperties::pbnSelectEditForm_clicked()
 
 void QgsAttributesFormProperties::apply()
 {
+
   storeAttributeWidgetEdit();
   storeAttributeContainerEdit();
   storeAttributeTypeDialog();
+
+  if ( mAttributeContainerEdit && mAttributeContainerEdit->name().isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Container Properties" ), tr( "Container name cannot be blank. Please specify a name to edit a container." ) );
+    return;
+  }
 
   QgsEditFormConfig editFormConfig = mLayer->editFormConfig();
 


### PR DESCRIPTION
As described in #49494, the form designer currently allows the creation of containers with empty titles,
leading to confusing behaviour. This MR prevents users from creating or editing in empty titles
for containers, warning them that a title is required.

Fixes #49494
