### PR TITLE
The collapsing options belong to group boxes

### DIFF
--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -39,7 +39,7 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
   mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
-  mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
+  mVisibilityExpressionWidget->setAllowEmptyFieldName( true );
   mVisibilityExpressionWidget->setLayer( layer );
   mVisibilityExpressionWidget->setExpression( itemData.visibilityExpression()->expression() );
   mColumnCountSpinBox->setValue( itemData.columnCount() );
@@ -75,7 +75,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );
-  visibilityExpression.setEnabled( mControlVisibilityGroupBox->isChecked() );
+  visibilityExpression.setEnabled( true );
   itemData.setVisibilityExpression( visibilityExpression );
 
   QgsOptionalExpression collapsedExpression;

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -37,7 +37,6 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
 
   mTitleLineEdit->setText( itemData.name() );
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
-  mShowLabelCheckBox->setEnabled( itemData.showAsGroupBox() ); // show label makes sense for group box, not for tabs
   mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
   mControlVisibilityGroupBox->setChecked( itemData.visibilityExpression().enabled() );
@@ -53,8 +52,6 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
 
   mFormLabelFormatWidget->setLabelStyle( itemData.labelStyle() );
 
-  // show label makes sense for group box, not for tabs
-  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mShowLabelCheckBox, &QCheckBox::setEnabled );
   connect( mShowAsGroupBox, &QCheckBox::stateChanged, mCollapsedCheckBox, &QCheckBox::setEnabled );
   connect( mShowAsGroupBox, &QCheckBox::stateChanged, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
 }

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -75,7 +75,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
 
   QgsOptionalExpression visibilityExpression;
   visibilityExpression.setData( QgsExpression( mVisibilityExpressionWidget->expression() ) );
-  visibilityExpression.setEnabled( true );
+  visibilityExpression.setEnabled( !mVisibilityExpressionWidget->currentText().isEmpty() );
   itemData.setVisibilityExpression( visibilityExpression );
 
   QgsOptionalExpression collapsedExpression;

--- a/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
+++ b/src/gui/attributeformconfig/qgsattributeformcontaineredit.cpp
@@ -29,15 +29,16 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
 
   if ( item->parent() )
   {
-    // only top level items can be tabs
-    // i.e. it's always a group box if it's a nested container
-    mShowAsGroupBox->hide();
-    mShowAsGroupBox->setEnabled( false );
+    // a nested container is always a group box, then hide the checkbox
+    mShowAsGroupBox->setCheckable( false );
+  }
+  else
+  {
+    mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
   }
 
   mTitleLineEdit->setText( itemData.name() );
   mShowLabelCheckBox->setChecked( itemData.showLabel() );
-  mShowAsGroupBox->setChecked( itemData.showAsGroupBox() );
 
   mVisibilityExpressionWidget->setAllowEmptyFieldName( true );
   mVisibilityExpressionWidget->setLayer( layer );
@@ -45,15 +46,11 @@ QgsAttributeFormContainerEdit::QgsAttributeFormContainerEdit( QTreeWidgetItem *i
   mColumnCountSpinBox->setValue( itemData.columnCount() );
   mBackgroundColorButton->setColor( itemData.backgroundColor() );
   mCollapsedCheckBox->setChecked( itemData.collapsed() );
-  mCollapsedCheckBox->setEnabled( itemData.showAsGroupBox() );
-  mControlCollapsedGroupBox->setChecked( itemData.collapsedExpression().enabled() );
-  mControlCollapsedGroupBox->setEnabled( itemData.showAsGroupBox() );
+  mCollapsedExpressionWidget->setAllowEmptyFieldName( true );
+  mCollapsedExpressionWidget->setLayer( layer );
   mCollapsedExpressionWidget->setExpression( itemData.collapsedExpression()->expression() );
 
   mFormLabelFormatWidget->setLabelStyle( itemData.labelStyle() );
-
-  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mCollapsedCheckBox, &QCheckBox::setEnabled );
-  connect( mShowAsGroupBox, &QCheckBox::stateChanged, mControlCollapsedGroupBox, &QCheckBox::setEnabled );
 }
 
 void QgsAttributeFormContainerEdit::registerExpressionContextGenerator( QgsExpressionContextGenerator *generator )
@@ -67,7 +64,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
   QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
 
   itemData.setColumnCount( mColumnCountSpinBox->value() );
-  itemData.setShowAsGroupBox( mShowAsGroupBox->isEnabled() ? mShowAsGroupBox->isChecked() : false );
+  itemData.setShowAsGroupBox( mShowAsGroupBox->isCheckable() ? mShowAsGroupBox->isChecked() : true );
   itemData.setName( mTitleLineEdit->text() );
   itemData.setShowLabel( mShowLabelCheckBox->isChecked() );
   itemData.setBackgroundColor( mBackgroundColorButton->color() );
@@ -80,7 +77,7 @@ void QgsAttributeFormContainerEdit::updateItemData()
 
   QgsOptionalExpression collapsedExpression;
   collapsedExpression.setData( QgsExpression( mCollapsedExpressionWidget->expression() ) );
-  collapsedExpression.setEnabled( mControlCollapsedGroupBox->isChecked() );
+  collapsedExpression.setEnabled( itemData.showAsGroupBox() );
   itemData.setCollapsedExpression( collapsedExpression );
   itemData.setCollapsed( mCollapsedCheckBox->isEnabled() ? mCollapsedCheckBox->isChecked() : false );
 

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -14,19 +14,18 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="mControlVisibilityGroupBox">
-     <property name="title">
-      <string>Control Visibility by Expression</string>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Control visibility</string>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true">
+     <property name="toolTip">
+      <string>Controls container's visibility using an expression</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true"/>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="9" column="0" colspan="2">
@@ -171,7 +170,6 @@
   <tabstop>mShowLabelCheckBox</tabstop>
   <tabstop>mTitleLineEdit</tabstop>
   <tabstop>mColumnCountSpinBox</tabstop>
-  <tabstop>mControlVisibilityGroupBox</tabstop>
   <tabstop>mShowAsGroupBox</tabstop>
   <tabstop>mCollapsedCheckBox</tabstop>
   <tabstop>mControlCollapsedGroupBox</tabstop>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -28,7 +28,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Style</string>
@@ -57,7 +57,7 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="6" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -94,13 +94,6 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QCheckBox" name="mShowAsGroupBox">
-     <property name="text">
-      <string>Show as Group Box</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
     <widget class="QLineEdit" name="mTitleLineEdit"/>
    </item>
@@ -111,24 +104,38 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QCheckBox" name="mCollapsedCheckBox">
-     <property name="text">
-      <string>Collapsed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="mControlCollapsedGroupBox">
+   <item row="4" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mShowAsGroupBox">
      <property name="title">
-      <string>Control Collapsed by Expression</string>
+      <string>Show as Group Box</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QgsFieldExpressionWidget" name="mCollapsedExpressionWidget" native="true"/>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCollapsedCheckBox">
+        <property name="toolTip">
+         <string>Always collapse the group box at the form opening</string>
+        </property>
+        <property name="text">
+         <string>Collapse</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelExpressionCollapse">
+        <property name="text">
+         <string>Collapsing expression</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsFieldExpressionWidget" name="mCollapsedExpressionWidget" native="true">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Collapses the group box using an expression.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Comment out or delete the expression to deactivate the option.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -172,7 +179,6 @@
   <tabstop>mColumnCountSpinBox</tabstop>
   <tabstop>mShowAsGroupBox</tabstop>
   <tabstop>mCollapsedCheckBox</tabstop>
-  <tabstop>mControlCollapsedGroupBox</tabstop>
   <tabstop>mBackgroundColorButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
+++ b/src/ui/attributeformconfig/qgsattributeformcontaineredit.ui
@@ -14,17 +14,17 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Control visibility</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="3" column="1">
     <widget class="QgsFieldExpressionWidget" name="mVisibilityExpressionWidget" native="true">
      <property name="toolTip">
-      <string>Controls container's visibility using an expression</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;lt;html&amp;gt;&amp;lt;head/&amp;gt;&amp;lt;body&amp;gt;&amp;lt;p&amp;gt;Controls container's visibility using an expression.&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;span style=&amp;quot; font-style:italic;&amp;quot;&amp;gt;Comment out or delete the expression to deactivate the option.&amp;lt;/span&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;/body&amp;gt;&amp;lt;/html&amp;gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -77,14 +77,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Columns</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="2" column="1">
     <widget class="QgsSpinBox" name="mColumnCountSpinBox">
      <property name="minimum">
       <number>1</number>
@@ -101,10 +101,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="1" column="1">
     <widget class="QLineEdit" name="mTitleLineEdit"/>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Title</string>


### PR DESCRIPTION
Make this statement visually obvious by embedding the items
Ensure that group boxes are always collapsible, at any level and not only at the top
Keep collapsing setting when moving around the container
Add layer fields to the collapse expression widget context

Fixes #49500

I made videos showing how it plays but github either says they are corrupted or do not display cursor so.... here screenshots (they include UI changes in #49497)
when a top level item (tab or group box)
![image](https://user-images.githubusercontent.com/7983394/181914708-4ed6302c-f828-43e3-9670-e1cb79be3c76.png)
![image](https://user-images.githubusercontent.com/7983394/181914763-7d83b5dc-2348-4bf0-bbf5-1d44b203ed93.png)

when a subitem (group box)
![image](https://user-images.githubusercontent.com/7983394/181914814-bb15b2a4-1b29-4cd1-9c83-d2ad68497488.png)

resulting at attribute table opening to
![Capture d’écran du 2022-07-30 10-20-34](https://user-images.githubusercontent.com/7983394/181914880-6059460d-b35a-47f7-8f3d-1633896dba17.png)

