### PR TITLE
Send QgsDebugMsg errors to std::cerr instead of qDebug 

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -485,6 +485,7 @@ int main( int argc, char *argv[] )
 {
   //log messages written before creating QgsApplication
   QStringList preApplicationLogMessages;
+  QStringList preApplicationWarningMessages;
 
 #ifdef Q_OS_UNIX
   // Increase file resource limits (i.e., number of allowed open files)
@@ -511,17 +512,17 @@ int main( int argc, char *argv[] )
 
       if ( setrlimit( RLIMIT_NOFILE, &rescLimit ) == 0 )
       {
-        QgsDebugMsg( QStringLiteral( "RLIMIT_NOFILE Soft NEW: %1 / %2" )
-                     .arg( rescLimit.rlim_cur ).arg( rescLimit.rlim_max ) );
+        QgsDebugMsgLevel( QStringLiteral( "RLIMIT_NOFILE Soft NEW: %1 / %2" )
+                          .arg( rescLimit.rlim_cur ).arg( rescLimit.rlim_max ), 2 );
       }
     }
     Q_UNUSED( oldSoft ) //avoid warnings
-    QgsDebugMsg( QStringLiteral( "RLIMIT_NOFILE Soft/Hard ORIG: %1 / %2" )
-                 .arg( oldSoft ).arg( rescLimit.rlim_max ) );
+    QgsDebugMsgLevel( QStringLiteral( "RLIMIT_NOFILE Soft/Hard ORIG: %1 / %2" )
+                      .arg( oldSoft ).arg( rescLimit.rlim_max ), 2 );
   }
 #endif
 
-  QgsDebugMsg( QStringLiteral( "Starting qgis main" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Starting qgis main" ), 0 );
 #ifdef WIN32  // Windows
 #ifdef _MSC_VER
   _set_fmode( _O_BINARY );
@@ -957,7 +958,7 @@ int main( int argc, char *argv[] )
   {
     if ( !QgsSettings::setGlobalSettingsPath( globalsettingsfile ) )
     {
-      preApplicationLogMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
+      preApplicationWarningMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
     }
     else
     {
@@ -1063,8 +1064,11 @@ int main( int argc, char *argv[] )
   QgsApplication::setLocale( QLocale() );
 
   //write the log messages written before creating QgsApplication
+  for ( const QString &preApplicationLogMessage : std::as_const( preApplicationWarningMessages ) )
+    QgsMessageLog::logMessage( preApplicationLogMessage, QString(), Qgis::MessageLevel::Warning );
+
   for ( const QString &preApplicationLogMessage : std::as_const( preApplicationLogMessages ) )
-    QgsMessageLog::logMessage( preApplicationLogMessage );
+    QgsMessageLog::logMessage( preApplicationLogMessage, QString(), Qgis::MessageLevel::Info );
 
   // Settings migration is only supported on the default profile for now.
   if ( profileName == QLatin1String( "default" ) )

--- a/src/core/providers/qgsproviderregistry.cpp
+++ b/src/core/providers/qgsproviderregistry.cpp
@@ -334,7 +334,7 @@ void QgsProviderRegistry::init()
   }
 
 #endif
-  QgsDebugMsg( QStringLiteral( "Loaded %1 providers (%2) " ).arg( mProviders.size() ).arg( providerList().join( ';' ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "Loaded %1 providers (%2) " ).arg( mProviders.size() ).arg( providerList().join( ';' ) ), 0 );
 
   QStringList pointCloudWildcards;
   QStringList pointCloudFilters;

--- a/src/core/qgslogger.cpp
+++ b/src/core/qgslogger.cpp
@@ -101,7 +101,15 @@ void QgsLogger::debug( const QString &msg, int debuglevel, const char *file, con
 
   if ( sLogFile()->isEmpty() )
   {
-    qDebug( "%s", m.toUtf8().constData() );
+    if ( debuglevel == 1 )
+    {
+      // debug level 1 is for errors only, so highlight these by dumping them to stderr
+      std::cerr << m.toUtf8().constData() << std::endl;
+    }
+    else
+    {
+      qDebug( "%s", m.toUtf8().constData() );
+    }
   }
   else
   {

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -26,7 +26,7 @@ class QgsMessageLogConsole;
 
 void QgsMessageLog::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser )
 {
-  QgsDebugMsg( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ) );
+  QgsDebugMsgLevel( QStringLiteral( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ), level == Qgis::MessageLevel::Info ? 0 : 1 );
 
   QgsApplication::messageLog()->emitMessage( message, tag, level, notifyUser );
 }


### PR DESCRIPTION
Since QgsDebugMsg should ONLY be used for errors, if we send them to std::cerr then they'll get correct color formatting
in terminals (e.g. helping with debug output when running tests)