### PR TITLE
Add API to QgsProjectViewSettings to allow setting default map rotation

### DIFF
--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -157,6 +157,42 @@ while working with this project.
 .. seealso:: :py:func:`mapScales`
 %End
 
+    double defaultRotation() const;
+%Docstring
+Returns the default map rotation (in clockwise degrees) for maps in the project.
+
+.. warning::
+
+   When a project is opened in the QGIS desktop application and saved, individual
+   map canvases will store their own previous map rotations as custom project properties. Reloading
+   this saved version of the project will trigger the canvases to restore their individual rotations.
+   Accordingly, in the QGIS desktop application, this setting only forms a default, initial
+   view used when the project is opened for the very first time (or when new map canvases are opened in
+   that project.)
+
+.. seealso:: :py:func:`setDefaultRotation`
+
+.. versionadded:: 3.28
+%End
+
+    void setDefaultRotation( double rotation );
+%Docstring
+Set the default ``rotation`` of maps in the project, in clockwise degrees.
+
+.. warning::
+
+   When a project is opened in the QGIS desktop application and saved, individual
+   map canvases will store their own previous map rotations as custom project properties. Reloading
+   this saved version of the project will trigger the canvases to restore their individual rotations.
+   Accordingly, in the QGIS desktop application, this setting only forms a default, initial
+   view used when the project is opened for the very first time (or when new map canvases are opened in
+   that project.)
+
+.. seealso:: :py:func:`defaultRotation`
+
+.. versionadded:: 3.28
+%End
+
     bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Reads the settings's state from a DOM element.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6414,6 +6414,7 @@ bool QgisApp::fileSave()
 
   // Store current map view settings into the project
   QgsProject::instance()->viewSettings()->setDefaultViewExtent( QgsReferencedRectangle( mapCanvas()->extent(), QgsProject::instance()->crs() ) );
+  QgsProject::instance()->viewSettings()->setDefaultRotation( mapCanvas()->rotation() );
 
   if ( QgsProject::instance()->write() )
   {

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -16,7 +16,6 @@
 #include "qgsprojectviewsettings.h"
 #include "qgis.h"
 #include "qgsproject.h"
-#include "qgslogger.h"
 #include "qgsmaplayerutils.h"
 #include "qgscoordinatetransform.h"
 #include <QDomElement>
@@ -31,6 +30,8 @@ QgsProjectViewSettings::QgsProjectViewSettings( QgsProject *project )
 void QgsProjectViewSettings::reset()
 {
   mDefaultViewExtent = QgsReferencedRectangle();
+
+  mDefaultRotation = 0;
 
   const bool fullExtentChanged = !mPresetFullExtent.isNull();
   mPresetFullExtent = QgsReferencedRectangle();
@@ -130,6 +131,16 @@ bool QgsProjectViewSettings::useProjectScales() const
   return mUseProjectScales;
 }
 
+double QgsProjectViewSettings::defaultRotation() const
+{
+  return mDefaultRotation;
+}
+
+void QgsProjectViewSettings::setDefaultRotation( double rotation )
+{
+  mDefaultRotation = rotation;
+}
+
 bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadWriteContext & )
 {
   const bool useProjectScale = element.attribute( QStringLiteral( "UseProjectScales" ), QStringLiteral( "0" ) ).toInt();
@@ -185,6 +196,8 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
     setPresetFullExtent( QgsReferencedRectangle() );
   }
 
+  mDefaultRotation = element.attribute( QStringLiteral( "rotation" ), QStringLiteral( "0" ) ).toDouble();
+
   return true;
 }
 
@@ -192,6 +205,8 @@ QDomElement QgsProjectViewSettings::writeXml( QDomDocument &doc, const QgsReadWr
 {
   QDomElement element = doc.createElement( QStringLiteral( "ProjectViewSettings" ) );
   element.setAttribute( QStringLiteral( "UseProjectScales" ), mUseProjectScales ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+
+  element.setAttribute( QStringLiteral( "rotation" ), qgsDoubleToString( mDefaultRotation ) );
 
   QDomElement scales = doc.createElement( QStringLiteral( "Scales" ) );
   for ( const double scale : mMapScales )

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -163,6 +163,36 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     bool useProjectScales() const;
 
     /**
+     * Returns the default map rotation (in clockwise degrees) for maps in the project.
+     *
+     * \warning When a project is opened in the QGIS desktop application and saved, individual
+     * map canvases will store their own previous map rotations as custom project properties. Reloading
+     * this saved version of the project will trigger the canvases to restore their individual rotations.
+     * Accordingly, in the QGIS desktop application, this setting only forms a default, initial
+     * view used when the project is opened for the very first time (or when new map canvases are opened in
+     * that project.)
+     *
+     * \see setDefaultRotation()
+     * \since QGIS 3.28
+     */
+    double defaultRotation() const;
+
+    /**
+     * Set the default \a rotation of maps in the project, in clockwise degrees.
+     *
+     * \warning When a project is opened in the QGIS desktop application and saved, individual
+     * map canvases will store their own previous map rotations as custom project properties. Reloading
+     * this saved version of the project will trigger the canvases to restore their individual rotations.
+     * Accordingly, in the QGIS desktop application, this setting only forms a default, initial
+     * view used when the project is opened for the very first time (or when new map canvases are opened in
+     * that project.)
+     *
+     * \see defaultRotation()
+     * \since QGIS 3.28
+     */
+    void setDefaultRotation( double rotation );
+
+    /**
      * Reads the settings's state from a DOM element.
      * \see writeXml()
      */
@@ -198,6 +228,7 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     bool mUseProjectScales = false;
     QgsReferencedRectangle mDefaultViewExtent;
     QgsReferencedRectangle mPresetFullExtent;
+    double mDefaultRotation = 0;
 };
 
 #endif // QGSPROJECTVIEWSETTINGS_H

--- a/src/gui/layout/qgslayoutguiutils.cpp
+++ b/src/gui/layout/qgslayoutguiutils.cpp
@@ -127,6 +127,7 @@ void QgsLayoutGuiUtils::registerGuiForKnownItemTypes( QgsMapCanvas *mapCanvas )
 
     if ( mapCanvas )
     {
+      map->setMapRotation( mapCanvas->rotation() );
       map->zoomToExtent( mapCanvas->mapSettings().visibleExtent() );
     }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -3210,8 +3210,10 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
     if ( !project->viewSettings()->defaultViewExtent().isNull() )
     {
       setReferencedExtent( project->viewSettings()->defaultViewExtent() );
-      clearExtentHistory(); // clear the extent history on project load
     }
+
+    setRotation( project->viewSettings()->defaultRotation() );
+    clearExtentHistory(); // clear the extent history on project load
   }
 }
 

--- a/tests/src/python/test_qgsprojectviewsettings.py
+++ b/tests/src/python/test_qgsprojectviewsettings.py
@@ -129,6 +129,32 @@ class TestQgsProjectViewSettings(unittest.TestCase):
         self.assertAlmostEqual(canvas.extent().yMaximum(), 0.02245788, 3)
         self.assertEqual(canvas.mapSettings().destinationCrs().authid(), 'EPSG:4326')
 
+    def testDefaultRotation(self):
+        p = QgsProjectViewSettings()
+        self.assertEqual(p.defaultRotation(), 0)
+
+        p.setDefaultRotation(37)
+        self.assertEqual(p.defaultRotation(), 37)
+
+        p.reset()
+        self.assertEqual(p.defaultRotation(), 0)
+
+    def testDefaultRotationWithCanvas(self):
+        p = QgsProject()
+        p.viewSettings().setDefaultRotation(14)
+
+        canvas = QgsMapCanvas()
+        canvas.setRotation(37)
+        canvas.show()
+
+        tmpDir = QTemporaryDir()
+        tmpFile = "{}/project.qgz".format(tmpDir.path())
+        self.assertTrue(p.write(tmpFile))
+
+        QgsProject.instance().read(tmpFile)
+
+        self.assertEqual(canvas.rotation(), 14)
+
     def testPresetFullExtent(self):
         p = QgsProjectViewSettings()
         self.assertTrue(p.presetFullExtent().isNull())


### PR DESCRIPTION
Provides a stable means for scripts to set the map rotation.

I'd like to backport this -- it's a bad gap in our current PyQGIS API.
