### PR TITLE
Store render test results report as an artifact 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -404,3 +404,11 @@ jobs:
           echo "DOCKERFILE=$DOCKERFILE"
           mkdir -p /tmp/webdav_tests && chmod 777 /tmp/webdav_tests
           docker-compose -f .docker/$DOCKERFILE run qgis-deps /root/QGIS/.docker/docker-qgis-test.sh $TEST_BATCH
+
+      - name: Archive test results report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: qgis_test_report
+

--- a/python/core/auto_additions/qgsrenderchecker.py
+++ b/python/core/auto_additions/qgsrenderchecker.py
@@ -1,0 +1,8 @@
+# The following has been generated automatically from src/core/qgsrenderchecker.h
+# monkey patching scoped based enum
+QgsRenderChecker.Flag.AvoidExportingRenderedImage.__doc__ = "Avoids exporting rendered images to reports"
+QgsRenderChecker.Flag.__doc__ = 'Render checker flags.\n\n.. versionadded:: 3.28\n\n' + '* ``AvoidExportingRenderedImage``: ' + QgsRenderChecker.Flag.AvoidExportingRenderedImage.__doc__
+# --
+QgsRenderChecker.Flag.baseClass = QgsRenderChecker
+QgsRenderChecker.Flags.baseClass = QgsRenderChecker
+Flags = QgsRenderChecker  # dirty hack since SIP seems to introduce the flags in module

--- a/python/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/core/auto_generated/qgsrenderchecker.sip.in
@@ -29,6 +29,21 @@ or render time.
 Constructor for QgsRenderChecker.
 %End
 
+    static QDir testReportDir();
+%Docstring
+Returns the directory to use for generating a test report.
+
+.. versionadded:: 3.28
+%End
+
+    static bool shouldGenerateReport();
+%Docstring
+Returns ``True`` if a test report should be generated given the
+current environment.
+
+.. versionadded:: 3.28
+%End
+
     QString controlImagePath() const;
 %Docstring
 Returns the base path containing the reference images.

--- a/python/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/core/auto_generated/qgsrenderchecker.sip.in
@@ -23,6 +23,9 @@ or render time.
 #include "qgsrenderchecker.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     QgsRenderChecker();
 %Docstring
@@ -163,7 +166,15 @@ Sets the largest allowable difference in size between the rendered and the expec
 .. versionadded:: 2.12
 %End
 
-    bool runTest( const QString &testName, unsigned int mismatchCount = 0 );
+    enum class Flag
+    {
+      AvoidExportingRenderedImage,
+    };
+
+    typedef QFlags<QgsRenderChecker::Flag> Flags;
+
+
+    bool runTest( const QString &testName, unsigned int mismatchCount = 0, QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 %Docstring
 Test using renderer to generate the image to be compared.
 
@@ -173,13 +184,14 @@ Test using renderer to generate the image to be compared.
                       are allowed to be different from the control image. In some cases
                       rendering may be non-deterministic. This parameter allows you to account
                       for that by providing a tolerance.
+:param flags: render checker flags
 
 .. note::
 
    make sure to call setExpectedImage and setMapRenderer first
 %End
 
-    bool compareImages( const QString &testName, unsigned int mismatchCount = 0, const QString &renderedImageFile = QString() );
+    bool compareImages( const QString &testName, unsigned int mismatchCount = 0, const QString &renderedImageFile = QString(), QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 %Docstring
 Test using two arbitrary images (map renderer will not be used)
 
@@ -190,10 +202,11 @@ Test using two arbitrary images (map renderer will not be used)
                       rendering may be non-deterministic. This parameter allows you to account
                       for that by providing a tolerance.
 :param renderedImageFile: to optionally override the output filename
+:param flags: render checker flags
 \note: make sure to call setExpectedImage and setRenderedImage first.
 %End
 
-    bool compareImages( const QString &testName, const QString &referenceImageFile, const QString &renderedImageFile, unsigned int mismatchCount = 0 );
+    bool compareImages( const QString &testName, const QString &referenceImageFile, const QString &renderedImageFile, unsigned int mismatchCount = 0, QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 %Docstring
 Test using two arbitrary images at the specified paths for equality.
 
@@ -243,7 +256,9 @@ Only will return something if you call enableDashBuffering( ``True`` ); before.
 
   protected:
 
-}; // class QgsRenderChecker
+};
+
+QFlags<QgsRenderChecker::Flag> operator|(QgsRenderChecker::Flag f1, QFlags<QgsRenderChecker::Flag> f2);
 
 
 

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -34,6 +34,16 @@ QgsRenderChecker::QgsRenderChecker()
     mIsCiRun = true;
 }
 
+QDir QgsRenderChecker::testReportDir()
+{
+  return QDir( QDir::temp().filePath( QStringLiteral( "qgis_test_report" ) ) );
+}
+
+bool QgsRenderChecker::shouldGenerateReport()
+{
+  return true;
+}
+
 QString QgsRenderChecker::controlImagePath() const
 {
   return mBasePath + ( mBasePath.endsWith( '/' ) ? QString() : QStringLiteral( "/" ) ) + mControlPathPrefix;
@@ -182,6 +192,35 @@ void QgsRenderChecker::dumpRenderedImageAsBase64()
   qDebug() << "End dump";
 }
 
+void QgsRenderChecker::performPostTestActions()
+{
+  if ( mResult )
+    return;
+
+  if ( mIsCiRun && QFile::exists( mRenderedImageFile ) )
+    dumpRenderedImageAsBase64();
+
+  if ( shouldGenerateReport() )
+  {
+    const QDir reportDir = QgsRenderChecker::testReportDir();
+    if ( !reportDir.exists() )
+      QDir().mkpath( reportDir.path() );
+
+    if ( QFile::exists( mRenderedImageFile ) )
+    {
+      QFileInfo fi( mRenderedImageFile );
+      const QString destPath = reportDir.filePath( fi.fileName() );
+      QFile::copy( mRenderedImageFile, destPath );
+    }
+    if ( QFile::exists( mDiffImageFile ) )
+    {
+      QFileInfo fi( mDiffImageFile );
+      const QString destPath = reportDir.filePath( fi.fileName() );
+      QFile::copy( mDiffImageFile, destPath );
+    }
+  }
+}
+
 bool QgsRenderChecker::runTest( const QString &testName,
                                 unsigned int mismatchCount )
 {
@@ -193,6 +232,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File not set.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
   //
@@ -206,6 +246,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File could not be loaded.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
   mMatchTarget = myExpectedImage.width() * myExpectedImage.height();
@@ -243,6 +284,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
               "Image File could not be saved.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
 
@@ -277,6 +319,7 @@ bool QgsRenderChecker::compareImages( const QString &testName,
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Expected "
               "Image File not set.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
 
@@ -301,6 +344,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
               "Image File not set.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
 
@@ -316,12 +360,13 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
               "<tr><td>Test Result:</td><td>Expected Result:</td></tr>\n"
               "<tr><td>Nothing rendered</td>\n<td>Failed because Rendered "
               "Image File could not be loaded.</td></tr></table>\n";
+    performPostTestActions();
     return mResult;
   }
   QImage myDifferenceImage( myExpectedImage.width(),
                             myExpectedImage.height(),
                             QImage::Format_RGB32 );
-  const QString myDiffImageFile = QDir::tempPath() + '/' + testName + "_result_diff.png";
+  mDiffImageFile = QDir::tempPath() + '/' + testName + "_result_diff.png";
   myDifferenceImage.fill( qRgb( 152, 219, 249 ) );
 
   //check for mask
@@ -365,21 +410,23 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
     imgHeight = myExpectedImage.height() * imgWidth / myExpectedImage.width();
   }
 
+  const QString renderedImageFileName = QFileInfo( mRenderedImageFile ).fileName();
+  const QString diffImageFileName = QFileInfo( mDiffImageFile ).fileName();
   const QString myImagesString = QString(
                                    "<tr>"
                                    "<td colspan=2>Compare actual and expected result</td>"
                                    "<td>Difference (all blue is good, any red is bad)</td>"
                                    "</tr>\n<tr>"
                                    "<td colspan=2 id=\"td-%1-%7\"></td>\n"
-                                   "<td align=center><img width=%5 height=%6 src=\"file://%2\"></td>\n"
+                                   "<td align=center><img width=%5 height=%6 src=\"%2\"></td>\n"
                                    "</tr>"
                                    "</table>\n"
-                                   "<script>\naddComparison(\"td-%1-%7\",\"file://%3\",\"file://%4\",%5,%6);\n</script>\n"
+                                   "<script>\naddComparison(\"td-%1-%7\",\"%3\",\"file://%4\",%5,%6);\n</script>\n"
                                    "<p>If the new image looks good, create or update a test mask with<br>"
                                    "<code>scripts/generate_test_mask_image.py \"%8\" \"%9\"</code>" )
                                  .arg( testName,
-                                       myDiffImageFile,
-                                       mRenderedImageFile,
+                                       diffImageFileName,
+                                       renderedImageFileName,
                                        referenceImageFile )
                                  .arg( imgWidth ).arg( imgHeight )
                                  .arg( QUuid::createUuid().toString().mid( 1, 6 ),
@@ -421,8 +468,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += "<font color=red>Expected image and result image for " + testName + " are different dimensions - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      if ( mIsCiRun )
-        dumpRenderedImageAsBase64();
+      performPostTestActions();
       return mResult;
     }
     else
@@ -443,8 +489,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += "<font color=red>Expected image and result image for " + testName + " have different formats (8bit format is expected) - FAILING!</font>";
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      if ( mIsCiRun )
-        dumpRenderedImageAsBase64();
+      performPostTestActions();
       return mResult;
     }
 
@@ -509,8 +554,8 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   //
   //save the diff image to disk
   //
-  myDifferenceImage.save( myDiffImageFile );
-  emitDashMessage( "Difference Image " + testName + prefix, QgsDartMeasurement::ImagePng, myDiffImageFile );
+  myDifferenceImage.save( mDiffImageFile );
+  emitDashMessage( "Difference Image " + testName + prefix, QgsDartMeasurement::ImagePng, mDiffImageFile );
 
   //
   // Send match result to debug
@@ -544,25 +589,26 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
       mReport += QLatin1String( "<font color=red>Test failed because render step took too long</font>" );
       mReport += QLatin1String( "</td></tr>" );
       mReport += myImagesString;
-      if ( mIsCiRun )
-        dumpRenderedImageAsBase64();
+      performPostTestActions();
       return mResult;
     }
     else
     {
       mReport += myImagesString;
       mResult = true;
+      performPostTestActions();
       return mResult;
     }
   }
 
-  const bool myAnomalyMatchFlag = isKnownAnomaly( myDiffImageFile );
+  const bool myAnomalyMatchFlag = isKnownAnomaly( mDiffImageFile );
   if ( myAnomalyMatchFlag )
   {
     mReport += "<tr><td colspan=3>"
                "Difference image matched a known anomaly - passing test! "
                "</td></tr>";
     mResult = true;
+    performPostTestActions();
     return mResult;
   }
 
@@ -570,7 +616,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   emitDashMessage( QStringLiteral( "Image mismatch" ), QgsDartMeasurement::Text, "Difference image did not match any known anomaly or mask."
                    " If you feel the difference image should be considered an anomaly "
                    "you can do something like this\n"
-                   "cp '" + myDiffImageFile + "' " + controlImagePath() + mControlName +
+                   "cp '" + mDiffImageFile + "' " + controlImagePath() + mControlName +
                    "/\nIf it should be included in the mask run\n"
                    "scripts/generate_test_mask_image.py '" + referenceImageFile + "' '" + mRenderedImageFile + "'\n" );
 
@@ -578,7 +624,7 @@ bool QgsRenderChecker::compareImages( const QString &testName, const QString &re
   mReport += "<font color=red>Test image and result image for " + testName + " are mismatched</font><br>";
   mReport += QLatin1String( "</td></tr>" );
   mReport += myImagesString;
-  if ( mIsCiRun )
-    dumpRenderedImageAsBase64();
+
+  performPostTestActions();
   return mResult;
 }

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -175,7 +175,11 @@ void QgsRenderChecker::dumpRenderedImageAsBase64()
 
   const QByteArray blob = fileSource.readAll();
   const QByteArray encoded = blob.toBase64();
+  qDebug() << "Dumping rendered image " << mRenderedImageFile << " as base64\n";
+  qDebug() << "################################################################";
   qDebug() << encoded;
+  qDebug() << "################################################################";
+  qDebug() << "End dump";
 }
 
 bool QgsRenderChecker::runTest( const QString &testName,

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -38,6 +38,8 @@ class QImage;
  */
 class CORE_EXPORT QgsRenderChecker
 {
+    Q_GADGET
+
   public:
 
     /**
@@ -171,6 +173,25 @@ class CORE_EXPORT QgsRenderChecker
     void setSizeTolerance( int xTolerance, int yTolerance ) { mMaxSizeDifferenceX = xTolerance; mMaxSizeDifferenceY = yTolerance; }
 
     /**
+     * Render checker flags.
+     *
+     * \since QGIS 3.28
+     */
+    enum class Flag : int
+    {
+      AvoidExportingRenderedImage = 1 << 0, //!< Avoids exporting rendered images to reports
+    };
+    Q_ENUM( Flag )
+
+    /**
+     * Render checker flags.
+     *
+     * \since QGIS 3.28
+     */
+    Q_DECLARE_FLAGS( Flags, Flag )
+    Q_FLAG( Flags )
+
+    /**
      * Test using renderer to generate the image to be compared.
      * \param testName - to be used as the basis for writing a file to
      * e.g. /tmp/theTestName.png
@@ -178,9 +199,10 @@ class CORE_EXPORT QgsRenderChecker
      * are allowed to be different from the control image. In some cases
      * rendering may be non-deterministic. This parameter allows you to account
      * for that by providing a tolerance.
+     * \param flags render checker flags
      * \note make sure to call setExpectedImage and setMapRenderer first
      */
-    bool runTest( const QString &testName, unsigned int mismatchCount = 0 );
+    bool runTest( const QString &testName, unsigned int mismatchCount = 0, QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 
     /**
      * Test using two arbitrary images (map renderer will not be used)
@@ -191,16 +213,17 @@ class CORE_EXPORT QgsRenderChecker
      * rendering may be non-deterministic. This parameter allows you to account
      * for that by providing a tolerance.
      * \param renderedImageFile to optionally override the output filename
+     * \param flags render checker flags
      * \note: make sure to call setExpectedImage and setRenderedImage first.
      */
-    bool compareImages( const QString &testName, unsigned int mismatchCount = 0, const QString &renderedImageFile = QString() );
+    bool compareImages( const QString &testName, unsigned int mismatchCount = 0, const QString &renderedImageFile = QString(), QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 
     /**
      * Test using two arbitrary images at the specified paths for equality.
      *
      * \since QGIS 3.18
      */
-    bool compareImages( const QString &testName, const QString &referenceImageFile, const QString &renderedImageFile, unsigned int mismatchCount = 0 );
+    bool compareImages( const QString &testName, const QString &referenceImageFile, const QString &renderedImageFile, unsigned int mismatchCount = 0, QgsRenderChecker::Flags flags = QgsRenderChecker::Flags() );
 
     /**
      * Gets a list of all the anomalies. An anomaly is a rendered difference
@@ -253,7 +276,7 @@ class CORE_EXPORT QgsRenderChecker
     void emitDashMessage( const QgsDartMeasurement &dashMessage );
     void emitDashMessage( const QString &name, QgsDartMeasurement::Type type, const QString &value );
     void dumpRenderedImageAsBase64();
-    void performPostTestActions();
+    void performPostTestActions( Flags flags );
 
     bool mResult = false;
 
@@ -273,8 +296,9 @@ class CORE_EXPORT QgsRenderChecker
     QVector<QgsDartMeasurement> mDashMessages;
     bool mBufferDashMessages = false;
     QString mDiffImageFile;
-}; // class QgsRenderChecker
+};
 
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsRenderChecker::Flags )
 
 /**
  * Compare two WKT strings with some tolerance

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -46,6 +46,21 @@ class CORE_EXPORT QgsRenderChecker
     QgsRenderChecker();
 
     /**
+     * Returns the directory to use for generating a test report.
+     *
+     * \since QGIS 3.28
+     */
+    static QDir testReportDir();
+
+    /**
+     * Returns TRUE if a test report should be generated given the
+     * current environment.
+     *
+     * \since QGIS 3.28
+     */
+    static bool shouldGenerateReport();
+
+    /**
      * Returns the base path containing the reference images.
      *
      * This defaults to an internal QGIS test data path, but can be changed via setControlImagePath().
@@ -238,6 +253,7 @@ class CORE_EXPORT QgsRenderChecker
     void emitDashMessage( const QgsDartMeasurement &dashMessage );
     void emitDashMessage( const QString &name, QgsDartMeasurement::Type type, const QString &value );
     void dumpRenderedImageAsBase64();
+    void performPostTestActions();
 
     bool mResult = false;
 
@@ -256,6 +272,7 @@ class CORE_EXPORT QgsRenderChecker
     bool mIsCiRun = false;
     QVector<QgsDartMeasurement> mDashMessages;
     bool mBufferDashMessages = false;
+    QString mDiffImageFile;
 }; // class QgsRenderChecker
 
 

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -44,6 +44,7 @@
 #include "qgsregularpolygon.h"
 #include "qgsrange.h"
 #include "qgsinterval.h"
+#include "qgsrenderchecker.h"
 #include "qgis_test.h"
 
 #define QGSTEST_MAIN(TestObject) \
@@ -136,9 +137,13 @@ class TEST_EXPORT QgsTest : public QObject
      */
     void writeLocalHtmlReport( const QString &report )
     {
-      const QString reportFile = QDir::tempPath() + QDir::separator() + "qgistest.html";
+      const QDir reportDir = QgsRenderChecker::testReportDir();
+      if ( !reportDir.exists() )
+        QDir().mkpath( reportDir.path() );
+
+      const QString reportFile = reportDir.filePath( "index.html" );
       QFile file( reportFile );
-      if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+      if ( file.open( QIODevice::WriteOnly | QIODevice::Append ) )
       {
         QTextStream stream( &file );
         stream << QStringLiteral( "<h1>%1</h1>\n" ).arg( mName );


### PR DESCRIPTION
Allows retrieval of the render test images and report as an artifact after the test run. This gives us an easy way to retrieve the rendered test results without relying on the (broken for a long time) cdash setup. 