### PR TITLE
Reset SVG if path is empty

### DIFF
--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -487,6 +487,7 @@ void QgsLayoutItemPicture::loadPictureUsingCache( const QString &path )
   if ( path.isEmpty() )
   {
     mImage = QImage();
+    mSVG.load( QByteArray() );
     return;
   }
 


### PR DESCRIPTION
## Description

Currently, previous loaded SVG is still render even if path is cleared. This is because only `mImage` is cleared but not `mSVG`.
This PR loads an empty `QByteArray` in `mSVG` is path is empty.
It solves this:
![export13](https://user-images.githubusercontent.com/39594821/183354012-694c6f5d-10ab-4dcf-ba8d-cac9d2cba39a.gif)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
