### PR TITLE
Do not switch to FormatUnknown when evaluating expression of picture item layout

### DIFF
--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -497,10 +497,10 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
     case FormatRaster:
     {
       bool fitsInCache = false;
-      bool isMissing = false;
-      mImage = QgsApplication::imageCache()->pathAsImage( path, QSize(), true, 1, fitsInCache, true, mLayout->renderContext().dpi(), -1, &isMissing );
-      if ( mImage.isNull() || isMissing )
-        mMode = FormatUnknown;
+      bool isMissingImage = false;
+      mImage = QgsApplication::imageCache()->pathAsImage( path, QSize(), true, 1, fitsInCache, true, mLayout->renderContext().dpi(), -1, &isMissingImage );
+      if ( mImage.isNull() || isMissingImage )
+        mIsMissingImage = true;
       break;
     }
 
@@ -526,7 +526,7 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
       }
       else
       {
-        mMode = FormatUnknown;
+        mIsMissingImage = true;
       }
       break;
     }
@@ -578,7 +578,8 @@ void QgsLayoutItemPicture::loadPicture( const QVariant &data )
   {
     recalculateSize();
   }
-  else if ( mHasExpressionError || !mEvaluatedPath.isEmpty() )
+
+  if ( mHasExpressionError || mIsMissingImage )
   {
     //trying to load an invalid file or bad expression, show cross picture
     mIsMissingImage = true;

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -486,6 +486,7 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
   if ( path.isEmpty() )
   {
     mImage = QImage();
+    mSVG.load( QByteArray() );
     return;
   }
 

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -409,6 +409,7 @@ void QgsLayoutItemPicture::loadRemotePicture( const QString &url )
   else
   {
     mMode = FormatUnknown;
+    mIsMissingImage = true;
   }
 }
 
@@ -420,6 +421,7 @@ void QgsLayoutItemPicture::loadLocalPicture( const QString &path )
   if ( !pic.exists() )
   {
     mMode = FormatUnknown;
+    mIsMissingImage = true;
   }
   else
   {
@@ -447,6 +449,7 @@ void QgsLayoutItemPicture::loadLocalPicture( const QString &path )
       else
       {
         mMode = FormatUnknown;
+        mIsMissingImage = true;
       }
     }
     else
@@ -476,6 +479,7 @@ void QgsLayoutItemPicture::loadLocalPicture( const QString &path )
       else
       {
         mMode = FormatUnknown;
+        mIsMissingImage = true;
       }
     }
   }
@@ -493,6 +497,7 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
   switch ( mMode )
   {
     case FormatUnknown:
+      mIsMissingImage = true;
       break;
 
     case FormatRaster:

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -352,7 +352,6 @@ void QgsLayoutItemPicture::refreshPicture( const QgsExpressionContext *context )
   mHasExpressionError = false;
   if ( mDataDefinedProperties.isActive( QgsLayoutObject::PictureSource ) )
   {
-    mMode = FormatUnknown;
     bool ok = false;
     const QgsProperty &sourceProperty = mDataDefinedProperties.property( QgsLayoutObject::PictureSource );
     source = sourceProperty.value( *evalContext, source, &ok );

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -398,7 +398,7 @@ void TestQgsLayoutPicture::svgParameters()
   //test rendering an SVG file with parameters
   mLayout->addLayoutItem( mPicture );
   mPicture->setResizeMode( QgsLayoutItemPicture::Zoom );
-  mPicture->setPicturePath( mSvgParamsImage );
+  mPicture->setPicturePath( mSvgParamsImage, QgsLayoutItemPicture::FormatSVG );
   mPicture->setSvgFillColor( QColor( 30, 90, 200, 100 ) );
   mPicture->setSvgStrokeColor( QColor( 255, 45, 20, 200 ) );
   mPicture->setSvgStrokeWidth( 2.2 );
@@ -408,8 +408,8 @@ void TestQgsLayoutPicture::svgParameters()
   QVERIFY( checker.testLayout( mReport, 0, 0 ) );
 
   mLayout->removeItem( mPicture );
+  mPicture->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatRaster );
   mPicture->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );
-  mPicture->setPicturePath( mPngImage );
 }
 
 void TestQgsLayoutPicture::dynamicSvgParameters()
@@ -417,7 +417,7 @@ void TestQgsLayoutPicture::dynamicSvgParameters()
   //test rendering an SVG file with parameters
   mLayout->addLayoutItem( mPicture );
   mPicture->setResizeMode( QgsLayoutItemPicture::Zoom );
-  mPicture->setPicturePath( mDynamicSvgParamsImage );
+  mPicture->setPicturePath( mDynamicSvgParamsImage, QgsLayoutItemPicture::FormatSVG );
 
   QMap<QString, QgsProperty> parametersProperties;
   parametersProperties.insert( QStringLiteral( "text1" ), QgsProperty::fromExpression( QStringLiteral( "'green?'" ) ) );
@@ -431,8 +431,8 @@ void TestQgsLayoutPicture::dynamicSvgParameters()
   QVERIFY( checker.testLayout( mReport, 0, 0 ) );
 
   mLayout->removeItem( mPicture );
-  mPicture->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );
-  mPicture->setPicturePath( mPngImage );
+  mPicture->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatRaster );
+  mPicture->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );;
 }
 
 void TestQgsLayoutPicture::issue_14644()
@@ -440,15 +440,15 @@ void TestQgsLayoutPicture::issue_14644()
   //test rendering SVG file with text
   mLayout->addLayoutItem( mPicture );
   mPicture->setResizeMode( QgsLayoutItemPicture::Zoom );
-  mPicture->setPicturePath( QStringLiteral( TEST_DATA_DIR ) + "/svg/issue_14644.svg" );
+  mPicture->setPicturePath( QStringLiteral( TEST_DATA_DIR ) + "/svg/issue_14644.svg", QgsLayoutItemPicture::FormatSVG );
 
   QgsLayoutChecker checker( QStringLiteral( "composerpicture_issue_14644" ), mLayout );
   checker.setControlPathPrefix( QStringLiteral( "composer_picture" ) );
   QVERIFY( checker.testLayout( mReport, 0, 0 ) );
 
   mLayout->removeItem( mPicture );
+  mPicture->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatRaster );
   mPicture->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );
-  mPicture->setPicturePath( mPngImage );
 }
 
 void TestQgsLayoutPicture::pictureExpression()

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -455,6 +455,7 @@ void TestQgsLayoutPicture::pictureExpression()
 {
   //test picture source via expression
   mLayout->addLayoutItem( mPicture );
+  mPicture->setMode( QgsLayoutItemPicture::FormatSVG );
 
   const QString expr = QStringLiteral( "'%1' || '/sample_svg.svg'" ).arg( TEST_DATA_DIR );
   mPicture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( expr ) );


### PR DESCRIPTION
Fixes #49165
Fixes #47981
Fixes #38031
Fixes #37804

During expression evaluation, `mMode` was set to `FormatUnknown` causing gui to switch to SVG mode even if user click on raster radio button (as it evaluates the expression, switch to FormatUnknown, etc etc).

Need backport if it's okay.

ping @3nids 