### PR TITLE
[Backport release-3_26] Fix crash caused by the Orthogonalize processing algorithm (Fix #49621)

### DIFF
--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -526,6 +526,10 @@ QgsVector calcMotion( const QgsPoint &a, const QgsPoint &b, const QgsPoint &c,
     dotProduct += 1.0;
 
   QgsVector new_v = p + q;
+  if ( qgsDoubleNear( new_v.length(), 0.0 ) )
+  {
+    return QgsVector( 0, 0 );
+  }
   // 0.1 magic number from JOSM implementation - think this is to limit each iterative step
   return new_v.normalized() * ( 0.1 * dotProduct * scale );
 }

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -5166,6 +5166,15 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertTrue(compareWkt(result, exp, 0.00001),
                         "orthogonalize: mismatch Expected:\n{}\nGot:\n{}\n".format(exp, result))
 
+        # already orthogonal polygon with a vertex on a "straight line" (https://github.com/qgis/QGIS/issues/49621)
+        polygon = QgsGeometry.fromWkt(
+            'Polygon ((0 0, 5 0, 10 0, 10 10, 0 10, 0 0))')
+        o = polygon.orthogonalize()
+        exp = 'Polygon ((0 0, 5 0, 10 0, 10 10, 0 10, 0 0))'
+        result = o.asWkt()
+        self.assertTrue(compareWkt(result, exp, 0.00001),
+                        "orthogonalize: mismatch Expected:\n{}\nGot:\n{}\n".format(exp, result))
+
     def testPolygonize(self):
         o = QgsGeometry.polygonize([])
         self.assertFalse(o)


### PR DESCRIPTION
Backport #49715