### PR TITLE
3DMapScene: selects entities to apply shadows on

### DIFF
--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -139,7 +139,6 @@ void QgsOffscreen3DEngine::setRootEntity( Qt3DCore::QEntity *root )
   mSceneRoot = root;
   mSceneRoot->setParent( mRoot );
   root->addComponent( mFrameGraph->forwardRenderLayer() );
-  root->addComponent( mFrameGraph->castShadowsLayer() );
 }
 
 Qt3DRender::QRenderSettings *QgsOffscreen3DEngine::renderSettings()

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -70,7 +70,6 @@ void QgsWindow3DEngine::setRootEntity( Qt3DCore::QEntity *root )
   mSceneRoot = root;
   mSceneRoot->setParent( mRoot );
   mSceneRoot->addComponent( mFrameGraph->forwardRenderLayer() );
-  mSceneRoot->addComponent( mFrameGraph->castShadowsLayer() );
 }
 
 Qt3DRender::QRenderSettings *QgsWindow3DEngine::renderSettings()


### PR DESCRIPTION
These is a proposal to fix https://github.com/qgis/QGIS/issues/49595

I add a boolean according to the chunk loader to decide if a new entity should be shadowable or not.

Here is the previous version:
![terrain_shadows_issue](https://user-images.githubusercontent.com/64401067/183043983-918627ed-b620-4796-91c8-6e417bfed644.png)

and the corrected version:

![terrain_shadows_resolved](https://user-images.githubusercontent.com/64401067/183042987-3d9c3522-c266-4d0e-a0fa-2a28a3e3d55d.png)

