### PR TITLE
Introduce QgsVariantUtils::isNull( QVariant ) 

### DIFF
--- a/python/core/auto_generated/qgsvariantutils.sip.in
+++ b/python/core/auto_generated/qgsvariantutils.sip.in
@@ -29,6 +29,16 @@ Returns a user-friendly translated string representing a QVariant ``type``.
 The optional ``subType`` can be used to specify the type of variant list or map values.
 %End
 
+    static bool isNull( const QVariant &variant );
+%Docstring
+Returns ``True`` if the specified ``variant`` should be considered a NULL value.
+
+This method is more rigorous vs QVariant.isNull(), which will return
+``False`` on newer Qt versions for tests like `QVariant( QDateTime() ).isNull()`.
+
+.. versionadded:: 3.28
+%End
+
 };
 
 /************************************************************************

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -21,6 +21,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
 #include "qgsfeedback.h"
+#include "qgsvariantutils.h"
 
 QgsInterpolator::QgsInterpolator( const QList<LayerData> &layerData )
   : mLayerData( layerData )
@@ -88,7 +89,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
         case ValueAttribute:
         {
           QVariant attributeVariant = feature.attribute( layer.interpolationAttribute );
-          if ( !attributeVariant.isValid() || attributeVariant.isNull() ) //attribute not found, something must be wrong (e.g. NULL value)
+          if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
           {
             continue;
           }

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -25,7 +25,7 @@
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgsvectorlayer.h"
-#include "qgswkbptr.h"
+#include "qgsvariantutils.h"
 #include "qgsfeedback.h"
 #include "qgscurve.h"
 #include "qgsmulticurve.h"
@@ -184,7 +184,7 @@ int QgsTinInterpolator::insertData( const QgsFeature &f, QgsInterpolator::ValueS
     case ValueAttribute:
     {
       QVariant attributeVariant = f.attribute( attr );
-      if ( !attributeVariant.isValid() || attributeVariant.isNull() ) //attribute not found, something must be wrong (e.g. NULL value)
+      if ( QgsVariantUtils::isNull( attributeVariant ) ) //attribute not found, something must be wrong (e.g. NULL value)
       {
         return 3;
       }

--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmgeometrybyexpression.h"
-#include "qgsgeometrycollection.h"
+#include "qgsvariantutils.h"
 
 ///@cond PRIVATE
 
@@ -139,7 +139,7 @@ QgsFeatureList QgsGeometryByExpressionAlgorithm::processFeature( const QgsFeatur
     throw QgsProcessingException( QObject::tr( "Evaluation error: %1" ).arg( mExpression.evalErrorString() ) );
   }
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     feature.setGeometry( QgsGeometry() );
   }

--- a/src/analysis/processing/qgsalgorithmpointslayerfromtable.cpp
+++ b/src/analysis/processing/qgsalgorithmpointslayerfromtable.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmpointslayerfromtable.h"
+#include "qgsvariantutils.h"
 
 ///@cond PRIVATE
 
@@ -132,14 +133,14 @@ QVariantMap QgsPointsLayerFromTableAlgorithm::processAlgorithm( const QVariantMa
     const double x = attrs.at( xFieldIndex ).toDouble( &xOk );
     const double y = attrs.at( yFieldIndex ).toDouble( &yOk );
 
-    if ( ! attrs.at( xFieldIndex ).isNull() && ! attrs.at( yFieldIndex ).isNull() && xOk && yOk )
+    if ( ! QgsVariantUtils::isNull( attrs.at( xFieldIndex ) ) && ! QgsVariantUtils::isNull( attrs.at( yFieldIndex ) ) && xOk && yOk )
     {
       QgsPoint point( x, y );
 
-      if ( zFieldIndex >= 0 && ! attrs.at( zFieldIndex ).isNull() )
+      if ( zFieldIndex >= 0 && ! QgsVariantUtils::isNull( attrs.at( zFieldIndex ) ) )
         point.addZValue( attrs.at( zFieldIndex ).toDouble() );
 
-      if ( mFieldIndex >= 0 && ! attrs.at( mFieldIndex ).isNull() )
+      if ( mFieldIndex >= 0 && ! QgsVariantUtils::isNull( attrs.at( mFieldIndex ) ) )
         point.addMValue( attrs.at( mFieldIndex ).toDouble() );
 
       f.setGeometry( QgsGeometry( point.clone() ) );

--- a/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
+++ b/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
@@ -20,6 +20,7 @@
 #include "qgsreclassifyutils.h"
 #include "qgsrasteranalysisutils.h"
 #include "qgis.h"
+#include "qgsvariantutils.h"
 
 ///@cond PRIVATE
 
@@ -230,7 +231,7 @@ QVector<QgsReclassifyUtils::RasterClass> QgsReclassifyByLayerAlgorithm::createCl
     // null values map to nan, which corresponds to a range extended to +/- infinity....
     const QVariant minVariant = f.attribute( mMinFieldIdx );
     double minValue;
-    if ( minVariant.isNull() || minVariant.toString().isEmpty() )
+    if ( QgsVariantUtils::isNull( minVariant ) || minVariant.toString().isEmpty() )
     {
       minValue = std::numeric_limits<double>::quiet_NaN();
     }
@@ -242,7 +243,7 @@ QVector<QgsReclassifyUtils::RasterClass> QgsReclassifyByLayerAlgorithm::createCl
     }
     const QVariant maxVariant = f.attribute( mMaxFieldIdx );
     double maxValue;
-    if ( maxVariant.isNull() || maxVariant.toString().isEmpty() )
+    if ( QgsVariantUtils::isNull( maxVariant ) || maxVariant.toString().isEmpty() )
     {
       maxValue = std::numeric_limits<double>::quiet_NaN();
       ok = true;
@@ -323,7 +324,7 @@ QVector<QgsReclassifyUtils::RasterClass> QgsReclassifyByTableAlgorithm::createCl
     // null values map to nan, which corresponds to a range extended to +/- infinity....
     const QVariant minVariant = table.at( row * 3 );
     double minValue;
-    if ( minVariant.isNull()  || minVariant.toString().isEmpty() )
+    if ( QgsVariantUtils::isNull( minVariant )  || minVariant.toString().isEmpty() )
     {
       minValue = std::numeric_limits<double>::quiet_NaN();
     }
@@ -335,7 +336,7 @@ QVector<QgsReclassifyUtils::RasterClass> QgsReclassifyByTableAlgorithm::createCl
     }
     const QVariant maxVariant = table.at( row * 3 + 1 );
     double maxValue;
-    if ( maxVariant.isNull() || maxVariant.toString().isEmpty() )
+    if ( QgsVariantUtils::isNull( maxVariant ) || maxVariant.toString().isEmpty() )
     {
       maxValue = std::numeric_limits<double>::quiet_NaN();
       ok = true;

--- a/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitvectorlayer.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsalgorithmsplitvectorlayer.h"
 #include "qgsvectorfilewriter.h"
+#include "qgsvariantutils.h"
 
 ///@cond PRIVATE
 
@@ -120,7 +121,7 @@ QVariantMap QgsSplitVectorLayerAlgorithm::processAlgorithm( const QVariantMap &p
       break;
 
     QString fileName;
-    if ( ( *it ).isNull() )
+    if ( QgsVariantUtils::isNull( *it ) )
     {
       fileName = QStringLiteral( "%1_NULL.%2" ).arg( baseName ).arg( outputFormat );
     }

--- a/src/app/labeling/qgslabelpropertydialog.cpp
+++ b/src/app/labeling/qgslabelpropertydialog.cpp
@@ -376,7 +376,7 @@ void QgsLabelPropertyDialog::setDataDefinedValues( QgsVectorLayer *vlayer )
 
     //TODO - pass expression context
     const QVariant result = mDataDefinedProperties.value( key, context );
-    if ( !result.isValid() || result.isNull() )
+    if ( QgsVariantUtils::isNull( result ) )
     {
       //could not evaluate data defined value
       continue;

--- a/src/app/labeling/qgsmaptoollabel.cpp
+++ b/src/app/labeling/qgsmaptoollabel.cpp
@@ -378,7 +378,7 @@ QgsMapToolLabel::LabelAlignment QgsMapToolLabel::currentAlignment()
     if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::OffsetQuad ) )
     {
       QVariant exprVal = evaluateDataDefinedProperty( QgsPalLayerSettings::OffsetQuad, mCurrentLabel.settings, f, static_cast< int >( quadrantOffset ) );
-      if ( !exprVal.isNull() )
+      if ( !QgsVariantUtils::isNull( exprVal ) )
       {
         bool ok;
         int quadInt = exprVal.toInt( &ok );
@@ -829,7 +829,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedPosition( double &x, bool &xSuccess
     if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::PositionPoint ) )
     {
       if ( pointCol >= 0
-           && !attributes.at( pointCol ).isNull() )
+           && !QgsVariantUtils::isNull( attributes.at( pointCol ) ) )
       {
         QVariant pointAsVariant = attributes.at( pointCol );
         if ( pointAsVariant.userType() == QMetaType::type( "QgsGeometry" ) )
@@ -848,9 +848,9 @@ bool QgsMapToolLabel::currentLabelDataDefinedPosition( double &x, bool &xSuccess
     }
     else
     {
-      if ( !attributes.at( xCol ).isNull() )
+      if ( !QgsVariantUtils::isNull( attributes.at( xCol ) ) )
         x = attributes.at( xCol ).toDouble( &xSuccess );
-      if ( !attributes.at( yCol ).isNull() )
+      if ( !QgsVariantUtils::isNull( attributes.at( yCol ) ) )
         y = attributes.at( yCol ).toDouble( &ySuccess );
     }
   }
@@ -891,7 +891,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedLineAnchorPercent( double &lineAnch
 
   if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::LineAnchorPercent ) )
   {
-    if ( !attributes.at( lineAnchorPercentCol ).isNull() )
+    if ( !QgsVariantUtils::isNull( attributes.at( lineAnchorPercentCol ) ) )
     {
       lineAnchorPercent = attributes.at( lineAnchorPercentCol ).toDouble( &lineAnchorPercentSuccess );
     }
@@ -899,7 +899,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedLineAnchorPercent( double &lineAnch
 
   if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::LineAnchorClipping ) )
   {
-    if ( !attributes.at( lineAnchorClippingCol ).isNull() )
+    if ( !QgsVariantUtils::isNull( attributes.at( lineAnchorClippingCol ) ) )
     {
       lineAnchorClipping = attributes.at( lineAnchorClippingCol ).toString();
     }
@@ -911,7 +911,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedLineAnchorPercent( double &lineAnch
 
   if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::LineAnchorType ) )
   {
-    if ( !attributes.at( lineAnchorTypeCol ).isNull() )
+    if ( !QgsVariantUtils::isNull( attributes.at( lineAnchorTypeCol ) ) )
     {
       lineAnchorType = attributes.at( lineAnchorTypeCol ).toString();
     }
@@ -923,7 +923,7 @@ bool QgsMapToolLabel::currentLabelDataDefinedLineAnchorPercent( double &lineAnch
 
   if ( mCurrentLabel.settings.dataDefinedProperties().isActive( QgsPalLayerSettings::LineAnchorTextPoint ) )
   {
-    if ( !attributes.at( lineAnchorTextPointCol ).isNull() )
+    if ( !QgsVariantUtils::isNull( attributes.at( lineAnchorTextPointCol ) ) )
     {
       lineAnchorTextPoint = attributes.at( lineAnchorTextPointCol ).toString();
     }

--- a/src/app/labeling/qgsmaptoolmovelabel.cpp
+++ b/src/app/labeling/qgsmaptoolmovelabel.cpp
@@ -833,9 +833,9 @@ bool QgsMapToolMoveLabel::currentCalloutDataDefinedPosition( double &x, bool &xS
   }
 
   const QgsAttributes attributes = f.attributes();
-  if ( !attributes.at( xCol ).isNull() )
+  if ( !QgsVariantUtils::isNull( attributes.at( xCol ) ) )
     x = attributes.at( xCol ).toDouble( &xSuccess );
-  if ( !attributes.at( yCol ).isNull() )
+  if ( !QgsVariantUtils::isNull( attributes.at( yCol ) ) )
     y = attributes.at( yCol ).toDouble( &ySuccess );
 
   return true;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1010,7 +1010,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipBadLayers
 
   connect( mMapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
 
-  if ( settings.value( QStringLiteral( "qgis/main_canvas_preview_jobs" ) ).isNull() )
+  if ( !settings.value( QStringLiteral( "qgis/main_canvas_preview_jobs" ) ).isValid() )
   {
     // So that it appears in advanced settings
     settings.setValue( QStringLiteral( "qgis/main_canvas_preview_jobs" ), true );

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -278,7 +278,7 @@ void QgsGeometryValidationDock::onCurrentErrorChanged( const QModelIndex &curren
     }
   }
 
-  const bool hasContextRectangle = !current.data( QgsGeometryValidationModel::FeatureExtentRole ).isNull();
+  const bool hasContextRectangle = !QgsVariantUtils::isNull( current.data( QgsGeometryValidationModel::FeatureExtentRole ) );
   mZoomToFeatureButton->setEnabled( hasContextRectangle );
 }
 

--- a/src/app/qgsgeometryvalidationmodel.cpp
+++ b/src/app/qgsgeometryvalidationmodel.cpp
@@ -82,7 +82,7 @@ QVariant QgsGeometryValidationModel::data( const QModelIndex &index, int role ) 
         mExpressionContext.setFeature( feature );
         const QVariant featureTitle = mDisplayExpression.evaluate( &mExpressionContext );
 
-        if ( featureTitle.isNull() )
+        if ( QgsVariantUtils::isNull( featureTitle ) )
         {
           return topologyError->description();
         }

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -706,7 +706,7 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
       continue;
     }
 
-    if ( attrs.at( i ).isNull() && QgsIdentifyResultsDialog::settingHideNullValues.value() )
+    if ( QgsVariantUtils::isNull( attrs.at( i ) ) && QgsIdentifyResultsDialog::settingHideNullValues.value() )
     {
       continue;
     }
@@ -1259,7 +1259,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorTileLayer *layer,
     if ( i >= fields.count() )
       break;
 
-    if ( attrs.at( i ).isNull() || !attrs.at( i ).isValid() )
+    if ( QgsVariantUtils::isNull( attrs.at( i ) ) )
       continue;  // skip attributes that are not present (there can be many of them)
 
     const QString value = fields.at( i ).displayString( attrs.at( i ) );

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -369,7 +369,7 @@ void QgsMapToolOffsetCurve::applyOffset( double offset, Qt::KeyboardModifiers mo
         QgsAttributeMap attrs;
         for ( int idx = 0; idx < destLayer->fields().count(); ++idx )
         {
-          if ( !feature.attribute( idx ).isNull() )
+          if ( !QgsVariantUtils::isNull( feature.attribute( idx ) ) )
             attrs[idx] = feature.attribute( idx );
         }
 

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -287,7 +287,7 @@ void QgsStatisticalSummaryDockWidget::updateNumericStatistics()
     const double val = value.toDouble( &convertOk );
     if ( convertOk )
       values << val;
-    else if ( value.isNull() )
+    else if ( QgsVariantUtils::isNull( value ) )
     {
       missingValues += 1;
     }

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -207,7 +207,7 @@ void QgsWelcomePage::recentProjectItemActivated( const QModelIndex &index )
 
 void QgsWelcomePage::templateProjectItemActivated( const QModelIndex &index )
 {
-  if ( index.data( QgsProjectListItemDelegate::NativePathRole ).isNull() )
+  if ( !index.data( QgsProjectListItemDelegate::NativePathRole ).isValid() )
     QgisApp::instance()->newProject();
   else
     QgisApp::instance()->fileNewFromTemplate( index.data( QgsProjectListItemDelegate::NativePathRole ).toString() );

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -567,7 +567,7 @@ QWidget *CoordinateItemDelegate::createEditor( QWidget *parent, const QStyleOpti
 {
   QLineEdit *lineEdit = new QLineEdit( parent );
   QgsDoubleValidator *validator = new QgsDoubleValidator( lineEdit );
-  if ( !index.data( MIN_RADIUS_ROLE ).isNull() )
+  if ( index.data( MIN_RADIUS_ROLE ).isValid() )
     validator->setBottom( index.data( MIN_RADIUS_ROLE ).toDouble() );
   lineEdit->setValidator( validator );
   return lineEdit;

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -21,7 +21,7 @@
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
-
+#include "qgsvariantutils.h"
 
 QgsAuthOAuth2Config::QgsAuthOAuth2Config( QObject *parent )
   : QObject( parent )
@@ -480,7 +480,7 @@ QVariantMap QgsAuthOAuth2Config::variantFromSerialized(
         return vmap;
       }
 
-      if ( var.isNull() )
+      if ( QgsVariantUtils::isNull( var ) )
       {
         QgsDebugMsg( QStringLiteral( "Error parsing JSON to variant: %1" ).arg( "invalid or null" ) );
         if ( ok )

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "qgsauthmanager.h"
+#include "qgsvariantutils.h"
 
 #include <QDir>
 #include <QEventLoop>
@@ -2707,11 +2708,11 @@ const QList<QSslCertificate> QgsAuthManager::extraFileCAs()
   QList<QSslCertificate> certs;
   QList<QSslCertificate> filecerts;
   QVariant cafileval = QgsAuthManager::instance()->authSetting( QStringLiteral( "cafile" ) );
-  if ( cafileval.isNull() )
+  if ( QgsVariantUtils::isNull( cafileval ) )
     return certs;
 
   QVariant allowinvalid = QgsAuthManager::instance()->authSetting( QStringLiteral( "cafileallowinvalid" ), QVariant( false ) );
-  if ( allowinvalid.isNull() )
+  if ( QgsVariantUtils::isNull( allowinvalid ) )
     return certs;
 
   QString cafile( cafileval.toString() );
@@ -2945,7 +2946,7 @@ QgsAuthCertUtils::CertTrustPolicy QgsAuthManager::defaultCertTrustPolicy()
 {
   QMutexLocker locker( mMutex.get() );
   QVariant policy( authSetting( QStringLiteral( "certdefaulttrust" ) ) );
-  if ( policy.isNull() )
+  if ( QgsVariantUtils::isNull( policy ) )
   {
     return QgsAuthCertUtils::Trusted;
   }

--- a/src/core/callouts/qgscallout.cpp
+++ b/src/core/callouts/qgscallout.cpp
@@ -23,7 +23,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsxmlutils.h"
 #include "qgslinestring.h"
-#include "qgslogger.h"
+#include "qgsvariantutils.h"
 #include "qgsgeos.h"
 #include "qgsgeometryutils.h"
 #include "qgscircularstring.h"
@@ -1236,7 +1236,7 @@ QPolygonF QgsBalloonCallout::getPoints( QgsRenderContext &context, QgsPointXY or
   if ( dataDefinedProperties().isActive( QgsCallout::Margins ) )
   {
     const QVariant value = dataDefinedProperties().value( QgsCallout::Margins, context.expressionContext() );
-    if ( !value.isNull() )
+    if ( !QgsVariantUtils::isNull( value ) )
     {
       if ( value.type() == QVariant::List )
       {

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -50,6 +50,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsdxfexport_p.h"
 #include "qgssymbol.h"
+#include "qgsvariantutils.h"
 
 #include "qgswkbtypes.h"
 #include "qgspoint.h"
@@ -1308,7 +1309,7 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
     if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
     {
       const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
-      if ( !exprVal.isNull() )
+      if ( !QgsVariantUtils::isNull( exprVal ) )
       {
         offsetQuad = static_cast<Qgis::LabelQuadrantPosition>( exprVal.toInt() );
       }
@@ -1362,7 +1363,7 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
     hali = HAlign::HLeft;
     QVariant exprVal = props.value( QgsPalLayerSettings::Hali, expressionContext );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const QString haliString = exprVal.toString();
       if ( haliString.compare( QLatin1String( "Center" ), Qt::CaseInsensitive ) == 0 )
@@ -1381,7 +1382,7 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
   {
     vali = VAlign::VBottom;
     QVariant exprVal = props.value( QgsPalLayerSettings::Vali, expressionContext );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const QString valiString = exprVal.toString();
       if ( valiString.compare( QLatin1String( "Bottom" ), Qt::CaseInsensitive ) != 0 )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -25,6 +25,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsexpressionutils.h"
 #include "qgsexpression_p.h"
+#include "qgsvariantutils.h"
 
 #include <QRegularExpression>
 
@@ -86,7 +87,7 @@ QString QgsExpression::quotedValue( const QVariant &value )
 
 QString QgsExpression::quotedValue( const QVariant &value, QVariant::Type type )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( type )
@@ -1129,7 +1130,7 @@ QString QgsExpression::createFieldEqualityExpression( const QString &fieldName, 
 {
   QString expr;
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     expr = QStringLiteral( "%1 IS NULL" ).arg( quotedColumnRef( fieldName ) );
   else if ( fieldType == QVariant::Type::Invalid )
     expr = QStringLiteral( "%1 = %2" ).arg( quotedColumnRef( fieldName ), quotedValue( value ) );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -38,6 +38,7 @@
 #include "qgsregularpolygon.h"
 #include "qgsquadrilateral.h"
 #include "qgsmultipolygon.h"
+#include "qgsvariantutils.h"
 #include "qgsogcutils.h"
 #include "qgsdistancearea.h"
 #include "qgsgeometryengine.h"
@@ -530,7 +531,7 @@ static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *
   double maxVal = std::numeric_limits<double>::quiet_NaN();
   for ( const QVariant &val : values )
   {
-    double testVal = val.isNull() ? std::numeric_limits<double>::quiet_NaN() : QgsExpressionUtils::getDoubleValue( val, parent );
+    double testVal = QgsVariantUtils::isNull( val ) ? std::numeric_limits<double>::quiet_NaN() : QgsExpressionUtils::getDoubleValue( val, parent );
     if ( std::isnan( maxVal ) )
     {
       maxVal = testVal;
@@ -554,7 +555,7 @@ static QVariant fcnMin( const QVariantList &values, const QgsExpressionContext *
   double minVal = std::numeric_limits<double>::quiet_NaN();
   for ( const QVariant &val : values )
   {
-    double testVal = val.isNull() ? std::numeric_limits<double>::quiet_NaN() : QgsExpressionUtils::getDoubleValue( val, parent );
+    double testVal = QgsVariantUtils::isNull( val ) ? std::numeric_limits<double>::quiet_NaN() : QgsExpressionUtils::getDoubleValue( val, parent );
     if ( std::isnan( minVal ) )
     {
       minVal = testVal;
@@ -905,7 +906,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
     QgsExpression groupByExp( groupBy );
     QVariant groupByValue = groupByExp.evaluate( context );
     QString groupByClause = QStringLiteral( "%1 %2 %3" ).arg( groupBy,
-                            groupByValue.isNull() ? QStringLiteral( "is" ) : QStringLiteral( "=" ),
+                            QgsVariantUtils::isNull( groupByValue ) ? QStringLiteral( "is" ) : QStringLiteral( "=" ),
                             QgsExpression::quotedValue( groupByValue ) );
     if ( !parameters.filter.isEmpty() )
       parameters.filter = QStringLiteral( "(%1) AND (%2)" ).arg( parameters.filter, groupByClause );
@@ -1103,7 +1104,7 @@ static QVariant fcnMapScale( const QVariantList &, const QgsExpressionContext *c
 
   QVariant scale = context->variable( QStringLiteral( "map_scale" ) );
   bool ok = false;
-  if ( !scale.isValid() || scale.isNull() )
+  if ( QgsVariantUtils::isNull( scale ) )
     return QVariant();
 
   const double v = scale.toDouble( &ok );
@@ -1258,7 +1259,7 @@ static QVariant fcnCoalesce( const QVariantList &values, const QgsExpressionCont
 {
   for ( const QVariant &value : values )
   {
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
       continue;
     return value;
   }
@@ -1711,7 +1712,7 @@ static QVariant fcnAttribute( const QVariantList &values, const QgsExpressionCon
 static QVariant fcnAttributes( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsFeature feature;
-  if ( values.size() == 0 || values.at( 0 ).isNull() )
+  if ( values.size() == 0 || QgsVariantUtils::isNull( values.at( 0 ) ) )
   {
     feature = context->feature();
   }
@@ -2123,7 +2124,7 @@ static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContex
   QString concat;
   for ( const QVariant &value : values )
   {
-    if ( !value.isNull() )
+    if ( !QgsVariantUtils::isNull( value ) )
       concat += QgsExpressionUtils::getStringValue( value, parent );
   }
   return concat;
@@ -4108,7 +4109,7 @@ static QVariant fcnIsEmpty( const QVariantList &values, const QgsExpressionConte
 
 static QVariant fcnIsEmptyOrNull( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  if ( values.at( 0 ).isNull() )
+  if ( QgsVariantUtils::isNull( values.at( 0 ) ) )
     return QVariant::fromValue( true );
 
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -20,6 +20,7 @@
 #include "qgsgeometry.h"
 #include "qgsfeaturerequest.h"
 #include "qgsstringutils.h"
+#include "qgsvariantutils.h"
 
 #include <QRegularExpression>
 
@@ -1358,7 +1359,7 @@ bool QgsExpressionNodeLiteral::prepareNode( QgsExpression *parent, const QgsExpr
 
 QString QgsExpressionNodeLiteral::valueAsString() const
 {
-  if ( mValue.isNull() )
+  if ( QgsVariantUtils::isNull( mValue ) )
     return QStringLiteral( "NULL" );
 
   switch ( mValue.type() )
@@ -1817,7 +1818,7 @@ bool QgsExpressionNodeBetweenOperator::prepareNode( QgsExpression *parent, const
 QVariant QgsExpressionNodeBetweenOperator::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   const QVariant nodeVal = mNode->eval( parent, context );
-  if ( nodeVal.isNull() )
+  if ( QgsVariantUtils::isNull( nodeVal ) )
   {
     return QVariant();
   }
@@ -1828,7 +1829,7 @@ QVariant QgsExpressionNodeBetweenOperator::evalNode( QgsExpression *parent, cons
   const QVariant lowBoundValue = lowBound.eval( parent, context );
   const bool lowBoundBool { lowBoundValue.toBool() };
 
-  if ( ! lowBoundValue.isNull() && ! lowBoundBool )
+  if ( ! QgsVariantUtils::isNull( lowBoundValue ) && ! lowBoundBool )
   {
     return QVariant( mNegate );
   }
@@ -1836,7 +1837,7 @@ QVariant QgsExpressionNodeBetweenOperator::evalNode( QgsExpression *parent, cons
   QgsExpressionNodeBinaryOperator highBound { QgsExpressionNodeBinaryOperator::BinaryOperator::boLE, nodeValNode.clone(), mHigherBound->clone() };
   const QVariant highBoundValue = highBound.eval( parent, context );
 
-  if ( lowBoundValue.isNull() && highBoundValue.isNull() )
+  if ( QgsVariantUtils::isNull( lowBoundValue ) && QgsVariantUtils::isNull( highBoundValue ) )
   {
     return QVariant();
   }
@@ -1844,12 +1845,12 @@ QVariant QgsExpressionNodeBetweenOperator::evalNode( QgsExpression *parent, cons
   const bool highBoundBool { highBoundValue.toBool() };
 
   // We already checked if both are nulls
-  if ( lowBoundValue.isNull() || highBoundValue.isNull() )
+  if ( QgsVariantUtils::isNull( lowBoundValue ) || QgsVariantUtils::isNull( highBoundValue ) )
   {
 
     // In this case we can return a boolean
-    if ( ( lowBoundValue.isNull() && ! highBoundBool ) ||
-         ( highBoundValue.isNull() && ! lowBoundBool ) )
+    if ( ( QgsVariantUtils::isNull( lowBoundValue ) && ! highBoundBool ) ||
+         ( QgsVariantUtils::isNull( highBoundValue ) && ! lowBoundBool ) )
     {
       return QVariant( mNegate );
     }
@@ -1859,7 +1860,7 @@ QVariant QgsExpressionNodeBetweenOperator::evalNode( QgsExpression *parent, cons
 
   }
 
-  if ( ! highBoundValue.isNull() && ! highBoundBool )
+  if ( ! QgsVariantUtils::isNull( highBoundValue ) && ! highBoundBool )
   {
     return QVariant( mNegate );
   }
@@ -2008,7 +2009,7 @@ QVariant QgsExpressionNodeIndexOperator::evalNode( QgsExpression *parent, const 
     }
 
     default:
-      if ( !container.isNull() )
+      if ( !QgsVariantUtils::isNull( container ) )
         parent->setEvalErrorString( tr( "[] can only be used with map or array values, not %1" ).arg( QMetaType::typeName( container.type() ) ) );
       return QVariant();
   }

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -18,6 +18,7 @@
 #include "qgsvectorlayer.h"
 #include "qgscolorrampimpl.h"
 #include "qgsproviderregistry.h"
+#include "qgsvariantutils.h"
 
 ///@cond PRIVATE
 
@@ -63,7 +64,7 @@ QString QgsExpressionUtils::getFilePathValue( const QVariant &value, QgsExpressi
   if ( res.isEmpty() )
     res = value.toString();
 
-  if ( res.isEmpty() && !value.isNull() )
+  if ( res.isEmpty() && !QgsVariantUtils::isNull( value ) )
   {
     parent->setEvalErrorString( QObject::tr( "Cannot convert value to a file path" ) );
   }
@@ -91,7 +92,7 @@ std::tuple<QVariant::Type, int> QgsExpressionUtils::determineResultType( const Q
   {
     context.setFeature( f );
     const QVariant value = exp.evaluate( &context );
-    if ( !value.isNull() )
+    if ( !QgsVariantUtils::isNull( value ) )
     {
       return std::make_tuple( value.type(), value.userType() );
     }

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -27,6 +27,7 @@
 #include "qgsrelationmanager.h"
 #include "qgsvectorlayer.h"
 #include "qgsmeshlayer.h"
+#include "qgsvariantutils.h"
 
 #include <QThread>
 #include <QLocale>
@@ -88,7 +89,7 @@ class CORE_EXPORT QgsExpressionUtils
     static TVL getTVLValue( const QVariant &value, QgsExpression *parent )
     {
       // we need to convert to TVL
-      if ( value.isNull() )
+      if ( QgsVariantUtils::isNull( value ) )
         return Unknown;
 
       //handle some special cases
@@ -185,7 +186,7 @@ class CORE_EXPORT QgsExpressionUtils
 
     static inline bool isNull( const QVariant &v )
     {
-      return v.isNull();
+      return QgsVariantUtils::isNull( v );
     }
 
     static inline bool isList( const QVariant &v )

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
@@ -19,7 +19,7 @@
 #include "qgscheckboxfieldformatter.h"
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
-
+#include "qgsvariantutils.h"
 
 QString QgsCheckBoxFieldFormatter::id() const
 {
@@ -44,7 +44,7 @@ QString QgsCheckBoxFieldFormatter::representValue( QgsVectorLayer *layer, int fi
     else (value.toString)
   */
 
-  bool isNull = value.isNull();
+  bool isNull = QgsVariantUtils::isNull( value );
   bool boolValue = false;
   QString textValue = QgsApplication::nullRepresentation();
 

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -19,6 +19,7 @@
 #include "qgsfield.h"
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
 const QString QgsDateTimeFieldFormatter::TIME_FORMAT = QStringLiteral( "HH:mm:ss" );
@@ -40,7 +41,7 @@ QString QgsDateTimeFieldFormatter::representValue( QgsVectorLayer *layer, int fi
 
   QString result;
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/src/core/fieldformatter/qgskeyvaluefieldformatter.cpp
+++ b/src/core/fieldformatter/qgskeyvaluefieldformatter.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 #include "qgskeyvaluefieldformatter.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 #include <QSettings>
 
@@ -30,7 +31,7 @@ QString QgsKeyValueFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   Q_UNUSED( config )
   Q_UNUSED( cache )
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/src/core/fieldformatter/qgslistfieldformatter.cpp
+++ b/src/core/fieldformatter/qgslistfieldformatter.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 #include "qgslistfieldformatter.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 #include <QSettings>
 
 QString QgsListFieldFormatter::id() const
@@ -29,7 +30,7 @@ QString QgsListFieldFormatter::representValue( QgsVectorLayer *layer, int fieldI
   Q_UNUSED( config )
   Q_UNUSED( cache )
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -22,7 +22,7 @@
 #include "qgsfield.h"
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
-
+#include "qgsvariantutils.h"
 
 QString QgsRangeFieldFormatter::id() const
 {
@@ -34,7 +34,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
   Q_UNUSED( cache )
   Q_UNUSED( config )
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
@@ -16,6 +16,7 @@
 #include "qgsvaluemapfieldformatter.h"
 
 #include "qgsvectorlayer.h"
+#include "qgsvariantutils.h"
 
 const QString QgsValueMapFieldFormatter::NULL_VALUE = QStringLiteral( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
 
@@ -34,7 +35,7 @@ QString QgsValueMapFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   Q_UNUSED( cache )
 
   QString valueInternalText;
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     valueInternalText = NULL_VALUE;
   else
     valueInternalText = value.toString();

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -24,6 +24,7 @@
 #include "qgsvectorlayerref.h"
 #include "qgspostgresstringutils.h"
 #include "qgsmessagelog.h"
+#include "qgsvariantutils.h"
 
 #include <nlohmann/json.hpp>
 using namespace nlohmann;
@@ -91,7 +92,7 @@ QString QgsValueRelationFieldFormatter::representValue( QgsVectorLayer *layer, i
   }
   else
   {
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
     {
       return QgsApplication::nullRepresentation();
     }
@@ -110,7 +111,7 @@ QString QgsValueRelationFieldFormatter::representValue( QgsVectorLayer *layer, i
 
 QVariant QgsValueRelationFieldFormatter::sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const
 {
-  return value.isNull() ? QString() : representValue( layer, fieldIndex, config, cache, value );
+  return QgsVariantUtils::isNull( value ) ? QString() : representValue( layer, fieldIndex, config, cache, value );
 }
 
 QVariant QgsValueRelationFieldFormatter::createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -18,6 +18,7 @@
 #include "qgsmessagelog.h"
 #include "qgslogger.h"
 #include "qgsgeonoderequest.h"
+#include "qgsvariantutils.h"
 
 #include <QEventLoop>
 #include <QNetworkCacheMetaData>
@@ -175,7 +176,7 @@ void QgsGeoNodeRequest::replyFinished()
     {
       QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
       QVariant redirect = mGeoNodeReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
 
         emit statusChanged( QStringLiteral( "GeoNode request redirected." ) );

--- a/src/core/labeling/qgslabelobstaclesettings.cpp
+++ b/src/core/labeling/qgslabelobstaclesettings.cpp
@@ -17,6 +17,7 @@
 #include "qgspropertycollection.h"
 #include "qgsexpressioncontext.h"
 #include "qgspallabeling.h"
+#include "qgsvariantutils.h"
 
 void QgsLabelObstacleSettings::setObstacleGeometry( const QgsGeometry &obstacleGeom )
 {
@@ -34,7 +35,7 @@ void QgsLabelObstacleSettings::updateDataDefinedProperties( const QgsPropertyCol
   {
     context.setOriginalValueVariable( mObstacleFactor );
     QVariant exprVal = properties.value( QgsPalLayerSettings::ObstacleFactor, context );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       bool ok;
       double factorD = exprVal.toDouble( &ok );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -24,11 +24,6 @@
 
 #include <list>
 
-#include "pal/pal.h"
-#include "pal/feature.h"
-#include "pal/layer.h"
-#include "pal/palexception.h"
-#include "pal/problem.h"
 #include "pal/labelposition.h"
 
 #include <cmath>
@@ -47,26 +42,15 @@
 #endif
 #include <QTextBoundaryFinder>
 
-#include "diagram/qgsdiagram.h"
-#include "qgsdiagramrenderer.h"
 #include "qgsfontutils.h"
-#include "qgslabelsearchtree.h"
 #include "qgsexpression.h"
 #include "qgslabelingengine.h"
-#include "qgsvectorlayerlabeling.h"
 #include "qgstextrendererutils.h"
-#include "qgstextfragment.h"
 #include "qgsmultisurface.h"
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
-#include "qgsvectordataprovider.h"
-#include "qgsvectorlayerdiagramprovider.h"
-#include "qgsvectorlayerlabelprovider.h"
 #include "qgsgeometry.h"
 #include "qgsreferencedgeometry.h"
-#include "qgsmarkersymbollayer.h"
-#include "qgspainting.h"
-#include "qgsproject.h"
 #include "qgsproperty.h"
 #include "qgssymbollayerutils.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
@@ -78,6 +62,7 @@
 #include "qgsvectortilelayer.h"
 #include "qgsvectortilebasiclabeling.h"
 #include "qgsfontmanager.h"
+#include "qgsvariantutils.h"
 
 using namespace pal;
 
@@ -1845,7 +1830,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   // data defined font units?
   QgsUnitTypes::RenderUnit fontunits = mFormat.sizeUnit();
   exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::FontSizeUnit, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -1929,12 +1914,12 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
       QgsDebugMsgLevel( QStringLiteral( "Expression parser eval error:%1" ).arg( exp->evalErrorString() ), 4 );
       return nullptr;
     }
-    labelText = result.isNull() ? QString() : result.toString();
+    labelText = QgsVariantUtils::isNull( result ) ? QString() : result.toString();
   }
   else
   {
     const QVariant &v = feature.attribute( fieldIndex );
-    labelText = v.isNull() ? QString() : v.toString();
+    labelText = QgsVariantUtils::isNull( v ) ? QString() : v.toString();
   }
 
   // apply text replacements
@@ -1954,7 +1939,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::FontCase ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::FontCase, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString fcase = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal FontCase:%1" ).arg( fcase ), 4 );
@@ -2069,7 +2054,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::CentroidWhole ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::CentroidWhole, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString str = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal CentroidWhole:%1" ).arg( str ), 4 );
@@ -2130,7 +2115,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::PolygonLabelOutside ) )
   {
     const QVariant dataDefinedOutside = mDataDefinedProperties.value( QgsPalLayerSettings::PolygonLabelOutside, context.expressionContext() );
-    if ( !dataDefinedOutside.isNull() )
+    if ( !QgsVariantUtils::isNull( dataDefinedOutside ) )
     {
       if ( dataDefinedOutside.type() == QVariant::String )
       {
@@ -2292,7 +2277,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   {
     context.expressionContext().setOriginalValueVariable( static_cast< int >( quadOff ) );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::OffsetQuad, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       bool ok;
       int quadInt = exprVal.toInt( &ok );
@@ -2364,7 +2349,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::OffsetUnits ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::OffsetUnits, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString units = exprVal.toString().trimmed();
       if ( !units.isEmpty() )
@@ -2398,7 +2383,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   {
     context.expressionContext().setOriginalValueVariable( angleOffset );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::LabelRotation, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       bool ok;
       const double rotation = exprVal.toDouble( &ok );
@@ -2426,8 +2411,8 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
     {
       const QVariant xPosProperty = mDataDefinedProperties.value( QgsPalLayerSettings::PositionX, context.expressionContext() );
       const QVariant yPosProperty = mDataDefinedProperties.value( QgsPalLayerSettings::PositionY, context.expressionContext() );
-      if ( !xPosProperty.isNull()
-           && !yPosProperty.isNull() )
+      if ( !QgsVariantUtils::isNull( xPosProperty )
+           && !QgsVariantUtils::isNull( yPosProperty ) )
       {
         ddPosition = true;
 
@@ -2441,7 +2426,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
     else if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::PositionPoint ) )
     {
       const QVariant pointPosProperty = mDataDefinedProperties.value( QgsPalLayerSettings::PositionPoint, context.expressionContext() );
-      if ( !pointPosProperty.isNull() )
+      if ( !QgsVariantUtils::isNull( pointPosProperty ) )
       {
         ddPosition = true;
 
@@ -2485,7 +2470,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
         if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::Hali ) )
         {
           exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::Hali, context.expressionContext() );
-          if ( !exprVal.isNull() )
+          if ( !QgsVariantUtils::isNull( exprVal ) )
           {
             QString haliString = exprVal.toString();
             if ( haliString.compare( QLatin1String( "Center" ), Qt::CaseInsensitive ) == 0 )
@@ -2503,7 +2488,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
         if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::Vali ) )
         {
           exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::Vali, context.expressionContext() );
-          if ( !exprVal.isNull() )
+          if ( !QgsVariantUtils::isNull( exprVal ) )
           {
             QString valiString = exprVal.toString();
             if ( valiString.compare( QLatin1String( "Bottom" ), Qt::CaseInsensitive ) != 0 )
@@ -2595,7 +2580,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::RepeatDistanceUnit ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::RepeatDistanceUnit, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString units = exprVal.toString().trimmed();
       if ( !units.isEmpty() )
@@ -2727,7 +2712,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::DistanceUnits ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::DistanceUnits, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString units = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal DistanceUnits:%1" ).arg( units ), 4 );
@@ -2790,7 +2775,7 @@ std::unique_ptr<QgsLabelFeature> QgsPalLayerSettings::registerFeatureWithDetails
   {
     context.expressionContext().setOriginalValueVariable( priority );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::Priority, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       bool ok;
       double priorityD = exprVal.toDouble( &ok );
@@ -2929,7 +2914,7 @@ bool QgsPalLayerSettings::dataDefinedValEval( DataDefinedValueType valType,
 
   context.setOriginalValueVariable( originalValue );
   exprVal = mDataDefinedProperties.value( p, context );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     switch ( valType )
     {
@@ -3117,7 +3102,7 @@ void QgsPalLayerSettings::parseTextStyle( QFont &labelFont,
   {
     context.expressionContext().setOriginalValueVariable( labelFont.family() );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::Family, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString family = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal Font family:%1" ).arg( family ), 4 );
@@ -3140,7 +3125,7 @@ void QgsPalLayerSettings::parseTextStyle( QFont &labelFont,
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::FontStyle ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::FontStyle, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString fontstyle = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal Font style:%1" ).arg( fontstyle ), 4 );
@@ -3297,7 +3282,7 @@ void QgsPalLayerSettings::parseTextBuffer( QgsRenderContext &context )
   {
     drawBuffer = exprVal.toBool();
   }
-  else if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::BufferDraw ) && exprVal.isNull() )
+  else if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::BufferDraw ) && QgsVariantUtils::isNull( exprVal ) )
   {
     dataDefinedValues.insert( QgsPalLayerSettings::BufferDraw, QVariant( drawBuffer ) );
   }
@@ -3418,7 +3403,7 @@ void QgsPalLayerSettings::parseTextFormatting( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( mFormat.lineHeight() );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::MultiLineAlignment, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString str = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal MultiLineAlignment:%1" ).arg( str ), 4 );
@@ -3455,7 +3440,7 @@ void QgsPalLayerSettings::parseTextFormatting( QgsRenderContext &context )
     const QString encoded = QgsTextRendererUtils::encodeTextOrientation( mFormat.orientation() );
     context.expressionContext().setOriginalValueVariable( encoded );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::TextOrientation, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString str = exprVal.toString().trimmed();
       if ( !str.isEmpty() )
@@ -3480,7 +3465,7 @@ void QgsPalLayerSettings::parseTextFormatting( QgsRenderContext &context )
 
     // data defined direction symbol placement?
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::DirSymbPlacement, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString str = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal DirSymbPlacement:%1" ).arg( str ), 4 );
@@ -3548,7 +3533,7 @@ void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::ShapeKind ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::ShapeKind, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString skind = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal ShapeKind:%1" ).arg( skind ), 4 );
@@ -3567,7 +3552,7 @@ void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( svgPath );
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::ShapeSVGFile, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString svgfile = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal ShapeSVGFile:%1" ).arg( svgfile ), 4 );
@@ -3583,7 +3568,7 @@ void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::ShapeSizeType ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::ShapeSizeType, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString stype = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal ShapeSizeType:%1" ).arg( stype ), 4 );
@@ -3654,7 +3639,7 @@ void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::ShapeRotationType ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::ShapeRotationType, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString rotstr = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal ShapeRotationType:%1" ).arg( rotstr ), 4 );
@@ -3757,7 +3742,7 @@ void QgsPalLayerSettings::parseDropShadow( QgsRenderContext &context )
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::ShadowUnder ) )
   {
     exprVal = mDataDefinedProperties.value( QgsPalLayerSettings::ShadowUnder, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString str = exprVal.toString().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "exprVal ShadowUnder:%1" ).arg( str ), 4 );

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -39,6 +39,7 @@
 #include "qgssettings.h"
 #include "qgsfileutils.h"
 #include "qgsmarkersymbol.h"
+#include "qgsvariantutils.h"
 
 #include <QBuffer>
 
@@ -390,7 +391,7 @@ QString QgsSymbolLegendNode::symbolLabel() const
   if ( mEmbeddedInParent )
   {
     const QVariant legendlabel = mLayerNode->customProperty( QStringLiteral( "legend/title-label" ) );
-    const QString layerName = legendlabel.isNull() ? mLayerNode->name() : legendlabel.toString();
+    const QString layerName = QgsVariantUtils::isNull( legendlabel ) ? mLayerNode->name() : legendlabel.toString();
     label = mUserLabel.isEmpty() ? layerName : mUserLabel;
   }
   else

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -25,6 +25,7 @@
 #include "qgsfeatureiterator.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsvariantutils.h"
 
 QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
   : QObject( layout )
@@ -35,7 +36,7 @@ QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
   //listen out for layer removal
   connect( mLayout->project(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsLayoutAtlas::removeLayers );
 
-  if ( mLayout->customProperty( QStringLiteral( "singleFile" ) ).isNull() )
+  if ( QgsVariantUtils::isNull( mLayout->customProperty( QStringLiteral( "singleFile" ) ) ) )
     mLayout->setCustomProperty( QStringLiteral( "singleFile" ), true );
 }
 

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -35,6 +35,7 @@
 #include "qgsgeometryengine.h"
 #include "qgsconditionalstyle.h"
 #include "qgsfontutils.h"
+#include "qgsvariantutils.h"
 
 //
 // QgsLayoutItemAttributeTable
@@ -601,7 +602,7 @@ bool QgsLayoutItemAttributeTable::getTableContents( QgsLayoutTableContents &cont
           val = fieldFormatter->representValue( layer, idx, setup.config(), cache, val );
         }
 
-        QVariant v = val.isNull() ? QString() : replaceWrapChar( val );
+        QVariant v = QgsVariantUtils::isNull( val ) ? QString() : replaceWrapChar( val );
         currentRow << Cell( v, style, f );
         rowContents << v;
       }

--- a/src/core/network/qgsblockingnetworkrequest.cpp
+++ b/src/core/network/qgsblockingnetworkrequest.cpp
@@ -20,6 +20,7 @@
 #include "qgsauthmanager.h"
 #include "qgsmessagelog.h"
 #include "qgsfeedback.h"
+#include "qgsvariantutils.h"
 #include <QUrl>
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -298,7 +299,7 @@ void QgsBlockingNetworkRequest::replyProgress( qint64 bytesReceived, qint64 byte
     if ( mReply->error() == QNetworkReply::NoError )
     {
       const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
         // We don't want to emit downloadProgress() for a redirect
         return;
@@ -321,7 +322,7 @@ void QgsBlockingNetworkRequest::replyFinished()
     {
       QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
       const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
         QgsDebugMsgLevel( QStringLiteral( "Request redirected." ), 2 );
 

--- a/src/core/network/qgsfiledownloader.cpp
+++ b/src/core/network/qgsfiledownloader.cpp
@@ -17,6 +17,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsapplication.h"
 #include "qgsauthmanager.h"
+#include "qgsvariantutils.h"
 
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
@@ -187,7 +188,7 @@ void QgsFileDownloader::onFinished()
       mFile.remove();
       error( tr( "Download failed: %1" ).arg( mReply->errorString() ) );
     }
-    else if ( !redirectionTarget.isNull() )
+    else if ( !QgsVariantUtils::isNull( redirectionTarget ) )
     {
       const QUrl newUrl = mUrl.resolved( redirectionTarget.toUrl() );
       mUrl = newUrl;

--- a/src/core/network/qgsnetworkcontentfetcher.cpp
+++ b/src/core/network/qgsnetworkcontentfetcher.cpp
@@ -21,6 +21,7 @@
 #include "qgsmessagelog.h"
 #include "qgsapplication.h"
 #include "qgsauthmanager.h"
+#include "qgsvariantutils.h"
 #include <QNetworkReply>
 #include <QTextCodec>
 
@@ -191,11 +192,11 @@ void QgsNetworkContentFetcher::contentLoaded( bool ok )
   }
 
   const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-  if ( redirect.isNull() )
+  if ( QgsVariantUtils::isNull( redirect ) )
   {
     //no error or redirect, got target
     const QVariant status = mReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       QgsMessageLog::logMessage( tr( "HTTP fetch %1 failed with error %2" ).arg( mReply->url().toString(), status.toString() ) );
     }

--- a/src/core/numericformats/qgsbasicnumericformat.cpp
+++ b/src/core/numericformats/qgsbasicnumericformat.cpp
@@ -155,8 +155,8 @@ QVariantMap QgsBasicNumericFormat::configuration( const QgsReadWriteContext & ) 
   res.insert( QStringLiteral( "show_plus" ), mShowPlusSign );
   res.insert( QStringLiteral( "show_trailing_zeros" ), mShowTrailingZeros );
   res.insert( QStringLiteral( "rounding_type" ), static_cast< int >( mRoundingType ) );
-  res.insert( QStringLiteral( "thousand_separator" ), mThousandsSeparator );
-  res.insert( QStringLiteral( "decimal_separator" ), mDecimalSeparator );
+  res.insert( QStringLiteral( "thousand_separator" ), mThousandsSeparator.isNull() ? QVariant() : QVariant::fromValue( mThousandsSeparator ) );
+  res.insert( QStringLiteral( "decimal_separator" ), mDecimalSeparator.isNull() ? QVariant() : QVariant::fromValue( mDecimalSeparator ) );
   return res;
 }
 

--- a/src/core/numericformats/qgsfractionnumericformat.cpp
+++ b/src/core/numericformats/qgsfractionnumericformat.cpp
@@ -162,7 +162,7 @@ QVariantMap QgsFractionNumericFormat::configuration( const QgsReadWriteContext &
   QVariantMap res;
   res.insert( QStringLiteral( "show_thousand_separator" ), mShowThousandsSeparator );
   res.insert( QStringLiteral( "show_plus" ), mShowPlusSign );
-  res.insert( QStringLiteral( "thousand_separator" ), mThousandsSeparator );
+  res.insert( QStringLiteral( "thousand_separator" ), mThousandsSeparator.isNull() ? QVariant() : QVariant::fromValue( mThousandsSeparator ) );
   res.insert( QStringLiteral( "use_dedicated_unicode" ), mUseDedicatedUnicode );
   res.insert( QStringLiteral( "use_unicode_supersubscript" ), mUseUnicodeSuperSubscript );
   return res;

--- a/src/core/pointcloud/qgspointcloudattributemodel.cpp
+++ b/src/core/pointcloud/qgspointcloudattributemodel.cpp
@@ -19,6 +19,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgspointcloudindex.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 QgsPointCloudAttributeModel::QgsPointCloudAttributeModel( QObject *parent )
   : QAbstractItemModel( parent )
@@ -273,7 +274,7 @@ bool QgsPointCloudAttributeProxyModel::filterAcceptsRow( int source_row, const Q
     return true;
 
   const QVariant typeVar = mModel->data( index, QgsPointCloudAttributeModel::AttributeTypeRole );
-  if ( typeVar.isNull() )
+  if ( QgsVariantUtils::isNull( typeVar ) )
     return true;
 
   bool ok;

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -38,6 +38,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsfileutils.h"
 #include "qgsproviderregistry.h"
+#include "qgsvariantutils.h"
 #include <functional>
 #include <QRegularExpression>
 
@@ -5095,7 +5096,7 @@ QgsProcessingParameterDefinition *QgsProcessingParameterString::clone() const
 
 QString QgsProcessingParameterString::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
   if ( value.userType() == QMetaType::type( "QgsProperty" ) )
@@ -7440,7 +7441,7 @@ QgsProcessingParameterDefinition *QgsProcessingParameterLayout::clone() const
 
 QString QgsProcessingParameterLayout::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
   if ( value.userType() == QMetaType::type( "QgsProperty" ) )
@@ -7515,7 +7516,7 @@ QgsProcessingParameterDefinition *QgsProcessingParameterLayoutItem::clone() cons
 
 QString QgsProcessingParameterLayoutItem::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
   if ( value.userType() == QMetaType::type( "QgsProperty" ) )
@@ -7648,7 +7649,7 @@ QgsProcessingParameterDefinition *QgsProcessingParameterColor::clone() const
 
 QString QgsProcessingParameterColor::valueAsPythonString( const QVariant &value, QgsProcessingContext & ) const
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
   if ( value.userType() == QMetaType::type( "QgsProperty" ) )
@@ -7796,7 +7797,7 @@ QgsProcessingParameterDefinition *QgsProcessingParameterCoordinateOperation::clo
 
 QString QgsProcessingParameterCoordinateOperation::valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "None" );
 
   if ( value.userType() == QMetaType::type( "QgsCoordinateReferenceSystem" ) )

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -22,6 +22,7 @@
 #include "qgsmessagelog.h"
 #include "qgsauthmanager.h"
 #include "qgscoordinatetransform.h"
+#include "qgsvariantutils.h"
 
 #include <QUrl>
 #include <QUrlQuery>
@@ -532,7 +533,7 @@ void QgsArcGisAsyncQuery::handleReply()
 
   // Handle HTTP redirects
   const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-  if ( !redirect.isNull() )
+  if ( !QgsVariantUtils::isNull( redirect ) )
   {
     QNetworkRequest request = mReply->request();
     QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisAsyncQuery" ) );
@@ -604,7 +605,7 @@ void QgsArcGisAsyncParallelQuery::handleReply()
     mErrors.append( reply->errorString() );
     --mPendingRequests;
   }
-  else if ( !redirect.isNull() )
+  else if ( !QgsVariantUtils::isNull( redirect ) )
   {
     // Handle HTTP redirects
     QNetworkRequest request = reply->request();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -40,6 +40,7 @@
 #include "qgsmarkersymbol.h"
 #include "qgslinesymbol.h"
 #include "qgsfillsymbol.h"
+#include "qgsvariantutils.h"
 
 #include <QRegularExpression>
 
@@ -942,7 +943,7 @@ Qt::BrushStyle QgsArcGisRestUtils::convertFillStyle( const QString &style )
 
 QDateTime QgsArcGisRestUtils::convertDateTime( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QDateTime();
   bool ok = false;
   QDateTime dt = QDateTime::fromMSecsSinceEpoch( value.toLongLong( &ok ) );
@@ -1475,7 +1476,7 @@ QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const 
 
 QVariant QgsArcGisRestUtils::variantToAttributeValue( const QVariant &variant, QVariant::Type expectedType, const QgsArcGisRestContext &context )
 {
-  if ( variant.isNull() )
+  if ( QgsVariantUtils::isNull( variant ) )
     return QVariant();
 
   switch ( expectedType )

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -472,7 +472,7 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     {
       const QVariant originalValue = it->attribute( i );
       QVariant attrValue = originalValue;
-      if ( ! attrValue.isNull() && ! mFields.at( i ).convertCompatible( attrValue, &errorMessage ) )
+      if ( ! QgsVariantUtils::isNull( attrValue ) && ! mFields.at( i ).convertCompatible( attrValue, &errorMessage ) )
       {
         // Push first conversion error only
         if ( result )
@@ -676,7 +676,7 @@ bool QgsMemoryProvider::changeAttributeValues( const QgsChangedAttributesMap &at
     {
       QVariant attrValue = it2.value();
       // Check attribute conversion
-      const bool conversionError { ! attrValue.isNull()
+      const bool conversionError { ! QgsVariantUtils::isNull( attrValue )
                                    && ! mFields.at( it2.key() ).convertCompatible( attrValue, &errorMessage ) };
       if ( conversionError )
       {

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -37,6 +37,7 @@ email                : sherman at mrcc.com
 #include "qgsprovidersublayerdetails.h"
 #include "qgsvectorlayer.h"
 #include "qgsproviderregistry.h"
+#include "qgsvariantutils.h"
 
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
 #include <gdal.h>         // to collect version information
@@ -1240,7 +1241,7 @@ bool QgsOgrProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::C
   else
   {
     // stricter check
-    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString() && !value.isNull();
+    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString() && !QgsVariantUtils::isNull( value );
   }
 }
 
@@ -1389,7 +1390,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
   if ( mFirstFieldIsFid && attributes.count() > 0 )
   {
     QVariant attrFid = attributes.at( 0 );
-    if ( !attrFid.isNull() )
+    if ( !QgsVariantUtils::isNull( attrFid ) )
     {
       bool ok = false;
       qlonglong id = attrFid.toLongLong( &ok );
@@ -1429,7 +1430,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags, QgsFeatureId
     {
       OGR_F_UnsetField( feature.get(), ogrAttributeId );
     }
-    else if ( attrVal.isNull() || ( type != OFTString && ( ( attrVal.type() != QVariant::List && attrVal.toString().isEmpty() && attrVal.type() != QVariant::StringList && attrVal.toStringList().isEmpty() ) || ( attrVal.type() == QVariant::List && attrVal.toList().empty() ) ) ) )
+    else if ( QgsVariantUtils::isNull( attrVal ) || ( type != OFTString && ( ( attrVal.type() != QVariant::List && attrVal.toString().isEmpty() && attrVal.type() != QVariant::StringList && attrVal.toStringList().isEmpty() ) || ( attrVal.type() == QVariant::List && attrVal.toList().empty() ) ) ) )
     {
 // Starting with GDAL 2.2, there are 2 concepts: unset fields and null fields
 // whereas previously there was only unset fields. For a GeoJSON output,
@@ -2230,7 +2231,7 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
       }
 
       OGRFieldType type = OGR_Fld_GetType( fd );
-      if ( it2->isNull() || ( type != OFTString && ( ( it2->type() != QVariant::List && it2->type() != QVariant::StringList && it2->toString().isEmpty() ) || ( it2->type() == QVariant::List && it2->toList().empty() ) || ( it2->type() == QVariant::StringList && it2->toStringList().empty() ) ) ) )
+      if ( QgsVariantUtils::isNull( *it2 ) || ( type != OFTString && ( ( it2->type() != QVariant::List && it2->type() != QVariant::StringList && it2->toString().isEmpty() ) || ( it2->type() == QVariant::List && it2->toList().empty() ) || ( it2->type() == QVariant::StringList && it2->toStringList().empty() ) ) ) )
       {
 // Starting with GDAL 2.2, there are 2 concepts: unset fields and null fields
 // whereas previously there was only unset fields. For a GeoJSON output,

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -26,6 +26,7 @@ email                : nyall dot dawson at gmail dot com
 #include "qgsgeopackageproviderconnection.h"
 #include "qgsogrdbconnection.h"
 #include "qgsfileutils.h"
+#include "qgsvariantutils.h"
 
 #include <ogr_srs_api.h>
 #include <cpl_port.h>
@@ -1327,7 +1328,7 @@ QByteArray QgsOgrProviderUtils::quotedIdentifier( QByteArray field, const QStrin
 
 QString QgsOgrProviderUtils::quotedValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( value.type() )

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -25,6 +25,7 @@
 #include "qgsapplication.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsnetworkcontentfetchertask.h"
+#include "qgsvariantutils.h"
 
 #include <QObject>
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
@@ -394,7 +395,7 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
         bool ok = true;
 
         const QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-        if ( !status.isNull() && status.toInt() >= 400 )
+        if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
         {
           const QVariant phrase = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
           QgsMessageLog::logMessage( tr( "%4 request error [status: %1 - reason phrase: %2] for %3" ).arg( status.toInt() ).arg( phrase.toString(), path, mTypeString ), mTypeString );

--- a/src/core/qgsaction.cpp
+++ b/src/core/qgsaction.cpp
@@ -37,7 +37,7 @@
 #include "qgswebview.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsmessagelog.h"
-
+#include "qgsvariantutils.h"
 
 bool QgsAction::runable() const
 {
@@ -128,7 +128,7 @@ void QgsAction::handleFormSubmitAction( const QString &expandedAction ) const
     if ( reply->error() == QNetworkReply::NoError )
     {
 
-      if ( reply->attribute( QNetworkRequest::RedirectionTargetAttribute ).isNull() )
+      if ( QgsVariantUtils::isNull( reply->attribute( QNetworkRequest::RedirectionTargetAttribute ) ) )
       {
 
         const QByteArray replyData = reply->readAll();
@@ -196,7 +196,7 @@ void QgsAction::handleFormSubmitAction( const QString &expandedAction ) const
             filename = QString::fromStdString( ascii );
           }
         }
-        else if ( !reply->header( QNetworkRequest::KnownHeaders::ContentTypeHeader ).isNull() )
+        else if ( !QgsVariantUtils::isNull( reply->header( QNetworkRequest::KnownHeaders::ContentTypeHeader ) ) )
         {
           QString contentTypeHeader { reply->header( QNetworkRequest::KnownHeaders::ContentTypeHeader ).toString() };
           // Strip charset if any

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -31,6 +31,7 @@
 
 
 #include "qgsfields.h"
+#include "qgsvariantutils.h"
 
 
 class QgsRectangle;
@@ -108,7 +109,7 @@ class QgsAttributes : public QVector<QVariant>
       // QVariant == comparisons do some weird things, like reporting that a QDateTime(2021, 2, 10, 0, 0) variant is equal
       // to a QString "2021-02-10 00:00" variant!
       while ( i != b )
-        if ( !( ( --i )->isNull() == ( --j )->isNull() && ( i->isNull() || i->type() == j->type() ) && *i == *j ) )
+        if ( !( QgsVariantUtils::isNull( *( --i ) ) == QgsVariantUtils::isNull( *( --j ) ) && ( QgsVariantUtils::isNull( *i ) || i->type() == j->type() ) && *i == *j ) )
           return false;
       return true;
     }

--- a/src/core/qgsdatetimestatisticalsummary.cpp
+++ b/src/core/qgsdatetimestatisticalsummary.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsdatetimestatisticalsummary.h"
+#include "qgsvariantutils.h"
 #include <QString>
 #include <QDateTime>
 #include <QStringList>
@@ -61,20 +62,20 @@ void QgsDateTimeStatisticalSummary::addValue( const QVariant &value )
 
   if ( value.type() == QVariant::DateTime )
   {
-    testDateTime( value.toDateTime(), value.isNull() );
+    testDateTime( value.toDateTime(), QgsVariantUtils::isNull( value ) );
   }
   else if ( value.type() == QVariant::Date )
   {
     const QDate date = value.toDate();
     testDateTime( date.isValid() ? QDateTime( date, QTime( 0, 0, 0 ) )
-                  : QDateTime(), value.isNull() );
+                  : QDateTime(), QgsVariantUtils::isNull( value ) );
   }
   else if ( value.type() == QVariant::Time )
   {
     mIsTimes = true;
     const QTime time = value.toTime();
     testDateTime( time.isValid() ? QDateTime( QDate::fromJulianDay( 0 ), time )
-                  : QDateTime(), value.isNull() );
+                  : QDateTime(), QgsVariantUtils::isNull( value ) );
   }
   else //not a date
   {

--- a/src/core/qgsexpressionsorter_p.h
+++ b/src/core/qgsexpressionsorter_p.h
@@ -43,16 +43,16 @@ class QgsExpressionSorter
         ++i;
 
         // Both NULL: don't care
-        if ( v1.isNull() && v2.isNull() )
+        if ( QgsVariantUtils::isNull( v1 ) && QgsVariantUtils::isNull( v2 ) )
           continue;
 
         // Check for NULLs first
-        if ( v1.isNull() != v2.isNull() )
+        if ( QgsVariantUtils::isNull( v1 ) != QgsVariantUtils::isNull( v2 ) )
         {
           if ( orderBy.nullsFirst() )
-            return v1.isNull();
+            return QgsVariantUtils::isNull( v1 );
           else
-            return !v1.isNull();
+            return !QgsVariantUtils::isNull( v1 );
         }
 
         // Both values are not NULL

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -19,7 +19,7 @@
 #include "qgsconditionalstyle.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
-
+#include "qgsvariantutils.h"
 
 bool qVariantListCompare( const QVariantList &a, const QVariantList &b )
 {
@@ -96,7 +96,7 @@ bool QgsFeatureFilterModel::identifierIsNull( const QVariant &identifier ) const
   const QVariantList values = identifier.toList();
   for ( const QVariant &value : values )
   {
-    if ( !value.isNull() )
+    if ( !QgsVariantUtils::isNull( value ) )
     {
       return false;
     }

--- a/src/core/qgsfeaturesource.cpp
+++ b/src/core/qgsfeaturesource.cpp
@@ -64,7 +64,7 @@ QVariant QgsFeatureSource::minimumValue( int fieldIndex ) const
   while ( it.nextFeature( f ) )
   {
     const QVariant v = f.attribute( fieldIndex );
-    if ( !v.isNull() && ( qgsVariantLessThan( v, min ) || min.isNull() ) )
+    if ( !QgsVariantUtils::isNull( v ) && ( qgsVariantLessThan( v, min ) || QgsVariantUtils::isNull( min ) ) )
     {
       min = v;
     }
@@ -87,7 +87,7 @@ QVariant QgsFeatureSource::maximumValue( int fieldIndex ) const
   while ( it.nextFeature( f ) )
   {
     const QVariant v = f.attribute( fieldIndex );
-    if ( !v.isNull() && ( qgsVariantGreaterThan( v, max ) || max.isNull() ) )
+    if ( !QgsVariantUtils::isNull( v ) && ( qgsVariantGreaterThan( v, max ) || QgsVariantUtils::isNull( max ) ) )
     {
       max = v;
     }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -20,6 +20,7 @@
 #include "qgsapplication.h"
 #include "qgssettings.h"
 #include "qgsreferencedgeometry.h"
+#include "qgsvariantutils.h"
 
 #include <QDataStream>
 #include <QIcon>
@@ -254,7 +255,7 @@ void QgsField::setConfigurationFlags( QgsField::ConfigurationFlags flags )
 
 QString QgsField::displayString( const QVariant &v ) const
 {
-  if ( v.isNull() )
+  if ( QgsVariantUtils::isNull( v ) )
   {
     return QgsApplication::nullRepresentation();
   }
@@ -405,7 +406,7 @@ bool QgsField::convertCompatible( QVariant &v, QString *errorMessage ) const
   if ( errorMessage )
     errorMessage->clear();
 
-  if ( v.isNull() )
+  if ( QgsVariantUtils::isNull( v ) )
   {
     v.convert( d->type );
     return true;

--- a/src/core/qgsfieldformatter.cpp
+++ b/src/core/qgsfieldformatter.cpp
@@ -37,7 +37,7 @@ QString QgsFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex
   {
     return defVal;
   }
-  else if ( value.isNull() )
+  else if ( QgsVariantUtils::isNull( value ) )
   {
     return QgsApplication::nullRepresentation();
   }

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -35,7 +35,7 @@ QgsFieldProxyModel *QgsFieldProxyModel::setFilters( QgsFieldProxyModel::Filters 
 bool QgsFieldProxyModel::isReadOnly( const QModelIndex &index ) const
 {
   const QVariant originVariant = sourceModel()->data( index, QgsFieldModel::FieldOriginRole );
-  if ( originVariant.isNull() )
+  if ( QgsVariantUtils::isNull( originVariant ) )
   {
     //expression
     return true;
@@ -91,7 +91,7 @@ bool QgsFieldProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
   const QVariant typeVar = sourceModel()->data( index, QgsFieldModel::FieldTypeRole );
 
   // if expression, consider valid
-  if ( typeVar.isNull() )
+  if ( QgsVariantUtils::isNull( typeVar ) )
     return true;
 
   bool ok;

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -270,7 +270,7 @@ QgsFields QgsJsonUtils::stringToFields( const QString &string, QTextCodec *encod
 
 QString QgsJsonUtils::encodeValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "null" );
 
   switch ( value.type() )
@@ -400,7 +400,7 @@ QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type 
 
 json QgsJsonUtils::jsonFromVariant( const QVariant &val )
 {
-  if ( val.isNull() || ! val.isValid() )
+  if ( QgsVariantUtils::isNull( val ) )
   {
     return nullptr;
   }

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2087,7 +2087,7 @@ QDomElement QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter( const 
     if ( node->opRight()->nodeType() == QgsExpressionNode::ntLiteral )
     {
       const QgsExpressionNodeLiteral *rightLit = static_cast<const QgsExpressionNodeLiteral *>( node->opRight() );
-      if ( rightLit->value().isNull() )
+      if ( QgsVariantUtils::isNull( rightLit->value() ) )
       {
 
         QDomElement elem = mDoc.createElement( mFilterPrefix + ":PropertyIsNull" );
@@ -2538,7 +2538,7 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
     if ( node->opRight()->nodeType() == QgsSQLStatement::ntLiteral )
     {
       const QgsSQLStatement::NodeLiteral *rightLit = static_cast<const QgsSQLStatement::NodeLiteral *>( node->opRight() );
-      if ( rightLit->value().isNull() )
+      if ( QgsVariantUtils::isNull( rightLit->value() ) )
       {
 
         QDomElement elem = mDoc.createElement( mFilterPrefix + ":PropertyIsNull" );
@@ -3046,7 +3046,7 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
       return QDomElement();
     }
     const QgsSQLStatement::NodeLiteral *lit = static_cast<const QgsSQLStatement::NodeLiteral *>( distanceNode );
-    if ( lit->value().isNull() )
+    if ( QgsVariantUtils::isNull( lit->value() ) )
     {
       mErrorMessage = QObject::tr( "Function %1 3rd argument should be a numeric value or a string made of a numeric value followed by a string" ).arg( node->name() );
       return QDomElement();

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -561,7 +561,7 @@ QVariant QgsProperty::propertyValue( const QgsExpressionContext &context, const 
         return defaultValue;
 
       QVariant result = d->expression.evaluate( &context );
-      if ( !result.isNull() )
+      if ( !QgsVariantUtils::isNull( result ) )
       {
         if ( ok )
           *ok = true;
@@ -610,7 +610,7 @@ QDateTime QgsProperty::valueAsDateTime( const QgsExpressionContext &context, con
   bool valOk = false;
   const QVariant val = value( context, defaultDateTime, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
   {
     if ( ok )
       *ok = false;
@@ -642,7 +642,7 @@ QString QgsProperty::valueAsString( const QgsExpressionContext &context, const Q
   bool valOk = false;
   const QVariant val = value( context, defaultString, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
   {
     if ( ok )
       *ok = false;
@@ -664,7 +664,7 @@ QColor QgsProperty::valueAsColor( const QgsExpressionContext &context, const QCo
   bool valOk = false;
   const QVariant val = value( context, defaultColor, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
     return defaultColor;
 
   QColor color;
@@ -695,7 +695,7 @@ double QgsProperty::valueAsDouble( const QgsExpressionContext &context, double d
   bool valOk = false;
   const QVariant val = value( context, defaultValue, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
     return defaultValue;
 
   bool convertOk = false;
@@ -718,7 +718,7 @@ int QgsProperty::valueAsInt( const QgsExpressionContext &context, int defaultVal
   bool valOk = false;
   const QVariant val = value( context, defaultValue, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
     return defaultValue;
 
   bool convertOk = false;
@@ -754,7 +754,7 @@ bool QgsProperty::valueAsBool( const QgsExpressionContext &context, bool default
   bool valOk = false;
   const QVariant val = value( context, defaultValue, &valOk );
 
-  if ( !valOk || val.isNull() )
+  if ( !valOk || QgsVariantUtils::isNull( val ) )
     return defaultValue;
 
   if ( ok )

--- a/src/core/qgspropertytransformer.cpp
+++ b/src/core/qgspropertytransformer.cpp
@@ -191,7 +191,7 @@ QVariant QgsGenericNumericTransformer::transform( const QgsExpressionContext &co
 {
   Q_UNUSED( context )
 
-  if ( v.isNull() )
+  if ( QgsVariantUtils::isNull( v ) )
     return mNullOutput;
 
   bool ok;
@@ -395,7 +395,7 @@ QVariant QgsSizeScaleTransformer::transform( const QgsExpressionContext &context
 {
   Q_UNUSED( context )
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return mNullSize;
 
   bool ok;
@@ -598,7 +598,7 @@ QVariant QgsColorRampTransformer::transform( const QgsExpressionContext &context
 {
   Q_UNUSED( context )
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return mNullColor;
 
   bool ok;

--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -17,6 +17,7 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgsexpressionfunction.h"
 #include "qgsexpression.h"
+#include "qgsvariantutils.h"
 
 QgsSqlExpressionCompiler::QgsSqlExpressionCompiler( const QgsFields &fields, Flags flags, bool ignoreStaticNodes )
   : mFields( fields )
@@ -62,7 +63,7 @@ QString QgsSqlExpressionCompiler::quotedValue( const QVariant &value, bool &ok )
 {
   ok = true;
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( value.type() )
@@ -530,5 +531,5 @@ bool QgsSqlExpressionCompiler::nodeIsNullLiteral( const QgsExpressionNode *node 
     return false;
 
   const QgsExpressionNodeLiteral *nLit = static_cast<const QgsExpressionNodeLiteral *>( node );
-  return nLit->value().isNull();
+  return QgsVariantUtils::isNull( nLit->value() );
 }

--- a/src/core/qgssqliteutils.cpp
+++ b/src/core/qgssqliteutils.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgssqliteutils.h"
+#include "qgsvariantutils.h"
 
 #include <sqlite3.h>
 #include <cstdarg>
@@ -265,7 +266,7 @@ QString QgsSqliteUtils::quotedIdentifier( const QString &identifier )
 
 QString QgsSqliteUtils::quotedValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( value.type() )

--- a/src/core/qgssqlstatement.cpp
+++ b/src/core/qgssqlstatement.cpp
@@ -16,6 +16,7 @@
 
 #include "qgssqlstatement.h"
 #include "qgis.h"
+#include "qgsvariantutils.h"
 
 #include <QRegularExpression>
 
@@ -479,7 +480,7 @@ QgsSQLStatement::Node *QgsSQLStatement::NodeFunction::clone() const
 
 QString QgsSQLStatement::NodeLiteral::dump() const
 {
-  if ( mValue.isNull() )
+  if ( QgsVariantUtils::isNull( mValue ) )
     return QStringLiteral( "NULL" );
 
   switch ( mValue.type() )

--- a/src/core/qgsstatisticalsummary.cpp
+++ b/src/core/qgsstatisticalsummary.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsstatisticalsummary.h"
+#include "qgsvariantutils.h"
 #include <limits>
 #include <QString>
 #include <QObject>
@@ -101,7 +102,7 @@ void QgsStatisticalSummary::addValue( double value )
 void QgsStatisticalSummary::addVariant( const QVariant &value )
 {
   bool convertOk = false;
-  if ( !value.isValid() || value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     mMissing++;
   else
   {

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -316,13 +316,6 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
         return true;
       }
       return false;
-    case QVariant::Color:
-      if ( !variant.value< QColor >().isValid() )
-      {
-        QgsDebugMsg( QStringLiteral( "Invalid QColor was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
-        return true;
-      }
-      return false;
     case QVariant::Region:
       if ( variant.value< QRegion >().isNull() )
       {
@@ -374,6 +367,7 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
       return false;
 
     case QVariant::LastCoreType:
+    case QVariant::Color:
     case QVariant::Font:
     case QVariant::Brush:
     case QVariant::Polygon:

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -14,6 +14,8 @@
  ***************************************************************************/
 
 #include "qgsvariantutils.h"
+#include "qgslogger.h"
+
 #include <QDate>
 #include <QTime>
 #include <QDateTime>
@@ -189,57 +191,187 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
       return false;
 
     case QVariant::Date:
-      return variant.toDate().isNull();
+      if ( variant.toDate().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QDateTime was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Time:
-      return variant.toTime().isNull();
+      if ( variant.toTime().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QTime was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::DateTime:
-      return variant.toDate().isNull();
+      if ( variant.toDate().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QDate was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Char:
-      return variant.toChar().isNull();
+      if ( variant.toChar().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QChar was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::String:
-      return variant.toString().isNull();
+      if ( variant.toString().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QString was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::ByteArray:
-      return variant.toByteArray().isNull();
+      if ( variant.toByteArray().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QByteArray was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::BitArray:
-      return variant.toBitArray().isNull();
+      if ( variant.toBitArray().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QBitArray was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Rect:
-      return variant.toRect().isNull();
+      if ( variant.toRect().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QRect was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::RectF:
-      return variant.toRectF().isNull();
+      if ( variant.toRectF().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QRectF was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Size:
-      return variant.toSize().isNull();
+      if ( variant.toSize().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QSize was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::SizeF:
-      return variant.toSizeF().isNull();
+      if ( variant.toSizeF().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QSizeF was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Line:
-      return variant.toLine().isNull();
+      if ( variant.toLine().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QLine was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::LineF:
-      return variant.toLineF().isNull();
+      if ( variant.toLineF().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QLineF was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Point:
-      return variant.toPoint().isNull();
+      if ( variant.toPoint().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QPoint was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::PointF:
-      return variant.toPointF().isNull();
+      if ( variant.toPointF().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QPointF was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Uuid:
-      return variant.toUuid().isNull();
+      if ( variant.toUuid().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QUuid was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Pixmap:
-      return variant.value< QPixmap >().isNull();
+      if ( variant.value< QPixmap >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QPixmap was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Image:
-      return variant.value< QImage >().isNull();
+      if ( variant.value< QImage >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QImage was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Color:
-      return !variant.value< QColor >().isValid();
+      if ( !variant.value< QColor >().isValid() )
+      {
+        QgsDebugMsg( QStringLiteral( "Invalid QColor was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Region:
-      return variant.value< QRegion >().isNull();
+      if ( variant.value< QRegion >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QRegion was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Bitmap:
-      return variant.value< QBitmap >().isNull();
+      if ( variant.value< QBitmap >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QBitmap was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Icon:
-      return variant.value< QIcon>().isNull();
+      if ( variant.value< QIcon >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QIcon was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Vector2D:
-      return variant.value< QVector2D>().isNull();
+      if ( variant.value< QVector2D >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QVector2D was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Vector3D:
-      return variant.value< QVector3D>().isNull();
+      if ( variant.value< QVector3D >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QVector3D was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Vector4D:
-      return variant.value< QVector4D>().isNull();
+      if ( variant.value< QVector4D >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QVector4D was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
     case QVariant::Quaternion:
-      return variant.value< QQuaternion>().isNull();
+      if ( variant.value< QQuaternion >().isNull() )
+      {
+        QgsDebugMsg( QStringLiteral( "NULL QQuaternion was stored in a QVariant -- stop it! Always use an invalid QVariant() instead." ) );
+        return true;
+      }
+      return false;
 
     case QVariant::LastCoreType:
     case QVariant::Font:
@@ -259,6 +391,9 @@ bool QgsVariantUtils::isNull( const QVariant &variant )
       break;
 
     case QVariant::UserType:
+      break;
+
+    default:
       break;
   }
 

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -14,7 +14,23 @@
  ***************************************************************************/
 
 #include "qgsvariantutils.h"
-
+#include <QDate>
+#include <QTime>
+#include <QDateTime>
+#include <QBitArray>
+#include <QRect>
+#include <QLine>
+#include <QUuid>
+#include <QImage>
+#include <QPixmap>
+#include <QBrush>
+#include <QColor>
+#include <QBitmap>
+#include <QIcon>
+#include <QVector2D>
+#include <QVector3D>
+#include <QVector4D>
+#include <QQuaternion>
 
 QString QgsVariantUtils::typeToDisplayString( QVariant::Type type, QVariant::Type subType )
 {
@@ -142,3 +158,111 @@ QString QgsVariantUtils::typeToDisplayString( QVariant::Type type, QVariant::Typ
   }
   return QString();
 }
+
+bool QgsVariantUtils::isNull( const QVariant &variant )
+{
+  if ( variant.isNull() || !variant.isValid() )
+    return true;
+
+  switch ( variant.type() )
+  {
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::Int:
+    case QVariant::UInt:
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Double:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RegularExpression:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::ModelIndex:
+    case QVariant::PersistentModelIndex:
+
+    case QVariant::LastType:
+
+      return false;
+
+    case QVariant::Date:
+      return variant.toDate().isNull();
+    case QVariant::Time:
+      return variant.toTime().isNull();
+    case QVariant::DateTime:
+      return variant.toDate().isNull();
+    case QVariant::Char:
+      return variant.toChar().isNull();
+    case QVariant::String:
+      return variant.toString().isNull();
+    case QVariant::ByteArray:
+      return variant.toByteArray().isNull();
+    case QVariant::BitArray:
+      return variant.toBitArray().isNull();
+    case QVariant::Rect:
+      return variant.toRect().isNull();
+    case QVariant::RectF:
+      return variant.toRectF().isNull();
+    case QVariant::Size:
+      return variant.toSize().isNull();
+    case QVariant::SizeF:
+      return variant.toSizeF().isNull();
+    case QVariant::Line:
+      return variant.toLine().isNull();
+    case QVariant::LineF:
+      return variant.toLineF().isNull();
+    case QVariant::Point:
+      return variant.toPoint().isNull();
+    case QVariant::PointF:
+      return variant.toPointF().isNull();
+    case QVariant::Uuid:
+      return variant.toUuid().isNull();
+    case QVariant::Pixmap:
+      return variant.value< QPixmap >().isNull();
+    case QVariant::Image:
+      return variant.value< QImage >().isNull();
+    case QVariant::Color:
+      return !variant.value< QColor >().isValid();
+    case QVariant::Region:
+      return variant.value< QRegion >().isNull();
+    case QVariant::Bitmap:
+      return variant.value< QBitmap >().isNull();
+    case QVariant::Icon:
+      return variant.value< QIcon>().isNull();
+    case QVariant::Vector2D:
+      return variant.value< QVector2D>().isNull();
+    case QVariant::Vector3D:
+      return variant.value< QVector3D>().isNull();
+    case QVariant::Vector4D:
+      return variant.value< QVector4D>().isNull();
+    case QVariant::Quaternion:
+      return variant.value< QQuaternion>().isNull();
+
+    case QVariant::LastCoreType:
+    case QVariant::Font:
+    case QVariant::Brush:
+    case QVariant::Polygon:
+    case QVariant::Palette:
+    case QVariant::Cursor:
+    case QVariant::KeySequence:
+    case QVariant::Pen:
+    case QVariant::TextLength:
+    case QVariant::PolygonF:
+    case QVariant::TextFormat:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::SizePolicy:
+    case QVariant::LastGuiType:
+      break;
+
+    case QVariant::UserType:
+      break;
+  }
+
+  return false;
+}
+
+

--- a/src/core/qgsvariantutils.h
+++ b/src/core/qgsvariantutils.h
@@ -39,6 +39,16 @@ class CORE_EXPORT QgsVariantUtils
      */
     static QString typeToDisplayString( QVariant::Type type, QVariant::Type subType = QVariant::Type::Invalid );
 
+    /**
+     * Returns TRUE if the specified \a variant should be considered a NULL value.
+     *
+     * This method is more rigorous vs QVariant::isNull(), which will return
+     * FALSE on newer Qt versions for tests like `QVariant( QDateTime() ).isNull()`.
+     *
+     * \since QGIS 3.28
+     */
+    static bool isNull( const QVariant &variant );
+
 };
 
 #endif // QGSVARIANTUTILS_H

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2455,7 +2455,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
       OGR_F_UnsetField( poFeature.get(), ogrField );
       continue;
     }
-    else if ( !attrValue.isValid() || attrValue.isNull() )
+    else if ( QgsVariantUtils::isNull( attrValue ) )
     {
 // Starting with GDAL 2.2, there are 2 concepts: unset fields and null fields
 // whereas previously there was only unset fields. For a GeoJSON output,

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -169,7 +169,7 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
 
     case QVariant::Char:
       element.setAttribute( QStringLiteral( "type" ), QVariant::typeToName( value.type() ) );
-      element.setAttribute( QStringLiteral( "value" ), value.isNull() || value.toChar().isNull() ? QString() : QString( value.toChar() ) );
+      element.setAttribute( QStringLiteral( "value" ), QgsVariantUtils::isNull( value ) ? QString() : QString( value.toChar() ) );
       break;
 
     case QVariant::Color:

--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -21,6 +21,7 @@
 #include <QDir>
 
 #include "qgssettings.h"
+#include "qgsvariantutils.h"
 #include "qgslogger.h"
 
 Q_GLOBAL_STATIC( QString, sGlobalSettingsPath )
@@ -161,7 +162,7 @@ QString QgsSettings::globalSettingsPath()
 QVariant QgsSettings::value( const QString &key, const QVariant &defaultValue, const QgsSettings::Section section ) const
 {
   const QString pKey = prefixedKey( key, section );
-  if ( !mUserSettings->value( pKey ).isNull() )
+  if ( !QgsVariantUtils::isNull( mUserSettings->value( pKey ) ) )
   {
     return mUserSettings->value( pKey );
   }

--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -639,7 +639,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyArrowWidth ) )
   {
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowWidth, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const double w = exprVal.toDouble( &ok );
       if ( ok )
@@ -652,7 +652,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   {
     context.setOriginalValueVariable( arrowStartWidth() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowStartWidth, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const double w = exprVal.toDouble( &ok );
       if ( ok )
@@ -665,7 +665,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   {
     context.setOriginalValueVariable( headLength() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowHeadLength, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const double w = exprVal.toDouble( &ok );
       if ( ok )
@@ -678,7 +678,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   {
     context.setOriginalValueVariable( headThickness() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowHeadThickness, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const double w = exprVal.toDouble( &ok );
       if ( ok )
@@ -702,7 +702,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   {
     context.setOriginalValueVariable( headType() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowHeadType, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const HeadType h = QgsSymbolLayerUtils::decodeArrowHeadType( exprVal, &ok );
       if ( ok )
@@ -716,7 +716,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   {
     context.setOriginalValueVariable( arrowType() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyArrowType, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const ArrowType h = QgsSymbolLayerUtils::decodeArrowType( exprVal, &ok );
       if ( ok )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -145,7 +145,7 @@ void QgsRendererCategory::toSld( QDomDocument &doc, QDomElement &element, QVaria
 
   // create the ogc:Filter for the range
   QString filterFunc;
-  if ( mValue.isNull() || mValue.toString().isEmpty() )
+  if ( QgsVariantUtils::isNull( mValue ) || mValue.toString().isEmpty() )
   {
     filterFunc = QStringLiteral( "%1 = '%2' or %1 is null" )
                  .arg( attrName.replace( '\"', QLatin1String( "\"\"" ) ),
@@ -225,7 +225,7 @@ QgsSymbol *QgsCategorizedSymbolRenderer::symbolForValue( const QVariant &value, 
   foundMatchingSymbol = false;
 
   // TODO: special case for int, double
-  QHash<QString, QgsSymbol *>::const_iterator it = mSymbolHash.constFind( value.isNull() ? QString() : value.toString() );
+  QHash<QString, QgsSymbol *>::const_iterator it = mSymbolHash.constFind( QgsVariantUtils::isNull( value ) ? QString() : value.toString() );
   if ( it == mSymbolHash.constEnd() )
   {
     if ( mSymbolHash.isEmpty() )
@@ -542,7 +542,7 @@ QString QgsCategorizedSymbolRenderer::filter( const QgsFields &fields )
 
   for ( const QgsRendererCategory &cat : std::as_const( mCategories ) )
   {
-    if ( cat.value() == "" || cat.value().isNull() )
+    if ( cat.value() == "" || QgsVariantUtils::isNull( cat.value() ) )
     {
       hasDefault = true;
       defaultActive = cat.renderState();
@@ -930,7 +930,7 @@ QString QgsCategorizedSymbolRenderer::displayString( const QVariant &v, int prec
   auto _displayString = [ ]( const QVariant & v, int precision ) -> QString
   {
 
-    if ( v.isNull() )
+    if ( QgsVariantUtils::isNull( v ) )
     {
       return QgsApplication::nullRepresentation();
     }
@@ -1107,9 +1107,9 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
     else
     {
       // Numeric NULL cat value is stored as an empty string
-      if ( value.isNull() && ( value.type() == QVariant::Double || value.type() == QVariant::Int ||
-                               value.type() == QVariant::UInt || value.type() == QVariant::LongLong ||
-                               value.type() == QVariant::ULongLong ) )
+      if ( QgsVariantUtils::isNull( value ) && ( value.type() == QVariant::Double || value.type() == QVariant::Int ||
+           value.type() == QVariant::UInt || value.type() == QVariant::LongLong ||
+           value.type() == QVariant::ULongLong ) )
       {
         match = cat.value().toString().isEmpty();
       }
@@ -1170,7 +1170,7 @@ QString QgsCategorizedSymbolRenderer::legendKeyToExpression( const QString &key,
       value = QVariant();
     }
 
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
       return QStringLiteral( "%1 IS NULL" ).arg( attributeComponent );
     else if ( fieldType == QVariant::Type::Invalid )
       return QStringLiteral( "%1 = %2" ).arg( attributeComponent, QgsExpression::quotedValue( value ) );
@@ -1433,7 +1433,7 @@ QgsCategoryList QgsCategorizedSymbolRenderer::createCategories( const QList<QVar
     for ( const QVariant &value : vals )
     {
       QgsSymbol *newSymbol = symbol->clone();
-      if ( !value.isNull() )
+      if ( !QgsVariantUtils::isNull( value ) )
       {
         const int fieldIdx = fields.lookupField( attributeName );
         QString categoryName = displayString( value );

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -189,7 +189,7 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
   {
     context.setOriginalValueVariable( mStrokeWidth );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeWidth, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       double width = exprVal.toDouble( &ok );
       if ( ok )
@@ -205,7 +205,7 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenStyle( mStrokeStyle ) );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       mPen.setStyle( QgsSymbolLayerUtils::decodePenStyle( exprVal.toString() ) );
       mSelPen.setStyle( mPen.style() );
@@ -216,7 +216,7 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenJoinStyle( mPenJoinStyle ) );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyJoinStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       mPen.setJoinStyle( QgsSymbolLayerUtils::decodePenJoinStyle( exprVal.toString() ) );
       mSelPen.setJoinStyle( mPen.joinStyle() );
@@ -255,7 +255,7 @@ void QgsEllipseSymbolLayer::renderPoint( QPointF point, QgsSymbolRenderContext &
   {
     context.setOriginalValueVariable( encodeShape( shape ) );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyName, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       shape = decodeShape( exprVal.toString() );
     }
@@ -858,7 +858,7 @@ QRectF QgsEllipseSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &con
     context.setOriginalValueVariable( mStrokeWidth );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeWidth, context.renderContext().expressionContext() );
 
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       bool ok;
       const double strokeWidth = exprVal.toDouble( &ok );
@@ -874,7 +874,7 @@ QRectF QgsEllipseSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &con
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenStyle( mStrokeStyle ) );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() && exprVal.toString() == QLatin1String( "no" ) )
+    if ( !QgsVariantUtils::isNull( exprVal ) && exprVal.toString() == QLatin1String( "no" ) )
     {
       penWidth = 0.0;
     }

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -120,7 +120,7 @@ void QgsSimpleFillSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodeBrushStyle( mBrushStyle ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyFillStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       brush.setStyle( QgsSymbolLayerUtils::decodeBrushStyle( exprVal.toString() ) );
   }
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyStrokeColor ) )
@@ -134,7 +134,7 @@ void QgsSimpleFillSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     context.setOriginalValueVariable( mStrokeWidth );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeWidth, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       double width = exprVal.toDouble( &ok );
       if ( ok )

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -152,7 +152,7 @@ QgsSymbol *QgsGraduatedSymbolRenderer::originalSymbolForFeature( const QgsFeatur
   QVariant value = valueForFeature( feature, context );
 
   // Null values should not be categorized
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return nullptr;
 
   // find the right category
@@ -791,7 +791,7 @@ QSet< QString > QgsGraduatedSymbolRenderer::legendKeysForFeature( const QgsFeatu
   QVariant value = valueForFeature( feature, context );
 
   // Null values should not be categorized
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QSet< QString >();
 
   // find the right category

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -710,7 +710,7 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     QVector<qreal> dashVector;
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyCustomDash, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QStringList dashList = exprVal.toString().split( ';' );
       QStringList::const_iterator dashIt = dashList.constBegin();
@@ -748,7 +748,7 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenStyle( mPenStyle ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyStrokeStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       pen.setStyle( QgsSymbolLayerUtils::decodePenStyle( exprVal.toString() ) );
   }
 
@@ -757,7 +757,7 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenJoinStyle( mPenJoinStyle ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyJoinStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       pen.setJoinStyle( QgsSymbolLayerUtils::decodePenJoinStyle( exprVal.toString() ) );
   }
 
@@ -766,7 +766,7 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenCapStyle( mPenCapStyle ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyCapStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       pen.setCapStyle( QgsSymbolLayerUtils::decodePenCapStyle( exprVal.toString() ) );
   }
 }
@@ -1289,7 +1289,7 @@ void QgsTemplatedLineSymbolLayerBase::renderPolyline( const QPolygonF &points, Q
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyPlacement ) )
   {
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyPlacement, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       QString placementString = exprVal.toString();
       if ( placementString.compare( QLatin1String( "interval" ), Qt::CaseInsensitive ) == 0 )
@@ -3074,7 +3074,7 @@ void QgsAbstractBrushedLineSymbolLayer::renderLine( const QPolygonF &points, Qgs
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenJoinStyle( join ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyJoinStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       join = QgsSymbolLayerUtils::decodePenJoinStyle( exprVal.toString() );
   }
 
@@ -3083,7 +3083,7 @@ void QgsAbstractBrushedLineSymbolLayer::renderLine( const QPolygonF &points, Qgs
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenCapStyle( cap ) );
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyCapStyle, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
       cap = QgsSymbolLayerUtils::decodePenCapStyle( exprVal.toString() );
   }
 

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -242,7 +242,7 @@ void QgsSimpleMarkerSymbolLayerBase::renderPoint( QPointF point, QgsSymbolRender
   {
     context.setOriginalValueVariable( encodeShape( symbol ) );
     const QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyName, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const Qgis::MarkerShape decoded = decodeShape( exprVal.toString(), &ok );
       if ( ok )

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1285,7 +1285,7 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
   {
     QString value;
     // not quoting numbers saves a type cast
-    if ( cat.value().isNull() )
+    if ( QgsVariantUtils::isNull( cat.value() ) )
       value = "NULL";
     else if ( cat.value().type() == QVariant::Int )
       value = cat.value().toString();
@@ -1295,7 +1295,7 @@ void QgsRuleBasedRenderer::refineRuleCategories( QgsRuleBasedRenderer::Rule *ini
       value = QString::number( cat.value().toDouble(), 'f', 4 );
     else
       value = QgsExpression::quotedString( cat.value().toString() );
-    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, cat.value().isNull() ? QStringLiteral( "IS" ) : QStringLiteral( "=" ), value );
+    const QString filter = QStringLiteral( "%1 %2 %3" ).arg( attr, QgsVariantUtils::isNull( cat.value() ) ? QStringLiteral( "IS" ) : QStringLiteral( "=" ), value );
     const QString label = !cat.label().isEmpty() ? cat.label() :
                           cat.value().isValid() ? value : QString();
     initialRule->appendChild( new Rule( cat.symbol()->clone(), 0, 0, filter, label ) );

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -593,7 +593,7 @@ void QgsMarkerSymbolLayer::markerOffset( QgsSymbolRenderContext &context, double
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyHorizontalAnchor ) )
   {
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyHorizontalAnchor, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       horizontalAnchorPoint = decodeHorizontalAnchorPoint( exprVal.toString() );
     }
@@ -601,7 +601,7 @@ void QgsMarkerSymbolLayer::markerOffset( QgsSymbolRenderContext &context, double
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyVerticalAnchor ) )
   {
     QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::PropertyVerticalAnchor, context.renderContext().expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       verticalAnchorPoint = decodeVerticalAnchorPoint( exprVal.toString() );
     }

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -553,7 +553,7 @@ QPointF QgsSymbolLayerUtils::toPoint( const QVariant &value, bool *ok )
   if ( ok )
     *ok = false;
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QPoint();
 
   if ( value.type() == QVariant::List )
@@ -617,7 +617,7 @@ QSizeF QgsSymbolLayerUtils::toSize( const QVariant &value, bool *ok )
   if ( ok )
     *ok = false;
 
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QSizeF();
 
   if ( value.type() == QVariant::List )

--- a/src/core/textrenderer/qgstextbackgroundsettings.cpp
+++ b/src/core/textrenderer/qgstextbackgroundsettings.cpp
@@ -776,7 +776,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   QVariant exprVal = properties.value( QgsPalLayerSettings::ShapeSizeUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -789,7 +789,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShapeKind, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString skind = exprVal.toString().trimmed();
     if ( !skind.isEmpty() )
@@ -799,7 +799,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShapeSizeType, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString stype = exprVal.toString().trimmed();
     if ( !stype.isEmpty() )
@@ -811,7 +811,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   // data defined shape SVG path?
   context.expressionContext().setOriginalValueVariable( d->svgFile );
   exprVal = properties.value( QgsPalLayerSettings::ShapeSVGFile, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString svgfile = exprVal.toString().trimmed();
     d->svgFile = QgsSymbolLayerUtils::svgSymbolNameToPath( svgfile, context.pathResolver() );
@@ -823,7 +823,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
     d->rotation = properties.valueAsDouble( QgsPalLayerSettings::ShapeRotation, context.expressionContext(), d->rotation );
   }
   exprVal = properties.value( QgsPalLayerSettings::ShapeRotationType, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString rotstr = exprVal.toString().trimmed();
     if ( !rotstr.isEmpty() )
@@ -833,7 +833,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShapeOffset, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     bool ok = false;
     const QPointF res = QgsSymbolLayerUtils::toPoint( exprVal, &ok );
@@ -843,7 +843,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
     }
   }
   exprVal = properties.value( QgsPalLayerSettings::ShapeOffsetUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -856,7 +856,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShapeRadii, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     bool ok = false;
     const QSizeF res = QgsSymbolLayerUtils::toSize( exprVal, &ok );
@@ -867,7 +867,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShapeRadiiUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -883,7 +883,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
   {
     context.expressionContext().setOriginalValueVariable( d->opacity * 100 );
     const QVariant val = properties.value( QgsPalLayerSettings::ShapeOpacity, context.expressionContext(), d->opacity * 100 );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->opacity = val.toDouble() / 100.0;
     }
@@ -908,7 +908,7 @@ void QgsTextBackgroundSettings::updateDataDefinedProperties( QgsRenderContext &c
     d->strokeWidth = properties.valueAsDouble( QgsPalLayerSettings::ShapeStrokeWidth, context.expressionContext(), d->strokeWidth );
   }
   exprVal = properties.value( QgsPalLayerSettings::ShapeStrokeWidthUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )

--- a/src/core/textrenderer/qgstextbuffersettings.cpp
+++ b/src/core/textrenderer/qgstextbuffersettings.cpp
@@ -184,7 +184,7 @@ void QgsTextBufferSettings::updateDataDefinedProperties( QgsRenderContext &conte
   }
 
   QVariant exprVal = properties.value( QgsPalLayerSettings::BufferUnit, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -200,7 +200,7 @@ void QgsTextBufferSettings::updateDataDefinedProperties( QgsRenderContext &conte
   {
     context.expressionContext().setOriginalValueVariable( d->opacity * 100 );
     const QVariant val = properties.value( QgsPalLayerSettings::BufferOpacity, context.expressionContext(), d->opacity * 100 );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->opacity = val.toDouble() / 100.0;
     }

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -879,7 +879,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   QString ddFontFamily;
   context.expressionContext().setOriginalValueVariable( d->textFont.family() );
   QVariant exprVal = d->mDataDefinedProperties.value( QgsPalLayerSettings::Family, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     QString family = exprVal.toString().trimmed();
     family = QgsApplication::fontManager()->processFontFamilyName( family );
@@ -898,7 +898,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   QString ddFontStyle;
   context.expressionContext().setOriginalValueVariable( d->textNamedStyle );
   exprVal = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontStyle, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     QString fontstyle = exprVal.toString().trimmed();
     ddFontStyle = fontstyle;
@@ -1003,7 +1003,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   }
 
   exprVal = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontSizeUnit, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -1019,7 +1019,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( d->opacity * 100 );
     const QVariant val = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontOpacity, context.expressionContext(), d->opacity * 100 );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->opacity = val.toDouble() / 100.0;
     }
@@ -1048,7 +1048,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( d->textFont.letterSpacing() );
     const QVariant val = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontLetterSpacing, context.expressionContext(), d->textFont.letterSpacing() );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->textFont.setLetterSpacing( QFont::AbsoluteSpacing, val.toDouble() );
     }
@@ -1058,7 +1058,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( d->textFont.wordSpacing() );
     const QVariant val = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontWordSpacing, context.expressionContext(), d->textFont.wordSpacing() );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->textFont.setWordSpacing( val.toDouble() );
     }

--- a/src/core/textrenderer/qgstextformat.cpp
+++ b/src/core/textrenderer/qgstextformat.cpp
@@ -1030,7 +1030,7 @@ void QgsTextFormat::updateDataDefinedProperties( QgsRenderContext &context )
   {
     context.expressionContext().setOriginalValueVariable( d->textFont.stretch() );
     const QVariant val = d->mDataDefinedProperties.value( QgsPalLayerSettings::FontStretchFactor, context.expressionContext(), d->textFont.stretch() );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->textFont.setStretch( val.toInt() );
     }

--- a/src/core/textrenderer/qgstextmasksettings.cpp
+++ b/src/core/textrenderer/qgstextmasksettings.cpp
@@ -159,7 +159,7 @@ void QgsTextMaskSettings::updateDataDefinedProperties( QgsRenderContext &context
   if ( properties.isActive( QgsPalLayerSettings::MaskBufferUnit ) )
   {
     const QVariant exprVal = properties.value( QgsPalLayerSettings::MaskBufferUnit, context.expressionContext() );
-    if ( !exprVal.isNull() )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
       const QString units = exprVal.toString();
       if ( !units.isEmpty() )
@@ -176,7 +176,7 @@ void QgsTextMaskSettings::updateDataDefinedProperties( QgsRenderContext &context
   {
     context.expressionContext().setOriginalValueVariable( d->opacity * 100 );
     const QVariant val = properties.value( QgsPalLayerSettings::MaskOpacity, context.expressionContext(), d->opacity * 100 );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->opacity = val.toDouble() / 100.0;
     }

--- a/src/core/textrenderer/qgstextshadowsettings.cpp
+++ b/src/core/textrenderer/qgstextshadowsettings.cpp
@@ -385,7 +385,7 @@ void QgsTextShadowSettings::updateDataDefinedProperties( QgsRenderContext &conte
 
   // data defined shadow under type?
   QVariant exprVal = properties.value( QgsPalLayerSettings::ShadowUnder, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString str = exprVal.toString().trimmed();
     if ( !str.isEmpty() )
@@ -406,7 +406,7 @@ void QgsTextShadowSettings::updateDataDefinedProperties( QgsRenderContext &conte
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShadowOffsetUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -425,7 +425,7 @@ void QgsTextShadowSettings::updateDataDefinedProperties( QgsRenderContext &conte
   }
 
   exprVal = properties.value( QgsPalLayerSettings::ShadowRadiusUnits, context.expressionContext() );
-  if ( !exprVal.isNull() )
+  if ( !QgsVariantUtils::isNull( exprVal ) )
   {
     const QString units = exprVal.toString();
     if ( !units.isEmpty() )
@@ -441,7 +441,7 @@ void QgsTextShadowSettings::updateDataDefinedProperties( QgsRenderContext &conte
   {
     context.expressionContext().setOriginalValueVariable( d->opacity * 100 );
     const QVariant val = properties.value( QgsPalLayerSettings::ShadowOpacity, context.expressionContext(), d->opacity * 100 );
-    if ( !val.isNull() )
+    if ( !QgsVariantUtils::isNull( val ) )
     {
       d->opacity = val.toDouble() / 100.0;
     }

--- a/src/core/vector/qgsvectordataprovider.cpp
+++ b/src/core/vector/qgsvectordataprovider.cpp
@@ -561,7 +561,7 @@ void QgsVectorDataProvider::fillMinMaxCache() const
     {
       const QVariant &varValue = attrs.at( attributeIndex );
 
-      if ( varValue.isNull() )
+      if ( QgsVariantUtils::isNull( varValue ) )
         continue;
 
       switch ( flds.at( attributeIndex ).type() )
@@ -623,11 +623,11 @@ void QgsVectorDataProvider::fillMinMaxCache() const
         default:
         {
           const QString value = varValue.toString();
-          if ( mCacheMinValues[ attributeIndex ].isNull() || value < mCacheMinValues[attributeIndex ].toString() )
+          if ( QgsVariantUtils::isNull( mCacheMinValues[ attributeIndex ] ) || value < mCacheMinValues[attributeIndex ].toString() )
           {
             mCacheMinValues[attributeIndex] = value;
           }
-          if ( mCacheMaxValues[attributeIndex].isNull() || value > mCacheMaxValues[attributeIndex].toString() )
+          if ( QgsVariantUtils::isNull( mCacheMaxValues[attributeIndex] ) || value > mCacheMaxValues[attributeIndex].toString() )
           {
             mCacheMaxValues[attributeIndex] = value;
           }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -4492,7 +4492,7 @@ void QgsVectorLayer::minimumOrMaximumValue( int index, QVariant *minimum, QVaria
       while ( fit.nextFeature( f ) )
       {
         const QVariant currentValue = f.attribute( index );
-        if ( currentValue.isNull() )
+        if ( QgsVariantUtils::isNull( currentValue ) )
           continue;
 
         if ( firstValue )

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -1126,7 +1126,7 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( Qg
 
   subsetString.append( QStringLiteral( "\"%1\"" ).arg( joinFieldName ) );
 
-  if ( joinValue.isNull() )
+  if ( QgsVariantUtils::isNull( joinValue ) )
   {
     subsetString += QLatin1String( " IS NULL" );
   }

--- a/src/core/vector/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/vector/qgsvectorlayerjoinbuffer.cpp
@@ -624,7 +624,7 @@ bool QgsVectorLayerJoinBuffer::addFeatures( QgsFeatureList &features, QgsFeature
             if ( field.name() == info.joinFieldName() )
               continue;
 
-            if ( !joinFeature.attribute( field.name() ).isNull() )
+            if ( !QgsVariantUtils::isNull( joinFeature.attribute( field.name() ) ) )
             {
               notNullFields = true;
               break;

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -137,7 +137,7 @@ QList<double> QgsVectorLayerUtils::getDoubleValues( const QgsVectorLayer *layer,
     double val = value.toDouble( &convertOk );
     if ( convertOk )
       values << val;
-    else if ( value.isNull() )
+    else if ( QgsVariantUtils::isNull( value ) )
     {
       if ( nullCount )
         *nullCount += 1;
@@ -425,9 +425,9 @@ bool QgsVectorLayerUtils::validateAttribute( const QgsVectorLayer *layer, const 
 
     if ( !exempt )
     {
-      valid = valid && !value.isNull();
+      valid = valid && !QgsVariantUtils::isNull( value );
 
-      if ( value.isNull() )
+      if ( QgsVariantUtils::isNull( value ) )
       {
         errors << QObject::tr( "value is NULL" );
         notNullConstraintViolated = true;
@@ -541,8 +541,8 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
       // 2. client side default expression
       // note - deliberately not using else if!
       QgsDefaultValue defaultValueDefinition = layer->defaultValueDefinition( idx );
-      if ( ( v.isNull() || ( hasUniqueConstraint
-                             && checkUniqueValue( idx, v ) )
+      if ( ( QgsVariantUtils::isNull( v ) || ( hasUniqueConstraint
+             && checkUniqueValue( idx, v ) )
              || defaultValueDefinition.applyOnUpdate() )
            && defaultValueDefinition.isValid() )
       {
@@ -554,8 +554,8 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
       // 3. provider side default value clause
       // note - not an else if deliberately. Users may return null from a default value expression to fallback to provider defaults
-      if ( ( v.isNull() || ( hasUniqueConstraint
-                             && checkUniqueValue( idx, v ) ) )
+      if ( ( QgsVariantUtils::isNull( v ) || ( hasUniqueConstraint
+             && checkUniqueValue( idx, v ) ) )
            && fields.fieldOrigin( idx ) == QgsFields::OriginProvider )
       {
         int providerIndex = fields.fieldOriginIndex( idx );
@@ -569,9 +569,9 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
       // 4. provider side default literal
       // note - deliberately not using else if!
-      if ( ( v.isNull() || ( checkUnique
-                             && hasUniqueConstraint
-                             && checkUniqueValue( idx, v ) ) )
+      if ( ( QgsVariantUtils::isNull( v ) || ( checkUnique
+             && hasUniqueConstraint
+             && checkUniqueValue( idx, v ) ) )
            && fields.fieldOrigin( idx ) == QgsFields::OriginProvider )
       {
         int providerIndex = fields.fieldOriginIndex( idx );
@@ -585,7 +585,7 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
       // 5. passed attribute value
       // note - deliberately not using else if!
-      if ( v.isNull() && fd.attributes().contains( idx ) )
+      if ( QgsVariantUtils::isNull( v ) && fd.attributes().contains( idx ) )
       {
         v = fd.attributes().value( idx );
       }

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -270,7 +270,7 @@ void QgsVectorTileMVTEncoder::addFeature( vector_tile::Tile_Layer *tileLayer, co
   for ( int i = 0; i < attrs.count(); ++i )
   {
     const QVariant v = attrs.at( i );
-    if ( !v.isValid() || v.isNull() )
+    if ( QgsVariantUtils::isNull( v ) )
       continue;
 
     int valueIndex;

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -122,7 +122,7 @@ void QgsAttributeTableDelegate::setModelData( QWidget *editor, QAbstractItemMode
   newValues.append( eww->additionalFieldValues() );
 
   if ( ( oldValue != newValues.at( 0 ) && newValues.at( 0 ).isValid() )
-       || oldValue.isNull() != newValues.at( 0 ).isNull()
+       || QgsVariantUtils::isNull( oldValue ) != QgsVariantUtils::isNull( newValues.at( 0 ) )
        || newValues.count() > 1 )
   {
     // This fixes https://github.com/qgis/QGIS/issues/24398
@@ -188,7 +188,7 @@ void QgsAttributeTableDelegate::paint( QPainter *painter, const QStyleOptionView
 
     QStyleOptionViewItem myOpt = option;
 
-    if ( index.model()->data( index, Qt::EditRole ).isNull() )
+    if ( QgsVariantUtils::isNull( index.model()->data( index, Qt::EditRole ) ) )
     {
       myOpt.font.setItalic( true );
       myOpt.palette.setColor( QPalette::Text, QColor( "gray" ) );

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -38,6 +38,7 @@
 #include "qgsauthmanager.h"
 #include "qgsauthtrustedcasdialog.h"
 #include "qgslogger.h"
+#include "qgsvariantutils.h"
 
 QgsAuthAuthoritiesEditor::QgsAuthAuthoritiesEditor( QWidget *parent )
   : QWidget( parent )
@@ -77,14 +78,14 @@ QgsAuthAuthoritiesEditor::QgsAuthAuthoritiesEditor( QWidget *parent )
     connect( btnViewRefresh, &QAbstractButton::clicked, this, &QgsAuthAuthoritiesEditor::refreshCaCertsView );
 
     const QVariant cafileval = QgsApplication::authManager()->authSetting( QStringLiteral( "cafile" ) );
-    if ( !cafileval.isNull() )
+    if ( !QgsVariantUtils::isNull( cafileval ) )
     {
       leCaFile->setText( cafileval.toString() );
     }
 
     btnGroupByOrg->setChecked( false );
     const QVariant sortbyval = QgsApplication::authManager()->authSetting( QStringLiteral( "casortby" ), QVariant( false ) );
-    if ( !sortbyval.isNull() )
+    if ( !QgsVariantUtils::isNull( sortbyval ) )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
     mDefaultTrustPolicy = QgsApplication::authManager()->defaultCertTrustPolicy();

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -28,7 +28,7 @@
 #include "qgsauthmanager.h"
 #include "qgsauthguiutils.h"
 #include "qgslogger.h"
-
+#include "qgsvariantutils.h"
 
 QgsAuthIdentitiesEditor::QgsAuthIdentitiesEditor( QWidget *parent )
   : QWidget( parent )
@@ -67,7 +67,7 @@ QgsAuthIdentitiesEditor::QgsAuthIdentitiesEditor( QWidget *parent )
 
     btnGroupByOrg->setChecked( false );
     const QVariant sortbyval = QgsApplication::authManager()->authSetting( QStringLiteral( "identitiessortby" ), QVariant( false ) );
-    if ( !sortbyval.isNull() )
+    if ( !QgsVariantUtils::isNull( sortbyval ) )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
     populateIdentitiesView();

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -28,6 +28,7 @@
 #include "qgsauthmanager.h"
 #include "qgsauthguiutils.h"
 #include "qgslogger.h"
+#include "qgsvariantutils.h"
 
 QgsAuthServersEditor::QgsAuthServersEditor( QWidget *parent )
   : QWidget( parent )
@@ -66,7 +67,7 @@ QgsAuthServersEditor::QgsAuthServersEditor( QWidget *parent )
 
     btnGroupByOrg->setChecked( false );
     const QVariant sortbyval = QgsApplication::authManager()->authSetting( QStringLiteral( "serverssortby" ), QVariant( false ) );
-    if ( !sortbyval.isNull() )
+    if ( !QgsVariantUtils::isNull( sortbyval ) )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
     populateSslConfigsView();

--- a/src/gui/auth/qgsauthtrustedcasdialog.cpp
+++ b/src/gui/auth/qgsauthtrustedcasdialog.cpp
@@ -26,7 +26,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
-
+#include "qgsvariantutils.h"
 
 QgsAuthTrustedCAsDialog::QgsAuthTrustedCAsDialog( QWidget *parent,
     const QList<QSslCertificate> &trustedCAs )
@@ -61,7 +61,7 @@ QgsAuthTrustedCAsDialog::QgsAuthTrustedCAsDialog( QWidget *parent,
 
     btnGroupByOrg->setChecked( false );
     const QVariant sortbyval = QgsApplication::authManager()->authSetting( QStringLiteral( "trustedcasortby" ), QVariant( false ) );
-    if ( !sortbyval.isNull() )
+    if ( !QgsVariantUtils::isNull( sortbyval ) )
       btnGroupByOrg->setChecked( sortbyval.toBool() );
 
     populateCaCertsView();

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -112,7 +112,7 @@ bool QgsBinaryWidgetWrapper::valid() const
 
 void QgsBinaryWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
-  mValue = value.isValid() && !value.isNull() && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
+  mValue = value.isValid() && !QgsVariantUtils::isNull( value ) && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
   if ( mValue.length() == 0 )
     mValue = QByteArray();
 

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -76,7 +76,7 @@ bool QgsColorWidgetWrapper::valid() const
 void QgsColorWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mColorButton )
-    mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );
+    mColorButton->setColor( !QgsVariantUtils::isNull( value ) ? QColor( value.toString() ) : QColor() );
 }
 
 void QgsColorWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -82,7 +82,7 @@ void QgsDateTimeEdit::clear()
     // Check if it's really changed or crash, see GH #29937
     if ( ! dateTime().isNull() )
     {
-      changed( QDateTime() );
+      changed( QVariant() );
     }
 
     // emit signal of QDateTime::dateTimeChanged with an invalid date
@@ -237,7 +237,7 @@ void QgsDateTimeEdit::changed( const QVariant &dateTime )
 
   mClearAction->setVisible( mAllowNull && !mIsNull );
   if ( !mBlockChangedSignal )
-    emitValueChanged( dateTime );
+    emitValueChanged( isNull ? QVariant() : dateTime );
 }
 ///@endcond
 

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -24,8 +24,7 @@
 #include "qgsdatetimeedit.h"
 
 #include "qgsapplication.h"
-#include "qgslogger.h"
-
+#include "qgsvariantutils.h"
 
 
 QgsDateTimeEdit::QgsDateTimeEdit( QWidget *parent )
@@ -218,7 +217,7 @@ void QgsDateTimeEdit::showEvent( QShowEvent *event )
 void QgsDateTimeEdit::changed( const QVariant &dateTime )
 {
   mIsEmpty = false;
-  const bool isNull = dateTime.isNull();
+  const bool isNull = QgsVariantUtils::isNull( dateTime );
   if ( isNull != mIsNull )
   {
     mIsNull = isNull;

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -236,7 +236,7 @@ void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, cons
 {
   if ( mLineEdit )
   {
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
     {
       mLineEdit->setText( QgsApplication::nullRepresentation() );
     }
@@ -257,7 +257,7 @@ void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, cons
 
   if ( mQgsWidget )
   {
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
     {
       mQgsWidget->setDocumentPath( QgsApplication::nullRepresentation() );
     }

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -275,7 +275,7 @@ void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QVariantL
 {
   if ( mDoubleSpinBox )
   {
-    if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
+    if ( QgsVariantUtils::isNull( value ) && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       mDoubleSpinBox->setValue( mDoubleSpinBox->minimum() );
     }
@@ -287,7 +287,7 @@ void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QVariantL
 
   if ( mIntSpinBox )
   {
-    if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
+    if ( QgsVariantUtils::isNull( value ) && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       mIntSpinBox->setValue( mIntSpinBox->minimum() );
     }

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -102,13 +102,13 @@ QString QgsRelationReferenceSearchWidgetWrapper::createExpression( QgsSearchWidg
     {
       if ( flags & EqualTo )
       {
-        if ( v.isNull() )
+        if ( QgsVariantUtils::isNull( v ) )
           return fieldName + " IS NULL";
         return fieldName + '=' + v.toString();
       }
       else if ( flags & NotEqualTo )
       {
-        if ( v.isNull() )
+        if ( QgsVariantUtils::isNull( v ) )
           return fieldName + " IS NOT NULL";
         return fieldName + "<>" + v.toString();
       }
@@ -166,7 +166,7 @@ void QgsRelationReferenceSearchWidgetWrapper::onValuesChanged( const QVariantLis
     const QgsSettings settings;
     // TODO: adapt for composite keys
     const QVariant value = values.at( 0 );
-    setExpression( value.isNull() ? QgsApplication::nullRepresentation() : value.toString() );
+    setExpression( QgsVariantUtils::isNull( value ) ? QgsApplication::nullRepresentation() : value.toString() );
     emit valueChanged();
   }
   emit expressionChanged( mExpression );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -54,7 +54,7 @@ bool qVariantListIsNull( const QVariantList &list )
 
   for ( int i = 0; i < list.size(); ++i )
   {
-    if ( !list.at( i ).isNull() )
+    if ( !QgsVariantUtils::isNull( list.at( i ) ) )
       return false;
   }
   return true;
@@ -270,7 +270,7 @@ void QgsRelationReferenceWidget::setForeignKeys( const QVariantList &values )
     for ( int i = 0; i < count; i++ )
     {
       QVariant v = mFeature.attribute( mFilterFields[i] );
-      QString f = v.isNull() ? nullValue.toString() : v.toString();
+      QString f = QgsVariantUtils::isNull( v ) ? nullValue.toString() : v.toString();
       mFilterComboBoxes.at( i )->setCurrentIndex( mFilterComboBoxes.at( i )->findText( f ) );
     }
   }
@@ -464,8 +464,8 @@ void QgsRelationReferenceWidget::init()
           {
             QVariant cv = ft.attribute( mFilterFields.at( i ) );
             QVariant nv = ft.attribute( mFilterFields.at( i + 1 ) );
-            QString cf = cv.isNull() ? nullValue.toString() : cv.toString();
-            QString nf = nv.isNull() ? nullValue.toString() : nv.toString();
+            QString cf = QgsVariantUtils::isNull( cv ) ? nullValue.toString() : cv.toString();
+            QString nf = QgsVariantUtils::isNull( nv ) ? nullValue.toString() : nv.toString();
             mFilterCache[mFilterFields[i]][cf] << nf;
           }
         }
@@ -498,7 +498,7 @@ void QgsRelationReferenceWidget::init()
       for ( int i = 0; i < mFilterFields.size(); i++ )
       {
         QVariant v = mFeature.attribute( mFilterFields[i] );
-        QString f = v.isNull() ? nullValue.toString() : v.toString();
+        QString f = QgsVariantUtils::isNull( v ) ? nullValue.toString() : v.toString();
         mFilterComboBoxes.at( i )->setCurrentIndex( mFilterComboBoxes.at( i )->findText( f ) );
       }
     }

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -190,7 +190,7 @@ QStringList QgsRelationReferenceWidgetWrapper::additionalFields() const
 
 void QgsRelationReferenceWidgetWrapper::updateValues( const QVariant &val, const QVariantList &additionalValues )
 {
-  if ( !mWidget || ( !mIndeterminateState && val == value() && val.isNull() == value().isNull() ) )
+  if ( !mWidget || ( !mIndeterminateState && val == value() && QgsVariantUtils::isNull( val ) == QgsVariantUtils::isNull( value() ) ) )
     return;
 
   mIndeterminateState = false;

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -74,7 +74,7 @@ QVariant QgsTextEditWrapper::value() const
     return QVariant( field().type() );
   }
 
-  if ( !defaultValue().isNull() && v == defaultValue().toString() )
+  if ( !QgsVariantUtils::isNull( defaultValue() ) && v == defaultValue().toString() )
   {
     return defaultValue();
   }
@@ -165,7 +165,7 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
     mLineEdit->setValidator( new QgsFieldValidator( mLineEdit, field(), defaultValue().toString() ) );
 
     QVariant defVal = defaultValue();
-    if ( defVal.isNull() )
+    if ( QgsVariantUtils::isNull( defVal ) )
     {
       defVal = QgsApplication::nullRepresentation();
     }
@@ -288,7 +288,7 @@ void QgsTextEditWrapper::textChanged( const QString & )
 void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
 {
   QString v;
-  if ( val.isNull() )
+  if ( QgsVariantUtils::isNull( val ) )
   {
     if ( !( field().type() == QVariant::Int || field().type() == QVariant::Double || field().type() == QVariant::LongLong || field().type() == QVariant::Date ) )
       v = QgsApplication::nullRepresentation();
@@ -338,7 +338,7 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
   const QVariant currentValue = value( );
   // Note: comparing QVariants leads to funny (and wrong) results:
   // QVariant(0.0) == QVariant(QVariant.Double) -> True
-  const bool changed { val != currentValue || val.isNull() != currentValue.isNull() };
+  const bool changed { val != currentValue || QgsVariantUtils::isNull( val ) != QgsVariantUtils::isNull( currentValue ) };
 
   if ( changed )
   {

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -132,7 +132,7 @@ void QgsUniqueValuesWidgetWrapper::updateValues( const QVariant &value, const QV
 
   if ( mLineEdit )
   {
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
       mLineEdit->setText( QgsApplication::nullRepresentation() );
     else
       mLineEdit->setText( value.toString() );

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -70,7 +70,7 @@ bool QgsUuidWidgetWrapper::valid() const
 
 void QgsUuidWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     int maxLength = 0;
     if ( field().type() == QVariant::String && field().length() > 0 )

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -104,7 +104,7 @@ void QgsValueMapConfigDlg::setConfig( const QVariantMap &config )
     const QVariantMap values = config.value( QStringLiteral( "map" ) ).toMap();
     for ( QVariantMap::ConstIterator mit = values.constBegin(); mit != values.constEnd(); mit++, row++ )
     {
-      if ( mit.value().isNull() )
+      if ( QgsVariantUtils::isNull( mit.value() ) )
         setRow( row, mit.key(), QString() );
       else
         setRow( row, mit.value().toString(), mit.key() );
@@ -177,7 +177,7 @@ void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant>> &lis
 
   for ( const auto &pair : list )
   {
-    if ( pair.second.isNull() )
+    if ( QgsVariantUtils::isNull( pair.second ) )
       setRow( row, pair.first, QString() );
     else
       setRow( row, pair.first, pair.second.toString() );

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -76,7 +76,7 @@ bool QgsValueMapWidgetWrapper::valid() const
 void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   QString v;
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     v = QgsValueMapFieldFormatter::NULL_VALUE;
   else
     v = value.toString();
@@ -85,7 +85,7 @@ void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVaria
   {
     if ( mComboBox->findData( v ) == -1 )
     {
-      if ( value.isNull( ) )
+      if ( QgsVariantUtils::isNull( value ) )
       {
         mComboBox->addItem( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ), v );
       }

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -163,7 +163,7 @@ void QgsValueRelationSearchWidgetWrapper::onValueChanged()
   }
   else
   {
-    setExpression( vl.isNull() ? QgsApplication::nullRepresentation() : vl.toString() );
+    setExpression( QgsVariantUtils::isNull( vl ) ? QgsApplication::nullRepresentation() : vl.toString() );
     emit valueChanged();
   }
   emit expressionChanged( mExpression );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -57,7 +57,7 @@ QVariant QgsValueRelationWidgetWrapper::value() const
     if ( cbxIdx > -1 )
     {
       v = mComboBox->currentData();
-      if ( v.isNull() )
+      if ( QgsVariantUtils::isNull( v ) )
         v = QVariant( field().type() );
     }
   }
@@ -252,7 +252,7 @@ void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const Q
     if ( idx == -1 )
     {
       // if value doesn't exist, we show it in '(...)' (just like value map widget)
-      if ( value.isNull( ) )
+      if ( QgsVariantUtils::isNull( value ) )
       {
         mComboBox->setCurrentIndex( -1 );
       }

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1498,7 +1498,7 @@ QgsLayoutLegendNodeWidget::QgsLayoutLegendNodeWidget( QgsLayoutItemLegend *legen
   {
     currentLabel = mLayer->name();
     QVariant v = mLayer->customProperty( QStringLiteral( "legend/title-label" ) );
-    if ( !v.isNull() )
+    if ( !QgsVariantUtils::isNull( v ) )
       currentLabel = v.toString();
     mColumnBreakBeforeCheckBox->setChecked( mLayer->customProperty( QStringLiteral( "legend/column-break" ) ).toInt() );
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -131,7 +131,7 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
 
     const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( layerItem->providerKey(), layerItem->uri() );
     QString errCause;
-    if ( parts.empty() || parts.value( QStringLiteral( "path" ) ).isNull() || parts.value( QStringLiteral( "layerName" ) ).isNull() )
+    if ( parts.empty() || QgsVariantUtils::isNull( parts.value( QStringLiteral( "path" ) ) ) || QgsVariantUtils::isNull( parts.value( QStringLiteral( "layerName" ) ) ) )
     {
       errCause = QObject::tr( "Layer URI %1 is not valid!" ).arg( layerItem->uri() );
     }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -442,9 +442,9 @@ bool QgsAttributeForm::saveEdits( QString *error )
 
           QgsDebugMsgLevel( QStringLiteral( "Updating field %1" ).arg( i ), 2 );
           QgsDebugMsgLevel( QStringLiteral( "dst:'%1' (type:%2, isNull:%3, isValid:%4)" )
-                            .arg( dst.at( i ).toString(), dst.at( i ).typeName() ).arg( dst.at( i ).isNull() ).arg( dst.at( i ).isValid() ), 2 );
+                            .arg( dst.at( i ).toString(), dst.at( i ).typeName() ).arg( QgsVariantUtils::isNull( dst.at( i ) ) ).arg( dst.at( i ).isValid() ), 2 );
           QgsDebugMsgLevel( QStringLiteral( "src:'%1' (type:%2, isNull:%3, isValid:%4)" )
-                            .arg( src.at( i ).toString(), src.at( i ).typeName() ).arg( src.at( i ).isNull() ).arg( src.at( i ).isValid() ), 2 );
+                            .arg( src.at( i ).toString(), src.at( i ).typeName() ).arg( QgsVariantUtils::isNull( src.at( i ) ) ).arg( src.at( i ).isValid() ), 2 );
 
           newValues[i] = dst.at( i );
           oldValues[i] = src.at( i );
@@ -1211,7 +1211,7 @@ bool QgsAttributeForm::currentFormValuesFeature( QgsFeature &feature )
       {
         // need to check dstVar.isNull() != srcVar.isNull()
         // otherwise if dstVar=NULL and scrVar=0, then dstVar = srcVar
-        if ( ( !qgsVariantEqual( dstVars[i], srcVars[i] ) || dstVars[i].isNull() != srcVars[i].isNull() ) && srcVars[i].isValid() )
+        if ( ( !qgsVariantEqual( dstVars[i], srcVars[i] ) || QgsVariantUtils::isNull( dstVars[i] ) != QgsVariantUtils::isNull( srcVars[i] ) ) && srcVars[i].isValid() )
         {
           dst[fieldIndexes[i]] = srcVars[i];
         }

--- a/src/gui/qgsattributetypeloaddialog.cpp
+++ b/src/gui/qgsattributetypeloaddialog.cpp
@@ -139,8 +139,8 @@ void QgsAttributeTypeLoadDialog::createPreview( int fieldIndex, bool full )
   {
     const QVariant val1 = f.attribute( idx );
     const QVariant val2 = f.attribute( idx2 );
-    if ( val1.isValid() && !val1.isNull() && !val1.toString().isEmpty()
-         && val2.isValid() && !val2.isNull() && !val2.toString().isEmpty() )
+    if ( val1.isValid() && !QgsVariantUtils::isNull( val1 ) && !val1.toString().isEmpty()
+         && val2.isValid() && !QgsVariantUtils::isNull( val2 ) && !val2.toString().isEmpty() )
     {
       valueMap.insert( val1.toString(), val2.toString() );
     }
@@ -186,7 +186,7 @@ void QgsAttributeTypeLoadDialog::loadDataToValueMap()
   while ( fit.nextFeature( f ) )
   {
     const QVariant val = f.attribute( idx );
-    if ( val.isValid() && !val.isNull() && !val.toString().isEmpty() )
+    if ( val.isValid() && !QgsVariantUtils::isNull( val ) && !val.toString().isEmpty() )
     {
       mValueMap.insert( f.attribute( idx2 ).toString(), val );
     }

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgsvariantutils.h"
 
 #include <QToolButton>
 #include <QMouseEvent>
@@ -601,13 +602,13 @@ void QgsCollapsibleGroupBox::loadState()
   if ( mSaveCheckedState )
   {
     const QVariant val = mSettings->value( key + "/checked" );
-    if ( ! val.isNull() )
+    if ( ! QgsVariantUtils::isNull( val ) )
       setChecked( val.toBool() );
   }
   if ( mSaveCollapsedState )
   {
     const QVariant val = mSettings->value( key + "/collapsed" );
-    if ( ! val.isNull() )
+    if ( ! QgsVariantUtils::isNull( val ) )
       setCollapsed( val.toBool() );
   }
 

--- a/src/gui/qgsdial.cpp
+++ b/src/gui/qgsdial.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsdial.h"
 #include "qgslogger.h"
+#include "qgsvariantutils.h"
 
 #include <QPaintEvent>
 #include <QPainter>
@@ -65,10 +66,10 @@ void QgsDial::setValue( const QVariant &value )
 
 void QgsDial::update()
 {
-  if ( mMin.isNull() || mMax.isNull() || mStep.isNull() )
+  if ( QgsVariantUtils::isNull( mMin ) || QgsVariantUtils::isNull( mMax ) || QgsVariantUtils::isNull( mStep ) )
     return;
 
-  if ( mValue.isNull() )
+  if ( QgsVariantUtils::isNull( mValue ) )
     mValue = mMin;
 
   if ( mMin.type() == QVariant::Int &&
@@ -110,7 +111,7 @@ QVariant QgsDial::variantValue() const
 
 void QgsDial::onValueChanged( int value )
 {
-  if ( mMin.isNull() || mMax.isNull() || mStep.isNull() )
+  if ( QgsVariantUtils::isNull( mMin ) || QgsVariantUtils::isNull( mMax ) || QgsVariantUtils::isNull( mStep ) )
   {
     mValue = QVariant();
   }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -355,7 +355,7 @@ void QgsExpressionBuilderWidget::runPythonCode( const QString &code )
 QgsVectorLayer *QgsExpressionBuilderWidget::contextLayer( const QgsExpressionItem *item ) const
 {
   QgsVectorLayer *layer = nullptr;
-  if ( ! item->data( QgsExpressionItem::LAYER_ID_ROLE ).isNull() )
+  if ( ! QgsVariantUtils::isNull( item->data( QgsExpressionItem::LAYER_ID_ROLE ) ) )
   {
     layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( item->data( QgsExpressionItem::LAYER_ID_ROLE ).toString() ) );
   }
@@ -558,7 +558,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, QgsV
   {
     QString strValue;
     bool forceRepresentedValue = false;
-    if ( value.isNull() )
+    if ( QgsVariantUtils::isNull( value ) )
       strValue = QStringLiteral( "NULL" );
     else if ( value.type() == QVariant::Int || value.type() == QVariant::Double || value.type() == QVariant::LongLong )
       strValue = value.toString();

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -1063,7 +1063,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
       for ( auto it = values.constBegin(); it != values.constEnd(); ++it )
       {
         QString valueString;
-        if ( it.value().isNull() )
+        if ( QgsVariantUtils::isNull( it.value() ) )
         {
           valueString = tr( "no data" );
         }

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -797,7 +797,7 @@ bool QgsMetadataWidget::checkMetadata()
     for ( const QgsAbstractMetadataBaseValidator::ValidationResult &result : std::as_const( validationResults ) )
     {
       errors += QLatin1String( "<b>" ) % result.section;
-      if ( ! result._identifier().isNull() )
+      if ( ! QgsVariantUtils::isNull( result._identifier() ) )
       {
         errors += QLatin1Char( ' ' ) % QVariant( result._identifier().toInt() + 1 ).toString();
       }

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -39,6 +39,7 @@
 #include "qgsoptionswidgetfactory.h"
 #include "qgsguiutils.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 QgsOptionsDialogBase::QgsOptionsDialogBase( const QString &settingsKey, QWidget *parent, Qt::WindowFlags fl, QgsSettings *settings )
   : QDialog( parent, fl )
@@ -228,7 +229,7 @@ void QgsOptionsDialogBase::restoreOptionsBaseUi( const QString &title )
   if ( optView )
   {
     optView->setMaximumWidth(
-      mSettings->value( QStringLiteral( "/Windows/%1/splitState" ).arg( mOptsKey ) ).isNull() ? 150 : 16777215 );
+      QgsVariantUtils::isNull( mSettings->value( QStringLiteral( "/Windows/%1/splitState" ).arg( mOptsKey ) ) ) ? 150 : 16777215 );
     // get rid of annoying outer focus rect on Mac
     optView->setAttribute( Qt::WA_MacShowFocusRect, false );
   }

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -167,7 +167,7 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
   for ( const QVariant &var : constValues )
   {
     QString value;
-    if ( var.isNull() )
+    if ( QgsVariantUtils::isNull( var ) )
       value = nullValue;
     else if ( var.type() == QVariant::Date && mLayer->providerType() == QLatin1String( "ogr" ) && mLayer->storageType() == QLatin1String( "ESRI Shapefile" ) )
       value = var.toDate().toString( QStringLiteral( "yyyy/MM/dd" ) );
@@ -178,7 +178,7 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
       {
         if ( !value.isEmpty() )
           value.append( ", " );
-        value.append( val.isNull() ? nullValue : val.toString() );
+        value.append( QgsVariantUtils::isNull( val ) ? nullValue : val.toString() );
       }
     }
     else
@@ -188,7 +188,7 @@ void QgsQueryBuilder::fillValues( int idx, int limit )
     myItem->setEditable( false );
     myItem->setData( var, Qt::UserRole + 1 );
     mModelValues->insertRow( mModelValues->rowCount(), myItem );
-    QgsDebugMsg( QStringLiteral( "Value is null: %1\nvalue: %2" ).arg( var.isNull() ).arg( var.isNull() ? nullValue : var.toString() ) );
+    QgsDebugMsg( QStringLiteral( "Value is null: %1\nvalue: %2" ).arg( QgsVariantUtils::isNull( var ) ).arg( QgsVariantUtils::isNull( var ) ? nullValue : var.toString() ) );
   }
 }
 
@@ -387,7 +387,7 @@ void QgsQueryBuilder::lstFields_doubleClicked( const QModelIndex &index )
 void QgsQueryBuilder::lstValues_doubleClicked( const QModelIndex &index )
 {
   const QVariant value = index.data( Qt::UserRole + 1 );
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     mTxtSql->insertText( QStringLiteral( "NULL" ) );
   else if ( value.type() == QVariant::Date && mLayer->providerType() == QLatin1String( "ogr" ) && mLayer->storageType() == QLatin1String( "ESRI Shapefile" ) )
     mTxtSql->insertText( '\'' + value.toDate().toString( QStringLiteral( "yyyy/MM/dd" ) ) + '\'' );

--- a/src/gui/qgsslider.cpp
+++ b/src/gui/qgsslider.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsslider.h"
 #include "qgslogger.h"
+#include "qgsvariantutils.h"
 
 #include <QPaintEvent>
 #include <QPainter>
@@ -70,10 +71,10 @@ void QgsSlider::setValue( const QVariant &value )
 
 void QgsSlider::update()
 {
-  if ( mMin.isNull() || mMax.isNull() || mStep.isNull() )
+  if ( QgsVariantUtils::isNull( mMin ) || QgsVariantUtils::isNull( mMax ) || QgsVariantUtils::isNull( mStep ) )
     return;
 
-  if ( mValue.isNull() )
+  if ( QgsVariantUtils::isNull( mValue ) )
     mValue = mMin;
 
   if ( mMin.type() == QVariant::Int &&
@@ -111,7 +112,7 @@ QVariant QgsSlider::variantValue() const
 
 void QgsSlider::onValueChanged( int value )
 {
-  if ( mMin.isNull() || mMax.isNull() || mStep.isNull() )
+  if ( QgsVariantUtils::isNull( mMin ) || QgsVariantUtils::isNull( mMax ) || QgsVariantUtils::isNull( mStep ) )
   {
     mValue = QVariant();
   }

--- a/src/gui/qgstreewidgetitem.cpp
+++ b/src/gui/qgstreewidgetitem.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgstreewidgetitem.h"
+#include "qgsvariantutils.h"
 #include "qgis.h"
 
 QgsTreeWidgetItem::QgsTreeWidgetItem( QTreeWidget *parent, int type )
@@ -106,7 +107,7 @@ bool QgsTreeWidgetItem::operator<( const QTreeWidgetItem &other ) const
   if ( !val2.isValid() )
     val2 = other.text( column );
 
-  if ( !val1.isNull() && !val2.isNull() )
+  if ( !QgsVariantUtils::isNull( val1 ) && !QgsVariantUtils::isNull( val2 ) )
   {
     val = val1.toDouble( &ok1 ) < val2.toDouble( &ok2 );
     if ( ok1 && ok2 )

--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -582,7 +582,7 @@ void QgsRasterTransparencyWidget::pixelSelected( const QgsPointXY &canvasPoint )
       const int bandNo = bands.value( i );
       if ( myPixelMap.count( bandNo ) == 1 )
       {
-        if ( myPixelMap.value( bandNo ).isNull() )
+        if ( QgsVariantUtils::isNull( myPixelMap.value( bandNo ) ) )
         {
           return; // Don't add nodata, transparent anyway
         }

--- a/src/gui/symbology/qgs25drendererwidget.cpp
+++ b/src/gui/symbology/qgs25drendererwidget.cpp
@@ -65,8 +65,8 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
   const QVariant angle = scope->variable( QStringLiteral( "qgis_25d_angle" ) );
   delete scope;
 
-  mHeightWidget->setField( height.isNull() ? QStringLiteral( "10" ) : height.toString() );
-  mAngleWidget->setValue( angle.isNull() ? 70 : angle.toDouble() );
+  mHeightWidget->setField( QgsVariantUtils::isNull( height ) ? QStringLiteral( "10" ) : height.toString() );
+  mAngleWidget->setValue( QgsVariantUtils::isNull( angle ) ? 70 : angle.toDouble() );
   mAngleWidget->setClearValue( 70 );
   mWallColorButton->setColor( mRenderer->wallColor() );
   mRoofColorButton->setColor( mRenderer->roofColor() );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -170,7 +170,7 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
             else // tooltip
               return res.join( '\n' );
           }
-          else if ( !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() )
+          else if ( QgsVariantUtils::isNull( category.value() ) || category.value().toString().isEmpty() )
           {
             return tr( "all other values" );
           }
@@ -187,7 +187,7 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
 
     case Qt::FontRole:
     {
-      if ( index.column() == 1 && category.value().type() != QVariant::List && ( !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() ) )
+      if ( index.column() == 1 && category.value().type() != QVariant::List && ( QgsVariantUtils::isNull( category.value() ) || category.value().toString().isEmpty() ) )
       {
         QFont italicFont;
         italicFont.setItalic( true );
@@ -210,7 +210,7 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
     {
       QBrush brush( qApp->palette().color( QPalette::Text ), Qt::SolidPattern );
       if ( index.column() == 1 && ( category.value().type() == QVariant::List
-                                    || !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() ) )
+                                    || QgsVariantUtils::isNull( category.value() ) || category.value().toString().isEmpty() ) )
       {
         QColor fadedTextColor = brush.color();
         fadedTextColor.setAlpha( 128 );
@@ -510,7 +510,7 @@ QWidget *QgsCategorizedRendererViewItemDelegate::createEditor( QWidget *parent, 
   QVariant::Type userType { index.data( QgsCategorizedSymbolRendererWidget::CustomRoles::ValueRole ).type() };
 
   // In case of new values the type is not known
-  if ( userType == QVariant::String && index.data( QgsCategorizedSymbolRendererWidget::CustomRoles::ValueRole ).isNull() )
+  if ( userType == QVariant::String && QgsVariantUtils::isNull( index.data( QgsCategorizedSymbolRendererWidget::CustomRoles::ValueRole ) ) )
   {
     bool isExpression;
     bool isValid;

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -94,7 +94,7 @@ QVariant DockModel::data( const QModelIndex &index, int role ) const
       val = QVariant();
   }
 
-  if ( val.isNull() )
+  if ( QgsVariantUtils::isNull( val ) )
   {
     return QVariant();
   }

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -200,7 +200,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
     for ( int idx = 0; idx < mFields.size(); ++idx )
     {
       QVariant attribute = attributesData[mFields.at( idx ).name()];
-      if ( attribute.isNull() )
+      if ( QgsVariantUtils::isNull( attribute ) )
       {
         // ensure that null values are mapped correctly for PyQGIS
         attribute = QVariant( QVariant::Int );

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -1023,7 +1023,7 @@ void QgsAmsTiledImageDownloadHandler::tileReplyFinished()
   if ( reply->error() == QNetworkReply::NoError )
   {
     QVariant redirect = reply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       QNetworkRequest request( redirect.toUrl() );
       QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsAmsTiledImageDownloadHandler" ) );
@@ -1055,7 +1055,7 @@ void QgsAmsTiledImageDownloadHandler::tileReplyFinished()
     }
 
     QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       mReplies.removeOne( reply );
       reply->deleteLater();

--- a/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
+++ b/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
@@ -103,7 +103,7 @@ QgsSqlExpressionCompiler::Result QgsMssqlExpressionCompiler::compileNode( const 
 QString QgsMssqlExpressionCompiler::quotedValue( const QVariant &value, bool &ok )
 {
   ok = true;
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
   {
     //no NULL literal support
     ok = false;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -278,7 +278,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
         {
           QString colName = mSource->mFields[mSource->mPrimaryKeyAttrs[i]].name();
           QString expr;
-          if ( key[i].isNull() )
+          if ( QgsVariantUtils::isNull( key[i] ) )
             expr = QString( "[%1] IS NULL" ).arg( colName );
           else
             expr = QString( "[%1]=%2" ).arg( colName, QgsMssqlProvider::quotedValue( key[i] ) );
@@ -494,7 +494,7 @@ bool QgsMssqlFeatureIterator::fetchFeature( QgsFeature &feature )
         v = QgsVectorDataProvider::convertValue( fld.type(), originalValue.toString() );
 
       // second chance for time fields -- time fields are not correctly handled by sql server driver on linux (maybe win too?)
-      if ( v.isNull() && fld.type() == QVariant::Time && originalValue.isValid() && originalValue.type() == QVariant::ByteArray )
+      if ( QgsVariantUtils::isNull( v ) && fld.type() == QVariant::Time && originalValue.isValid() && originalValue.type() == QVariant::ByteArray )
       {
         // time fields can be returned as byte arrays... woot
         const QByteArray ba = originalValue.toByteArray();

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -520,7 +520,7 @@ void QgsMssqlProvider::loadFields()
       mAttributeFields.append( field );
 
       // Default value
-      if ( !query.value( QStringLiteral( "COLUMN_DEF" ) ).isNull() )
+      if ( !QgsVariantUtils::isNull( query.value( QStringLiteral( "COLUMN_DEF" ) ) ) )
       {
         mDefaultValues.insert( i, query.value( QStringLiteral( "COLUMN_DEF" ) ).toString() );
       }
@@ -614,7 +614,7 @@ void QgsMssqlProvider::loadFields()
 
 QString QgsMssqlProvider::quotedValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( value.type() )
@@ -936,10 +936,10 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
 
   if ( LoggedExec( query, statement ) )
   {
-    if ( query.next() && ( !query.value( 0 ).isNull() ||
-                           !query.value( 1 ).isNull() ||
-                           !query.value( 2 ).isNull() ||
-                           !query.value( 3 ).isNull() ) )
+    if ( query.next() && ( !QgsVariantUtils::isNull( query.value( 0 ) ) ||
+                           !QgsVariantUtils::isNull( query.value( 1 ) ) ||
+                           !QgsVariantUtils::isNull( query.value( 2 ) ) ||
+                           !QgsVariantUtils::isNull( query.value( 3 ) ) ) )
     {
       QgsDebugMsgLevel( QStringLiteral( "Found extents in spatial index" ), 2 );
       mExtent.setXMinimum( query.value( 0 ).toDouble() );
@@ -1023,7 +1023,7 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
     const QString statementSample = statement + ( mSqlWhereClause.isEmpty() ? " WHERE " : " AND " ) + sampleFilter;
 
     if ( LoggedExec( query, statementSample ) && query.next() &&
-         !query.value( 0 ).isNull() && query.value( 4 ).toInt() >= minSampleCount )
+         !QgsVariantUtils::isNull( query.value( 0 ) ) && query.value( 4 ).toInt() >= minSampleCount )
     {
       mExtent.setXMinimum( query.value( 0 ).toDouble() );
       mExtent.setYMinimum( query.value( 1 ).toDouble() );
@@ -1314,7 +1314,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
         continue; // skip computed columns because they are done server side.
 
       const QVariant::Type type = fld.type();
-      if ( attrs.at( i ).isNull() || !attrs.at( i ).isValid() )
+      if ( QgsVariantUtils::isNull( attrs.at( i ) ) )
       {
         // binding null values
         if ( type == QVariant::Date || type == QVariant::DateTime )
@@ -1603,7 +1603,7 @@ bool QgsMssqlProvider::changeAttributeValues( const QgsChangedAttributesMap &att
         continue; // skip computed columns because they are done server side.
 
       const QVariant::Type type = fld.type();
-      if ( it2->isNull() || !it2->isValid() )
+      if ( QgsVariantUtils::isNull( *it2 ) )
       {
         // binding null values
         if ( type == QVariant::Date || type == QVariant::DateTime )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1289,7 +1289,7 @@ static QString quotedList( const QVariantList &list )
 
 QString QgsPostgresConn::quotedValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   switch ( value.type() )
@@ -1320,7 +1320,7 @@ QString QgsPostgresConn::quotedValue( const QVariant &value )
 
 QString QgsPostgresConn::quotedJsonValue( const QVariant &value )
 {
-  if ( value.isNull() || !value.isValid() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "null" );
   // where json is a string literal just construct it from that rather than dump
   if ( value.type() == QVariant::String )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -479,7 +479,7 @@ void QgsPostgresProvider::disconnectDb()
 
 QString QgsPostgresProvider::quotedByteaValue( const QVariant &value )
 {
-  if ( value.isNull() )
+  if ( QgsVariantUtils::isNull( value ) )
     return QStringLiteral( "NULL" );
 
   const QByteArray ba = value.toByteArray();
@@ -658,7 +658,7 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields &
       {
         QgsField fld = fields.at( pkAttrs[0] );
         whereClause = conn->fieldExpression( fld );
-        if ( !pkVals[0].isNull() )
+        if ( !QgsVariantUtils::isNull( pkVals[0] ) )
           whereClause += '=' + pkVals[0].toString();
         else
           whereClause += QLatin1String( " IS NULL" );
@@ -680,7 +680,7 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields &
           QgsField fld = fields.at( idx );
 
           whereClause += delim + conn->fieldExpressionForWhereClause( fld, pkVals[i].type() );
-          if ( pkVals[i].isNull() )
+          if ( QgsVariantUtils::isNull( pkVals[i] ) )
             whereClause += QLatin1String( " IS NULL" );
           else
             whereClause += '=' + QgsPostgresConn::quotedValue( pkVals[i] ); // remove toString as it must be handled by quotedValue function
@@ -2317,7 +2317,7 @@ bool QgsPostgresProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstrain
   {
     // stricter check - if we are evaluating default values only on commit then we can only bypass the check
     // if the attribute values matches the original default clause
-    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString() && !value.isNull();
+    return mDefaultValues.contains( fieldIndex ) && mDefaultValues.value( fieldIndex ) == value.toString() && !QgsVariantUtils::isNull( value );
   }
 }
 
@@ -2486,7 +2486,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
           QVariant v2 = attrs2.value( idx, QVariant( QVariant::Int ) );
           // a PK field with a sequence val is auto populate by QGIS with this default
           // we are only interested in non default values
-          if ( !v2.isNull() && v2.toString() != defaultValue )
+          if ( !QgsVariantUtils::isNull( v2 ) && v2.toString() != defaultValue )
           {
             foundNonEmptyPK = true;
             break;
@@ -2672,7 +2672,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
         QVariant value = attrIdx < attrs.length() ? attrs.at( attrIdx ) : QVariant( QVariant::Int );
 
         QString v;
-        if ( value.isNull() )
+        if ( QgsVariantUtils::isNull( value ) )
         {
           QgsField fld = field( attrIdx );
           v = paramValue( defaultValues[ i ], defaultValues[ i ] );

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -4264,7 +4264,7 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList &flist, Flags flags )
             // use auto-generated value if user hasn't specified a unique value
             ++ia;
           }
-          else if ( v.isNull() )
+          else if ( QgsVariantUtils::isNull( v ) )
           {
             // binding a NULL value
             sqlite3_bind_null( stmt, ++ia );
@@ -4656,7 +4656,7 @@ bool QgsSpatiaLiteProvider::changeAttributeValues( const QgsChangedAttributesMap
 
         QVariant::Type type = fld.type();
 
-        if ( val.isNull() || !val.isValid() )
+        if ( QgsVariantUtils::isNull( val ) )
         {
           // binding a NULL value
           sql += QStringLiteral( "%1=NULL" ).arg( QgsSqliteUtils::quotedIdentifier( fld.name() ) );

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -692,7 +692,7 @@ int vtableColumn( sqlite3_vtab_cursor *cursor, sqlite3_context *ctxt, int idx )
   }
 
   QVariant v = c->currentAttribute( idx );
-  if ( v.isNull() )
+  if ( QgsVariantUtils::isNull( v ) )
   {
     sqlite3_result_null( ctxt );
   }
@@ -808,7 +808,7 @@ void qgisFunctionWrapper( sqlite3_context *ctxt, int nArgs, sqlite3_value **args
     return;
   }
 
-  if ( ret.isNull() )
+  if ( QgsVariantUtils::isNull( ret ) )
   {
     sqlite3_result_null( ctxt );
     return;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -367,7 +367,7 @@ void QgsWcsCapabilities::capabilitiesReplyFinished()
   if ( mCapabilitiesReply->error() == QNetworkReply::NoError )
   {
     QVariant redirect = mCapabilitiesReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       emit statusChanged( tr( "Capabilities request redirected." ) );
 

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1740,7 +1740,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
   if ( mCacheReply->error() == QNetworkReply::NoError )
   {
     const QVariant redirect = mCacheReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       mCacheReply->deleteLater();
 
@@ -1771,7 +1771,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
 
     const QVariant status = mCacheReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
     QgsDebugMsg( QStringLiteral( "status = %1" ).arg( status.toInt() ) );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       const QVariant phrase = mCacheReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
 

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -656,7 +656,7 @@ bool QgsBackgroundCachedFeatureIterator::fetchFeature( QgsFeature &f )
       Q_ASSERT( idx >= 0 );
 
       const QVariant &v = cachedFeature.attributes().value( idx );
-      if ( !v.isNull() && v.type() == QVariant::String )
+      if ( !QgsVariantUtils::isNull( v ) && v.type() == QVariant::String )
       {
         QByteArray wkbGeom( QByteArray::fromHex( v.toString().toLatin1() ) );
         QgsGeometry g;
@@ -939,11 +939,11 @@ void QgsBackgroundCachedFeatureIterator::copyFeature( const QgsFeature &srcFeatu
     {
       const QVariant &v = srcFeature.attributes().value( idx );
       const QVariant::Type fieldType = fields.at( i ).type();
-      if ( v.isNull() )
+      if ( QgsVariantUtils::isNull( v ) )
         dstFeature.setAttribute( i, QVariant( fieldType ) );
       else if ( QgsWFSUtils::isCompatibleType( v.type(), fieldType ) )
         dstFeature.setAttribute( i, v );
-      else if ( fieldType == QVariant::DateTime && !v.isNull() )
+      else if ( fieldType == QVariant::DateTime && !QgsVariantUtils::isNull( v ) )
         dstFeature.setAttribute( i, QVariant( QDateTime::fromMSecsSinceEpoch( v.toLongLong() ) ) );
       else
         dstFeature.setAttribute( i, QgsVectorDataProvider::convertValue( fieldType, v.toString() ) );

--- a/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.cpp
@@ -627,7 +627,7 @@ void QgsBackgroundCachedSharedData::serializeFeatures( QVector<QgsFeatureUniqueI
       {
         const QVariant &v = srcFeature.attributes().value( i );
         const QVariant::Type fieldType = dataProviderFields.at( idx ).type();
-        if ( v.type() == QVariant::DateTime && !v.isNull() )
+        if ( v.type() == QVariant::DateTime && !QgsVariantUtils::isNull( v ) )
           cachedFeature.setAttribute( idx, QVariant( v.toDateTime().toMSecsSinceEpoch() ) );
         else if ( QgsWFSUtils::isCompatibleType( v.type(), fieldType ) )
           cachedFeature.setAttribute( idx, v );
@@ -1119,7 +1119,7 @@ bool QgsBackgroundCachedSharedData::changeAttributeValues( const QgsChangedAttri
     {
       int idx = dataProviderFields.indexFromName( mMapUserVisibleFieldNameToSpatialiteColumnName[mFields.at( siter.key() ).name()] );
       Q_ASSERT( idx >= 0 );
-      if ( siter.value().type() == QVariant::DateTime && !siter.value().isNull() )
+      if ( siter.value().type() == QVariant::DateTime && !QgsVariantUtils::isNull( siter.value() ) )
         newAttrMap[idx] = QVariant( siter.value().toDateTime().toMSecsSinceEpoch() );
       else
         newAttrMap[idx] = siter.value();
@@ -1139,7 +1139,7 @@ QString QgsBackgroundCachedSharedData::getMD5( const QgsFeature &f )
   {
     const QVariant &v = attrs[i];
     hash.addData( QByteArray( ( const char * )&i, sizeof( i ) ) );
-    if ( v.isNull() )
+    if ( QgsVariantUtils::isNull( v ) )
     {
       // nothing to do
     }

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -20,6 +20,7 @@
 #include "qgsmessagelog.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 #include <QEventLoop>
 #include <QNetworkCacheMetaData>
@@ -332,7 +333,7 @@ void QgsBaseNetworkRequest::replyProgress( qint64 bytesReceived, qint64 bytesTot
     if ( mReply->error() == QNetworkReply::NoError )
     {
       const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
         // We don't want to emit downloadProgress() for a redirect
         return;
@@ -351,7 +352,7 @@ void QgsBaseNetworkRequest::replyFinished()
     {
       QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 4 );
       const QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
         QgsDebugMsgLevel( QStringLiteral( "Request redirected." ), 4 );
 

--- a/src/providers/wfs/qgsoapifprovider.cpp
+++ b/src/providers/wfs/qgsoapifprovider.cpp
@@ -790,7 +790,7 @@ void QgsOapifFeatureDownloaderImpl::run( bool serializeFeatures, long long maxFe
         {
           const QVariant &v = srcAttrs.value( srcIdx );
           const auto dstFieldType = dstFields.at( j ).type();
-          if ( v.isNull() )
+          if ( QgsVariantUtils::isNull( v ) )
             dstFeat.setAttribute( j, QVariant( dstFieldType ) );
           else if ( QgsWFSUtils::isCompatibleType( v.type(), dstFieldType ) )
             dstFeat.setAttribute( j, v );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -950,7 +950,7 @@ bool QgsWFSProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     for ( int i = 0; i < nAttrs; ++i )
     {
       const QVariant &value = featureAttributes.at( i );
-      if ( value.isValid() && !value.isNull() )
+      if ( value.isValid() && !QgsVariantUtils::isNull( value ) )
       {
         QDomElement fieldElem = transactionDoc.createElementNS( mApplicationNamespace, mShared->mFields.at( i ).name() );
         QDomText fieldText = transactionDoc.createTextNode( convertToXML( value ) );
@@ -1237,7 +1237,7 @@ bool QgsWFSProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
 
       QDomElement valueElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Value" ) );
 
-      if ( attMapIt.value().isValid() && !attMapIt.value().isNull() )
+      if ( attMapIt.value().isValid() && !QgsVariantUtils::isNull( attMapIt.value() ) )
       {
         // WFS does not support :nil='true'
         // if value is NULL, do not add value element

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -771,7 +771,7 @@ QSize QgsWFSItemDelegate::sizeHint( const QStyleOptionViewItem &option, const QM
 {
   QVariant indexData;
   indexData = index.data( Qt::DisplayRole );
-  if ( indexData.isNull() )
+  if ( QgsVariantUtils::isNull( indexData ) )
   {
     return QSize();
   }

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2585,7 +2585,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
     {
       QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
       QVariant redirect = mCapabilitiesReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-      if ( !redirect.isNull() )
+      if ( !QgsVariantUtils::isNull( redirect ) )
       {
         emit statusChanged( tr( "Capabilities request redirected." ) );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3893,7 +3893,7 @@ void QgsWmsProvider::identifyReplyFinished()
   if ( mIdentifyReply->error() == QNetworkReply::NoError )
   {
     QVariant redirect = mIdentifyReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       QgsDebugMsgLevel( QStringLiteral( "identify request redirected to %1" ).arg( redirect.toString() ), 2 );
 
@@ -3908,7 +3908,7 @@ void QgsWmsProvider::identifyReplyFinished()
     }
 
     QVariant status = mIdentifyReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       QVariant phrase = mIdentifyReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
       mErrorFormat = QStringLiteral( "text/plain" );
@@ -4440,7 +4440,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
   if ( mCacheReply->error() == QNetworkReply::NoError )
   {
     QVariant redirect = mCacheReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       mCacheReply->deleteLater();
 
@@ -4451,7 +4451,7 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
     }
 
     QVariant status = mCacheReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       QVariant phrase = mCacheReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
 
@@ -4690,7 +4690,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
   if ( reply->error() == QNetworkReply::NoError )
   {
     QVariant redirect = reply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    if ( !redirect.isNull() )
+    if ( !QgsVariantUtils::isNull( redirect ) )
     {
       QNetworkRequest request( redirect.toUrl() );
       QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsTiledImageDownloadHandler" ) );
@@ -4716,7 +4716,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     }
 
     QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    if ( !status.isNull() && status.toInt() >= 400 )
+    if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
     {
       QVariant phrase = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
       QgsWmsProvider::showMessageBox( tr( "Tile request error" ), tr( "Status: %1\nReason phrase: %2" ).arg( status.toInt() ).arg( phrase.toString() ) );
@@ -5071,7 +5071,7 @@ void QgsWmsLegendDownloadHandler::finished()
 
   QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
   QVariant redirect = mReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-  if ( !redirect.isNull() )
+  if ( !QgsVariantUtils::isNull( redirect ) )
   {
     mReply->deleteLater();
     mReply = nullptr;
@@ -5080,7 +5080,7 @@ void QgsWmsLegendDownloadHandler::finished()
   }
 
   QVariant status = mReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-  if ( !status.isNull() && status.toInt() >= 400 )
+  if ( !QgsVariantUtils::isNull( status ) && status.toInt() >= 400 )
   {
     QVariant phrase = mReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
     QString msg( tr( "GetLegendGraphic request error" ) );

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -19,6 +19,7 @@
 #include "qgsserverexception.h"
 #include "qgsnetworkcontentfetcher.h"
 #include "qgsmessagelog.h"
+#include "qgsvariantutils.h"
 #include <QObject>
 #include <QUrl>
 #include <QNetworkReply>
@@ -358,7 +359,7 @@ QString QgsServerParameterDefinition::loadUrl( bool &ok ) const
   }
 
   const QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-  if ( !status.isNull() && status.toInt() >= 400 )
+  if ( status.isValid() && status.toInt() >= 400 )
   {
     ok = false;
     if ( reply->error() != QNetworkReply::NoError )
@@ -605,7 +606,7 @@ QMap<QString, QString> QgsServerParameters::toMap() const
 
   for ( const auto &parameter : mParameters.toStdMap() )
   {
-    if ( parameter.second.mValue.isNull() )
+    if ( QgsVariantUtils::isNull( parameter.second.mValue ) )
       continue;
 
     if ( parameter.second.mName == QgsServerParameter::VERSION_SERVICE )

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -18,6 +18,7 @@
 
 #include "qgsserversettings.h"
 #include "qgsapplication.h"
+#include "qgsvariantutils.h"
 
 #include <QSettings>
 #include <QDir>
@@ -445,7 +446,7 @@ void QgsServerSettings::prioritize( const QMap<QgsServerSettingsEnv::EnvVar, QSt
       varValue.setValue( env.value( e ) );
     }
 
-    if ( ! varValue.isNull() && varValue.canConvert( s.type ) )
+    if ( !QgsVariantUtils::isNull( varValue ) && varValue.canConvert( s.type ) )
     {
       s.val = varValue;
       s.src = QgsServerSettingsEnv::ENVIRONMENT_VARIABLE;

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1549,7 +1549,7 @@ namespace QgsWfs
       const QgsEditorWidgetSetup setup = field.editorWidgetSetup();
       const QString attributeName = field.name().replace( ' ', '_' ).replace( cleanTagNameRegExp, QString() );
       QDomElement fieldElem = doc.createElement( QStringLiteral( "qgs:" ) + attributeName );
-      if ( value.isNull() )
+      if ( QgsVariantUtils::isNull( value ) )
       {
         fieldElem.setAttribute( QStringLiteral( "xsi:nil" ), QStringLiteral( "true" ) );
       }
@@ -1571,7 +1571,7 @@ namespace QgsWfs
 
     QString encodeValueToText( const QVariant &value, const QgsEditorWidgetSetup &setup )
     {
-      if ( value.isNull() )
+      if ( QgsVariantUtils::isNull( value ) )
         return QString();
 
       if ( setup.type() ==  QStringLiteral( "DateTime" ) )

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -429,7 +429,7 @@ namespace QgsWfs
           }
           QgsField field = fields.at( fieldMapIt.value() );
           QVariant value = it.value();
-          if ( value.isNull() )
+          if ( QgsVariantUtils::isNull( value ) )
           {
             if ( field.constraints().constraints() & QgsFieldConstraints::Constraint::ConstraintNotNull )
             {

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -406,7 +406,7 @@ namespace QgsWfs
             }
             QgsField field = fields.at( fieldMapIt.value() );
             QVariant value = it.value();
-            if ( value.isNull() )
+            if ( QgsVariantUtils::isNull( value ) )
             {
               if ( field.constraints().constraints() & QgsFieldConstraints::Constraint::ConstraintNotNull )
               {

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1477,7 +1477,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
           const QgsFields fields = mapLayer->fields();
           for ( const auto &field : fields )
           {
-            if ( ! properties.value( field.name() ).isNull() )
+            if ( ! QgsVariantUtils::isNull( properties.value( field.name() ) ) )
             {
               if ( ! authorizedFieldNames.contains( field.name() ) )
               {
@@ -1487,7 +1487,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
               {
                 QVariant value = properties.value( field.name() );
                 // Convert blobs
-                if ( ! properties.value( field.name() ).isNull() && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
+                if ( !QgsVariantUtils::isNull( properties.value( field.name() ) ) && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
                 {
                   value = QByteArray::fromBase64( value.toByteArray() );
                 }
@@ -1745,7 +1745,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
           int fieldIndex = 0;
           for ( const auto &field : fields )
           {
-            if ( ! properties.value( field.name() ).isNull() )
+            if ( ! QgsVariantUtils::isNull( properties.value( field.name() ) ) )
             {
               if ( ! authorizedFieldNames.contains( field.name() ) )
               {
@@ -1755,7 +1755,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
               {
                 QVariant value = properties.value( field.name() );
                 // Convert blobs
-                if ( ! properties.value( field.name() ).isNull() && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
+                if ( ! QgsVariantUtils::isNull( properties.value( field.name() ) ) && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
                 {
                   value = QByteArray::fromBase64( value.toByteArray() );
                 }
@@ -1865,7 +1865,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
           int fieldIndex = 0;
           for ( const auto &field : fields )
           {
-            if ( ! properties.value( field.name() ).isNull() )
+            if ( ! QgsVariantUtils::isNull( properties.value( field.name() ) ) )
             {
               if ( ! authorizedFieldNames.contains( field.name() ) )
               {
@@ -1875,7 +1875,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
               {
                 QVariant value = properties.value( field.name() );
                 // Convert blobs
-                if ( ! properties.value( field.name() ).isNull() && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
+                if ( ! QgsVariantUtils::isNull( properties.value( field.name() ) ) && static_cast<QMetaType::Type>( field.type() ) == QMetaType::QByteArray )
                 {
                   value = QByteArray::fromBase64( value.toByteArray() );
                 }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2082,7 +2082,7 @@ namespace QgsWms
           attributeElement.setAttribute( QStringLiteral( "name" ), layer->bandName( it.key() ) );
 
           QString value;
-          if ( ! it.value().isNull() )
+          if ( ! QgsVariantUtils::isNull( it.value() ) )
           {
             value  = QString::number( it.value().toDouble() );
           }


### PR DESCRIPTION
This method restores the Qt 5 logic for testing for null variants,
where for core Qt types the isNull check is forwarded to the actual
data type.

E.g. on Qt 5:  QVariant( QDateTime()).isNull() is true, but
on Qt 6 it's false

This breaks a LOT of assumptions made throughout QGIS. The new
helper method avoids this breakage by ensuring we follow the Qt 5
logic also on Qt 6 builds, and also gives us the option to extend
this logic for user types (e.g QVariant( QgsGeometry() ).isNull() could
return true). (That's not included here)