### PR TITLE
Handle GetFeatureInfo with type text/xml

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -538,17 +538,7 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
       format = QgsRaster::IdentifyFormatText;
     else if ( f == QLatin1String( "text/html" ) )
       format = QgsRaster::IdentifyFormatHtml;
-    else if ( f.startsWith( QLatin1String( "GML." ) ) )
-      format = QgsRaster::IdentifyFormatFeature; // 1.0
-    else if ( f == QLatin1String( "application/vnd.ogc.gml" ) )
-      format = QgsRaster::IdentifyFormatFeature;
-    else if ( f == QLatin1String( "application/json" ) )
-      format = QgsRaster::IdentifyFormatFeature;
-    else if ( f == QLatin1String( "application/geojson" ) )
-      format = QgsRaster::IdentifyFormatFeature;
-    else if ( f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) )
-      format = QgsRaster::IdentifyFormatFeature;
-    else if ( f == QLatin1String( "text/xml" ) )
+    else if ( f.startsWith( QLatin1String( "GML." ) ) || f == QLatin1String( "application/vnd.ogc.gml" ) || f == QLatin1String( "application/json" ) || f == QLatin1String( "application/geojson" ) || f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) || f == QLatin1String( "text/xml" ) )
       format = QgsRaster::IdentifyFormatFeature;
 
     mIdentifyFormats.insert( format, f );

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -548,6 +548,8 @@ bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParser
       format = QgsRaster::IdentifyFormatFeature;
     else if ( f.contains( QLatin1String( "gml" ), Qt::CaseInsensitive ) )
       format = QgsRaster::IdentifyFormatFeature;
+    else if ( f == QLatin1String( "text/xml" ) )
+      format = QgsRaster::IdentifyFormatFeature;
 
     mIdentifyFormats.insert( format, f );
   }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3533,10 +3533,13 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
         if ( isXml && parseServiceExceptionReportDom( body, mErrorCaption, mError ) )
         {
-          QgsMessageLog::logMessage( tr( "Get feature info request error (Title: %1; Error: %2; URL: %3)" )
-                                     .arg( mErrorCaption, mError,
-                                           requestUrl.toString() ), tr( "WMS" ) );
-          continue;
+          if ( !mError.isEmpty() ) //xml is not necessarily an exception
+          {
+            QgsMessageLog::logMessage( tr( "Get feature info request error (Title: %1; Error: %2; URL: %3)" )
+                                       .arg( mErrorCaption, mError,
+                                             requestUrl.toString() ), tr( "WMS" ) );
+            continue;
+          }
         }
       }
     }

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -456,7 +456,7 @@ class TestQgsWmsCapabilities: public QObject
       QTest::addColumn<int>( "capability" );
 
       QTest::newRow( "text/plain" ) << QByteArray( "text/plain" ) << static_cast<int>( QgsRasterInterface::IdentifyText );
-      QTest::newRow( "text/xml" ) << QByteArray( "text/xml" ) << static_cast<int>( QgsRasterInterface::NoCapabilities );
+      QTest::newRow( "text/xml" ) << QByteArray( "text/xml" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
       QTest::newRow( "text/html" ) << QByteArray( "text/html" ) << static_cast<int>( QgsRasterInterface::IdentifyHtml );
       QTest::newRow( "application/json" ) << QByteArray( "application/json" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );
       QTest::newRow( "application/geojson" ) << QByteArray( "application/geojson" ) << static_cast<int>( QgsRasterInterface::IdentifyFeature );


### PR DESCRIPTION
Some WMS Servers offer GetFeatureInfo in GML format and declare it as 'text/xml'. This is not wrong, as GML is also XML. However QGIS currently thinks the reply is an exception delivered in XML format. This PR makes two small changes to allow hadling of GetFeatureInfo in GML/XML-format if declared as text/xml.