### PR TITLE
Use CORE_DEPRECATED_EXPORT instead of CORE_EXPORT Q_DECL_DEPRECATED

### DIFF
--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -31,7 +31,7 @@
  * \deprecated since QGIS 3.24
  * \since QGIS 3.0 QSortFilterProxyModel with native recursive filtering can be used instead
 */
-class CORE_EXPORT Q_DECL_DEPRECATED QgsDatabaseFilterProxyModel : public QSortFilterProxyModel SIP_DEPRECATED
+class CORE_DEPRECATED_EXPORT QgsDatabaseFilterProxyModel : public QSortFilterProxyModel SIP_DEPRECATED
 {
     Q_OBJECT
 

--- a/src/core/symbology/qgsrendererrange.h
+++ b/src/core/symbology/qgsrendererrange.h
@@ -197,7 +197,7 @@ typedef QList<QgsRendererRange> QgsRangeList;
  * \since QGIS 2.6
  * \deprecated since QGIS 3.10, use QgsClassificationMethod instead
  */
-class CORE_EXPORT Q_DECL_DEPRECATED QgsRendererRangeLabelFormat SIP_DEPRECATED
+class CORE_DEPRECATED_EXPORT QgsRendererRangeLabelFormat SIP_DEPRECATED
 {
   public:
     QgsRendererRangeLabelFormat();


### PR DESCRIPTION
The former combination breaks the qt6 build on gcc
