### PR TITLE
Add write permissions for PRs to unstale workflow

### DIFF
--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -9,6 +9,7 @@ jobs:
   remove_labels:
     permissions:
       issues: write  # for actions-ecosystem/action-remove-labels to remove issue labels
+      pull-requests: write  # for actions-ecosystem/action-remove-labels to remove PR labels
     if: contains(github.event.issue.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To be able to remove "stale" labels from PRs.

Fix https://github.com/qgis/QGIS/issues/49593