### PR TITLE
[Feature] Adds the $m, $z_at and $m_at expressions

### DIFF
--- a/resources/function_help/json/$m
+++ b/resources/function_help/json/$m
@@ -1,0 +1,11 @@
+{
+  "name": "$m",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Returns the m value of the current point feature, or NULL if the geometry has no m value. If the feature is a multipoint feature, then the m value of the first point will be returned.",
+  "examples": [{
+    "expression": "$m",
+    "returns": "12"
+  }],
+  "tags": ["first", "point", "current", "multipoint", "altitude", "measure"]
+}

--- a/resources/function_help/json/$m_at
+++ b/resources/function_help/json/$m_at
@@ -1,0 +1,15 @@
+{
+  "name": "$m_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a m coordinate of the current feature's geometry, or NULL if the geometry has no m value.",
+  "arguments": [{
+    "arg": "i",
+    "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "$m_at(1)",
+    "returns": "9"
+  }],
+  "tags": ["current", "retrieves", "feature", "coordinate", "measure"]
+}

--- a/resources/function_help/json/$z
+++ b/resources/function_help/json/$z
@@ -2,7 +2,7 @@
   "name": "$z",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns the z value of the current point feature if it is 3D. If the feature is a multipoint feature, then the z value of the first point will be returned.",
+  "description": "Returns the z value of the current point feature, or NULL if the geometry has no z value. If the feature is a multipoint feature, then the z value of the first point will be returned.",
   "examples": [{
     "expression": "$z",
     "returns": "123"

--- a/resources/function_help/json/$z_at
+++ b/resources/function_help/json/$z_at
@@ -1,0 +1,15 @@
+{
+  "name": "$z_at",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Retrieves a z coordinate of the current feature's geometry, or NULL if the geometry has no z value.",
+  "arguments": [{
+    "arg": "i",
+    "description": "index of point of a line (indices start at 0; negative values apply from the last index, starting at -1)"
+  }],
+  "examples": [{
+    "expression": "$z_at(1)",
+    "returns": "5"
+  }],
+  "tags": ["current", "retrieves", "feature", "coordinate", "3D"]
+}

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -130,7 +130,7 @@ col_first    [A-Za-z_]|{non_ascii}
 col_next     [A-Za-z0-9_]|{non_ascii}
 identifier  {col_first}{col_next}*
 
-deprecated_function "$"[xXyY]_?[aA][tT]
+deprecated_function "$"[xXyYzZmM]_?[aA][tT]
 special_col "$"{identifier}
 variable "@"{identifier}
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3264,7 +3264,7 @@ class TestQgsExpression: public QObject
       context.setFeature( fPolygon );
       yAt = expYAt.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 6.0 );
-      QgsExpression expYAt2( QStringLiteral( "$y_at(1)" ) );
+      QgsExpression expYAt2( QStringLiteral( "y_at(1)" ) );
       context.setFeature( fPolyline );
       yAt = expYAt2.evaluate( &context );
       QCOMPARE( yAt.toDouble(), 0.0 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3095,13 +3095,14 @@ class TestQgsExpression: public QObject
       QTest::addColumn<bool>( "evalError" );
       QTest::addColumn<QVariant>( "result" );
 
-      QgsPoint point( 123, 456, 789 );
+      QgsPoint point( 123, 456, 789, 987 );
       QgsPolylineXY line;
       line << QgsPointXY( 1, 1 ) << QgsPointXY( 4, 2 ) << QgsPointXY( 3, 1 );
 
       QTest::newRow( "geom x" ) << "$x" << QgsGeometry( std::make_unique<QgsPoint>( point ) ) << false << QVariant( 123. );
       QTest::newRow( "geom y" ) << "$y" << QgsGeometry( std::make_unique<QgsPoint>( point ) ) << false << QVariant( 456. );
       QTest::newRow( "geom z" ) << "$z" << QgsGeometry( std::make_unique<QgsPoint>( point ) ) << false << QVariant( 789. );
+      QTest::newRow( "geom m" ) << "$m" << QgsGeometry( std::make_unique<QgsPoint>( point ) ) << false << QVariant( 987. );
       QTest::newRow( "geom xat" ) << "xat(-1)" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 3. );
       QTest::newRow( "geom yat" ) << "yat(1)" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 2. );
       QTest::newRow( "null geometry" ) << "$geometry" << QgsGeometry() << false << QVariant();


### PR DESCRIPTION
## Description

This PR adds the `$m` (`$z` has already been added), `$z_at()` and `$m_at()` functions in the expressions.

Sponsored by: Métropole Européenne de Lille, cc @Jean-Roc