### PR TITLE
QgsRangeConfigDlg: allow to set minimum value, maximum value and step…

### DIFF
--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -22,6 +22,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
 {
   setupUi( this );
   precisionSpinBox->setClearValue( 4 );
+  setPrecision( precisionSpinBox->value() );
 
   minimumSpinBox->setMinimum( std::numeric_limits<int>::lowest() );
   minimumSpinBox->setMaximum( std::numeric_limits<int>::max() );
@@ -106,6 +107,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
   connect( rangeWidget, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( allowNullCheckBox, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( suffixLineEdit, &QLineEdit::textChanged, this, &QgsEditorConfigWidget::changed );
+  connect( precisionSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsRangeConfigDlg::setPrecision );
 }
 
 QVariantMap QgsRangeConfigDlg::config()
@@ -163,4 +165,11 @@ void QgsRangeConfigDlg::rangeWidgetChanged( int index )
 {
   const QString style = rangeWidget->itemData( index ).toString();
   allowNullCheckBox->setEnabled( style == QLatin1String( "SpinBox" ) );
+}
+
+void QgsRangeConfigDlg::setPrecision( int precision )
+{
+  minimumDoubleSpinBox->setDecimals( precision );
+  maximumDoubleSpinBox->setDecimals( precision );
+  stepDoubleSpinBox->setDecimals( precision );
 }

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -107,7 +107,7 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget 
   connect( rangeWidget, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( allowNullCheckBox, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( suffixLineEdit, &QLineEdit::textChanged, this, &QgsEditorConfigWidget::changed );
-  connect( precisionSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsRangeConfigDlg::setPrecision );
+  connect( precisionSpinBox, qOverload< int > ( &QSpinBox::valueChanged ), this, &QgsRangeConfigDlg::setPrecision );
 }
 
 QVariantMap QgsRangeConfigDlg::config()

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.h
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.h
@@ -39,6 +39,7 @@ class GUI_EXPORT QgsRangeConfigDlg : public QgsEditorConfigWidget, private Ui::Q
 
   protected slots:
     void rangeWidgetChanged( int index );
+    void setPrecision( int precision );
 };
 
 #endif // QGSRANGECONFIGDLG_H

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.h
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.h
@@ -39,6 +39,11 @@ class GUI_EXPORT QgsRangeConfigDlg : public QgsEditorConfigWidget, private Ui::Q
 
   protected slots:
     void rangeWidgetChanged( int index );
+
+    /**
+     * Sets the precision of minimum value, maximum value, step size UI elements
+     * \param precision the precision
+     */
     void setPrecision( int precision );
 };
 


### PR DESCRIPTION
It would be nice to select minimum value, maximum value and step with in the selected precision in QgsRangeConfigDlg. Currently it is limited to 2 decimal places. This PR sets the spin box precisions to the selected precision. Please review
