### PR TITLE
NMEA satellites count (sat inuse, sat inview)

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -390,7 +390,7 @@ int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack )
     return 0;
   }
 
-  if ( type != 'P' && type != 'N' )
+  if ( type != 'P' && type != 'N' && type != 'L' && type != 'A' && type != 'B' && type != 'Q' )
   {
     nmea_error( "G?GSV invalid type " );
     return 0;

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -972,7 +972,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     mTxtFixMode->setText( info.fixMode == 'A' ? tr( "Automatic" ) : info.fixMode == 'M' ? tr( "Manual" ) : QString() ); // A=automatic 2d/3d, M=manual; allowing for anything else
     mTxtFixType->setText( info.fixType == 3 ? tr( "3D" ) : info.fixType == 2 ? tr( "2D" ) : info.fixType == 1 ? tr( "No fix" ) : QString::number( info.fixType ) ); // 1=no fix, 2=2D, 3=3D; allowing for anything else
     mTxtQuality->setText( info.qualityDescription() );
-    mTxtSatellitesUsed->setText( QString::number( info.satellitesUsed ) );
+    mTxtSatellitesUsed->setText( "used: " + QString::number( info.satellitesUsed ) + " (view: " + QString::number( info.satellitesInView.size() ) + ")" );
     mTxtStatus->setText( info.status == 'A' ? tr( "Valid" ) : info.status == 'V' ? tr( "Invalid" ) : QString() );
   } //position
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -972,7 +972,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     mTxtFixMode->setText( info.fixMode == 'A' ? tr( "Automatic" ) : info.fixMode == 'M' ? tr( "Manual" ) : QString() ); // A=automatic 2d/3d, M=manual; allowing for anything else
     mTxtFixType->setText( info.fixType == 3 ? tr( "3D" ) : info.fixType == 2 ? tr( "2D" ) : info.fixType == 1 ? tr( "No fix" ) : QString::number( info.fixType ) ); // 1=no fix, 2=2D, 3=3D; allowing for anything else
     mTxtQuality->setText( info.qualityDescription() );
-    mTxtSatellitesUsed->setText( "used: " + QString::number( info.satellitesUsed ) + " (view: " + QString::number( info.satellitesInView.size() ) + ")" );
+    mTxtSatellitesUsed->setText( tr( "%1 used (%2 in view)" ).arg( info.satellitesUsed ).arg( info.satellitesInView.size() ) );
     mTxtStatus->setText( info.status == 'A' ? tr( "Valid" ) : info.status == 'V' ? tr( "Invalid" ) : QString() );
   } //position
 

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsnmeaconnection.h"
 #include "qgslogger.h"
-#include "qgsgpsconnection.h"
 
 #include <QIODevice>
 #include <QApplication>

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsnmeaconnection.h"
 #include "qgslogger.h"
+#include "qgsgpsconnection.h"
 
 #include <QIODevice>
 #include <QApplication>
@@ -108,7 +109,8 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) || substring.startsWith( QLatin1String( "$GNGSV" ) ) )
+        // GPS+SBAS GLONASS GALILEO BEIDOU;
+        else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) || substring.startsWith( QLatin1String( "$GNGSV" ) ) || substring.startsWith( QLatin1String( "$GLGSV" ) ) || substring.startsWith( QLatin1String( "$GAGSV" ) ) || substring.startsWith( QLatin1String( "$GBGSV" ) ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           processGsvSentence( ba.data(), ba.length() );
@@ -200,7 +202,7 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
       mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
     }
 
-    mLastGPSInformation.satellitesUsed = result.satinuse;
+    // use GSA for satellites in use;
   }
 }
 
@@ -354,14 +356,12 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
   if ( nmea_parse_GPGSV( data, len, &result ) )
   {
     //clear satellite information when a new series of packs arrives
-    if ( result.pack_index == 1 )
-    {
-      mLastGPSInformation.satellitesInView.clear();
-    }
+    // clear() on VTG
 
     // for determining when to graph sat info
     mLastGPSInformation.satInfoComplete = ( result.pack_index == result.pack_count );
 
+    int IDfind = 0;
     for ( int i = 0; i < NMEA_SATINPACK; ++i )
     {
       const nmeaSATELLITE currentSatellite = result.sat_data[i];
@@ -369,9 +369,29 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
       satelliteInfo.azimuth = currentSatellite.azimuth;
       satelliteInfo.elevation = currentSatellite.elv;
       satelliteInfo.id = currentSatellite.id;
-      satelliteInfo.inUse = currentSatellite.in_use; // the GSA processing below does NOT set the sats in use
+      satelliteInfo.inUse = 0;
       satelliteInfo.signal = currentSatellite.sig;
-      mLastGPSInformation.satellitesInView.append( satelliteInfo );
+      
+      IDfind = 0;
+      if ( mLastGPSInformation.satellitesInView.size() > NMEA_SATINPACK )
+      {
+        for ( int j = 0; j < mLastGPSInformation.satellitesInView.size(); ++j )
+        {
+          QgsSatelliteInfo FindsatInView = mLastGPSInformation.satellitesInView.at( j );
+          if ( FindsatInView.id == currentSatellite.id )
+          {
+            IDfind = 1;
+          }
+        }
+      }
+      if ( currentSatellite.sig > 0 )
+      {  
+        satelliteInfo.inUse = 1; // check where used ???? (+=1)
+      }
+      if ( IDfind == 0 && ( currentSatellite.azimuth > 0 && currentSatellite.elv > 0 ) )
+      {
+        mLastGPSInformation.satellitesInView.append( satelliteInfo );
+      }
     }
 
   }
@@ -379,6 +399,12 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
 
 void QgsNmeaConnection::processVtgSentence( const char *data, int len )
 {
+  //GSA
+  mLastGPSInformation.satPrn.clear(); 
+  //GSV
+  mLastGPSInformation.satellitesInView.clear();
+  mLastGPSInformation.satellitesUsed = 0; 
+  
   nmeaGPVTG result;
   if ( nmea_parse_GPVTG( data, len, &result ) )
   {
@@ -391,7 +417,7 @@ void QgsNmeaConnection::processGsaSentence( const char *data, int len )
   nmeaGPGSA result;
   if ( nmea_parse_GPGSA( data, len, &result ) )
   {
-    mLastGPSInformation.satPrn.clear();
+    // clear() on VTG
     mLastGPSInformation.hdop = result.HDOP;
     mLastGPSInformation.pdop = result.PDOP;
     mLastGPSInformation.vdop = result.VDOP;
@@ -399,7 +425,11 @@ void QgsNmeaConnection::processGsaSentence( const char *data, int len )
     mLastGPSInformation.fixType = result.fix_type;
     for ( int i = 0; i < NMEA_MAXSAT; i++ )
     {
-      mLastGPSInformation.satPrn.append( result.sat_prn[ i ] );
+      if ( result.sat_prn[ i ] > 0 )
+      {
+        mLastGPSInformation.satPrn.append( result.sat_prn[ i ] );
+        mLastGPSInformation.satellitesUsed +=1;
+      }
     }
   }
 }

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -428,7 +428,7 @@ void QgsNmeaConnection::processGsaSentence( const char *data, int len )
       if ( result.sat_prn[ i ] > 0 )
       {
         mLastGPSInformation.satPrn.append( result.sat_prn[ i ] );
-        mLastGPSInformation.satellitesUsed +=1;
+        mLastGPSInformation.satellitesUsed += 1;
       }
     }
   }

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -371,7 +371,6 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
       satelliteInfo.id = currentSatellite.id;
       satelliteInfo.inUse = 0;
       satelliteInfo.signal = currentSatellite.sig;
-      
       IDfind = 0;
       if ( mLastGPSInformation.satellitesInView.size() > NMEA_SATINPACK )
       {

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -108,8 +108,8 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
-        // GPS+SBAS GLONASS GALILEO BEIDOU;
-        else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) || substring.startsWith( QLatin1String( "$GNGSV" ) ) || substring.startsWith( QLatin1String( "$GLGSV" ) ) || substring.startsWith( QLatin1String( "$GAGSV" ) ) || substring.startsWith( QLatin1String( "$GBGSV" ) ) )
+        // GPS+SBAS GLONASS GALILEO BEIDOU QZSS;
+        else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) || substring.startsWith( QLatin1String( "$GNGSV" ) ) || substring.startsWith( QLatin1String( "$GLGSV" ) ) || substring.startsWith( QLatin1String( "$GAGSV" ) ) || substring.startsWith( QLatin1String( "$GBGSV" ) ) || substring.startsWith( QLatin1String( "$GQGSV" ) ) )
         {
           QgsDebugMsgLevel( substring, 2 );
           processGsvSentence( ba.data(), ba.length() );

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -384,7 +384,7 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
         }
       }
       if ( currentSatellite.sig > 0 )
-      {  
+      {
         satelliteInfo.inUse = 1; // check where used ???? (+=1)
       }
       if ( IDfind == 0 && ( currentSatellite.azimuth > 0 && currentSatellite.elv > 0 ) )

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -399,11 +399,11 @@ void QgsNmeaConnection::processGsvSentence( const char *data, int len )
 void QgsNmeaConnection::processVtgSentence( const char *data, int len )
 {
   //GSA
-  mLastGPSInformation.satPrn.clear(); 
+  mLastGPSInformation.satPrn.clear();
   //GSV
   mLastGPSInformation.satellitesInView.clear();
-  mLastGPSInformation.satellitesUsed = 0; 
-  
+  mLastGPSInformation.satellitesUsed = 0;
+
   nmeaGPVTG result;
   if ( nmea_parse_GPVTG( data, len, &result ) )
   {


### PR DESCRIPTION
With this proposed NMEA code change, the count:
- number of satellites in use;
- number of satellists in the view of the GNSS receiver
is resolved.
**
The count of satellites in use was previously set up to read GPGGA / GNGGA messages (with a maximum result of 12 satellites), with this modification the count has been moved to GPGSA / GNGSA messages.
https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_gsa.html
**
As for satellites in view to GNSS receiver, I changed the routine related to GxGSV messages, in particular to previous GPGSV / GNGSV messages, they were added:
GLGSV (Glonass),
GBGSV (Beidou),
GAGSV (Galileo);
GQGSV (QZSS).
https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_gsv.html
**
Since the GxGSA and GxGSV messages are multi-line in the NMEA sentence, the GxVTG message is used as a "clock" to reset the satellite counts and associated values.
**
I updated the GPS Tools widget (it should be called: GNSS Tools) and reactivated: SkyPlot satellites
**
The tests were performed with U-Blox ZED-F9P GNSS receiver (ArdusimpleRTK2BLite), with excellent results comparable with other GNSS applications.
I hope the QField version can benefit from this update.
**
![QGIS_NMEA_sat_used_sat_onview_1](https://user-images.githubusercontent.com/23143342/185174011-ca94b289-9edb-441f-a4af-6f1fdbee9e3d.jpg)
**
![QGIS_NMEA_sat_used_sat_onview_3](https://user-images.githubusercontent.com/23143342/185174092-8084ab01-3a59-46c3-99aa-6a8c08cb44c2.jpg)
**
![QGIS_NMEA_sat_used_sat_onview_2](https://user-images.githubusercontent.com/23143342/185174162-c630ce41-b5f9-4c47-bb69-dbd2b2f6d56d.jpg)

Thank you