### PR TITLE
Don't dump rendered images as base64 in logs anymore

### DIFF
--- a/python/core/auto_generated/qgsrenderchecker.sip.in
+++ b/python/core/auto_generated/qgsrenderchecker.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsRenderChecker
 {
 %Docstring(signature="appended")

--- a/src/core/qgsmultirenderchecker.cpp
+++ b/src/core/qgsmultirenderchecker.cpp
@@ -99,6 +99,7 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
                             "If this is a rendering inconsistency, please add another control image folder, add an anomaly image or increase the color tolerance." );
     msg.send();
 
+#if DUMP_BASE64_IMAGES
     QFile fileSource( mRenderedImage );
     fileSource.open( QIODevice::ReadOnly );
 
@@ -109,7 +110,7 @@ bool QgsMultiRenderChecker::runTest( const QString &testName, unsigned int misma
     qDebug() << encoded;
     qDebug() << "################################################################";
     qDebug() << "End dump";
-
+#endif
   }
 
   if ( !mResult )

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -178,6 +178,7 @@ void QgsRenderChecker::emitDashMessage( const QString &name, QgsDartMeasurement:
   emitDashMessage( QgsDartMeasurement( name, type, value ) );
 }
 
+#if DUMP_BASE64_IMAGES
 void QgsRenderChecker::dumpRenderedImageAsBase64()
 {
   QFile fileSource( mRenderedImageFile );
@@ -194,14 +195,17 @@ void QgsRenderChecker::dumpRenderedImageAsBase64()
   qDebug() << "################################################################";
   qDebug() << "End dump";
 }
+#endif
 
 void QgsRenderChecker::performPostTestActions( Flags flags )
 {
   if ( mResult )
     return;
 
+#if DUMP_BASE64_IMAGES
   if ( mIsCiRun && QFile::exists( mRenderedImageFile ) && !( flags & Flag::AvoidExportingRenderedImage ) )
     dumpRenderedImageAsBase64();
+#endif
 
   if ( shouldGenerateReport() )
   {

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -317,7 +317,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( QgsRenderChecker::Flags )
 inline bool compareWkt( const QString &a, const QString &b, double tolerance = 0.000001 )
 {
   QgsDebugMsg( QStringLiteral( "a:%1 b:%2 tol:%3" ).arg( a, b ).arg( tolerance ) );
-  const QRegularExpression re( "-?\\d+(?:\\.\\d+)?(?:[eE]\\d+)?" );
+  const thread_local QRegularExpression re( "-?\\d+(?:\\.\\d+)?(?:[eE]\\d+)?" );
 
   QString a0( a ), b0( b );
   a0.replace( re, QStringLiteral( "#" ) );
@@ -338,7 +338,6 @@ inline bool compareWkt( const QString &a, const QString &b, double tolerance = 0
     pos = match.capturedStart( 0 ) + match.capturedLength( 0 );
     match = re.match( a, pos );
   }
-  pos = 0;
   match = re.match( b );
   while ( match.hasMatch() )
   {

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -30,6 +30,8 @@
 
 class QImage;
 
+#define DUMP_BASE64_IMAGES 0
+
 /**
  * \ingroup core
  * \brief This is a helper class for unit tests that need to
@@ -275,7 +277,11 @@ class CORE_EXPORT QgsRenderChecker
   private:
     void emitDashMessage( const QgsDartMeasurement &dashMessage );
     void emitDashMessage( const QString &name, QgsDartMeasurement::Type type, const QString &value );
+
+#if DUMP_BASE64_IMAGES
     void dumpRenderedImageAsBase64();
+#endif
+
     void performPostTestActions( Flags flags );
 
     bool mResult = false;


### PR DESCRIPTION
We now have an alternative way to get rendered images (via the artifacts), so we can massively reduce the size of logs by avoiding this output
