### PR TITLE
Backport LTR: fix removing a single raster from GPKG

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -3826,7 +3826,13 @@ QList<QgsProviderSublayerDetails> QgsGdalProviderMetadata::querySublayers( const
 
       QString name;
       const QVariantMap parts = decodeUri( uri );
-      if ( !parts.value( QStringLiteral( "vsiSuffix" ) ).toString().isEmpty() )
+
+      const QString identifier = GDALGetMetadataItem( dataset.get(), "IDENTIFIER", "" );
+      if ( !identifier.isEmpty() )
+      {
+        name = identifier;
+      }
+      else if ( !parts.value( QStringLiteral( "vsiSuffix" ) ).toString().isEmpty() )
       {
         name = parts.value( QStringLiteral( "vsiSuffix" ) ).toString();
         if ( name.startsWith( '/' ) )

--- a/tests/src/core/testqgsgdalprovider.cpp
+++ b/tests/src/core/testqgsgdalprovider.cpp
@@ -498,6 +498,16 @@ void TestQgsGdalProvider::testGdalProviderQuerySublayers()
   QCOMPARE( res.at( 1 ).driverName(), QStringLiteral( "GPKG" ) );
   rl.reset( qgis::down_cast< QgsRasterLayer * >( res.at( 1 ).toLayer( options ) ) );
   QVERIFY( rl->isValid() );
+  // geopackage with one raster layer with an identifier
+  res = mGdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/qgis_server/test_project_wms_grouped_layers.gpkg" );
+  QCOMPARE( res.count(), 1 );
+  QCOMPARE( res.at( 0 ).layerNumber(), 1 );
+  QCOMPARE( res.at( 0 ).name(), QStringLiteral( "osm" ) );
+  QCOMPARE( res.at( 0 ).description(), QString() );
+  QCOMPARE( res.at( 0 ).uri(), QStringLiteral( "%1/qgis_server/test_project_wms_grouped_layers.gpkg" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+  QCOMPARE( res.at( 0 ).providerKey(), QStringLiteral( "gdal" ) );
+  QCOMPARE( res.at( 0 ).type(), QgsMapLayerType::RasterLayer );
+  QCOMPARE( res.at( 0 ).driverName(), QStringLiteral( "GPKG" ) );
 
   // aigrid file
   res = gdalMetadata->querySublayers( QStringLiteral( TEST_DATA_DIR ) + "/aigrid" );


### PR DESCRIPTION
In QGIS 3.22, if a GPKG contains a single raster layer, its name is taken from the file, not the actual table. If the table name is different, it makes it impossible to remove such single layer:

![single_raster_in_gpkg](https://user-images.githubusercontent.com/1000043/183357436-e0429912-b26d-4318-afa8-0e7a7a00b349.png)


This issue was later fixed in https://github.com/qgis/QGIS/commit/825482db2a2329b59a97371642a902af2d6d8986 but never backported, so this PR is a backport to LTR.