### PR TITLE
Silence QT3D_FUNCTOR deprecation warning

### DIFF
--- a/src/3d/mesh/qgsmesh3dmaterial_p.cpp
+++ b/src/3d/mesh/qgsmesh3dmaterial_p.cpp
@@ -95,7 +95,10 @@ class ArrowsTextureGenerator: public Qt3DRender::QTextureImageDataGenerator
     const bool mFixedSize;
     const double mMaxVectorLength;
 
+    // marked as deprecated in 5.15, but undeprecated for Qt 6.0. TODO -- remove when we require 6.0
+    Q_NOWARN_DEPRECATED_PUSH
     QT3D_FUNCTOR( ArrowsTextureGenerator )
+    Q_NOWARN_DEPRECATED_POP
 };
 
 

--- a/src/3d/qgscolorramptexture.h
+++ b/src/3d/qgscolorramptexture.h
@@ -49,7 +49,10 @@ class QgsColorRampTextureGenerator: public Qt3DRender::QTextureImageDataGenerato
 
     bool operator ==( const Qt3DRender::QTextureImageDataGenerator &other ) const override;
 
+    // marked as deprecated in 5.15, but undeprecated for Qt 6.0. TODO -- remove when we require 6.0
+    Q_NOWARN_DEPRECATED_PUSH
     QT3D_FUNCTOR( QgsColorRampTextureGenerator )
+    Q_NOWARN_DEPRECATED_POP
 
   private:
     QgsColorRampShader mColorRampShader;

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <cmath>
 #include "qgsraycastingutils_p.h"
+#include "qgis.h"
 
 ///@cond PRIVATE
 
@@ -235,7 +236,10 @@ class PlaneVertexBufferFunctor : public QBufferDataGenerator
       return false;
     }
 
+    // marked as deprecated in 5.15, but undeprecated for Qt 6.0. TODO -- remove when we require 6.0
+    Q_NOWARN_DEPRECATED_PUSH
     QT3D_FUNCTOR( PlaneVertexBufferFunctor )
+    Q_NOWARN_DEPRECATED_POP
 
   private:
     int mResolution;
@@ -268,7 +272,10 @@ class PlaneIndexBufferFunctor : public QBufferDataGenerator
       return false;
     }
 
+    // marked as deprecated in 5.15, but undeprecated for Qt 6.0. TODO -- remove when we require 6.0
+    Q_NOWARN_DEPRECATED_PUSH
     QT3D_FUNCTOR( PlaneIndexBufferFunctor )
+    Q_NOWARN_DEPRECATED_POP
 
   private:
     int mResolution;

--- a/src/3d/terrain/qgsterraintextureimage_p.cpp
+++ b/src/3d/terrain/qgsterraintextureimage_p.cpp
@@ -53,7 +53,10 @@ class TerrainTextureImageDataGenerator : public Qt3DRender::QTextureImageDataGen
              mExtent == otherFunctor->mExtent;
     }
 
+    // marked as deprecated in 5.15, but undeprecated for Qt 6.0. TODO -- remove when we require 6.0
+    Q_NOWARN_DEPRECATED_PUSH
     QT3D_FUNCTOR( TerrainTextureImageDataGenerator )
+    Q_NOWARN_DEPRECATED_POP
 
   private:
     QgsRectangle mExtent;


### PR DESCRIPTION
Unfortunately there's zero explanation of how to replace this in Qt docs, so for now hiding the deprecation warning is the only way to avoid this breaking the build on > 5.12 on ci.

@vcloarec @NEDJIMAbelgacem @wonder-sk  if you have any ideas on how to correctly remove this class, I'd love to hear them. (We'll need to do this properly before we'll be able to get working qgis 3d on qt 6 builds)