### PR TITLE
When deleting a map canvas, first clear all the pointers to that canvas from child map tools

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -253,8 +253,20 @@ QgsMapCanvas::~QgsMapCanvas()
   if ( mMapTool )
   {
     mMapTool->deactivate();
+    disconnect( mMapTool, &QObject::destroyed, this, &QgsMapCanvas::mapToolDestroyed );
     mMapTool = nullptr;
   }
+
+  // we also clear the canvas pointer for all child map tools. We're now in a partially destroyed state and it's
+  // no longer safe for map tools to try to cleanup things in the canvas during their destruction (such as removing
+  // associated canvas items)
+  // NOTE -- it may be better to just delete the map tool children here upfront?
+  const QList< QgsMapTool * > tools = findChildren< QgsMapTool *>();
+  for ( QgsMapTool *tool : tools )
+  {
+    tool->mCanvas = nullptr;
+  }
+
   mLastNonZoomMapTool = nullptr;
 
   cancelJobs();

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -353,6 +353,7 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! The translated name of the map tool
     QString mToolName;
 
+    friend class QgsMapCanvas;
     friend class TestQgsMapToolEdit;
 
 };


### PR DESCRIPTION
Otherwise we risk the map tools trying to do things with the canvas within their cleanup code, and at that stage the canvas
is already partially destroyed.

On qt 5 builds this leads to undefined behavior, and on qt 6 builds it triggers a newly introduced assert designed to
catch these kinds of bugs. 

It's possible that we should just delete the map tool children upfront here instead, but that's a little more risky.
