### PR TITLE
[Qt6] date time widget fixes

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -7,7 +7,6 @@ test_core_labelingengine
 test_core_layoutpicture
 test_core_ogcutils
 test_core_vectortilelayer
-test_gui_datetimeedit
 test_gui_processinggui
 test_gui_querybuilder
 test_app_advanceddigitizing

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -314,6 +314,13 @@ void QgsDateTimeEdit::resetBeforeChange( int delta )
   QDateTimeEdit::setDateTime( dt );
 }
 
+void QgsDateTimeEdit::setMinimumEditDateTime()
+{
+  setDateRange( QDate( 1, 1, 1 ), maximumDate() );
+  setMinimumTime( QTime( 0, 0, 0 ) );
+  setMaximumTime( QTime( 23, 59, 59, 999 ) );
+}
+
 void QgsDateTimeEdit::setDateTime( const QDateTime &dateTime )
 {
   mIsEmpty = false;

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -204,10 +204,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     * \note not available in Python bindings
     * \since QGIS 3.0
     */
-    void setMinimumEditDateTime()
-    {
-      setDateTimeRange( QDateTime( QDate( 1, 1, 1 ), QTime( 0, 0, 0 ) ), maximumDateTime() );
-    }
+    void setMinimumEditDateTime();
 
     friend class TestQgsDateTimeEdit;
 };

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -181,6 +181,9 @@ QVariant QgsDateTimeEditWrapper::value() const
     dateTime = mQDateTimeEdit->dateTime();
   }
 
+  if ( dateTime.isNull() )
+    return QVariant( field().type() );
+
   switch ( field().type() )
   {
     case QVariant::DateTime:


### PR DESCRIPTION
There's a VERY subtle difference in qt 6 which will cause us some
pain. In Qt 5 QVariant(QDateTime()).isNull()/!isValid() returns true,
but in Qt 6 this returns false. So we have to instead check
variant.toDateTime().isNull().

The same applies for other null types stored in a variant.