### PR TITLE
Disable image cache threading test on Qt 5.15

### DIFF
--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -123,6 +123,10 @@ void TestQgsImageCache::threadSafeImage()
   // This unit test checks that concurrent rendering of paths as QImage from QgsImageCache
   // works without issues across threads
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) or QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  // test deadlocks on 5.15 - see https://bugreports.qt.io/browse/QTBUG-84857
+  // this is supposed to be fixed in 5.15.1, but I can still reproduce in Fedora on 5.15.5..!
+
   QgsImageCache cache;
   const QString imagePath = TEST_DATA_DIR + QStringLiteral( "/sample_image.png" );
 
@@ -130,6 +134,8 @@ void TestQgsImageCache::threadSafeImage()
   QVector< int > list;
   list.resize( 100 );
   QtConcurrent::blockingMap( list, RenderImageWrapper( cache, imagePath ) );
+#endif
+
 }
 
 void TestQgsImageCache::broken()


### PR DESCRIPTION
We bump up against the deadlock described in https://bugreports.qt.io/browse/QTBUG-84857

(This is actually a really nasty upstream bug which I can
still reproduce on 5.15.5 on Fedora, in a range of
circumstances)
