### PR TITLE
Fix qgsfeature equality handling of null geometries and restore in sip bindings

### DIFF
--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -156,7 +156,9 @@ Copy constructor
 %End
 
 
+    bool operator==( const QgsFeature &other ) const;
 
+    bool operator!=( const QgsFeature &other ) const;
 
     virtual ~QgsFeature();
 

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -64,15 +64,22 @@ bool QgsFeature::operator ==( const QgsFeature &other ) const
   if ( d == other.d )
     return true;
 
-  if ( d->fid == other.d->fid
-       && d->valid == other.d->valid
-       && d->fields == other.d->fields
-       && d->attributes == other.d->attributes
-       && d->geometry.equals( other.d->geometry )
-       && d->symbol == other.d->symbol )
-    return true;
+  if ( !( d->fid == other.d->fid
+          && d->valid == other.d->valid
+          && d->fields == other.d->fields
+          && d->attributes == other.d->attributes
+          && d->symbol == other.d->symbol ) )
+    return false;
 
-  return false;
+  // compare geometry
+  if ( d->geometry.isNull() && other.d->geometry.isNull() )
+    return true;
+  else if ( d->geometry.isNull() || other.d->geometry.isNull() )
+    return false;
+  else if ( !d->geometry.equals( other.d->geometry ) )
+    return false;
+
+  return true;
 }
 
 bool QgsFeature::operator!=( const QgsFeature &other ) const

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -200,17 +200,17 @@ class CORE_EXPORT QgsFeature
     /**
      * Assignment operator
      */
-    QgsFeature &operator=( const QgsFeature &rhs ) SIP_SKIP;
+    QgsFeature &operator=( const QgsFeature &rhs );
 
     /**
      * Compares two features
      */
-    bool operator==( const QgsFeature &other ) const SIP_SKIP;
+    bool operator==( const QgsFeature &other ) const;
 
     /**
      * Compares two features
      */
-    bool operator!=( const QgsFeature &other ) const SIP_SKIP;
+    bool operator!=( const QgsFeature &other ) const;
 
     virtual ~QgsFeature();
 

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -519,6 +519,30 @@ void TestQgsFeature::equality()
   feature7.setGeometry( QgsGeometry( new QgsPoint( 1, 3 ) ) );
 
   QVERIFY( feature != feature7 );
+
+  // features without geometry
+  QgsFeature feature8;
+  feature8.setFields( mFields, true );
+  feature8.setAttribute( 0, QStringLiteral( "attr1" ) );
+  feature8.setAttribute( 1, QStringLiteral( "attr2" ) );
+  feature8.setAttribute( 2, QStringLiteral( "attr3" ) );
+  feature8.setValid( true );
+  feature8.setId( 1 );
+  QgsFeature feature9;
+  feature9.setFields( mFields, true );
+  feature9.setAttribute( 0, QStringLiteral( "attr1" ) );
+  feature9.setAttribute( 1, QStringLiteral( "attr2" ) );
+  feature9.setAttribute( 2, QStringLiteral( "attr3" ) );
+  feature9.setValid( true );
+  feature9.setId( 1 );
+  QVERIFY( feature8 == feature9 );
+  feature8.setGeometry( QgsGeometry( new QgsPoint( 1, 3 ) ) );
+  QVERIFY( feature8 != feature9 );
+  feature8.clearGeometry();
+  feature9.setGeometry( QgsGeometry( new QgsPoint( 1, 3 ) ) );
+  QVERIFY( feature8 != feature9 );
+  feature8.setGeometry( QgsGeometry( new QgsPoint( 1, 3 ) ) );
+  QVERIFY( feature8 == feature9 );
 }
 
 void TestQgsFeature::attributeUsingField()

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -57,6 +57,47 @@ class TestQgsFeature(unittest.TestCase):
         feat = QgsFeature(QgsFields(), 1234)
         self.assertEqual(feat.id(), 1234)
 
+    def test_equality(self):
+        fields = QgsFields()
+        field1 = QgsField('my_field')
+        fields.append(field1)
+        field2 = QgsField('my_field2')
+        fields.append(field2)
+
+        feat = QgsFeature(fields, 0)
+        feat.initAttributes(1)
+        feat.setAttribute(0, "text")
+        feat.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(123, 456)))
+
+        self.assertNotEqual(feat, QgsFeature())
+
+        feat2 = QgsFeature(fields, 0)
+        feat2.initAttributes(1)
+        feat2.setAttribute(0, "text")
+        feat2.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(123, 456)))
+
+        self.assertEqual(feat, feat2)
+
+        feat2.setId(5)
+        self.assertNotEqual(feat, feat2)
+        feat2.setId(0)
+        self.assertEqual(feat, feat2)
+
+        feat2.setAttribute(0, "text2")
+        self.assertNotEqual(feat, feat2)
+        feat2.setAttribute(0, "text")
+        self.assertEqual(feat, feat2)
+
+        feat2.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(1231, 4561)))
+        self.assertNotEqual(feat, feat2)
+        feat2.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(123, 456)))
+        self.assertEqual(feat, feat2)
+
+        field2 = QgsField('my_field3')
+        fields.append(field2)
+        feat2.setFields(fields)
+        self.assertNotEqual(feat, feat2)
+
     def test_ValidFeature(self):
         myPath = os.path.join(unitTestDataPath(), 'points.shp')
         myLayer = QgsVectorLayer(myPath, 'Points', 'ogr')


### PR DESCRIPTION
These were (accidentally?) ommited in https://github.com/qgis/QGIS/commit/9050cc14d4c83de4b4ed44499ba73f5b70660044, and then incorrectly marked as sip_skip when sipify was first introduced as a result