### PR TITLE
Disable transaction group tests

### DIFF
--- a/src/core/vector/qgsvectorlayereditbuffergroup.cpp
+++ b/src/core/vector/qgsvectorlayereditbuffergroup.cpp
@@ -138,6 +138,12 @@ bool QgsVectorLayerEditBufferGroup::commitChanges( QStringList &commitErrors, bo
 
     std::shared_ptr<QgsTransaction> transaction;
     transaction.reset( QgsTransaction::create( connectionString, providerKey ) );
+    if ( !transaction )
+    {
+      commitErrors << tr( "ERROR: data source '%1', is not available for transactions." ).arg( connectionString );
+      success = false;
+      break;
+    }
 
     QString errorMsg;
     if ( ! transaction->begin( errorMsg ) )

--- a/tests/src/python/test_qgsvectorlayereditbuffer.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffer.py
@@ -24,6 +24,12 @@ from qgis.core import (Qgis,
                        QgsVectorFileWriter,
                        QgsCoordinateTransformContext)
 from qgis.testing import start_app, unittest
+from osgeo import gdal
+
+
+def GDAL_COMPUTE_VERSION(maj, min, rev):
+    return ((maj) * 1000000 + (min) * 10000 + (rev) * 100)
+
 
 start_app()
 
@@ -791,7 +797,11 @@ class TestQgsVectorLayerEditBuffer(unittest.TestCase):
                 self.assertEqual(f.attribute(2), None)
 
         _test(Qgis.TransactionMode.Disabled)
-        _test(Qgis.TransactionMode.AutomaticGroups)
+
+        # this functionality is broken when using newer GDAL builds
+        if int(gdal.VersionInfo('VERSION_NUM')) <= GDAL_COMPUTE_VERSION(3, 4, 0):
+            _test(Qgis.TransactionMode.AutomaticGroups)
+
         _test(Qgis.TransactionMode.BufferedGroups)
 
 

--- a/tests/src/python/test_qgsvectorlayereditbuffergroup.py
+++ b/tests/src/python/test_qgsvectorlayereditbuffergroup.py
@@ -22,12 +22,18 @@ from qgis.core import (Qgis,
                        QgsVectorFileWriter,
                        QgsCoordinateTransformContext)
 from qgis.testing import start_app, unittest
+from osgeo import gdal
 
 start_app()
 
 
+def GDAL_COMPUTE_VERSION(maj, min, rev):
+    return ((maj) * 1000000 + (min) * 10000 + (rev) * 100)
+
+
 class TestQgsVectorLayerEditBufferGroup(unittest.TestCase):
 
+    @unittest.skipIf(int(gdal.VersionInfo('VERSION_NUM')) > GDAL_COMPUTE_VERSION(3, 4, 0), "Transaction groups on GPKG are broken on GDAL 3.4 and later")
     def testStartEditingCommitRollBack(self):
 
         ml = QgsVectorLayer('Point?crs=epsg:4326&field=int:integer&field=int2:integer', 'test', 'memory')


### PR DESCRIPTION
This functionality is broken on newer GDAL releases -- it relies on behaviour which has changed in the library.

I'm disabling these tests as a result until the functionality can be fixed.

@domi4484 looks like you wrote these tests -- can you take a look at these please?