### PR TITLE
qgisapp.cpp cleanup

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -110,6 +110,8 @@ set(QGIS_APP_SRCS
   annotations/qgsannotationitempropertieswidget.cpp
   annotations/qgsannotationlayerproperties.cpp
 
+  canvas/qgscanvasrefreshblocker.cpp
+
   decorations/qgsdecorationitem.cpp
   decorations/qgsdecorationtitle.cpp
   decorations/qgsdecorationtitledialog.cpp

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -199,6 +199,8 @@ set(QGIS_APP_SRCS
   labeling/qgsmaptoolmovelabel.cpp
   labeling/qgsmaptoolrotatelabel.cpp
 
+  layers/qgsapplayerhandling.cpp
+
   layout/qgslayoutappmenuprovider.cpp
   layout/qgslayoutdesignerdialog.cpp
   layout/qgslayoutimagedrophandler.cpp

--- a/src/app/canvas/qgscanvasrefreshblocker.cpp
+++ b/src/app/canvas/qgscanvasrefreshblocker.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+    qgscanvasrefreshblocker.cpp
+    ---------------------------
+    begin                : July 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscanvasrefreshblocker.h"
+#include "qgisapp.h"
+
+QgsCanvasRefreshBlocker::QgsCanvasRefreshBlocker()
+{
+  if ( QgisApp::instance()->mFreezeCount++ == 0 )
+  {
+    // going from unfrozen to frozen, so freeze canvases
+    QgisApp::instance()->freezeCanvases( true );
+  }
+}
+
+void QgsCanvasRefreshBlocker::release()
+{
+  if ( mReleased )
+    return;
+
+  mReleased = true;
+  if ( --QgisApp::instance()->mFreezeCount == 0 )
+  {
+    // going from frozen to unfrozen, so unfreeze canvases
+    QgisApp::instance()->freezeCanvases( false );
+    QgisApp::instance()->refreshMapCanvas();
+  }
+}
+
+QgsCanvasRefreshBlocker::~QgsCanvasRefreshBlocker()
+{
+  if ( !mReleased )
+    release();
+}
+

--- a/src/app/canvas/qgscanvasrefreshblocker.h
+++ b/src/app/canvas/qgscanvasrefreshblocker.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+    qgscanvasrefreshblocker.h
+    -------------------------
+    begin                : July 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCANVASREFRESHBLOCKER_H
+#define QGSCANVASREFRESHBLOCKER_H
+
+#include "qgis.h"
+
+class QgsCanvasRefreshBlocker
+{
+  public:
+
+    QgsCanvasRefreshBlocker();
+    QgsCanvasRefreshBlocker( const QgsCanvasRefreshBlocker &other ) = delete;
+    QgsCanvasRefreshBlocker &operator=( const QgsCanvasRefreshBlocker &other ) = delete;
+
+    void release();
+
+    ~QgsCanvasRefreshBlocker();
+
+  private:
+
+    bool mReleased = false;
+};
+
+#endif // QGSCANVASREFRESHBLOCKER_H

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -14,6 +14,8 @@
  ***************************************************************************/
 
 #include "qgsapplayerhandling.h"
+
+#include "qgsconfig.h"
 #include "qgsmaplayer.h"
 #include "qgsmeshlayer.h"
 #include "qgsproject.h"
@@ -23,8 +25,29 @@
 #include "qgisapp.h"
 #include "qgsmessagebar.h"
 #include "qgspointcloudlayer3drenderer.h"
+#include "canvas/qgscanvasrefreshblocker.h"
+#include "qgsproviderutils.h"
+#include "qgszipitem.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidersublayerdetails.h"
+#include "qgsprovidersublayersdialog.h"
+#include "qgslayertreenode.h"
+#include "qgslayertree.h"
+#include "qgslayertreeview.h"
+#include "qgsgui.h"
+#include "qgsmbtiles.h"
+#include "qgsmessagelog.h"
+#include "qgsapplication.h"
+#include "qgsvectortilelayer.h"
+#include "qgsprojectstorageregistry.h"
+#include "qgsprojectstorage.h"
+#include "qgsmaplayerfactory.h"
+#include "qgsrasterlayer.h"
+#include "qgsauthguiutils.h"
 
 #include <QObject>
+#include <QMessageBox>
+#include <QUrlQuery>
 
 void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
 {
@@ -98,3 +121,929 @@ void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
     }
   }
 }
+
+bool QgsAppLayerHandling::addVectorLayers( const QStringList &layers, const QString &enc, const QString &dataSourceType, bool guiWarning )
+{
+  //note: this method ONLY supports vector layers from the OGR provider!
+
+  QgsCanvasRefreshBlocker refreshBlocker;
+
+  QList<QgsMapLayer *> layersToAdd;
+  QList<QgsMapLayer *> addedLayers;
+  QgsSettings settings;
+  bool userAskedToAddLayers = false;
+
+  for ( const QString &layerUri : layers )
+  {
+    const QString uri = layerUri.trimmed();
+    QString baseName;
+    if ( dataSourceType == QLatin1String( "file" ) )
+    {
+      QString srcWithoutLayername( uri );
+      int posPipe = srcWithoutLayername.indexOf( '|' );
+      if ( posPipe >= 0 )
+        srcWithoutLayername.resize( posPipe );
+      baseName = QgsProviderUtils::suggestLayerNameFromFilePath( srcWithoutLayername );
+
+      // if needed prompt for zipitem layers
+      QString vsiPrefix = QgsZipItem::vsiPrefix( uri );
+      if ( ! uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) &&
+           ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
+      {
+        if ( askUserForZipItemLayers( uri, { QgsMapLayerType::VectorLayer } ) )
+          continue;
+      }
+    }
+    else if ( dataSourceType == QLatin1String( "database" ) )
+    {
+      // Try to extract the database name and use it as base name
+      // sublayers names (if any) will be appended to the layer name
+      const QVariantMap parts( QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri ) );
+      if ( parts.value( QStringLiteral( "databaseName" ) ).isValid() )
+        baseName = parts.value( QStringLiteral( "databaseName" ) ).toString();
+      else
+        baseName = uri;
+    }
+    else //directory //protocol
+    {
+      baseName = QgsProviderUtils::suggestLayerNameFromFilePath( uri );
+    }
+
+    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+    {
+      baseName = QgsMapLayer::formatLayerName( baseName );
+    }
+
+    QgsDebugMsgLevel( "completeBaseName: " + baseName, 2 );
+    const bool isVsiCurl { uri.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) };
+    const auto scheme { QUrl( uri ).scheme() };
+    const bool isRemoteUrl { scheme.startsWith( QLatin1String( "http" ) ) || scheme == QLatin1String( "ftp" ) };
+
+    std::unique_ptr< QgsTemporaryCursorOverride > cursorOverride;
+    if ( isVsiCurl || isRemoteUrl )
+    {
+      cursorOverride = std::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
+      QgisApp::instance()->visibleMessageBar()->pushInfo( QObject::tr( "Remote layer" ), QObject::tr( "loading %1, please wait …" ).arg( uri ) );
+      qApp->processEvents();
+    }
+
+    QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) )->querySublayers( uri, Qgis::SublayerQueryFlag::IncludeSystemTables );
+    // filter out non-vector sublayers
+    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
+    {
+      return sublayer.type() != QgsMapLayerType::VectorLayer;
+    } ), sublayers.end() );
+
+    cursorOverride.reset();
+
+    const QVariantMap uriParts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri );
+    const QString path = uriParts.value( QStringLiteral( "path" ) ).toString();
+
+    if ( !sublayers.empty() )
+    {
+      userAskedToAddLayers = true;
+
+      const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
+      const bool singleSublayerOnly = sublayers.size() == 1;
+      QString groupName;
+
+      if ( !singleSublayerOnly || detailsAreIncomplete )
+      {
+        // ask user for sublayers (unless user settings dictate otherwise!)
+        switch ( shouldAskUserForSublayers( sublayers ) )
+        {
+          case SublayerHandling::AskUser:
+          {
+            // prompt user for sublayers
+            QgsProviderSublayersDialog dlg( uri, path, sublayers, {QgsMapLayerType::VectorLayer}, QgisApp::instance() );
+
+            if ( dlg.exec() )
+              sublayers = dlg.selectedLayers();
+            else
+              sublayers.clear(); // dialog was canceled, so don't add any sublayers
+            groupName = dlg.groupName();
+            break;
+          }
+
+          case SublayerHandling::LoadAll:
+          {
+            if ( detailsAreIncomplete )
+            {
+              // requery sublayers, resolving geometry types
+              sublayers = QgsProviderRegistry::instance()->querySublayers( uri, Qgis::SublayerQueryFlag::ResolveGeometryType );
+              // filter out non-vector sublayers
+              sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
+              {
+                return sublayer.type() != QgsMapLayerType::VectorLayer;
+              } ), sublayers.end() );
+            }
+            break;
+          }
+
+          case SublayerHandling::AbortLoading:
+            sublayers.clear(); // don't add any sublayers
+            break;
+        };
+      }
+      else if ( detailsAreIncomplete )
+      {
+        // requery sublayers, resolving geometry types
+        sublayers = QgsProviderRegistry::instance()->querySublayers( uri, Qgis::SublayerQueryFlag::ResolveGeometryType );
+        // filter out non-vector sublayers
+        sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
+        {
+          return sublayer.type() != QgsMapLayerType::VectorLayer;
+        } ), sublayers.end() );
+      }
+
+      // now add sublayers
+      if ( !sublayers.empty() )
+      {
+        addedLayers << addSublayers( sublayers, baseName, groupName );
+      }
+
+    }
+    else
+    {
+      QString msg = QObject::tr( "%1 is not a valid or recognized data source." ).arg( uri );
+      // If the failed layer was a vsicurl type, give the user a chance to try the normal download.
+      if ( isVsiCurl &&
+           QMessageBox::question( QgisApp::instance(), QObject::tr( "Invalid Data Source" ),
+                                  QObject::tr( "Download with \"Protocol\" source type has failed, do you want to try the \"File\" source type?" ) ) == QMessageBox::Yes )
+      {
+        QString fileUri = uri;
+        fileUri.replace( QLatin1String( "/vsicurl/" ), " " );
+        return addVectorLayers( QStringList() << fileUri, enc, dataSourceType, guiWarning );
+      }
+      else if ( guiWarning )
+      {
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
+      }
+    }
+  }
+
+  // make sure at least one layer was successfully added
+  if ( layersToAdd.isEmpty() )
+  {
+    // we also return true if we asked the user for sublayers, but they choose none. In this case nothing
+    // went wrong, so we shouldn't return false and cause GUI warnings to appear
+    return userAskedToAddLayers || !addedLayers.isEmpty();
+  }
+
+  // Register this layer with the layers registry
+  QgsProject::instance()->addMapLayers( layersToAdd );
+  for ( QgsMapLayer *l : std::as_const( layersToAdd ) )
+  {
+    if ( !enc.isEmpty() )
+    {
+      if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( l ) )
+        vl->setProviderEncoding( enc );
+    }
+
+    QgisApp::instance()->askUserForDatumTransform( l->crs(), QgsProject::instance()->crs(), l );
+    QgsAppLayerHandling::postProcessAddedLayer( l );
+  }
+  QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
+
+  return true;
+}
+
+QgsPointCloudLayer *QgsAppLayerHandling::addPointCloudLayer( const QString &uri, const QString &baseName, const QString &providerKey, bool guiWarning )
+{
+  QgsCanvasRefreshBlocker refreshBlocker;
+  QgsSettings settings;
+
+  QString base( baseName );
+
+  if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+  {
+    base = QgsMapLayer::formatLayerName( base );
+  }
+
+  QgsDebugMsgLevel( "completeBaseName: " + base, 2 );
+
+  // create the layer
+  std::unique_ptr<QgsPointCloudLayer> layer( new QgsPointCloudLayer( uri, base, providerKey ) );
+
+  if ( !layer || !layer->isValid() )
+  {
+    if ( guiWarning )
+    {
+      QString msg = QObject::tr( "%1 is not a valid or recognized data source, error: \"%2\"" ).arg( uri ).arg( layer->error().message( QgsErrorMessage::Format::Text ) );
+      QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
+    }
+
+    // since the layer is bad, stomp on it
+    return nullptr;
+  }
+
+  QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
+
+
+  QgsProject::instance()->addMapLayer( layer.get() );
+  QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
+
+  return layer.release();
+}
+
+bool QgsAppLayerHandling::askUserForZipItemLayers( const QString &path, const QList<QgsMapLayerType> &acceptableTypes )
+{
+  // query sublayers
+  QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::IncludeSystemTables );
+
+  // filter out non-matching sublayers
+  sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
+  {
+    return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
+  } ), sublayers.end() );
+
+  if ( sublayers.empty() )
+    return false;
+
+  const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
+  const bool singleSublayerOnly = sublayers.size() == 1;
+  QString groupName;
+
+  if ( !singleSublayerOnly || detailsAreIncomplete )
+  {
+    // ask user for sublayers (unless user settings dictate otherwise!)
+    switch ( shouldAskUserForSublayers( sublayers ) )
+    {
+      case SublayerHandling::AskUser:
+      {
+        // prompt user for sublayers
+        QgsProviderSublayersDialog dlg( path, path, sublayers, acceptableTypes, QgisApp::instance() );
+
+        if ( dlg.exec() )
+          sublayers = dlg.selectedLayers();
+        else
+          sublayers.clear(); // dialog was canceled, so don't add any sublayers
+        groupName = dlg.groupName();
+        break;
+      }
+
+      case SublayerHandling::LoadAll:
+      {
+        if ( detailsAreIncomplete )
+        {
+          // requery sublayers, resolving geometry types
+          sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::ResolveGeometryType );
+          sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
+          {
+            return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
+          } ), sublayers.end() );
+        }
+        break;
+      }
+
+      case SublayerHandling::AbortLoading:
+        sublayers.clear(); // don't add any sublayers
+        break;
+    };
+  }
+  else if ( detailsAreIncomplete )
+  {
+    // requery sublayers, resolving geometry types
+    sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::ResolveGeometryType );
+    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
+    {
+      return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
+    } ), sublayers.end() );
+  }
+
+  // now add sublayers
+  if ( !sublayers.empty() )
+  {
+    QgsCanvasRefreshBlocker refreshBlocker;
+    QgsSettings settings;
+
+    QString base = QgsProviderUtils::suggestLayerNameFromFilePath( path );
+    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+    {
+      base = QgsMapLayer::formatLayerName( base );
+    }
+
+    addSublayers( sublayers, base, groupName );
+    QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
+  }
+
+  return true;
+}
+
+QgsAppLayerHandling::SublayerHandling QgsAppLayerHandling::shouldAskUserForSublayers( const QList<QgsProviderSublayerDetails> &layers, bool hasNonLayerItems )
+{
+  if ( hasNonLayerItems )
+    return SublayerHandling::AskUser;
+
+  QgsSettings settings;
+  const Qgis::SublayerPromptMode promptLayers = settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), Qgis::SublayerPromptMode::AlwaysAsk );
+
+  switch ( promptLayers )
+  {
+    case Qgis::SublayerPromptMode::AlwaysAsk:
+      return SublayerHandling::AskUser;
+
+    case Qgis::SublayerPromptMode::AskExcludingRasterBands:
+    {
+      // if any non-raster layers are found, we ask the user. Otherwise we load all
+      for ( const QgsProviderSublayerDetails &sublayer : layers )
+      {
+        if ( sublayer.type() != QgsMapLayerType::RasterLayer )
+          return SublayerHandling::AskUser;
+      }
+      return SublayerHandling::LoadAll;
+    }
+
+    case Qgis::SublayerPromptMode::NeverAskSkip:
+      return SublayerHandling::AbortLoading;
+
+    case Qgis::SublayerPromptMode::NeverAskLoadAll:
+      return SublayerHandling::LoadAll;
+  }
+
+  return SublayerHandling::AskUser;
+}
+
+QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName )
+{
+  QgsLayerTreeGroup *group = nullptr;
+  if ( !groupName.isEmpty() )
+  {
+    int index { 0 };
+    QgsLayerTreeNode *currentNode { QgisApp::instance()->layerTreeView()->currentNode() };
+    if ( currentNode && currentNode->parent() )
+    {
+      if ( QgsLayerTree::isGroup( currentNode ) )
+      {
+        group = qobject_cast<QgsLayerTreeGroup *>( currentNode )->insertGroup( 0, groupName );
+      }
+      else if ( QgsLayerTree::isLayer( currentNode ) )
+      {
+        const QList<QgsLayerTreeNode *> currentNodeSiblings { currentNode->parent()->children() };
+        int nodeIdx { 0 };
+        for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
+        {
+          nodeIdx++;
+          if ( child == currentNode )
+          {
+            index = nodeIdx;
+            break;
+          }
+        }
+        group = qobject_cast<QgsLayerTreeGroup *>( currentNode->parent() )->insertGroup( index, groupName );
+      }
+      else
+      {
+        group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
+      }
+    }
+    else
+    {
+      group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
+    }
+  }
+
+  QgsSettings settings;
+  const bool formatLayerNames = settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool();
+
+  // if we aren't adding to a group, we need to add the layers in reverse order so that they maintain the correct
+  // order in the layer tree!
+  QList<QgsProviderSublayerDetails> sortedLayers = layers;
+  if ( groupName.isEmpty() )
+  {
+    std::reverse( sortedLayers.begin(), sortedLayers.end() );
+  }
+
+  QList< QgsMapLayer * > result;
+  result.reserve( sortedLayers.size() );
+
+  for ( const QgsProviderSublayerDetails &sublayer : std::as_const( sortedLayers ) )
+  {
+    QgsProviderSublayerDetails::LayerOptions options( QgsProject::instance()->transformContext() );
+    options.loadDefaultStyle = false;
+
+    std::unique_ptr<QgsMapLayer> layer( sublayer.toLayer( options ) );
+    if ( !layer )
+      continue;
+
+    QgsMapLayer *ml = layer.get();
+    // if we aren't adding to a group, then we're iterating the layers in the reverse order
+    // so account for that in the returned list of layers
+    if ( groupName.isEmpty() )
+      result.insert( 0, ml );
+    else
+      result << ml;
+
+    QString layerName = layer->name();
+    if ( formatLayerNames )
+    {
+      layerName = QgsMapLayer::formatLayerName( layerName );
+    }
+
+    const bool projectWasEmpty = QgsProject::instance()->mapLayers().empty();
+
+    // if user has opted to add sublayers to a group, then we don't need to include the
+    // filename in the layer's name, because the group is already titled with the filename.
+    // But otherwise, we DO include the file name so that users can differentiate the source
+    // when multiple layers are loaded from a GPX file or similar (refs https://github.com/qgis/QGIS/issues/37551)
+    if ( group )
+    {
+      if ( !layerName.isEmpty() )
+        layer->setName( layerName );
+      else if ( !baseName.isEmpty() )
+        layer->setName( baseName );
+      QgsProject::instance()->addMapLayer( layer.release(), false );
+      group->addLayer( ml );
+    }
+    else
+    {
+      if ( layerName != baseName && !layerName.isEmpty() && !baseName.isEmpty() )
+        layer->setName( QStringLiteral( "%1 — %2" ).arg( baseName, layerName ) );
+      else if ( !layerName.isEmpty() )
+        layer->setName( layerName );
+      else if ( !baseName.isEmpty() )
+        layer->setName( baseName );
+      QgsProject::instance()->addMapLayer( layer.release() );
+    }
+
+    // Some of the logic relating to matching a new project's CRS to the first layer added CRS is deferred to happen when the event loop
+    // next runs -- so in those cases we can't assume that the project's CRS has been matched to the actual desired CRS yet.
+    // In these cases we don't need to show the coordinate operation selection choice, so just hardcode an exception in here to avoid that...
+    QgsCoordinateReferenceSystem projectCrsAfterLayerAdd = QgsProject::instance()->crs();
+    const QgsGui::ProjectCrsBehavior projectCrsBehavior = QgsSettings().enumValue( QStringLiteral( "/projections/newProjectCrsBehavior" ),  QgsGui::UseCrsOfFirstLayerAdded, QgsSettings::App );
+    switch ( projectCrsBehavior )
+    {
+      case QgsGui::UseCrsOfFirstLayerAdded:
+      {
+        if ( projectWasEmpty )
+          projectCrsAfterLayerAdd = ml->crs();
+        break;
+      }
+
+      case QgsGui::UsePresetCrs:
+        break;
+    }
+
+    QgisApp::instance()->askUserForDatumTransform( ml->crs(), projectCrsAfterLayerAdd, ml );
+    QgsAppLayerHandling::postProcessAddedLayer( ml );
+  }
+
+  if ( group )
+  {
+    // Respect if user don't want the new group of layers visible.
+    QgsSettings settings;
+    const bool newLayersVisible = settings.value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool();
+    if ( !newLayersVisible )
+      group->setItemVisibilityCheckedRecursive( newLayersVisible );
+  }
+
+  return result;
+}
+
+bool QgsAppLayerHandling::openLayer( const QString &fileName, bool allowInteractive )
+{
+  bool ok = false;
+  const QFileInfo fileInfo( fileName );
+
+  // highest priority = delegate to provider registry to handle
+  const QList< QgsProviderRegistry::ProviderCandidateDetails > candidateProviders = QgsProviderRegistry::instance()->preferredProvidersForUri( fileName );
+  if ( candidateProviders.size() == 1 && candidateProviders.at( 0 ).layerTypes().size() == 1 )
+  {
+    // one good candidate provider and possible layer type -- that makes things nice and easy!
+    switch ( candidateProviders.at( 0 ).layerTypes().at( 0 ) )
+    {
+      case QgsMapLayerType::VectorLayer:
+      case QgsMapLayerType::RasterLayer:
+      case QgsMapLayerType::MeshLayer:
+      case QgsMapLayerType::AnnotationLayer:
+      case QgsMapLayerType::PluginLayer:
+      case QgsMapLayerType::VectorTileLayer:
+      case QgsMapLayerType::GroupLayer:
+        // not supported here yet!
+        break;
+
+      case QgsMapLayerType::PointCloudLayer:
+        ok = static_cast< bool >( addPointCloudLayer( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), false ) );
+        break;
+    }
+  }
+
+  if ( ok )
+    return true;
+
+  CPLPushErrorHandler( CPLQuietErrorHandler );
+
+  // if needed prompt for zipitem layers
+  QString vsiPrefix = QgsZipItem::vsiPrefix( fileName );
+  if ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) )
+  {
+    if ( askUserForZipItemLayers( fileName, {} ) )
+    {
+      CPLPopErrorHandler();
+      return true;
+    }
+  }
+
+  if ( fileName.endsWith( QStringLiteral( ".mbtiles" ), Qt::CaseInsensitive ) )
+  {
+    QgsMbTiles reader( fileName );
+    if ( reader.open() )
+    {
+      if ( reader.metadataValue( "format" ) == QLatin1String( "pbf" ) )
+      {
+        // these are vector tiles
+        QUrlQuery uq;
+        uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
+        uq.addQueryItem( QStringLiteral( "url" ), fileName );
+        const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
+        std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
+        if ( vtLayer->isValid() )
+        {
+          QgsProject::instance()->addMapLayer( vtLayer.release() );
+          return true;
+        }
+      }
+      else // raster tiles
+      {
+        // prefer to use WMS provider's implementation to open MBTiles rasters
+        QUrlQuery uq;
+        uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
+        uq.addQueryItem( QStringLiteral( "url" ), QUrl::fromLocalFile( fileName ).toString() );
+        if ( addRasterLayer( uq.toString(), fileInfo.completeBaseName(), QStringLiteral( "wms" ) ) )
+          return true;
+      }
+    }
+  }
+  else if ( fileName.endsWith( QStringLiteral( ".vtpk" ), Qt::CaseInsensitive ) )
+  {
+    // these are vector tiles
+    QUrlQuery uq;
+    uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "vtpk" ) );
+    uq.addQueryItem( QStringLiteral( "url" ), fileName );
+    const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
+    std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
+    if ( vtLayer->isValid() )
+    {
+      QgsAppLayerHandling::postProcessAddedLayer( vtLayer.get() );
+      QgsProject::instance()->addMapLayer( vtLayer.release() );
+      return true;
+    }
+  }
+
+  QList< QgsProviderSublayerModel::NonLayerItem > nonLayerItems;
+  if ( QgsProjectStorage *ps = QgsApplication::projectStorageRegistry()->projectStorageFromUri( fileName ) )
+  {
+    const QStringList projects = ps->listProjects( fileName );
+    for ( const QString &project : projects )
+    {
+      QgsProviderSublayerModel::NonLayerItem projectItem;
+      projectItem.setType( QStringLiteral( "project" ) );
+      projectItem.setName( project );
+      projectItem.setUri( QStringLiteral( "%1://%2?projectName=%3" ).arg( ps->type(), fileName, project ) );
+      projectItem.setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIconQgsProjectFile.svg" ) ) );
+      nonLayerItems << projectItem;
+    }
+  }
+
+  // query sublayers
+  QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::IncludeSystemTables );
+
+  if ( !sublayers.empty() || !nonLayerItems.empty() )
+  {
+    const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
+    const bool singleSublayerOnly = sublayers.size() == 1;
+    QString groupName;
+
+    if ( allowInteractive && ( !singleSublayerOnly || detailsAreIncomplete || !nonLayerItems.empty() ) )
+    {
+      // ask user for sublayers (unless user settings dictate otherwise!)
+      switch ( shouldAskUserForSublayers( sublayers, !nonLayerItems.empty() ) )
+      {
+        case SublayerHandling::AskUser:
+        {
+          // prompt user for sublayers
+          QgsProviderSublayersDialog dlg( fileName, fileName, sublayers, {}, QgisApp::instance() );
+          dlg.setNonLayerItems( nonLayerItems );
+
+          if ( dlg.exec() )
+          {
+            sublayers = dlg.selectedLayers();
+            nonLayerItems = dlg.selectedNonLayerItems();
+          }
+          else
+          {
+            sublayers.clear(); // dialog was canceled, so don't add any sublayers
+            nonLayerItems.clear();
+          }
+          groupName = dlg.groupName();
+          break;
+        }
+
+        case SublayerHandling::LoadAll:
+        {
+          if ( detailsAreIncomplete )
+          {
+            // requery sublayers, resolving geometry types
+            sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::ResolveGeometryType );
+          }
+          break;
+        }
+
+        case SublayerHandling::AbortLoading:
+          sublayers.clear(); // don't add any sublayers
+          break;
+      };
+    }
+    else if ( detailsAreIncomplete )
+    {
+      // requery sublayers, resolving geometry types
+      sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::ResolveGeometryType );
+    }
+
+    ok = true;
+
+    // now add sublayers
+    if ( !sublayers.empty() )
+    {
+      QgsCanvasRefreshBlocker refreshBlocker;
+      QgsSettings settings;
+
+      QString base = QgsProviderUtils::suggestLayerNameFromFilePath( fileName );
+      if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+      {
+        base = QgsMapLayer::formatLayerName( base );
+      }
+
+      addSublayers( sublayers, base, groupName );
+      QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
+    }
+    else if ( !nonLayerItems.empty() )
+    {
+      QgsCanvasRefreshBlocker refreshBlocker;
+      if ( QgisApp::instance()->checkTasksDependOnProject() )
+        return true;
+
+      // possibly save any pending work before opening a different project
+      if ( QgisApp::instance()->checkUnsavedLayerEdits() && QgisApp::instance()->checkMemoryLayers() && QgisApp::instance()->saveDirty() )
+      {
+        // error handling and reporting is in addProject() function
+        QgisApp::instance()->addProject( nonLayerItems.at( 0 ).uri() );
+      }
+      return true;
+    }
+  }
+
+  CPLPopErrorHandler();
+
+  if ( !ok )
+  {
+    // maybe a known file type, which couldn't be opened due to a missing dependency... (eg. las for a non-pdal-enabled build)
+    QgsProviderRegistry::UnusableUriDetails details;
+    if ( QgsProviderRegistry::instance()->handleUnusableUri( fileName, details ) )
+    {
+      ok = true;
+
+      if ( details.detailedWarning.isEmpty() )
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QString(), details.warning, Qgis::MessageLevel::Critical );
+      else
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QString(), details.warning, details.detailedWarning, Qgis::MessageLevel::Critical );
+    }
+  }
+
+  if ( !ok )
+  {
+    // we have no idea what this file is...
+    QgsMessageLog::logMessage( QObject::tr( "Unable to load %1" ).arg( fileName ) );
+
+    const QString msg = QObject::tr( "%1 is not a valid or recognized data source." ).arg( fileName );
+    QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
+  }
+
+  return ok;
+}
+
+QgsRasterLayer *QgsAppLayerHandling::addRasterLayer( const QString &uri, const QString &baseName, const QString &providerKey )
+{
+  return addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, uri, baseName, !providerKey.isEmpty() ? providerKey : QLatin1String( "gdal" ), true );
+}
+
+bool QgsAppLayerHandling::addRasterLayers( const QStringList &files, bool guiWarning )
+{
+  if ( files.empty() )
+  {
+    return false;
+  }
+
+  QgsCanvasRefreshBlocker refreshBlocker;
+
+  // this is messy since some files in the list may be rasters and others may
+  // be ogr layers. We'll set returnValue to false if one or more layers fail
+  // to load.
+  bool returnValue = true;
+  for ( const QString &src : files )
+  {
+    QString errMsg;
+    bool ok = false;
+
+    // if needed prompt for zipitem layers
+    QString vsiPrefix = QgsZipItem::vsiPrefix( src );
+    if ( ( !src.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) || src.endsWith( QLatin1String( ".zip" ) ) || src.endsWith( QLatin1String( ".tar" ) ) ) &&
+         ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
+    {
+      if ( askUserForZipItemLayers( src, { QgsMapLayerType::RasterLayer } ) )
+        continue;
+    }
+
+    const bool isVsiCurl { src.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) };
+    const bool isRemoteUrl { src.startsWith( QLatin1String( "http" ) ) || src == QLatin1String( "ftp" ) };
+
+    std::unique_ptr< QgsTemporaryCursorOverride > cursorOverride;
+    if ( isVsiCurl || isRemoteUrl )
+    {
+      cursorOverride = std::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
+      QgisApp::instance()->visibleMessageBar()->pushInfo( QObject::tr( "Remote layer" ), QObject::tr( "loading %1, please wait …" ).arg( src ) );
+      qApp->processEvents();
+    }
+
+    if ( QgsRasterLayer::isValidRasterFileName( src, errMsg ) )
+    {
+      QFileInfo myFileInfo( src );
+
+      // set the layer name to the file base name unless provided explicitly
+      QString layerName;
+      const QVariantMap uriDetails = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), src );
+      if ( !uriDetails[ QStringLiteral( "layerName" ) ].toString().isEmpty() )
+      {
+        layerName = uriDetails[ QStringLiteral( "layerName" ) ].toString();
+      }
+      else
+      {
+        layerName = QgsProviderUtils::suggestLayerNameFromFilePath( src );
+      }
+
+      // try to create the layer
+      cursorOverride.reset();
+      QgsRasterLayer *layer = addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, src, layerName, QStringLiteral( "gdal" ), guiWarning );
+
+      if ( layer && layer->isValid() )
+      {
+        //only allow one copy of a ai grid file to be loaded at a
+        //time to prevent the user selecting all adfs in 1 dir which
+        //actually represent 1 coverage,
+
+        if ( myFileInfo.fileName().endsWith( QLatin1String( ".adf" ), Qt::CaseInsensitive ) )
+        {
+          break;
+        }
+      }
+      // if layer is invalid addLayerPrivate() will show the error
+
+    } // valid raster filename
+    else
+    {
+      ok = false;
+
+      // Issue message box warning unless we are loading from cmd line since
+      // non-rasters are passed to this function first and then successfully
+      // loaded afterwards (see main.cpp)
+      if ( guiWarning )
+      {
+        QString msg = QObject::tr( "%1 is not a supported raster data source" ).arg( src );
+        if ( !errMsg.isEmpty() )
+          msg += '\n' + errMsg;
+
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Unsupported Data Source" ), msg, Qgis::MessageLevel::Critical );
+      }
+    }
+    if ( ! ok )
+    {
+      returnValue = false;
+    }
+  }
+  return returnValue;
+}
+
+template<typename T>
+T *QgsAppLayerHandling::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &name, const QString &providerKey, bool guiWarnings )
+{
+  QgsSettings settings;
+
+  QgsCanvasRefreshBlocker refreshBlocker;
+
+  QString baseName = settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() ? QgsMapLayer::formatLayerName( name ) : name;
+
+  // if the layer needs authentication, ensure the master password is set
+  const QRegularExpression rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
+  if ( rx.match( uri ).hasMatch() )
+  {
+    if ( !QgsAuthGuiUtils::isDisabled( QgisApp::instance()->messageBar() ) )
+    {
+      QgsApplication::authManager()->setMasterPassword( true );
+    }
+  }
+
+  QVariantMap uriElements = QgsProviderRegistry::instance()->decodeUri( providerKey, uri );
+  QString path = uri;
+  if ( uriElements.contains( QStringLiteral( "path" ) ) )
+  {
+    // run layer path through QgsPathResolver so that all inbuilt paths and other localised paths are correctly expanded
+    path = QgsPathResolver().readPath( uriElements.value( QStringLiteral( "path" ) ).toString() );
+    uriElements[ QStringLiteral( "path" ) ] = path;
+  }
+  // Not all providers implement decodeUri(), so use original uri if uriElements is empty
+  const QString updatedUri = uriElements.isEmpty() ? uri : QgsProviderRegistry::instance()->encodeUri( providerKey, uriElements );
+
+  const bool canQuerySublayers = QgsProviderRegistry::instance()->providerMetadata( providerKey ) &&
+                                 ( QgsProviderRegistry::instance()->providerMetadata( providerKey )->capabilities() & QgsProviderMetadata::QuerySublayers );
+
+  T *result = nullptr;
+  if ( canQuerySublayers )
+  {
+    // query sublayers
+    QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->providerMetadata( providerKey ) ?
+        QgsProviderRegistry::instance()->providerMetadata( providerKey )->querySublayers( updatedUri, Qgis::SublayerQueryFlag::IncludeSystemTables )
+        : QgsProviderRegistry::instance()->querySublayers( updatedUri );
+
+    // filter out non-matching sublayers
+    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [type]( const QgsProviderSublayerDetails & sublayer )
+    {
+      return sublayer.type() != type;
+    } ), sublayers.end() );
+
+    if ( sublayers.empty() )
+    {
+      if ( guiWarnings )
+      {
+        QString msg = QObject::tr( "%1 is not a valid or recognized data source." ).arg( uri );
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
+      }
+
+      // since the layer is bad, stomp on it
+      return nullptr;
+    }
+    else if ( sublayers.size() > 1 || QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount ) )
+    {
+      // ask user for sublayers (unless user settings dictate otherwise!)
+      switch ( shouldAskUserForSublayers( sublayers ) )
+      {
+        case SublayerHandling::AskUser:
+        {
+          QgsProviderSublayersDialog dlg( updatedUri, path, sublayers, {type}, QgisApp::instance() );
+          if ( dlg.exec() )
+          {
+            const QList< QgsProviderSublayerDetails > selectedLayers = dlg.selectedLayers();
+            if ( !selectedLayers.isEmpty() )
+            {
+              result = qobject_cast< T * >( addSublayers( selectedLayers, baseName, dlg.groupName() ).value( 0 ) );
+            }
+          }
+          break;
+        }
+        case SublayerHandling::LoadAll:
+        {
+          result = qobject_cast< T * >( addSublayers( sublayers, baseName, QString() ).value( 0 ) );
+          break;
+        }
+        case SublayerHandling::AbortLoading:
+          break;
+      };
+    }
+    else
+    {
+      result = qobject_cast< T * >( addSublayers( sublayers, name, QString() ).value( 0 ) );
+
+      if ( result )
+      {
+        QString base( baseName );
+        if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+        {
+          base = QgsMapLayer::formatLayerName( base );
+        }
+        result->setName( base );
+      }
+    }
+  }
+  else
+  {
+    QgsMapLayerFactory::LayerOptions options( QgsProject::instance()->transformContext() );
+    options.loadDefaultStyle = false;
+    result = qobject_cast< T * >( QgsMapLayerFactory::createLayer( uri, name, type, options, providerKey ) );
+    if ( result )
+    {
+      QString base( baseName );
+      if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
+      {
+        base = QgsMapLayer::formatLayerName( base );
+      }
+      result->setName( base );
+      QgsProject::instance()->addMapLayer( result );
+
+      QgisApp::instance()->askUserForDatumTransform( result->crs(), QgsProject::instance()->crs(), result );
+      QgsAppLayerHandling::postProcessAddedLayer( result );
+    }
+  }
+
+  QgisApp::instance()->activateDeactivateLayerRelatedActions( QgisApp::instance()->activeLayer() );
+  return result;
+}
+

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+    qgsapplayerhandling.cpp
+    -------------------------
+    begin                : July 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsapplayerhandling.h"
+#include "qgsmaplayer.h"
+#include "qgsmeshlayer.h"
+#include "qgsproject.h"
+#include "qgsprojecttimesettings.h"
+#include "qgspointcloudlayer.h"
+#include "qgsmeshlayertemporalproperties.h"
+#include "qgisapp.h"
+#include "qgsmessagebar.h"
+#include "qgspointcloudlayer3drenderer.h"
+
+#include <QObject>
+
+void QgsAppLayerHandling::postProcessAddedLayer( QgsMapLayer *layer )
+{
+  switch ( layer->type() )
+  {
+    case QgsMapLayerType::VectorLayer:
+    case QgsMapLayerType::RasterLayer:
+    {
+      bool ok = false;
+      layer->loadDefaultStyle( ok );
+      layer->loadDefaultMetadata( ok );
+      break;
+    }
+
+    case QgsMapLayerType::PluginLayer:
+      break;
+
+    case QgsMapLayerType::MeshLayer:
+    {
+      QgsMeshLayer *meshLayer = qobject_cast< QgsMeshLayer *>( layer );
+      QDateTime referenceTime = QgsProject::instance()->timeSettings()->temporalRange().begin();
+      if ( !referenceTime.isValid() ) // If project reference time is invalid, use current date
+        referenceTime = QDateTime( QDate::currentDate(), QTime( 0, 0, 0 ), Qt::UTC );
+
+      if ( meshLayer->dataProvider() && !qobject_cast< QgsMeshLayerTemporalProperties * >( meshLayer->temporalProperties() )->referenceTime().isValid() )
+        qobject_cast< QgsMeshLayerTemporalProperties * >( meshLayer->temporalProperties() )->setReferenceTime( referenceTime, meshLayer->dataProvider()->temporalCapabilities() );
+
+      bool ok = false;
+      meshLayer->loadDefaultStyle( ok );
+      meshLayer->loadDefaultMetadata( ok );
+      break;
+    }
+
+    case QgsMapLayerType::VectorTileLayer:
+    {
+      bool ok = false;
+      QString error = layer->loadDefaultStyle( ok );
+      if ( !ok )
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Error loading style" ), error, Qgis::MessageLevel::Warning );
+      error = layer->loadDefaultMetadata( ok );
+      if ( !ok )
+        QgisApp::instance()->visibleMessageBar()->pushMessage( QObject::tr( "Error loading layer metadata" ), error, Qgis::MessageLevel::Warning );
+
+      break;
+    }
+
+    case QgsMapLayerType::AnnotationLayer:
+    case QgsMapLayerType::GroupLayer:
+      break;
+
+    case QgsMapLayerType::PointCloudLayer:
+    {
+      bool ok = false;
+      layer->loadDefaultStyle( ok );
+      layer->loadDefaultMetadata( ok );
+
+#ifdef HAVE_3D
+      if ( !layer->renderer3D() )
+      {
+        QgsPointCloudLayer *pcLayer = qobject_cast< QgsPointCloudLayer * >( layer );
+        // If the layer has no 3D renderer and syncing 3D to 2D renderer is enabled, we create a renderer and set it up with the 2D renderer
+        if ( pcLayer->sync3DRendererTo2DRenderer() )
+        {
+          std::unique_ptr< QgsPointCloudLayer3DRenderer > renderer3D = std::make_unique< QgsPointCloudLayer3DRenderer >();
+          renderer3D->convertFrom2DRenderer( pcLayer->renderer() );
+          layer->setRenderer3D( renderer3D.release() );
+        }
+      }
+#endif
+      break;
+    }
+  }
+}

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -24,7 +24,9 @@
 #include "qgsmeshlayertemporalproperties.h"
 #include "qgisapp.h"
 #include "qgsmessagebar.h"
+#ifdef HAVE_3D
 #include "qgspointcloudlayer3drenderer.h"
+#endif
 #include "canvas/qgscanvasrefreshblocker.h"
 #include "qgsproviderutils.h"
 #include "qgszipitem.h"

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -19,6 +19,9 @@
 #include "qgsconfig.h"
 
 class QgsMapLayer;
+class QgsProviderSublayerDetails;
+class QgsPointCloudLayer;
+class QgsRasterLayer;
 
 /**
  * Contains logic related to general layer handling in QGIS app.
@@ -28,10 +31,66 @@ class QgsAppLayerHandling
 
   public:
 
+    enum class SublayerHandling
+    {
+      AskUser,
+      LoadAll,
+      AbortLoading
+    };
 
     static void postProcessAddedLayer( QgsMapLayer *layer );
 
 
+
+    static bool addVectorLayers( const QStringList &layers, const QString &enc, const QString &dataSourceType, bool guiWarning = true );
+
+
+    //! Open a point cloud layer - this is the generic function which takes all parameters
+    static QgsPointCloudLayer *addPointCloudLayer( const QString &uri,
+        const QString &baseName,
+        const QString &providerKey,
+        bool guiWarning = true );
+
+    /**
+     * This method will open a dialog so the user can select GDAL sublayers to load
+     * \returns TRUE if any items were loaded
+     */
+    static bool askUserForZipItemLayers( const QString &path, const QList< QgsMapLayerType > &acceptableTypes );
+
+
+    static SublayerHandling shouldAskUserForSublayers( const QList< QgsProviderSublayerDetails > &layers, bool hasNonLayerItems = false );
+
+    static QList< QgsMapLayer * > addSublayers( const QList< QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName );
+
+
+    /**
+     * Open a raster or vector file; ignore other files.
+     * Used to process a commandline argument, FileOpen or Drop event.
+     * Set \a allowInteractive to TRUE if it is OK to ask the user for information (mostly for
+     * when a vector layer has sublayers and we want to ask which sublayers to use).
+     * \returns TRUE if the file is successfully opened
+     */
+    static bool openLayer( const QString &fileName, bool allowInteractive = false );
+
+    template<typename T> static T *addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &baseName, const QString &providerKey, bool guiWarnings = true );
+
+    /**
+     * Add a raster layer directly without prompting user for location
+     * The caller must provide information compatible with the provider plugin
+     * using the \a uri and \a baseName. The provider can use these
+     * parameters in any way necessary to initialize the layer. The \a baseName
+     * parameter is used in the Map Legend so it should be formed in a meaningful
+     * way.
+     */
+    static QgsRasterLayer *addRasterLayer( QString const &uri, QString const &baseName, QString const &providerKey = QLatin1String( "gdal" ) );
+
+    /**
+     * Overloaded version of the private addRasterLayer()
+     * Method that takes a list of file names instead of prompting
+     * user with a dialog.
+     * \returns TRUE if successfully added layer(s)
+     */
+    static bool addRasterLayers( const QStringList &files, bool guiWarning = true );
 
 };
 

--- a/src/app/layers/qgsapplayerhandling.h
+++ b/src/app/layers/qgsapplayerhandling.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+    qgsapplayerhandling.h
+    -------------------------
+    begin                : July 2022
+    copyright            : (C) 2022 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSAPPLAYERHANDLING_H
+#define QGSAPPLAYERHANDLING_H
+
+#include "qgis.h"
+#include "qgsconfig.h"
+
+class QgsMapLayer;
+
+/**
+ * Contains logic related to general layer handling in QGIS app.
+ */
+class QgsAppLayerHandling
+{
+
+  public:
+
+
+    static void postProcessAddedLayer( QgsMapLayer *layer );
+
+
+
+};
+
+#endif // QGSAPPLAYERHANDLING_H

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -118,6 +118,7 @@ typedef SInt32 SRefCon;
 
 #include "qgsuserprofilemanager.h"
 #include "qgsuserprofile.h"
+#include "layers/qgsapplayerhandling.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -1440,11 +1441,11 @@ int main( int argc, char *argv[] )
     }
     else if ( layerName.endsWith( QLatin1String( ".qlr" ), Qt::CaseInsensitive ) )
     {
-      qgis->openLayerDefinition( layerName );
+      QgsAppLayerHandling::openLayerDefinition( layerName );
     }
     else
     {
-      qgis->openLayer( layerName );
+      QgsAppLayerHandling::openLayer( layerName );
     }
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -79,12 +79,10 @@
 
 #include "qgssettingsregistrycore.h"
 #include "qgsnetworkaccessmanager.h"
-#include "qgsrelationmanager.h"
 #include "qgsapplication.h"
 #include "qgslayerstylingwidget.h"
 #include "qgsdevtoolspanelwidget.h"
 #include "qgstaskmanager.h"
-#include "qgsweakrelation.h"
 #include "qgsziputils.h"
 #include "qgsbrowserguimodel.h"
 #include "qgsvectorlayerjoinbuffer.h"
@@ -93,7 +91,6 @@
 #include "qgsprovidermetadata.h"
 #include "qgsfixattributedialog.h"
 #include "qgsprojecttimesettings.h"
-#include "qgsmaplayerutils.h"
 #include "qgsgeometrycollection.h"
 #include "qgsvectorlayersavestyledialog.h"
 #include "maptools/qgsappmaptools.h"
@@ -418,7 +415,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "devtools/querylogger/qgsappquerylogger.h"
 #include "devtools/querylogger/qgsqueryloggerwidgetfactory.h"
 #include "devtools/profiler/qgsprofilerwidgetfactory.h"
-#include "qgsabstractdatabaseproviderconnection.h"
 
 #include "browser/qgsinbuiltdataitemproviders.h"
 
@@ -706,26 +702,6 @@ void QgisApp::onActiveLayerChanged( QgsMapLayer *layer )
   }
 
   emit activeLayerChanged( layer );
-}
-
-void QgisApp::vectorLayerStyleLoaded( QgsVectorLayer *vl, QgsMapLayer::StyleCategories categories )
-{
-  if ( vl && vl->isValid( ) )
-  {
-
-    // Check broken dependencies in forms
-    if ( categories.testFlag( QgsMapLayer::StyleCategory::Forms ) )
-    {
-      resolveVectorLayerDependencies( vl );
-    }
-
-    // Check broken relations and try to restore them
-    if ( categories.testFlag( QgsMapLayer::StyleCategory::Relations ) )
-    {
-      resolveVectorLayerWeakRelations( vl );
-    }
-
-  }
 }
 
 void QgisApp::toggleEventTracing()
@@ -2306,7 +2282,7 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 
       if ( subLayers.empty() )
       {
-        addMapLayer( layer );
+        QgsAppLayerHandling::addMapLayer( layer );
       }
       else
       {
@@ -2407,7 +2383,6 @@ bool QgisApp::event( QEvent *event )
   return done;
 }
 
-
 QgsMessageBar *QgisApp::visibleMessageBar()
 {
   if ( mDataSourceManagerDialog &&
@@ -2422,218 +2397,9 @@ QgsMessageBar *QgisApp::visibleMessageBar()
   }
 }
 
-const QList<QgsVectorLayerRef> QgisApp::findBrokenLayerDependencies( QgsVectorLayer *vl, QgsMapLayer::StyleCategories categories ) const
+QgsDockWidget *QgisApp::logDock()
 {
-  QList<QgsVectorLayerRef> brokenDependencies;
-
-  if ( categories.testFlag( QgsMapLayer::StyleCategory::Forms ) )
-  {
-    for ( int i = 0; i < vl->fields().count(); i++ )
-    {
-      const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( vl, vl->fields().field( i ).name() );
-      QgsFieldFormatter *fieldFormatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
-      if ( fieldFormatter )
-      {
-        const QList<QgsVectorLayerRef> constDependencies { fieldFormatter->layerDependencies( setup.config() ) };
-        for ( const QgsVectorLayerRef &dependency : constDependencies )
-        {
-          // I guess we need and isNull()/isValid() method for the ref
-          if ( dependency.layer ||
-               ! dependency.name.isEmpty() ||
-               ! dependency.source.isEmpty() ||
-               ! dependency.layerId.isEmpty() )
-          {
-            const QgsVectorLayer *depVl { QgsVectorLayerRef( dependency ).resolveWeakly( QgsProject::instance(), QgsVectorLayerRef::MatchType::Name ) };
-            if ( ! depVl || ! depVl->isValid() )
-            {
-              brokenDependencies.append( dependency );
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if ( categories.testFlag( QgsMapLayer::StyleCategory::Relations ) )
-  {
-    // Check for layer weak relations
-    const QList<QgsWeakRelation> constWeakRelations { vl->weakRelations() };
-    for ( const QgsWeakRelation &rel : constWeakRelations )
-    {
-      QgsRelation relation { rel.resolvedRelation( QgsProject::instance(), QgsVectorLayerRef::MatchType::Name ) };
-      QgsVectorLayerRef dependency;
-      bool found = false;
-      if ( ! relation.isValid() )
-      {
-        // This is the big question: do we really
-        // want to automatically load the referencing layer(s) too?
-        // This could potentially lead to a cascaded load of a
-        // long list of layers.
-        // The code is in place but let's leave it disabled for now.
-        if ( relation.referencedLayer() == vl )
-        {
-          // Do nothing because vl is the referenced layer
-#if 0
-          dependency = rel.referencingLayer();
-          found = true;
-#endif
-        }
-        else if ( relation.referencingLayer() == vl )
-        {
-          dependency = rel.referencedLayer();
-          found = true;
-        }
-        else
-        {
-          // Something wrong is going on here, maybe this relation
-          // does not really apply to this layer?
-          QgsMessageLog::logMessage( tr( "None of the layers in the relation stored in the style match the current layer, skipping relation id: %1." ).arg( relation.id() ) );
-        }
-
-        if ( found )
-        {
-          // Make sure we don't add it twice if it was already added by the form widgets check
-          bool refFound = false;
-          for ( const QgsVectorLayerRef &otherRef : std::as_const( brokenDependencies ) )
-          {
-            if ( dependency.layerId == otherRef.layerId || ( dependency.source == otherRef.source && dependency.provider == otherRef.provider ) )
-            {
-              refFound = true;
-              break;
-            }
-          }
-          if ( ! refFound )
-          {
-            brokenDependencies.append( dependency );
-          }
-        }
-      }
-    }
-  }
-  return brokenDependencies;
-}
-
-void QgisApp::resolveVectorLayerDependencies( QgsVectorLayer *vl, QgsMapLayer::StyleCategories categories )
-{
-  if ( vl && vl->isValid() )
-  {
-    const auto constDependencies { findBrokenLayerDependencies( vl, categories ) };
-    for ( const QgsVectorLayerRef &dependency : constDependencies )
-    {
-      // Check for projects without layer dependencies (see 7e8c7b3d0e094737336ff4834ea2af625d2921bf)
-      if ( QgsProject::instance()->mapLayer( dependency.layerId ) || ( dependency.name.isEmpty() && dependency.source.isEmpty() ) )
-      {
-        continue;
-      }
-      // try to aggressively resolve the broken dependencies
-      bool loaded = false;
-      const QString providerName { vl->dataProvider()->name() };
-      QgsProviderMetadata *providerMetadata { QgsProviderRegistry::instance()->providerMetadata( providerName ) };
-      if ( providerMetadata )
-      {
-        // Retrieve the DB connection (if any)
-
-        std::unique_ptr< QgsAbstractDatabaseProviderConnection > conn { QgsMapLayerUtils::databaseConnection( vl ) };
-        if ( conn )
-        {
-          QString tableSchema;
-          QString tableName;
-          const QVariantMap sourceParts = providerMetadata->decodeUri( dependency.source );
-
-          // This part should really be abstracted out to the connection classes or to the providers directly.
-          // Different providers decode the uri differently, for example we don't get the table name out of OGR
-          // but the layerName/layerId instead, so let's try different approaches
-
-          // This works for GPKG
-          tableName = sourceParts.value( QStringLiteral( "layerName" ) ).toString();
-
-          // This works for PG and spatialite
-          if ( tableName.isEmpty() )
-          {
-            tableName = sourceParts.value( QStringLiteral( "table" ) ).toString();
-            tableSchema = sourceParts.value( QStringLiteral( "schema" ) ).toString();
-          }
-
-          // Helper to find layers in connections
-          auto layerFinder = [ &conn, &dependency, &providerName ]( const QString & tableSchema, const QString & tableName ) -> bool
-          {
-            // First try the current schema (or no schema if it's not supported from the provider)
-            try
-            {
-              const QString layerUri { conn->tableUri( tableSchema, tableName )};
-              // Load it!
-              std::unique_ptr< QgsVectorLayer > newVl = std::make_unique< QgsVectorLayer >( layerUri, dependency.name, providerName );
-              if ( newVl->isValid() )
-              {
-                QgsProject::instance()->addMapLayer( newVl.release() );
-                return true;
-              }
-            }
-            catch ( QgsProviderConnectionException & )
-            {
-              // Do nothing!
-            }
-            return false;
-          };
-
-          loaded = layerFinder( tableSchema, tableName );
-
-          // Try different schemas
-          if ( ! loaded && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::Schemas ) && ! tableSchema.isEmpty() )
-          {
-            const QStringList schemas { conn->schemas() };
-            for ( const QString &schemaName : schemas )
-            {
-              if ( schemaName != tableSchema )
-              {
-                loaded = layerFinder( schemaName, tableName );
-              }
-              if ( loaded )
-              {
-                break;
-              }
-            }
-          }
-        }
-      }
-      if ( ! loaded )
-      {
-        const QString msg { tr( "layer '%1' requires layer '%2' to be loaded but '%2' could not be found, please load it manually if possible." ).arg( vl->name(), dependency.name ) };
-        messageBar()->pushWarning( tr( "Missing layer form dependency" ), msg );
-      }
-      else
-      {
-        messageBar()->pushSuccess( tr( "Missing layer form dependency" ), tr( "Layer dependency '%2' required by '%1' was automatically loaded." )
-                                   .arg( vl->name() )
-                                   .arg( dependency.name ) );
-      }
-    }
-  }
-}
-
-void QgisApp::resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer )
-{
-  if ( vectorLayer && vectorLayer->isValid() )
-  {
-    const QList<QgsWeakRelation> constWeakRelations { vectorLayer->weakRelations( ) };
-    for ( const QgsWeakRelation &rel : constWeakRelations )
-    {
-      QgsRelation relation { rel.resolvedRelation( QgsProject::instance(), QgsVectorLayerRef::MatchType::Name ) };
-      if ( relation.isValid() )
-      {
-        // Avoid duplicates
-        const QList<QgsRelation> constRelations { QgsProject::instance()->relationManager()->relations().values() };
-        for ( const QgsRelation &other : constRelations )
-        {
-          if ( relation.hasEqualDefinition( other ) )
-          {
-            continue;
-          }
-        }
-        QgsProject::instance()->relationManager()->addRelation( relation );
-      }
-    }
-  }
+  return mLogDock;
 }
 
 void QgisApp::dataSourceManager( const QString &pageName )
@@ -2654,7 +2420,7 @@ void QgisApp::dataSourceManager( const QString &pageName )
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addVectorTileLayer, this, &QgisApp::addVectorTileLayer );
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addPointCloudLayer, this, &QgisApp::addPointCloudLayer );
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::showStatusMessage, this, &QgisApp::showStatusMessage );
-    connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addDatabaseLayers, this, &QgisApp::addDatabaseLayers );
+    connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addDatabaseLayers, this, []( const QStringList & layerPathList, const QString & providerKey ) { QgsAppLayerHandling::addDatabaseLayers( layerPathList, providerKey ); } );
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::replaceSelectedVectorLayer, this, &QgisApp::replaceSelectedVectorLayer );
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::handleDropUriList, this, &QgisApp::handleDropUriList );
     connect( this, &QgisApp::newProject, mDataSourceManagerDialog, &QgsDataSourceManagerDialog::updateProjectHome );
@@ -2966,7 +2732,7 @@ void QgisApp::createActions()
   connect( mActionShowMeshCalculator, &QAction::triggered, this, &QgisApp::showMeshCalculator );
   connect( mActionShowAlignRasterTool, &QAction::triggered, this, &QgisApp::showAlignRasterTool );
   connect( mActionEmbedLayers, &QAction::triggered, this, &QgisApp::embedLayers );
-  connect( mActionAddLayerDefinition, &QAction::triggered, this, &QgisApp::addLayerDefinition );
+  connect( mActionAddLayerDefinition, &QAction::triggered, this, [] { QgsAppLayerHandling::addLayerDefinition(); } );
   connect( mActionAddOgrLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "ogr" ) ); } );
   connect( mActionAddRasterLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "gdal" ) ); } );
   connect( mActionAddMeshLayer, &QAction::triggered, this, [ = ] { dataSourceManager( QStringLiteral( "mdal" ) ); } );
@@ -5384,7 +5150,7 @@ void QgisApp::about()
     }
     else
     {
-      versionString += QStringLiteral( "%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ) ).arg( Qgis::devVersion() );
+      versionString += QStringLiteral( "%1</td><td><a href=\"https://github.com/qgis/QGIS/commit/%2\">%2</a></td>" ).arg( tr( "QGIS code revision" ), Qgis::devVersion() );
     }
     versionString += QLatin1String( "</tr><tr>" );
 
@@ -5548,21 +5314,6 @@ void QgisApp::about()
   sAbt->activateWindow();
 }
 
-void QgisApp::addLayerDefinition()
-{
-  QgsSettings settings;
-  QString lastUsedDir = settings.value( QStringLiteral( "UI/lastQLRDir" ), QDir::homePath() ).toString();
-
-  QString path = QFileDialog::getOpenFileName( this, QStringLiteral( "Add Layer Definition File" ), lastUsedDir, QStringLiteral( "*.qlr" ) );
-  if ( path.isEmpty() )
-    return;
-
-  QFileInfo fi( path );
-  settings.setValue( QStringLiteral( "UI/lastQLRDir" ), fi.path() );
-
-  openLayerDefinition( path );
-}
-
 QString QgisApp::crsAndFormatAdjustedLayerUri( const QString &uri, const QStringList &supportedCrs, const QStringList &supportedFormats ) const
 {
   QString newuri = uri;
@@ -5603,123 +5354,17 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
 
 QgsMeshLayer *QgisApp::addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey )
 {
-  return QgsAppLayerHandling::addLayerPrivate< QgsMeshLayer >( QgsMapLayerType::MeshLayer, url, baseName, providerKey, true );
+  return QgsAppLayerHandling::addMeshLayer( url, baseName, providerKey );
 }
 
 QgsVectorTileLayer *QgisApp::addVectorTileLayer( const QString &url, const QString &baseName )
 {
-  return addVectorTileLayerPrivate( url, baseName );
+  return QgsAppLayerHandling::addVectorTileLayer( url, baseName );
 }
 
 QgsPointCloudLayer *QgisApp::addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey )
 {
   return QgsAppLayerHandling::addPointCloudLayer( url, baseName, providerKey );
-}
-
-QgsVectorTileLayer *QgisApp::addVectorTileLayerPrivate( const QString &url, const QString &baseName, const bool guiWarning )
-{
-  QgsCanvasRefreshBlocker refreshBlocker;
-  QgsSettings settings;
-
-  QString base( baseName );
-
-  if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-  {
-    base = QgsMapLayer::formatLayerName( base );
-  }
-
-  QgsDebugMsgLevel( "completeBaseName: " + base, 2 );
-
-  // create the layer
-  const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
-  std::unique_ptr<QgsVectorTileLayer> layer( new QgsVectorTileLayer( url, base, options ) );
-
-  if ( !layer || !layer->isValid() )
-  {
-    if ( guiWarning )
-    {
-      QString msg = tr( "%1 is not a valid or recognized data source." ).arg( url );
-      visibleMessageBar()->pushMessage( tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
-    }
-
-    // since the layer is bad, stomp on it
-    return nullptr;
-  }
-
-  QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
-
-  QgsProject::instance()->addMapLayer( layer.get() );
-  activateDeactivateLayerRelatedActions( activeLayer() );
-
-  return layer.release();
-}
-
-void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const &providerKey )
-{
-  QList<QgsMapLayer *> myList;
-
-  if ( layerPathList.empty() )
-  {
-    // no layers to add so bail out, but
-    // allow mMapCanvas to handle events
-    // first
-    return;
-  }
-
-  QgsCanvasRefreshBlocker refreshBlocker;
-
-  QApplication::setOverrideCursor( Qt::WaitCursor );
-
-  const auto constLayerPathList = layerPathList;
-  for ( const QString &layerPath : constLayerPathList )
-  {
-    // create the layer
-    QgsDataSourceUri uri( layerPath );
-
-    QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-    options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( uri.uri( false ), uri.table(), providerKey, options );
-    Q_CHECK_PTR( layer );
-
-    if ( ! layer )
-    {
-      QApplication::restoreOverrideCursor();
-
-      // XXX insert meaningful whine to the user here
-      return;
-    }
-
-    if ( layer->isValid() )
-    {
-      // add to list of layers to register
-      //with the central layers registry
-      myList << layer;
-    }
-    else
-    {
-      QgsMessageLog::logMessage( tr( "%1 is an invalid layer - not loaded" ).arg( layerPath ) );
-      QLabel *msgLabel = new QLabel( tr( "%1 is an invalid layer and cannot be loaded. Please check the <a href=\"#messageLog\">message log</a> for further info." ).arg( layerPath ), messageBar() );
-      msgLabel->setWordWrap( true );
-      connect( msgLabel, &QLabel::linkActivated, mLogDock, &QWidget::show );
-      QgsMessageBarItem *item = new QgsMessageBarItem( msgLabel, Qgis::MessageLevel::Warning );
-      messageBar()->pushItem( item );
-      delete layer;
-    }
-    //qWarning("incrementing iterator");
-  }
-
-  QgsProject::instance()->addMapLayers( myList );
-
-  // load default style after adding to process readCustomSymbology signals
-  const auto constMyList = myList;
-  for ( QgsMapLayer *l : constMyList )
-  {
-    bool ok;
-    l->loadDefaultStyle( ok );
-    l->loadDefaultMetadata( ok );
-  }
-
-  QApplication::restoreOverrideCursor();
 }
 
 void QgisApp::addVirtualLayer()
@@ -6222,7 +5867,8 @@ void QgisApp::showRasterCalculator()
     QStringList rLayerDictionaryRef = calcNodeApp->cleanRasterReferences();
     QSet<QPair<QString, QString>> uniqueRasterUriTmp;
 
-    for ( const auto &r : QgsRasterCalculatorEntry::rasterEntries() )
+    const QVector<QgsRasterCalculatorEntry> rasterEntries = QgsRasterCalculatorEntry::rasterEntries();
+    for ( const QgsRasterCalculatorEntry &r : rasterEntries )
     {
       if ( ( ! rLayerDictionaryRef.contains( r.ref ) ) ||
            uniqueRasterUriTmp.contains( QPair( r.raster->source(), r.ref.mid( 0, r.ref.lastIndexOf( "@" ) ) ) ) ) continue;
@@ -6428,7 +6074,7 @@ void QgisApp::fileOpen()
 
     // generate master "all projects" extension list
     QString allEntry = tr( "All Project Files" ) + QStringLiteral( " (" );
-    for ( const QString &extension : extensions )
+    for ( const QString &extension : std::as_const( extensions ) )
       allEntry += QStringLiteral( "*.%1 *.%2 " ).arg( extension.toLower(), extension.toUpper() );
     allEntry.chop( 1 ); // remove trailing ' '
     allEntry += ')';
@@ -6600,7 +6246,7 @@ bool QgisApp::addProject( const QString &projectFile )
     {
       if ( vl->isValid() )
       {
-        resolveVectorLayerDependencies( vl );
+        QgsAppLayerHandling::resolveVectorLayerDependencies( vl );
       }
     }
 
@@ -6901,57 +6547,6 @@ void QgisApp::dwgImport()
   d.exec();
 }
 
-void QgisApp::openLayerDefinition( const QString &path )
-{
-  QString errorMessage;
-  QgsReadWriteContext context;
-  bool loaded = false;
-
-  QFile file( path );
-  if ( !file.open( QIODevice::ReadOnly ) )
-  {
-    errorMessage = QStringLiteral( "Can not open file" );
-  }
-  else
-  {
-    QDomDocument doc;
-    QString message;
-    if ( !doc.setContent( &file, &message ) )
-    {
-      errorMessage = message;
-    }
-    else
-    {
-      QFileInfo fileinfo( file );
-      QDir::setCurrent( fileinfo.absoluteDir().path() );
-
-      context.setPathResolver( QgsPathResolver( path ) );
-      context.setProjectTranslator( QgsProject::instance() );
-
-      loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context );
-    }
-  }
-
-  if ( loaded )
-  {
-    const QList< QgsReadWriteContext::ReadWriteMessage > messages = context.takeMessages();
-    QVector< QgsReadWriteContext::ReadWriteMessage > shownMessages;
-    for ( const QgsReadWriteContext::ReadWriteMessage &message : messages )
-    {
-      if ( shownMessages.contains( message ) )
-        continue;
-
-      visibleMessageBar()->pushMessage( QString(), message.message(), message.categories().join( '\n' ), message.level() );
-
-      shownMessages.append( message );
-    }
-  }
-  else if ( !loaded || !errorMessage.isEmpty() )
-  {
-    visibleMessageBar()->pushMessage( tr( "Error loading layer definition" ), errorMessage, Qgis::MessageLevel::Warning );
-  }
-}
-
 void QgisApp::openTemplate( const QString &fileName )
 {
   QFile templateFile;
@@ -7072,7 +6667,7 @@ void QgisApp::openFile( const QString &fileName, const QString &fileTypeHint )
   }
   else if ( fi.suffix().compare( QLatin1String( "qlr" ), Qt::CaseInsensitive ) == 0 )
   {
-    openLayerDefinition( fileName );
+    QgsAppLayerHandling::openLayerDefinition( fileName );
   }
   else if ( fi.suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) == 0 )
   {
@@ -7792,7 +7387,7 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
         // Re-apply original style and subset string  when fixing bad layers
         if ( !( layerWasValid || layer->originalXmlProperties().isEmpty() ) )
         {
-          if ( ! subsetString.isEmpty() )
+          if ( vlayer && ! subsetString.isEmpty() )
           {
             vlayer->setSubsetString( subsetString );
           }
@@ -7807,18 +7402,18 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
             if ( ! layer->readSymbology( layer_node, errorMsg, context ) )
             {
               QgsDebugMsg( QStringLiteral( "Failed to restore original layer style from stored XML for layer %1: %2" )
-                           .arg( layer->name( ) )
-                           .arg( errorMsg ) );
+                           .arg( layer->name( ),
+                                 errorMsg ) );
             }
           }
           else
           {
             QgsDebugMsg( QStringLiteral( "Failed to create XML QDomDocument for layer %1: %2" )
-                         .arg( layer->name( ) )
-                         .arg( errorMsg ) );
+                         .arg( layer->name( ),
+                               errorMsg ) );
           }
         }
-        else if ( !subsetString.isEmpty() )
+        else if ( vlayer && !subsetString.isEmpty() )
         {
           vlayer->setSubsetString( subsetString );
         }
@@ -8761,16 +8356,11 @@ void QgisApp::layerProperties()
   showLayerProperties( activeLayer() );
 }
 
-void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFeaturesVisible )
+void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *, bool checkFeaturesVisible )
 {
   if ( !layer )
   {
     layer = mLayerTreeView->currentLayer();
-  }
-
-  if ( !parent )
-  {
-    parent = this;
   }
 
   if ( !layer )
@@ -8857,7 +8447,7 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget *parent, bool checkFea
 
     // for extra safety to make sure we know that the delete can have impact on children and joins
     int res = QMessageBox::question( mMapCanvas, tr( "Delete at least %1 feature(s) on other layer(s)" ).arg( childrenCount ),
-                                     tr( "Delete %1 feature(s) on layer \"%2\", %3 as well\nand all of its other descendants.\nDelete these features?" ).arg( numberOfSelectedFeatures ).arg( vlayer->name() ).arg( childrenInfo ),
+                                     tr( "Delete %1 feature(s) on layer \"%2\", %3 as well\nand all of its other descendants.\nDelete these features?" ).arg( numberOfSelectedFeatures ).arg( vlayer->name(), childrenInfo ),
                                      QMessageBox::Yes | QMessageBox::No );
     if ( res != QMessageBox::Yes )
       return;
@@ -9329,7 +8919,7 @@ Qgs3DMapCanvasWidget *QgisApp::duplicate3DMapView( const QString &existingViewNa
 Qgs3DMapCanvasWidget *QgisApp::get3DMapView( const QString &viewName )
 {
 #ifdef HAVE_3D
-  for ( Qgs3DMapCanvasWidget *w : mOpen3DMapViews )
+  for ( Qgs3DMapCanvasWidget *w : std::as_const( mOpen3DMapViews ) )
   {
     if ( w->canvasName() == viewName )
       return w;
@@ -9344,7 +8934,7 @@ QList<Qgs3DMapCanvasWidget *> QgisApp::get3DMapViews()
 {
   QList<Qgs3DMapCanvasWidget *> views;
 #ifdef HAVE_3D
-  for ( Qgs3DMapCanvasWidget *w : mOpen3DMapViews )
+  for ( Qgs3DMapCanvasWidget *w : std::as_const( mOpen3DMapViews ) )
     views.append( w );
 #endif
   return views;
@@ -10482,7 +10072,7 @@ std::unique_ptr<QgsVectorLayer> QgisApp::pasteToNewMemoryVector()
     }
   }
 
-  const QgsWkbTypes::Type wkbType = !typeCounts.isEmpty() ? typeCounts.keys().value( 0 ) : QgsWkbTypes::NoGeometry;
+  const QgsWkbTypes::Type wkbType = !typeCounts.isEmpty() ? typeCounts.constBegin().key() : QgsWkbTypes::NoGeometry;
 
   if ( features.isEmpty() )
   {
@@ -12096,7 +11686,7 @@ void QgisApp::legendLayerZoomNative()
       // find closest native resolution
       QList< double > diagonalNativeResolutions;
       diagonalNativeResolutions.reserve( nativeResolutions.size() );
-      for ( double d : nativeResolutions )
+      for ( double d : std::as_const( nativeResolutions ) )
         diagonalNativeResolutions << std::sqrt( 2 * d * d );
 
       int i;
@@ -12586,7 +12176,7 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
     mMapTools->mapTool< QgsMapToolMeasureBearing >( QgsAppMapTools::MeasureBearing )->updateSettings();
 
 #ifdef HAVE_3D
-    for ( Qgs3DMapCanvasWidget *canvas3D : mOpen3DMapViews )
+    for ( Qgs3DMapCanvasWidget *canvas3D : std::as_const( mOpen3DMapViews ) )
     {
       canvas3D->measurementLineTool()->updateSettings();
     }
@@ -13009,29 +12599,8 @@ void QgisApp::show3DMapViewsManager()
 
 QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const QString &name, const QString &providerKey )
 {
-  return QgsAppLayerHandling::addLayerPrivate< QgsVectorLayer >( QgsMapLayerType::VectorLayer, vectorLayerPath, name, !providerKey.isEmpty() ? providerKey : QLatin1String( "ogr" ), true );
+  return QgsAppLayerHandling::addVectorLayer( vectorLayerPath, name, providerKey );
 }
-
-void QgisApp::addMapLayer( QgsMapLayer *mapLayer )
-{
-  QgsCanvasRefreshBlocker refreshBlocker;
-
-  if ( mapLayer->isValid() )
-  {
-    // Register this layer with the layers registry
-    QList<QgsMapLayer *> myList;
-    myList << mapLayer;
-    QgsProject::instance()->addMapLayers( myList );
-
-    askUserForDatumTransform( mapLayer->crs(), QgsProject::instance()->crs(), mapLayer );
-  }
-  else
-  {
-    QString msg = tr( "The layer is not a valid layer and can not be added to the map" );
-    visibleMessageBar()->pushMessage( tr( "Layer is not valid" ), msg, Qgis::MessageLevel::Critical );
-  }
-}
-
 
 void QgisApp::embedLayers()
 {
@@ -13079,7 +12648,7 @@ void QgisApp::addEmbeddedItems( const QString &projectFile, const QStringList &g
   {
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( id ) );
     if ( vlayer )
-      vectorLayerStyleLoaded( vlayer, QgsMapLayer::AllStyleCategories );
+      QgsAppLayerHandling::onVectorLayerStyleLoaded( vlayer, QgsMapLayer::AllStyleCategories );
   }
 
   // Resolve references to other layers
@@ -13175,7 +12744,7 @@ void QgisApp::initLayouts()
 Qgs3DMapCanvasWidget *QgisApp::createNew3DMapCanvasDock( const QString &name, bool isDocked )
 {
 #ifdef HAVE_3D
-  for ( Qgs3DMapCanvasWidget *canvas : mOpen3DMapViews )
+  for ( Qgs3DMapCanvasWidget *canvas : std::as_const( mOpen3DMapViews ) )
   {
     if ( canvas->canvasName() == name )
     {
@@ -14302,7 +13871,7 @@ void QgisApp::layersWereAdded( const QList<QgsMapLayer *> &layers )
       // be in place in order to update the GUI
       connect( vlayer, &QgsVectorLayer::readOnlyChanged, this, &QgisApp::layerEditStateChanged );
       connect( vlayer, &QgsVectorLayer::raiseError, this, &QgisApp::onLayerError );
-      connect( vlayer, &QgsVectorLayer::styleLoaded, this, [this, vlayer]( QgsMapLayer::StyleCategories categories ) { vectorLayerStyleLoaded( vlayer, categories ); } );
+      connect( vlayer, &QgsVectorLayer::styleLoaded, this, [vlayer]( QgsMapLayer::StyleCategories categories ) { QgsAppLayerHandling::onVectorLayerStyleLoaded( vlayer, categories ); } );
     }
 
     if ( QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layer ) )
@@ -15592,18 +15161,8 @@ QgsRasterLayer *QgisApp::addRasterLayer( QString const &uri, QString const &base
 
 QgsPluginLayer *QgisApp::addPluginLayer( const QString &uri, const QString &baseName, const QString &providerKey )
 {
-  QgsPluginLayer *layer = QgsApplication::pluginLayerRegistry()->createLayer( providerKey, uri );
-  if ( !layer )
-    return nullptr;
-
-  layer->setName( baseName );
-
-  QgsProject::instance()->addMapLayer( layer );
-
-  return layer;
+  return QgsAppLayerHandling::addPluginLayer( uri, baseName, providerKey );
 }
-
-
 
 #ifdef ANDROID
 void QgisApp::keyReleaseEvent( QKeyEvent *event )
@@ -17026,7 +16585,7 @@ void QgisApp::addTabifiedDockWidget( Qt::DockWidgetArea area, QDockWidget *dockW
       bool objectNameFound = false;
       for ( int i = 0; i < tabifyWith.size(); i++ )
       {
-        for ( QDockWidget *cw : dockWidgetsInArea )
+        for ( QDockWidget *cw : std::as_const( dockWidgetsInArea ) )
         {
           if ( cw->objectName() == tabifyWith.at( i ) || cw->property( "dock_uuid" ).toString() == tabifyWith.at( i ) )
           {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -90,14 +90,11 @@
 #include "qgsvectorlayerjoinbuffer.h"
 #include "qgsgeometryvalidationservice.h"
 #include "qgssourceselectproviderregistry.h"
-#include "qgssourceselectprovider.h"
 #include "qgsprovidermetadata.h"
 #include "qgsfixattributedialog.h"
 #include "qgsprojecttimesettings.h"
-#include "qgsmaplayertemporalproperties.h"
 #include "qgsmaplayerutils.h"
 #include "qgsgeometrycollection.h"
-#include "qgsmeshlayertemporalproperties.h"
 #include "qgsvectorlayersavestyledialog.h"
 #include "maptools/qgsappmaptools.h"
 #include "qgsexpressioncontextutils.h"
@@ -111,9 +108,11 @@
 #include "qgsannotationlayer.h"
 #include "qgsdockablewidgethelper.h"
 #include "vertextool/qgsvertexeditor.h"
-#include "qgsanalysis.h"
-#include "qgsgeometrycheckregistry.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsadvanceddigitizingdockwidget.h"
+#include "qgsabstractdatasourcewidget.h"
+#include "qgsmeshlayer.h"
+#include <geos_c.h>
 
 #include "options/qgscodeeditoroptions.h"
 #include "options/qgsfontoptions.h"
@@ -128,6 +127,8 @@
 #include "mesh/qgsmeshelevationpropertieswidget.h"
 #include "elevation/qgselevationprofilewidget.h"
 
+#include "layers/qgsapplayerhandling.h"
+
 #ifdef HAVE_3D
 #include "qgs3d.h"
 #include "qgs3danimationsettings.h"
@@ -139,7 +140,6 @@
 #include "qgslayoutitem3dmap.h"
 #include "processing/qgs3dalgorithms.h"
 #include "qgs3dmaptoolmeasureline.h"
-#include "qgs3dsymbolregistry.h"
 #include "layout/qgslayout3dmapwidget.h"
 #include "layout/qgslayoutviewrubberband.h"
 #include "qgsvectorlayer3drendererwidget.h"
@@ -149,8 +149,6 @@
 #include "qgs3doptions.h"
 #include "qgsmapviewsmanager.h"
 #include "qgs3dmapcanvaswidget.h"
-#include "qgs3dviewsmanagerdialog.h"
-#include "qgs3dutils.h"
 #endif
 
 #ifdef HAVE_GEOREFERENCER
@@ -195,7 +193,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgisappinterface.h"
 #include "qgisappstylesheet.h"
 #include "qgis.h"
-#include "qgisplugin.h"
 #include "qgsabout.h"
 #include "qgsabstractmaptoolhandler.h"
 #include "qgsalignrasterdialog.h"
@@ -211,16 +208,11 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsattributedialog.h"
 #include "qgsauthmanager.h"
 #include "qgsauthguiutils.h"
-#ifndef QT_NO_SSL
-#include "qgsauthcertutils.h"
-#include "qgsauthsslerrorsdialog.h"
-#endif
 #include "qgsappscreenshots.h"
 #include "qgsapplicationexitblockerinterface.h"
 #include "qgsbookmarks.h"
 #include "qgsbookmarkeditordialog.h"
 #include "qgsbrowserdockwidget.h"
-#include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsclipboard.h"
 #include "qgsconfigureshortcutsdialog.h"
 #include "qgscoordinatetransform.h"
@@ -246,9 +238,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsdecorationscalebar.h"
 #include "qgsdecorationgrid.h"
 #include "qgsdecorationlayoutextent.h"
-#include "qgsencodingfiledialog.h"
 #include "qgserror.h"
-#include "qgserrordialog.h"
 #include "qgseventtracing.h"
 #include "qgsexception.h"
 #include "qgsexpressionselectiondialog.h"
@@ -259,13 +249,10 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsfileutils.h"
 #include "qgsfontmanager.h"
 #include "qgsformannotation.h"
-#include "qgsgeos.h"
 #include "qgsguiutils.h"
-#include "qgshtmlannotation.h"
 #include "qgsprojectionselectiondialog.h"
 #include "qgsgpsinformationwidget.h"
 #include "qgsguivectorlayertools.h"
-#include "qgslabelingwidget.h"
 #include "qgsdiagramproperties.h"
 #include "qgslayerdefinition.h"
 #include "qgslayertree.h"
@@ -288,7 +275,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewtemporalindicator.h"
 #include "qgslayertreeviewofflineindicator.h"
 #include "qgsrasterpipe.h"
-#include "qgslayout.h"
 #include "qgslayoutatlas.h"
 #include "qgslayoutcustomdrophandler.h"
 #include "qgslayoutdesignerdialog.h"
@@ -309,7 +295,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayoutlocatorfilter.h"
 #include "qgsnominatimlocatorfilter.h"
 #include "qgssettingslocatorfilter.h"
-#include "qgsgeocoderlocatorfilter.h"
 #include "qgsnominatimgeocoder.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
@@ -317,12 +302,10 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsmapcanvassnappingutils.h"
 #include "qgsmapcanvastracer.h"
 #include "qgsmaplayer.h"
-#include "qgsmaplayerstyleguiutils.h"
 #include "qgsmapoverviewcanvas.h"
 #include "qgsmapsettings.h"
 #include "qgsmaptip.h"
 #include "qgsmbtiles.h"
-#include "qgsmenuheader.h"
 #include "qgsmergeattributesdialog.h"
 #include "qgsmessageviewer.h"
 #include "qgsmessagebar.h"
@@ -333,7 +316,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsmemoryproviderutils.h"
 #include "qgsmimedatautils.h"
 #include "qgsmessagelog.h"
-#include "qgsmultibandcolorrenderer.h"
 #include "qgsnative.h"
 #include "qgsnativealgorithms.h"
 #include "qgsnewvectorlayerdialog.h"
@@ -368,12 +350,10 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsmeshcalculatordialog.h"
 #include "qgsrasterfilewriter.h"
 #include "qgsrasterfilewritertask.h"
-#include "qgsrasteriterator.h"
 #include "qgsrasterlayer.h"
 #include "qgsrasterlayerproperties.h"
 #include "qgsrasternuller.h"
 #include "qgsbrightnesscontrastfilter.h"
-#include "qgsrasterrenderer.h"
 #include "qgsrasterlayersaveasdialog.h"
 #include "qgsrasterprojector.h"
 #include "qgsreadwritecontext.h"
@@ -383,7 +363,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsgroupwmsdatadialog.h"
 #include "qgsselectbyformdialog.h"
 #include "qgsshortcutsmanager.h"
-#include "qgssinglebandgrayrenderer.h"
 #include "qgssnappingwidget.h"
 #include "qgsstatisticalsummarydockwidget.h"
 #include "qgsstatusbar.h"
@@ -392,13 +371,10 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsstatusbarscalewidget.h"
 #include "qgsstyle.h"
 #include "qgssubsetstringeditorproviderregistry.h"
-#include "qgssubsetstringeditorprovider.h"
 #include "qgssubsetstringeditorinterface.h"
-#include "qgssvgannotation.h"
 #include "qgstaskmanager.h"
 #include "qgstaskmanagerwidget.h"
 #include "qgssymbolselectordialog.h"
-#include "qgstextannotation.h"
 #include "qgsundowidget.h"
 #include "qgsuserinputwidget.h"
 #include "qgsvectordataprovider.h"
@@ -411,7 +387,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgspointcloudlayerproperties.h"
 #include "qgsmapthemes.h"
 #include "qgsmessagelogviewer.h"
-#include "qgsdataitem.h"
 #include "qgsmaplayeractionregistry.h"
 #include "qgswelcomepage.h"
 #include "qgsversioninfo.h"
@@ -425,7 +400,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgshelp.h"
 #include "qgsvectorfilewritertask.h"
 #include "qgsmapsavedialog.h"
-#include "qgsmaprenderertask.h"
 #include "qgsmapdecoration.h"
 #include "qgsnewnamedialog.h"
 #include "qgsgui.h"
@@ -434,7 +408,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsvaliditycheckregistry.h"
 #include "qgsappcoordinateoperationhandlers.h"
 #include "qgsprojectviewsettings.h"
-#include "qgscoordinateformatter.h"
 #include "qgslocaldefaultsettings.h"
 #include "qgsbearingnumericformat.h"
 #include "qgsprojectdisplaysettings.h"
@@ -451,7 +424,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 
 #include "browser/qgsinbuiltdataitemproviders.h"
 
-#include "qgssublayersdialog.h"
 #include "ogr/qgsvectorlayersaveasdialog.h"
 #include "qgsannotationitemguiregistry.h"
 #include "annotations/qgsannotationlayerproperties.h"
@@ -5810,7 +5782,7 @@ bool QgisApp::addVectorLayersPrivate( const QStringList &layers, const QString &
     }
 
     askUserForDatumTransform( l->crs(), QgsProject::instance()->crs(), l );
-    postProcessAddedLayer( l );
+    QgsAppLayerHandling::postProcessAddedLayer( l );
   }
   activateDeactivateLayerRelatedActions( activeLayer() );
 
@@ -5943,7 +5915,7 @@ QList< QgsMapLayer * > QgisApp::addSublayers( const QList<QgsProviderSublayerDet
     }
 
     askUserForDatumTransform( ml->crs(), projectCrsAfterLayerAdd, ml );
-    postProcessAddedLayer( ml );
+    QgsAppLayerHandling::postProcessAddedLayer( ml );
   }
 
   if ( group )
@@ -5956,79 +5928,6 @@ QList< QgsMapLayer * > QgisApp::addSublayers( const QList<QgsProviderSublayerDet
   }
 
   return result;
-}
-
-void QgisApp::postProcessAddedLayer( QgsMapLayer *layer )
-{
-  switch ( layer->type() )
-  {
-    case QgsMapLayerType::VectorLayer:
-    case QgsMapLayerType::RasterLayer:
-    {
-      bool ok = false;
-      layer->loadDefaultStyle( ok );
-      layer->loadDefaultMetadata( ok );
-      break;
-    }
-
-    case QgsMapLayerType::PluginLayer:
-      break;
-
-    case QgsMapLayerType::MeshLayer:
-    {
-      QgsMeshLayer *meshLayer = qobject_cast< QgsMeshLayer *>( layer );
-      QDateTime referenceTime = QgsProject::instance()->timeSettings()->temporalRange().begin();
-      if ( !referenceTime.isValid() ) // If project reference time is invalid, use current date
-        referenceTime = QDateTime( QDate::currentDate(), QTime( 0, 0, 0 ), Qt::UTC );
-
-      if ( meshLayer->dataProvider() && !qobject_cast< QgsMeshLayerTemporalProperties * >( meshLayer->temporalProperties() )->referenceTime().isValid() )
-        qobject_cast< QgsMeshLayerTemporalProperties * >( meshLayer->temporalProperties() )->setReferenceTime( referenceTime, meshLayer->dataProvider()->temporalCapabilities() );
-
-      bool ok = false;
-      meshLayer->loadDefaultStyle( ok );
-      meshLayer->loadDefaultMetadata( ok );
-      break;
-    }
-
-    case QgsMapLayerType::VectorTileLayer:
-    {
-      bool ok = false;
-      QString error = layer->loadDefaultStyle( ok );
-      if ( !ok )
-        visibleMessageBar()->pushMessage( tr( "Error loading style" ), error, Qgis::MessageLevel::Warning );
-      error = layer->loadDefaultMetadata( ok );
-      if ( !ok )
-        visibleMessageBar()->pushMessage( tr( "Error loading layer metadata" ), error, Qgis::MessageLevel::Warning );
-
-      break;
-    }
-
-    case QgsMapLayerType::AnnotationLayer:
-    case QgsMapLayerType::GroupLayer:
-      break;
-
-    case QgsMapLayerType::PointCloudLayer:
-    {
-      bool ok = false;
-      layer->loadDefaultStyle( ok );
-      layer->loadDefaultMetadata( ok );
-
-#ifdef HAVE_3D
-      if ( !layer->renderer3D() )
-      {
-        QgsPointCloudLayer *pcLayer = qobject_cast< QgsPointCloudLayer * >( layer );
-        // If the layer has no 3D renderer and syncing 3D to 2D renderer is enabled, we create a renderer and set it up with the 2D renderer
-        if ( pcLayer->sync3DRendererTo2DRenderer() )
-        {
-          std::unique_ptr< QgsPointCloudLayer3DRenderer > renderer3D = std::make_unique< QgsPointCloudLayer3DRenderer >();
-          renderer3D->convertFrom2DRenderer( pcLayer->renderer() );
-          layer->setRenderer3D( renderer3D.release() );
-        }
-      }
-#endif
-      break;
-    }
-  }
 }
 
 QgsVectorTileLayer *QgisApp::addVectorTileLayer( const QString &url, const QString &baseName )
@@ -6071,7 +5970,7 @@ QgsVectorTileLayer *QgisApp::addVectorTileLayerPrivate( const QString &url, cons
     return nullptr;
   }
 
-  postProcessAddedLayer( layer.get() );
+  QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
 
   QgsProject::instance()->addMapLayer( layer.get() );
   activateDeactivateLayerRelatedActions( activeLayer() );
@@ -6108,7 +6007,7 @@ QgsPointCloudLayer *QgisApp::addPointCloudLayerPrivate( const QString &uri, cons
     return nullptr;
   }
 
-  postProcessAddedLayer( layer.get() );
+  QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
 
 
   QgsProject::instance()->addMapLayer( layer.get() );
@@ -7725,7 +7624,7 @@ bool QgisApp::openLayer( const QString &fileName, bool allowInteractive )
     std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
     if ( vtLayer->isValid() )
     {
-      postProcessAddedLayer( vtLayer.get() );
+      QgsAppLayerHandling::postProcessAddedLayer( vtLayer.get() );
       QgsProject::instance()->addMapLayer( vtLayer.release() );
       return true;
     }
@@ -13932,7 +13831,7 @@ T *QgisApp::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QSt
       QgsProject::instance()->addMapLayer( result );
 
       askUserForDatumTransform( result->crs(), QgsProject::instance()->crs(), result );
-      postProcessAddedLayer( result );
+      QgsAppLayerHandling::postProcessAddedLayer( result );
     }
   }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -98,10 +98,7 @@
 #include "qgsvectorlayersavestyledialog.h"
 #include "maptools/qgsappmaptools.h"
 #include "qgsexpressioncontextutils.h"
-#include "qgsprovidersublayerdetails.h"
-#include "qgsproviderutils.h"
-#include "qgsprovidersublayersdialog.h"
-#include "qgsmaplayerfactory.h"
+
 #include "qgsbrowserwidget.h"
 #include "annotations/qgsannotationitempropertieswidget.h"
 #include "qgsmaptoolmodifyannotation.h"
@@ -128,6 +125,8 @@
 #include "elevation/qgselevationprofilewidget.h"
 
 #include "layers/qgsapplayerhandling.h"
+
+#include "canvas/qgscanvasrefreshblocker.h"
 
 #ifdef HAVE_3D
 #include "qgs3d.h"
@@ -420,7 +419,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "devtools/querylogger/qgsqueryloggerwidgetfactory.h"
 #include "devtools/profiler/qgsprofilerwidgetfactory.h"
 #include "qgsabstractdatabaseproviderconnection.h"
-#include "qgszipitem.h"
 
 #include "browser/qgsinbuiltdataitemproviders.h"
 
@@ -2258,7 +2256,7 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 
     if ( u.layerType == QLatin1String( "collection" ) )
     {
-      openLayer( uri, true );
+      QgsAppLayerHandling::openLayer( uri, true );
     }
     else if ( u.layerType == QLatin1String( "vector" ) )
     {
@@ -2647,7 +2645,7 @@ void QgisApp::dataSourceManager( const QString &pageName )
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::connectionsChanged, this, &QgisApp::connectionsChanged );
     connect( mDataSourceManagerDialog, SIGNAL( addRasterLayer( QString const &, QString const &, QString const & ) ),
              this, SLOT( addRasterLayer( QString const &, QString const &, QString const & ) ) );
-    connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addRasterLayers, this, [ = ]( const QStringList & layersList ) { addRasterLayers( layersList ); } );
+    connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::addRasterLayers, this, [ = ]( const QStringList & layersList ) { QgsAppLayerHandling::addRasterLayers( layersList ); } );
     connect( mDataSourceManagerDialog, SIGNAL( addVectorLayer( QString const &, QString const &, QString const & ) ),
              this, SLOT( addVectorLayer( QString const &, QString const &, QString const & ) ) );
     connect( mDataSourceManagerDialog, SIGNAL( addVectorLayers( QStringList const &, QString const &, QString const & ) ),
@@ -5600,334 +5598,12 @@ QString QgisApp::crsAndFormatAdjustedLayerUri( const QString &uri, const QString
 
 bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QString &enc, const QString &dataSourceType )
 {
-  return addVectorLayersPrivate( layerQStringList, enc, dataSourceType );
-}
-
-bool QgisApp::addVectorLayersPrivate( const QStringList &layers, const QString &enc, const QString &dataSourceType, const bool guiWarning )
-{
-  //note: this method ONLY supports vector layers from the OGR provider!
-
-  QgsCanvasRefreshBlocker refreshBlocker;
-
-  QList<QgsMapLayer *> layersToAdd;
-  QList<QgsMapLayer *> addedLayers;
-  QgsSettings settings;
-  bool userAskedToAddLayers = false;
-
-  for ( const QString &layerUri : layers )
-  {
-    const QString uri = layerUri.trimmed();
-    QString baseName;
-    if ( dataSourceType == QLatin1String( "file" ) )
-    {
-      QString srcWithoutLayername( uri );
-      int posPipe = srcWithoutLayername.indexOf( '|' );
-      if ( posPipe >= 0 )
-        srcWithoutLayername.resize( posPipe );
-      baseName = QgsProviderUtils::suggestLayerNameFromFilePath( srcWithoutLayername );
-
-      // if needed prompt for zipitem layers
-      QString vsiPrefix = QgsZipItem::vsiPrefix( uri );
-      if ( ! uri.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) &&
-           ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
-      {
-        if ( askUserForZipItemLayers( uri, { QgsMapLayerType::VectorLayer } ) )
-          continue;
-      }
-    }
-    else if ( dataSourceType == QLatin1String( "database" ) )
-    {
-      // Try to extract the database name and use it as base name
-      // sublayers names (if any) will be appended to the layer name
-      const QVariantMap parts( QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri ) );
-      if ( parts.value( QStringLiteral( "databaseName" ) ).isValid() )
-        baseName = parts.value( QStringLiteral( "databaseName" ) ).toString();
-      else
-        baseName = uri;
-    }
-    else //directory //protocol
-    {
-      baseName = QgsProviderUtils::suggestLayerNameFromFilePath( uri );
-    }
-
-    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-    {
-      baseName = QgsMapLayer::formatLayerName( baseName );
-    }
-
-    QgsDebugMsgLevel( "completeBaseName: " + baseName, 2 );
-    const bool isVsiCurl { uri.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) };
-    const auto scheme { QUrl( uri ).scheme() };
-    const bool isRemoteUrl { scheme.startsWith( QLatin1String( "http" ) ) || scheme == QLatin1String( "ftp" ) };
-
-    std::unique_ptr< QgsTemporaryCursorOverride > cursorOverride;
-    if ( isVsiCurl || isRemoteUrl )
-    {
-      cursorOverride = std::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
-      visibleMessageBar()->pushInfo( tr( "Remote layer" ), tr( "loading %1, please wait …" ).arg( uri ) );
-      qApp->processEvents();
-    }
-
-    QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) )->querySublayers( uri, Qgis::SublayerQueryFlag::IncludeSystemTables );
-    // filter out non-vector sublayers
-    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
-    {
-      return sublayer.type() != QgsMapLayerType::VectorLayer;
-    } ), sublayers.end() );
-
-    cursorOverride.reset();
-
-    const QVariantMap uriParts = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "ogr" ), uri );
-    const QString path = uriParts.value( QStringLiteral( "path" ) ).toString();
-
-    if ( !sublayers.empty() )
-    {
-      userAskedToAddLayers = true;
-
-      const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
-      const bool singleSublayerOnly = sublayers.size() == 1;
-      QString groupName;
-
-      if ( !singleSublayerOnly || detailsAreIncomplete )
-      {
-        // ask user for sublayers (unless user settings dictate otherwise!)
-        switch ( shouldAskUserForSublayers( sublayers ) )
-        {
-          case SublayerHandling::AskUser:
-          {
-            // prompt user for sublayers
-            QgsProviderSublayersDialog dlg( uri, path, sublayers, {QgsMapLayerType::VectorLayer}, this );
-
-            if ( dlg.exec() )
-              sublayers = dlg.selectedLayers();
-            else
-              sublayers.clear(); // dialog was canceled, so don't add any sublayers
-            groupName = dlg.groupName();
-            break;
-          }
-
-          case SublayerHandling::LoadAll:
-          {
-            if ( detailsAreIncomplete )
-            {
-              // requery sublayers, resolving geometry types
-              sublayers = QgsProviderRegistry::instance()->querySublayers( uri, Qgis::SublayerQueryFlag::ResolveGeometryType );
-              // filter out non-vector sublayers
-              sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
-              {
-                return sublayer.type() != QgsMapLayerType::VectorLayer;
-              } ), sublayers.end() );
-            }
-            break;
-          }
-
-          case SublayerHandling::AbortLoading:
-            sublayers.clear(); // don't add any sublayers
-            break;
-        };
-      }
-      else if ( detailsAreIncomplete )
-      {
-        // requery sublayers, resolving geometry types
-        sublayers = QgsProviderRegistry::instance()->querySublayers( uri, Qgis::SublayerQueryFlag::ResolveGeometryType );
-        // filter out non-vector sublayers
-        sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), []( const QgsProviderSublayerDetails & sublayer )
-        {
-          return sublayer.type() != QgsMapLayerType::VectorLayer;
-        } ), sublayers.end() );
-      }
-
-      // now add sublayers
-      if ( !sublayers.empty() )
-      {
-        addedLayers << addSublayers( sublayers, baseName, groupName );
-      }
-
-    }
-    else
-    {
-      QString msg = tr( "%1 is not a valid or recognized data source." ).arg( uri );
-      // If the failed layer was a vsicurl type, give the user a chance to try the normal download.
-      if ( isVsiCurl &&
-           QMessageBox::question( this, tr( "Invalid Data Source" ),
-                                  tr( "Download with \"Protocol\" source type has failed, do you want to try the \"File\" source type?" ) ) == QMessageBox::Yes )
-      {
-        QString fileUri = uri;
-        fileUri.replace( QLatin1String( "/vsicurl/" ), " " );
-        return addVectorLayersPrivate( QStringList() << fileUri, enc, dataSourceType, guiWarning );
-      }
-      else if ( guiWarning )
-      {
-        visibleMessageBar()->pushMessage( tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
-      }
-    }
-  }
-
-  // make sure at least one layer was successfully added
-  if ( layersToAdd.isEmpty() )
-  {
-    // we also return true if we asked the user for sublayers, but they choose none. In this case nothing
-    // went wrong, so we shouldn't return false and cause GUI warnings to appear
-    return userAskedToAddLayers || !addedLayers.isEmpty();
-  }
-
-  // Register this layer with the layers registry
-  QgsProject::instance()->addMapLayers( layersToAdd );
-  for ( QgsMapLayer *l : std::as_const( layersToAdd ) )
-  {
-    if ( !enc.isEmpty() )
-    {
-      if ( QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( l ) )
-        vl->setProviderEncoding( enc );
-    }
-
-    askUserForDatumTransform( l->crs(), QgsProject::instance()->crs(), l );
-    QgsAppLayerHandling::postProcessAddedLayer( l );
-  }
-  activateDeactivateLayerRelatedActions( activeLayer() );
-
-  return true;
+  return QgsAppLayerHandling::addVectorLayers( layerQStringList, enc, dataSourceType );
 }
 
 QgsMeshLayer *QgisApp::addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey )
 {
-  return addLayerPrivate< QgsMeshLayer >( QgsMapLayerType::MeshLayer, url, baseName, providerKey, true );
-}
-
-QList< QgsMapLayer * > QgisApp::addSublayers( const QList<QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName )
-{
-  QgsLayerTreeGroup *group = nullptr;
-  if ( !groupName.isEmpty() )
-  {
-    int index { 0 };
-    QgsLayerTreeNode *currentNode { mLayerTreeView->currentNode() };
-    if ( currentNode && currentNode->parent() )
-    {
-      if ( QgsLayerTree::isGroup( currentNode ) )
-      {
-        group = qobject_cast<QgsLayerTreeGroup *>( currentNode )->insertGroup( 0, groupName );
-      }
-      else if ( QgsLayerTree::isLayer( currentNode ) )
-      {
-        const QList<QgsLayerTreeNode *> currentNodeSiblings { currentNode->parent()->children() };
-        int nodeIdx { 0 };
-        for ( const QgsLayerTreeNode *child : std::as_const( currentNodeSiblings ) )
-        {
-          nodeIdx++;
-          if ( child == currentNode )
-          {
-            index = nodeIdx;
-            break;
-          }
-        }
-        group = qobject_cast<QgsLayerTreeGroup *>( currentNode->parent() )->insertGroup( index, groupName );
-      }
-      else
-      {
-        group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
-      }
-    }
-    else
-    {
-      group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, groupName );
-    }
-  }
-
-  QgsSettings settings;
-  const bool formatLayerNames = settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool();
-
-  // if we aren't adding to a group, we need to add the layers in reverse order so that they maintain the correct
-  // order in the layer tree!
-  QList<QgsProviderSublayerDetails> sortedLayers = layers;
-  if ( groupName.isEmpty() )
-  {
-    std::reverse( sortedLayers.begin(), sortedLayers.end() );
-  }
-
-  QList< QgsMapLayer * > result;
-  result.reserve( sortedLayers.size() );
-
-  for ( const QgsProviderSublayerDetails &sublayer : std::as_const( sortedLayers ) )
-  {
-    QgsProviderSublayerDetails::LayerOptions options( QgsProject::instance()->transformContext() );
-    options.loadDefaultStyle = false;
-
-    std::unique_ptr<QgsMapLayer> layer( sublayer.toLayer( options ) );
-    if ( !layer )
-      continue;
-
-    QgsMapLayer *ml = layer.get();
-    // if we aren't adding to a group, then we're iterating the layers in the reverse order
-    // so account for that in the returned list of layers
-    if ( groupName.isEmpty() )
-      result.insert( 0, ml );
-    else
-      result << ml;
-
-    QString layerName = layer->name();
-    if ( formatLayerNames )
-    {
-      layerName = QgsMapLayer::formatLayerName( layerName );
-    }
-
-    const bool projectWasEmpty = QgsProject::instance()->mapLayers().empty();
-
-    // if user has opted to add sublayers to a group, then we don't need to include the
-    // filename in the layer's name, because the group is already titled with the filename.
-    // But otherwise, we DO include the file name so that users can differentiate the source
-    // when multiple layers are loaded from a GPX file or similar (refs https://github.com/qgis/QGIS/issues/37551)
-    if ( group )
-    {
-      if ( !layerName.isEmpty() )
-        layer->setName( layerName );
-      else if ( !baseName.isEmpty() )
-        layer->setName( baseName );
-      QgsProject::instance()->addMapLayer( layer.release(), false );
-      group->addLayer( ml );
-    }
-    else
-    {
-      if ( layerName != baseName && !layerName.isEmpty() && !baseName.isEmpty() )
-        layer->setName( QStringLiteral( "%1 — %2" ).arg( baseName, layerName ) );
-      else if ( !layerName.isEmpty() )
-        layer->setName( layerName );
-      else if ( !baseName.isEmpty() )
-        layer->setName( baseName );
-      QgsProject::instance()->addMapLayer( layer.release() );
-    }
-
-    // Some of the logic relating to matching a new project's CRS to the first layer added CRS is deferred to happen when the event loop
-    // next runs -- so in those cases we can't assume that the project's CRS has been matched to the actual desired CRS yet.
-    // In these cases we don't need to show the coordinate operation selection choice, so just hardcode an exception in here to avoid that...
-    QgsCoordinateReferenceSystem projectCrsAfterLayerAdd = QgsProject::instance()->crs();
-    const QgsGui::ProjectCrsBehavior projectCrsBehavior = QgsSettings().enumValue( QStringLiteral( "/projections/newProjectCrsBehavior" ),  QgsGui::UseCrsOfFirstLayerAdded, QgsSettings::App );
-    switch ( projectCrsBehavior )
-    {
-      case QgsGui::UseCrsOfFirstLayerAdded:
-      {
-        if ( projectWasEmpty )
-          projectCrsAfterLayerAdd = ml->crs();
-        break;
-      }
-
-      case QgsGui::UsePresetCrs:
-        break;
-    }
-
-    askUserForDatumTransform( ml->crs(), projectCrsAfterLayerAdd, ml );
-    QgsAppLayerHandling::postProcessAddedLayer( ml );
-  }
-
-  if ( group )
-  {
-    // Respect if user don't want the new group of layers visible.
-    QgsSettings settings;
-    const bool newLayersVisible = settings.value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool();
-    if ( !newLayersVisible )
-      group->setItemVisibilityCheckedRecursive( newLayersVisible );
-  }
-
-  return result;
+  return QgsAppLayerHandling::addLayerPrivate< QgsMeshLayer >( QgsMapLayerType::MeshLayer, url, baseName, providerKey, true );
 }
 
 QgsVectorTileLayer *QgisApp::addVectorTileLayer( const QString &url, const QString &baseName )
@@ -5937,7 +5613,7 @@ QgsVectorTileLayer *QgisApp::addVectorTileLayer( const QString &url, const QStri
 
 QgsPointCloudLayer *QgisApp::addPointCloudLayer( const QString &url, const QString &baseName, const QString &providerKey )
 {
-  return addPointCloudLayerPrivate( url, baseName, providerKey );
+  return QgsAppLayerHandling::addPointCloudLayer( url, baseName, providerKey );
 }
 
 QgsVectorTileLayer *QgisApp::addVectorTileLayerPrivate( const QString &url, const QString &baseName, const bool guiWarning )
@@ -5976,162 +5652,6 @@ QgsVectorTileLayer *QgisApp::addVectorTileLayerPrivate( const QString &url, cons
   activateDeactivateLayerRelatedActions( activeLayer() );
 
   return layer.release();
-}
-
-QgsPointCloudLayer *QgisApp::addPointCloudLayerPrivate( const QString &uri, const QString &baseName, const QString &providerKey, bool guiWarning )
-{
-  QgsCanvasRefreshBlocker refreshBlocker;
-  QgsSettings settings;
-
-  QString base( baseName );
-
-  if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-  {
-    base = QgsMapLayer::formatLayerName( base );
-  }
-
-  QgsDebugMsgLevel( "completeBaseName: " + base, 2 );
-
-  // create the layer
-  std::unique_ptr<QgsPointCloudLayer> layer( new QgsPointCloudLayer( uri, base, providerKey ) );
-
-  if ( !layer || !layer->isValid() )
-  {
-    if ( guiWarning )
-    {
-      QString msg = tr( "%1 is not a valid or recognized data source, error: \"%2\"" ).arg( uri ).arg( layer->error().message( QgsErrorMessage::Format::Text ) );
-      visibleMessageBar()->pushMessage( tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
-    }
-
-    // since the layer is bad, stomp on it
-    return nullptr;
-  }
-
-  QgsAppLayerHandling::postProcessAddedLayer( layer.get() );
-
-
-  QgsProject::instance()->addMapLayer( layer.get() );
-  activateDeactivateLayerRelatedActions( activeLayer() );
-
-  return layer.release();
-}
-
-bool QgisApp::askUserForZipItemLayers( const QString &path, const QList< QgsMapLayerType > &acceptableTypes )
-{
-  // query sublayers
-  QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::IncludeSystemTables );
-
-  // filter out non-matching sublayers
-  sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
-  {
-    return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
-  } ), sublayers.end() );
-
-  if ( sublayers.empty() )
-    return false;
-
-  const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
-  const bool singleSublayerOnly = sublayers.size() == 1;
-  QString groupName;
-
-  if ( !singleSublayerOnly || detailsAreIncomplete )
-  {
-    // ask user for sublayers (unless user settings dictate otherwise!)
-    switch ( shouldAskUserForSublayers( sublayers ) )
-    {
-      case SublayerHandling::AskUser:
-      {
-        // prompt user for sublayers
-        QgsProviderSublayersDialog dlg( path, path, sublayers, acceptableTypes, this );
-
-        if ( dlg.exec() )
-          sublayers = dlg.selectedLayers();
-        else
-          sublayers.clear(); // dialog was canceled, so don't add any sublayers
-        groupName = dlg.groupName();
-        break;
-      }
-
-      case SublayerHandling::LoadAll:
-      {
-        if ( detailsAreIncomplete )
-        {
-          // requery sublayers, resolving geometry types
-          sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::ResolveGeometryType );
-          sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
-          {
-            return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
-          } ), sublayers.end() );
-        }
-        break;
-      }
-
-      case SublayerHandling::AbortLoading:
-        sublayers.clear(); // don't add any sublayers
-        break;
-    };
-  }
-  else if ( detailsAreIncomplete )
-  {
-    // requery sublayers, resolving geometry types
-    sublayers = QgsProviderRegistry::instance()->querySublayers( path, Qgis::SublayerQueryFlag::ResolveGeometryType );
-    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [acceptableTypes]( const QgsProviderSublayerDetails & sublayer )
-    {
-      return !acceptableTypes.empty() && !acceptableTypes.contains( sublayer.type() );
-    } ), sublayers.end() );
-  }
-
-  // now add sublayers
-  if ( !sublayers.empty() )
-  {
-    QgsCanvasRefreshBlocker refreshBlocker;
-    QgsSettings settings;
-
-    QString base = QgsProviderUtils::suggestLayerNameFromFilePath( path );
-    if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-    {
-      base = QgsMapLayer::formatLayerName( base );
-    }
-
-    addSublayers( sublayers, base, groupName );
-    activateDeactivateLayerRelatedActions( activeLayer() );
-  }
-
-  return true;
-}
-
-QgisApp::SublayerHandling QgisApp::shouldAskUserForSublayers( const QList<QgsProviderSublayerDetails> &layers, bool hasNonLayerItems ) const
-{
-  if ( hasNonLayerItems )
-    return SublayerHandling::AskUser;
-
-  QgsSettings settings;
-  const Qgis::SublayerPromptMode promptLayers = settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), Qgis::SublayerPromptMode::AlwaysAsk );
-
-  switch ( promptLayers )
-  {
-    case Qgis::SublayerPromptMode::AlwaysAsk:
-      return SublayerHandling::AskUser;
-
-    case Qgis::SublayerPromptMode::AskExcludingRasterBands:
-    {
-      // if any non-raster layers are found, we ask the user. Otherwise we load all
-      for ( const QgsProviderSublayerDetails &sublayer : layers )
-      {
-        if ( sublayer.type() != QgsMapLayerType::RasterLayer )
-          return SublayerHandling::AskUser;
-      }
-      return SublayerHandling::LoadAll;
-    }
-
-    case Qgis::SublayerPromptMode::NeverAskSkip:
-      return SublayerHandling::AbortLoading;
-
-    case Qgis::SublayerPromptMode::NeverAskLoadAll:
-      return SublayerHandling::LoadAll;
-  }
-
-  return SublayerHandling::AskUser;
 }
 
 void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const &providerKey )
@@ -7540,229 +7060,6 @@ void QgisApp::openProject( const QString &fileName )
   }
 }
 
-bool QgisApp::openLayer( const QString &fileName, bool allowInteractive )
-{
-  bool ok = false;
-  const QFileInfo fileInfo( fileName );
-
-  // highest priority = delegate to provider registry to handle
-  const QList< QgsProviderRegistry::ProviderCandidateDetails > candidateProviders = QgsProviderRegistry::instance()->preferredProvidersForUri( fileName );
-  if ( candidateProviders.size() == 1 && candidateProviders.at( 0 ).layerTypes().size() == 1 )
-  {
-    // one good candidate provider and possible layer type -- that makes things nice and easy!
-    switch ( candidateProviders.at( 0 ).layerTypes().at( 0 ) )
-    {
-      case QgsMapLayerType::VectorLayer:
-      case QgsMapLayerType::RasterLayer:
-      case QgsMapLayerType::MeshLayer:
-      case QgsMapLayerType::AnnotationLayer:
-      case QgsMapLayerType::PluginLayer:
-      case QgsMapLayerType::VectorTileLayer:
-      case QgsMapLayerType::GroupLayer:
-        // not supported here yet!
-        break;
-
-      case QgsMapLayerType::PointCloudLayer:
-        ok = static_cast< bool >( addPointCloudLayerPrivate( fileName, fileInfo.completeBaseName(), candidateProviders.at( 0 ).metadata()->key(), false ) );
-        break;
-    }
-  }
-
-  if ( ok )
-    return true;
-
-  CPLPushErrorHandler( CPLQuietErrorHandler );
-
-  // if needed prompt for zipitem layers
-  QString vsiPrefix = QgsZipItem::vsiPrefix( fileName );
-  if ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) )
-  {
-    if ( askUserForZipItemLayers( fileName, {} ) )
-    {
-      CPLPopErrorHandler();
-      return true;
-    }
-  }
-
-  if ( fileName.endsWith( QStringLiteral( ".mbtiles" ), Qt::CaseInsensitive ) )
-  {
-    QgsMbTiles reader( fileName );
-    if ( reader.open() )
-    {
-      if ( reader.metadataValue( "format" ) == QLatin1String( "pbf" ) )
-      {
-        // these are vector tiles
-        QUrlQuery uq;
-        uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
-        uq.addQueryItem( QStringLiteral( "url" ), fileName );
-        const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
-        std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
-        if ( vtLayer->isValid() )
-        {
-          QgsProject::instance()->addMapLayer( vtLayer.release() );
-          return true;
-        }
-      }
-      else // raster tiles
-      {
-        // prefer to use WMS provider's implementation to open MBTiles rasters
-        QUrlQuery uq;
-        uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "mbtiles" ) );
-        uq.addQueryItem( QStringLiteral( "url" ), QUrl::fromLocalFile( fileName ).toString() );
-        if ( addRasterLayer( uq.toString(), fileInfo.completeBaseName(), QStringLiteral( "wms" ) ) )
-          return true;
-      }
-    }
-  }
-  else if ( fileName.endsWith( QStringLiteral( ".vtpk" ), Qt::CaseInsensitive ) )
-  {
-    // these are vector tiles
-    QUrlQuery uq;
-    uq.addQueryItem( QStringLiteral( "type" ), QStringLiteral( "vtpk" ) );
-    uq.addQueryItem( QStringLiteral( "url" ), fileName );
-    const QgsVectorTileLayer::LayerOptions options( QgsProject::instance()->transformContext() );
-    std::unique_ptr<QgsVectorTileLayer> vtLayer( new QgsVectorTileLayer( uq.toString(), fileInfo.completeBaseName(), options ) );
-    if ( vtLayer->isValid() )
-    {
-      QgsAppLayerHandling::postProcessAddedLayer( vtLayer.get() );
-      QgsProject::instance()->addMapLayer( vtLayer.release() );
-      return true;
-    }
-  }
-
-  QList< QgsProviderSublayerModel::NonLayerItem > nonLayerItems;
-  if ( QgsProjectStorage *ps = QgsApplication::projectStorageRegistry()->projectStorageFromUri( fileName ) )
-  {
-    const QStringList projects = ps->listProjects( fileName );
-    for ( const QString &project : projects )
-    {
-      QgsProviderSublayerModel::NonLayerItem projectItem;
-      projectItem.setType( QStringLiteral( "project" ) );
-      projectItem.setName( project );
-      projectItem.setUri( QStringLiteral( "%1://%2?projectName=%3" ).arg( ps->type(), fileName, project ) );
-      projectItem.setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIconQgsProjectFile.svg" ) ) );
-      nonLayerItems << projectItem;
-    }
-  }
-
-  // query sublayers
-  QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::IncludeSystemTables );
-
-  if ( !sublayers.empty() || !nonLayerItems.empty() )
-  {
-    const bool detailsAreIncomplete = QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount );
-    const bool singleSublayerOnly = sublayers.size() == 1;
-    QString groupName;
-
-    if ( allowInteractive && ( !singleSublayerOnly || detailsAreIncomplete || !nonLayerItems.empty() ) )
-    {
-      // ask user for sublayers (unless user settings dictate otherwise!)
-      switch ( shouldAskUserForSublayers( sublayers, !nonLayerItems.empty() ) )
-      {
-        case SublayerHandling::AskUser:
-        {
-          // prompt user for sublayers
-          QgsProviderSublayersDialog dlg( fileName, fileName, sublayers, {}, this );
-          dlg.setNonLayerItems( nonLayerItems );
-
-          if ( dlg.exec() )
-          {
-            sublayers = dlg.selectedLayers();
-            nonLayerItems = dlg.selectedNonLayerItems();
-          }
-          else
-          {
-            sublayers.clear(); // dialog was canceled, so don't add any sublayers
-            nonLayerItems.clear();
-          }
-          groupName = dlg.groupName();
-          break;
-        }
-
-        case SublayerHandling::LoadAll:
-        {
-          if ( detailsAreIncomplete )
-          {
-            // requery sublayers, resolving geometry types
-            sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::ResolveGeometryType );
-          }
-          break;
-        }
-
-        case SublayerHandling::AbortLoading:
-          sublayers.clear(); // don't add any sublayers
-          break;
-      };
-    }
-    else if ( detailsAreIncomplete )
-    {
-      // requery sublayers, resolving geometry types
-      sublayers = QgsProviderRegistry::instance()->querySublayers( fileName, Qgis::SublayerQueryFlag::ResolveGeometryType );
-    }
-
-    ok = true;
-
-    // now add sublayers
-    if ( !sublayers.empty() )
-    {
-      QgsCanvasRefreshBlocker refreshBlocker;
-      QgsSettings settings;
-
-      QString base = QgsProviderUtils::suggestLayerNameFromFilePath( fileName );
-      if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-      {
-        base = QgsMapLayer::formatLayerName( base );
-      }
-
-      addSublayers( sublayers, base, groupName );
-      activateDeactivateLayerRelatedActions( activeLayer() );
-    }
-    else if ( !nonLayerItems.empty() )
-    {
-      QgsCanvasRefreshBlocker refreshBlocker;
-      if ( checkTasksDependOnProject() )
-        return true;
-
-      // possibly save any pending work before opening a different project
-      if ( checkUnsavedLayerEdits() && checkMemoryLayers() && saveDirty() )
-      {
-        // error handling and reporting is in addProject() function
-        addProject( nonLayerItems.at( 0 ).uri() );
-      }
-      return true;
-    }
-  }
-
-  CPLPopErrorHandler();
-
-  if ( !ok )
-  {
-    // maybe a known file type, which couldn't be opened due to a missing dependency... (eg. las for a non-pdal-enabled build)
-    QgsProviderRegistry::UnusableUriDetails details;
-    if ( QgsProviderRegistry::instance()->handleUnusableUri( fileName, details ) )
-    {
-      ok = true;
-
-      if ( details.detailedWarning.isEmpty() )
-        visibleMessageBar()->pushMessage( QString(), details.warning, Qgis::MessageLevel::Critical );
-      else
-        visibleMessageBar()->pushMessage( QString(), details.warning, details.detailedWarning, Qgis::MessageLevel::Critical );
-    }
-  }
-
-  if ( !ok )
-  {
-    // we have no idea what this file is...
-    QgsMessageLog::logMessage( tr( "Unable to load %1" ).arg( fileName ) );
-
-    const QString msg = tr( "%1 is not a valid or recognized data source." ).arg( fileName );
-    visibleMessageBar()->pushMessage( tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
-  }
-
-  return ok;
-}
-
-
 // Open a file specified by a commandline argument, Drop or FileOpen event.
 void QgisApp::openFile( const QString &fileName, const QString &fileTypeHint )
 {
@@ -7788,7 +7085,7 @@ void QgisApp::openFile( const QString &fileName, const QString &fileTypeHint )
   else
   {
     QgsDebugMsgLevel( "Adding " + fileName + " to the map canvas", 2 );
-    openLayer( fileName, true );
+    QgsAppLayerHandling::openLayer( fileName, true );
   }
 }
 
@@ -8993,11 +8290,11 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
     {
       if ( outputFormat == QLatin1String( "GPKG" ) && !outputLayerName.isEmpty() )
       {
-        addRasterLayers( QStringList( QStringLiteral( "GPKG:%1:%2" ).arg( fileName, outputLayerName ) ) );
+        QgsAppLayerHandling::addRasterLayers( QStringList( QStringLiteral( "GPKG:%1:%2" ).arg( fileName, outputLayerName ) ) );
       }
       else
       {
-        addRasterLayers( QStringList( fileName ) );
+        QgsAppLayerHandling::addRasterLayers( QStringList( fileName ) );
       }
     }
     if ( rlWeakPointer )
@@ -13712,131 +13009,7 @@ void QgisApp::show3DMapViewsManager()
 
 QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const QString &name, const QString &providerKey )
 {
-  return addLayerPrivate< QgsVectorLayer >( QgsMapLayerType::VectorLayer, vectorLayerPath, name, !providerKey.isEmpty() ? providerKey : QLatin1String( "ogr" ), true );
-}
-
-template<typename T>
-T *QgisApp::addLayerPrivate( QgsMapLayerType type, const QString &uri, const QString &name, const QString &providerKey, bool guiWarnings )
-{
-  QgsSettings settings;
-
-  QgsCanvasRefreshBlocker refreshBlocker;
-
-  QString baseName = settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() ? QgsMapLayer::formatLayerName( name ) : name;
-
-  // if the layer needs authentication, ensure the master password is set
-  const QRegularExpression rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
-  if ( rx.match( uri ).hasMatch() )
-  {
-    if ( !QgsAuthGuiUtils::isDisabled( messageBar() ) )
-    {
-      QgsApplication::authManager()->setMasterPassword( true );
-    }
-  }
-
-  QVariantMap uriElements = QgsProviderRegistry::instance()->decodeUri( providerKey, uri );
-  QString path = uri;
-  if ( uriElements.contains( QStringLiteral( "path" ) ) )
-  {
-    // run layer path through QgsPathResolver so that all inbuilt paths and other localised paths are correctly expanded
-    path = QgsPathResolver().readPath( uriElements.value( QStringLiteral( "path" ) ).toString() );
-    uriElements[ QStringLiteral( "path" ) ] = path;
-  }
-  // Not all providers implement decodeUri(), so use original uri if uriElements is empty
-  const QString updatedUri = uriElements.isEmpty() ? uri : QgsProviderRegistry::instance()->encodeUri( providerKey, uriElements );
-
-  const bool canQuerySublayers = QgsProviderRegistry::instance()->providerMetadata( providerKey ) &&
-                                 ( QgsProviderRegistry::instance()->providerMetadata( providerKey )->capabilities() & QgsProviderMetadata::QuerySublayers );
-
-  T *result = nullptr;
-  if ( canQuerySublayers )
-  {
-    // query sublayers
-    QList< QgsProviderSublayerDetails > sublayers = QgsProviderRegistry::instance()->providerMetadata( providerKey ) ?
-        QgsProviderRegistry::instance()->providerMetadata( providerKey )->querySublayers( updatedUri, Qgis::SublayerQueryFlag::IncludeSystemTables )
-        : QgsProviderRegistry::instance()->querySublayers( updatedUri );
-
-    // filter out non-matching sublayers
-    sublayers.erase( std::remove_if( sublayers.begin(), sublayers.end(), [type]( const QgsProviderSublayerDetails & sublayer )
-    {
-      return sublayer.type() != type;
-    } ), sublayers.end() );
-
-    if ( sublayers.empty() )
-    {
-      if ( guiWarnings )
-      {
-        QString msg = tr( "%1 is not a valid or recognized data source." ).arg( uri );
-        visibleMessageBar()->pushMessage( tr( "Invalid Data Source" ), msg, Qgis::MessageLevel::Critical );
-      }
-
-      // since the layer is bad, stomp on it
-      return nullptr;
-    }
-    else if ( sublayers.size() > 1 || QgsProviderUtils::sublayerDetailsAreIncomplete( sublayers, QgsProviderUtils::SublayerCompletenessFlag::IgnoreUnknownFeatureCount ) )
-    {
-      // ask user for sublayers (unless user settings dictate otherwise!)
-      switch ( shouldAskUserForSublayers( sublayers ) )
-      {
-        case SublayerHandling::AskUser:
-        {
-          QgsProviderSublayersDialog dlg( updatedUri, path, sublayers, {type}, this );
-          if ( dlg.exec() )
-          {
-            const QList< QgsProviderSublayerDetails > selectedLayers = dlg.selectedLayers();
-            if ( !selectedLayers.isEmpty() )
-            {
-              result = qobject_cast< T * >( addSublayers( selectedLayers, baseName, dlg.groupName() ).value( 0 ) );
-            }
-          }
-          break;
-        }
-        case SublayerHandling::LoadAll:
-        {
-          result = qobject_cast< T * >( addSublayers( sublayers, baseName, QString() ).value( 0 ) );
-          break;
-        }
-        case SublayerHandling::AbortLoading:
-          break;
-      };
-    }
-    else
-    {
-      result = qobject_cast< T * >( addSublayers( sublayers, name, QString() ).value( 0 ) );
-
-      if ( result )
-      {
-        QString base( baseName );
-        if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-        {
-          base = QgsMapLayer::formatLayerName( base );
-        }
-        result->setName( base );
-      }
-    }
-  }
-  else
-  {
-    QgsMapLayerFactory::LayerOptions options( QgsProject::instance()->transformContext() );
-    options.loadDefaultStyle = false;
-    result = qobject_cast< T * >( QgsMapLayerFactory::createLayer( uri, name, type, options, providerKey ) );
-    if ( result )
-    {
-      QString base( baseName );
-      if ( settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() )
-      {
-        base = QgsMapLayer::formatLayerName( base );
-      }
-      result->setName( base );
-      QgsProject::instance()->addMapLayer( result );
-
-      askUserForDatumTransform( result->crs(), QgsProject::instance()->crs(), result );
-      QgsAppLayerHandling::postProcessAddedLayer( result );
-    }
-  }
-
-  activateDeactivateLayerRelatedActions( activeLayer() );
-  return result;
+  return QgsAppLayerHandling::addLayerPrivate< QgsVectorLayer >( QgsMapLayerType::VectorLayer, vectorLayerPath, name, !providerKey.isEmpty() ? providerKey : QLatin1String( "ogr" ), true );
 }
 
 void QgisApp::addMapLayer( QgsMapLayer *mapLayer )
@@ -16414,103 +15587,7 @@ void QgisApp::renameView()
 
 QgsRasterLayer *QgisApp::addRasterLayer( QString const &uri, QString const &baseName, QString const &providerKey )
 {
-  return addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, uri, baseName, !providerKey.isEmpty() ? providerKey : QLatin1String( "gdal" ), true );
-}
-
-bool QgisApp::addRasterLayers( QStringList const &files, bool guiWarning )
-{
-  if ( files.empty() )
-  {
-    return false;
-  }
-
-  QgsCanvasRefreshBlocker refreshBlocker;
-
-  // this is messy since some files in the list may be rasters and others may
-  // be ogr layers. We'll set returnValue to false if one or more layers fail
-  // to load.
-  bool returnValue = true;
-  for ( const QString &src : files )
-  {
-    QString errMsg;
-    bool ok = false;
-
-    // if needed prompt for zipitem layers
-    QString vsiPrefix = QgsZipItem::vsiPrefix( src );
-    if ( ( !src.startsWith( QLatin1String( "/vsi" ), Qt::CaseInsensitive ) || src.endsWith( QLatin1String( ".zip" ) ) || src.endsWith( QLatin1String( ".tar" ) ) ) &&
-         ( vsiPrefix == QLatin1String( "/vsizip/" ) || vsiPrefix == QLatin1String( "/vsitar/" ) ) )
-    {
-      if ( askUserForZipItemLayers( src, { QgsMapLayerType::RasterLayer } ) )
-        continue;
-    }
-
-    const bool isVsiCurl { src.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) };
-    const bool isRemoteUrl { src.startsWith( QLatin1String( "http" ) ) || src == QLatin1String( "ftp" ) };
-
-    std::unique_ptr< QgsTemporaryCursorOverride > cursorOverride;
-    if ( isVsiCurl || isRemoteUrl )
-    {
-      cursorOverride = std::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
-      visibleMessageBar()->pushInfo( tr( "Remote layer" ), tr( "loading %1, please wait …" ).arg( src ) );
-      qApp->processEvents();
-    }
-
-    if ( QgsRasterLayer::isValidRasterFileName( src, errMsg ) )
-    {
-      QFileInfo myFileInfo( src );
-
-      // set the layer name to the file base name unless provided explicitly
-      QString layerName;
-      const QVariantMap uriDetails = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), src );
-      if ( !uriDetails[ QStringLiteral( "layerName" ) ].toString().isEmpty() )
-      {
-        layerName = uriDetails[ QStringLiteral( "layerName" ) ].toString();
-      }
-      else
-      {
-        layerName = QgsProviderUtils::suggestLayerNameFromFilePath( src );
-      }
-
-      // try to create the layer
-      cursorOverride.reset();
-      QgsRasterLayer *layer = addLayerPrivate< QgsRasterLayer >( QgsMapLayerType::RasterLayer, src, layerName, QStringLiteral( "gdal" ), guiWarning );
-
-      if ( layer && layer->isValid() )
-      {
-        //only allow one copy of a ai grid file to be loaded at a
-        //time to prevent the user selecting all adfs in 1 dir which
-        //actually represent 1 coverage,
-
-        if ( myFileInfo.fileName().endsWith( QLatin1String( ".adf" ), Qt::CaseInsensitive ) )
-        {
-          break;
-        }
-      }
-      // if layer is invalid addLayerPrivate() will show the error
-
-    } // valid raster filename
-    else
-    {
-      ok = false;
-
-      // Issue message box warning unless we are loading from cmd line since
-      // non-rasters are passed to this function first and then successfully
-      // loaded afterwards (see main.cpp)
-      if ( guiWarning )
-      {
-        QString msg = tr( "%1 is not a supported raster data source" ).arg( src );
-        if ( !errMsg.isEmpty() )
-          msg += '\n' + errMsg;
-
-        visibleMessageBar()->pushMessage( tr( "Unsupported Data Source" ), msg, Qgis::MessageLevel::Critical );
-      }
-    }
-    if ( ! ok )
-    {
-      returnValue = false;
-    }
-  }
-  return returnValue;
+  return QgsAppLayerHandling::addRasterLayer( uri, baseName, providerKey );
 }
 
 QgsPluginLayer *QgisApp::addPluginLayer( const QString &uri, const QString &baseName, const QString &providerKey )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1315,6 +1315,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QgsAttributeEditorContext createAttributeEditorContext();
 
+    //! Returns the message bar of the datasource manager dialog if it is visible, the canvas's message bar otherwise.
+    QgsMessageBar *visibleMessageBar();
+
   protected:
     void showEvent( QShowEvent *event ) override;
 
@@ -2135,7 +2138,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QList< QgsMapLayer * > addSublayers( const QList< QgsProviderSublayerDetails> &layers, const QString &baseName, const QString &groupName );
 
-    void postProcessAddedLayer( QgsMapLayer *layer );
 
     //! Open a vector tile layer - this is the generic function which takes all parameters
     QgsVectorTileLayer *addVectorTileLayerPrivate( const QString &uri, const QString &baseName, bool guiWarning = true );
@@ -2361,9 +2363,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Create the option dialog
     QgsOptions *createOptionsDialog( QWidget *parent = nullptr );
-
-    //! Returns the message bar of the datasource manager dialog if it is visible, the canvas's message bar otherwise.
-    QgsMessageBar *visibleMessageBar();
 
     /**
      * Searches for layer dependencies by querying the form widgets and the

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -74,7 +74,6 @@ class QgsMapTool;
 class QgsMapToolsDigitizingTechniqueManager;
 class QgsOptions;
 class QgsPluginLayer;
-class QgsPluginLayer;
 class QgsPluginManager;
 class QgsPointCloudLayer;
 class QgsPointXY;
@@ -168,7 +167,6 @@ class QgsElevationProfileWidget;
 #include "qgspointxy.h"
 #include "qgsmimedatautils.h"
 #include "qgsrecentprojectsitemsmodel.h"
-#include "qgsraster.h"
 #include "qgsrasterminmaxorigin.h"
 #include "qgslayertreeregistrybridge.h"
 #include "qgsmaplayeractionregistry.h"
@@ -180,7 +178,6 @@ class QgsElevationProfileWidget;
 #include "qgis.h"
 #include "ui_qgisapp.h"
 #include "qgis_app.h"
-#include "qgsvectorlayerref.h"
 #include "devtools/qgsappdevtoolutils.h"
 #include "options/qgsoptionsutils.h"
 
@@ -225,9 +222,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QString crsAndFormatAdjustedLayerUri( const QString &uri, const QStringList &supportedCrs, const QStringList &supportedFormats ) const;
 
-    //! Add a 'pre-made' map layer to the project
-    void addMapLayer( QgsMapLayer *mapLayer );
-
     //! Sets the extents of the map canvas
     void setExtent( const QgsRectangle &rect );
 
@@ -236,8 +230,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Used to process a commandline argument, FileOpen or Drop event.
      */
     void openProject( const QString &fileName );
-
-    void openLayerDefinition( const QString &filename );
 
     /**
      * Opens a layout template file and creates a new layout designer window for it.
@@ -1302,6 +1294,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Returns the message bar of the datasource manager dialog if it is visible, the canvas's message bar otherwise.
     QgsMessageBar *visibleMessageBar();
 
+    //! Returns the message log dock
+    QgsDockWidget *logDock();
+
     //! Checks for running tasks dependent on the open project
     bool checkTasksDependOnProject();
 
@@ -1381,8 +1376,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! About QGIS
     void about();
 
-    //! Add a list of database layers to the map
-    void addDatabaseLayers( QStringList const &layerPathList, QString const &providerKey );
     //! Add a vector layer defined by uri, layer name, data source uri
     void addSelectedVectorLayer( const QString &uri, const QString &layerName, const QString &provider );
     //! Replace the selected layer by a vector layer defined by uri, layer name, data source uri
@@ -1845,8 +1838,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void removeMapToolMessage();
     void updateMouseCoordinatePrecision();
     //    void debugHook();
-    //! Add a Layer Definition file
-    void addLayerDefinition();
+
     //! Exit Qgis
     void fileExit();
     //! Sets map tool to Zoom out
@@ -2035,13 +2027,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void onActiveLayerChanged( QgsMapLayer *layer );
 
-    /**
-     * Triggered when a vector layer style has changed, checks for widget config layer dependencies
-     * \param categories style categories
-     * \since QGIS 3.12
-     */
-    void vectorLayerStyleLoaded( QgsVectorLayer *vl, const QgsMapLayer::StyleCategories categories );
-
     //! Enable or disable event tracing (for debugging)
     void toggleEventTracing();
 
@@ -2138,9 +2123,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void functionProfile( void ( QgisApp::*fnc )(), QgisApp *instance, const QString &name );
 
     void showProgress( int progress, int totalSteps );
-
-    //! Open a vector tile layer - this is the generic function which takes all parameters
-    QgsVectorTileLayer *addVectorTileLayerPrivate( const QString &uri, const QString &baseName, bool guiWarning = true );
 
     /**
      * Add the current project to the recently opened/saved projects list
@@ -2322,32 +2304,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Create the option dialog
     QgsOptions *createOptionsDialog( QWidget *parent = nullptr );
-
-    /**
-     * Searches for layer dependencies by querying the form widgets and the
-     * \a vectorLayer itself for broken relations. Style \a categories can be
-     * used to limit the search to one or more of the currently implemented search
-     * categories ("Forms" for the form widgets and "Relations" for layer weak relations).
-     * \return a list of weak references to broken layer dependencies
-     */
-    const QList< QgsVectorLayerRef > findBrokenLayerDependencies( QgsVectorLayer *vectorLayer,
-        QgsMapLayer::StyleCategories categories = QgsMapLayer::StyleCategory::AllStyleCategories ) const;
-
-    /**
-     * Scans the \a vectorLayer for broken dependencies and automatically
-     * try to load the missing layers, users are notified about the operation
-     * result. Style \a categories can be
-     * used to exclude one of the currently implemented search categories
-     * ("Forms" for the form widgets and "Relations" for layer weak relations).
-     */
-    void resolveVectorLayerDependencies( QgsVectorLayer *vectorLayer,
-                                         QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
-
-    /**
-     * Scans the \a vectorLayer for weak relations and automatically
-     * try to resolve and create the broken relations.
-     */
-    void resolveVectorLayerWeakRelations( QgsVectorLayer *vectorLayer );
 
     /**
      * Pastes the \a features to the \a pasteVectorLayer and gives feedback to the user

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -28,6 +28,7 @@
 #include "qgsguiutils.h"
 #include "qgsfileutils.h"
 #include "qgsnewnamedialog.h"
+#include "layers/qgsapplayerhandling.h"
 
 #include <QDesktopServices>
 #include <QMessageBox>
@@ -145,7 +146,7 @@ QString QgsQlrDropHandler::customUriProviderKey() const
 void QgsQlrDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const
 {
   const QString path = uri.uri;
-  QgisApp::instance()->openLayerDefinition( path );
+  QgsAppLayerHandling::openLayerDefinition( path );
 }
 
 //


### PR DESCRIPTION
This PR moves some code out of the monolithic qgisapp.cpp file into some separate files.

There's no actual changes here -- it's just moving existing code out of qgisapp.cpp and the necessary fixes to get things compiling with that. Hence the mixed quality of docstrings in the new class (actually cleaning up that code is out of scope and I'm not interested in review comments of that nature).

The motivation here is to thin out qgisapp.cpp by moving things to more modular grouping. qgisapp.cpp is a horrible file to work with -- it's nearly 20k lines, which is larger than a lot of projects alone! :scream: It's correspondingly horrible to find things, and IDEs hate parsing it because it's so large.

There's lots more we can/should do here, but this is a start at least :smile:  

