### PR TITLE
[arcgis] Fix missing features when the query for objects' geometry results in a 500 error

### DIFF
--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -178,7 +178,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
                   QStringList(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ),
                   filterRect, errorTitle, errorMessage, mDataSource.httpHeaders(), feedback );
 
-    if ( feedback->isCanceled() )
+    if ( feedback && feedback->isCanceled() )
     {
       return false;
     }

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -144,39 +144,62 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
     return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
   }
 
-  // Fetch 100 features at the time
-  const int startId = ( id / 100 ) * 100;
-  const int stopId = std::min< size_t >( startId + 100, mObjectIds.length() );
+  bool featureFetched = false;
+  int startId, stopId;
   QList<quint32> objectIds;
-  objectIds.reserve( stopId );
-  for ( int i = startId; i < stopId; ++i )
+  QVariantMap queryData;
+  while ( !featureFetched )
   {
-    if ( i >= 0 && i < mObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
-      objectIds.append( mObjectIds.at( i ) );
-  }
+    startId = ( id / mMaximumFetchObjectsCount ) * mMaximumFetchObjectsCount;
+    stopId = std::min< size_t >( startId + mMaximumFetchObjectsCount, mObjectIds.length() );
+    objectIds.clear();
+    objectIds.reserve( stopId );
+    for ( int i = startId; i < stopId; ++i )
+    {
+      if ( i >= 0 && i < mObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
+        objectIds.append( mObjectIds.at( i ) );
+    }
 
-  if ( objectIds.empty() )
-  {
-    QgsDebugMsgLevel( QStringLiteral( "No valid features IDs to fetch" ), 2 );
-    return false;
-  }
+    if ( objectIds.empty() )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "No valid features IDs to fetch" ), 2 );
+      return false;
+    }
 
-  // don't lock while doing the fetch
-  locker.unlock();
+    // don't lock while doing the fetch
+    locker.unlock();
 
-  // Query
-  QString errorTitle, errorMessage;
+    // Query
+    QString errorTitle, errorMessage;
 
-  const QString authcfg = mDataSource.authConfigId();
-  const QVariantMap queryData = QgsArcGisRestQueryUtils::getObjects(
-                                  mDataSource.param( QStringLiteral( "url" ) ), authcfg, objectIds, mDataSource.param( QStringLiteral( "crs" ) ), true,
-                                  QStringList(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ),
-                                  filterRect, errorTitle, errorMessage, mDataSource.httpHeaders(), feedback );
+    const QString authcfg = mDataSource.authConfigId();
+    queryData = QgsArcGisRestQueryUtils::getObjects(
+                  mDataSource.param( QStringLiteral( "url" ) ), authcfg, objectIds, mDataSource.param( QStringLiteral( "crs" ) ), true,
+                  QStringList(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ),
+                  filterRect, errorTitle, errorMessage, mDataSource.httpHeaders(), feedback );
 
-  if ( queryData.isEmpty() )
-  {
-    QgsDebugMsgLevel( QStringLiteral( "Query returned empty result" ), 2 );
-    return false;
+    if ( feedback->isCanceled() )
+    {
+      return false;
+    }
+
+    if ( queryData.isEmpty() )
+    {
+      if ( mMaximumFetchObjectsCount <= 1 )
+      {
+        QgsDebugMsgLevel( QStringLiteral( "Query returned empty result" ), 2 );
+        return false;
+      }
+      else
+      {
+        locker.changeMode( QgsReadWriteLocker::Read );
+        mMaximumFetchObjectsCount = std::max( 1, mMaximumFetchObjectsCount / 5 );
+      }
+    }
+    else
+    {
+      featureFetched = true;
+    }
   }
 
   // but re-lock while updating cache

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -74,6 +74,7 @@ class QgsAfsSharedData : public QObject
     QgsRectangle mExtent;
     QgsWkbTypes::Type mGeometryType = QgsWkbTypes::Unknown;
     QgsFields mFields;
+    int mMaximumFetchObjectsCount = 100;
 
     QString mObjectIdFieldName;
     int mObjectIdFieldIdx = -1;


### PR DESCRIPTION
## Description

This PR fixes a bad issue with the arcgis feature provider whereas a query for 100 objects' fields & geometry can error out on the server side if the queried geometries result in an overly large JSON. It can often be the case with large, complex geometries.

The fix is to dynamically adjust the maximum number of objects being fetched in one query, lowering the number when an error occurred. 

